### PR TITLE
(PC-11794)(WebApp) amélioration du wording de redirection v1 vers v2

### DIFF
--- a/webapp/scripts/build_redirects.js
+++ b/webapp/scripts/build_redirects.js
@@ -27,7 +27,7 @@ require('../config/env')
 
 function createRedirectFile() {
   try {
-    const disableV1ToV2Redirect = JSON.parse(process.env.DISABLE_V1_TO_V2_REDIRECT || 'false')
+    const disableV1ToV2Redirect = JSON.parse(process.env.DISABLE_V1_TO_V2_REDIRECT)
 
     console.log(
       `Building redirects for ${process.env.NODE_ENV}`,

--- a/webapp/src/components/layout/Details/Details.jsx
+++ b/webapp/src/components/layout/Details/Details.jsx
@@ -69,7 +69,7 @@ class Details extends PureComponent {
           trackV1toV2OfferRedirect({ url: offerV2Url, offerId: dehumanizedOfferId })
           this.v2Redirect(
             offerV2Url,
-            `Ce lien n'est plus à jour, tu vas être redirigé vers le nouveau site du pass Culture, pense à mettre à jour tes favoris.`,
+            `Le pass Culture fait peau neuve. Rendez-vous sur ${WEBAPP_V2_URL}. Pense à mettre à jour tes favoris !`,
             isInstantRedirect
           )
         }
@@ -81,7 +81,7 @@ class Details extends PureComponent {
           })
           this.v2Redirect(
             WEBAPP_V2_URL,
-            `Ce lien n'est plus à jour, tu vas être redirigé vers le nouveau site du pass Culture.`,
+            `Le pass Culture fait peau neuve. Rendez-vous sur ${WEBAPP_V2_URL}. Pense à mettre à jour tes favoris !`,
             isInstantRedirect
           )
         }

--- a/webapp/src/components/layout/Details/__specs__/Details.spec.jsx
+++ b/webapp/src/components/layout/Details/__specs__/Details.spec.jsx
@@ -95,7 +95,7 @@ describe('src | components | Details', () => {
       expect(trackV1toV2OfferRedirect).not.toHaveBeenCalledTimes(1)
       jest.advanceTimersByTime(10000)
       expect(toast.error).toHaveBeenCalledWith(
-        "Ce lien n'est plus à jour, tu vas être redirigé vers le nouveau site du pass Culture."
+        `Le pass Culture fait peau neuve. Rendez-vous sur ${process.env.WEBAPP_V2_URL}. Pense à mettre à jour tes favoris !`
       )
       expect(replace).toHaveBeenCalledWith(process.env.WEBAPP_V2_URL)
     })
@@ -127,7 +127,7 @@ describe('src | components | Details', () => {
       expect(trackV1toV2OfferRedirect).not.toHaveBeenCalledTimes(1)
       jest.advanceTimersByTime(10000)
       expect(toast.error).toHaveBeenCalledWith(
-        "Ce lien n'est plus à jour, tu vas être redirigé vers le nouveau site du pass Culture."
+        `Le pass Culture fait peau neuve. Rendez-vous sur ${process.env.WEBAPP_V2_URL}. Pense à mettre à jour tes favoris !`
       )
       expect(replace).toHaveBeenCalledWith(process.env.WEBAPP_V2_URL)
     })
@@ -159,7 +159,7 @@ describe('src | components | Details', () => {
       expect(trackV1toV2HomeRedirect).not.toHaveBeenCalledTimes(1)
       jest.advanceTimersByTime(10000)
       expect(toast.error).toHaveBeenCalledWith(
-        "Ce lien n'est plus à jour, tu vas être redirigé vers le nouveau site du pass Culture, pense à mettre à jour tes favoris."
+        `Le pass Culture fait peau neuve. Rendez-vous sur ${process.env.WEBAPP_V2_URL}. Pense à mettre à jour tes favoris !`
       )
       expect(replace).toHaveBeenCalledWith(`${process.env.WEBAPP_V2_URL}/offre/3183`)
     })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11794


## But de la pull request

amélioration du wording de redirection v1 vers v2

##  Implémentation

- amélioration du wording de redirection v1 vers v2
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
