### PR TITLE
[PC-11784][PRO]: Display new invoice section when FF is active

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -111,6 +111,7 @@
     "@testing-library/user-event": "^13.1.9",
     "@types/jest": "^26.0.23",
     "@types/node": "^16.7.10",
+    "@types/lodash.isequal": "^4.5.5",
     "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.9",
     "@types/react-redux": "^7.1.18",

--- a/pro/src/components/pages/Reimbursements/Reimbursement.scss
+++ b/pro/src/components/pages/Reimbursements/Reimbursement.scss
@@ -15,6 +15,40 @@
   * @debt duplicated "Gaël : duplicated styles for reset filters (in ...pages/Offers/Offers.scss), + we already have a tertiary-button class that is very close... we should create a component for this and standardise a behavior"
   */
 
+  .section-nav {
+    @include button();
+
+    background: none;
+    border: none;
+    position: relative;
+
+    &#refund-proof-nav {
+      margin-right: rem(16px);
+    }
+
+    &.is-active {
+      color: $primary;
+
+      &::before {
+        border-bottom: 2px solid $primary;
+        content: "";
+        height: 1px;
+        left: 0;
+        position: absolute;
+        top: 22px;
+        width: rem(56px);
+      }
+    }
+  }
+
+  .section {
+    display: none;
+
+    &.is-active {
+      display: block;
+    }
+  }
+
   .reset-filters {
     @include body-important();
 

--- a/pro/src/components/pages/Reimbursements/ReimbursementsDetails.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsDetails.tsx
@@ -1,0 +1,168 @@
+import isEqual from 'lodash.isequal'
+import React, { useCallback, useEffect, useState } from 'react'
+
+import CsvTableButtonContainer from 'components/layout/CsvTableButton/CsvTableButtonContainer'
+import DownloadButtonContainer from 'components/layout/DownloadButton/DownloadButtonContainer'
+import PeriodSelector from 'components/layout/inputs/PeriodSelector/PeriodSelector'
+import Select from 'components/layout/inputs/Select'
+import { API_URL } from 'utils/config'
+import { FORMAT_ISO_DATE_ONLY, formatBrowserTimezonedDateAsUTC, getToday } from 'utils/date'
+
+type venuesOptionsType = [{
+  id: string,
+  displayName: string,
+}]
+
+type filtersType = {
+  venue: string,
+  periodStart: Date,
+  periodEnd: Date,
+}
+
+interface IReimbursementsDetailsProps {
+  isCurrentUserAdmin: boolean,
+  venuesOptions: venuesOptionsType,
+}
+
+const ReimbursementsDetails = (
+  {
+    isCurrentUserAdmin,
+    venuesOptions,
+  }: IReimbursementsDetailsProps): JSX.Element => {
+  const ALL_VENUES_OPTION_ID = 'allVenues'
+  const INITIAL_CSV_URL = `${API_URL}/reimbursements/csv`
+  const today = getToday()
+  const oneMonthAGo = new Date(today.getFullYear(), today.getMonth() - 1, today.getDate())
+  const INITIAL_FILTERS = {
+    venue: ALL_VENUES_OPTION_ID,
+    periodStart: oneMonthAGo,
+    periodEnd: today,
+  }
+
+  const [filters, setFilters] = useState(INITIAL_FILTERS)
+  const {
+    venue: selectedVenue,
+    periodStart: selectedPeriodStart,
+    periodEnd: selectedPeriodEnd
+  } = filters
+  const [csvUrl, setCsvUrl] = useState(INITIAL_CSV_URL)
+
+  const dateFilterFormat = (date: Date) => formatBrowserTimezonedDateAsUTC(date, FORMAT_ISO_DATE_ONLY)
+  const isPeriodFilterSelected = selectedPeriodStart && selectedPeriodEnd
+  const requireVenueFilterForAdmin = isCurrentUserAdmin && selectedVenue === 'allVenues'
+  const shouldDisableButtons = !isPeriodFilterSelected || requireVenueFilterForAdmin
+
+  function resetFilters() {
+    setFilters(INITIAL_FILTERS)
+  }
+
+  const buildCsvUrlWithParameters = useCallback((selectedVenue: string, selectedPeriodStart: Date, selectedPeriodEnd: Date) => {
+    const url = new URL(INITIAL_CSV_URL)
+
+    if (selectedVenue && selectedVenue !== ALL_VENUES_OPTION_ID) {
+      url.searchParams.set('venueId', selectedVenue)
+    }
+
+    if (selectedPeriodStart) {
+      url.searchParams.set('reimbursementPeriodBeginningDate', dateFilterFormat(selectedPeriodStart))
+    }
+
+    if (selectedPeriodEnd) {
+      url.searchParams.set('reimbursementPeriodEndingDate', dateFilterFormat(selectedPeriodEnd))
+    }
+
+    return url.toString()
+  }, [INITIAL_CSV_URL])
+
+  const setVenueFilter = useCallback(
+    event => {
+      const venueId = event.target.value
+      setFilters((prevFilters: filtersType) => ({ ...prevFilters, venue: venueId }))
+    },
+    [setFilters]
+  )
+
+  const setStartDateFilter = useCallback(
+    startDate => {
+      setFilters((prevFilters: filtersType) => ({ ...prevFilters, periodStart: startDate }))
+    },
+    [setFilters]
+  )
+
+  const setEndDateFilter = useCallback(
+    endDate => {
+      setFilters((prevFilters: filtersType) => ({ ...prevFilters, periodEnd: endDate }))
+    },
+    [setFilters]
+  )
+
+  useEffect(() => {
+    setCsvUrl(buildCsvUrlWithParameters(selectedVenue, selectedPeriodStart, selectedPeriodEnd))
+  }, [buildCsvUrlWithParameters, selectedPeriodEnd, selectedPeriodStart, selectedVenue])
+
+
+  return (
+    <>
+      <div className="header">
+        <h2 className="header-title">
+          Affichage des remboursements
+        </h2>
+        <button
+          className="tertiary-button reset-filters"
+          disabled={isEqual(filters, INITIAL_FILTERS)}
+          onClick={resetFilters}
+          type="button"
+        >
+          Réinitialiser les filtres
+        </button>
+      </div>
+
+      <div className="filters">
+        <Select
+          defaultOption={{ displayName: 'Tous les lieux', id: ALL_VENUES_OPTION_ID }}
+          handleSelection={setVenueFilter}
+          label="Lieu"
+          name="lieu"
+          options={venuesOptions}
+          selectedValue={selectedVenue}
+        />
+        <PeriodSelector
+          changePeriodBeginningDateValue={setStartDateFilter}
+          changePeriodEndingDateValue={setEndDateFilter}
+          isDisabled={false}
+          label="Période"
+          maxDateEnding={getToday()}
+          periodBeginningDate={selectedPeriodStart}
+          periodEndingDate={selectedPeriodEnd}
+          todayDate={getToday()}
+        />
+      </div>
+
+      <div className="button-group">
+        <span className="button-group-separator" />
+        <div className="button-group-buttons">
+          <DownloadButtonContainer
+            filename="remboursements_pass_culture"
+            href={csvUrl}
+            isDisabled={shouldDisableButtons}
+            mimeType="text/csv"
+          >
+            Télécharger
+          </DownloadButtonContainer>
+          <CsvTableButtonContainer
+            href={csvUrl}
+            isDisabled={shouldDisableButtons}
+          >
+            Afficher
+          </CsvTableButtonContainer>
+        </div>
+      </div>
+
+      <p className="format-mention">
+        Le fichier est au format CSV, compatible avec tous les tableurs et éditeurs de texte.
+      </p>
+    </>
+  )
+}
+
+export default ReimbursementsDetails

--- a/pro/src/components/pages/Reimbursements/__specs__/ReimbursementWithFilters.spec.jsx
+++ b/pro/src/components/pages/Reimbursements/__specs__/ReimbursementWithFilters.spec.jsx
@@ -1,12 +1,5 @@
 import '@testing-library/jest-dom'
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-  within,
-} from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved, within, } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryHistory } from 'history'
 import React from 'react'
