### PR TITLE
(PC-11480) API: update venue BusinessUnitId

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -63,7 +63,11 @@ def _get_digital_venue_type_id() -> int:
     return VenueType.query.filter_by(label="Offre numérique").one().id
 
 
-def update_venue(venue: Venue, contact_data: venues_serialize.VenueContactModel = None, **attrs: typing.Any) -> Venue:
+def update_venue(
+    venue: Venue,
+    contact_data: venues_serialize.VenueContactModel = None,
+    **attrs: typing.Any,
+) -> Venue:
     validation.validate_coordinates(attrs.get("latitude"), attrs.get("longitude"))
     modifications = {field: value for field, value in attrs.items() if venue.field_exists_and_has_changed(field, value)}
 

--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -17,14 +17,10 @@ VENUE_BANNER_MAX_SIZE = 200_000
 def check_existing_business_unit(business_unit_id: int, offerer: Offerer):
     business_unit = BusinessUnit.query.filter_by(id=business_unit_id).one_or_none()
     if not business_unit:
-        errors = ApiErrors()
-        errors.add_error("businessUnitId", "Ce point de facturation n'existe pas.")
-        raise errors
+        raise ApiErrors(errors={"businessUnitId": ["Ce point de facturation n'existe pas."]})
 
     if business_unit.siret[:9] != offerer.siren:
-        errors = ApiErrors()
-        errors.add_error("businessUnitId", "Ce point de facturation n'est pas un choix valide pour ce lieu.")
-        raise errors
+        raise ApiErrors(errors={"businessUnitId": ["Ce point de facturation n'est pas un choix valide pour ce lieu."]})
 
 
 def check_existing_venue(venue: Venue):
@@ -51,14 +47,10 @@ def validate_coordinates(raw_latitude, raw_longitude):
 def check_venue_creation(data):
     offerer_id = dehumanize(data.get("managingOffererId"))
     if not offerer_id:
-        errors = ApiErrors()
-        errors.add_error("managingOffererId", "Vous devez choisir une structure pour votre lieu.")
-        raise errors
+        raise ApiErrors(errors={"managingOffererId": ["Vous devez choisir une structure pour votre lieu."]})
     offerer = Offerer.query.filter(Offerer.id == offerer_id).one_or_none()
     if not offerer:
-        errors = ApiErrors()
-        errors.add_error("managingOffererId", "La structure que vous avez choisie n'existe pas.")
-        raise errors
+        raise ApiErrors(errors={"managingOffererId": ["La structure que vous avez choisie n'existe pas."]})
 
     if None in [
         data.get("audioDisabilityCompliant"),
@@ -66,9 +58,7 @@ def check_venue_creation(data):
         data.get("motorDisabilityCompliant"),
         data.get("visualDisabilityCompliant"),
     ]:
-        errors = ApiErrors()
-        errors.add_error("global", "L'accessibilité du lieu doit être définie.")
-        raise errors
+        raise ApiErrors(errors={"global": ["L'accessibilité du lieu doit être définie."]})
 
     business_unit_id = data.get("businessUnitId")
     if business_unit_id:
@@ -94,23 +84,15 @@ def check_venue_edition(modifications, venue):
     ]
 
     if managing_offerer_id:
-        errors = ApiErrors()
-        errors.add_error("managingOffererId", "Vous ne pouvez pas changer la structure d'un lieu")
-        raise errors
+        raise ApiErrors(errors={"managingOffererId": ["Vous ne pouvez pas changer la structure d'un lieu"]})
     if siret and venue.siret and siret != venue.siret:
-        errors = ApiErrors()
-        errors.add_error("siret", "Vous ne pouvez pas modifier le siret d'un lieu")
-        raise errors
+        raise ApiErrors(errors={"siret": ["Vous ne pouvez pas modifier le siret d'un lieu"]})
     if siret:
         venue_with_same_siret = Venue.query.filter_by(siret=siret).one_or_none()
         if venue_with_same_siret:
-            errors = ApiErrors()
-            errors.add_error("siret", "Un lieu avec le même siret existe déjà")
-            raise errors
+            raise ApiErrors(errors={"siret": ["Un lieu avec le même siret existe déjà"]})
     if None in venue_disability_compliance and None in modifications_disability_compliance:
-        errors = ApiErrors()
-        errors.add_error("global", "L'accessibilité du lieu doit etre définie.")
-        raise errors
+        raise ApiErrors(errors={"global": ["L'accessibilité du lieu doit etre définie."]})
 
     if business_unit_id:
         check_existing_business_unit(business_unit_id, offerer=venue.managingOfferer)

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -111,7 +111,7 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
         for field in accessibility_fields
     )
     have_withdrawal_details_changes = body.withdrawalDetails != venue.withdrawalDetails
-    venue = offerers_api.update_venue(venue, body.contact, **update_venue_attrs)
+    venue = offerers_api.update_venue(venue, contact_data=body.contact, **update_venue_attrs)
     venue_attrs = as_dict(venue)
 
     if have_accessibility_changes and body.isAccessibilityAppliedOnAllOffers:

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -77,6 +77,7 @@ class PostVenueBodyModel(BaseModel):
     motorDisabilityCompliant: Optional[bool]
     visualDisabilityCompliant: Optional[bool]
     contact: Optional[VenueContactModel]
+    businessUnitId: Optional[int]
 
     class Config:
         extra = "forbid"
@@ -215,6 +216,7 @@ class EditVenueBodyModel(BaseModel):
     motorDisabilityCompliant: Optional[bool]
     visualDisabilityCompliant: Optional[bool]
     contact: Optional[VenueContactModel]
+    businessUnitId: Optional[int]
 
     _dehumanize_venue_label_id = dehumanize_field("venueLabelId")
     _dehumanize_venue_type_id = dehumanize_field("venueTypeId")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11480


## But de la pull request

Lorsque les route d'édition et de création de lieu contienne un `businessUnitId`, le lieu doit être édité en conséquence.
​
##  Informations supplémentaires

- Un développement future ajoutera un règle spécial pour l'édition de lieu etant "porteur" de business unit, voir : https://passculture.atlassian.net/browse/PC-11923
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
