### PR TITLE
(PC-11865) avoid checking id piece number with current applicant user

### DIFF
--- a/api/src/pcapi/scripts/beneficiary/remote_import.py
+++ b/api/src/pcapi/scripts/beneficiary/remote_import.py
@@ -178,7 +178,8 @@ def process_application(
 
     if information.id_piece_number:
         _duplicated_user = users_models.User.query.filter(
-            users_models.User.idPieceNumber == information.id_piece_number
+            users_models.User.idPieceNumber == information.id_piece_number,
+            users_models.User.id != user.id,
         ).first()
         if _duplicated_user:
             subscription_messages.on_duplicate_user(user)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11865


## But de la pull request

Corriger un probleme de vérification d'utilisateur en doublon, lorsqu'il a deja effectué une vérification
de doublon de pièce d'identité, via jouve par exemple, et que l'information est deja en base: 
l'utilisateur se retrouve doublon de lui-meme


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)