### PR TITLE
(PC-11783) api: First name and last name with Ubble moved later in account process

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -172,8 +172,6 @@ def create_account(
     email: str,
     password: str,
     birthdate: date,
-    first_name: Optional[str] = None,
-    last_name: Optional[str] = None,
     marketing_email_subscription: bool = False,
     is_email_validated: bool = False,
     send_activation_mail: bool = True,
@@ -193,8 +191,6 @@ def create_account(
         email=email,
         dateOfBirth=datetime.combine(birthdate, datetime.min.time()),
         isEmailValidated=is_email_validated,
-        firstName=first_name,
-        lastName=last_name,
         publicName=VOID_PUBLIC_NAME,  # Required because model validation requires 3+ chars
         hasSeenTutorials=False,
         notificationSubscriptions=asdict(NotificationSubscriptions(marketing_email=marketing_email_subscription)),
@@ -274,7 +270,14 @@ def validate_phone_number_and_activate_user(user: User, code: str) -> User:
 
 
 def update_beneficiary_mandatory_information(
-    user: User, address: str, city: str, postal_code: str, activity: str, phone_number: Optional[str] = None
+    user: User,
+    address: str,
+    city: str,
+    postal_code: str,
+    activity: str,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
+    phone_number: Optional[str] = None,
 ) -> None:
     user_initial_roles = user.roles
 
@@ -286,6 +289,13 @@ def update_beneficiary_mandatory_information(
         "activity": activity,
         "hasCompletedIdCheck": True,
     }
+
+    if first_name:
+        update_payload["firstName"] = first_name
+
+    if last_name:
+        update_payload["lastName"] = last_name
+
     if not FeatureToggle.ENABLE_PHONE_VALIDATION.is_active() and not user.phoneNumber and phone_number:
         update_payload["phoneNumber"] = phone_number
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -141,6 +141,8 @@ def get_email_update_token_expiration_date(user: User) -> serializers.UpdateEmai
 def update_beneficiary_mandatory_information(user: User, body: serializers.BeneficiaryInformationUpdateRequest) -> None:
     api.update_beneficiary_mandatory_information(
         user=user,
+        first_name=body.first_name,
+        last_name=body.last_name,
         address=body.address,
         city=body.city,
         postal_code=body.postal_code,
@@ -181,8 +183,6 @@ def create_account(body: serializers.AccountRequest) -> None:
             email=body.email,
             password=body.password,
             birthdate=body.birthdate,
-            first_name=body.first_name,
-            last_name=body.last_name,
             marketing_email_subscription=body.marketing_email_subscription,
             is_email_validated=False,
             postal_code=body.postal_code,

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -440,8 +440,6 @@ class AccountCreationTest:
             "email": "John.doe@example.com",
             "password": "Aazflrifaoi6@",
             "birthdate": "1960-12-31",
-            "firstName": "John",
-            "lastName": "Doe",
             "notifications": True,
             "token": "gnagna",
             "marketingEmailSubscription": True,
@@ -453,8 +451,6 @@ class AccountCreationTest:
         user = User.query.first()
         assert user is not None
         assert user.email == "john.doe@example.com"
-        assert user.firstName == "John"
-        assert user.lastName == "Doe"
         assert user.get_notification_subscriptions().marketing_email
         assert user.isEmailValidated is False
         mocked_check_recaptcha_token_is_valid.assert_called()
@@ -531,55 +527,6 @@ class AccountCreationTest:
         response = test_client.post("/native/v1/account", json=data)
         assert response.status_code == 400
         assert push_testing.requests == []
-
-    @override_features(**{FeatureToggle.ENABLE_UBBLE.name: True})
-    @pytest.mark.parametrize("age", [15, 16, 17, 18])
-    @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
-    def test_account_creation_enable_ubble_eligible(self, mocked_check_recaptcha_token_is_valid, age, app):
-        date_of_birth = date.today() - relativedelta(years=age, months=6)
-        assert FeatureToggle.ENABLE_UBBLE.is_active()
-        test_client = TestClient(app.test_client())
-        assert User.query.first() is None
-        data = {
-            "email": "John.doe@example.com",
-            "password": "Aazflrifaoi6@",
-            "birthdate": date_of_birth.isoformat(),
-            "firstName": "John",
-            "lastName": "Doe",
-            "notifications": True,
-            "token": "gnagna",
-            "marketingEmailSubscription": True,
-        }
-
-        response = test_client.post("/native/v1/account", json=data)
-        assert response.status_code == 204
-
-    @override_features(**{FeatureToggle.ENABLE_UBBLE.name: True})
-    @pytest.mark.parametrize("age,expected", [(15, 400), (16, 400), (17, 400), (18, 400), (19, 204), (20, 204)])
-    @pytest.mark.parametrize("missing_value", [None, ""])
-    @pytest.mark.parametrize("missing_key", ["firstName", "lastName"])
-    @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
-    def test_account_creation_enable_ubble_name_missing(
-        self, mocked_check_recaptcha_token_is_valid, missing_key, missing_value, age, expected, app
-    ):
-        date_of_birth = date.today() - relativedelta(years=age, months=6)
-        assert FeatureToggle.ENABLE_UBBLE.is_active()
-        test_client = TestClient(app.test_client())
-        assert User.query.first() is None
-        data = {
-            "email": "John.doe@example.com",
-            "password": "Aazflrifaoi6@",
-            "birthdate": date_of_birth.isoformat(),
-            "firstName": "John",
-            "lastName": "Doe",
-            "notifications": True,
-            "token": "gnagna",
-            "marketingEmailSubscription": True,
-        }
-        data[missing_key] = missing_value
-
-        response = test_client.post("/native/v1/account", json=data)
-        assert response.status_code == expected
 
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
     @override_settings(IS_PERFORMANCE_TESTS=True)
@@ -1686,6 +1633,8 @@ class UpdateBeneficiaryInformationTest:
         test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
 
         profile_data = {
+            "firstName": "John",
+            "lastName": "Doe",
             "address": "1 rue des rues",
             "city": "Uneville",
             "postalCode": "77000",
@@ -1697,6 +1646,8 @@ class UpdateBeneficiaryInformationTest:
         assert response.status_code == 204
 
         user = User.query.get(user.id)
+        assert user.firstName == "John"
+        assert user.lastName == "Doe"
         assert user.address == "1 rue des rues"
         assert user.city == "Uneville"
         assert user.postalCode == "77000"
@@ -1864,6 +1815,88 @@ class UpdateBeneficiaryInformationTest:
         assert user.deposit.amount == 20
 
         assert len(push_testing.requests) == 1
+
+    @override_features(ENABLE_UBBLE=True)
+    @pytest.mark.parametrize("age", [15, 16, 17, 18])
+    def test_update_beneficiary_underage_ubble_eligible(self, age, client, app):
+        """
+        Test that valid request:
+            * updates the user's id check profile information;
+            * sets the user to beneficiary;
+            * send a request to Batch to update the user's information
+        """
+        assert FeatureToggle.ENABLE_UBBLE.is_active()
+
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
+            phoneNumber="+33609080706",
+            dateOfBirth=date.today() - relativedelta(years=age, months=6),
+        )
+
+        profile_data = {
+            "firstName": "John",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activity": "Lycéen",
+        }
+
+        client.with_token(user.email)
+        response = client.patch("/native/v1/beneficiary_information", profile_data)
+
+        assert response.status_code == 204
+
+        user = User.query.get(user.id)
+        assert user.firstName == "John"
+        assert user.lastName == "Doe"
+        assert user.address == "1 rue des rues"
+        assert user.city == "Uneville"
+        assert user.postalCode == "77000"
+        assert user.activity == "Lycéen"
+        assert user.phoneNumber == "+33609080706"
+
+    @override_features(ENABLE_UBBLE=True)
+    @pytest.mark.parametrize("age", [15, 16, 17, 18])
+    @pytest.mark.parametrize("missing_value", [None, ""])
+    @pytest.mark.parametrize("missing_key", ["firstName", "lastName"])
+    def test_update_beneficiary_underage_ubble_name_missing(self, missing_key, missing_value, age, client, app):
+        """
+        Test that valid request:
+            * updates the user's id check profile information;
+            * sets the user to beneficiary;
+            * send a request to Batch to update the user's information
+        """
+        assert FeatureToggle.ENABLE_UBBLE.is_active()
+
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
+            phoneNumber="+33609080706",
+            dateOfBirth=date.today() - relativedelta(years=age, months=6),
+        )
+
+        profile_data = {
+            "firstName": "John",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activity": "Lycéen",
+        }
+        profile_data[missing_key] = missing_value
+
+        client.with_token(user.email)
+        response = client.patch("/native/v1/beneficiary_information", profile_data)
+
+        assert response.status_code == 400
 
 
 class ProfilingFraudScoreTest:


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11783


## But de la pull request

Déplacement de la demande des prénom et nom du jeune bénéficiaire plus tard dans le parcours d'inscription.

- `first_name` et `last_name` ne sont plus demandés à la création du compte dans la route `/account`
- on les demande par contre dans la route `/beneficiary_information`
- ni le prénom ni le nom n’est obligatoire si le FF ENABLE_UBBLE n’est pas activé
- prénom et nom sont tous deux obligatoires si le FF ENABLE_UBBLE est activé ; plus besoin de vérifier l'âge car cet écran sera de base affiché uniquement aux users de 15 à 18 ans

##  Implémentation

##  Informations supplémentaires

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
