### PR TITLE
Pc 11783 create account with first and last name

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -4,7 +4,6 @@ import re
 from typing import Optional
 from typing import Union
 
-from dateutil.relativedelta import relativedelta
 import sqlalchemy
 
 from pcapi.connectors.beneficiaries import jouve_backend
@@ -381,7 +380,7 @@ def _get_threshold_id_fraud_item(
 
 
 def _underage_user_fraud_item(birth_date: datetime.date) -> models.FraudItem:
-    age = relativedelta(datetime.date.today(), birth_date).years
+    age = user_models.get_age_from_birth_date(birth_date)
     if age in constants.ELIGIBILITY_UNDERAGE_RANGE:
         return models.FraudItem(
             status=models.FraudStatus.OK,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11783


## But de la pull request

Le nom et le prénom, devenus obligatoires pour la parcours d'inscription via Ubble, ne doivent finalement être obligatoires que pour les utilisateurs de 15 à 18 ans, éligibles au crédit. Les autres utilisateurs peuvent s'inscrire sans prénom ni nom.

##  Implémentation

Mise à jour du validateur pydantic et enrichissement des tests unitaires
​
##  Informations supplémentaires

Je passe en même temps un commit pour enrichir les tests sur le session id

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
