### PR TITLE
(PC-12061) improve PRO offer page response time

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -81,7 +81,7 @@ from .models import Mediation
 logger = logging.getLogger(__name__)
 
 
-OFFERS_RECAP_LIMIT = 201
+OFFERS_RECAP_LIMIT = 501
 UNCHANGED = object()
 VALIDATION_KEYWORDS_MAPPING = {
     "APPROVED": OfferValidationStatus.APPROVED,

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -118,10 +118,9 @@ def get_offers_by_filters(
             .filter(and_(UserOfferer.userId == user_id, UserOfferer.validationToken.is_(None)))
         )
     if offerer_id is not None:
-        venue_alias = aliased(Venue)
-        query = query.join(venue_alias, Offer.venueId == venue_alias.id).filter(
-            venue_alias.managingOffererId == offerer_id
-        )
+        if user_is_admin:
+            query = query.join(Venue)
+        query = query.filter(Venue.managingOffererId == offerer_id)
     if venue_id is not None:
         query = query.filter(Offer.venueId == venue_id)
     if creation_mode is not None:

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -70,6 +70,7 @@ def get_capped_offers_for_filters(
         .options(joinedload(Offer.stocks))
         .options(joinedload(Offer.mediations))
         .options(joinedload(Offer.product))
+        .options(joinedload(Offer.lastProvider))
         .limit(offers_limit)
         .all()
     )

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+from operator import attrgetter
 from typing import Optional
 
 from sqlalchemy import and_
@@ -64,19 +65,23 @@ def get_capped_offers_for_filters(
         period_ending_date=period_ending_date,
     )
 
-    query = (
+    offers = (
         query.options(joinedload(Offer.venue).joinedload(Venue.managingOfferer))
         .options(joinedload(Offer.stocks))
         .options(joinedload(Offer.mediations))
         .options(joinedload(Offer.product))
-        .order_by(Offer.id.desc())
         .limit(offers_limit)
         .all()
     )
 
+    # Do not use `ORDER BY` in SQL, which sometimes applies on a very large result set
+    # _before_ the `LIMIT` clause (and kills performance).
+    if len(offers) < offers_limit:
+        offers = sorted(offers, key=attrgetter("id"), reverse=True)
+
     # FIXME (cgaunet, 2020-11-03): we should not have serialization logic in the repository
     return to_domain(
-        offers=query,
+        offers=offers,
     )
 
 
@@ -162,7 +167,7 @@ def get_offers_by_filters(
                 <= period_ending_date
             )
 
-    return query.distinct(Offer.id)
+    return query
 
 
 def _filter_by_creation_mode(query: Query, creation_mode: str) -> Query:

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -39,9 +39,7 @@ class GetCappedOffersForFiltersTest:
         # Given
         user_offerer = offers_factories.UserOffererFactory()
         older_offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
-        expected_offer = offers_factories.OfferFactory(
-            venue=older_offer.venue, venue__managingOfferer=user_offerer.offerer
-        )
+        offers_factories.OfferFactory(venue=older_offer.venue, venue__managingOfferer=user_offerer.offerer)
 
         requested_max_offers_count = 1
 
@@ -55,7 +53,6 @@ class GetCappedOffersForFiltersTest:
         # Then
         assert isinstance(offers, OffersRecap)
         assert len(offers.offers) == 1
-        assert offers.offers[0].id == expected_offer.id
 
     @pytest.mark.usefixtures("db_session")
     def should_return_offers_sorted_by_id_desc(self):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12061


## But de la pull request

Make the offer view great again.
Permettre à la vue des offres de répondre rapidement même en l'absence de filtres et/ou avec des filtres trop larges.

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

In order to order the offer list the database had to scan the
full list of possible offers, order them and only then limit the
count to a limited numbers.
Since the offers number is quite impressive for some offerer the
associated route would time out.
We now return an unordered list of offers and only order them
whenever the offer count is lower than the requested limit.

En staging:

- avec un utilisateur d'une grosse structure, sur la page des offres sans filtres:
  - avant: Elapsed time: 386.0754 seconds
  - après: Elapsed time: 2.5086 seconds

- avec un admin, sur la page des offres sans filtres:
  - avant: Elapsed time: 1.1059 seconds
  - après: Elapsed time: 0.7512  seconds

- avec un utilisateur d'une grosse structure, sur la page des offres  en filtrant par nom ("demo"):
  - avant: Elapsed time: 11.5467 seconds
  - après: Elapsed time: 2.7462 seconds

- avec un admin, sur la page des offres en filtrant par nom ("demo"):
  - avant: Elapsed time: 74.9401 seconds
  - après: Elapsed time: 2.6844 seconds

​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
