### PR TITLE
(PC-12005)[PRO] fix design offer type screen

### DIFF
--- a/pro/src/new_components/FormLayout/FormLayout.module.scss
+++ b/pro/src/new_components/FormLayout/FormLayout.module.scss
@@ -1,4 +1,8 @@
 .form-layout {
+  &.small {
+    width: rem(468px);
+  }
+
   &-section {
     margin-bottom: rem(32px);
 
@@ -27,7 +31,6 @@
       display: flex;
 
       > *:not(:last-child) {
-        flex: 1;
         margin-right: rem(24px);
       }
     }
@@ -35,12 +38,11 @@
 
   &-actions {
     display: flex;
-    justify-content: center;
     margin-top: rem(64px);
   }
 
   &-action {
-    flex: 1;
+    width: rem(192px);
     margin-left: rem(24px);
     text-align: center;
 

--- a/pro/src/new_components/FormLayout/FormLayout.tsx
+++ b/pro/src/new_components/FormLayout/FormLayout.tsx
@@ -10,10 +10,19 @@ import SubSection from './FormLayoutSubSection'
 interface IFormLayoutProps {
   children: React.ReactNode | React.ReactNode[]
   className?: string
+  small?: boolean
 }
 
-const FormLayout = ({ children, className }: IFormLayoutProps): JSX.Element => (
-  <div className={cn(style['form-layout'], className)}>{children}</div>
+const FormLayout = ({
+  children,
+  className,
+  small,
+}: IFormLayoutProps): JSX.Element => (
+  <div
+    className={cn(style['form-layout'], { [style.small]: small }, className)}
+  >
+    {children}
+  </div>
 )
 
 FormLayout.Row = Row

--- a/pro/src/new_components/FormLayout/FormLayoutActions.tsx
+++ b/pro/src/new_components/FormLayout/FormLayoutActions.tsx
@@ -8,9 +8,13 @@ interface IFormLayoutActionsProps {
   className?: string
 }
 
-const addActionClass = (element: React.ReactElement): JSX.Element =>
+const addActionClass = (
+  element: React.ReactElement,
+  index?: number
+): JSX.Element =>
   React.cloneElement(element, {
     ...element.props,
+    key: index,
     className: cn(style['form-layout-action'], element.props.className),
   })
 

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -58,7 +58,7 @@ const OfferEducationalForm = ({
   }, [values.offererId, userOfferers])
 
   return (
-    <FormLayout className={styles['educational-form']}>
+    <FormLayout className={styles['educational-form']} small>
       <p className={styles['educational-form-information']}>
         Tous les champs sont obligatoires sauf mention contraire.
       </p>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12005


## But de la pull request

Fix design du bouton de droite qui prenait trop de place

##  Implémentation

Suppression de l'utilisation du design du formulaire
Ajout du css scopé pour cet écran
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
<img width="863" alt="Capture d’écran 2021-11-26 à 16 58 30" src="https://user-images.githubusercontent.com/35567446/143606453-9420e0fc-18fc-443e-9b69-8352d60af044.png">
