### PR TITLE
(PC-12040) Fix adage query performance issue

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -106,7 +106,11 @@ def find_educational_bookings_for_adage(
             joinedload(educational_models.EducationalBooking.booking, innerjoin=True)
             .joinedload(Booking.stock, innerjoin=True)
             .joinedload(Stock.offer, innerjoin=True)
-            .joinedload(Offer.venue, innerjoin=True)
+            .options(
+                joinedload(Offer.venue, innerjoin=True),
+                joinedload(Offer.product, innerjoin=True),
+                joinedload(Offer.mediations),
+            )
         )
         .join(educational_models.EducationalInstitution)
         .join(educational_models.EducationalRedactor)

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -6,6 +6,7 @@ from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.offers.utils import offer_webapp_link
+from pcapi.core.testing import assert_num_queries
 from pcapi.utils.date import format_into_utc_date
 
 from tests.conftest import TestClient
@@ -108,6 +109,53 @@ class Returns200Test:
                 }
             ],
         }
+
+    def test_get_educational_institution_num_queries(self, app) -> None:
+        redactor = EducationalRedactorFactory()
+        educational_year = EducationalYearFactory()
+        educational_institution = EducationalInstitutionFactory()
+        EducationalDepositFactory(
+            educationalInstitution=educational_institution,
+            educationalYear=educational_year,
+            amount=200000,
+            isFinal=True,
+        )
+        EducationalInstitutionFactory()
+        EducationalBookingFactory.create_batch(
+            10,
+            educationalBooking__educationalRedactor=redactor,
+            educationalBooking__educationalYear=educational_year,
+            educationalBooking__educationalInstitution=educational_institution,
+        )
+        other_educational_year = EducationalYearFactory(adageId="toto")
+        other_educational_institution = EducationalInstitutionFactory(institutionId="tata")
+        EducationalBookingFactory(educationalBooking__educationalYear=other_educational_year)
+        EducationalBookingFactory(educationalBooking__educationalInstitution=other_educational_institution)
+        EducationalDepositFactory(
+            educationalInstitution=educational_institution,
+            educationalYear=other_educational_year,
+            amount=2000,
+            isFinal=False,
+        )
+        EducationalDepositFactory(
+            educationalInstitution=other_educational_institution,
+            educationalYear=educational_year,
+            amount=2000,
+            isFinal=False,
+        )
+
+        client = TestClient(app.test_client()).with_eac_token()
+        adage_id = educational_year.adageId
+        institution_id = educational_institution.institutionId
+
+        n_queries = 0
+        n_queries += 1  # Check for educational institution
+        n_queries += 1  # Get needed data
+        n_queries += 1  # Get deposit
+        n_queries += 1  # Check webapp_v2 feature toggle
+
+        with assert_num_queries(n_queries):
+            client.get(f"/adage/v1/years/{adage_id}/educational_institution/{institution_id}")
 
     def test_get_educational_institution_without_deposit(self, app) -> None:
         educational_year = EducationalYearFactory()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12040


## But de la pull request

Réparer les problèmes de performance sur Adage (Query pas optim et N+1 corrigée au passage)

##  Implémentation

- Utilisation de contains_eager au lieu de joinedload pour éviter les problèmes de données récupérées sans filtre
​

