### PR TITLE
api: hooks: Fix Alembic pre-commit check

### DIFF
--- a/api/hooks/pre-commit
+++ b/api/hooks/pre-commit
@@ -4,8 +4,11 @@ ALEMBIC_STAGED_FILES=$(git diff --staged --name-only -- 'api/src/pcapi/alembic/v
 if [[ "$ALEMBIC_STAGED_FILES" != "" ]]; then
   echo -e "\033[0;96mMigration changes detected: $ALEMBIC_STAGED_FILES \033[0m"
   echo -e "\033[0;96mUpdating alembic_version_conflict_detection.txt \033[0m\n"
-  alembic heads > api/alembic_version_conflict_detection.txt
-  git add api/alembic_version_conflict_detection.txt
+  pushd `pwd`
+  cd api
+  alembic --config alembic.ini heads > alembic_version_conflict_detection.txt
+  git add alembic_version_conflict_detection.txt
+  popd
 fi
 
 counter=0


### PR DESCRIPTION
Git hooks are run from the root of the Git repository. As such,
running `alembic` fails because it cannot find its configuration
file. We could provide it (`alembic --config api/alembic.ini`). But
this file mentions `src/pcapi/alembic/` as the path of the "alembic"
folder, which cannot be found from the root of the Git repository. We
could specify `%(here)s/src/pcapi/alembic` and Alembic would find the
directory... but there would be an error while importing modules
because required environment variables are missing, since `.env.` file
are in the `api/` directory (and thus not read when running from the
Git repository).