### PR TITLE
(PC-11219) Reset user.hasCompletedIdCheck after beneficiary activation

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -98,6 +98,8 @@ def activate_beneficiary(
 
     deposit = payments_api.create_deposit(user, deposit_source=deposit_source, eligibility=eligibility)
 
+    user.hasCompletedIdCheck = False
+
     db.session.add_all((user, deposit))
     db.session.commit()
     logger.info("Activated beneficiary and created deposit", extra={"user": user.id, "source": deposit_source})

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -132,7 +132,7 @@ class BeneficiaryGrant18Factory(BaseFactory):
     departementCode = "75"
     firstName = "Jeanne"
     lastName = "Doux"
-    hasCompletedIdCheck = True
+    hasCompletedIdCheck = False
     isEmailValidated = True
     isAdmin = False
     roles = [users_models.UserRole.BENEFICIARY]

--- a/api/tests/core/users/external/external_users_test.py
+++ b/api/tests/core/users/external/external_users_test.py
@@ -107,7 +107,7 @@ def test_get_user_attributes():
         booking_count=2,
         booking_subcategories=["SUPPORT_PHYSIQUE_FILM"],
         deposit_activation_date=user.deposit_activation_date,
-        has_completed_id_check=True,
+        has_completed_id_check=False,
         user_id=user.id,
         is_eligible=True,
         is_email_validated=True,

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -697,7 +697,7 @@ class UpdateBeneficiaryMandatoryInformationTest:
         assert user.address == new_address
         assert user.city == new_city
 
-        assert user.hasCompletedIdCheck
+        assert not user.hasCompletedIdCheck
         assert user.has_beneficiary_role
         assert user.deposit
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -96,7 +96,7 @@ class AccountTest:
         assert response.json["email"] == ["Utilisateur introuvable"]
 
     @freeze_time("2018-06-01")
-    def test_get_user_profile(self, app):
+    def test_get_user_profile(self, client, app):
         USER_DATA = {
             "email": self.identifier,
             "firstName": "john",
@@ -122,11 +122,9 @@ class AccountTest:
         booking = IndividualBookingFactory(individualBooking__user=user, amount=Decimal("123.45"))
         CancelledIndividualBookingFactory(individualBooking__user=user, amount=Decimal("123.45"))
 
-        access_token = create_access_token(identity=self.identifier)
-        test_client = TestClient(app.test_client())
-        test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
+        client.with_token(self.identifier)
 
-        response = test_client.get("/native/v1/me")
+        response = client.get("/native/v1/me")
 
         EXPECTED_DATA = {
             "allowedEligibilityCheckMethods": ["jouve"],
@@ -146,7 +144,7 @@ class AccountTest:
             "eligibilityStartDatetime": "2015-01-01T00:00:00Z",
             "isBeneficiary": True,
             "roles": ["BENEFICIARY"],
-            "hasCompletedIdCheck": True,
+            "hasCompletedIdCheck": False,
             "nextBeneficiaryValidationStep": None,
             "pseudo": "jdo",
             "recreditAmountToShow": None,

--- a/api/tests/routes/shared/get_user_profile_test.py
+++ b/api/tests/routes/shared/get_user_profile_test.py
@@ -54,7 +54,7 @@ class Returns200Test:
             "email": "toto@example.com",
             "externalIds": {},
             "firstName": "Jean",
-            "hasCompletedIdCheck": True,
+            "hasCompletedIdCheck": False,
             "hasPhysicalVenues": False,
             "hasSeenProTutorials": True,
             "id": humanize(user.id),

--- a/api/tests/scripts/batch_update_users_attributes_test.py
+++ b/api/tests/scripts/batch_update_users_attributes_test.py
@@ -113,7 +113,7 @@ def test_format_sendinblue_user():
         "DEPOSIT_EXPIRATION_DATE": user.deposit_expiration_date,
         "ELIGIBILITY": user.eligibility,
         "FIRSTNAME": "Jeanne",
-        "HAS_COMPLETED_ID_CHECK": True,
+        "HAS_COMPLETED_ID_CHECK": False,
         "INITIAL_CREDIT": Decimal("500.00"),
         "IS_BENEFICIARY": True,
         "IS_BENEFICIARY_18": True,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11219


## But de la pull request

This field is used during signup process to prevent from re-entering the process if a CNI has already been uploaded.

This is a legacy field that will be soon removed with the introduction of user.subscriptionState.
For now, we need to reset it to let an ex-underage beneficiary user renter the subscription process
ld from).

J'ai eu la confirmation des data analystes : ils n'utilisent pas ce champ après l'activation du bénéficiaire (et les requêtes qui l'utilisent sur metabase sont parait-il obsolètes).

Et j'ai prévenu Coline du marketing qui l'utilise dans ses "automations" sur sendinblue...
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
