### PR TITLE
[PC-11837][API] Prepare BeneficiaryFraudCheck for subscription refactor

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-42ebfa8a45aa (head)
+8794f331080c (head)

--- a/api/src/pcapi/alembic/versions/20211117T110737_8794f331080c_update_beneficiaryfraudcheck.py
+++ b/api/src/pcapi/alembic/versions/20211117T110737_8794f331080c_update_beneficiaryfraudcheck.py
@@ -1,0 +1,33 @@
+"""Update BeneficiaryFraudCheck
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8794f331080c"
+down_revision = "42ebfa8a45aa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("beneficiary_fraud_check", sa.Column("reason", sa.Text(), nullable=True))
+    op.add_column(
+        "beneficiary_fraud_check",
+        sa.Column(
+            "reasonCodes",
+            sa.ARRAY(sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "beneficiary_fraud_check",
+        sa.Column("status", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("beneficiary_fraud_check", "status")
+    op.drop_column("beneficiary_fraud_check", "reason_codes")
+    op.drop_column("beneficiary_fraud_check", "reason")

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -170,6 +170,7 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
     user = factory.SubFactory(users_factories.BeneficiaryGrant18Factory)
     type = models.FraudCheckType.JOUVE
     thirdPartyId = factory.Sequence("ThirdPartyIdentifier-{0}".format)
+    status = models.FraudCheckStatus.PENDING
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -216,6 +216,13 @@ class FraudReasonCode(enum.Enum):
     INE_NOT_WHITELISTED = "ine_not_whitelisted"
 
 
+class FraudCheckStatus(enum.Enum):
+    KO = "ko"
+    OK = "ok"
+    SUSPICIOUS = "suspiscious"
+    PENDING = "pending"
+
+
 class BeneficiaryFraudCheck(PcObject, Model):
     __tablename__ = "beneficiary_fraud_check"
 
@@ -232,6 +239,15 @@ class BeneficiaryFraudCheck(PcObject, Model):
     thirdPartyId = sqlalchemy.Column(sqlalchemy.TEXT(), nullable=False)
 
     resultContent = sqlalchemy.Column(sqlalchemy.dialects.postgresql.JSONB)
+
+    status = sqlalchemy.Column(sqlalchemy.Enum(FraudCheckStatus, create_constraint=False), nullable=True)
+
+    reason = sqlalchemy.Column(sqlalchemy.Text, nullable=True)
+
+    reasonCodes = sqlalchemy.Column(
+        sqlalchemy.ARRAY(sqlalchemy.Enum(FraudReasonCode, create_constraint=False, native_enum=False)),
+        nullable=True,
+    )
 
     def source_data(self) -> typing.Union[JouveContent, DMSContent, UserProfilingFraudData, EduconnectContent]:
         if self.type not in FRAUD_CHECK_MAPPING:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11837

## But de la pull request

Démarrer le refactor des modèles de fraudes, afin de simplifier la modélisation en base, et mieux respecter les usages actuels et le workflow d'inscription revu récemment.

##  Implémentation

On ajoute au FraudCheck l'état, les codes d'erreurs, et un message pour un operationnel

Mise à jour des factories

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
