### PR TITLE
(PC-11624) [api][finance] Generate and store Invoices

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-1e92f54267a9 (head)
+d71dd05eae76 (head)

--- a/api/src/pcapi/alembic/versions/20220110T114500_7b8966ff7913_add_invoice_models.py
+++ b/api/src/pcapi/alembic/versions/20220110T114500_7b8966ff7913_add_invoice_models.py
@@ -1,0 +1,52 @@
+"""Add Invoice-related models"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "7b8966ff7913"
+down_revision = "1e92f54267a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "invoice_cashflow",
+        sa.Column("invoiceId", sa.BigInteger(), nullable=False),
+        sa.Column("cashflowId", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["cashflowId"],
+            ["cashflow.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["invoiceId"],
+            ["invoice.id"],
+        ),
+        sa.PrimaryKeyConstraint("invoiceId", "cashflowId"),
+        sa.UniqueConstraint("invoiceId", "cashflowId", name="unique_invoice_cashflow_association"),
+    )
+    op.create_index(op.f("ix_invoice_cashflow_cashflowId"), "invoice_cashflow", ["cashflowId"], unique=False)
+    op.create_index(op.f("ix_invoice_cashflow_invoiceId"), "invoice_cashflow", ["invoiceId"], unique=False)
+    op.create_table(
+        "invoice_line",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("invoiceId", sa.BigInteger(), nullable=False),
+        sa.Column("label", sa.Text(), nullable=False),
+        sa.Column("group", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("contribution_amount", sa.Integer(), nullable=False),
+        sa.Column("reimbursed_amount", sa.Integer(), nullable=False),
+        sa.Column("rate", sa.Numeric(precision=5, scale=4), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["invoiceId"],
+            ["invoice.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_invoice_line_invoiceId"), "invoice_line", ["invoiceId"], unique=False)
+
+
+def downgrade():
+    op.drop_table("invoice_line")
+    op.drop_table("invoice_cashflow")

--- a/api/src/pcapi/alembic/versions/20220110T155918_d71dd05eae76_edit_invoice_url.py
+++ b/api/src/pcapi/alembic/versions/20220110T155918_d71dd05eae76_edit_invoice_url.py
@@ -1,0 +1,17 @@
+"""Rename invoice.url"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d71dd05eae76"
+down_revision = "7b8966ff7913"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("invoice", "url", new_column_name="token")
+
+
+def downgrade():
+    op.alter_column("invoice", "token", new_column_name="url")

--- a/api/src/pcapi/core/finance/conf.py
+++ b/api/src/pcapi/core/finance/conf.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+# TODO(fseguin|dbaty, 2022-01-11): maybe merge with core.categories.subcategories.ReimbursementRuleChoices ?
+class RuleGroups(Enum):
+    STANDARD = dict(
+        label="Barème général",
+        position=1,
+    )
+    BOOK = dict(
+        label="Barème livres",
+        position=2,
+    )
+    NOT_REIMBURSED = dict(
+        label="Barème non remboursé",
+        position=3,
+    )
+    CUSTOM = dict(
+        label="Barème dérogatoire",
+        position=4,
+    )
+    DEPRECATED = dict(
+        label="Barème désuet",
+        position=5,
+    )

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -28,7 +28,7 @@ class PricingFactory(BaseFactory):
     siret = factory.SelfAttribute("booking.venue.siret")
     valueDate = factory.SelfAttribute("booking.dateUsed")
     amount = LazyAttribute(lambda pricing: -int(100 * pricing.booking.total_amount))
-    standardRule = "full reimbursement"
+    standardRule = "Remboursement total pour les offres physiques"
     revenue = LazyAttribute(lambda pricing: int(100 * pricing.booking.total_amount))
 
 

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -1,3 +1,5 @@
+import secrets
+
 import factory
 from factory.declarations import LazyAttribute
 
@@ -58,7 +60,7 @@ class InvoiceFactory(BaseFactory):
     businessUnit = factory.SubFactory(BusinessUnitFactory)
     amount = 1000
     reference = factory.Sequence("{:09}".format)
