### PR TITLE
(PC-11876) fix:[Recredit] fix double recredit on birthday bug

### DIFF
--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def has_celebrated_their_birthday_since_activation(user: users_models.User) -> bool:
-    return user.deposit_activation_date is not None and user.deposit_activation_date.date() <= user.latest_birthday
+    return user.deposit_activation_date is not None and user.deposit_activation_date.date() < user.latest_birthday
 
 
 def has_been_recredited(user: users_models.User) -> bool:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11876

But de la pull request
Corriger le bug suivant: si un utilisateur créé son compte le jour de son anniversaire, il est recrédité à minuit, alors qu'il n'est pas éligible au recredit

Implémentation
`<=` devient `<` #changementmicroscopique