### PR TITLE
[PC-12061][API] drop order from offer list when over limit

### DIFF
--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -39,9 +39,7 @@ class GetCappedOffersForFiltersTest:
         # Given
         user_offerer = offers_factories.UserOffererFactory()
         older_offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
-        expected_offer = offers_factories.OfferFactory(
-            venue=older_offer.venue, venue__managingOfferer=user_offerer.offerer
-        )
+        offers_factories.OfferFactory(venue=older_offer.venue, venue__managingOfferer=user_offerer.offerer)
 
         requested_max_offers_count = 1
 
@@ -55,7 +53,6 @@ class GetCappedOffersForFiltersTest:
         # Then
         assert isinstance(offers, OffersRecap)
         assert len(offers.offers) == 1
-        assert offers.offers[0].id == expected_offer.id
 
     @pytest.mark.usefixtures("db_session")
     def should_return_offers_sorted_by_id_desc(self):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12061

## But de la pull request

Make the offer view great again.
Permettre à la vue des offres de répondre rapidement même en l'absence de filtres et/ou avec des filtres trop larges.

##  Implémentation

In order to order the offer list the database had to scan the
full list of possible offers, order them and only then limit the
count to a limited numbers.
Since the offers number is quite impressive for some offerer the
associated route would time out.
We now return an unordered list of offers and only order them
whenever the offer count is lower than the requested limit.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
