### PR TITLE
(PC-11783) Enable account creation with first and last name, mandator…

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -173,6 +173,8 @@ def create_account(
     email: str,
     password: str,
     birthdate: date,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
     marketing_email_subscription: bool = False,
     is_email_validated: bool = False,
     send_activation_mail: bool = True,
@@ -192,6 +194,8 @@ def create_account(
         email=email,
         dateOfBirth=datetime.combine(birthdate, datetime.min.time()),
         isEmailValidated=is_email_validated,
+        firstName=first_name,
+        lastName=last_name,
         publicName=VOID_PUBLIC_NAME,  # Required because model validation requires 3+ chars
         hasSeenTutorials=False,
         notificationSubscriptions=asdict(NotificationSubscriptions(marketing_email=marketing_email_subscription)),

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -101,6 +101,8 @@ def create_account(body: serializers.AccountRequest) -> None:
             email=body.email,
             password=body.password,
             birthdate=body.birthdate,
+            first_name=body.first_name,
+            last_name=body.last_name,
             marketing_email_subscription=body.marketing_email_subscription,
             is_email_validated=False,
             postal_code=body.postal_code,

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -29,6 +29,7 @@ from pcapi.core.users.models import User
 from pcapi.core.users.models import UserRole
 from pcapi.core.users.models import VOID_FIRST_NAME
 from pcapi.core.users.models import VOID_PUBLIC_NAME
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.native.utils import convert_to_cent
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
@@ -52,6 +53,8 @@ class AccountRequest(BaseModel):
     email: str
     password: str
     birthdate: datetime.date
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
     marketing_email_subscription: Optional[bool] = False
     token: str
     postal_code: Optional[str] = None
@@ -60,6 +63,22 @@ class AccountRequest(BaseModel):
 
     class Config:
         alias_generator = to_camel
+
+    @validator("first_name")
+    def first_name_mandatory(cls, first_name: Optional[str]) -> str:  # pylint: disable=no-self-argument
+        if FeatureToggle.ENABLE_UBBLE.is_active():
+            if not first_name or first_name.isspace():
+                raise ValueError("Le prénom est obligatoire")
+            first_name = first_name.strip()
+        return first_name
+
+    @validator("last_name")
+    def last_name_mandatory(cls, last_name: Optional[str]) -> str:  # pylint: disable=no-self-argument
+        if FeatureToggle.ENABLE_UBBLE.is_active():
+            if not last_name or last_name.isspace():
+                raise ValueError("Le nom est obligatoire")
+            last_name = last_name.strip()
+        return last_name
 
 
 class InstitutionalProjectRedactorAccountRequest(BaseModel):


### PR DESCRIPTION
…y when Ubble is enabled

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11783


## But de la pull request

La vérification de l'identité via Ubble nécessite d'envoyer le nom et prénom, cependant l'api ne l'autorisait pas pour le moment.

##  Implémentation

Ajout de champs optionnels first_name et last_name
​
##  Informations supplémentaires

Vérifié par des tests unitaires
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
