### PR TITLE
(PC-11730) Catch OfferCategoryNotBookableByUser exception for webapp booking route

### DIFF
--- a/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -6,6 +6,7 @@ from pcapi.core.bookings.exceptions import BookingIsAlreadyUsed
 from pcapi.core.bookings.exceptions import CannotBookFreeOffers
 from pcapi.core.bookings.exceptions import CannotCancelConfirmedBooking
 from pcapi.core.bookings.exceptions import DigitalExpenseLimitHasBeenReached
+from pcapi.core.bookings.exceptions import OfferCategoryNotBookableByUser
 from pcapi.core.bookings.exceptions import OfferIsAlreadyBooked
 from pcapi.core.bookings.exceptions import PhysicalExpenseLimitHasBeenReached
 from pcapi.core.bookings.exceptions import QuantityIsInvalid
@@ -21,6 +22,7 @@ from pcapi.domain.users import UnauthorizedForAdminUser
 @app.errorhandler(UserHasInsufficientFunds)
 @app.errorhandler(PhysicalExpenseLimitHasBeenReached)
 @app.errorhandler(DigitalExpenseLimitHasBeenReached)
+@app.errorhandler(OfferCategoryNotBookableByUser)
 def handle_book_an_offer(exception):
     return jsonify(exception.errors), 400
 


### PR DESCRIPTION
Cf cette erreur sur sentry : https://sentry.internal-passculture.app/organizations/sentry/issues/238571
