### PR TITLE
(pc-11987)(API)(FlaskAdmin) Add Reason of account suspension for PRO/…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-503904c2cab7 (head)
+f76061a19b8f (head)

--- a/api/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
+++ b/api/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
@@ -43,7 +43,9 @@ def _action_links(view, context, model, name):
         text = "Suspendre…"
     else:
         url = url_for(".unsuspend_user_view")
-        text = "Réactiver…"
+        text = "Réactiver…({})".format(
+            dict(users_constants.SUSPENSION_REASON_CHOICES)[users_constants.SuspensionReason(model.suspensionReason)]
+        )
 
     return Markup('<a href="{url}?user_id={model_id}">{text}</a>').format(
         url=url,

--- a/api/src/pcapi/alembic/versions/20211201T154901_f76061a19b8f_users_migrate_suspension_reason.py
+++ b/api/src/pcapi/alembic/versions/20211201T154901_f76061a19b8f_users_migrate_suspension_reason.py
@@ -1,0 +1,19 @@
+"""
+Switch 'fraud' to 'fraud suspicion'
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f76061a19b8f"
+down_revision = "503904c2cab7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""UPDATE "user" SET "suspensionReason" = 'fraud suspicion' WHERE "user"."suspensionReason" = 'fraud'""")
+
+
+def downgrade() -> None:
+    op.execute("""UPDATE "user" SET "suspensionReason" = 'fraud' WHERE "user"."suspensionReason" = 'fraud suspicion'""")

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -374,7 +374,7 @@ def suspend_account(user: User, reason: constants.SuspensionReason, actor: User)
 
     # Cancel all bookings of the related offerer if the suspended
     # account was the last active offerer's account.
-    if reason == constants.SuspensionReason.FRAUD:
+    if reason == constants.SuspensionReason.FRAUD_SUSPICION:
         for offerer in user.offerers:
             if any(u.isActive and u != user for u in offerer.users):
                 continue
@@ -386,7 +386,7 @@ def suspend_account(user: User, reason: constants.SuspensionReason, actor: User)
     # Cancel all bookings of the user (the following works even if the
     # user is not a beneficiary).
     cancel_booking_callback = {
-        constants.SuspensionReason.FRAUD: bookings_api.cancel_booking_for_fraud,
+        constants.SuspensionReason.FRAUD_SUSPICION: bookings_api.cancel_booking_for_fraud,
         constants.SuspensionReason.UPON_USER_REQUEST: bookings_api.cancel_booking_on_user_requested_account_suspension,
     }.get(reason)
     if cancel_booking_callback:

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -40,17 +40,39 @@ class SuspensionReason(Enum):
 
     # If you add a new reason, update `suspend_account()` to cancel
     # bookings if applicable.
+    CLOSED_STRUCTURE_DEFINITIVE = "definitively closed structure"
+    CLOSED_STRUCTURE_TEMP = "temporarly closed structure"
     END_OF_CONTRACT = "end of contract"
     END_OF_ELIGIBILITY = "end of eligibility"
-    FRAUD = "fraud"
+    FRAUD_BOOKING_CANCEL = "booking cancel fraud"
+    FRAUD_CREATION_PRO = "creation PRO fraud"
+    FRAUD_DUPLICATE = "duplicate fraud"
+    FRAUD_FAKE_DOCUMENT = "fake document fraud"
+    FRAUD_HACK = "hacking fraud"
+    FRAUD_RESELL_PASS = "pass resell fraud"
+    FRAUD_RESELL_PRODUCT = "product resell fraud"
+    FRAUD_SUSPICION = "fraud suspicion"
+    FRAUD_USURPATION = "usurpating fraud"
+    FRAUD_USURPATION_PRO = "usurpating PRO fraud"
     UPON_USER_REQUEST = "upon user request"
 
 
 SUSPENSION_REASON_CHOICES = (
-    (SuspensionReason.END_OF_ELIGIBILITY, "fin d'éligibilité"),
-    (SuspensionReason.END_OF_CONTRACT, "fin de contrat"),
-    (SuspensionReason.FRAUD, "fraude"),
-    (SuspensionReason.UPON_USER_REQUEST, "demande de l'utilisateur"),
+    (SuspensionReason.CLOSED_STRUCTURE_DEFINITIVE, "Structure définitivement fermée"),
+    (SuspensionReason.CLOSED_STRUCTURE_TEMP, "Structure fermée provisoirement"),
+    (SuspensionReason.END_OF_CONTRACT, "Fin de contrat"),
+    (SuspensionReason.END_OF_ELIGIBILITY, "Fin d'éligibilité"),
+    (SuspensionReason.FRAUD_BOOKING_CANCEL, "Fraude annulation réservation"),
+    (SuspensionReason.FRAUD_CREATION_PRO, "Fraude PRO création"),
+    (SuspensionReason.FRAUD_DUPLICATE, "Fraude doublon"),
+    (SuspensionReason.FRAUD_FAKE_DOCUMENT, "Fraude faux document"),
+    (SuspensionReason.FRAUD_HACK, "Fraude hacking"),
+    (SuspensionReason.FRAUD_RESELL_PASS, "Fraude revente pass"),
+    (SuspensionReason.FRAUD_RESELL_PRODUCT, "Fraude revente produit"),
+    (SuspensionReason.FRAUD_SUSPICION, "Fraude suspicion"),
+    (SuspensionReason.UPON_USER_REQUEST, "Demande de l'utilisateur"),
+    (SuspensionReason.FRAUD_USURPATION, "Fraude usurpation"),
+    (SuspensionReason.FRAUD_USURPATION_PRO, "Fraude PRO usurpation"),
 )
 
 assert set(_t[0] for _t in SUSPENSION_REASON_CHOICES) == set(SuspensionReason)

