### PR TITLE
(PC-11703) Fix ubble response parsing and fixture

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -56,4 +56,4 @@ def start_identification(
         }
     }
     response = session.post(build_url("/identifications/"), json=data)
-    return fraud_models.UbbleIdentificationResponse(**response.json()["attributes"])
+    return fraud_models.UbbleIdentificationResponse(**response.json()["data"]["attributes"])

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -111,20 +111,20 @@ class JouveContent(pydantic.BaseModel):
 
 
 class UbbleIdentificationResponse(pydantic.BaseModel):
-    comment: str
+    comment: typing.Optional[str]
     created_at: datetime.datetime = pydantic.Field(alias="created-at")
-    ended_at: datetime.datetime = pydantic.Field(alias="ended-at")
+    ended_at: typing.Optional[datetime.datetime] = pydantic.Field(alias="ended-at")
     identification_id: str = pydantic.Field(alias="identification-id")
     identification_url: str = pydantic.Field(alias="identification-url")
     number_of_attempts: int = pydantic.Field(alias="number-of-attempts")
     redirect_url: str = pydantic.Field(alias="redirect-url")
-    score: float
-    started_at: datetime.datetime = pydantic.Field(alias="started-at")
+    score: typing.Optional[float]
+    started_at: typing.Optional[datetime.datetime] = pydantic.Field(alias="started-at")
     status: str  # migrate to an enum ?
     updated_at: datetime.datetime = pydantic.Field(alias="updated-at")
     status_updated_at: datetime.datetime = pydantic.Field(alias="status-updated-at")
-    user_agent: str = pydantic.Field(alias="user-agent")
-    user_ip_address: str = pydantic.Field(alias="user-ip-address")
+    user_agent: typing.Optional[str] = pydantic.Field(alias="user-agent")
+    user_ip_address: typing.Optional[str] = pydantic.Field(alias="user-ip-address")
     webhook: str
 
 

--- a/api/tests/connectors/beneficiaries/ubble_fixtures.py
+++ b/api/tests/connectors/beneficiaries/ubble_fixtures.py
@@ -1,52 +1,46 @@
 UBBLE_IDENTIFICATION_RESPONSE = {
-    "type": "identifications",
-    "id": "801",
-    "attributes": {
-        "comment": "Identity Verified",
-        "created-at": "2019-02-26T16:29:19.857313Z",
-        "ended-at": "2019-02-26T17:05:49.096401Z",
-        "identification-id": "70f01f19-6ec5-4b14-9b30-2c493e49df15",
-        "identification-url": "https://id.ubble.ai/70f01f19-6ec5-4b14-9b30-2c493e49df15",
-        "number-of-attempts": 1,
-        "redirect-url": "https://www.ubble.ai/",
-        "score": 1.0,
-        "started-at": "2019-02-26T16:29:43.075181Z",
-        "status": "processed",
-        "updated-at": "2019-02-26T17:12:02.226018Z",
-        "status-updated-at": "2019-02-26T17:12:02.226018Z",
-        "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",
-        "user-ip-address": "123.123.123.123",
-        "webhook": "https://3eb5c250.ngrok.io",
-    },
-    "relationships": {
-        "doc-face-matches": {
-            "data": [{"type": "doc-face-matches", "id": "546"}],
-            "links": {"related": "http://api/api/identifications/801/doc_face_matches/"},
-            "meta": {"count": 1},
+    "data": {
+        "type": "identifications",
+        "id": "3191295",
+        "attributes": {
+            "anonymized-at": None,
+            "comment": None,
+            "created-at": "2021-11-18T18:59:59.273402Z",
+            "ended-at": None,
+            "identification-id": "29d9eca4-dce6-49ed-b1b5-8bb0179493a8",
+            "identification-url": "https://id.ubble.ai/29d9eca4-dce6-49ed-b1b5-8bb0179493a8",
+            "is-live": False,
+            "number-of-attempts": 0,
+            "redirect-url": "https://example.com/redirect-url",
+            "started-at": None,
+            "status-updated-at": "2021-11-18T18:59:59.273171Z",
+            "status": "uninitiated",
+            "updated-at": "2021-11-18T18:59:59.329011Z",
+            "user-agent": None,
+            "user-ip-address": None,
+            "webhook": "https://example.com/webhook",
         },
-        "doc-doc-matches": {
-            "data": [{"type": "doc-doc-matches", "id": "62"}],
-            "links": {"related": "http://api/api/identifications/801/doc_doc_matches/"},
-            "meta": {"count": 1},
-        },
-        "document-checks": {
-            "data": [{"type": "document-checks", "id": "546"}],
-            "links": {"related": "http://api/api/identifications/801/document_checks/"},
-            "meta": {"count": 1},
-        },
-        "face-checks": {
-            "data": [{"type": "face-checks", "id": "546"}],
-            "links": {"related": "http://api/api/identifications/801/face_checks/"},
-            "meta": {"count": 1},
-        },
-        "identity-form-match": {
-            "data": [{"type": "identity-form-matches", "id": "646"}],
-            "links": {"related": "http://api/api/identifications/801/identity-form-matches/"},
-            "meta": {"count": 1},
-        },
-        "identity": {
-            "data": {"type": "identities", "id": "661"},
-            "links": {"related": "http://api/api/identifications/801/identity/"},
+        "relationships": {
+            "identity": {
+                "data": {"type": "identities", "id": "3187041"},
+                "links": {"related": "https://api.example.com/api/identifications/3191295/identity"},
+            },
+            "reference-data": {
+                "data": {"type": "reference-data", "id": "119617"},
+                "links": {"related": "https://api.example.com/api/identifications/3191295/reference_data"},
+            },
         },
     },
+    "included": [
+        {
+            "type": "identities",
+            "id": "3187041",
+            "attributes": {"birth-date": None, "first-name": None, "last-name": None},
+        },
+        {
+            "type": "reference-data",
+            "id": "119617",
+            "attributes": {"last-name": "LastName", "first-name": "FirstName", "birth-date": "2003-10-18"},
+        },
+    ],
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11703


## But de la pull request

Apres des tests de branchement, le retour de la 1ere requete n'étais pas le bon,
cette PR corrige la prise en compte du retour de l' API.

##  Implémentation

Modification de la fixture, du modele de retour de ubble avec des champs optionnels.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)