-    url = LazyAttribute(lambda invoice: f"/finance/invoices/{invoice.reference}.pdf")
+    token = factory.LazyFunction(secrets.token_urlsafe)
 
 
 class CashflowBatchFactory(BaseFactory):

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -13,6 +13,7 @@ import sqlalchemy as sqla
 import sqlalchemy.dialects.postgresql as sqla_psql
 import sqlalchemy.orm as sqla_orm
 
+from pcapi import settings
 from pcapi.domain import payments
 from pcapi.models import Model
 import pcapi.utils.db as db_utils
@@ -307,6 +308,10 @@ class Invoice(Model):
     token = sqla.Column(sqla.Text, unique=True, nullable=False)
     lines = sqla_orm.relationship("InvoiceLine", back_populates="invoice")
     cashflows = sqla_orm.relationship("Cashflow", secondary="invoice_cashflow", back_populates="invoices")
+
+    @property
+    def url(self):
+        return f"{settings.OBJECT_STORAGE_URL}/invoices/{self.token}.pdf"
 
 
 class InvoiceCashflow(Model):

--- a/api/src/pcapi/core/finance/utils.py
+++ b/api/src/pcapi/core/finance/utils.py
@@ -1,11 +1,28 @@
 import decimal
 import typing
 
+from babel import numbers
 
-def to_eurocents(amount_in_euros: typing.Union[decimal.Decimal, float]):
+
+def to_eurocents(amount_in_euros: typing.Union[decimal.Decimal, float]) -> int:
     return int(100 * decimal.Decimal(f"{amount_in_euros}"))
 
 
 def to_euros(amount_in_eurocents: int) -> decimal.Decimal:
     exp = decimal.Decimal("0.01")
     return decimal.Decimal(amount_in_eurocents / 100).quantize(exp)
+
+
+def fr_percentage_filter(decimal_rate: decimal.Decimal) -> str:
+    return numbers.format_percent(decimal_rate, locale="fr_FR", decimal_quantization=False)
+
+
+def fr_currency_filter(eurocents: int) -> float:
+    """Returns a localized str without signing nor currency symbol"""
+    amount_in_euros = to_euros(abs(eurocents))
+    return numbers.format_decimal(amount_in_euros, format="#,##0.00", locale="fr_FR")
+
+
+def install_template_filters(app) -> None:
+    app.jinja_env.filters["fr_percentage"] = fr_percentage_filter
+    app.jinja_env.filters["fr_currency"] = fr_currency_filter

--- a/api/src/pcapi/core/payments/models.py
+++ b/api/src/pcapi/core/payments/models.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.sqltypes import SmallInteger
 
+from pcapi.core.finance import conf as finance_conf
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 
@@ -46,6 +47,10 @@ class ReimbursementRule:
 
     def apply(self, booking: "Booking") -> Decimal:
         return Decimal(booking.total_amount * self.rate)
+
+    @property
+    def group(self) -> str:
+        raise NotImplementedError()
 
 
 class CustomReimbursementRule(ReimbursementRule, Model):
@@ -123,6 +128,10 @@ class CustomReimbursementRule(ReimbursementRule, Model):
     @property
     def description(self):  # implementation of ReimbursementRule.description
         raise TypeError("A custom reimbursement rule does not have any description")
+
+    @property
+    def group(self):
+        return finance_conf.RuleGroups.CUSTOM
 
 
 class DepositType(enum.Enum):

--- a/api/src/pcapi/domain/reimbursement.py
+++ b/api/src/pcapi/domain/reimbursement.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from pcapi.core.bookings.models import Booking
 from pcapi.core.categories import subcategories
+from pcapi.core.finance import conf as finance_conf
 from pcapi.core.offers.models import Offer
 import pcapi.core.payments.models as payments_models
 
@@ -17,6 +18,7 @@ SEPTEMBER_2021 = datetime.datetime(2021, 9, 1) - datetime.timedelta(hours=2)
 class DigitalThingsReimbursement(payments_models.ReimbursementRule):
     rate = Decimal(0)
     description = "Pas de remboursement pour les offres digitales"
