### PR TITLE
(PC-11548) : modifiy sandbox : add UsedIndividualBookings along with EducationalBookings to make it easier for PO to test the feature in testing

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
@@ -2,9 +2,11 @@ import datetime
 
 from pcapi.core.bookings.factories import EducationalBookingFactory
 from pcapi.core.bookings.factories import UsedEducationalBookingFactory
+from pcapi.core.bookings.factories import UsedIndividualBookingFactory
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.offers.factories import EducationalEventStockFactory
+from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import MediationFactory
 from pcapi.core.offers.factories import UserOffererFactory
 from pcapi.core.offers.factories import VenueFactory
@@ -168,6 +170,19 @@ def create_industrial_educational_bookings() -> None:
                 stock=EducationalEventStockFactory(
                     quantity=100,
                     price=1200,
+                    beginningDatetime=now - datetime.timedelta(days=10),
+                    bookingLimitDatetime=now - datetime.timedelta(days=10),
+                    offer__venue=venue_reimbursements,
+                ),
+            )
+
+            # Here are individual booking data to make it easier for PO to review the correct generation of the csv listing payments
+            # FIXME (gvanneste, 2021-11-16) : delete the factory below when user stories has been reviewed by PO on testing
+            UsedIndividualBookingFactory(
+                cancellation_limit_date=now - datetime.timedelta(days=15),
+                dateUsed=now - datetime.timedelta(6),
+                status=BookingStatus.USED,
+                stock=EventStockFactory(
                     beginningDatetime=now - datetime.timedelta(days=10),
                     bookingLimitDatetime=now - datetime.timedelta(days=10),
                     offer__venue=venue_reimbursements,


### PR DESCRIPTION


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11548


## But de la pull request

Notre PO souhaite pouvoir tester que les paiements pour les réservations éducationnelles et individuelles remontent bien, ensemble, dans le csv des paiements.

##  Implémentation

Dans le script sandbox qui crée des réservations éducationnelles, ajout d'une série de réservations individuelles avec le même offerer, afin de rendre testable facilement cette feature
​
##  Informations supplémentaires

La génération de ses réservations individuelles, au sein d'un script sur les réservations éducationnelles sera supprimée dans quelques heures, après la revue PO.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
