### PR TITLE
Remove unused port opening

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -10,8 +10,6 @@ services:
       - env_file
     networks:
       - db_nw
-    ports:
-      - 5434:5432
     command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
 
   postgres-test:


### PR DESCRIPTION
As the docker port is still used by scripts that don't use docker compose network (E2E tests or developers that launch api on their local machine), we want to keep a port redirection in the docker-compose.

Let's keep it at 5434 to avoid conflict on local machines