### PR TITLE
[PC-11809][api] : extend cancellation limit date to 15 days prior event for eac bookings

### DIFF
--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -9,7 +9,6 @@ from pcapi.core import mails
 from pcapi.core import search
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.bookings import repository as bookings_repository
-from pcapi.core.bookings.api import compute_cancellation_limit_date
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational import validation
@@ -19,6 +18,7 @@ from pcapi.core.educational.models import EducationalBookingStatus
 from pcapi.core.educational.models import EducationalDeposit
 from pcapi.core.educational.models import EducationalInstitution
 from pcapi.core.educational.models import EducationalRedactor
+from pcapi.core.educational.utils import compute_educational_booking_cancellation_limit_date
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -84,7 +84,9 @@ def book_educational_offer(redactor_informations: RedactorInformation, stock_id:
         )
 
         booking.dateCreated = datetime.utcnow()
-        booking.cancellationLimitDate = compute_cancellation_limit_date(stock.beginningDatetime, booking.dateCreated)
+        booking.cancellationLimitDate = compute_educational_booking_cancellation_limit_date(
+            stock.beginningDatetime, booking.dateCreated
+        )
         stock.dnBookedQuantity += EAC_DEFAULT_BOOKED_QUANTITY
 
         repository.save(booking)

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -1,5 +1,9 @@
 from datetime import datetime
+from datetime import timedelta
 
 
-def compute_cancellation_limit_date_for_educational_booking(event_beginning: datetime, booking_creation: datetime):
-    return datetime.utcnow()
+def compute_educational_booking_cancellation_limit_date(
+    event_beginning: datetime, booking_creation_date: datetime
+) -> datetime:
+    fifteen_days_before_event = event_beginning - timedelta(days=15)
+    return max(fifteen_days_before_event, booking_creation_date)

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+
+def compute_cancellation_limit_date_for_educational_booking(event_beginning: datetime, booking_creation: datetime):
+    return datetime.utcnow()

--- a/api/tests/core/educational/test_utils.py
+++ b/api/tests/core/educational/test_utils.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from datetime import timedelta
+
+from pcapi.core.educational.utils import compute_cancellation_limit_date_for_educational_booking
+
+
+class ComputeCancellationLimitDateForEducationalBookingTest:
+    def test_cancellation_limit_date_is_15_days_before_event_when_booking_occured_more_than_15_days_before_event_and_event_utc(
+        self,
+    ):
+        # Given
+        booking_datetime = datetime(2021, 11, 5, 15, 30)
+        event_beginning_datetime = booking_datetime + timedelta(days=30, hours=4)
+
+        # When
+        cancellation_limit_date = compute_cancellation_limit_date_for_educational_booking(
+            event_beginning_datetime, booking_datetime
+        )
+
+        # Then
+        assert cancellation_limit_date == event_beginning_datetime - timedelta(days=15)
+
+    def test_cancellation_limit_date_is_booking_date_when_booking_occured_less_than_15_days_before_event_and_event_utc(
+        self,
+    ):
+        pass

--- a/api/tests/core/educational/test_utils.py
+++ b/api/tests/core/educational/test_utils.py
@@ -1,26 +1,36 @@
 from datetime import datetime
-from datetime import timedelta
 
-from pcapi.core.educational.utils import compute_cancellation_limit_date_for_educational_booking
+from pcapi.core.educational.utils import compute_educational_booking_cancellation_limit_date
 
 
-class ComputeCancellationLimitDateForEducationalBookingTest:
-    def test_cancellation_limit_date_is_15_days_before_event_when_booking_occured_more_than_15_days_before_event_and_event_utc(
+class ComputeEducationalBookingCancellationLimitDate:
+    def test_should_be_15_days_before_event_when_booking_occured_more_than_15_days_before_event(
         self,
     ):
         # Given
-        booking_datetime = datetime(2021, 11, 5, 15, 30)
-        event_beginning_datetime = booking_datetime + timedelta(days=30, hours=4)
+        booking_datetime = datetime.fromisoformat("2021-11-04T15:00:00")
+        event_beginning_datetime = datetime.fromisoformat("2021-12-15T20:00:00")
+        fifteen_days_before_event = datetime.fromisoformat("2021-11-30T20:00:00")
 
         # When
-        cancellation_limit_date = compute_cancellation_limit_date_for_educational_booking(
+        cancellation_limit_date = compute_educational_booking_cancellation_limit_date(
             event_beginning_datetime, booking_datetime
         )
 
         # Then
-        assert cancellation_limit_date == event_beginning_datetime - timedelta(days=15)
+        assert cancellation_limit_date == fifteen_days_before_event
 
-    def test_cancellation_limit_date_is_booking_date_when_booking_occured_less_than_15_days_before_event_and_event_utc(
+    def test_should_be_booking_date_when_booking_occured_less_than_15_days_before_event(
         self,
     ):
-        pass
+        # Given
+        booking_datetime = datetime.fromisoformat("2021-12-04T15:00:00")
+        event_beginning_datetime = datetime.fromisoformat("2021-12-15T20:00:00")
+
+        # When
+        cancellation_limit_date = compute_educational_booking_cancellation_limit_date(
+            event_beginning_datetime, booking_datetime
+        )
+
+        # Then
+        assert cancellation_limit_date == booking_datetime


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11809


## But de la pull request

Jusqu'à présent, les règles métiers régissant la date limite d'annulation pour les réservations eac étaient les mêmes que pour les réservations individuelles.
Désormais, ces règles divergent. Pour l'instant, la règle est : 15 jours avant l'évènement ou date de réservations

##  Implémentation

- Ajout d'une fonction `compute_cancellation_limit_date_for_educational_booking` dans un fichier `utils` dans `core.educational.api`
- Remplacement de l'appel existant par un appel à cette nouvelle fonction dans `api.create_educational_booking`
​
##  Informations supplémentaires

- NA
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
