### PR TITLE
(PC-11955) fix:notifications: use internal task

### DIFF
--- a/api/src/pcapi/tasks/batch_tasks.py
+++ b/api/src/pcapi/tasks/batch_tasks.py
@@ -5,6 +5,7 @@ import logging
 from pydantic import BaseModel
 
 from pcapi import settings
+from pcapi.notifications.push import delete_user_attributes
 from pcapi.notifications.push import update_user_attributes_with_legacy_internal_task
 from pcapi.tasks.decorator import task
 
@@ -19,6 +20,15 @@ class UpdateBatchAttributesRequest(BaseModel):
     attributes: dict
 
 
+class DeleteBatchUserAttributesRequest(BaseModel):
+    user_id: int
+
+
 @task(BATCH_CUSTOM_DATA_QUEUE_NAME, "/batch/update_user_attributes")
 def update_user_attributes_task(payload: UpdateBatchAttributesRequest) -> None:
     update_user_attributes_with_legacy_internal_task(payload.user_id, payload.attributes)
+
+
+@task(BATCH_CUSTOM_DATA_QUEUE_NAME, "/batch/delete_user_attributes")
+def delete_user_attributes_task(payload: DeleteBatchUserAttributesRequest) -> None:
+    delete_user_attributes(payload.user_id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11955

## But de la pull request

Fix : les cloud tasks n'acceptent pas les méthodes DELETE (http), il faut donc transformer passer par une tâche interne, appelée par une cloud task.