### PR TITLE
[PC-12155][api] Suppression du champs face-required dans les requêtes d'Ubble

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -88,7 +88,6 @@ def start_identification(
     last_name: str,
     webhook_url: str,
     redirect_url: str,
-    face_required: bool,
 ) -> fraud_models.UbbleContent:
     session = configure_session()
 
@@ -107,7 +106,6 @@ def start_identification(
                 },
                 "webhook": webhook_url,
                 "redirect_url": redirect_url,
-                "face_required": face_required,
             },
         }
     }

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -191,7 +191,6 @@ def start_ubble_workflow(user: users_models.User, redirect_url: str) -> str:
         last_name=user.lastName,
         webhook_url=flask.url_for("Public API.ubble_webhook_update_application_status", _external=True),
         redirect_url=redirect_url,
-        face_required=True,  # TODO(bcalvez): setting ? hardcode ?
     )
     fraud_api.start_ubble_fraud_check(user, content)
     return content.identification_url

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -18,7 +18,6 @@ class StartIdentificationTest:
             last_name="nom",
             webhook_url="http://webhook/url/",
             redirect_url="http://redirect/url",
-            face_required=True,
         )
 
         assert isinstance(response, fraud_models.UbbleContent)
@@ -33,7 +32,6 @@ class StartIdentificationTest:
         assert attributes["reference-data"]["last-name"] == "nom"
         assert attributes["webhook"] == "http://webhook/url/"
         assert attributes["redirect_url"] == "http://redirect/url"
-        assert attributes["face_required"] is True
 
     def test_start_identification_connection_error(self, ubble_mock_connection_error):
         with pytest.raises(exceptions.IdentificationServiceUnavailable):
@@ -45,7 +43,6 @@ class StartIdentificationTest:
                 last_name="nom",
                 webhook_url="http://webhook/url/",
                 redirect_url="http://redirect/url",
-                face_required=True,
             )
 
         assert ubble_mock_connection_error.call_count == 1
@@ -60,7 +57,6 @@ class StartIdentificationTest:
                 last_name="nom",
                 webhook_url="http://webhook/url/",
                 redirect_url="http://redirect/url",
-                face_required=True,
             )
 
         assert ubble_mock_http_error_status.call_count == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12155


## But de la pull request

Supprimer le champs qui est configuré en dur dans le Dashboard UBBLE, et non nécessaire ici
