### PR TITLE
(PC-11991) api: add subcategory 'Pratique artistique - vente a distance'

### DIFF
--- a/api/src/pcapi/core/categories/subcategories.py
+++ b/api/src/pcapi/core/categories/subcategories.py
@@ -1032,6 +1032,24 @@ ABO_PRATIQUE_ART = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
 )
+PRATIQUE_ART_VENTE_DISTANCE = Subcategory(
+    id="PRATIQUE_ART_VENTE_DISTANCE",
+    category_id=categories.PRATIQUE_ART.id,
+    matching_type="EventType.PRATIQUE_ARTISTIQUE",
+    pro_label="Pratique artistique - vente à distance",
+    app_label="Pratique artistique - vente à distance",
+    search_group_name=SearchGroups.COURS.name,
+    homepage_label_name=HomepageLabels.COURS.name,
+    is_event=True,
+    conditional_fields=["speaker"],
+    can_expire=False,
+    can_be_duo=True,
+    can_be_educational=False,
+    online_offline_platform=OnlineOfflinePlatformChoices.ONLINE.value,
+    is_digital_deposit=False,
+    is_physical_deposit=True,
+    reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+)
 # endregion
 # region MEDIAS
 ABO_PRESSE_EN_LIGNE = Subcategory(
@@ -1416,6 +1434,7 @@ ALL_SUBCATEGORIES = (
     MUSEE_VENTE_DISTANCE,
     OEUVRE_ART,
     PARTITION,
+    PRATIQUE_ART_VENTE_DISTANCE,
     PODCAST,
     RENCONTRE_EN_LIGNE,
     RENCONTRE_JEU,

--- a/api/tests/models/offer_type_test.py
+++ b/api/tests/models/offer_type_test.py
@@ -31,7 +31,12 @@ def test_category_enum_content():
             "Jeux en ligne",
             "Rencontres - jeux",
         ],
-        "LECON": ["Abonnement pratique artistique", "Atelier, stage de pratique artistique", "Séance d'essai"],
+        "LECON": [
+            "Abonnement pratique artistique",
+            "Atelier, stage de pratique artistique",
+            "Pratique artistique - vente à distance",
+            "Séance d'essai",
+        ],
         "LIVRE": [
             "Abonnement (bibliothèques, médiathèques...)",
             "Abonnement livres numériques",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11991


## But de la pull request

Ajout d'une sous-catégorie :
https://www.notion.so/passcultureapp/Pratique-artistique-vente-distance-c0b652a5ee3d4983981f5832f1d024b5

##  Implémentation

Telle que décrite ici :
https://www.notion.so/passcultureapp/Process-de-cr-ation-de-sous-cat-gories-edbb6684ec084464b9766aee3744fe66
​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
