### PR TITLE
(PC-11243): fix null values venue id at offer provider

### DIFF
--- a/api/src/pcapi/alembic/versions/20211115T073416_a0a822d365ac_add_not_null_venue_provider_venue_id_at_offer_provider_step_1.py
+++ b/api/src/pcapi/alembic/versions/20211115T073416_a0a822d365ac_add_not_null_venue_provider_venue_id_at_offer_provider_step_1.py
@@ -1,0 +1,23 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_2
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a0a822d365ac"
+down_revision = "5ff1b52e2f08"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+            ALTER TABLE venue_provider DROP CONSTRAINT IF EXISTS venueid_at_offer_provider_not_null_constraint;
+            ALTER TABLE venue_provider ADD CONSTRAINT venueid_at_offer_provider_not_null_constraint CHECK ("venueIdAtOfferProvider" IS NOT NULL) NOT VALID;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("venueid_at_offer_provider_not_null_constraint", table_name="venue_provider")

--- a/api/src/pcapi/alembic/versions/20211115T080547_010aba57cb3e_add_not_null_venue_provider_venue_id_at_offer_provider_step_2.py
+++ b/api/src/pcapi/alembic/versions/20211115T080547_010aba57cb3e_add_not_null_venue_provider_venue_id_at_offer_provider_step_2.py
@@ -1,0 +1,31 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_2
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from pcapi import settings
+
+
+revision = "010aba57cb3e"
+down_revision = "a0a822d365ac"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        SET SESSION statement_timeout = '900s'
+        """
+    )
+    op.execute("ALTER TABLE venue_provider VALIDATE CONSTRAINT venueid_at_offer_provider_not_null_constraint;")
+    op.execute(
+        f"""
+        SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/alembic/versions/20211115T080553_f2cb5833253a_add_not_null_venue_provider_venue_id_at_offer_provider_step_3.py
+++ b/api/src/pcapi/alembic/versions/20211115T080553_f2cb5833253a_add_not_null_venue_provider_venue_id_at_offer_provider_step_3.py
@@ -1,0 +1,18 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_3
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f2cb5833253a"
+down_revision = "010aba57cb3e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("venue_provider", "venueIdAtOfferProvider", nullable=False)
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/alembic/versions/20211115T080556_32c7ca9be253_add_not_null_venue_provider_venue_id_at_offer_provider_step_4.py
+++ b/api/src/pcapi/alembic/versions/20211115T080556_32c7ca9be253_add_not_null_venue_provider_venue_id_at_offer_provider_step_4.py
@@ -1,0 +1,22 @@
+"""add_not_null_venue_provider_venue_id_at_offer_provider_step_4
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "32c7ca9be253"
+down_revision = "f2cb5833253a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("venueid_at_offer_provider_not_null_constraint", table_name="venue_provider")
+
+
+def downgrade():
+    op.execute(
+        """
+            ALTER TABLE venue_provider ADD CONSTRAINT venueid_at_offer_provider_not_null_constraint CHECK ("venueIdAtOfferProvider" IS NOT NULL) NOT VALID;
+        """
+    )

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -82,7 +82,7 @@ class VenueProvider(PcObject, Model, ProvidableMixin, DeactivableMixin):
 
     provider = relationship("Provider", foreign_keys=[providerId])
 
-    venueIdAtOfferProvider = Column(String(70))
+    venueIdAtOfferProvider = Column(String(70), nullable=False)
 
     lastSyncDate = Column(DateTime, nullable=True)
 

--- a/api/tests/admin/custom_views/venue_provider_view_test.py
+++ b/api/tests/admin/custom_views/venue_provider_view_test.py
@@ -129,7 +129,7 @@ class EditModelTest:
             allocine_quantity=222,
             provider=provider.id,
             venue=venue.id,
-            venueIdAtOfferProvider=None,
+            venueIdAtOfferProvider="ABCDEF12345",
         )
 
         client.with_session_auth("user@example.com")

--- a/api/tests/local_providers/allocine_stocks_test.py
+++ b/api/tests/local_providers/allocine_stocks_test.py
@@ -7,21 +7,18 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi.core.categories import subcategories
-from pcapi.core.providers.repository import get_provider_by_local_class
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderPriceRuleFactory
 from pcapi.local_providers import AllocineStocks
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider_price_rule
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.provider_creators import activate_provider
-from pcapi.model_creators.specific_creators import create_offer_with_event_product
-from pcapi.model_creators.specific_creators import create_product_with_event_subcategory
 from pcapi.models import Offer
 from pcapi.models import Product
 from pcapi.models import Stock
 from pcapi.repository import repository
 import pcapi.sandboxes
 from pcapi.utils.human_ids import humanize
+from src.pcapi.core.offers.factories import OfferFactory
+from src.pcapi.core.offers.factories import OffererFactory
+from src.pcapi.core.offers.factories import ProductFactory
 from src.pcapi.core.offers.factories import VenueFactory
 
 
@@ -98,16 +95,8 @@ class AllocineStocksTest:
             # Given
             theater_token = "test"
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(offerer, name="Cinéma Allociné", siret="77567146400110")
-            repository.save(venue)
-
-            allocine_provider = get_provider_by_local_class("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(
-                venue, allocine_provider, venue_id_at_offer_provider=theater_token
-            )
-
-            repository.save(allocine_venue_provider)
+            venue = VenueFactory(managingOfferer__siren="775671464", name="Cinéma Allociné", siret="77567146400110")
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, venueIdAtOfferProvider=theater_token)
 
             # When
             AllocineStocks(allocine_venue_provider)
@@ -140,14 +129,14 @@ class AllocineStocksTest:
                 ]
             )
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(
-                offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com"
+            venue = VenueFactory(
+                managingOfferer__siren="775671464",
+                name="Cinema Allocine",
+                siret="77567146400110",
+                bookingEmail="toto@example.com",
             )
 
-            allocine_provider = get_provider_by_local_class("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-            repository.save(venue, allocine_venue_provider)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
 
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -206,19 +195,16 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer(siren="775671464")
         venue = VenueFactory(
-            managingOfferer=offerer,
+            managingOfferer__siren="775671464",
             name="Cinema Allocine",
             siret="77567146400110",
             bookingEmail="toto@example.com",
             withdrawalDetails="Modalités",
         )
 
-        allocine_provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, internalId="PXXXXX", isDuo=False)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -322,14 +308,15 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, isDuo=False)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -403,15 +390,15 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -457,38 +444,42 @@ class UpdateObjectsTest:
             ]
         )
 
-        product = create_product_with_event_subcategory(
-            event_name="Test event",
-            event_subcategory_id=subcategories.SEANCE_CINE.id,
-            duration_minutes=60,
-            id_at_providers="TW92aWU6Mzc4MzI=",
+        product = ProductFactory(
+            name="Test event",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            durationMinutes=60,
+            idAtProviders="TW92aWU6Mzc4MzI=",
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinéma Allociné", siret="77567146400110", booking_email="toto@example.com")
-
-        offer_vo = create_offer_with_event_product(
-            product=product,
-            event_name="Test event",
-            event_subcategory_id=subcategories.SEANCE_CINE.id,
-            duration_minutes=60,
-            id_at_providers="TW92aWU6Mzc4MzI=%77567146400110-VO",
-            venue=venue,
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinéma Allociné",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
         )
-        offer_vf = create_offer_with_event_product(
+
+        # offer VO
+        OfferFactory(
             product=product,
-            event_name="Test event",
-            event_subcategory_id=subcategories.SEANCE_CINE.id,
-            duration_minutes=60,
-            id_at_providers="TW92aWU6Mzc4MzI=%77567146400110-VF",
+            name="Test event",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            durationMinutes=60,
+            idAtProviders="TW92aWU6Mzc4MzI=%77567146400110-VO",
             venue=venue,
         )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, product, offer_vo, offer_vf, allocine_venue_provider, venue_provider_price_rule)
+        # offer VF
+        OfferFactory(
+            product=product,
+            name="Test event",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            durationMinutes=60,
+            idAtProviders="TW92aWU6Mzc4MzI=%77567146400110-VF",
+            venue=venue,
+        )
+
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -530,21 +521,22 @@ class UpdateObjectsTest:
             ]
         )
 
-        product = create_product_with_event_subcategory(
-            event_name="Test event",
-            event_subcategory_id=subcategories.SEANCE_CINE.id,
-            duration_minutes=60,
-            id_at_providers="TW92aWU6Mzc4MzI=",
+        ProductFactory(
+            name="Test event",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            durationMinutes=60,
+            idAtProviders="TW92aWU6Mzc4MzI=",
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, product, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -584,14 +576,15 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider, internal_id="P12345")
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, internalId="P12345")
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -663,13 +656,10 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer()
-        venue = create_venue(offerer)
+        venue = VenueFactory()
 
-        allocine_provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(allocine_venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -710,22 +700,23 @@ class UpdateObjectsTest:
         with open(file_path, "rb") as thumb_file:
             mock_get_object_thumb.return_value = thumb_file.read()
 
-        product = create_product_with_event_subcategory(
-            event_name="Test event",
-            event_subcategory_id=subcategories.SEANCE_CINE.id,
-            duration_minutes=60,
-            id_at_providers="TW92aWU6Mzc4MzI=",
-            thumb_count=0,
+        ProductFactory(
+            name="Test event",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            durationMinutes=60,
+            idAtProviders="TW92aWU6Mzc4MzI=",
+            thumbCount=0,
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, product, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -768,22 +759,23 @@ class UpdateObjectsTest:
         with open(file_path, "rb") as thumb_file:
             mock_get_object_thumb.return_value = thumb_file.read()
 
-        product = create_product_with_event_subcategory(
-            event_name="Test event",
-            event_subcategory_id=subcategories.SEANCE_CINE.id,
-            duration_minutes=60,
-            id_at_providers="TW92aWU6Mzc4MzI=",
-            thumb_count=1,
+        ProductFactory(
+            name="Test event",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            durationMinutes=60,
+            idAtProviders="TW92aWU6Mzc4MzI=",
+            thumbCount=1,
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(venue, product, allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -833,15 +825,15 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
-        repository.save(venue)
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, quantity=None)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider, price=10)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -927,15 +919,15 @@ class UpdateObjectsTest:
             ]
         )
 
-        offerer = create_offerer(siren="775671464")
-        venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com")
-        repository.save(venue)
+        venue = VenueFactory(
+            managingOfferer__siren="775671464",
+            name="Cinema Allocine",
+            siret="77567146400110",
+            bookingEmail="toto@example.com",
+        )
 
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-        repository.save(allocine_venue_provider, venue_provider_price_rule)
+        allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, quantity=None)
+        AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider, price=10)
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
 
@@ -1032,17 +1024,15 @@ class UpdateObjectsTest:
                 ),
             ]
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(
-                offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com"
+            venue = VenueFactory(
+                managingOfferer__siren="775671464",
+                name="Cinema Allocine",
+                siret="77567146400110",
+                bookingEmail="toto@example.com",
             )
-            repository.save(venue)
 
-            allocine_provider = get_provider_by_local_class("AllocineStocks")
-            allocine_provider.isActive = True
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-            venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-            repository.save(allocine_venue_provider, venue_provider_price_rule)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
             # When
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
@@ -1092,26 +1082,28 @@ class UpdateObjectsTest:
             ]
             mock_call_allocine_api.side_effect = [iter(allocine_api_response), iter(allocine_api_response)]
             mock_poster_get_allocine.return_value = bytes()
-
-            offerer = create_offerer(siren="775671464")
-            venue1 = create_venue(
-                offerer, name="Cinema Allocine 1", siret="77567146400110", booking_email="toto1@example.com"
+            offerer = OffererFactory(siren="775671464")
+            venue1 = VenueFactory(
+                managingOfferer=offerer,
+                name="Cinema Allocine 1",
+                siret="77567146400110",
+                bookingEmail="toto1@example.com",
             )
-            venue2 = create_venue(
-                offerer, name="Cinema Allocine 2", siret="98765432345677", booking_email="toto2@example.com"
+            venue2 = VenueFactory(
+                managingOfferer=offerer,
+                name="Cinema Allocine 2",
+                siret="98765432345677",
+                bookingEmail="toto2@example.com",
             )
-            repository.save(venue1, venue2)
 
-            allocine_provider = get_provider_by_local_class("AllocineStocks")
-            allocine_provider.isActive = True
-
-            venue_provider1 = create_allocine_venue_provider(venue1, allocine_provider, internal_id="P12345")
-            venue_provider1.venueIdAtOfferProvider = theater_token1
-            venue_provider_price_rule1 = create_allocine_venue_provider_price_rule(venue_provider1)
-            venue_provider2 = create_allocine_venue_provider(venue2, allocine_provider, internal_id="C12345")
-            venue_provider2.venueIdAtOfferProvider = theater_token2
-            venue_provider_price_rule2 = create_allocine_venue_provider_price_rule(venue_provider2)
-            repository.save(venue_provider1, venue_provider2, venue_provider_price_rule1, venue_provider_price_rule2)
+            venue_provider1 = AllocineVenueProviderFactory(
+                venue=venue1, internalId="P12345", venueIdAtOfferProvider=theater_token1
+            )
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=venue_provider1)
+            venue_provider2 = AllocineVenueProviderFactory(
+                venue=venue2, internalId="C12345", venueIdAtOfferProvider=theater_token2
+            )
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=venue_provider2)
 
             allocine_stocks_provider1 = AllocineStocks(venue_provider1)
             allocine_stocks_provider1.updateObjects()
@@ -1190,16 +1182,15 @@ class UpdateObjectsTest:
                 ),
             ]
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(
-                offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com"
+            venue = VenueFactory(
+                managingOfferer__siren="775671464",
+                name="Cinema Allocine",
+                siret="77567146400110",
+                bookingEmail="toto@example.com",
             )
-            repository.save(venue)
 
-            allocine_provider = activate_provider("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-            venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-            repository.save(allocine_venue_provider, venue_provider_price_rule)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, quantity=None)
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider, price=10)
 
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
             allocine_stocks_provider.updateObjects()
@@ -1288,16 +1279,15 @@ class UpdateObjectsTest:
                 ),
             ]
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(
-                offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com"
+            venue = VenueFactory(
+                managingOfferer__siren="775671464",
+                name="Cinema Allocine",
+                siret="77567146400110",
+                bookingEmail="toto@example.com",
             )
-            repository.save(venue)
 
-            allocine_provider = activate_provider("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-            venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-            repository.save(allocine_venue_provider, venue_provider_price_rule)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
             allocine_stocks_provider.updateObjects()
@@ -1360,14 +1350,10 @@ class UpdateObjectsTest:
                 ),
             ]
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(offerer, name="Cinema Allocine", siret="77567146400110")
-            repository.save(venue)
+            venue = VenueFactory(managingOfferer__siren="775671464", name="Cinema Allocine", siret="77567146400110")
 
-            allocine_provider = activate_provider("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-            venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-            repository.save(allocine_venue_provider, venue_provider_price_rule)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
             allocine_stocks_provider.updateObjects()
@@ -1440,17 +1426,15 @@ class UpdateObjectsTest:
                 ),
             ]
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(
-                offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com"
+            venue = VenueFactory(
+                managingOfferer__siren="775671464",
+                name="Cinema Allocine",
+                siret="77567146400110",
+                bookingEmail="toto@example.com",
             )
-            repository.save(venue)
 
-            allocine_provider = activate_provider("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider, is_duo=True)
-            venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-
-            repository.save(allocine_venue_provider, venue_provider_price_rule)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue)
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
             # When
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
@@ -1487,17 +1471,15 @@ class UpdateObjectsTest:
                 )
             ]
 
-            offerer = create_offerer(siren="775671464")
-            venue = create_venue(
-                offerer, name="Cinema Allocine", siret="77567146400110", booking_email="toto@example.com"
+            venue = VenueFactory(
+                managingOfferer__siren="775671464",
+                name="Cinema Allocine",
+                siret="77567146400110",
+                bookingEmail="toto@example.com",
             )
-            repository.save(venue)
 
-            allocine_provider = activate_provider("AllocineStocks")
-            allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider, quantity=50)
-            venue_provider_price_rule = create_allocine_venue_provider_price_rule(allocine_venue_provider)
-
-            repository.save(allocine_venue_provider, venue_provider_price_rule)
+            allocine_venue_provider = AllocineVenueProviderFactory(venue=venue, quantity=50)
+            AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
 
             # When
             allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
@@ -1516,11 +1498,7 @@ class GetObjectThumbTest:
     def test_should_get_movie_poster_if_poster_url_exist(self, mock_poster_get_allocine, mock_call_allocine_api, app):
         # Given
         mock_poster_get_allocine.return_value = "poster_thumb"
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        repository.save(allocine_venue_provider)
+        allocine_venue_provider = AllocineVenueProviderFactory()
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
         allocine_stocks_provider.movie_information = dict()
@@ -1542,11 +1520,7 @@ class GetObjectThumbTest:
     ):
         # Given
         mock_poster_get_allocine.return_value = "poster_thumb"
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        repository.save(allocine_venue_provider)
+        allocine_venue_provider = AllocineVenueProviderFactory()
 
         allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
         allocine_stocks_provider.movie_information = dict()

--- a/api/tests/local_providers/provider_manager_test.py
+++ b/api/tests/local_providers/provider_manager_test.py
@@ -9,6 +9,7 @@ import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers.factories import APIProviderFactory
 from pcapi.core.offerers.factories import AllocineProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
 from pcapi.core.offerers.factories import VenueProviderFactory
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
@@ -16,11 +17,9 @@ from pcapi.local_providers.provider_manager import do_update
 from pcapi.local_providers.provider_manager import synchronize_data_for_provider
 from pcapi.local_providers.provider_manager import synchronize_venue_provider
 from pcapi.local_providers.provider_manager import synchronize_venue_providers_for_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.generic_creators import create_venue_provider
-from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.repository import repository
 
 from tests.local_providers.provider_test_utils import TestLocalProvider
@@ -158,12 +157,7 @@ class SynchronizeVenueProviderTest:
         self, mock_do_update, mock_get_provider_class, app
     ):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-
-        provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, provider, is_duo=True)
-        repository.save(allocine_venue_provider)
+        allocine_venue_provider = AllocineVenueProviderFactory()
 
         mock_provider_class = MagicMock()
         mock_get_provider_class.return_value = mock_provider_class

--- a/api/tests/models/allocine_venue_provider_price_rule_test.py
+++ b/api/tests/models/allocine_venue_provider_price_rule_test.py
@@ -1,13 +1,9 @@
 import pytest
 
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderPriceRuleFactory
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
-from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.domain.price_rule import PriceRule
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider_price_rule
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.provider_creators import activate_provider
 from pcapi.models import ApiErrors
 from pcapi.repository import repository
 
@@ -16,17 +12,10 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_add_price_rules_to_venue_provider(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=10
+        allocine_venue_provider = AllocineVenueProviderFactory()
+        AllocineVenueProviderPriceRuleFactory(
+            allocineVenueProvider=allocine_venue_provider, priceRule=PriceRule.default, price=10
         )
-
-        # When
-        repository.save(allocine_venue_provider_price_rule)
 
         # Then
         assert len(allocine_venue_provider.priceRules) == 1
@@ -34,18 +23,16 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_raise_error_when_price_is_negative(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_provider.isActive = True
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=-4
-        )
+        allocine_venue_provider = AllocineVenueProviderFactory()
+
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRule()
+        allocine_venue_provider_price_rule.allocineVenueProvider = allocine_venue_provider
+        allocine_venue_provider_price_rule.priceRule = PriceRule.default
+        allocine_venue_provider_price_rule.price = -4
 
         # When
         with pytest.raises(ApiErrors) as error:
-            repository.save(venue_provider_price_rule)
+            repository.save(allocine_venue_provider_price_rule)
 
         # Then
         assert error.value.errors["global"] == ["Vous ne pouvez renseigner un prix négatif"]
@@ -53,21 +40,20 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_raise_error_when_saving_existing_rule_price(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = activate_provider("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=10
+        allocine_venue_provider = AllocineVenueProviderFactory()
+
+        AllocineVenueProviderPriceRuleFactory(
+            allocineVenueProvider=allocine_venue_provider, priceRule=PriceRule.default, price=10
         )
-        repository.save(venue_provider_price_rule)
-        venue_provider_price_rule2 = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=12
-        )
+
+        allocine_venue_provider_price_rule_2 = AllocineVenueProviderPriceRule()
+        allocine_venue_provider_price_rule_2.allocineVenueProvider = allocine_venue_provider
+        allocine_venue_provider_price_rule_2.priceRule = PriceRule.default
+        allocine_venue_provider_price_rule_2.price = 12
 
         # When
         with pytest.raises(ApiErrors) as error:
-            repository.save(venue_provider_price_rule2)
+            repository.save(allocine_venue_provider_price_rule_2)
 
         # Then
         assert error.value.errors["global"] == ["Vous ne pouvez avoir qu''un seul prix par catégorie"]
@@ -75,18 +61,16 @@ class AllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_raise_error_when_saving_wrong_format_price(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = get_provider_by_local_class("AllocineStocks")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        price = "wrong_price_format"
-        venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=price
-        )
+        allocine_venue_provider = AllocineVenueProviderFactory()
+
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRule()
+        allocine_venue_provider_price_rule.allocineVenueProvider = allocine_venue_provider
+        allocine_venue_provider_price_rule.priceRule = PriceRule.default
+        allocine_venue_provider_price_rule.price = "wrong_price_format"
 
         # When
         with pytest.raises(ApiErrors) as error:
-            repository.save(venue_provider_price_rule)
+            repository.save(allocine_venue_provider_price_rule)
 
         # Then
         assert error.value.errors == {"global": ["Le prix doit être un nombre décimal"]}
@@ -96,11 +80,7 @@ class SaveAllocineVenueProviderPriceRuleTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_not_save_new_venue_provider_price_rule(self, app):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = activate_provider("AllocineStocks")
-
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
+        allocine_venue_provider = AllocineVenueProviderFactory()
 
         venue_provider_price_rule = AllocineVenueProviderPriceRule()
         venue_provider_price_rule.allocineVenueProvider = allocine_venue_provider

--- a/api/tests/models/allocine_venue_provider_test.py
+++ b/api/tests/models/allocine_venue_provider_test.py
@@ -1,27 +1,20 @@
 import pytest
 
+from pcapi.core.offerers.factories import AllocineProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import ProviderFactory
+from pcapi.core.offerers.factories import VenueProviderFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import VenueProvider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_provider
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.generic_creators import create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
-from pcapi.repository import repository
 
 
 class AllocineVenueProviderTest:
     @pytest.mark.usefixtures("db_session")
     def test_allocine_venue_provider_should_inherit_from_venue_provider(self, app):
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-
         provider_allocine = activate_provider("AllocineStocks")
-
-        allocine_venue_provider = create_allocine_venue_provider(venue, provider_allocine, is_duo=True)
-
-        repository.save(allocine_venue_provider)
+        AllocineVenueProviderFactory(provider=provider_allocine, isDuo=True)
 
         assert VenueProvider.query.count() == 1
         assert AllocineVenueProvider.query.count() == 1
@@ -32,17 +25,13 @@ class AllocineVenueProviderTest:
 
     @pytest.mark.usefixtures("db_session")
     def test_query_venue_provider_load_allocine_venue_provider_attributes_when_connected_to_allocine(self, app):
-        offerer = create_offerer()
-        venue = create_venue(offerer)
+        venue = VenueFactory()
 
-        provider_allocine = activate_provider("AllocineStocks")
-        provider = create_provider(local_class="TestLocalProvider")
+        provider_allocine = AllocineProviderFactory()
+        provider = ProviderFactory(localClass="TestLocalProvider")
 
-        venue_provider = create_venue_provider(venue, provider)
-
-        allocine_venue_provider = create_allocine_venue_provider(venue, provider_allocine, is_duo=True)
-
-        repository.save(venue_provider, allocine_venue_provider)
+        VenueProviderFactory(venue=venue, provider=provider)
+        AllocineVenueProviderFactory(venue=venue, provider=provider_allocine, isDuo=True)
 
         assert VenueProvider.query.count() == 2
         assert AllocineVenueProvider.query.count() == 1

--- a/api/tests/repository/venue_provider_queries_test.py
+++ b/api/tests/repository/venue_provider_queries_test.py
@@ -1,14 +1,11 @@
 import pytest
 
-from pcapi.core.offerers.factories import APIProviderFactory
+from pcapi.core.offerers.factories import APIProviderFactory, VenueProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offers.factories import VenueFactory, OffererFactory
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import VenueProvider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.model_creators.generic_creators import create_venue_provider
 from pcapi.model_creators.provider_creators import activate_provider
-from pcapi.repository import repository
 from pcapi.repository.venue_provider_queries import get_active_venue_providers_for_specific_provider
 from pcapi.repository.venue_provider_queries import get_venue_provider_by_id
 
@@ -17,14 +14,13 @@ class GetActiveVenueProvidersForSpecificProviderTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_return_all_venue_provider_matching_provider_id(self, app):
         # Given
-        offerer = create_offerer()
-        venue1 = create_venue(offerer, siret="12345678901234")
-        venue2 = create_venue(offerer)
+        offerer = OffererFactory()
+        venue1 = VenueFactory(managingOfferer=offerer, siret="12345678901234")
+        venue2 = VenueFactory(managingOfferer=offerer)
         titelive_provider = APIProviderFactory()
         allocine_provider = activate_provider("AllocineStocks")
-        venue_provider1 = create_venue_provider(venue1, titelive_provider)
-        venue_provider2 = create_venue_provider(venue2, allocine_provider)
-        repository.save(venue_provider1, venue_provider2)
+        venue_provider1 = VenueProviderFactory(venue=venue1, provider=titelive_provider)
+        VenueProviderFactory(venue=venue2, provider=allocine_provider)
 
         # When
         venue_providers = get_active_venue_providers_for_specific_provider(titelive_provider.id)
@@ -35,13 +31,12 @@ class GetActiveVenueProvidersForSpecificProviderTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_return_all_active_venue_providers_matching_provider_id(self, app):
         # Given
-        offerer = create_offerer()
-        venue1 = create_venue(offerer, siret="12345678901234")
-        venue2 = create_venue(offerer)
+        offerer = OffererFactory()
+        venue1 = VenueFactory(managingOfferer=offerer, siret="12345678901234")
+        venue2 = VenueFactory(managingOfferer=offerer)
         titelive_provider = APIProviderFactory()
-        venue_provider1 = create_venue_provider(venue1, titelive_provider)
-        venue_provider2 = create_venue_provider(venue2, titelive_provider, is_active=False)
-        repository.save(venue_provider1, venue_provider2)
+        venue_provider1 = VenueProviderFactory(venue=venue1, provider=titelive_provider)
+        VenueProviderFactory(venue=venue2, provider=titelive_provider, isActive=False)
 
         # When
         venue_providers = get_active_venue_providers_for_specific_provider(titelive_provider.id)
@@ -54,11 +49,8 @@ class GetVenueProviderByIdTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_return_matching_venue_provider(self):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
         titelive_provider = APIProviderFactory()
-        venue_provider = create_venue_provider(venue, titelive_provider)
-        repository.save(venue_provider)
+        venue_provider = VenueProviderFactory(provider=titelive_provider)
 
         # When
         existing_venue_provider = get_venue_provider_by_id(venue_provider.id)
@@ -70,15 +62,11 @@ class GetVenueProviderByIdTest:
     @pytest.mark.usefixtures("db_session")
     def test_should_return_matching_venue_provider_with_allocine_attributes(self):
         # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        titelive_provider = activate_provider("AllocineStocks")
-        venue_provider = create_allocine_venue_provider(venue, titelive_provider)
-        repository.save(venue_provider)
+        allocine_venue_provider = AllocineVenueProviderFactory()
 
         # When
-        existing_venue_provider = get_venue_provider_by_id(venue_provider.id)
+        existing_venue_provider = get_venue_provider_by_id(allocine_venue_provider.id)
 
         # Then
-        assert existing_venue_provider == venue_provider
-        assert isinstance(venue_provider, AllocineVenueProvider)
+        assert existing_venue_provider == allocine_venue_provider
+        assert isinstance(allocine_venue_provider, AllocineVenueProvider)

--- a/api/tests/scripts/venue/modify_allocine_price_rule_for_venue_test.py
+++ b/api/tests/scripts/venue/modify_allocine_price_rule_for_venue_test.py
@@ -2,14 +2,11 @@ from decimal import Decimal
 
 import pytest
 
+from pcapi.core.offerers.factories import AllocineVenueProviderFactory
+from pcapi.core.offerers.factories import AllocineVenueProviderPriceRuleFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.domain.price_rule import PriceRule
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider
-from pcapi.model_creators.generic_creators import create_allocine_venue_provider_price_rule
-from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_provider
-from pcapi.model_creators.generic_creators import create_venue
-from pcapi.repository import repository
 from pcapi.scripts.venue.modify_allocine_price_rule_for_venue import modify_allocine_price_rule_for_venue_by_id
 from pcapi.scripts.venue.modify_allocine_price_rule_for_venue import modify_allocine_price_rule_for_venue_by_siret
 
@@ -20,15 +17,10 @@ class ModifyAllocinePriceRuleForVenueTest:
         # Given
         initial_price = Decimal(7.5)
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = create_provider(local_class="TestLocalProvider")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=initial_price
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRuleFactory(
+            priceRule=PriceRule.default, price=initial_price
         )
-
-        repository.save(allocine_venue_provider_price_rule)
+        venue = allocine_venue_provider_price_rule.allocineVenueProvider.venue
 
         # When
         modify_allocine_price_rule_for_venue_by_id(venue.id, new_price)
@@ -41,15 +33,10 @@ class ModifyAllocinePriceRuleForVenueTest:
         # Given
         initial_price = Decimal(7.5)
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = create_provider(local_class="TestLocalProvider")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-        allocine_venue_provider_price_rule = create_allocine_venue_provider_price_rule(
-            allocine_venue_provider, price_rule=PriceRule.default, price=initial_price
+        allocine_venue_provider_price_rule = AllocineVenueProviderPriceRuleFactory(
+            priceRule=PriceRule.default, price=initial_price
         )
-
-        repository.save(allocine_venue_provider_price_rule)
+        venue = allocine_venue_provider_price_rule.allocineVenueProvider.venue
 
         # When
         modify_allocine_price_rule_for_venue_by_siret(venue.siret, new_price)
@@ -61,10 +48,7 @@ class ModifyAllocinePriceRuleForVenueTest:
     def should_not_update_allocine_price_rule_when_there_is_no_venue_provider_associated_to_the_venue(self, app):
         # Given
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-
-        repository.save(venue)
+        venue = VenueFactory()
 
         # When
         modify_allocine_price_rule_for_venue_by_siret(venue.siret, new_price)
@@ -76,12 +60,8 @@ class ModifyAllocinePriceRuleForVenueTest:
     def should_not_update_allocine_price_rule_when_there_is_no_allocine_price_rule_associated_to_the_venue(self, app):
         # Given
         new_price = Decimal(8)
-        offerer = create_offerer()
-        venue = create_venue(offerer)
-        allocine_provider = create_provider(local_class="TestLocalProvider")
-        allocine_venue_provider = create_allocine_venue_provider(venue, allocine_provider)
-
-        repository.save(allocine_venue_provider)
+        venue = VenueFactory()
+        AllocineVenueProviderFactory(venue=venue)
 
         # When
         modify_allocine_price_rule_for_venue_by_siret(venue.siret, new_price)


### PR DESCRIPTION
Old PR: pass-culture/pass-culture-api#3584

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11243


## But de la pull request
Rendre la colonne `venueIdAtOfferProvider` dans la table `venue_provider` non nullable


##  Informations supplémentaires

- Fix et migrations vers les factories des tests impactés 
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
