### PR TITLE
(PC-11894)[PRO]: fix eac tag splitting in multiple lines in offers list

### DIFF
--- a/pro/src/ui-kit/Tag/Tag.module.scss
+++ b/pro/src/ui-kit/Tag/Tag.module.scss
@@ -1,6 +1,7 @@
 .tag {
   @include highlight();
 
+  white-space: nowrap;
   border: solid rem(1px) $tertiary;
   border-radius: rem(4px);
   color: $tertiary;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11894


## But de la pull request

fix css du tag eac passant sur plusieurs lignes