### PR TITLE
First state machine implementation using transitions

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -71,6 +71,7 @@ spectree==0.3.15
 SQLAlchemy==1.3.*
 # FIXME (xordoquy, 2021-08-16): current apscheduler version (3.6.3)
 # does not work with tzlocal 3+.
+transitions
 tzlocal<3.0.0
 weasyprint
 Werkzeug==1.0.1


### PR DESCRIPTION
Tentative d'implementation de machine a état sur le modele utilisateur
en utilisant le module transitions

Exemple de l' API:

```
In [1]: user = User.query.get(137)                                                                                                                                                                                                            

In [2]: user                                                                                                                                                                                                                                  
Out[2]: <User #137/RE>

In [3]: user.machine                                                                                                                                                                                                                          
Out[3]: <transitions.core.Machine at 0x109c915e0>

In [4]: user.subscriptionState                                                                                                                                                                                                                
Out[4]: <SubscriptionState.EMAIL_VALIDATED: 'email_validated'>

In [5]: user.validate_phone()                                                                                                                                                                                                                 
INFO:transitions.core:Finished processing state EMAIL_VALIDATED exit callbacks.
INFO:transitions.core:Finished processing state PHONE_VALIDATED enter callbacks.
Out[5]: True

In [6]: db.session.add(user)                                                                                                                                                                                                                  

In [7]: db.session.commit()                                                                                                                                                                                                                   

In [8]: user = User.query.get(137)                                                                                                                                                                                                            

In [10]: user.subscriptionState                                                                                                                                                                                                               
Out[10]: <SubscriptionState.PHONE_VALIDATED: 'phone_validated'>
```

## But de la pull request

Présenter une Idée d'implémentation d'une machine a état pour valider un workflow


##  Implémentation
- Modification du modele User et initialiser la machine a état depuis l'état "subscriptionState"