### PR TITLE
(PC-11730) Fix bookability by underage for some subcategories

### DIFF
--- a/api/src/pcapi/core/categories/subcategories.py
+++ b/api/src/pcapi/core/categories/subcategories.py
@@ -288,7 +288,7 @@ CINE_VENTE_DISTANCE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
-    is_bookable_by_underage_when_not_free=False,
+    is_bookable_by_underage_when_not_free=True,
 )
 
 CINE_PLEIN_AIR = Subcategory(
@@ -802,7 +802,7 @@ MUSEE_VENTE_DISTANCE = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
-    is_bookable_by_underage_when_not_free=False,
+    is_bookable_by_underage_when_not_free=True,
 )
 # endregion
 # region MUSIQUE_LIVE
@@ -1146,6 +1146,7 @@ SPECTACLE_ENREGISTRE = Subcategory(
     is_digital_deposit=True,
     is_physical_deposit=False,
     reimbursement_rule=ReimbursementRuleChoices.NOT_REIMBURSED.value,
+    is_bookable_by_underage_when_not_free=False,
 )
 LIVESTREAM_EVENEMENT = Subcategory(
     id="LIVESTREAM_EVENEMENT",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11730

Commentaire de Mariam dans le ticket : 

Revue PO: KO

Les sous-catégories suivantes doivent être reservable quand c’est payant:
- Cinéma - Vente à distance
- Musée - Vente à distance

La catégorie suivante est non reservable quand payant:
- Spectacle enregistrée