### PR TITLE
(PC-11669) Create tokens with constant values if we are running performance tests

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -148,7 +148,11 @@ def generate_and_save_token(
     assert token_type.name in TokenType.__members__, "Only registered token types are allowed"
 
     expiration_date = datetime.now() + life_time if life_time else None
-    token_value = token_value or secrets.token_urlsafe(32)
+
+    if settings.IS_PERFORMANCE_TESTS:
+        token_value = f"performance-tests_{token_type.value}_{user.id}"
+    else:
+        token_value = token_value or secrets.token_urlsafe(32)
 
     token = Token(user=user, value=token_value, type=token_type, expirationDate=expiration_date)
     repository.save(token)

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -20,6 +20,8 @@ IS_STAGING = ENV == "staging"
 IS_PROD = ENV == "production"
 IS_TESTING = ENV == "testing"
 IS_RUNNING_TESTS = os.environ.get("RUN_ENV") == "tests"
+IS_PERFORMANCE_TESTS = bool(os.environ.get("IS_PERFORMANCE_TESTS", False))
+assert not (IS_PROD and IS_PERFORMANCE_TESTS)
 
 # Load configuration files
 env_path = Path(f"./.env.{ENV}")

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -480,6 +480,10 @@ class AccountCreationTest:
         assert len(push_testing.requests) == 1
         assert len(users_testing.sendinblue_requests) == 1
 
+        email_validation_token = Token.query.filter_by(user=user, type=TokenType.EMAIL_VALIDATION).one_or_none()
+        assert email_validation_token is not None
+        assert "performance-tests" not in email_validation_token.value
+
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
     def test_account_creation_with_existing_email_sends_email(self, mocked_check_recaptcha_token_is_valid, app):
         test_client = TestClient(app.test_client())
@@ -593,6 +597,27 @@ class AccountCreationTest:
 
         response = test_client.post("/native/v1/account", json=data)
         assert response.status_code == expected
+
+    @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
+    @override_settings(IS_PERFORMANCE_TESTS=True)
+    def test_account_creation_performance_tests(self, mocked_check_recaptcha_token_is_valid, client):
+        assert User.query.first() is None
+        data = {
+            "email": "John.doe@example.com",
+            "password": "Aazflrifaoi6@",
+            "birthdate": "1960-12-31",
+            "firstName": "John",
+            "lastName": "Doe",
+            "notifications": True,
+            "token": "gnagna",
+            "marketingEmailSubscription": True,
+        }
+
+        response = client.post("/native/v1/account", json=data)
+        assert response.status_code == 204, response.json
+
+        user = User.query.first()
+        assert Token.query.filter_by(user=user).first().value == f"performance-tests_email-validation_{user.id}"
 
 
 class UserProfileUpdateTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11669


## But de la pull request

Pour les tests de performance, les ops ne peuvent pas récupérer les token envoyés par email. 
On met donc en dur le nom du token créer.
Il y a une contrainte d'unicité sur Token.value. C'est pour cela qu'on spécifie le type de token créé et l'id de l'utilisateur dans le Token.value.
J'ai prévenu les ops qu'il ne faudra pas appeler ces routes plusieurs fois...

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
