### PR TITLE
[API][PC-11612] Notify adage of prebooking

### DIFF
--- a/api/.env.development
+++ b/api/.env.development
@@ -1,3 +1,4 @@
+ADAGE_BACKEND=pcapi.core.educational.adage_backends.logger.AdageLoggerNotifier
 ADMINISTRATION_EMAIL_ADDRESS=administration@example.com
 ALGOLIA_CRON_INDEXING_OFFERS_BY_OFFER_FREQUENCY=*
 ALGOLIA_CRON_INDEXING_OFFERS_BY_VENUE_FREQUENCY=*

--- a/api/.env.testauto
+++ b/api/.env.testauto
@@ -22,3 +22,4 @@ SUPPORT_EMAIL_ADDRESS=support@example.com
 WALLET_BALANCES_RECIPIENTS=accounting@example.com
 WEBAPP_URL=https://webapp.example.com
 WEBAPP_V2_URL=https://webapp-v2.example.com
+ADAGE_BACKEND=pcapi.core.educational.adage_backends.testing.AdageSpyNotifier

--- a/api/src/pcapi/connectors/api_adage.py
+++ b/api/src/pcapi/connectors/api_adage.py
@@ -8,7 +8,7 @@ class AdageException(Exception):
         self.message = message
         self.status_code = status_code
         self.response_text = response_text
-        super().__init__()
+        super().__init__(message)
 
 
 class InstitutionalProjectRedactorNotFoundException(Exception):

--- a/api/src/pcapi/core/educational/adage_backends/__init__.py
+++ b/api/src/pcapi/core/educational/adage_backends/__init__.py
@@ -1,0 +1,10 @@
+from pcapi import settings
+from pcapi.core.educational.models import AdageApiResult
+from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
+from pcapi.utils.module_loading import import_string
+
+
+def notify_prebooking(data: EducationalBookingResponse) -> AdageApiResult:
+    backend = import_string(settings.ADAGE_BACKEND)
+    result = backend().notify_prebooking(data=data)
+    return result

--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -1,0 +1,30 @@
+import requests
+
+from pcapi import settings
+from pcapi.connectors.api_adage import AdageException
+from pcapi.core.educational.adage_backends.base import AdageNotifier
+from pcapi.core.educational.models import AdageApiResult
+from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
+
+
+class AdageHttpNotifier(AdageNotifier):
+    def __init__(self):
+        self.api_key = settings.ADAGE_API_KEY
+        self.header_key = "X-omogen-api-key"
+        super().__init__()
+
+    def notify_prebooking(self, data: EducationalBookingResponse) -> AdageApiResult:
+        api_response = requests.post(
+            self.url,
+            headers={
+                self.header_key: self.api_key,
+            },
+            json=data.json(),
+        )
+
+        if api_response.status_code != 201:
+            raise AdageException(
+                "Error posting new prebooking to Adage API.", api_response.status_code, api_response.text
+            )
+
+        return AdageApiResult(sent_data=data, response=dict(api_response.json()), success=True)

--- a/api/src/pcapi/core/educational/adage_backends/base.py
+++ b/api/src/pcapi/core/educational/adage_backends/base.py
@@ -1,0 +1,12 @@
+from pcapi import settings
+from pcapi.core.educational.models import AdageApiResult
+from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
+
+
+class AdageNotifier:
+    def __init__(self):
+        self.base_url = settings.ADAGE_API_URL
+        self.url = f"{self.base_url}/v1/prereservation"
+
+    def notify_prebooking(self, data: EducationalBookingResponse) -> AdageApiResult:
+        raise NotImplementedError()

--- a/api/src/pcapi/core/educational/adage_backends/logger.py
+++ b/api/src/pcapi/core/educational/adage_backends/logger.py
@@ -1,0 +1,14 @@
+import logging
+
+from pcapi.core.educational.adage_backends.base import AdageNotifier
+from pcapi.core.educational.models import AdageApiResult
+from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+class AdageLoggerNotifier(AdageNotifier):
+    def notify_prebooking(self, data: EducationalBookingResponse) -> AdageApiResult:
+        logger.info("Adage has been notified at %s, with payload: %s", self.url, data)
+        return AdageApiResult(sent_data=data, response={"status_code": 201}, success=True)

--- a/api/src/pcapi/core/educational/adage_backends/testing.py
+++ b/api/src/pcapi/core/educational/adage_backends/testing.py
@@ -1,0 +1,11 @@
+from pcapi.core.educational.adage_backends.base import AdageNotifier
+from pcapi.core.educational.models import AdageApiResult
+from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
+
+from .. import testing
+
+
+class AdageSpyNotifier(AdageNotifier):
+    def notify_prebooking(self, data: EducationalBookingResponse) -> AdageApiResult:
+        testing.adage_requests.append({"url": self.url, "sent_data": data})
+        return AdageApiResult(sent_data=data, response={"status_code": 201}, success=True)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1,3 +1,4 @@
+import dataclasses
 from datetime import datetime
 from decimal import Decimal
 import enum
@@ -174,3 +175,10 @@ class EducationalBooking(PcObject, Model):
             raise exceptions.EducationalBookingAlreadyCancelled()
 
         self.status = EducationalBookingStatus.REFUSED
