### PR TITLE
(PC-11219) Do not update hasCompletedIdCheck on has_completed_id_check route

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -207,9 +207,8 @@ def create_account(body: serializers.AccountRequest) -> None:
 @spectree_serialize(api=blueprint.api, on_success_status=204)
 @authenticated_user_required
 def has_completed_id_check(user: User) -> None:
-    user.hasCompletedIdCheck = True
-    repository.save(user)
-    update_external_user(user)
+    # TODO(viconnex) remove route when frontend stops calling it
+    return
 
 
 @blueprint.native_v1.route("/resend_email_validation", methods=["POST"])


### PR DESCRIPTION
This route was created to prevent the user from re-entering the id-check process. But since then, a lot of patches have bee n added. Now the field is updated both in /beneficiary_information route and on jouve callback. So when the frontend calls the has_completed_id_check_ route we already had the information. And when we activate the beneficiary, we reset the field to false. So we dont want it to be re-updated afterwards

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX


## But de la pull request

(Ajout de fonctionnalités, Problèmes résolus, etc)

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
