### PR TITLE
[API] (PC-11753) feat:account: token expiration date

### DIFF
--- a/api/src/pcapi/core/users/email/__init__.py
+++ b/api/src/pcapi/core/users/email/__init__.py
@@ -1,3 +1,4 @@
 from .send import send_user_emails_for_email_change  # noqa: F401
 from .update import generate_token_expiration_date  # noqa: F401
+from .update import get_active_token_expiration  # noqa: F401
 from .update import request_email_update  # noqa: F401

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -128,6 +128,13 @@ def validate_user_email(body: beneficiaries_serialization.ChangeBeneficiaryEmail
         pass
 
 
+@blueprint.native_v1.route("/profile/token_expiration", methods=["GET"])
+@spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.UpdateEmailTokenExpiration)
+@authenticated_user_required
+def get_email_update_token_expiration_date(user: User) -> serializers.UpdateEmailTokenExpiration:
+    return serializers.UpdateEmailTokenExpiration(expiration=email_api.get_active_token_expiration(user))
+
+
 @blueprint.native_v1.route("/beneficiary_information", methods=["PATCH"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_user_required

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -280,6 +280,10 @@ class ValidateEmailRequest(BaseModel):
     token: str
 
 
+class UpdateEmailTokenExpiration(BaseModel):
+    expiration: Optional[datetime.datetime]
+
+
 class BeneficiaryInformationUpdateRequest(BaseModel):
     activity: ActivityEnum
     address: Optional[str]

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -31,6 +31,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import testing as users_testing
 from pcapi.core.users.api import create_phone_validation_token
 from pcapi.core.users.constants import SuspensionReason
+from pcapi.core.users.email import update as email_update
 from pcapi.core.users.factories import BeneficiaryImportFactory
 from pcapi.core.users.factories import TokenFactory
 from pcapi.core.users.models import EligibilityType
@@ -878,6 +879,42 @@ class ValidateEmailTest:
         )
 
         return client.with_token(email).put("/native/v1/profile/validate_email", json={"token": token})
+
+
+class GetTokenExpirationTest:
+    email = "some@email.com"
+
+    def test_token_expiration(self, app, client):
+        """
+        Setup the active token key with a TTL. Then test that the route
+        returns the expected expiration datetime, with a little error
+        margin: datetimes and redis commands do not have the same time
+        precision (ms vs s) which causes some little difference when
+        deserializing the redis ttl. Note that we absolutely don't need
+        a ms precision here.
+        """
+        user = users_factories.UserFactory(email=self.email)
+
+        expiration_date = datetime.now() + timedelta(hours=15)
+        key = email_update.get_no_active_token_key(user)
+
+        app.redis_client.incr(key)
+        app.redis_client.expireat(key, expiration_date)
+
+        response = client.with_token(user.email).get("/native/v1/profile/token_expiration")
+        assert response.status_code == 200
+
+        expiration = datetime.fromisoformat(response.json["expiration"])
+        delta = abs(expiration - expiration_date)
+        assert delta < timedelta(seconds=2)
+
+    def test_no_token(self, app, client):
+        user = users_factories.UserFactory(email=self.email)
+
+        response = client.with_token(user.email).get("/native/v1/profile/token_expiration")
+
+        assert response.status_code == 200
+        assert response.json["expiration"] is None
 
 
 class CulturalSurveyTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11753


## But de la pull request

Permettre au client natif de connaître la date d'expiration du token utilisé pour le changement d'email (ajouté récemment via [cette PR](https://github.com/pass-culture/pass-culture-main/pull/468)). S'il n'y a aucun token actif au moment de la requête. La date d'expiration est `None`.

Le besoin côté client natif est le suivant : si l'utilisateur n'a pas cliqué sur le lien d'activation et qu'il commence à nouveau le parcours de modification d'email, on aimerait lui indiquer si un lien d'activation (avec un token actif) existe pour l'inciter à vérifier ses emails.