+    group = finance_conf.RuleGroups.NOT_REIMBURSED
     valid_from = None
     valid_until = None
 
@@ -31,6 +33,7 @@ class DigitalThingsReimbursement(payments_models.ReimbursementRule):
 class EducationalOffersReimbursement(payments_models.ReimbursementRule):
     rate = Decimal(1)
     description = "Remboursement total pour les offres éducationnelles"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = None
     valid_until = None
 
@@ -42,6 +45,7 @@ class EducationalOffersReimbursement(payments_models.ReimbursementRule):
 class PhysicalOffersReimbursement(payments_models.ReimbursementRule):
     rate = Decimal(1)
     description = "Remboursement total pour les offres physiques"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = None
     valid_until = None
 
@@ -53,6 +57,7 @@ class MaxReimbursementByOfferer(payments_models.ReimbursementRule):
     # This rule is not used anymore.
     rate = Decimal(0)
     description = "Pas de remboursement au dessus du plafond de 20 000 € par acteur culturel"
+    group = finance_conf.RuleGroups.DEPRECATED
     valid_from = None
     valid_until = None
 
@@ -65,6 +70,7 @@ class MaxReimbursementByOfferer(payments_models.ReimbursementRule):
 class LegacyPreSeptember2021ReimbursementRateByVenueBetween20000And40000(payments_models.ReimbursementRule):
     rate = Decimal("0.95")
     description = "Remboursement à 95% entre 20 000 € et 40 000 € par lieu"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = None
     valid_until = SEPTEMBER_2021
 