--- a/api/src/pcapi/scripts/suspend_fraudulent_beneficiary_users.py
+++ b/api/src/pcapi/scripts/suspend_fraudulent_beneficiary_users.py
@@ -36,7 +36,7 @@ def suspend_fraudulent_beneficiary_users(fraudulent_users: list[User], admin_use
     if not dry_run:
         n_bookings = 0
         for fraudulent_user in fraudulent_users:
-            result = suspend_account(fraudulent_user, SuspensionReason.FRAUD, admin_user)
+            result = suspend_account(fraudulent_user, SuspensionReason.FRAUD_SUSPICION, admin_user)
             n_bookings += result["cancelled_bookings"]
         logger.info(
             "Fraudulent beneficiaries accounts suspended",

--- a/api/src/pcapi/scripts/suspend_fraudulent_pro_users.py
+++ b/api/src/pcapi/scripts/suspend_fraudulent_pro_users.py
@@ -32,4 +32,4 @@ def suspend_fraudulent_pro_by_email_providers(
 
 def _suspend_fraudulent_pro_users(users: list[User], admin_user: User) -> None:
     for fraudulent_user in users:
-        suspend_account(fraudulent_user, SuspensionReason.FRAUD, admin_user)
+        suspend_account(fraudulent_user, SuspensionReason.FRAUD_SUSPICION, admin_user)

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.testing import override_settings
+import pcapi.core.users.constants as users_constants
 import pcapi.core.users.factories as users_factories
 from pcapi.core.users.models import Token
 from pcapi.core.users.models import TokenType
@@ -117,13 +118,17 @@ class AdminUserViewTest:
 
         # Suspend
         url = f"/pc/back-office/admin_users/suspend?user_id={admin.id}"
-        suspend_response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+        suspend_response = client.post(
+            url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
+        )
         assert suspend_response.status_code == 302
         assert not admin.isActive
 
         # Unsuspend
         url = f"/pc/back-office/admin_users/unsuspend?user_id={admin.id}"
-        unsuspend_response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+        unsuspend_response = client.post(
+            url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
+        )
         assert unsuspend_response.status_code == 302
         assert admin.isActive
 
@@ -154,7 +159,9 @@ class AdminUserViewTest:
 
         # super_admin suspends admin_2
         url = f"/pc/back-office/admin_users/suspend?user_id={admin_2.id}"
-        suspend_response = super_admin_client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+        suspend_response = super_admin_client.post(
+            url, form={"reason": users_constants.SuspensionReason.FRAUD_SUSPICION.value, "csrf_token": "token"}
+        )
         assert suspend_response.status_code == 302
         assert not admin_2.isActive
 

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -200,7 +200,7 @@ class BeneficiaryUserViewTest:
         client = TestClient(app.test_client()).with_session_auth(admin.email)
         url = f"/pc/back-office/beneficiary_users/suspend?user_id={beneficiary.id}"
         data = {
-            "reason": "fraud",
+            "reason": "fraud suspicion",
             "csrf_token": "token",
         }
         response = client.post(url, form=data)

--- a/api/tests/admin/custom_views/partner_user_view_test.py
+++ b/api/tests/admin/custom_views/partner_user_view_test.py
@@ -107,13 +107,13 @@ class PartnerUserViewTest:
 
         # Super admin suspends partner
         url = f"/pc/back-office/partner_users/suspend?user_id={partner.id}"
-        suspend_response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+        suspend_response = client.post(url, form={"reason": "fraud suspicion", "csrf_token": "token"})
         assert suspend_response.status_code == 302
         assert not partner.isActive
 
         # Super admin unsuspends partner
         url = f"/pc/back-office/partner_users/unsuspend?user_id={partner.id}"
-        unsuspend_response = client.post(url, form={"reason": "fraud", "csrf_token": "token"})
+        unsuspend_response = client.post(url, form={"reason": "fraud suspicion", "csrf_token": "token"})
         assert unsuspend_response.status_code == 302
         assert partner.isActive
 

--- a/api/tests/admin/custom_views/pro_user_view_test.py
+++ b/api/tests/admin/custom_views/pro_user_view_test.py
@@ -133,7 +133,7 @@ class ProUserViewTest:
         client = TestClient(app.test_client()).with_session_auth(admin.email)
         url = f"/pc/back-office/pro_users/suspend?user_id={pro.id}"
         data = {
-            "reason": "fraud",
+            "reason": "fraud suspicion",
             "csrf_token": "token",
         }
         response = client.post(url, form=data)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -254,7 +254,7 @@ class SuspendAccountTest:
     def test_suspend_admin(self):
         user = users_factories.AdminFactory()
         users_factories.UserSessionFactory(user=user)
-        reason = users_constants.SuspensionReason.FRAUD
+        reason = users_constants.SuspensionReason.FRAUD_SUSPICION
         actor = users_factories.AdminFactory()
 
         users_api.suspend_account(user, reason, actor)
@@ -276,7 +276,7 @@ class SuspendAccountTest:
         used_booking = bookings_factories.UsedIndividualBookingFactory(individualBooking__user=user)
         actor = users_factories.AdminFactory()
 
-        users_api.suspend_account(user, users_constants.SuspensionReason.FRAUD, actor)
+        users_api.suspend_account(user, users_constants.SuspensionReason.FRAUD_SUSPICION, actor)
 
         assert not user.isActive
         assert cancellable_booking.isCancelled
@@ -291,7 +291,7 @@ class SuspendAccountTest:
         pro = offers_factories.UserOffererFactory(offerer=booking.offerer).user
         actor = users_factories.AdminFactory()
 
-        users_api.suspend_account(pro, users_constants.SuspensionReason.FRAUD, actor)
+        users_api.suspend_account(pro, users_constants.SuspensionReason.FRAUD_SUSPICION, actor)
 
         assert not pro.isActive
         assert booking.isCancelled
@@ -303,7 +303,7 @@ class SuspendAccountTest:
         offers_factories.UserOffererFactory(offerer=booking.offerer)
         actor = users_factories.AdminFactory()
 
-        users_api.suspend_account(pro, users_constants.SuspensionReason.FRAUD, actor)
+        users_api.suspend_account(pro, users_constants.SuspensionReason.FRAUD_SUSPICION, actor)
 
         assert not pro.isActive
         assert not booking.isCancelled


### PR DESCRIPTION
…Admin/Jeunes new list and display

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11987


## But de la pull request

En tant que contrôleur de la fraudeJ'aimerais ajouter un motif de suspension mieux défini sur le profil utilisateur dans FAAfin d’avoir un suivi précis sur les raisons de blocage et des statistiques 

##  Implémentation

- Sur FA, lorsque le compte utilisateur (Jeune, Pro, GP) est suspendu, on affiche la liste déroulante des raisons de suspension qui suit (dans l’ordre de la liste, et en remplacement da la liste actuelle) : 
    - Fraude faux document
    - Fraude revente produit
    - Fraude revente pass
    - Fraude usurpation
    - Fraude suspicion
    - Fraude doublon
    - Fraude hacking
    - Fraude annulation réservation
    - Fin de contrat
    - Fin d'éligibilité
    - Demande de l'utilisateur
    - Fraude PRO usurpation
    - Fraude PRO création
    - Structure définitivement fermée
    - Structure fermée provisoirement

- Afficher le motif de suspension dans la colonne de l’onglet principal FA “Utilisateurs > PRO/Jeunes/GP”​
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
![Capture d’écran 2021-12-01 à 14 51 20](https://user-images.githubusercontent.com/9610732/144247818-67676468-0185-492b-b7fd-ad66e47712ff.png)
![Capture d’écran 2021-12-01 à 14 51 32](https://user-images.githubusercontent.com/9610732/144247822-676f55db-a511-4f73-bbcc-abc26dabd445.png)

- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
