### PR TITLE
(PC-11892) improve bookings csv response time

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -48,7 +48,6 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.models.payment import Payment
 from pcapi.models.payment_status import TransactionStatus
 from pcapi.utils.date import get_department_timezone
-from pcapi.utils.db import get_batches
 from pcapi.utils.token import random_token
 
 
@@ -813,8 +812,8 @@ def _serialize_csv_report(query: Query) -> str:
             "Date et heure de remboursement",
         )
     )
-    for batch in get_batches(query, Booking.id, 1000):
-        rows = [
+    for booking in query.yield_per(1000):
+        writer.writerow(
             (
                 booking.venueName,
                 booking.offerName,
@@ -830,8 +829,6 @@ def _serialize_csv_report(query: Query) -> str:
                 BOOKING_STATUS_LABELS[booking.status],
                 _serialize_date_with_timezone(booking.reimbursedAt, booking),
             )
-            for booking in batch
-        ]
-        writer.writerows(rows)
+        )
 
     return output.getvalue()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11892


## But de la pull request

Amélioration des temps de réponse de l'export CSV.
Dans le cas d'usage pointé par le ticket Jira on a:
Avant: Elapsed time: 121.7035 seconds
Après: Elapsed time: 0.1169 seconds

##  Implémentation

- Use PostgresQL's cursor - through SQLAlchemy's `yield_by` - instead of home made pagination.
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