+
+
+@dataclasses.dataclass
+class AdageApiResult:
+    sent_data: dict
+    response: dict
+    success: bool

--- a/api/src/pcapi/core/educational/testing.py
+++ b/api/src/pcapi/core/educational/testing.py
@@ -1,0 +1,6 @@
+adage_requests = []
+
+
+def reset_requests():
+    global adage_requests  # pylint: disable=global-statement
+    adage_requests = []

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -338,6 +338,7 @@ ADAGE_API_KEY = os.environ.get("ADAGE_API_KEY", None)
 ADAGE_API_URL = os.environ.get("ADAGE_API_URL", None)
 EAC_API_KEY = os.environ.get("EAC_API_KEY", None)
 JWT_ADAGE_PUBLIC_KEY_FILENAME = os.environ.get("JWT_ADAGE_PUBLIC_KEY_FILENAME", "public_key.production")
+ADAGE_BACKEND = os.environ.get("ADAGE_BACKEND", "pcapi.core.educational.adage_backends.adage.AdageHttpNotifier")
 
 # NOTION
 NOTION_TOKEN = os.environ.get("NOTION_TOKEN", "")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -19,6 +19,7 @@ from requests.auth import _basic_auth_str
 # `isort: skip_file` above once fixed.
 import pcapi.models
 from pcapi import settings
+import pcapi.core.educational.testing as adage_api_testing
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.object_storage.testing as object_storage_testing
 import pcapi.core.search.testing as search_testing
@@ -85,6 +86,7 @@ def clear_outboxes():
         search_testing.reset_search_store()
         sms_notifications_testing.reset_requests()
         users_testing.reset_sendinblue_requests()
+        adage_api_testing.reset_requests()
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/connectors/api_adage_test.py
+++ b/api/tests/connectors/api_adage_test.py
@@ -5,7 +5,10 @@ from pcapi.connectors.api_adage import AdageException
 from pcapi.connectors.api_adage import InstitutionalProjectRedactorNotFoundException
 from pcapi.connectors.api_adage import get_institutional_project_redactor_by_email
 from pcapi.connectors.serialization.api_adage_serializers import InstitutionalProjectRedactorResponse
+from pcapi.core.bookings import factories as booking_factories
+import pcapi.core.educational.adage_backends as adage_notifier
 from pcapi.core.testing import override_settings
+from pcapi.routes.adage.v1.serialization.prebooking import serialize_educational_booking
 
 
 class GetInstitutionalProjectRedactorByEmailTest:
@@ -91,3 +94,54 @@ class GetInstitutionalProjectRedactorByEmailTest:
 
         # Then
         assert str(exception.value) == "Requested email is not a known Project Redactor for Adage"
+
+
+@pytest.mark.usefixtures("db_session")
+class AdageHttpNotiferTest:
+    @override_settings(ADAGE_API_URL="https://adage-api-url")
+    @override_settings(ADAGE_API_KEY="adage-api-key")
+    @override_settings(ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpNotifier")
+    def test_should_raise_AdageException_when_api_response_status_not_201(self):
+        # Given
+        booking = booking_factories.EducationalBookingFactory()
+
+        # When
+        with pytest.raises(AdageException) as exception:
+            with requests_mock.Mocker() as request_mock:
+                request_mock.post(
+                    "https://adage-api-url/v1/prereservation",
+                    request_headers={
+                        "X-omogen-api-key": "adage-api-key",
+                    },
+                    status_code=406,
+                )
+                adage_notifier.notify_prebooking(data=serialize_educational_booking(booking.educationalBooking))
+
+        # Then
+        assert str(exception.value) == "Error posting new prebooking to Adage API."
+
+    @override_settings(ADAGE_API_URL="https://adage-api-url")
+    @override_settings(ADAGE_API_KEY="adage-api-key")
+    @override_settings(ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpNotifier")
+    def test_should_not_raise_exception_when_api_response_status_201(self):
+        # Given
+        booking = booking_factories.EducationalBookingFactory()
+        expected_response = {"description": "created", "status_code": 201}
+
+        # When
+        with requests_mock.Mocker() as request_mock:
+            request_mock.post(
+                "https://adage-api-url/v1/prereservation",
+                request_headers={
+                    "X-omogen-api-key": "adage-api-key",
+                },
+                json=expected_response,
+                status_code=201,
+            )
+            adage_api_result = adage_notifier.notify_prebooking(
+                data=serialize_educational_booking(booking.educationalBooking)
+            )
+
+        # Then
+        assert adage_api_result.success
+        assert adage_api_result.response == expected_response


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11612


## But de la pull request

Notifier adage qu'un nouvelle préreservation a eu lieu pour une offre eac collective

##  Implémentation

- Dans la méthode `book_educational_offer`, ajouter la notification à adage après la sauvegarde du `prebooking`
- Creation de différents `adage_backends` en fonction des environnements:
     - Un AdageHttpNotifier pour testing / staging / prod
     - Un logger pour l'environnement de dev
     - Un AdageSpyNotifier pour les tests "métier"
​
##  Informations supplémentaires

Les tests spécifiques au `AdageHttpNotifier` sont dans le fichier `tests/connectors/api_adage_test.py`
Un test cas passant avec le Spy a été réalisé dans `core/educational/test_api.py`
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
