### PR TITLE
(PC-12077) Save school_uai in EduconnectContent

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -73,6 +73,8 @@ class EduconnectContent(pydantic.BaseModel):
     ine_hash: str
     last_name: str
     registration_datetime: datetime.datetime
+    school_uai: typing.Optional[str]
+    student_level: typing.Optional[str]
 
 
 class JouveContent(pydantic.BaseModel):

--- a/api/src/pcapi/core/users/external/educonnect/api.py
+++ b/api/src/pcapi/core/users/external/educonnect/api.py
@@ -120,8 +120,8 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
             logout_url=educonnect_identity[_get_field_oid("5")][0],
             user_type=user_type,
             saml_request_id=saml_request_id,
-            school=educonnect_identity.get(_get_field_oid("72"), [None])[0],
-            student_level=educonnect_identity.get(_get_field_oid("73"), [None])[0],
+            school_uai=educonnect_identity.get(_get_field_oid("72"))[0],
+            student_level=educonnect_identity.get(_get_field_oid("73"))[0],
         )
     except KeyError as exception:
         logger.error(

--- a/api/src/pcapi/core/users/external/educonnect/models.py
+++ b/api/src/pcapi/core/users/external/educonnect/models.py
@@ -14,5 +14,5 @@ class EduconnectUser:
     logout_url: str
     user_type: Optional[str]
     saml_request_id: str
-    school: Optional[str]
-    student_level: Optional[str]
+    school_uai: str
+    student_level: str

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -368,4 +368,4 @@ class EduconnectUserFactory(factory.Factory):
     saml_request_id = factory.Faker("lexify", text="id-?????????????????")
     ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
     student_level = "2212"
-    school = None
+    school_uai = "0910620E"

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -88,7 +88,7 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
             "logout_url": educonnect_user.logout_url,
             "user_type": educonnect_user.user_type,
             "saml_request_id": educonnect_user.saml_request_id,
-            "school": educonnect_user.school,
+            "school_uai": educonnect_user.school_uai,
             "student_level": educonnect_user.student_level,
         },
     )
@@ -100,6 +100,8 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
         ine_hash=educonnect_user.ine_hash,
         last_name=educonnect_user.last_name,
         registration_datetime=datetime.datetime.now(),
+        school_uai=educonnect_user.school_uai,
+        student_level=educonnect_user.student_level,
     )
 
     try:

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -513,6 +513,8 @@ class EduconnectFraudTest:
                 ine_hash="5ba682c0fc6a05edf07cd8ed0219258f",
                 last_name="Ellingson",
                 registration_datetime=datetime.datetime(2020, 1, 1),
+                school_uai="shchool-uai",
+                student_level="2212",
             ),
         )
 
@@ -529,6 +531,8 @@ class EduconnectFraudTest:
             "last_name": "Ellingson",
             "birth_date": birth_date,
             "registration_datetime": datetime.datetime(2020, 1, 1),
+            "school_uai": "shchool-uai",
+            "student_level": "2212",
         }
         assert len(user.beneficiaryFraudResults) == 1
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
@@ -544,6 +548,8 @@ class EduconnectFraudTest:
                 ine_hash="0000",
                 last_name="Ellingson",
                 registration_datetime=datetime.datetime(2020, 1, 1),
+                school_uai="shchool-uai",
+                student_level="2212",
             ),
         )
 
@@ -559,6 +565,8 @@ class EduconnectFraudTest:
             "last_name": "Ellingson",
             "birth_date": birth_date,
             "registration_datetime": datetime.datetime(2020, 1, 1),
+            "school_uai": "shchool-uai",
+            "student_level": "2212",
         }
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -154,6 +154,8 @@ class EduconnectFlowTest:
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.73": ["2212"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.6": ["2021-10-08 11:51:33.437"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.64": [ine_hash],
+            "urn:oid:1.3.6.1.4.1.20326.10.999.1.7": ["eleve1d"],
+            "urn:oid:1.3.6.1.4.1.20326.10.999.1.72": ["school_uai"],
         }
         mock_saml_response.in_response_to = request_id
 

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -123,7 +123,7 @@ class EduconnectTest:
             "logout_url": "https://educonnect.education.gouv.fr/Logout",
             "user_type": "eleve1d",
             "saml_request_id": self.request_id,
-            "school": "school_uai",
+            "school_uai": "school_uai",
             "student_level": "2212",
             "user_email": self.email,
         }
@@ -139,6 +139,8 @@ class EduconnectTest:
             "ine_hash": ine_hash,
             "last_name": "SENS",
             "registration_datetime": "2021-10-10T00:00:00",
+            "school_uai": "school_uai",
+            "student_level": "2212",
         }
         assert len(user.beneficiaryFraudResults) == 1
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12077

## Implémentation

Côté EduconnectContent, je laisse les champs en Optional vu qu'on a déjà des données en base sans le `school_uai`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
