### PR TITLE
Backend - Décli Web - Intégration de TMX - Ajout du endpoint qui génére le TMX Session ID

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+import uuid
 
 from flask import request
 
@@ -315,6 +316,17 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
     else:
         logger.info("Success when profiling user: returned userdata %r", profiling_infos.dict())
         fraud_api.on_user_profiling_result(user, profiling_infos)
+
+
+@blueprint.native_v1.route("/user_profiling/session_id", methods=["GET"])
+@spectree_serialize(api=blueprint.api, response_model=serializers.UserProfilingSessionIdResponse)
+@authenticated_user_required
+def profiling_session_id(user: User) -> serializers.UserProfilingSessionIdResponse:
+    """
+    Generate a unique hash which will be used as an identifier for user profiling
+    """
+    session_id = str(uuid.uuid4())
+    return serializers.UserProfilingSessionIdResponse(sessionId=session_id)
 
 
 @blueprint.native_v1.route("/ubble_identification", methods=["POST"])

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -320,6 +320,8 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
 @blueprint.native_v1.route("/ubble_identification", methods=["POST"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.IdentificationSessionResponse)
 @authenticated_user_required
-def start_identification_session(user: User, body: serializers.IdentificationSessionRequest) -> None:
+def start_identification_session(
+    user: User, body: serializers.IdentificationSessionRequest
+) -> serializers.IdentificationSessionResponse:
     identification_url = subscription_api.start_ubble_workflow(user, body.redirectUrl)
     return serializers.IdentificationSessionResponse(identificationUrl=identification_url)

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -328,6 +328,10 @@ class UserProfilingFraudRequest(BaseModel):
         return session_id
 
 
+class UserProfilingSessionIdResponse(BaseModel):
+    sessionId: str
+
+
 class IdentificationSessionRequest(BaseModel):
     redirectUrl: str
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11847


## But de la pull request

Fournir un hash unique au frontend à travers un endpoint, utilisé comme sessionId pour le profiling utilisateur

##  Implémentation

Endpoint native, hash par uuid4, de la forme '0900788f-0e04-4129-a652-1a5f045b06c8'
​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
