### PR TITLE
(PC-11486): [API][FA] async suspend fraudulent users by ids

### DIFF
--- a/api/src/pcapi/domain/admin_emails.py
+++ b/api/src/pcapi/domain/admin_emails.py
@@ -9,6 +9,7 @@ from pcapi.utils.mailing import make_offer_rejection_notification_email
 from pcapi.utils.mailing import make_payment_details_email
 from pcapi.utils.mailing import make_payment_message_email
 from pcapi.utils.mailing import make_payments_report_email
+from pcapi.utils.mailing import make_suspended_fraudulent_beneficiary_by_ids_notification_email
 from pcapi.utils.mailing import make_validation_email_object
 from pcapi.utils.mailing import make_wallet_balances_email
 
@@ -66,3 +67,8 @@ def send_offer_validation_notification_to_administration(
     if validation_status is OfferValidationStatus.REJECTED:
         return send_offer_rejection_notification_to_administration(offer)
     return False
+
+
+def send_suspended_fraudulent_users_email(fraudulent_users: dict, nb_cancelled_bookings: int, recipient: str) -> bool:
+    email = make_suspended_fraudulent_beneficiary_by_ids_notification_email(fraudulent_users, nb_cancelled_bookings)
+    return mails.send(recipients=[recipient], data=email)

--- a/api/src/pcapi/templates/admin/suspend_fraudulent_users_by_user_ids.html
+++ b/api/src/pcapi/templates/admin/suspend_fraudulent_users_by_user_ids.html
@@ -15,22 +15,5 @@
             </div>
         </div>
     </form>
-
-    {% if fraudulent_users %}
-        <div class="col mb-3">
-            <div>
-                Nombre d'utilisateurs suspendus : {{ nb_fraud_users }}
-            </div>
-            <div>
-                ID des utilisateurs suspendus :
-            </div>
-            {% for user in fraudulent_users %}
-                <div>{{ user.id }}</div>
-            {% endfor %}
-            <div>
-                Nombre de réservations annulées : {{ nb_cancelled_bookings }}
-            </div>
-        </div>
-    {% endif %}
   {% endif %}
 {% endblock %}

--- a/api/src/pcapi/templates/mails/suspend_fraudulent_beneficiary_by_ids_notification_email.html
+++ b/api/src/pcapi/templates/mails/suspend_fraudulent_beneficiary_by_ids_notification_email.html
@@ -1,0 +1,28 @@
+<html>
+    <body>
+        <h1 id="title">Suspension d'utilisateurs via identifiants</h1>
+        {% if fraudulent_users %}
+        <div id="suspension-result">
+            <div id="nb-suspended-users">
+                Nombre d'utilisateurs suspendus : {{ nb_fraud_users }}
+            </div>
+            <div>
+                ID des utilisateurs suspendus :
+            </div>
+            <ul id="suspended-users-id">
+            {% for user in fraudulent_users %}
+                <li>{{ user.id }}</li>
+            </ul>
+            {% endfor %}
+            <div id="cancelled-bookings-count">
+                Nombre de réservations annulées : {{ nb_cancelled_bookings }}
+            </div>
+        </div>
+        {% endif %}
+        {% if not fraudulent_users %}
+        <div id="no-suspended-users">
+            Aucun utilisateur n'a été suspendu.
+        </div>
+        {% endif %}
+    </body>
+</html>

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -315,6 +315,22 @@ def make_admin_user_validation_email(user: User, token: str) -> dict:
     }
 
 
