### PR TITLE
(PC-4517) Adapt to new pcapi Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,8 +450,8 @@ Pour la remplir, il faut jouer les sandboxes `industrial` et `activation`.
 
 Execution des sandboxes sur le conteneur :
 ``` bash
-scalingo -a pass-culture-api-perf --region osc-fr1 run 'PYTHONPATH=. python scripts/pc.py sandbox -n industrial'
-scalingo -a pass-culture-api-perf --region osc-fr1 run 'PYTHONPATH=. python scripts/pc.py sandbox -n activation'
+scalingo -a pass-culture-api-perf --region osc-fr1 run 'python src/pcapi/scripts/pc.py sandbox -n industrial'
+scalingo -a pass-culture-api-perf --region osc-fr1 run 'python src/pcapi/scripts/pc.py sandbox -n activation'
 ```
 
 Ensuite, lancer le script d'import des utilisateurs avec une liste d'utilisateurs en csv prédéfinie placée dans le dossier `artillery` sous le nom `user_list`.

--- a/docker-compose-app-worker.yml
+++ b/docker-compose-app-worker.yml
@@ -9,7 +9,7 @@ services:
                cd /opt/services/flaskapp/src;
                pip install -r ./requirements.txt;
                python -m nltk.downloader punkt stopwords;
-               while true; do PYTHONPATH=. python workers/worker.py; done;"
+               while true; do python src/pcapi/workers/worker.py; done;"
     volumes:
       - ./api:/opt/services/flaskapp/src
     env_file:

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -43,7 +43,6 @@ services:
       - SUPPORT_EMAIL_ADDRESS=${ADMINISTRATION_EMAIL_ADDRESS:-""}
       - ADMINISTRATION_EMAIL_ADDRESS=${ADMINISTRATION_EMAIL_ADDRESS:-""}
       - DEV_EMAIL_ADDRESS=${DEV_EMAIL_ADDRESS:-""}
-      - PYTHONPATH=.
     networks:
       - db_nw
       - web_nw

--- a/docker-compose-metabase.yml
+++ b/docker-compose-metabase.yml
@@ -8,8 +8,8 @@ services:
       bash -c "set -x;
                cd /opt/services/flaskapp/src;
                pip install -r ./requirements.txt;
-               PYTHONPATH=. python scripts/pc.py install_data_for_metabase;
-               PYTHONPATH=. python scripts/pc.py sandbox -n industrial"
+               python src/pcapi/scripts/pc.py install_data_for_metabase;
+               python src/pcapi/scripts/pc.py sandbox -n industrial"
     volumes:
       - ./api:/opt/services/flaskapp/src
     environment:

--- a/infra/pc_scripts/test_backend.sh
+++ b/infra/pc_scripts/test_backend.sh
@@ -10,6 +10,6 @@ function test_backend {
         docker rm -v pc-postgres-pytest;
         docker-compose -f "$ROOT_PATH"/docker-compose-app.yml up -d postgres-test;
         while ! docker-compose -f "$ROOT_PATH"/docker-compose-app.yml logs postgres-test 2> /dev/null | grep -q "listening on IPv4 address"; do echo "waiting for test-database"; sleep 0.5; done;
-        docker exec pc-flask bash -c "cd /opt/services/flaskapp/src/ && rm -rf static/object_store_data/thumbs/* && RUN_ENV=tests PYTHONPATH=. pytest --durations=5 --color=yes -rsx -v $PYTEST_ARGS"
+        docker exec pc-flask bash -c "cd /opt/services/flaskapp/src/ && rm -rf static/object_store_data/thumbs/* && RUN_ENV=tests pytest --durations=5 --color=yes -rsx -v $PYTEST_ARGS"
         '
 }

