### PR TITLE
[api] Fix color of Python shell prompt on development environment

### DIFF
--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -177,7 +177,7 @@ def _non_printable(seq):
 
 def _set_python_prompt():
     env = settings.ENV
-    if env in ("production", "development"):
+    if env in "production":
         color = "\x1b[1;49;31m"  # red
     elif env == "staging":
         color = "\x1b[1;49;35m"  # purple


### PR DESCRIPTION
Why would we want to use the same color (red) on development (local)
and production? "Oh, the prompt is red, it must be my local
environment, right?"

(Bug introduced (by myself) in eca20610328298d6c9dd42e24f9b4d696a63f3b2.)