### PR TITLE
(PC-11992) api: add subcategory 'Spectacle vivant - vente a distance'

### DIFF
--- a/api/src/pcapi/core/categories/subcategories.py
+++ b/api/src/pcapi/core/categories/subcategories.py
@@ -1185,6 +1185,24 @@ ABO_SPECTACLE = Subcategory(
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
 )
+SPECTACLE_VENTE_DISTANCE = Subcategory(
+    id="SPECTACLE_VENTE_DISTANCE",
+    category_id=categories.SPECTACLE.id,
+    matching_type="EventType.SPECTACLE_VIVANT",
+    pro_label="Spectacle vivant - vente à distance",
+    app_label="Spectacle vivant - vente à distance",
+    search_group_name=SearchGroups.SPECTACLE.name,
+    homepage_label_name=HomepageLabels.SPECTACLE.name,
+    is_event=True,
+    conditional_fields=["author", "showType", "stageDirector", "performer"],
+    can_expire=False,
+    can_be_duo=True,
+    can_be_educational=False,
+    online_offline_platform=OnlineOfflinePlatformChoices.ONLINE.value,
+    is_digital_deposit=False,
+    is_physical_deposit=True,
+    reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
+)
 # endregion
 # region INSTRUMENT
 ACHAT_INSTRUMENT = Subcategory(
@@ -1425,6 +1443,7 @@ ALL_SUBCATEGORIES = (
     SEANCE_ESSAI_PRATIQUE_ART,
     SPECTACLE_ENREGISTRE,
     SPECTACLE_REPRESENTATION,
+    SPECTACLE_VENTE_DISTANCE,
     SUPPORT_PHYSIQUE_FILM,
     SUPPORT_PHYSIQUE_MUSIQUE,
     TELECHARGEMENT_LIVRE_AUDIO,

--- a/api/tests/models/offer_type_test.py
+++ b/api/tests/models/offer_type_test.py
@@ -60,6 +60,7 @@ def test_category_enum_content():
             "Live stream d'événement",
             "Spectacle enregistré",
             "Spectacle, représentation",
+            "Spectacle vivant - vente à distance",
         ],
         "VISITE": [
             "Entrée libre ou abonnement musée",


### PR DESCRIPTION
[Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11992


## But de la pull request

Ajout d'une sous-catégorie :
https://www.notion.so/passcultureapp/Spectacle-vivant-vente-distance-2d98828e9d894672854f43f5e21933e0

##  Implémentation

Telle que décrite ici :
https://www.notion.so/passcultureapp/Process-de-cr-ation-de-sous-cat-gories-edbb6684ec084464b9766aee3744fe66
​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
](https://passculture.atlassian.net/browse/PC-11992)