### PR TITLE
(PC-11739)[api]: allow educaitonal booking uncancelling through FA

### DIFF
--- a/api/src/pcapi/admin/custom_views/booking_view.py
+++ b/api/src/pcapi/admin/custom_views/booking_view.py
@@ -13,6 +13,7 @@ from pcapi.admin.base_configuration import BaseCustomAdminView
 import pcapi.core.bookings.api as bookings_api
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import IndividualBooking
+from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.offers.models import Stock
 from pcapi.domain.client_exceptions import ClientError
 from pcapi.models.api_errors import ApiErrors
@@ -51,6 +52,7 @@ class BookingView(BaseCustomAdminView):
                 booking = (
                     Booking.query.filter_by(token=token)
                     .options(joinedload(Booking.individualBooking).joinedload(IndividualBooking.user))
+                    .options(joinedload(Booking.educationalBooking).joinedload(EducationalBooking.educationalRedactor))
                     .options(joinedload(Booking.stock).joinedload(Stock.offer))
                     .one_or_none()
                 )

--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -4,6 +4,7 @@ import factory
 
 from pcapi.core.educational.factories import EducationalBookingFactory as EducationalBookingSubFactory
 from pcapi.core.educational.factories import PendingEducationalBookingFactory as PendingEducationalBookingSubFactory
+from pcapi.core.educational.factories import RefusedEducationalBookingFactory as RefusedEducationalBookingSubFactory
 from pcapi.core.educational.factories import UsedEducationalBookingFactory as UsedEducationalBookingSubFactory
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import BaseFactory
@@ -90,6 +91,17 @@ class PendingEducationalBookingFactory(BookingFactory):
     educationalBooking = factory.SubFactory(PendingEducationalBookingSubFactory)
     stock = factory.SubFactory(offers_factories.EducationalEventStockFactory)
     status = models.BookingStatus.PENDING
+    userId = None
+    user = None
+
+
+class RefusedEducationalBookingFactory(BookingFactory):
+    educationalBooking = factory.SubFactory(RefusedEducationalBookingSubFactory)
+    stock = factory.SubFactory(offers_factories.EducationalEventStockFactory)
+    status = models.BookingStatus.CANCELLED
+    isCancelled = True
+    cancellationDate = factory.LazyFunction(datetime.datetime.utcnow)
+    cancellationReason = models.BookingCancellationReasons.REFUSED_BY_INSTITUTE
     userId = None
     user = None
 

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -24,6 +24,7 @@ from pcapi.core.bookings import exceptions
 from pcapi.core.bookings.constants import BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.bookings.constants import BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY
 from pcapi.core.categories import subcategories
+from pcapi.core.educational.models import EducationalBookingStatus
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 from pcapi.utils.human_ids import humanize
@@ -184,6 +185,8 @@ class Booking(PcObject, Model):
     def uncancel_booking_set_used(self) -> None:
         if not (self.status is BookingStatus.CANCELLED or self.isCancelled):
             raise exceptions.BookingIsNotCancelledCannotBeUncancelled()
+        if self.educationalBookingId is not None:
+            self.educationalBooking.status = EducationalBookingStatus.USED_BY_INSTITUTE
         self.isCancelled = False
         self.cancellationDate = None
         self.cancellationReason = None

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -85,3 +85,7 @@ class UsedEducationalBookingFactory(EducationalBookingFactory):
 class PendingEducationalBookingFactory(EducationalBookingFactory):
     status = None
     confirmationLimitDate = datetime.datetime.utcnow() + datetime.timedelta(days=15)
+
+
+class RefusedEducationalBookingFactory(EducationalBookingFactory):
+    status = EducationalBookingStatus.REFUSED

--- a/api/src/pcapi/templates/admin/booking.html
+++ b/api/src/pcapi/templates/admin/booking.html
@@ -12,7 +12,11 @@
 <hr>
 <p>
 <div><b>Code :</b> {{ booking.token }}</div>
+{% if booking.individualBookingId %}
 <div><b>Bénéficiaire :</b> {{ booking.email }} ({{ booking.individualBooking.user.id }})</div>
+{% else %}
+<div><b>Rédacteur:</b> {{ booking.email }} ({{ booking.educationalBooking.educationalRedactor.id }})</div>
+{% endif %}
 <div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
 <div><b>Date d'annulation :</b>
     {% if booking.isCancelled %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11739


## But de la pull request

Permettre aux admins de dés-annuler une réservation portant sur une offre éducationnelle, via la BookingView de FA

##  Implémentation

- Adaptation de la query
- Adaptation du booking.html
- Ajout d'un test
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