@@ -77,6 +83,7 @@ class LegacyPreSeptember2021ReimbursementRateByVenueBetween20000And40000(payment
 class LegacyPreSeptember2021ReimbursementRateByVenueBetween40000And150000(payments_models.ReimbursementRule):
     rate = Decimal("0.85")
     description = "Remboursement à 85% entre 40 000 € et 150 000 € par lieu"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = None
     valid_until = SEPTEMBER_2021
 
@@ -89,6 +96,7 @@ class LegacyPreSeptember2021ReimbursementRateByVenueBetween40000And150000(paymen
 class LegacyPreSeptember2021ReimbursementRateByVenueAbove150000(payments_models.ReimbursementRule):
     rate = Decimal("0.70")
     description = "Remboursement à 70% au dessus de 150 000 € par lieu"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = None
     valid_until = SEPTEMBER_2021
 
@@ -101,6 +109,7 @@ class LegacyPreSeptember2021ReimbursementRateByVenueAbove150000(payments_models.
 class ReimbursementRateByVenueBetween20000And40000(payments_models.ReimbursementRule):
     rate = Decimal("0.95")
     description = "Remboursement à 95% entre 20 000 € et 40 000 € par lieu (>= 2021-09-01)"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = SEPTEMBER_2021
     valid_until = None
 
@@ -113,6 +122,7 @@ class ReimbursementRateByVenueBetween20000And40000(payments_models.Reimbursement
 class ReimbursementRateByVenueBetween40000And150000(payments_models.ReimbursementRule):
     rate = Decimal("0.92")
     description = "Remboursement à 92% entre 40 000 € et 150 000 € par lieu (>= 2021-09-01)"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = SEPTEMBER_2021
     valid_until = None
 
@@ -125,6 +135,7 @@ class ReimbursementRateByVenueBetween40000And150000(payments_models.Reimbursemen
 class ReimbursementRateByVenueAbove150000(payments_models.ReimbursementRule):
     rate = Decimal("0.90")
     description = "Remboursement à 90% au dessus de 150 000 € par lieu (>= 2021-09-01)"
+    group = finance_conf.RuleGroups.STANDARD
     valid_from = SEPTEMBER_2021
     valid_until = None
 
@@ -137,6 +148,7 @@ class ReimbursementRateByVenueAbove150000(payments_models.ReimbursementRule):
 class ReimbursementRateForBookBelow20000(payments_models.ReimbursementRule):
     rate = Decimal(1)
     description = "Remboursement à 100% jusqu'à 20 000 € pour les livres"
+    group = finance_conf.RuleGroups.BOOK
     valid_from = None
     valid_until = None
 
@@ -151,6 +163,7 @@ class ReimbursementRateForBookBelow20000(payments_models.ReimbursementRule):
 class ReimbursementRateForBookAbove20000(payments_models.ReimbursementRule):
     rate = Decimal("0.95")
     description = "Remboursement à 95% au dessus de 20 000 € pour les livres"
+    group = finance_conf.RuleGroups.BOOK
     valid_from = None
     valid_until = None
 
@@ -174,6 +187,21 @@ REGULAR_RULES = [
     ReimbursementRateByVenueAbove150000(),
     ReimbursementRateForBookBelow20000(),
     ReimbursementRateForBookAbove20000(),
+]
+
+# A description must be unique and should never be modified, or it will break Invoice generation
+assert [r.description for r in REGULAR_RULES] == [
+    "Pas de remboursement pour les offres digitales",
+    "Remboursement total pour les offres éducationnelles",
+    "Remboursement total pour les offres physiques",
+    "Remboursement à 95% entre 20 000 € et 40 000 € par lieu",
+    "Remboursement à 85% entre 40 000 € et 150 000 € par lieu",
+    "Remboursement à 70% au dessus de 150 000 € par lieu",
+    "Remboursement à 95% entre 20 000 € et 40 000 € par lieu (>= 2021-09-01)",
+    "Remboursement à 92% entre 40 000 € et 150 000 € par lieu (>= 2021-09-01)",
+    "Remboursement à 90% au dessus de 150 000 € par lieu (>= 2021-09-01)",
+    "Remboursement à 100% jusqu'à 20 000 € pour les livres",
+    "Remboursement à 95% au dessus de 20 000 € pour les livres",
 ]
 
 

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -19,6 +19,7 @@ from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from pcapi import settings
+from pcapi.core.finance import utils as finance_utils
 from pcapi.core.logging import get_or_set_correlation_id
 from pcapi.core.logging import install_logging
 from pcapi.models import db
@@ -164,7 +165,7 @@ db.init_app(app)
 orm.configure_mappers()
 login_manager.init_app(app)
 install_commands(app)
-
+finance_utils.install_template_filters(app)
 
 app.url_map.strict_slashes = False
 

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <style>
+        html {
+            font-family: sans-serif;
+            font-size: 11pt;
+            line-height: 1.5;
+        }
+
+        body {
+            margin: 5pt;
+        }
+
+        h1 {
+            color: purple;
+            font-size: 18pt;
+            margin: 0;
+            text-align: center;
+        }
+
+        h2 {
+            color: purple;
+            font-size: 12pt;
+            margin: 0;
+        }
+
+        table, th, td {
+            border: 0.2mm solid #2f1313;
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th {
+            font-weight: bold;
+        }
+
+        td {
+            padding-top: 7mm;
+        }
+
+        th, td {
+            text-align: center;
+        }
+
+
+    </style>
+    <title>Justificatif de remboursement</title>
+    <meta name="description" content="Etat justifiant du montant du remboursement">
+</head>
+
+<body>
+
+<h1>Justificatif de remboursement</h1>
+<h2 class="invoice_info">Relevé n°{{ invoice.reference }} du {{ invoice.date.strftime('%d/%m/%Y') }}</h2>
+
+<p>
+<div><b>Nom :</b> {{ invoice.businessUnit.name }}</div>
+<div><b>SIRET :</b> {{ invoice.businessUnit.siret }}</div>
+</p>
+
+<h4>
+    Détail des offres remboursées incluant la contribution offreur,
+    appliquée selon le barème définis dans nos conditions générales de ventes
+</h4>
+
+<table>
+    <thead>
+    <tr>
+        <th>Typologie</th>
+        <th>Taux de remboursement (%)</th>
+        <th>Montant des réservations validées (TTC)</th>
+        <th>Taux de contribution offreur (%)</th>
+        <th>Montant de la contribution offreur (TTC)</th>
+        <th>Montant remboursé (TTC)</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {% for group in groups %}
+        <tr>
+            <td colspan="6" style="text-align:left;background: lightcyan"><b> {{ group.label }} </b></td>
+        </tr>
+
+        {% for line in group.lines %}
+            <tr>
+                <td>Montant remboursé</td>
+                <td>{{ line.rate|fr_percentage }}</td>
+                <td>{{ line.get_bookings_amount|fr_currency }}</td>
+                <td>{{ line.contribution_rate|fr_percentage }}</td>
+                <td>{{ line.contribution_amount|fr_currency }}</td>
+                <td>{{ line.reimbursed_amount|fr_currency }}</td>
+            </tr>
+        {% endfor %}
+
+        <tr style="color: dimgrey">
+            <td>SOUS-TOTAL</td>
+            <td></td>
+            <td>{{ group.used_bookings_subtotal|fr_currency }}</td>
+            <td></td>
+            <td>{{ group.contribution_subtotal|fr_currency }}</td>
+            <td>{{ group.reimbursed_amount_subtotal|fr_currency }}</td>
+        </tr>
+    {% endfor %}
+    <tr>
+        <td>TOTAL</td>
+        <td></td>
+        <td>{{ total_used_bookings_amount|fr_currency }}</td>
+        <td></td>
+        <td>{{ total_contribution_amount|fr_currency }}</td>
+        <td>{{ total_reimbursed_amount|fr_currency }}</td>
+    </tr>
+    </tbody>
+
+</table>
+
+
+<p>
+    Au regard de la taxe sur la valeur ajoutée (TVA), les remboursements s’entendent toutes taxes comprises (TTC).
+    L’Offreur s’engage à s’acquitter de la TVA résultant de l’application de son régime fiscal et selon le taux
+    applicable à ses Offres.
+    Il est considéré que la contribution offreur relative à l’application du barème constitue une réduction de
+    prix, au sens de l’article 267 du code général des impôts, et qu’à ce titre, les offreurs pourront ainsi
+    régulariser leur base imposable (article 267 du CGI).
+</p>
+
+
+<h3>Règlements effectués correspondant au montant remboursé</h3>
+
+<table>
+    <thead>
+    <tr>
+        <th>Mode de règlement</th>
+        <th>N° de Règlement</th>
+        <th>Date</th>
+        <th>Montant Réglé</th>
+        <th>Destinataire</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    {% for cashflow in invoice.cashflows %}
+        <tr>
+            <td>Virement {{ cashflow.bankAccount.iban }}</td>
+            <td class="cashflow_id">{{ cashflow.id }}</td>
+            <td class="cashflow_creation_date">{{ cashflow.creationDate.strftime("%d/%m/%Y") }}</td>
+            <td>{{ cashflow.amount|fr_currency }}</td>
+            <td> {{ invoice.businessUnit.name }}</td>
+        </tr>
+    {% endfor %}
+    <tr style="background: lightcyan">
+        <td colspan="3">TOTAL REGLEMENT PASS CULTURE</td>
+        <td>{{ invoice.amount|fr_currency }} </td>
+    </tr>
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -106,6 +106,15 @@ def clear_tests_assets_bucket():
         object_storage_testing.reset_bucket()
 
 
+@pytest.fixture()
+def clear_tests_invoices_bucket():
+    try:
+        Path(settings.LOCAL_STORAGE_DIR / "invoices").mkdir(parents=True, exist_ok=True)
+        yield
+    finally:
+        object_storage_testing.reset_bucket()
+
+
 def clean_database(f: object) -> object:
     @wraps(f)
     def decorated_function(*args, **kwargs):

--- a/api/tests/core/finance/test_utils.py
+++ b/api/tests/core/finance/test_utils.py
@@ -15,3 +15,16 @@ def test_to_eurocents():
 def test_to_euros():
     assert utils.to_euros(1000) == 10
     assert utils.to_euros(1234) == decimal.Decimal("12.34")
+
+
+def test_fr_percentage_filter():
+    assert utils.fr_percentage_filter(decimal.Decimal("1.0000")) == "100 %"
+    assert utils.fr_percentage_filter(decimal.Decimal("0.0000")) == "0 %"
+    assert utils.fr_percentage_filter(decimal.Decimal("0.5000")) == "50 %"
+    assert utils.fr_percentage_filter(decimal.Decimal("0.1234")) == "12,34 %"
+
+
+def test_fr_currency_filter():
+    assert utils.fr_currency_filter(0) == "0,00"
+    assert utils.fr_currency_filter(-1234) == "12,34"
+    assert utils.fr_currency_filter(500000) == "5 000,00"

--- a/api/tests/domain/reimbursement_test.py
+++ b/api/tests/domain/reimbursement_test.py
@@ -360,6 +360,10 @@ class ReimbursementRuleIsActiveTest:
         def is_relevant(self, booking, cumulative_revenue):
             return True
 
+        @property
+        def group(self):
+            return None
+
     booking = Booking(dateCreated=datetime.now() + timedelta(days=365), dateUsed=datetime.now())
 
     def test_is_active_if_rule_has_no_start_nor_end(self):

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <style>
+        html {
+            font-family: sans-serif;
+            font-size: 11pt;
+            line-height: 1.5;
+        }
+
+        body {
+            margin: 5pt;
+        }
+
+        h1 {
+            color: purple;
+            font-size: 18pt;
+            margin: 0;
+            text-align: center;
+        }
+
+        h2 {
+            color: purple;
+            font-size: 12pt;
+            margin: 0;
+        }
+
+        table, th, td {
+            border: 0.2mm solid #2f1313;
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        th {
+            font-weight: bold;
+        }
+
+        td {
+            padding-top: 7mm;
+        }
+
+        th, td {
+            text-align: center;
+        }
+
+
+    </style>
+    <title>Justificatif de remboursement</title>
+    <meta name="description" content="Etat justifiant du montant du remboursement">
+</head>
+
+<body>
+
+<h1>Justificatif de remboursement</h1>
+<h2 class="invoice_info">Relevé n°JUSTIFICATIF #4 du 21/12/2021</h2>
+
+<p>
+<div><b>Nom :</b> SARL LIBRAIRIE BOOKING</div>
+<div><b>SIRET :</b> 85331845900023</div>
+</p>
+
+<h4>
+    Détail des offres remboursées incluant la contribution offreur,
+    appliquée selon le barème définis dans nos conditions générales de ventes
+</h4>
+
+<table>
+    <thead>
+    <tr>
+        <th>Typologie</th>
+        <th>Taux de remboursement (%)</th>
+        <th>Montant des réservations validées (TTC)</th>
+        <th>Taux de contribution offreur (%)</th>
+        <th>Montant de la contribution offreur (TTC)</th>
+        <th>Montant remboursé (TTC)</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+        <tr>
+            <td colspan="6" style="text-align:left;background: lightcyan"><b> Barème général </b></td>
+        </tr>
+
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>100 %</td>
+                <td>19 980,00</td>
+                <td>0 %</td>
+                <td>0,00</td>
+                <td>19 980,00</td>
+            </tr>
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>95 %</td>
+                <td>80,00</td>
+                <td>5 %</td>
+                <td>4,00</td>
+                <td>76,00</td>
+            </tr>
+        
+
+        <tr style="color: dimgrey">
+            <td>SOUS-TOTAL</td>
+            <td></td>
+            <td>20 052,00</td>
+            <td></td>
+            <td>4,00</td>
+            <td>20 056,00</td>
+        </tr>
+    
+        <tr>
+            <td colspan="6" style="text-align:left;background: lightcyan"><b> Barème livres </b></td>
+        </tr>
+
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>100 %</td>
+                <td>20,00</td>
+                <td>0 %</td>
+                <td>0,00</td>
+                <td>20,00</td>
+            </tr>
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>95 %</td>
+                <td>40,00</td>
+                <td>5 %</td>
+                <td>2,00</td>
+                <td>38,00</td>
+            </tr>
+        
+
+        <tr style="color: dimgrey">
+            <td>SOUS-TOTAL</td>
+            <td></td>
+            <td>56,00</td>
+            <td></td>
+            <td>2,00</td>
+            <td>58,00</td>
+        </tr>
+    
+        <tr>
+            <td colspan="6" style="text-align:left;background: lightcyan"><b> Barème non remboursé </b></td>
+        </tr>
+
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>0 %</td>
+                <td>58,00</td>
+                <td>100 %</td>
+                <td>58,00</td>
+                <td>0,00</td>
+            </tr>
+        
+
+        <tr style="color: dimgrey">
+            <td>SOUS-TOTAL</td>
+            <td></td>
+            <td>58,00</td>
+            <td></td>
+            <td>58,00</td>
+            <td>0,00</td>
+        </tr>
+    
+        <tr>
+            <td colspan="6" style="text-align:left;background: lightcyan"><b> Barème dérogatoire </b></td>
+        </tr>
+
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>95,65 %</td>
+                <td>23,00</td>
+                <td>4,35 %</td>
+                <td>1,00</td>
+                <td>22,00</td>
+            </tr>
+        
+            <tr>
+                <td>Montant remboursé</td>
+                <td>94 %</td>
+                <td>20,00</td>
+                <td>6 %</td>
+                <td>1,20</td>
+                <td>18,80</td>
+            </tr>
+        
+
+        <tr style="color: dimgrey">
+            <td>SOUS-TOTAL</td>
+            <td></td>
+            <td>38,60</td>
+            <td></td>
+            <td>2,20</td>
+            <td>40,80</td>
+        </tr>
+    
+    <tr>
+        <td>TOTAL</td>
+        <td></td>
+        <td>20 088,60</td>
+        <td></td>
+        <td>66,20</td>
+        <td>20 154,80</td>
+    </tr>
+    </tbody>
+
+</table>
+
+
+<p>
+    Au regard de la taxe sur la valeur ajoutée (TVA), les remboursements s’entendent toutes taxes comprises (TTC).
+    L’Offreur s’engage à s’acquitter de la TVA résultant de l’application de son régime fiscal et selon le taux
+    applicable à ses Offres.
+    Il est considéré que la contribution offreur relative à l’application du barème constitue une réduction de
+    prix, au sens de l’article 267 du code général des impôts, et qu’à ce titre, les offreurs pourront ainsi
+    régulariser leur base imposable (article 267 du CGI).
+</p>
+
+
+<h3>Règlements effectués correspondant au montant remboursé</h3>
+
+<table>
+    <thead>
+    <tr>
+        <th>Mode de règlement</th>
+        <th>N° de Règlement</th>
+        <th>Date</th>
+        <th>Montant Réglé</th>
+        <th>Destinataire</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    
+        <tr>
+            <td>Virement FR2710010000000000000000064</td>
+            <td class="cashflow_id">144</td>
+            <td class="cashflow_creation_date">21/12/2021</td>
+            <td>20 000,00</td>
+            <td> SARL LIBRAIRIE BOOKING</td>
+        </tr>
+    
+        <tr>
+            <td>Virement FR2710010000000000000000064</td>
+            <td class="cashflow_id">145</td>
+            <td class="cashflow_creation_date">21/12/2021</td>
+            <td>154,80</td>
+            <td> SARL LIBRAIRIE BOOKING</td>
+        </tr>
+    
+    <tr style="background: lightcyan">
+        <td colspan="3">TOTAL REGLEMENT PASS CULTURE</td>
+        <td>20 154,80 </td>
+    </tr>
+    </tbody>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11624


## But de la pull request

Créer des justificatifs de remboursement en DB, générer des PDF, les stocker.

##  Implémentation

- Ajout de fonctions d'API
- Ajout d'un template temporaire Jinja2 pour la génération de PDF avec weasyprint
- Stockage du PDF généré via le backend de stockage défini pour cet environnement
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