AVANT: ([Version dalibo](https://explain.dalibo.com/plan/SpF))
```
                                                                                                        QUERY PLAN

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather  (cost=14032669.70..24052178.03 rows=14979378 width=2724) (actual time=480791.927..1016348.214 rows=3 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Hash Left Join  (cost=14031669.70..22553240.23 rows=6241408 width=2724) (actual time=480783.964..480786.462 rows=1 loops=3)
         Hash Cond: (offer_1."venueId" = venue_1.id)
         ->  Parallel Hash Left Join  (cost=14028704.79..19302165.12 rows=6241408 width=2096) (actual time=440836.581..480750.558 rows=1 loops=3)
               Hash Cond: (stock_1."offerId" = offer_1.id)
               ->  Nested Loop  (cost=344128.37..681462.01 rows=6241408 width=378) (actual time=1937.386..1940.523 rows=1 loops=3)
                     Join Filter: (booking."educationalBookingId" = educational_booking.id)
                     Rows Removed by Join Filter: 69
                     ->  Nested Loop Left Join  (cost=344119.75..681430.83 rows=1 width=258) (actual time=1934.924..1938.840 rows=23 loops=3)
                           ->  Parallel Hash Join  (cost=344119.18..681424.65 rows=1 width=132) (actual time=1934.886..1938.623 rows=23 loops=3)
                                 Hash Cond: (booking."educationalBookingId" = booking_1."educationalBookingId")
                                 ->  Parallel Seq Scan on booking  (cost=0.00..241505.75 rows=3304275 width=8) (actual time=0.010..631.220 rows=2658734 loops=3)
                                 ->  Parallel Hash  (cost=241505.75..241505.75 rows=3304275 width=124) (actual time=1128.384..1128.386 rows=2658734 loops=3)
                                       Buckets: 32768  Batches: 512  Memory Usage: 288kB
                                       ->  Parallel Seq Scan on booking booking_1  (cost=0.00..241505.75 rows=3304275 width=124) (actual time=0.014..945.391 rows=2658734 loops=3)
                           ->  Index Scan using stock_pkey on stock stock_1  (cost=0.56..6.18 rows=1 width=126) (actual time=0.008..0.008 rows=1 loops=70)
                                 Index Cond: (id = booking_1."stockId")
                     ->  Nested Loop Left Join  (cost=8.62..31.17 rows=1 width=128) (actual time=0.056..0.069 rows=3 loops=70)
                           ->  Nested Loop  (cost=8.47..26.48 rows=1 width=46) (actual time=0.054..0.064 rows=3 loops=70)
                                 Join Filter: (educational_booking."educationalRedactorId" = educational_redactor.id)
                                 ->  Nested Loop  (cost=8.33..18.31 rows=1 width=46) (actual time=0.025..0.031 rows=3 loops=70)
                                       ->  Hash Join  (cost=8.18..10.13 rows=1 width=46) (actual time=0.022..0.025 rows=3 loops=70)
                                             Hash Cond: (educational_booking."educationalInstitutionId" = educational_institution.id)
                                             ->  Seq Scan on educational_booking  (cost=0.00..1.79 rows=63 width=46) (actual time=0.004..0.014 rows=70 loops=70)
                                                   Filter: (("educationalYearId")::text = '7'::text)
                                             ->  Hash  (cost=8.17..8.17 rows=1 width=4) (actual time=0.022..0.023 rows=1 loops=3)
                                                   Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                   ->  Index Scan using "ix_educational_institution_institutionId" on educational_institution  (cost=0.15..8.17 rows=1 width=4) (actual time=0.019..0.020 rows=1 loops=3)
                                                         Index Cond: (("institutionId")::text = '0220186H'::text)
                                       ->  Index Only Scan using "educational_year_adageId_key" on educational_year  (cost=0.15..8.17 rows=1 width=78) (actual time=0.001..0.001 rows=1 loops=210)
                                             Index Cond: ("adageId" = '7'::text)
                                             Heap Fetches: 210
                                 ->  Index Scan using ix_educational_redactor_email on educational_redactor  (cost=0.14..8.16 rows=1 width=8) (actual time=0.010..0.010 rows=1 loops=210)
                                       Index Cond: ((email)::text = 'Muriel.Leboutte@ac-rennes.fr'::text)
                           ->  Index Scan using educational_institution_pkey on educational_institution educational_institution_1  (cost=0.15..4.68 rows=1 width=82) (actual time=0.001..0.001 rows=1 loops=210)
                                 Index Cond: (id = educational_booking."educationalInstitutionId")
               ->  Parallel Hash  (cost=9134175.52..9134175.52 rows=20188952 width=1718) (actual time=330940.491..330940.492 rows=16163106 loops=3)
                     Buckets: 4096  Batches: 32768  Memory Usage: 1952kB
                     ->  Parallel Seq Scan on offer offer_1  (cost=0.00..9134175.52 rows=20188952 width=1718) (actual time=0.037..221831.938 rows=16163106 loops=3)
         ->  Parallel Hash  (cost=1455.07..1455.07 rows=16307 width=628) (actual time=14.000..14.001 rows=9382 loops=3)
               Buckets: 8192  Batches: 8  Memory Usage: 928kB
               ->  Parallel Seq Scan on venue venue_1  (cost=0.00..1455.07 rows=16307 width=628) (actual time=0.009..5.038 rows=9382 loops=3)
 Planning Time: 7.956 ms
 Execution Time: 1016353.553 ms
```

APRÈS: ([Version dalibo](https://explain.dalibo.com/plan/iBx))
```
 Hash Join  (cost=23166.96..2636164.90 rows=125877 width=5023) (actual time=290.322..290.666 rows=3 loops=1)
   Hash Cond: (offer_1."venueId" = venue_1.id)
   ->  Hash Left Join  (cost=19031.22..2493520.67 rows=125877 width=4395) (actual time=248.923..249.622 rows=3 loops=1)
         Hash Cond: (offer_1.id = mediation_1."offerId")
         ->  Nested Loop  (cost=2.58..2336155.62 rows=125877 width=4322) (actual time=0.182..0.289 rows=3 loops=1)
               ->  Nested Loop  (cost=2.15..1576810.11 rows=125877 width=2961) (actual time=0.160..0.251 rows=3 loops=1)
                     ->  Merge Join  (cost=1.58..788806.59 rows=125877 width=1250) (actual time=0.135..0.207 rows=3 loops=1)
                           Merge Cond: (educational_booking."educationalRedactorId" = educational_redactor.id)
                           ->  Nested Loop  (cost=1.44..787003.41 rows=125877 width=378) (actual time=0.118..0.184 rows=3 loops=1)
                                 ->  Nested Loop  (cost=0.87..47.00 rows=125877 width=252) (actual time=0.103..0.149 rows=3 loops=1)
                                       ->  Nested Loop  (cost=0.44..30.54 rows=1 width=128) (actual time=0.090..0.121 rows=3 loops=1)
                                             ->  Nested Loop  (cost=0.29..22.36 rows=1 width=128) (actual time=0.083..0.098 rows=3 loops=1)
                                                   Join Filter: (educational_booking."educationalInstitutionId" = educational_institution.id)
                                                   Rows Removed by Join Filter: 78
                                                   ->  Index Scan using "ix_educational_booking_educationalRedactorId" on educational_booking  (cost=0.14..13.24 rows=63 width=46) (actual time=0.015..0.044 rows=81 loops=1)
                                                         Filter: (("educationalYearId")::text = '7'::text)
                                                   ->  Materialize  (cost=0.15..8.17 rows=1 width=82) (actual time=0.000..0.000 rows=1 loops=81)
                                                         ->  Index Scan using "ix_educational_institution_institutionId" on educational_institution  (cost=0.15..8.17 rows=1 width=82) (actual time=0.008..0.009 rows=1 loops=1)
                                                               Index Cond: (("institutionId")::text = '0220186H'::text)
                                             ->  Index Only Scan using "educational_year_adageId_key" on educational_year  (cost=0.15..8.17 rows=1 width=78) (actual time=0.004..0.006 rows=1 loops=3)
                                                   Index Cond: ("adageId" = '7'::text)
                                                   Heap Fetches: 3
                                       ->  Index Scan using "ix_booking_educationalBookingId" on booking booking_1  (cost=0.43..8.45 rows=1 width=124) (actual time=0.006..0.006 rows=1 loops=3)
                                             Index Cond: ("educationalBookingId" = educational_booking.id)
                                 ->  Index Scan using stock_pkey on stock stock_1  (cost=0.56..6.25 rows=1 width=126) (actual time=0.008..0.008 rows=1 loops=3)
                                       Index Cond: (id = booking_1."stockId")
                           ->  Index Scan using educational_redactor_pkey on educational_redactor  (cost=0.14..229.49 rows=90 width=872) (actual time=0.005..0.009 rows=25 loops=1)
                     ->  Index Scan using offer_pkey on offer offer_1  (cost=0.56..6.26 rows=1 width=1711) (actual time=0.011..0.011 rows=1 loops=3)
                           Index Cond: (id = stock_1."offerId")
               ->  Index Scan using product_pkey on product product_1  (cost=0.43..6.03 rows=1 width=1361) (actual time=0.006..0.006 rows=1 loops=3)
                     Index Cond: (id = offer_1."productId")
         ->  Hash  (cost=10872.73..10872.73 rows=323673 width=73) (actual time=236.831..236.831 rows=323306 loops=1)
               Buckets: 65536  Batches: 16  Memory Usage: 2750kB
               ->  Seq Scan on mediation mediation_1  (cost=0.00..10872.73 rows=323673 width=73) (actual time=0.012..93.991 rows=323306 loops=1)
   ->  Hash  (cost=1569.22..1569.22 rows=27722 width=628) (actual time=38.306..38.307 rows=28176 loops=1)
         Buckets: 8192  Batches: 8  Memory Usage: 872kB
         ->  Seq Scan on venue venue_1  (cost=0.00..1569.22 rows=27722 width=628) (actual time=0.014..14.705 rows=28176 loops=1)
 Planning Time: 3.033 ms
 Execution Time: 290.942 ms
```
