### PR TITLE
(PC-11848) api: Agent type sent from frontend for user profiling + rename session_id into sessionId

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -298,7 +298,7 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
 
     try:
         profiling_infos = handler.get_user_profiling_fraud_data(
-            session_id=body.session_id,
+            session_id=body.sessionId,
             user_id=user.id,
             user_email=user.email,
             birth_date=user.dateOfBirth.date() if user.dateOfBirth else None,
@@ -309,7 +309,7 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
             line_of_business=user_profiling.LineOfBusiness.B2C,
             # Insert request unique identifier
             transaction_id=get_or_set_correlation_id(),
-            agent_type=user_profiling.AgentType.AGENT_MOBILE,
+            agent_type=body.agentType,
         )
     except user_profiling.BaseUserProfilingException:
         logger.exception("Error while retrieving user profiling infos", exc_info=True)

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1627,6 +1627,25 @@ class ProfilingFraudScoreTest:
         )
         client.with_token(user.email)
 
+        response = client.post(
+            "/native/v1/user_profiling", json={"sessionId": session_id, "agentType": "browser_mobile"}
+        )
+        assert response.status_code == 204
+        assert matcher.call_count == 1
+
+    @override_settings(USER_PROFILING_URL=USER_PROFILING_URL)
+    def test_profiling_fraud_score_call_legacy(self, client, requests_mock):
+        # Remove this test after session_id is removed and only sessionId kept
+        user = users_factories.UserFactory()
+        session_id = "arbitrarysessionid"
+        matcher = requests_mock.register_uri(
+            "POST",
+            settings.USER_PROFILING_URL,
+            json=user_profiling_fixtures.CORRECT_RESPONSE,
+            status_code=200,
+        )
+        client.with_token(user.email)
+
         response = client.post("/native/v1/user_profiling", json={"session_id": session_id})
         assert response.status_code == 204
         assert matcher.call_count == 1
@@ -1641,7 +1660,9 @@ class ProfilingFraudScoreTest:
             status_code=500,
         )
         client.with_token(user.email)
-        response = client.post("/native/v1/user_profiling", json={"session_id": "randomsessionid"})
+        response = client.post(
+            "/native/v1/user_profiling", json={"sessionId": "randomsessionid", "agentType": "agent_mobile"}
+        )
         assert response.status_code == 204
         assert matcher.call_count == 1
         assert caplog.record_tuples == [
@@ -1660,7 +1681,9 @@ class ProfilingFraudScoreTest:
         client.with_token(user.email)
 
         with caplog.at_level(logging.INFO):
-            response = client.post("/native/v1/user_profiling", json={"session_id": "randomsessionid"})
+            response = client.post(
+                "/native/v1/user_profiling", json={"sessionId": "randomsessionid", "agentType": "agent_mobile"}
+            )
         assert response.status_code == 204
         assert matcher.call_count == 1
         assert len(caplog.records) >= 2
@@ -1681,7 +1704,9 @@ class ProfilingFraudScoreTest:
             status_code=200,
         )
         client.with_token(user.email)
-        response = client.post("/native/v1/user_profiling", json={"session_id": "gdavmoioeuboaobç!p'è"})
+        response = client.post(
+            "/native/v1/user_profiling", json={"sessionId": "gdavmoioeuboaobç!p'è", "agentType": "agent_mobile"}
+        )
         assert response.status_code == 400
         assert matcher.call_count == 0
 
@@ -1707,7 +1732,7 @@ class ProfilingFraudScoreTest:
         )
         client.with_token(user.email)
 
-        response = client.post("/native/v1/user_profiling", json={"session_id": session_id})
+        response = client.post("/native/v1/user_profiling", json={"sessionId": session_id, "agentType": "agent_mobile"})
 
         assert response.status_code == 204
         assert (
@@ -1741,7 +1766,7 @@ class ProfilingFraudScoreTest:
         client.with_token(user.email)
         session_id = "arbitrarysessionid"
 
-        response = client.post("/native/v1/user_profiling", json={"session_id": session_id})
+        response = client.post("/native/v1/user_profiling", json={"sessionId": session_id, "agentType": "agent_mobile"})
 
         assert response.status_code == 204
         assert (


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11848


## But de la pull request

Récuperer depuis le client web app v2 l’agent type présent dans le body de la requête /native/v1/user_profiling, le client web peut envoyer soit:   'browser_computer' ou 'browser_mobile' et il faut le faire suivre au backend TMX

+ session_id renommé en sessionId avec cohabitation le temps de mettre à jour le frontend.

##  Implémentation

voir ticket
​
##  Informations supplémentaires

Le @root_validator est temporaire, pour gérer les deux session ids.
J'ai essayé avec @validator("session_id", "sessionId"), mais le même est appelé deux fois.
Avec @validator("sessionId") et le paramètres values pour récupérer l'autre, values est toujours vide.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
