### PR TITLE
dump_restore: Disable all venue providers

### DIFF
--- a/infra/docker-images/db-ops/dump_restore.sh
+++ b/infra/docker-images/db-ops/dump_restore.sh
@@ -146,3 +146,11 @@ if [ "$CREATE_USERS" = "true" ];then
     python3 ${PC_API_ROOT_PATH}/${IMPORT_USERS_SCRIPT_PATH} ${USERS_CSV_PATH}
     echo "Ended: python3 $(echo_time)"
 fi
+
+if [ "$DISABLE_VENUE_PROVIDERS" = "true" ];then
+    echo "Starting: disable all venue providers $(echo_time)"
+    psql "${POSTGRES_CONNEXION_STRING_DEST}" \
+        --echo-errors \
+        --command 'UPDATE venue_provider SET "isActive" = false'
+    echo "Ended: disable all venue providers $(echo_time)"
+fi


### PR DESCRIPTION
On staging, we don't want to synchronize all venues:
- we don't need to have up-to-date offers and stocks;
- it fills Algolia staging index and exhausts our records quota.