### PR TITLE
(PC-12114): [PRO] Offers serachFilters: check if category isSelectable

### DIFF
--- a/pro/src/components/pages/Offers/Offers/SearchFilters/SearchFilters.jsx
+++ b/pro/src/components/pages/Offers/Offers/SearchFilters/SearchFilters.jsx
@@ -40,10 +40,12 @@ const SearchFilters = ({
   useEffect(() => {
     pcapi.loadCategories().then(categoriesAndSubcategories => {
       let { categories } = categoriesAndSubcategories
-      let categoriesOptions = categories.map(categories => ({
-        id: categories.id,
-        displayName: categories.proLabel,
-      }))
+      let categoriesOptions = categories
+        .filter(category => category.isSelectable)
+        .map(category => ({
+          id: category.id,
+          displayName: category.proLabel,
+        }))
       setCategoriesOptions(
         categoriesOptions.sort((a, b) =>
           a.displayName.localeCompare(b.displayName)

--- a/pro/src/components/pages/Offers/Offers/__specs__/Offers.spec.jsx
+++ b/pro/src/components/pages/Offers/Offers/__specs__/Offers.spec.jsx
@@ -43,8 +43,9 @@ const renderOffers = (props, store) => {
 
 const categoriesAndSubcategories = {
   categories: [
-    { id: 'CINEMA', proLabel: 'Cinéma' },
-    { id: 'JEU', proLabel: 'Jeux' },
+    { id: 'CINEMA', proLabel: 'Cinéma', isSelectable: true },
+    { id: 'JEU', proLabel: 'Jeux', isSelectable: true },
+    { id: 'TECHNIQUE', proLabel: 'Technique', isSelectable: false },
   ],
   subcategories: [],
 }
@@ -236,6 +237,22 @@ describe('src | components | pages | Offers | Offers', () => {
     })
 
     describe('filters', () => {
+      it('should display only selectable categories on filters', async () => {
+        // When
+        renderOffers(props, store)
+
+        // Then
+        await expect(
+          screen.findByRole('option', { name: 'Cinéma' })
+        ).resolves.toBeInTheDocument()
+        await expect(
+          screen.findByRole('option', { name: 'Jeux' })
+        ).resolves.toBeInTheDocument()
+        await expect(
+          screen.findByRole('option', { name: 'Technique' })
+        ).rejects.toBeTruthy()
+      })
+
       it('should render venue filter with default option selected and given venues as options', async () => {
         // Given
         const expectedSelectOptions = [
@@ -1199,8 +1216,12 @@ describe('src | components | pages | Offers | Offers', () => {
       // Given
       pcapi.loadCategories.mockResolvedValue({
         categories: [
-          { id: 'test_id_1', proLabel: 'My test value' },
-          { id: 'test_id_2', proLabel: 'My second test value' },
+          { id: 'test_id_1', proLabel: 'My test value', isSelectable: true },
+          {
+            id: 'test_id_2',
+            proLabel: 'My second test value',
+            isSelectable: true,
+          },
         ],
       })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12114


## But de la pull request

Afficher seulement les catégories sélectionnables  dans le filtre 'Catégories' sur la page des offres

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
