### PR TITLE
(PC-8760) .gitignore: ignore the former `shared` submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ pro-packed-staging/
 webapp-packed-staging/
 
 *.retry
+
+# The `shared` submodule has been removed in https://github.com/pass-culture/pass-culture-main/pull/334
+/shared


### PR DESCRIPTION
The `shared` submodule has been removed in https://github.com/pass-culture/pass-culture-main/pull/334
To prevent a local copy to be used when creating a tag for the project, we ignore it