--- a/pc
+++ b/pc
@@ -194,7 +194,7 @@ function exit_success_restoring_branch {
 # Need to specify what alembic command you want to execute
 # Example: ./pc alembic upgrade head
 if [[ "$CMD" == "alembic" ]]; then
-  RUN='docker exec pc-flask bash -c "cd /opt/services/flaskapp/src && PYTHONPATH=. alembic '"$*"'"'
+  RUN='docker exec pc-flask bash -c "cd /opt/services/flaskapp/src && alembic '"$*"'"'
 
 # Connect to API container
 elif [[ "$CMD" == "bash" ]]; then
@@ -240,7 +240,7 @@ elif [[ "$CMD" == "restart-backend" ]]; then
 # Clear all data in postgresql database
 elif [[ "$CMD" == "reset-all-db" ]]; then
   RUN='docker exec -it pc-flask bash -c "rm -rf /opt/services/flaskapp/src/static/object_store_data/*";
-    docker exec pc-flask bash -c "cd /opt/services/flaskapp/src/ && PYTHONPATH=. python scripts/pc.py clean"'
+    docker exec pc-flask bash -c "cd /opt/services/flaskapp/src/ && python src/pcapi/scripts/pc.py clean"'
 
 # Remove all booking & reco from database
 elif [[ "$CMD" == "reset-reco-db" ]]; then
@@ -585,7 +585,7 @@ elif [[ "$CMD" == "symlink" ]]; then
 elif [[ "$CMD" == "api-licenses" ]]; then
   COLUMNS=${COLUMNS:-''};
   if [[ "$ENV" == "development" ]]; then
-    RUN='docker exec -it pc-flask bash -c "cd /opt/services/flaskapp/src/ && PYTHONPATH=. pip-licenses --format-html >> licenses.html"'
+    RUN='docker exec -it pc-flask bash -c "cd /opt/services/flaskapp/src/ && pip-licenses --format-html >> licenses.html"'
   else
     echo_error "These command is only available in DEV"
     exit
@@ -637,12 +637,12 @@ elif [[ "$CMD" == "pgcli" ]]; then
 elif [[ "$CMD" == "python" ]]; then
     COLUMNS=${COLUMNS:-''};
 	if [[ "$ENV" == "development" ]]; then
-		RUN='docker exec -it pc-flask bash -c "cd /opt/services/flaskapp/src/ && PYTHONPATH=. python -i scripts/interact.py '"$CMD $*"'"'
+		RUN='docker exec -it pc-flask bash -c "cd /opt/services/flaskapp/src/ && python -i src/pcapi/scripts/interact.py '"$CMD $*"'"'
 	else
     if [ "$FILE_TO_UPLOAD" == 'none' ]; then
-      scalingo -a "$SCALINGO_APP" run "python -i scripts/interact.py"
+      scalingo -a "$SCALINGO_APP" run "python -i src/pcapi/scripts/interact.py"
 		else
-      scalingo -a "$SCALINGO_APP" run --file "$FILE_TO_UPLOAD" "python -i scripts/interact.py"
+      scalingo -a "$SCALINGO_APP" run --file "$FILE_TO_UPLOAD" "python -i src/pcapi/scripts/interact.py"
 		fi
 		exit
 	fi
@@ -671,12 +671,12 @@ elif [[ "$CMD" == "db_restore_infos" ]]; then
 # Run python scripts from api/scripts
 else
   if [[ "$ENV" == "development" ]]; then
-    RUN='docker exec pc-flask bash -c "cd /opt/services/flaskapp/src/ && PYTHONPATH=. python scripts/pc.py '"$CMD $*"'"'
+    RUN='docker exec pc-flask bash -c "cd /opt/services/flaskapp/src/ && python src/pcapi/scripts/pc.py '"$CMD $*"'"'
   else
     if [ "$FILE_TO_UPLOAD" == 'none' ]; then
-      scalingo -a "$SCALINGO_APP" run 'python scripts/pc.py '"$CMD $*"''
+      scalingo -a "$SCALINGO_APP" run 'python src/pcapi/scripts/pc.py '"$CMD $*"''
     else
-      scalingo -a "$SCALINGO_APP" run --file "$FILE_TO_UPLOAD" 'python scripts/pc.py '"$CMD $*"''
+      scalingo -a "$SCALINGO_APP" run --file "$FILE_TO_UPLOAD" 'python src/pcapi/scripts/pc.py '"$CMD $*"''
     fi
     exit
   fi


### PR DESCRIPTION
A new "pcapi" Python package has been created so that we can get rid
of all PYTHONPATH overrides. See recent changes in `pass-culture-api`
for further details.