### PR TITLE
(PC-11784)(PRO): Fix classname for new refund section to prevent css override

### DIFF
--- a/pro/src/components/pages/Reimbursements/Reimbursement.scss
+++ b/pro/src/components/pages/Reimbursements/Reimbursement.scss
@@ -15,7 +15,7 @@
   * @debt duplicated "Gaël : duplicated styles for reset filters (in ...pages/Offers/Offers.scss), + we already have a tertiary-button class that is very close... we should create a component for this and standardise a behavior"
   */
 
-  .section-nav {
+  .refund-section-nav {
     @include button();
 
     background: none;
@@ -41,7 +41,7 @@
     }
   }
 
-  .section {
+  .refund-section {
     display: none;
 
     &.is-active {

--- a/pro/src/components/pages/Reimbursements/ReimbursementsWithFilters.jsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsWithFilters.jsx
@@ -120,7 +120,7 @@ const Reimbursements = ({ currentUser }) => {
                 <button
                   aria-controls="refund-proof"
                   aria-selected={isRefundProofActive}
-                  className={`section-nav ${
+                  className={`refund-section-nav ${
                     isRefundProofActive ? 'is-active' : ''
                   }`}
                   id="refund-proof-nav"
@@ -133,7 +133,7 @@ const Reimbursements = ({ currentUser }) => {
                 <button
                   aria-controls="refund-details"
                   aria-selected={isRefundDetailsActive}
-                  className={`section-nav ${
+                  className={`refund-section-nav ${
                     isRefundDetailsActive ? 'is-active' : ''
                   }`}
                   id="refund-details-nav"
@@ -147,7 +147,9 @@ const Reimbursements = ({ currentUser }) => {
               <div
                 aria-hidden={!isRefundProofActive}
                 aria-labelledby="refund-proof"
-                className={`section ${isRefundProofActive ? 'is-active' : ''}`}
+                className={`refund-section ${
+                  isRefundProofActive ? 'is-active' : ''
+                }`}
                 id="refund-proof"
                 role="tabpanel"
               >
@@ -159,7 +161,7 @@ const Reimbursements = ({ currentUser }) => {
               </div>
               <div
                 aria-hidden={!isRefundDetailsActive}
-                className={`section ${
+                className={`refund-section ${
                   isRefundDetailsActive ? 'is-active' : ''
                 }`}
                 id="refund-details"


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11784


## But de la pull request

Fix du titre Remboursements disparu après le merge de la première PR liée à ce ticket dû à dès règles CSS se chevauchant.

