### PR TITLE
(PC-11621) scheduled_tasks: Fix job definition for `price_bookings()`

### DIFF
--- a/api/src/pcapi/scheduled_tasks/clock.py
+++ b/api/src/pcapi/scheduled_tasks/clock.py
@@ -243,6 +243,6 @@ def clock() -> None:
 
     scheduler.add_job(pc_recredit_underage_users, "cron", day="*", hour="0")
 
-    scheduler.add_job(price_bookings, "cron", day="*", minute="/10")
+    scheduler.add_job(price_bookings, "cron", day="*", minute="5,15,25,35,45,55")
 
     scheduler.start()


### PR DESCRIPTION
There might be a cleaner way to express "every ten minutes", but I
can't find this information in APScheduler documentation.