### PR TITLE
(PC-5162) : use config file for the mail addresses

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -39,10 +39,6 @@ services:
     env_file:
       - env_file
       - ${ENV:-development}_env_file
-    environment:
-      - SUPPORT_EMAIL_ADDRESS=${ADMINISTRATION_EMAIL_ADDRESS:-""}
-      - ADMINISTRATION_EMAIL_ADDRESS=${ADMINISTRATION_EMAIL_ADDRESS:-""}
-      - DEV_EMAIL_ADDRESS=${DEV_EMAIL_ADDRESS:-""}
     networks:
       - db_nw
       - web_nw


### PR DESCRIPTION
Whether they are set or not the docker-compose variables are
overriding the config files and thus making the tests behave
differently from the CI.
Let's just keep consistent and reliable

Prerequisite for https://github.com/pass-culture/pass-culture-api/pull/1554 