@@ -55,19 +48,23 @@ const renderReimbursements = (store, props) => {
   )
 
   const getElements = () => ({
+    nav: {
+      refundProof: screen.queryByText('Justificatifs de remboursement'),
+      refundDetails: screen.queryByText('Détails des remboursements'),
+    },
     filters: {
-      venue: screen.getByLabelText('Lieu'),
-      periodStart: screen.getByLabelText('début de la période'),
-      periodEnd: screen.getByLabelText('fin de la période'),
+      venue: screen.queryByLabelText('Lieu'),
+      periodStart: screen.queryByLabelText('début de la période'),
+      periodEnd: screen.queryByLabelText('fin de la période'),
     },
     buttons: {
-      download: screen.getByRole('button', {
+      download: screen.queryByRole('button', {
         name: /Télécharger/i,
       }),
-      display: screen.getByRole('button', {
+      display: screen.queryByRole('button', {
         name: /Afficher/i,
       }),
-      resetFilters: screen.getByRole('button', {
+      resetFilters: screen.queryByRole('button', {
         name: /Réinitialiser les filtres/i,
       }),
     },
@@ -144,6 +141,27 @@ describe('reimbursementsWithFilters', () => {
     props = { currentUser: { isAdmin: false } }
     venues = BASE_VENUES
     pcapi.getVenuesForOfferer.mockResolvedValue(venues)
+  })
+
+  it('should display a new refund proof section when feature flag is up', async () => {
+    store = configureTestStore({
+      data: {
+        users: [{ publicName: 'Damien', isAdmin: false }],
+      },
+      features: {
+        list: [
+          { isActive: true, nameKey: 'SHOW_INVOICES_ON_PRO_PORTAL' },
+        ],
+      },
+    })
+
+    // when
+    const { getElementsOnLoadingComplete } = renderReimbursements(store, props)
+    const { nav } = await getElementsOnLoadingComplete()
+
+    // then
+    expect(nav.refundProof).toBeInTheDocument()
+    expect(nav.refundDetails).toBeInTheDocument()
   })
 
   it('should display the right informations and UI', async () => {

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -4231,6 +4231,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash.isequal@^4.5.5":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz#4fed1b1b00bef79e305de0352d797e9bb816c8ff"
+  integrity sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.177"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"
+  integrity sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw==
+
 "@types/lodash@^4.14.165":
   version "4.14.172"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11784


## But de la pull request

Implémenter un nouvel affichage en section sur la page des remboursements dépendamment du feature flag `SHOW_INVOICES_ON_PRO_PORTAL` pour permettre l'ajout d'une nouvelle section "Justificatifs de Remboursement" (vide pour le moment)

![image](https://user-images.githubusercontent.com/57532638/142239242-e415614d-cb00-48bf-a392-891b73770db6.png)

![image](https://user-images.githubusercontent.com/57532638/142239144-7ee81cbc-aa52-479a-9f6c-3e7efd313146.png)

​
##  Informations supplémentaires

- Creation d'un nouveau composant en tsx pour l'affichage des détails de remboursement
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
