### PR TITLE
[API] (PC-11726) feat:account: add new_email to link

### DIFF
--- a/api/src/pcapi/core/users/email/send.py
+++ b/api/src/pcapi/core/users/email/send.py
@@ -13,7 +13,11 @@ def _build_link_for_email_change(current_email: str, new_email: str, expiration_
     expiration = int(expiration_date.timestamp())
 
     path = "changement-email"
-    params = {"token": token, "expiration_timestamp": expiration}
+    params = {
+        "token": token,
+        "expiration_timestamp": expiration,
+        "new_email": new_email,
+    }
 
     return generate_firebase_dynamic_link(path, params)
 

--- a/api/tests/routes/webapp/change_beneficiary_email_test.py
+++ b/api/tests/routes/webapp/change_beneficiary_email_test.py
@@ -22,8 +22,9 @@ class Returns204Test:
     def when_account_is_known(self, app):
         # given
 
+        new_email = "new@email.com"
         user = users_factories.BeneficiaryGrant18Factory(email="test@mail.com")
-        data = {"new_email": "new@email.com", "password": users_factories.DEFAULT_PASSWORD}
+        data = {"new_email": new_email, "password": users_factories.DEFAULT_PASSWORD}
 
         # when
         client = TestClient(app.test_client()).with_session_auth(user.email)
@@ -51,7 +52,9 @@ class Returns204Test:
 
         app_link = (
             f"{settings.WEBAPP_FOR_NATIVE_REDIRECTION}/changement-email?"
-            f"token={confirmation_data_token}&expiration_timestamp=1602838800"
+            f"token={confirmation_data_token}"
+            f"&expiration_timestamp=1602838800"
+            f"&new_email={quote_plus(new_email)}"
         )
 
         confirmation_link = f"{settings.FIREBASE_DYNAMIC_LINKS_URL}/?link={quote_plus(app_link)}"
@@ -60,7 +63,7 @@ class Returns204Test:
             "FromEmail": "support@example.com",
             "MJ-TemplateID": 2066065,
             "MJ-TemplateLanguage": True,
-            "To": "new@email.com",
+            "To": new_email,
             "Vars": {
                 "beneficiary_name": "Jeanne",
                 "confirmation_link": confirmation_link,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11726

## But de la pull request

Ajouter la nouvelle adresse dans l'email d'activation de la nouvelle adresse.
Le but est de permettre au front de récupérer facilement cette information et de l'afficher, surtout en cas d'erreur (par exemple s'il y a besoin de contacter le support).