### PR TITLE
[PC-11929][api] Use new `User.has_xxx_role()` in `patch_profile` route

### DIFF
--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -40,7 +40,7 @@ def patch_profile(body: PatchProUserBodyModel) -> PatchProUserResponseModel:
     user = current_user._get_current_object()  # get underlying User object from proxy
     # This route should ony be used by "pro" users because it allows
     # to update different infos from `/beneficiaries/current`.
-    if not user.UserOfferers and not user.isAdmin:
+    if not user.has_pro_role and not user.has_admin_role:
         abort(400)
     attributes = body.dict()
     users_api.update_user_info(user, **attributes)

--- a/api/tests/routes/pro/patch_user_test.py
+++ b/api/tests/routes/pro/patch_user_test.py
@@ -1,7 +1,6 @@
 from pydantic import ValidationError
 import pytest
 
-import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.users.models import User
 from pcapi.routes.serialization.users import PatchProUserBodyModel
@@ -11,7 +10,7 @@ from tests.conftest import TestClient
 
 @pytest.mark.usefixtures("db_session")
 def test_patch_user(app):
-    pro = offers_factories.UserOffererFactory().user
+    pro = users_factories.ProFactory()
     data = {"firstName": "John", "lastName": "Doe", "email": "new@example.com", "phoneNumber": "09 99 99 99 99"}
 
     client = TestClient(app.test_client()).with_session_auth(email=pro.email)
@@ -47,7 +46,7 @@ def test_reject_beneficiary(app):
 
 @pytest.mark.usefixtures("db_session")
 def test_forbid_some_attributes(app):
-    pro = offers_factories.UserOffererFactory().user
+    pro = users_factories.ProFactory()
     # It's tedious to test all attributes. We focus on the most sensitive ones.
     forbidden_attributes = {
         "isAdmin": True,


### PR DESCRIPTION
It's clearer than looking for the presence of `UserOfferer` objects.
The downside is that only *validated* pro users will be able to change
their profile... but it's actually safer.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11929