### PR TITLE
Edit mypy step in pre commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -34,7 +34,7 @@ else
 fi
 
 echo -e "\n\033[0;96mRunning mypy for type checking (non-blocking step)\033[0m\n"
-mypy $LINTED_FILES --pretty
+mypy $LINTED_FILES --pretty --show-error-codes
 
 echo -e "\n\033[0;96mRunning pylint for code linting\033[0m\n"
 pylint $LINTED_FILES --output-format="colorized" --score=no

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -33,11 +33,8 @@ else
   echo -e "\033[0;92mCode correctly formatted\033[0m\n"
 fi
 
-echo -e "\n\033[0;96mRunning mypy for type checking\033[0m\n"
+echo -e "\n\033[0;96mRunning mypy for type checking (non-blocking step)\033[0m\n"
 mypy $LINTED_FILES --pretty
-if [[ "$?" != 0 ]]; then
-  counter=$((counter + 1))
-fi
 
 echo -e "\n\033[0;96mRunning pylint for code linting\033[0m\n"
 pylint $LINTED_FILES --output-format="colorized" --score=no


### PR DESCRIPTION
Comme discuté en point standards, ne pas bloquer le commit à cause d'erreurs MyPy, en attendant de bien le configurer et de rendre la codebase compatible.
Aussi, afficher le code d'erreur (utile pour les directives d'ignorance que l'on pourrait ajouter).