### PR TITLE
factories : Utiliser `utcnow()` au lieu de `now()`

### DIFF
--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -59,13 +59,13 @@ class BookingFactory(BaseFactory):
 class UsedBookingFactory(BookingFactory):
     status = models.BookingStatus.USED
     isUsed = True
-    dateUsed = factory.LazyFunction(datetime.datetime.now)
+    dateUsed = factory.LazyFunction(datetime.datetime.utcnow)
 
 
 class CancelledBookingFactory(BookingFactory):
     status = models.BookingStatus.CANCELLED
     isCancelled = True
-    cancellationDate = factory.LazyFunction(datetime.datetime.now)
+    cancellationDate = factory.LazyFunction(datetime.datetime.utcnow)
     cancellationReason = models.BookingCancellationReasons.BENEFICIARY
 
 
@@ -81,7 +81,7 @@ class UsedEducationalBookingFactory(BookingFactory):
     stock = factory.SubFactory(offers_factories.EducationalEventStockFactory)
     status = models.BookingStatus.USED
     isUsed = True
-    dateUsed = factory.LazyFunction(datetime.datetime.now)
+    dateUsed = factory.LazyFunction(datetime.datetime.utcnow)
     userId = None
     user = None
 

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -55,7 +55,6 @@ class EducationalDepositFactory(BaseFactory):
     educationalInstitution = factory.SubFactory(EducationalInstitutionFactory)
     educationalYear = factory.SubFactory(EducationalYearFactory)
     amount = 3000
-    dateCreated = datetime.datetime.now()
     isFinal = True
 
 


### PR DESCRIPTION
commits à relire séparément, cf. les messages de commit pour les détails.