### PR TITLE
infra: Fix anonymization of BIC

### DIFF
--- a/infra/docker-images/db-ops/anonymize.sql
+++ b/infra/docker-images/db-ops/anonymize.sql
@@ -34,7 +34,7 @@ COMMIT;
 
 -- Set fake IBAN and BIC in `bank_information` table...
 UPDATE bank_information SET "iban" = 'FR' || lpad(id::text, 25, '0') WHERE "iban" is not null;
-UPDATE bank_information SET "bic" = 'XX' || lpad(id::text, 6, '0') WHERE "bic" is not null;
+UPDATE bank_information SET "bic" = 'XXXXXX' || 'X' || lpad(upper(to_hex(id)), 4, '0') WHERE "bic" is not null;
 -- ... and reuse them in `payment` table.
 UPDATE payment
 SET iban = bank_information.iban, bic = bank_information.bic


### PR DESCRIPTION
Generated BIC (such as "XX001234") were not valid. They must be valid,
otherwise the validation of the "banque de France" XML file fails when
the "payment generation script" is run on staging.