### PR TITLE
(PC-11848) api: Fix session id validation for user profiling

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -1,7 +1,7 @@
 import datetime
 from enum import Enum
+import re
 from typing import Any
-from typing import Dict
 from typing import Optional
 from uuid import UUID
 
@@ -332,17 +332,17 @@ class UploadIdentityDocumentRequest(BaseModel):
 
 class UserProfilingFraudRequest(BaseModel):
     # Moving from session_id to sessionId - remove session_id and set sessionId not Optional when app version is forced
-    # to a new minimal version. Also restore previous validator session_id_alphanumerics for sessionId
+    # to a new minimal version. Also restore a simple validator session_id_alphanumerics for sessionId
     session_id: Optional[str]
     sessionId: Optional[str]
     agentType: Optional[AgentType]
 
     @root_validator()
-    def session_id_alphanumerics(cls, values: Dict[str, Any]) -> Dict[str, Any]:  # pylint: disable=no-self-argument
+    def session_id_alphanumerics(cls, values: dict[str, Any]) -> dict[str, Any]:  # pylint: disable=no-self-argument
         session_id = values.get("sessionId") or values.get("session_id")
         if not session_id:
             raise ValueError("L'identifiant de session est manquant")
-        if not session_id.isalnum():
+        if not re.match(r"^[A-Za-z0-9_-]{1,128}$", session_id):
             raise ValueError(
                 "L'identifiant de session ne doit être composé exclusivement que de caratères alphanumériques"
             )

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1816,10 +1816,12 @@ class ProfilingFraudScoreTest:
 
     USER_PROFILING_URL = "https://example.com/path"
 
+    # Remove parametrize() after session_id is removed and only sessionId kept
+    @pytest.mark.parametrize("session_id_key", ["sessionId", "session_id"])
     @override_settings(USER_PROFILING_URL=USER_PROFILING_URL)
-    def test_profiling_fraud_score_call(self, client, requests_mock):
+    def test_profiling_fraud_score_call(self, client, requests_mock, session_id_key):
         user = users_factories.UserFactory()
-        session_id = "arbitrarysessionid"
+        session_id = "b0c9ab58-cdfb-4461-a771-a00683b85bd2"
         matcher = requests_mock.register_uri(
             "POST",
             settings.USER_PROFILING_URL,
@@ -1829,25 +1831,8 @@ class ProfilingFraudScoreTest:
         client.with_token(user.email)
 
         response = client.post(
-            "/native/v1/user_profiling", json={"sessionId": session_id, "agentType": "browser_mobile"}
+            "/native/v1/user_profiling", json={session_id_key: session_id, "agentType": "browser_mobile"}
         )
-        assert response.status_code == 204
-        assert matcher.call_count == 1
-
-    @override_settings(USER_PROFILING_URL=USER_PROFILING_URL)
-    def test_profiling_fraud_score_call_legacy(self, client, requests_mock):
-        # Remove this test after session_id is removed and only sessionId kept
-        user = users_factories.UserFactory()
-        session_id = "arbitrarysessionid"
-        matcher = requests_mock.register_uri(
-            "POST",
-            settings.USER_PROFILING_URL,
-            json=user_profiling_fixtures.CORRECT_RESPONSE,
-            status_code=200,
-        )
-        client.with_token(user.email)
-
-        response = client.post("/native/v1/user_profiling", json={"session_id": session_id})
         assert response.status_code == 204
         assert matcher.call_count == 1
 
@@ -1921,7 +1906,7 @@ class ProfilingFraudScoreTest:
     )
     def test_fraud_result_on_risky_user_profiling(self, client, requests_mock, risk_rating):
         user = users_factories.UserFactory()
-        session_id = "arbitrarysessionid"
+        session_id = "8663ac09-db2a-46a1-9ccd-49a07d5cd7ae"
         payload = fraud_factories.UserProfilingFraudDataFactory(risk_rating=risk_rating).dict()
         payload["event_datetime"] = payload["event_datetime"].isoformat()  # because datetime is not json serializable
         payload["risk_rating"] = payload["risk_rating"].value  # because Enum is not json serializable
@@ -1965,7 +1950,7 @@ class ProfilingFraudScoreTest:
             status_code=200,
         )
         client.with_token(user.email)
-        session_id = "arbitrarysessionid"
+        session_id = "ffd4ad0f-be8c-4b1e-97ec-0fdd5e4edae0"
 
         response = client.post("/native/v1/user_profiling", json={"sessionId": session_id, "agentType": "agent_mobile"})
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11848


## But de la pull request

Corrections après les commentaires post-merge de la code review :
https://github.com/pass-culture/pass-culture-main/pull/503

##  Implémentation

La validation du session id n'était pas compatible avec le format créé dans :
https://passculture.atlassian.net/browse/PC-11847
​
##  Informations supplémentaires
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
