### PR TITLE
(PC-11877)[PRO] Add blank space between address and postalCode in OffererDetails

### DIFF
--- a/pro/src/components/pages/Home/Offerers/OffererDetails.jsx
+++ b/pro/src/components/pages/Home/Offerers/OffererDetails.jsx
@@ -129,7 +129,7 @@ const OffererDetails = ({
                       <li className="h-dl-row">
                         <span className="h-dl-title">{'Siège social : '}</span>
                         <address className="od-address">
-                          {selectedOfferer.address}
+                          {`${selectedOfferer.address} `}
                           {selectedOfferer.hasMissingBankInformation && <br />}
                           {`${selectedOfferer.postalCode} ${selectedOfferer.city}`}
                         </address>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11877

## But de la pull request

Ajout d'un espace entre le nom de la rue et le code postal

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
