### PR TITLE
[PC-11709] [API] add recredit amount to show

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-1e8ffcd7645a (head)
+e2ec54a156f2 (head)

--- a/api/src/pcapi/alembic/versions/20211115T135126_e2ec54a156f2_add_recredit_amount_to_show.py
+++ b/api/src/pcapi/alembic/versions/20211115T135126_e2ec54a156f2_add_recredit_amount_to_show.py
@@ -1,0 +1,19 @@
+"""add-recredit-amount-to-show
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e2ec54a156f2"
+down_revision = "1e8ffcd7645a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("recreditAmountToShow", sa.Numeric(precision=10, scale=2), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "recreditAmountToShow")

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -989,3 +989,8 @@ def update_notification_subscription(
 
     if not subscriptions.marketing_push:
         push_notifications.delete_user_attributes(user.id)
+
+
+def reset_recredit_amount_to_show(user: User) -> None:
+    user.recreditAmountToShow = None
+    repository.save(user)

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -124,30 +124,31 @@ def _get_latest_birthday(birth_date: date) -> date:
 class User(PcObject, Model, NeedsValidationMixin):
     __tablename__ = "user"
 
-    email = sa.Column(sa.String(120), nullable=False, unique=True)
-
+    activity = sa.Column(sa.String(128), nullable=True)
     address = sa.Column(sa.Text, nullable=True)
-
     city = sa.Column(sa.String(100), nullable=True)
-
+    civility = sa.Column(sa.String(20), nullable=True)
     clearTextPassword = None
-
-    culturalSurveyId = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)
-
     culturalSurveyFilledDate = sa.Column(sa.DateTime, nullable=True)
-
+    culturalSurveyId = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)
     dateCreated = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
-
     dateOfBirth = sa.Column(sa.DateTime, nullable=True)
-
     departementCode = sa.Column(sa.String(3), nullable=True)
-
+    email = sa.Column(sa.String(120), nullable=False, unique=True)
+    externalIds = sa.Column(postgresql.json.JSONB, nullable=True, default={}, server_default="{}")
+    extraData = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=True, default={}, server_default="{}")
     firstName = sa.Column(sa.String(128), nullable=True)
-
+    hasCompletedIdCheck = sa.Column(sa.Boolean, nullable=True)
+    hasSeenTutorials = sa.Column(sa.Boolean, nullable=True)
+    hasSeenProTutorials = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     idPieceNumber = sa.Column(sa.String, nullable=True, unique=True)
-
     ineHash = sa.Column(sa.Text, nullable=True, unique=True)
 
+    # FIXME (dbaty, 2020-12-14): once v114 has been deployed, populate
+    # existing rows, remove this field and let the User model
+    # use DeactivableMixin. We'll need to add a migration that adds a
+    # NOT NULL constraint.
+    isActive = sa.Column(sa.Boolean, nullable=True, server_default=expression.true(), default=True)
     isAdmin = sa.Column(
         sa.Boolean,
         sa.CheckConstraint(
@@ -161,247 +162,32 @@ class User(PcObject, Model, NeedsValidationMixin):
         server_default=expression.false(),
         default=False,
     )
-
-    lastName = sa.Column(sa.String(128), nullable=True)
-
+    isBeneficiary = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
+    isEmailValidated = sa.Column(sa.Boolean, nullable=True, server_default=expression.false())
     lastConnectionDate = sa.Column(sa.DateTime, nullable=True)
-
+    lastName = sa.Column(sa.String(128), nullable=True)
     needsToFillCulturalSurvey = sa.Column(sa.Boolean, server_default=expression.true(), default=True)
-
     notificationSubscriptions = sa.Column(
         MutableDict.as_mutable(postgresql.json.JSONB),
         nullable=True,
         default=asdict(NotificationSubscriptions()),
         server_default="""{"marketing_push": true, "marketing_email": true}""",
     )
-
     offerers = orm.relationship("Offerer", secondary="user_offerer")
-
     password = sa.Column(sa.LargeBinary(60), nullable=False)
-
     phoneNumber = sa.Column(sa.String(20), nullable=True)
-
+    phoneValidationStatus = sa.Column(sa.Enum(PhoneValidationStatusType, create_constraint=False), nullable=True)
     postalCode = sa.Column(sa.String(5), nullable=True)
-
     publicName = sa.Column(sa.String(255), nullable=False)
-
     roles = sa.Column(
         MutableList.as_mutable(postgresql.ARRAY(sa.Enum(UserRole, native_enum=False, create_constraint=False))),
         nullable=False,
         server_default="{}",
     )
 
-    civility = sa.Column(sa.String(20), nullable=True)
-
-    activity = sa.Column(sa.String(128), nullable=True)
-
-    hasSeenTutorials = sa.Column(sa.Boolean, nullable=True)
-
-    hasSeenProTutorials = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
-
-    isEmailValidated = sa.Column(sa.Boolean, nullable=True, server_default=expression.false())
-
-    isBeneficiary = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
-
-    phoneValidationStatus = sa.Column(sa.Enum(PhoneValidationStatusType, create_constraint=False), nullable=True)
-
     # FIXME (dbaty, 2020-12-14): once v114 has been deployed, populate
     # existing rows with the empty string and add NOT NULL constraint.
     suspensionReason = sa.Column(sa.Text, nullable=True, default="")
-
-    # FIXME (dbaty, 2020-12-14): once v114 has been deployed, populate
-    # existing rows, remove this field and let the User model
-    # use DeactivableMixin. We'll need to add a migration that adds a
-    # NOT NULL constraint.
-    isActive = sa.Column(sa.Boolean, nullable=True, server_default=expression.true(), default=True)
-
-    hasCompletedIdCheck = sa.Column(sa.Boolean, nullable=True)
-
-    externalIds = sa.Column(postgresql.json.JSONB, nullable=True, default={}, server_default="{}")
-
-    extraData = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=True, default={}, server_default="{}")
-
-    def checkPassword(self, passwordToCheck):
-        return crypto.check_password(passwordToCheck, self.password)
-
-    def get_id(self):
-        return str(self.id)
-
-    def has_access(self, offerer_id: int) -> bool:
-        if self.isAdmin:
-            return True
-        return db.session.query(
-            UserOfferer.query.filter(
-                (UserOfferer.offererId == offerer_id)
-                & (UserOfferer.userId == self.id)
-                & (UserOfferer.validationToken.is_(None))
-            ).exists()
-        ).scalar()
-
-    def is_authenticated(self) -> bool:
-        return True
-
-    def is_active(self) -> bool:
-        return True
-
-    def is_anonymous(self) -> bool:
-        return False
-
-    def is_super_admin(self) -> bool:
-        if settings.IS_PROD:
-            return self.email in settings.SUPER_ADMIN_EMAIL_ADDRESSES
-        return self.isAdmin
-
-    def populate_from_dict(self, data):
-        super().populate_from_dict(data)
-        if data.__contains__("password") and data["password"]:
-            self.setPassword(data["password"])
-
-    def setPassword(self, newpass):
-        self.clearTextPassword = newpass
-        self.password = crypto.hash_password(newpass)
-
-    @property
-    def age(self) -> Optional[int]:
-        return relativedelta(date.today(), self.dateOfBirth.date()).years if self.dateOfBirth is not None else None
-
-    @property
-    def deposit(self) -> Optional[Deposit]:
-        if len(self.deposits) == 0:
-            return None
-        return sorted(self.deposits, key=attrgetter("expirationDate"), reverse=True)[0]
-
-    @property
-    def deposit_activation_date(self) -> Optional[datetime]:
-        return self.deposit.dateCreated if self.deposit else None
-
-    @property
-    def deposit_expiration_date(self) -> Optional[datetime]:
-        return self.deposit.expirationDate if self.deposit else None
-
-    @property
-    def deposit_version(self) -> Optional[int]:
-        return self.deposit.version if self.deposit else None
-
-    @property
-    def deposit_type(self) -> Optional[DepositType]:
-        return self.deposit.type if self.deposit else None
-
-    @property
-    def has_active_deposit(self):
-        return self.deposit.expirationDate > datetime.utcnow() if self.deposit else False
-
-    @property
-    def real_wallet_balance(self):
-        balance = db.session.query(sa.func.get_wallet_balance(self.id, True)).scalar()
-        # Balance can be negative if the user has booked in the past
-        # but their deposit has expired. We don't want to expose a
-        # negative number.
-        return max(0, balance)
-
-    @property
-    def wallet_balance(self):
-        balance = db.session.query(sa.func.get_wallet_balance(self.id, False)).scalar()
-        return max(0, balance)
-
-    @property
-    def wallet_is_activated(self):
-        return len(self.deposits) > 0
-
-    @property
-    def hasPhysicalVenues(self):
-        for offerer in self.offerers:
-            if any(not venue.isVirtual for venue in offerer.managedVenues):
-                return True
-
-        return False
-
-    @property
-    def needsToSeeTutorials(self):
-        return self.is_beneficiary and not self.hasSeenTutorials
-
-    @property
-    def is_eligible(self) -> bool:
-        return self.eligibility is not None
-
-    @property
-    def eligibility(self) -> Optional[EligibilityType]:
-        # To avoid import loops
-        from pcapi.domain.beneficiary_pre_subscription.validator import _is_postal_code_eligible
-
-        if not _is_postal_code_eligible(self.departementCode):
-            return None
-
-        if self.age == constants.ELIGIBILITY_AGE_18:
-            return EligibilityType.AGE18
-
-        if self.age in constants.ELIGIBILITY_UNDERAGE_RANGE and FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active():
-            return EligibilityType.UNDERAGE
-
-        return None
-
-    @property
-    def allowed_eligibility_check_methods(self) -> Optional[list[EligibilityCheckMethods]]:
-        eligibility = self.eligibility
-        if eligibility is None:
-            return None
-
-        if eligibility == EligibilityType.AGE18:
-            return [EligibilityCheckMethods.JOUVE]
-
-        if eligibility == EligibilityType.UNDERAGE:
-            underage_elibility_check_methods = []
-            if FeatureToggle.ENABLE_EDUCONNECT_AUTHENTICATION.is_active():
-                underage_elibility_check_methods.append(EligibilityCheckMethods.EDUCONNECT)
-            if FeatureToggle.ALLOW_IDCHECK_UNDERAGE_REGISTRATION.is_active():
-                underage_elibility_check_methods.append(EligibilityCheckMethods.JOUVE)
-            return underage_elibility_check_methods
-
-        return None
-
-    @property
-    def eligibility_start_datetime(self) -> Optional[datetime]:
-        if not self.dateOfBirth:
-            return None
-
-        if FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active():
-            return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(
-                years=constants.ELIGIBILITY_UNDERAGE_RANGE[0]
-            )
-        return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(years=constants.ELIGIBILITY_AGE_18)
-
-    @property
-    def eligibility_end_datetime(self) -> Optional[datetime]:
-        if not self.dateOfBirth:
-            return None
-
-        if FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active() and self.age < constants.ELIGIBILITY_AGE_18:
-            return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(
-                years=constants.ELIGIBILITY_UNDERAGE_RANGE[-1] + 1
-            )
-        return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(years=constants.ELIGIBILITY_AGE_18 + 1)
-
-    @property
-    def latest_birthday(self) -> date:
-        return _get_latest_birthday(self.dateOfBirth.date())
-
-    @hybrid_property
-    def is_phone_validated(self):
-        return self.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
-
-    @is_phone_validated.expression
-    def is_phone_validated(cls):  # pylint: disable=no-self-argument
-        return cls.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
-
-    @hybrid_property
-    def is_beneficiary(self):
-        return self.has_beneficiary_role or self.has_underage_beneficiary_role
-
-    @is_beneficiary.expression
-    def is_beneficiary(cls):  # pylint: disable=no-self-argument
-        return expression.or_(
-            cls.roles.contains([UserRole.BENEFICIARY]), cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
-        )
 
     def _add_role(self, role: UserRole) -> None:
         if self.roles is None:
@@ -429,13 +215,56 @@ class User(PcObject, Model, NeedsValidationMixin):
             raise InvalidUserRoleException("User can't have both ADMIN and BENEFICIARY role")
         self._add_role(UserRole.BENEFICIARY)
 
+    def add_pro_role(self) -> None:
+        self._add_role(UserRole.PRO)
+
     def add_underage_beneficiary_role(self) -> None:
         if self.isAdmin:
             raise InvalidUserRoleException("User can't have both ADMIN and BENEFICIARY role")
         self._add_role(UserRole.UNDERAGE_BENEFICIARY)
 
-    def add_pro_role(self) -> None:
-        self._add_role(UserRole.PRO)
+    def checkPassword(self, passwordToCheck):
+        return crypto.check_password(passwordToCheck, self.password)
+
+    def get_id(self):
+        return str(self.id)
+
+    def get_notification_subscriptions(self) -> NotificationSubscriptions:
+        return NotificationSubscriptions(**self.notificationSubscriptions or {})
+
+    def has_access(self, offerer_id: int) -> bool:
+        if self.isAdmin:
+            return True
+        return db.session.query(
+            UserOfferer.query.filter(
+                (UserOfferer.offererId == offerer_id)
+                & (UserOfferer.userId == self.id)
+                & (UserOfferer.validationToken.is_(None))
+            ).exists()
+        ).scalar()
+
+    def has_enabled_push_notifications(self) -> bool:
+        subscriptions = self.get_notification_subscriptions()
+        return subscriptions.marketing_push
+
+    def is_authenticated(self) -> bool:
+        return True
+
+    def is_active(self) -> bool:
+        return True
+
+    def is_anonymous(self) -> bool:
+        return False
+
+    def is_super_admin(self) -> bool:
+        if settings.IS_PROD:
+            return self.email in settings.SUPER_ADMIN_EMAIL_ADDRESSES
+        return self.isAdmin
+
+    def populate_from_dict(self, data):
+        super().populate_from_dict(data)
+        if data.__contains__("password") and data["password"]:
+            self.setPassword(data["password"])
 
     def remove_admin_role(self) -> None:
         self.isAdmin = False
@@ -449,6 +278,152 @@ class User(PcObject, Model, NeedsValidationMixin):
     def remove_pro_role(self) -> None:
         if self.has_pro_role:  # pylint: disable=using-constant-test
             self.roles.remove(UserRole.PRO)
+
+    def setPassword(self, newpass):
+        self.clearTextPassword = newpass
+        self.password = crypto.hash_password(newpass)
+
+    @property
+    def age(self) -> Optional[int]:
+        return relativedelta(date.today(), self.dateOfBirth.date()).years if self.dateOfBirth is not None else None
+
+    @property
+    def allowed_eligibility_check_methods(self) -> Optional[list[EligibilityCheckMethods]]:
+        eligibility = self.eligibility
+        if eligibility is None:
+            return None
+
+        if eligibility == EligibilityType.AGE18:
+            return [EligibilityCheckMethods.JOUVE]
+
+        if eligibility == EligibilityType.UNDERAGE:
+            underage_elibility_check_methods = []
+            if FeatureToggle.ENABLE_EDUCONNECT_AUTHENTICATION.is_active():
+                underage_elibility_check_methods.append(EligibilityCheckMethods.EDUCONNECT)
+            if FeatureToggle.ALLOW_IDCHECK_UNDERAGE_REGISTRATION.is_active():
+                underage_elibility_check_methods.append(EligibilityCheckMethods.JOUVE)
+            return underage_elibility_check_methods
+
+        return None
+
+    @property
+    def deposit(self) -> Optional[Deposit]:
+        if len(self.deposits) == 0:
+            return None
+        return sorted(self.deposits, key=attrgetter("expirationDate"), reverse=True)[0]
+
+    @property
+    def deposit_activation_date(self) -> Optional[datetime]:
+        return self.deposit.dateCreated if self.deposit else None
+
+    @property
+    def deposit_expiration_date(self) -> Optional[datetime]:
+        return self.deposit.expirationDate if self.deposit else None
+
+    @property
+    def deposit_type(self) -> Optional[DepositType]:
+        return self.deposit.type if self.deposit else None
+
+    @property
+    def deposit_version(self) -> Optional[int]:
+        return self.deposit.version if self.deposit else None
+
+    @property
+    def eligibility(self) -> Optional[EligibilityType]:
+        # To avoid import loops
+        from pcapi.domain.beneficiary_pre_subscription.validator import _is_postal_code_eligible
+
+        if not _is_postal_code_eligible(self.departementCode):
+            return None
+
+        if self.age == constants.ELIGIBILITY_AGE_18:
+            return EligibilityType.AGE18
+
+        if self.age in constants.ELIGIBILITY_UNDERAGE_RANGE and FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active():
+            return EligibilityType.UNDERAGE
+
+        return None
+
+    @property
+    def eligibility_end_datetime(self) -> Optional[datetime]:
+        if not self.dateOfBirth:
+            return None
+
+        if FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active() and self.age < constants.ELIGIBILITY_AGE_18:
+            return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(
+                years=constants.ELIGIBILITY_UNDERAGE_RANGE[-1] + 1
+            )
+        return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(years=constants.ELIGIBILITY_AGE_18 + 1)
+
+    @property
+    def eligibility_start_datetime(self) -> Optional[datetime]:
+        if not self.dateOfBirth:
+            return None
+
+        if FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL.is_active():
+            return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(
+                years=constants.ELIGIBILITY_UNDERAGE_RANGE[0]
+            )
+        return datetime.combine(self.dateOfBirth, time(0, 0)) + relativedelta(years=constants.ELIGIBILITY_AGE_18)
+
+    @property
+    def has_active_deposit(self):
+        return self.deposit.expirationDate > datetime.utcnow() if self.deposit else False
+
+    @property
+    def hasPhysicalVenues(self):
+        for offerer in self.offerers:
+            if any(not venue.isVirtual for venue in offerer.managedVenues):
+                return True
+
+        return False
+
+    @property
+    def is_eligible(self) -> bool:
+        return self.eligibility is not None
+
+    @property
+    def latest_birthday(self) -> date:
+        return _get_latest_birthday(self.dateOfBirth.date())
+
+    @property
+    def needsToSeeTutorials(self):
+        return self.is_beneficiary and not self.hasSeenTutorials
+
+    @property
+    def real_wallet_balance(self):
+        balance = db.session.query(sa.func.get_wallet_balance(self.id, True)).scalar()
+        # Balance can be negative if the user has booked in the past
+        # but their deposit has expired. We don't want to expose a
+        # negative number.
+        return max(0, balance)
+
+    @property
+    def wallet_balance(self):
+        balance = db.session.query(sa.func.get_wallet_balance(self.id, False)).scalar()
+        return max(0, balance)
+
+    @property
+    def wallet_is_activated(self):
+        return len(self.deposits) > 0
+
+    @hybrid_property
+    def is_beneficiary(self):
+        return self.has_beneficiary_role or self.has_underage_beneficiary_role
+
+    @is_beneficiary.expression
+    def is_beneficiary(cls):  # pylint: disable=no-self-argument
+        return expression.or_(
+            cls.roles.contains([UserRole.BENEFICIARY]), cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
+        )
+
+    @hybrid_property
+    def is_phone_validated(self):
+        return self.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
+
+    @is_phone_validated.expression
+    def is_phone_validated(cls):  # pylint: disable=no-self-argument
+        return cls.phoneValidationStatus == PhoneValidationStatusType.VALIDATED
 
     @hybrid_property
     def has_admin_role(self) -> bool:
@@ -467,12 +442,12 @@ class User(PcObject, Model, NeedsValidationMixin):
         return cls.roles.contains([UserRole.BENEFICIARY])
 
     @hybrid_property
-    def has_underage_beneficiary_role(self) -> bool:
-        return UserRole.UNDERAGE_BENEFICIARY in self.roles if self.roles else False
+    def has_jouve_role(self) -> bool:
+        return UserRole.JOUVE in self.roles if self.roles else False
 
-    @has_underage_beneficiary_role.expression
-    def has_underage_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
-        return cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
+    @has_jouve_role.expression
+    def has_jouve_role(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.roles.contains([UserRole.JOUVE])
 
     @hybrid_property
     def has_pro_role(self) -> bool:
@@ -483,19 +458,12 @@ class User(PcObject, Model, NeedsValidationMixin):
         return cls.roles.contains([UserRole.PRO])
 
     @hybrid_property
-    def has_jouve_role(self) -> bool:
-        return UserRole.JOUVE in self.roles if self.roles else False
+    def has_underage_beneficiary_role(self) -> bool:
+        return UserRole.UNDERAGE_BENEFICIARY in self.roles if self.roles else False
 
-    @has_jouve_role.expression
-    def has_jouve_role(cls) -> bool:  # pylint: disable=no-self-argument
-        return cls.roles.contains([UserRole.JOUVE])
-
-    def get_notification_subscriptions(self) -> NotificationSubscriptions:
-        return NotificationSubscriptions(**self.notificationSubscriptions or {})
-
-    def has_enabled_push_notifications(self) -> bool:
-        subscriptions = self.get_notification_subscriptions()
-        return subscriptions.marketing_push
+    @has_underage_beneficiary_role.expression
+    def has_underage_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
 
 
 class ExpenseDomain(enum.Enum):

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -179,6 +179,7 @@ class User(PcObject, Model, NeedsValidationMixin):
     phoneValidationStatus = sa.Column(sa.Enum(PhoneValidationStatusType, create_constraint=False), nullable=True)
     postalCode = sa.Column(sa.String(5), nullable=True)
     publicName = sa.Column(sa.String(255), nullable=False)
+    recreditAmountToShow = sa.Column(sa.Numeric(10, 2), nullable=True)
     roles = sa.Column(
         MutableList.as_mutable(postgresql.ARRAY(sa.Enum(UserRole, native_enum=False, create_constraint=False))),
         nullable=False,

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -55,6 +55,18 @@ def update_user_profile(user: User, body: serializers.UserProfileUpdateRequest) 
     return serializers.UserProfileResponse.from_orm(user)
 
 
+@blueprint.native_v1.route("/reset_recredit_amount_to_show", methods=["POST"])
+@spectree_serialize(
+    on_success_status=200,
+    api=blueprint.api,
+)  # type: ignore
+@authenticated_user_required
+def reset_recredit_amount_to_show(user: User) -> None:
+    api.reset_recredit_amount_to_show(user)
+
+    return serializers.UserProfileResponse.from_orm(user)
+
+
 @blueprint.native_v1.route("/beneficiary_information", methods=["PATCH"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_user_required

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -186,10 +186,13 @@ class UserProfileResponse(BaseModel):
     next_beneficiary_validation_step: Optional[BeneficiaryValidationStep]
     phoneNumber: Optional[str]
     publicName: Optional[str] = Field(None, alias="pseudo")
+    recreditAmountToShow: Optional[int]
     roles: list[UserRole]
     show_eligible_card: bool
     subscriptions: NotificationSubscriptions  # if we send user.notification_subscriptions, pydantic will take the column and not the property
     subscriptionMessage: Optional[SubscriptionMessage]
+
+    _convert_recredit_amount_to_show = validator("recreditAmountToShow", pre=True, allow_reuse=True)(convert_to_cent)
 
     class Config:
         orm_mode = True

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -166,30 +166,30 @@ class SubscriptionMessage(BaseModel):
 
 
 class UserProfileResponse(BaseModel):
-    id: int
+    allowed_eligibility_check_methods: Optional[list[EligibilityCheckMethods]]
     booked_offers: dict[str, int]
-    domains_credit: Optional[DomainsCredit]
     dateOfBirth: Optional[datetime.date]
     deposit_expiration_date: Optional[datetime.datetime]
-    deposit_version: Optional[int]
     deposit_type: Optional[DepositType]
+    deposit_version: Optional[int]
+    domains_credit: Optional[DomainsCredit]
     eligibility: Optional[EligibilityType]
     eligibility_end_datetime: Optional[datetime.datetime]
     eligibility_start_datetime: Optional[datetime.datetime]
     email: str
     firstName: Optional[str]
     hasCompletedIdCheck: Optional[bool]
-    lastName: Optional[str]
-    next_beneficiary_validation_step: Optional[BeneficiaryValidationStep]
-    subscriptions: NotificationSubscriptions  # if we send user.notification_subscriptions, pydantic will take the column and not the property
-    subscriptionMessage: Optional[SubscriptionMessage]
+    id: int
     isBeneficiary: bool
-    roles: list[UserRole]
+    lastName: Optional[str]
+    needsToFillCulturalSurvey: bool
+    next_beneficiary_validation_step: Optional[BeneficiaryValidationStep]
     phoneNumber: Optional[str]
     publicName: Optional[str] = Field(None, alias="pseudo")
-    needsToFillCulturalSurvey: bool
+    roles: list[UserRole]
     show_eligible_card: bool
-    allowed_eligibility_check_methods: Optional[list[EligibilityCheckMethods]]
+    subscriptions: NotificationSubscriptions  # if we send user.notification_subscriptions, pydantic will take the column and not the property
+    subscriptionMessage: Optional[SubscriptionMessage]
 
     class Config:
         orm_mode = True

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -596,6 +596,18 @@ class UserProfileUpdateTest:
             "url": f"https://api.example.com/1.0/fake_android_api_key/data/users/{user.id}",
         }
 
+    def test_update_user_profile_reset_recredit_amount_to_show(self, app):
+        user = users_factories.UnderageBeneficiaryFactory(email=self.identifier, recreditAmountToShow=30)
+
+        access_token = create_access_token(identity=self.identifier)
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
+
+        response = test_client.post("/native/v1/reset_recredit_amount_to_show")
+
+        assert response.status_code == 200
+        assert user.recreditAmountToShow is None
+
 
 class CulturalSurveyTest:
     identifier = "email@example.com"

--- a/api/tests/scripts/payment/user_recredit_test.py
+++ b/api/tests/scripts/payment/user_recredit_test.py
@@ -128,6 +128,14 @@ class UserRecreditTest:
         assert user_17_already_recredited.deposit.amount == 30
         assert user_17_already_recredited_twice.deposit.amount == 30
 
+        assert user_15.recreditAmountToShow is None
+        assert user_16_not_recredited.recreditAmountToShow is None
+        assert user_16_already_recredited.recreditAmountToShow is None
+        assert user_17_not_recredited.recreditAmountToShow is None
+        assert user_17_only_recredited_at_16.recreditAmountToShow is None
+        assert user_17_already_recredited.recreditAmountToShow is None
+        assert user_17_already_recredited_twice.recreditAmountToShow is None
+
         with freeze_time("2020, 5, 2"):
             recredit_underage_users()
 
@@ -149,6 +157,14 @@ class UserRecreditTest:
         assert user_17_already_recredited.deposit.amount == 30
         assert user_17_already_recredited_twice.deposit.amount == 30
 
+        assert user_15.recreditAmountToShow is None
+        assert user_16_not_recredited.recreditAmountToShow == 30
+        assert user_16_already_recredited.recreditAmountToShow is None
+        assert user_17_not_recredited.recreditAmountToShow == 30
+        assert user_17_only_recredited_at_16.recreditAmountToShow == 30
+        assert user_17_already_recredited.recreditAmountToShow is None
+        assert user_17_already_recredited_twice.recreditAmountToShow is None
+
     def test_recredit_around_the_year(self):
         with freeze_time("2015-05-01"):
             user_activated_at_15 = user_factories.UnderageBeneficiaryFactory(subscription_age=15)
@@ -158,6 +174,9 @@ class UserRecreditTest:
         assert user_activated_at_15.deposit.amount == 20
         assert user_activated_at_16.deposit.amount == 30
         assert user_activated_at_17.deposit.amount == 30
+        assert user_activated_at_15.recreditAmountToShow is None
+        assert user_activated_at_16.recreditAmountToShow is None
+        assert user_activated_at_17.recreditAmountToShow is None
 
         # recredit the following year
         with freeze_time("2016-05-01"):
@@ -166,6 +185,9 @@ class UserRecreditTest:
         assert user_activated_at_15.deposit.amount == 50
         assert user_activated_at_16.deposit.amount == 60
         assert user_activated_at_17.deposit.amount == 30
+        assert user_activated_at_15.recreditAmountToShow == 30
+        assert user_activated_at_16.recreditAmountToShow == 30
+        assert user_activated_at_17.recreditAmountToShow is None
 
         # recrediting the day after does not affect the amount
         with freeze_time("2016-05-02"):
@@ -174,6 +196,9 @@ class UserRecreditTest:
         assert user_activated_at_15.deposit.amount == 50
         assert user_activated_at_16.deposit.amount == 60
         assert user_activated_at_17.deposit.amount == 30
+        assert user_activated_at_15.recreditAmountToShow == 30
+        assert user_activated_at_16.recreditAmountToShow == 30
+        assert user_activated_at_17.recreditAmountToShow is None
 
         # recredit the following year
         with freeze_time("2017-05-01"):
@@ -182,3 +207,6 @@ class UserRecreditTest:
         assert user_activated_at_15.deposit.amount == 80
         assert user_activated_at_16.deposit.amount == 60
         assert user_activated_at_17.deposit.amount == 30
+        assert user_activated_at_15.recreditAmountToShow == 30
+        assert user_activated_at_16.recreditAmountToShow == 30  # Was not reset
+        assert user_activated_at_17.recreditAmountToShow is None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11709


## But de la pull request

Remonter au front un point de donnée contenant le montant recrédité à un utilisateur lors de son passage de 15 à 16 ans, où 16 à 17 ans

##  Implémentation

- nouvelle colonne 
- update de la valeur au recredit
- route pour reset la valeur
​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
