### PR TITLE
(PC-11825) Add new route to query next subscription step

### DIFF
--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -12,3 +12,12 @@ def get_current_beneficiary_fraud_result(
         models.BeneficiaryFraudResult.userId == user.id,
         models.BeneficiaryFraudResult.eligibilityType == eligibilityType,
     ).one_or_none()
+
+
+def get_last_user_profiling_fraud_check(user: users_models.User) -> Optional[models.BeneficiaryFraudCheck]:
+    return (
+        models.BeneficiaryFraudCheck.query.filter(models.BeneficiaryFraudCheck.user == user)
+        .filter(models.BeneficiaryFraudCheck.type == models.FraudCheckType.USER_PROFILING)
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .first()
+    )

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -12,6 +12,15 @@ from pcapi.models.db import Model
 from pcapi.models.pc_object import PcObject
 
 
+class SubscriptionStep(enum.Enum):
+    EMAIL_VALIDATION = "email-validation"
+    MAINTENANCE = "maintenance"
+    PHONE_VALIDATION = "phone-validation"
+    PROFILE_COMPLETION = "profile-completion"
+    IDENTITY_CHECK = "identity-check"
+    USER_PROFILING = "user-profiling"
+
+
 @dataclasses.dataclass
 class BeneficiaryPreSubscription:
     activity: str

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -794,7 +794,7 @@ def get_id_check_validation_step(user: User) -> Optional[BeneficiaryValidationSt
 
 
 def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryValidationStep]:
-    if not user.can_upgrade_beneficiary_role() or user.eligibility is None:
+    if not user.can_upgrade_beneficiary_role():
         return None
 
     if user.eligibility == EligibilityType.AGE18:

--- a/api/src/pcapi/routes/native/v1/__init__.py
+++ b/api/src/pcapi/routes/native/v1/__init__.py
@@ -11,4 +11,5 @@ def install_routes(app: Flask) -> None:
     from . import offers
     from . import redirection
     from . import settings
+    from . import subscription
     from . import universal_links

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from pcapi.core.subscription import models as subscription_models
+from pcapi.serialization.utils import to_camel
+
+from . import BaseModel
+
+
+class NextSubscriptionStepRequest(BaseModel):
+    next_subscription_step: Optional[subscription_models.SubscriptionStep]
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Optional
+
+from pcapi.core.subscription.api import get_next_subscription_step
+from pcapi.core.users import models as users_models
+from pcapi.routes.native.security import authenticated_user_required
+from pcapi.serialization.decorator import spectree_serialize
+
+from . import blueprint
+from .serialization import subscription as serializers
+
+
+logger = logging.getLogger(__name__)
+
+
+@blueprint.native_v1.route("/subscription/next_step", methods=["GET"])
+@spectree_serialize(
+    response_model=serializers.NextSubscriptionStepRequest,
+    on_success_status=200,
+    api=blueprint.api,
+)  # type: ignore
+@authenticated_user_required
+def next_subscription_step(
+    user: users_models.User,
+) -> Optional[serializers.NextSubscriptionStepRequest]:
+    return serializers.NextSubscriptionStepRequest(next_subscription_step=get_next_subscription_step(user))

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -1,0 +1,23 @@
+import datetime
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_next_subscription_test(client):
+    user = users_factories.UserFactory(
+        dateOfBirth=datetime.datetime.combine(datetime.date.today(), datetime.time(0, 0))
+        - relativedelta(years=18, months=5),
+    )
+
+    client.with_token(user.email)
+
+    response = client.get("/native/v1/subscription/next_step")
+
+    assert response.status_code == 200
+    assert response.json == {"nextSubscriptionStep": "phone-validation"}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11825


## But de la pull request
Ajouter une route pour que le front puisse commencer à l'utiliser pour le nouveau parcours d'inscription.

La fonction `get_next_subscription_step` est temporaire puisqu'elle s'appuiera par la suite sur `user.subscriptionState`.