### PR TITLE
(PC-11612) : add required content-type header to adage call when preb…

### DIFF
--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -16,9 +16,7 @@ class AdageHttpNotifier(AdageNotifier):
     def notify_prebooking(self, data: EducationalBookingResponse) -> AdageApiResult:
         api_response = requests.post(
             self.url,
-            headers={
-                self.header_key: self.api_key,
-            },
+            headers={self.header_key: self.api_key, "Content-type": "application/json"},
             json=data.json(),
         )
 


### PR DESCRIPTION
…ooking

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11612


## But de la pull request

Ajout du header content-type à la requête post à adage, celui-ci étant requis

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
