### PR TITLE
(PC-11937) fix:[Sendinblue] remove params from body if it is empty

### DIFF
--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -14,7 +14,6 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
     to = [{"email": email} for email in payload.recipients]
     sender = {"email": settings.SUPPORT_EMAIL_ADDRESS, "name": "pass Culture"}
     template_id = payload.template_id
-    params = payload.params
     tags = payload.tags
 
     configuration = sib_api_v3_sdk.Configuration()
@@ -22,8 +21,10 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
     api_instance = sib_api_v3_sdk.TransactionalEmailsApi(sib_api_v3_sdk.ApiClient(configuration))
 
     send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(
-        to=to, sender=sender, reply_to=sender, template_id=template_id, params=params, tags=tags
+        to=to, sender=sender, reply_to=sender, template_id=template_id, tags=tags
     )
+    if payload.params:  # params cannot be an empty dict in the API
+        send_smtp_email.params = payload.params
 
     try:
         api_instance.send_transac_email(send_smtp_email)

--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -30,7 +30,12 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
         api_instance.send_transac_email(send_smtp_email)
         return True
     except ApiException as e:
-        logger.error("Exception when calling SMTPApi->send_transac_email: %s\n", e)
+        logger.error(
+            "Exception when calling SMTPApi->send_transac_email (status=%s): %s\n",
+            e.status,
+            e,
+            extra={"status": e.status, "template_id": payload.template_id, "recipients": payload.recipients},
+        )
         return False
     except Exception as e:  # pylint: disable=broad-except
         logger.error("Unknown exception occurred when calling SMTPApi->send_transac_email: %s\n", e)

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -32,4 +32,4 @@ class TransactionalEmail(Enum):
 @dataclasses.dataclass
 class SendinblueTransactionalEmailData:
     template: Template
-    params: dict
+    params: dict = dataclasses.field(default_factory=dict)

--- a/api/src/pcapi/core/mails/transactional/users/email_duplicate_pre_subscription_rejected.py
+++ b/api/src/pcapi/core/mails/transactional/users/email_duplicate_pre_subscription_rejected.py
@@ -26,8 +26,7 @@ def get_duplicate_beneficiary_pre_subscription_rejected_data() -> Union[dict, Se
         }
 
     return SendinblueTransactionalEmailData(
-        template=TransactionalEmail.EMAIL_DUPLICATE_BENEFICIARY_PRE_SUBCRIPTION_REJECTED.value,
-        params={},
+        template=TransactionalEmail.EMAIL_DUPLICATE_BENEFICIARY_PRE_SUBCRIPTION_REJECTED.value
     )
 
 

--- a/api/src/pcapi/core/mails/transactional/users/fraud_suspicion_email.py
+++ b/api/src/pcapi/core/mails/transactional/users/fraud_suspicion_email.py
@@ -15,7 +15,7 @@ def make_fraud_suspicion_data() -> Union[dict, SendinblueTransactionalEmailData]
             "Mj-campaign": "dossier-en-analyse",
         }
 
-    return SendinblueTransactionalEmailData(template=TransactionalEmail.FRAUD_SUSPICION.value, params={})
+    return SendinblueTransactionalEmailData(template=TransactionalEmail.FRAUD_SUSPICION.value)
 
 
 def send_fraud_suspicion_email(

--- a/api/tests/core/mails/transactional/test_send_fraud_suspicion_email.py
+++ b/api/tests/core/mails/transactional/test_send_fraud_suspicion_email.py
@@ -12,8 +12,8 @@ class FraudSuspicionEmailTest:
 
         assert mails_testing.outbox[0].sent_data == {
             "template": {"id_prod": 82, "id_not_prod": 24, "tags": ["jeunes_compte_en_cours_d_analyse"]},
-            "params": {},
             "To": beneficiary_pre_subscription.email,
+            "params": {},
         }
 
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)

--- a/api/tests/core/mails/transactional/test_send_transactional_email.py
+++ b/api/tests/core/mails/transactional/test_send_transactional_email.py
@@ -17,7 +17,7 @@ class BeneficiaryTransactionalEmailsTest:
         side_effect=ApiException(),
     )
     def test_send_transactional_email_expect_api_error(self, caplog):
-        payload = SendTransactionalEmailRequest(recipients=[], template_id=1, params={}, tags=[])
+        payload = SendTransactionalEmailRequest(recipients=[], params={}, template_id=1, tags=[])
         assert not send_transactional_email(payload)
         assert caplog.messages[0].startswith("Exception when calling SMTPApi->send_transac_email:")
 
@@ -40,7 +40,28 @@ class BeneficiaryTransactionalEmailsTest:
         assert mock_send_transac_email.call_args[0][0].params == {"name": "Avery"}
         assert mock_send_transac_email.call_args[0][0].template_id == TransactionalEmail.EMAIL_CONFIRMATION.value.id
         assert mock_send_transac_email.call_args[0][0].to == [{"email": "avery.kelly@woobmail.com"}]
-        assert mock_send_transac_email.call_args[0][0].tags == None
+        assert mock_send_transac_email.call_args[0][0].tags is None
+
+    @patch(
+        "pcapi.core.mails.transactional.send_transactional_email.sib_api_v3_sdk.api.TransactionalEmailsApi.send_transac_email"
+    )
+    def test_send_transactional_email_success_empty_params(self, mock_send_transac_email):
+        payload = SendTransactionalEmailRequest(
+            recipients=["avery.kelly@woobmail.com"],
+            template_id=TransactionalEmail.EMAIL_CONFIRMATION.value.id,
+            params={},
+        )
+        send_transactional_email(payload)
+
+        mock_send_transac_email.assert_called_once()
+        assert mock_send_transac_email.call_args[0][0].sender == {
+            "email": "support@example.com",
+            "name": "pass Culture",
+        }
+        assert mock_send_transac_email.call_args[0][0].params is None
+        assert mock_send_transac_email.call_args[0][0].template_id == TransactionalEmail.EMAIL_CONFIRMATION.value.id
+        assert mock_send_transac_email.call_args[0][0].to == [{"email": "avery.kelly@woobmail.com"}]
+        assert mock_send_transac_email.call_args[0][0].tags is None
 
     @override_settings(EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11937


## But de la pull request

Fixer https://sentry.internal-passculture.app/organizations/sentry/issues/235050/?referrer=jira_integration

##  Implémentation

- Sendinblue n'accepte pas `"params: {}` dans le body d'une requete pour envoyer un email
- On retire le champs à la place de le laisser vide
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
