### PR TITLE
(PC-12183)(Backend) Added logging in user profiling

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -382,7 +382,11 @@ def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudReques
     except user_profiling.BaseUserProfilingException:
         logger.exception("Error while retrieving user profiling infos", exc_info=True)
     else:
-        logger.info("Success when profiling user: returned userdata %r", profiling_infos.dict())
+        logger.info(
+            "Success when profiling user: returned userdata %r",
+            profiling_infos.dict(),
+            extra={"sessionId": body.sessionId},
+        )
         fraud_api.on_user_profiling_result(user, profiling_infos)
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12183


## But de la pull request

Ajout de log pour `user.id` et `sessionId` après un profiling

##  Implémentation

```py
        logger.info(
            "Success when profiling user: returned userdata %r",
            profiling_infos.dict(),
            extra={"sessionId": body.sessionId},
        )
```
​

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
