### PR TITLE
(PC-11782) Add feature flag for Ubble, disabled by default

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -78,6 +78,7 @@ class FeatureToggle(enum.Enum):
     ENABLE_INE_WHITELIST_FILTER = "Active le filtre sur les INE whitelistés"
     ALLOW_EMPTY_USER_PROFILING = "Autorise les inscriptions de bénéficiaires sans profile Threat Metrix"
     PRICE_BOOKINGS = "Active la valorisation des réservations"
+    ENABLE_UBBLE = "Active la vérification d'identité par Ubble"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -130,6 +131,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION,
     FeatureToggle.ALLOW_EMPTY_USER_PROFILING,
     FeatureToggle.PRICE_BOOKINGS,
+    FeatureToggle.ENABLE_UBBLE,
 )
 
 if not settings.IS_DEV:

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -35,6 +35,7 @@ def get_settings() -> serializers.SettingsResponse:
         FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
         FeatureToggle.WEBAPP_V2_ENABLED,
         FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL,
+        FeatureToggle.ENABLE_UBBLE,
     )
 
     return serializers.SettingsResponse(
@@ -55,4 +56,5 @@ def get_settings() -> serializers.SettingsResponse:
         is_webapp_v2_enabled=features[FeatureToggle.WEBAPP_V2_ENABLED],
         enable_native_eac_individual=features[FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL],
         account_creation_minimum_age=constants.ACCOUNT_CREATION_MINIMUM_AGE,
+        enable_ubble=features[FeatureToggle.ENABLE_UBBLE],
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11782


## But de la pull request

Conditionner l'utilisation de la vérification de l'identité de l'utilisateur via Ubble dans l'ensemble du produit : Aussi bien côté back / api que côté Front / app.

##  Implémentation

Ajout du feature toggle ENABLE_UBBLE
​
##  Informations supplémentaires

Vérifications de la présence du nouveau Feature Flag, à True et à False :
- dans le backoffice : http://localhost:5000/pc/back-office/feature/ => OK
- dans l'appel d'API réalisé par la webapp : http://localhost:5000/features => OK
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
