### PR TITLE
Pc 11910 check id fraud foreign

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -261,7 +261,23 @@ def validate_id_piece_number_format_fraud_item(id_piece_number) -> models.FraudI
         return models.FraudItem(
             status=models.FraudStatus.SUSPICIOUS, detail="Le numéro de la pièce d'identité est vide"
         )
-    if not re.fullmatch(r"^[\w]{8,12}|[\s\w]{14}$", id_piece_number):
+
+    regexp = "|".join(
+        (
+            r"(^\d{18}$)",  # ID Algérienne
+            r"(^[\w]{8,12}|[\s\w]{14}$)",  # ID Europeene ID Française
+            r"(^\w{1}\d{6}$)",  # ID Tunisienne
+            r"(^\w{1}\ *\d{8}$)",  # ID Turque
+            r"(^\w{2}\ *\d{7}$)",  # Ancienne ID Italienne
+            r"(^\d{3}\-\d{7}\-\d{2}$)",  # ID Belge
+            r"(^\d{7}$)",  # ID Congolaise, Camerounaise, Mauricienne
+        )
+    )
+
+    if not re.fullmatch(
+        regexp,
+        id_piece_number,
+    ):
         return models.FraudItem(
             status=models.FraudStatus.SUSPICIOUS, detail="Le format du numéro de la pièce d'identité n'est pas valide"
         )

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -166,6 +166,12 @@ class JouveFraudCheckTest:
         [
             "321070751234",
             "090435303687",
+            "Y808952",  # Tunisie
+            "U 13884935",  # Turquie
+            "AZ 1461290",  # Ancienne id italienne
+            "595-0103264-74",  # ID Belge
+            "1277367",  # ID Congolaise, Camerounaise, Mauricienne
+            "100030595009080004",  # ID Algerienne
             "00000000 0 ZU4",  # portugal format
             "03146310",  # andora CNI format
         ],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11910


## But de la pull request

En tant que pass Culture 
J'aimerais m’assurer que notre script d’import des dossiers DMS accepte bien les numéros de pièces étrangers. 
Afin de permettre aux utilisateurs avec les passeports et CNI étrangers de déposer un dossier.

##  Règles de gestion 

- Mettre à jour les règles de validation de format pour accepter les formats suivants : 

    - Tunisie (Y808952)
    - Turquie (U 13884935)
    - Ancienne ID italienne (AZ 1461290)
    - ID Belge (595-0103264-74)
    - ID Congolaise (1277367)
    - ID Camerounaise (1238034)
    - ID Algérienne (100030595009080004)
    - ID Mauricienne (1774519)​
    
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires