### PR TITLE
(PC-12062) api: Fix TypeError: 'Offer' object is not iterable

### DIFF
--- a/api/src/pcapi/admin/custom_views/offer_view.py
+++ b/api/src/pcapi/admin/custom_views/offer_view.py
@@ -482,7 +482,7 @@ class ValidationView(BaseAdminView):
                     send_offer_validation_status_update_email(offer, validation_status, recipients)
                     send_offer_validation_notification_to_administration(validation_status, offer)
                 else:
-                    not_updated_offers += offer
+                    not_updated_offers.append(offer)
             except Exception as exc:  # pylint: disable=broad-except
                 logger.exception(
                     "Une erreur s'est produite lors de la mise à jour du statut de validation: %s",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12062


## But de la pull request

Corriger une erreur remontée par Sentry :
TypeError: 'Offer' object is not iterable

##  Implémentation

##  Informations supplémentaires

Tests unitaires créés pour ces actions approve/reject (cas nominal et cas d'erreur)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
