### PR TITLE
(pc-11711)(API)(FA) Fix wording in beneficiary view

### DIFF
--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -190,7 +190,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         isEmailValidated="Email validé ?",
         has_active_deposit="Dépôt valable ?",
         total_remaining="Crédit global restant",
-        total_initial="Crédit global disponible",
+        total_initial="Crédit initial",
         digital_remaining="Crédit digital restant",
         physical_remaining="Crédit physique restant",
         deposit_type="Type du portefeuille",


### PR DESCRIPTION
![Capture d’écran 2021-11-26 à 15 33 22](https://user-images.githubusercontent.com/9610732/143596245-ae666d0c-4b59-4ba5-b49b-642ae311a39b.png)


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11711


## But de la pull request

En tant que l'équipe support. J’aimerais avoir accès au crédit restant de l’user dans FA Afin de traiter plus rapidement les tâches quotidiennes de calcul du crédit

##  Implémentation

Afficher dans l’onglet Jeunes du FA 

- le crédit global restant 
- le crédit restant par plafond (numérique, autre)​

