### PR TITLE
[PC-11973][api] educational offer stock creation

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-1ab309876ab0 (head)
-=======
 503904c2cab7 (head)
->>>>>>> c35307394... (PC-11973)[api]: add numberOfTickets column to stock model

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 1ab309876ab0 (head)
+=======
+503904c2cab7 (head)
+>>>>>>> c35307394... (PC-11973)[api]: add numberOfTickets column to stock model

--- a/api/src/pcapi/alembic/versions/20211202T112702_503904c2cab7_add_number_of_tickets_to_stock_model_for_eac_collective_offers.py
+++ b/api/src/pcapi/alembic/versions/20211202T112702_503904c2cab7_add_number_of_tickets_to_stock_model_for_eac_collective_offers.py
@@ -1,0 +1,18 @@
+"""add_number_of_tickets_to_stock_model_for_eac_collective_offers
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "503904c2cab7"
+down_revision = "1ab309876ab0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("stock", sa.Column("numberOfTickets", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("stock", "numberOfTickets")

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -98,3 +98,11 @@ class OfferAlreadyReportedError(OfferReportError):
 
 class ReportMalformed(OfferReportError):
     code = "REPORT_MALFORMED"
+
+
+class BookingLimitDatetimeTooLate(ClientError):
+    def __init__(self):
+        super().__init__(
+            "bookingLimitDatetime",
+            "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement",
+        )

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -194,6 +194,7 @@ class EducationalEventStockFactory(StockFactory):
     offer = factory.SubFactory(EducationalEventOfferFactory)
     beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=5))
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
+    numberOfTickets = 30
 
 
 class StockWithActivationCodesFactory(StockFactory):

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -97,6 +97,8 @@ class Stock(PcObject, Model, ProvidableMixin, SoftDeletableMixin):
 
     activationCodes = relationship("ActivationCode", back_populates="stock")
 
+    numberOfTickets = Column(Integer, nullable=True)
+
     @property
     def isBookable(self):
         return not self.isExpired and self.offer.isReleased and not self.isSoldOut

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -341,9 +341,4 @@ def check_booking_limit_datetime(
     beginning_datetime: datetime, booking_limit_datetime: datetime
 ) -> Union[None, ApiErrors]:
     if booking_limit_datetime > beginning_datetime:
-        error = ApiErrors()
-        error.add_error(
-            "bookingLimitDatetime",
-            "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement",
-        )
-        raise error
+        raise exceptions.BookingLimitDatetimeTooLate()

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -335,3 +335,15 @@ def check_offer_subcategory_is_valid(offer_subcategory_id):
         raise exceptions.UnknownOfferSubCategory()
     if not ALL_SUBCATEGORIES_DICT[offer_subcategory_id].is_selectable:
         raise exceptions.SubCategoryIsInactive()
+
+
+def check_booking_limit_datetime(
+    beginning_datetime: datetime, booking_limit_datetime: datetime
+) -> Union[None, ApiErrors]:
+    if booking_limit_datetime > beginning_datetime:
+        error = ApiErrors()
+        error.add_error(
+            "bookingLimitDatetime",
+            "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement",
+        )
+        raise error

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -7,6 +7,7 @@ from pcapi.core.offerers import exceptions as offerers_exceptions
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 import pcapi.core.offerers.repository
+from pcapi.core.offers import exceptions as offers_exceptions
 import pcapi.core.offers.api as offers_api
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -132,5 +133,8 @@ def create_educational_stock(body: EducationalStockCreationBodyModel) -> StockId
         raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
     check_user_has_access_to_offerer(current_user, offerer.id)
 
-    stock = offers_api.create_educational_stock(body, current_user)
+    try:
+        stock = offers_api.create_educational_stock(body, current_user)
+    except offers_exceptions.BookingLimitDatetimeTooLate as error:
+        raise ApiErrors(error.errors, status_code=404)
     return StockIdResponseModel.from_orm(stock)

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -72,6 +72,17 @@ class StockCreationBodyModel(BaseModel):
         extra = "forbid"
 
 
+class EducationalStockCreationBodyModel(BaseModel):
+    beginning_datetime: datetime
+    booking_limit_datetime: datetime
+    total_price: float
+    number_of_tickets: int
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
+
+
 class StockEditionBodyModel(BaseModel):
     beginning_datetime: Optional[datetime]
     booking_limit_datetime: Optional[datetime]

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -73,14 +73,23 @@ class StockCreationBodyModel(BaseModel):
 
 
 class EducationalStockCreationBodyModel(BaseModel):
+    offer_id: int
     beginning_datetime: datetime
-    booking_limit_datetime: datetime
+    booking_limit_datetime: Optional[datetime]
     total_price: float
     number_of_tickets: int
+
+    _dehumanize_id = dehumanize_field("offer_id")
 
     class Config:
         alias_generator = to_camel
         extra = "forbid"
+
+    @validator("number_of_tickets", pre=True)
+    def validate_number_of_tickets(cls, number_of_tickets):  # pylint: disable=no-self-argument
+        if number_of_tickets < 0:
+            raise ValueError("Le nombre de places ne peut pas être négatif.")
+        return number_of_tickets
 
 
 class StockEditionBodyModel(BaseModel):

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -658,7 +658,7 @@ class CreateEducationalOfferStocksTest:
             name="a great offer", validation=offer_models.OfferValidationStatus.DRAFT
         )
         draft_suspicious_offer = offer_factories.EducationalEventOfferFactory(
-            name="An PENDING offer", validation=offer_models.OfferValidationStatus.DRAFT
+            name="A PENDING offer", validation=offer_models.OfferValidationStatus.DRAFT
         )
         draft_fraudulent_offer = offer_factories.EducationalEventOfferFactory(
             name="A REJECTED offer", validation=offer_models.OfferValidationStatus.DRAFT

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -710,7 +710,7 @@ class CreateEducationalOfferStocksTest:
         )
 
         # When
-        with pytest.raises(api_errors.ApiErrors) as error:
+        with pytest.raises(offer_exceptions.BookingLimitDatetimeTooLate) as error:
             api.create_educational_stock(stock_data=created_stock_data, user=user)
 
         # Then

--- a/api/tests/routes/pro/post_educational_stock_test.py
+++ b/api/tests/routes/pro/post_educational_stock_test.py
@@ -1,0 +1,89 @@
+import pytest
+
+from pcapi.core.offers import factories as offer_factories
+from pcapi.core.offers.models import Stock
+from pcapi.utils.human_ids import dehumanize
+from pcapi.utils.human_ids import humanize
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class Return200Test:
+    def test_create_valid_stock_for_educational_offer(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory()
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        stock_payload = {
+            "offerId": humanize(offer.id),
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T20:00:00Z",
+            "totalPrice": 1500,
+            "numberOfTickets": 38,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post("/stocks/educational/", json=stock_payload)
+
+        # Then
+        assert response.status_code == 201
+        response_dict = response.json
+        created_stock = Stock.query.get(dehumanize(response_dict["id"]))
+        assert offer.id == created_stock.offerId
+        assert created_stock.price == 1500
+
+
+class Return400Test:
+    def test_upsert_educational_stocks_should_not_be_available_if_user_not_linked_to_offerer(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory()
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+        )
+
+        # When
+        stock_payload = {
+            "offerId": humanize(offer.id),
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T20:00:00Z",
+            "totalPrice": 1500,
+            "numberOfTickets": 38,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post("/stocks/educational/", json=stock_payload)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json == {
+            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+        }
+
+    def should_not_allow_number_of_tickets_to_be_negative_on_creation(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory()
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        stock_payload = {
+            "offerId": humanize(offer.id),
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T20:00:00Z",
+            "totalPrice": 1500,
+            "numberOfTickets": -1,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post("/stocks/educational/", json=stock_payload)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"numberOfTickets": ["Le nombre de places ne peut pas être négatif."]}

--- a/api/tests/routes/webapp/get_booking_by_id_test.py
+++ b/api/tests/routes/webapp/get_booking_by_id_test.py
@@ -71,6 +71,7 @@ class Returns200Test:
                 "isEventExpired": False,
                 "isSoftDeleted": False,
                 "lastProviderId": None,
+                "numberOfTickets": None,
                 "offer": {
                     "ageMax": None,
                     "ageMin": None,
@@ -114,6 +115,7 @@ class Returns200Test:
                             "isEventExpired": False,
                             "isSoftDeleted": False,
                             "lastProviderId": None,
+                            "numberOfTickets": None,
                             "offerId": humanize(offer.id),
                             "price": 0.0,
                             "quantity": None,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11973


## But de la pull request

Ajout d'une fonctionnalité côté eac collectif : création de stock en vue de la v0.1

##  Implémentation

- Ajout d'un nouveau champ dans le modèle `Stock` qui contiendra le nombre de places disponibles pour un évènement eac
- Nouvelle route de création de stock eac avec moins de contraintes métier
- Un seul stock possible par offre eac, d'où une quantité figée à 1, et la possibilité de séparer création et édition
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