+def make_suspended_fraudulent_beneficiary_by_ids_notification_email(
+    fraudulent_users: dict, nb_cancelled_bookings: int
+) -> dict:
+    html = render_template(
+        "mails/suspend_fraudulent_beneficiary_by_ids_notification_email.html",
+        fraudulent_users=fraudulent_users,
+        nb_cancelled_bookings=nb_cancelled_bookings,
+        nb_fraud_users=len(fraudulent_users),
+    )
+    return {
+        "Html-part": html,
+        "FromName": "pass Culture",
+        "Subject": "Fraude : suspension des utilisateurs frauduleux par ids",
+    }
+
+
 def _add_template_debugging(message_data: dict) -> None:
     message_data["TemplateErrorReporting"] = {
         "Email": settings.DEV_EMAIL_ADDRESS,

--- a/api/src/pcapi/workers/suspend_fraudulent_beneficiary_users_by_ids_job.py
+++ b/api/src/pcapi/workers/suspend_fraudulent_beneficiary_users_by_ids_job.py
@@ -1,0 +1,18 @@
+import logging
+
+from pcapi.core.users.models import User
+from pcapi.domain.admin_emails import send_suspended_fraudulent_users_email
+from pcapi.scripts.suspend_fraudulent_beneficiary_users import suspend_fraudulent_beneficiary_users_by_ids
+from pcapi.workers import worker
+from pcapi.workers.decorators import job
+
+
+logger = logging.getLogger(__name__)
+
+
+@job(worker.low_queue)
+def suspend_fraudulent_beneficiary_users_by_ids_job(fraudulent_users: list[int], admin_user: User) -> None:
+    suspended_users_info = suspend_fraudulent_beneficiary_users_by_ids(fraudulent_users, admin_user, dry_run=False)
+    send_suspended_fraudulent_users_email(
+        suspended_users_info["fraudulent_users"], suspended_users_info["nb_cancelled_bookings"], admin_user.email
+    )

--- a/api/tests/admin/custom_views/suspend_fraudulent_users_by_ids_test.py
+++ b/api/tests/admin/custom_views/suspend_fraudulent_users_by_ids_test.py
@@ -1,4 +1,5 @@
 import io
+from unittest.mock import patch
 
 import pytest
 
@@ -9,8 +10,12 @@ from pcapi.core.users.factories import BeneficiaryGrant18Factory
 
 @pytest.mark.usefixtures("db_session")
 class SuspendFraudulentUsersByIdsTest:
-    def test_suspend_users_by_ids(self, client):
-        admin_user = AdminFactory()
+    @patch("pcapi.admin.custom_views.suspend_fraudulent_users_by_ids.current_user")
+    @patch(
+        "pcapi.admin.custom_views.suspend_fraudulent_users_by_ids.suspend_fraudulent_beneficiary_users_by_ids_job.delay"
+    )
+    def test_suspend_users_by_ids(self, mocked_suspend_fraudulent_beneficiary_users_by_ids_job, current_user, client):
+        admin_user = AdminFactory(email="admin@example.com")
         fraudulent_user_1 = BeneficiaryGrant18Factory(id=5)
         fraudulent_user_2 = BeneficiaryGrant18Factory(id=16)
         booking_factories.IndividualBookingFactory(individualBooking__user=fraudulent_user_1)
@@ -22,9 +27,7 @@ class SuspendFraudulentUsersByIdsTest:
         client = client.with_session_auth(admin_user.email)
         response = client.post("/pc/back-office/suspend_fraud_users_by_user_ids", files=files, headers=headers)
 
+        mocked_suspend_fraudulent_beneficiary_users_by_ids_job.assert_called_once_with([5, 16], current_user)
         assert response.status_code == 200
         content = response.data.decode(response.charset)
-        assert not fraudulent_user_2.isActive
-        assert not fraudulent_user_1.isActive
-        assert "Nombre d'utilisateurs suspendus : 2" in content
-        assert "Nombre de réservations annulées : 1" in content
+        assert "La suspension des utilisateurs via ids a bien été lancée" in content

--- a/api/tests/domain/admin_emails_test.py
+++ b/api/tests/domain/admin_emails_test.py
@@ -15,6 +15,7 @@ from pcapi.domain.admin_emails import send_offer_rejection_notification_to_admin
 from pcapi.domain.admin_emails import send_offer_validation_notification_to_administration
 from pcapi.domain.admin_emails import send_payment_details_email
 from pcapi.domain.admin_emails import send_payments_report_emails
+from pcapi.domain.admin_emails import send_suspended_fraudulent_users_email
 from pcapi.domain.admin_emails import send_wallet_balances_email
 
 
@@ -149,3 +150,16 @@ class SendOfferNotificationToAdministrationTest:
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["To"] == "administration@example.com"
         assert mails_testing.outbox[0].sent_data["Subject"] == "[Création d’offre - 75] Test Book"
+
+
+@pytest.mark.usefixtures("db_session")
+def test_send_suspended_fraudulent_users_email(app):
+    admin = users_factories.UserFactory(email="admin@email.com")
+    fraudulent_users = [users_factories.UserFactory()]
+    nb_cancelled_bookings = 0
+
+    send_suspended_fraudulent_users_email(fraudulent_users, nb_cancelled_bookings, admin.email)
+
+    assert len(mails_testing.outbox) == 1
+    assert mails_testing.outbox[0].sent_data["To"] == "admin@email.com"
+    assert mails_testing.outbox[0].sent_data["Subject"] == "Fraude : suspension des utilisateurs frauduleux par ids"

--- a/api/tests/workers/suspend_fraudulent_beneficiary_users_by_ids_job_test.py
+++ b/api/tests/workers/suspend_fraudulent_beneficiary_users_by_ids_job_test.py
@@ -1,0 +1,27 @@
+from unittest import mock
+
+import pytest
+
+from pcapi.core.users.factories import AdminFactory
+from pcapi.core.users.factories import BeneficiaryGrant18Factory
+from pcapi.workers.suspend_fraudulent_beneficiary_users_by_ids_job import (
+    suspend_fraudulent_beneficiary_users_by_ids_job,
+)
+
+
+@mock.patch("pcapi.workers.suspend_fraudulent_beneficiary_users_by_ids_job.send_suspended_fraudulent_users_email")
+@mock.patch("pcapi.workers.suspend_fraudulent_beneficiary_users_by_ids_job.suspend_fraudulent_beneficiary_users_by_ids")
+@pytest.mark.usefixtures("db_session")
+def test_send_email_is_called(
+    mocked_suspend_fraudulent_benef_users_by_ids, mocked_send_suspended_fraudulent_users_email
+) -> None:
+    admin_user = AdminFactory(email="admin@example.com")
+    fraudulent_user = BeneficiaryGrant18Factory(id=15)
+    mocked_suspend_fraudulent_benef_users_by_ids.return_value = {
+        "fraudulent_users": [fraudulent_user],
+        "nb_cancelled_bookings": 0,
+    }
+
+    suspend_fraudulent_beneficiary_users_by_ids_job([15], admin_user)
+
+    mocked_send_suspended_fraudulent_users_email.assert_called_once_with([fraudulent_user], 0, admin_user.email)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX


## But de la pull request

Résolution du problème de timeout lors de la suspension de plusieurs utilisateurs via ID sur FA.

##  Implémentation

- Lancer la suspension en asynchrone sur la `low_queue`
- Envoi d'un mail récapitulatif à la fin de l'opération.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
