### PR TITLE
(PC-11842) api: Error message when Ubble API is down

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/exceptions.py
+++ b/api/src/pcapi/connectors/beneficiaries/exceptions.py
@@ -1,0 +1,6 @@
+class IdentificationServiceUnavailable(Exception):
+    pass
+
+
+class IdentificationServiceError(Exception):
+    pass

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -13,6 +13,7 @@ from flask_jwt_extended.utils import create_access_token
 import pytest
 from requests import Response
 from requests.auth import _basic_auth_str
+from requests.exceptions import ConnectionError as RequestConnectionError
 
 # FIXME (dbaty, 2020-02-08): avoid import loop (that occurs when
 # importing `pcapi.core.mails.testing`) when running tests. Remove
@@ -170,6 +171,44 @@ def ubble_mock(requests_mock):
             "https://api.example.com/identifications/",
             json=ubble_fixtures.UBBLE_IDENTIFICATION_RESPONSE,
             status_code=201,
+        )
+        yield request_matcher
+
+
+@pytest.fixture(name="ubble_mock_connection_error")
+def ubble_mock_connection_error(requests_mock):
+    """
+    Mocks Ubble request which returns ConnectionError (ex Max retries exceeded, Timeout)
+    """
+    UBBLE_URL = "https://api.example.com/"
+
+    with pcapi.core.testing.override_settings(
+        UBBLE_API_URL=UBBLE_URL,
+        UBBLE_CLIENT_ID="client_id",
+        UBBLE_CLIENT_SECRET="client_secret",
+    ):
+        request_matcher = requests_mock.register_uri(
+            "POST", "https://api.example.com/identifications/", exc=RequestConnectionError
+        )
+        yield request_matcher
+
+
+@pytest.fixture(name="ubble_mock_http_error_status")
+def ubble_mock_http_error_status(requests_mock):
+    """
+    Mocks Ubble request which returns ConnectionError (ex Max retries exceeded, Timeout)
+    """
+    UBBLE_URL = "https://api.example.com/"
+
+    with pcapi.core.testing.override_settings(
+        UBBLE_API_URL=UBBLE_URL,
+        UBBLE_CLIENT_ID="client_id",
+        UBBLE_CLIENT_SECRET="client_secret",
+    ):
+        request_matcher = requests_mock.register_uri(
+            "POST",
+            "https://api.example.com/identifications/",
+            status_code=401,
         )
         yield request_matcher
 

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -1,5 +1,8 @@
 import datetime
 
+import pytest
+
+from pcapi.connectors.beneficiaries import exceptions
 from pcapi.connectors.beneficiaries import ubble
 from pcapi.core.fraud import models as fraud_models
 
@@ -31,3 +34,33 @@ class StartIdentificationTest:
         assert attributes["webhook"] == "http://webhook/url/"
         assert attributes["redirect_url"] == "http://redirect/url"
         assert attributes["face_required"] == True
+
+    def test_start_identification_connection_error(self, ubble_mock_connection_error):
+        with pytest.raises(exceptions.IdentificationServiceUnavailable):
+            ubble.start_identification(
+                user_id=123,
+                phone_number="+33601232323",
+                birth_date=datetime.date(2001, 2, 23),
+                first_name="prenom",
+                last_name="nom",
+                webhook_url="http://webhook/url/",
+                redirect_url="http://redirect/url",
+                face_required=True,
+            )
+
+        assert ubble_mock_connection_error.call_count == 1
+
+    def test_start_identification_http_error_status(self, ubble_mock_http_error_status):
+        with pytest.raises(exceptions.IdentificationServiceError):
+            ubble.start_identification(
+                user_id=123,
+                phone_number="+33601232323",
+                birth_date=datetime.date(2001, 2, 23),
+                first_name="prenom",
+                last_name="nom",
+                webhook_url="http://webhook/url/",
+                redirect_url="http://redirect/url",
+                face_required=True,
+            )
+
+        assert ubble_mock_http_error_status.call_count == 1

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -2053,3 +2053,27 @@ class IdentificationSessionTest:
         check = user.beneficiaryFraudChecks[0]
         assert check.type == fraud_models.FraudCheckType.UBBLE
         assert response.json["identificationUrl"] == "https://id.ubble.ai/29d9eca4-dce6-49ed-b1b5-8bb0179493a8"
+
+    def test_request_connection_error(self, client, ubble_mock_connection_error):
+        user = users_factories.UserFactory()
+
+        client.with_token(user.email)
+
+        response = client.post("/native/v1/ubble_identification", json={"redirectUrl": "http://example.com/deeplink"})
+
+        assert response.status_code == 503
+        assert response.json["code"] == "IDCHECK_SERVICE_UNAVAILABLE"
+        assert len(user.beneficiaryFraudChecks) == 0
+        assert ubble_mock_connection_error.call_count == 1
+
+    def test_request_ubble_http_error_status(self, client, ubble_mock_http_error_status):
+        user = users_factories.UserFactory()
+
+        client.with_token(user.email)
+
+        response = client.post("/native/v1/ubble_identification", json={"redirectUrl": "http://example.com/deeplink"})
+
+        assert response.status_code == 500
+        assert response.json["code"] == "IDCHECK_SERVICE_ERROR"
+        assert len(user.beneficiaryFraudChecks) == 0
+        assert ubble_mock_http_error_status.call_count == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11842

## But de la pull request

Interne - Ubble (backend) - Message d'erreur en cas d'API down d'Ubble 

##  Implémentation

Renvoie une erreur HTTP avec un code d'erreur, afin d'être traité par le frontend
​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
