### PR TITLE
(PC-11763) Redirect parents to error page after educonnect

### DIFF
--- a/api/src/pcapi/core/users/external/educonnect/api.py
+++ b/api/src/pcapi/core/users/external/educonnect/api.py
@@ -109,7 +109,7 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
             ine_hash=educonnect_identity[_get_field_oid("64")][0],
             last_name=educonnect_identity["sn"][0],
             logout_url=educonnect_identity[_get_field_oid("5")][0],
-            person_affiliation=educonnect_identity.get(_get_field_oid("7"), [None])[0],
+            user_type=educonnect_identity.get(_get_field_oid("7"), [None])[0],
             saml_request_id=saml_request_id,
             school=educonnect_identity.get(_get_field_oid("72"), [None])[0],
             student_level=educonnect_identity.get(_get_field_oid("73"), [None])[0],

--- a/api/src/pcapi/core/users/external/educonnect/api.py
+++ b/api/src/pcapi/core/users/external/educonnect/api.py
@@ -100,6 +100,14 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
 
     saml_request_id = authn_response.in_response_to
 
+    user_type = educonnect_identity.get(_get_field_oid("7"), [None])[0]
+
+    if user_type in ["resp1d", "resp2d"]:
+        raise exceptions.UserTypeNotStudent(saml_request_id, user_type)
+
+    if user_type not in ["eleve1d", "eleve2d"]:
+        logger.error("Unknwon user type %s", user_type, extra={"saml_request_id": saml_request_id})
+
     try:
         return models.EduconnectUser(
             birth_date=datetime.strptime(educonnect_identity[_get_field_oid("67")][0], "%Y-%m-%d").date(),
@@ -109,7 +117,7 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
             ine_hash=educonnect_identity[_get_field_oid("64")][0],
             last_name=educonnect_identity["sn"][0],
             logout_url=educonnect_identity[_get_field_oid("5")][0],
-            user_type=educonnect_identity.get(_get_field_oid("7"), [None])[0],
+            user_type=user_type,
             saml_request_id=saml_request_id,
             school=educonnect_identity.get(_get_field_oid("72"), [None])[0],
             student_level=educonnect_identity.get(_get_field_oid("73"), [None])[0],

--- a/api/src/pcapi/core/users/external/educonnect/exceptions.py
+++ b/api/src/pcapi/core/users/external/educonnect/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class EduconnectAuthenticationException(Exception):
     pass
 
@@ -8,3 +11,13 @@ class ResponseTooOld(EduconnectAuthenticationException):
 
 class ParsingError(EduconnectAuthenticationException):
     pass
+
+
+class UserTypeNotStudent(EduconnectAuthenticationException):
+    request_id: str
+    user_type: Optional[str]
+
+    def __init__(self, request_id, user_type, *args: object) -> None:
+        super().__init__(*args)
+        self.request_id = request_id
+        self.user_type = user_type

--- a/api/src/pcapi/core/users/external/educonnect/models.py
+++ b/api/src/pcapi/core/users/external/educonnect/models.py
@@ -12,7 +12,7 @@ class EduconnectUser:
     ine_hash: str
     last_name: str
     logout_url: str
-    person_affiliation: Optional[str]
+    user_type: Optional[str]
     saml_request_id: str
     school: Optional[str]
     student_level: Optional[str]

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -364,7 +364,7 @@ class EduconnectUserFactory(factory.Factory):
     last_name = factory.Faker("last_name")
     first_name = factory.Faker("first_name")
     logout_url = "https://educonnect.education.gouv.fr/Logout"
-    person_affiliation = None
+    user_type = None
     saml_request_id = factory.Faker("lexify", text="id-?????????????????")
     ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
     student_level = "2212"

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -73,7 +73,7 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
             "first_name": educonnect_user.first_name,
             "last_name": educonnect_user.last_name,
             "logout_url": educonnect_user.logout_url,
-            "person_affiliation": educonnect_user.person_affiliation,
+            "user_type": educonnect_user.user_type,
             "saml_request_id": educonnect_user.saml_request_id,
             "school": educonnect_user.school,
             "student_level": educonnect_user.student_level,

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -16,7 +16,6 @@ from pcapi.core.users import models as user_models
 from pcapi.core.users.constants import ELIGIBILITY_AGE_18
 from pcapi.core.users.external.educonnect import api as educonnect_api
 from pcapi.core.users.external.educonnect import exceptions as educonnect_exceptions
-from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.native.security import authenticated_user_required
 
 from . import blueprint
@@ -54,7 +53,7 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
 
     except educonnect_exceptions.ResponseTooOld:
         logger.warning("Educonnect saml_response too old")
-        return redirect(f"{settings.WEBAPP_V2_URL}/idcheck/erreur", code=302)
+        return redirect(ERROR_PAGE_URL, code=302)
 
     except educonnect_exceptions.UserTypeNotStudent as exc:
         logger.info(
@@ -66,12 +65,12 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
 
     except educonnect_exceptions.EduconnectAuthenticationException:
         logger.warning("Educonnect authentication Error")
-        return redirect(f"{settings.WEBAPP_V2_URL}/idcheck/erreur", code=302)
+        return redirect(ERROR_PAGE_URL, code=302)
 
     user_id = _user_id_from_saml_request_id(educonnect_user.saml_request_id)
 
     if user_id is None:
-        raise ApiErrors({"saml_request_id": "user associated to saml_request_id not found"})
+        return redirect(ERROR_PAGE_URL, code=302)
 
     user = user_models.User.query.get(user_id)
 

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -117,7 +117,7 @@ class EduconnectTest:
             "first_name": "Max",
             "last_name": "SENS",
             "logout_url": "https://educonnect.education.gouv.fr/Logout",
-            "person_affiliation": None,
+            "user_type": None,
             "saml_request_id": self.request_id,
             "school": None,
             "student_level": "2212",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11763


## But de la pull request

Educonnect nous envoie une info sur le type d'utilisateur : élève ou représentant légal.

On veut tej les représentants légo.

![image](https://user-images.githubusercontent.com/22373097/143560037-d1c10cb2-2313-4b24-9df1-c0aac9de1e5b.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
