### PR TITLE
[PC-11985][API] Improve search performance on pro's offer page

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-91827317eb25 (head)
+3cb2b2fb88d3 (head)

--- a/api/src/pcapi/alembic/versions/20211125T162121_c86504df1384_create_index_on_offer_s_isbn.py
+++ b/api/src/pcapi/alembic/versions/20211125T162121_c86504df1384_create_index_on_offer_s_isbn.py
@@ -1,0 +1,24 @@
+"""Create index on offer's ISBN
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "c86504df1384"
+down_revision = "91827317eb25"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    # Since the index is quite long to create, we'll create it manually.
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS offer_expr_idx ON offer (("extraData" ->> 'isbn'::text))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("offer_expr_idx"), table_name="offer")

--- a/api/src/pcapi/alembic/versions/20211125T180047_3cb2b2fb88d3_create_index_on_product_s_isbn.py
+++ b/api/src/pcapi/alembic/versions/20211125T180047_3cb2b2fb88d3_create_index_on_product_s_isbn.py
@@ -1,0 +1,23 @@
+"""Create index on product's ISBN
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3cb2b2fb88d3"
+down_revision = "c86504df1384"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS product_expr_idx ON product (("extraData" ->> 'isbn'::text))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("product_expr_idx"), table_name="product")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -354,6 +354,8 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ProvidableMixin):
     #  can be used by PostgreSQL when filtering on the `venueId` column only.
     Index("venueId_idAtProvider_index", venueId, idAtProvider, unique=True)
 
+    Index("offer_expr_idx", ExtraDataMixin.extraData["isbn"].astext)
+
     @hybrid_property
     def isSoldOut(self):
         for stock in self.stocks:

--- a/api/src/pcapi/models/product.py
+++ b/api/src/pcapi/models/product.py
@@ -4,6 +4,7 @@ from sqlalchemy import BigInteger
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
+from sqlalchemy import Index
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
@@ -61,6 +62,8 @@ class Product(PcObject, Model, ExtraDataMixin, HasThumbMixin, ProvidableMixin):
     subcategoryId = Column(Text, nullable=False, index=True)
 
     thumb_path_component = "products"
+
+    Index("product_expr_idx", ExtraDataMixin.extraData["isbn"].astext)
 
     @property
     def subcategory(self) -> subcategories.Subcategory:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11985


## But de la pull request

(Ajout de fonctionnalités, Problèmes résolus, etc)

##  Implémentation

1. A missing index on `extraData -> isbn` forced the query to scan
the entire table which takes too much time.
2. searching for the name OR the ibsn made Postgres scan the
table instead of using the indexes. By using an union instead
of a OR condition, Postgres can spawn two worker to search against
the indexes and then create the result set.​

Un recherche via get_capped_offers_for_filters sur l'ISBN `9782075144292` avec un admin donne:
- ancienne méthode: coupée à 60 minutes
- nouvelle méthode: 0.7638 seconds (1.2391s avec la serialization)

## Checklist :


- [ ] Voir pourquoi l'index n'est pas détecté par Alembic (Django, tu me manques).
- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
