### PR TITLE
(PC-5837) Remove environment variable override

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -39,10 +39,6 @@ services:
     env_file:
       - env_file
       - ${ENV:-development}_env_file
-    environment:
-      - SUPPORT_EMAIL_ADDRESS=${ADMINISTRATION_EMAIL_ADDRESS:-""}
-      - ADMINISTRATION_EMAIL_ADDRESS=${ADMINISTRATION_EMAIL_ADDRESS:-""}
-      - DEV_EMAIL_ADDRESS=${DEV_EMAIL_ADDRESS:-""}
     networks:
       - db_nw
       - web_nw


### PR DESCRIPTION
The variables are defined in the api env files. The .env.development definitions were overriden by this setting