### PR TITLE
current version of chrome in ci

### DIFF
--- a/install_lib_ci.sh
+++ b/install_lib_ci.sh
@@ -13,5 +13,5 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update
 sudo apt-get install -y yarn realpath
-wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_74.0.3729.169-1_amd64.deb
-sudo dpkg -i google-chrome-stable_74.0.3729.169-1_amd64.deb
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo dpkg -i google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
[La version de Chrome avait été freezée il y a un an car une version nous posait problème lors des testcafé](https://github.com/pass-culture/pass-culture-main/commit/c52562b2363b0237746dd987ad3e9bb18378b8b5).
Nous avons 10 versions de retard donc il est temps d'être à jour pour éviter d'avoir un delta entre nos machines locales et la CI.