### PR TITLE
(PC-11730) Allow underage to book ABO_LIVRE_NUMERIQUE and TELECHARGEMENT_LIVRE_AUDIO even if not free

### DIFF
--- a/api/src/pcapi/core/categories/subcategories.py
+++ b/api/src/pcapi/core/categories/subcategories.py
@@ -597,7 +597,7 @@ TELECHARGEMENT_LIVRE_AUDIO = Subcategory(
     is_digital_deposit=True,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.NOT_REIMBURSED.value,
-    is_bookable_by_underage_when_not_free=False,
+    is_bookable_by_underage_when_not_free=True,
 )
 LIVRE_AUDIO_PHYSIQUE = Subcategory(
     id="LIVRE_AUDIO_PHYSIQUE",
@@ -653,7 +653,7 @@ ABO_LIVRE_NUMERIQUE = Subcategory(
     is_digital_deposit=True,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.BOOK.value,
-    is_bookable_by_underage_when_not_free=False,
+    is_bookable_by_underage_when_not_free=True,
 )
 FESTIVAL_LIVRE = Subcategory(
     id="FESTIVAL_LIVRE",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11730


## But de la pull request

Petit oubli de la part des POs pour ces 2 catégories de livres numériques