### PR TITLE
config.webpack dev: do not fail on linter error

### DIFF
--- a/pro/config/webpack.config.js
+++ b/pro/config/webpack.config.js
@@ -394,7 +394,7 @@ module.exports = function (webpackEnv) {
 
                 plugins: [
                   [
-                    require.resolve('babel-plugin-typescript-to-proptypes'), 
+                    require.resolve('babel-plugin-typescript-to-proptypes'),
                     { implicitChildren: true }
                   ],
                   [
@@ -680,6 +680,8 @@ module.exports = function (webpackEnv) {
         eslintPath: require.resolve('eslint'),
         context: paths.appSrc,
         cache: true,
+        failOnError: !isEnvDevelopment,
+        failOnWarning: !isEnvDevelopment,
         cacheLocation: path.resolve(paths.appNodeModules, '.cache', '.eslintcache'),
         // ESLint class options
         cwd: paths.appPath,


### PR DESCRIPTION
Depuis peu les changements de configuration du projet on fait passer le build webpack en failure quand eslint lève une erreur.
Ici on conserve l'affichage des erreurs du linter sans bloquer le rendu du site.