### PR TITLE
(pc-11982)(API)(FA) Add Comment to Detail View

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-b2f89508f9e0 (head)
+3b2ea23b8cf0 (head)

--- a/api/src/pcapi/admin/custom_views/admin_user_view.py
+++ b/api/src/pcapi/admin/custom_views/admin_user_view.py
@@ -26,6 +26,7 @@ def filter_email(value: Optional[str]) -> Optional[str]:
 class AdminUserView(SuspensionMixin, BaseAdminView):
     can_edit = False
     can_delete = False
+    can_view_details = True
 
     @property
     def can_create(self) -> bool:
@@ -45,6 +46,7 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
         "actions",
     ]
     column_labels = dict(
+        comment="Commentaire équipe anti-fraude",
         isActive="Est activé",
         email="Email",
         firstName="Prénom",
@@ -56,8 +58,14 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
     )
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
     column_filters = ["email", "isEmailValidated"]
+    column_details_list = ["comment"]
 
-    form_columns = ["email", "firstName", "lastName", "departementCode", "postalCode"]
+    @property
+    def form_columns(self):
+        fields = ("email", "firstName", "lastName", "departementCode", "postalCode")
+        if self.check_super_admins():
+            fields += ("comment",)
+        return fields
 
     form_args = dict(
         departementCode=dict(

--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -137,6 +137,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "total_remaining",
         "digital_remaining",
         "physical_remaining",
+        "comment",
         "validationToken",
         "activity",
         "address",
@@ -176,26 +177,27 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
     ]
 
     column_labels = dict(
-        email="Email",
-        isActive="Est activé",
-        has_beneficiary_role="Bénéficiaire 18 ans ?",
-        has_underage_beneficiary_role="Bénéficiaire 15-17 ?",
-        firstName="Prénom",
-        lastName="Nom",
-        publicName="Nom d'utilisateur",
+        comment="Commentaire équipe anti-fraude",
         dateOfBirth="Date de naissance",
         departementCode="Département",
-        phoneNumber="Numéro de téléphone",
-        postalCode="Code postal",
-        isEmailValidated="Email validé ?",
-        has_active_deposit="Dépôt valable ?",
-        total_remaining="Crédit global restant",
-        total_initial="Crédit initial",
-        digital_remaining="Crédit digital restant",
-        physical_remaining="Crédit physique restant",
         deposit_type="Type du portefeuille",
         deposit_version="Version du portefeuille",
+        digital_remaining="Crédit digital restant",
+        email="Email",
+        firstName="Prénom",
+        has_active_deposit="Dépôt valable ?",
+        has_beneficiary_role="Bénéficiaire 18 ans ?",
+        has_underage_beneficiary_role="Bénéficiaire 15-17 ?",
+        isActive="Est activé",
+        isEmailValidated="Email validé ?",
+        lastName="Nom",
         needsToFillCulturalSurvey="Doit remplir le questionnaire de pratiques culturelles",
+        phoneNumber="Numéro de téléphone",
+        physical_remaining="Crédit physique restant",
+        postalCode="Code postal",
+        publicName="Nom d'utilisateur",
+        total_remaining="Crédit global restant",
+        total_initial="Crédit initial",
     )
 
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
@@ -231,7 +233,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
             "needsToFillCulturalSurvey",
         )
         if self.check_super_admins():
-            fields += ("firstName", "lastName")
+            fields += ("firstName", "lastName", "comment")
         return fields
 
     form_args = dict(

--- a/api/src/pcapi/admin/custom_views/pro_user_view.py
+++ b/api/src/pcapi/admin/custom_views/pro_user_view.py
@@ -61,6 +61,8 @@ def create_user_offerer(user: User, offerer: Offerer) -> UserOfferer:
 class ProUserView(SuspensionMixin, BaseAdminView):
     can_edit = True
     can_create = True
+    can_view_details = True
+
     column_list = [
         "id",
         "isActive",
@@ -77,6 +79,7 @@ class ProUserView(SuspensionMixin, BaseAdminView):
         "actions",
     ]
     column_labels = dict(
+        comment="Commentaire équipe anti-fraude",
         email="Email",
         isActive="Est activé",
         firstName="Prénom",
@@ -93,14 +96,7 @@ class ProUserView(SuspensionMixin, BaseAdminView):
     )
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
     column_filters = ["postalCode", "has_beneficiary_role", "has_underage_beneficiary_role", "isEmailValidated"]
-    form_columns = [
-        "email",
-        "firstName",
-        "lastName",
-        "dateOfBirth",
-        "departementCode",
-        "postalCode",
-    ]
+    column_details_list = ["comment"]
 
     form_create_rules = (
         rules.Header("Utilisateur créé :"),
@@ -118,6 +114,20 @@ class ProUserView(SuspensionMixin, BaseAdminView):
         "offererCity",
         "csrf_token",
     )
+
+    @property
+    def form_columns(self):
+        fields = (
+            "email",
+            "firstName",
+            "lastName",
+            "dateOfBirth",
+            "departementCode",
+            "postalCode",
+        )
+        if self.check_super_admins():
+            fields += ("comment",)
+        return fields
 
     # This override is necessary to prevent SIREN and offererName to be in edit form as well
     def get_create_form(self) -> Form:

--- a/api/src/pcapi/alembic/versions/20211206T090159_3b2ea23b8cf0_add_comment_to_users.py
+++ b/api/src/pcapi/alembic/versions/20211206T090159_3b2ea23b8cf0_add_comment_to_users.py
@@ -1,0 +1,19 @@
+"""Add comment to User
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "3b2ea23b8cf0"
+down_revision = "b2f89508f9e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("comment", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "comment")

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -185,6 +185,7 @@ class User(PcObject, Model, NeedsValidationMixin):
     city = sa.Column(sa.String(100), nullable=True)
     civility = sa.Column(sa.String(20), nullable=True)
     clearTextPassword = None
+    comment = sa.Column(sa.Text(), nullable=True)
     culturalSurveyFilledDate = sa.Column(sa.DateTime, nullable=True)
     culturalSurveyId = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)
     dateCreated = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -142,6 +142,10 @@
         <td>{{ model.idPieceNumber }}</td>
       </tr>
       <tr>
+        <th scope="row">Commentaire équipe anti-fraude</th>
+        <td>{{ model.comment }}</td>
+      </tr>
+      <tr>
     </table>
     </dl>
   </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11982

## But de la pull request

En tant que contrôleur de la fraude
J'aimerais ajouter un commentaire dans le profil utilisateur 
Afin d’avoir de la visibilité sur les motifs de blocage ou autres informations pertinentes sur le profil du demandeur 

##  Implémentation

- Ajout d’un champs “Commentaire” sur le modèle User

- Rendre le champs éditable dans l’admin qu’aux super admins
 
- Activer la vue détails sur chaque onglet utilisateur

- Ajouter le champs détails dans chaque vue utilisateur, ainsi que dans la page Support > Beneficiaires​


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)

![Capture d’écran 2021-12-06 à 15 48 46](https://user-images.githubusercontent.com/9610732/144867408-5f4c3bb1-48ea-4337-bfcc-e72ce8fa6bbc.png)
![Capture d’écran 2021-12-06 à 15 49 03](https://user-images.githubusercontent.com/9610732/144867410-a7e05a30-2063-44be-a3a3-0f30be9c2cef.png)
