### PR TITLE
(PC-11486)[API][FA] suspend fraudulent users by ids: convert file extention to lower case before check allowed file

### DIFF
--- a/api/src/pcapi/admin/custom_views/suspend_fraudulent_users_by_ids.py
+++ b/api/src/pcapi/admin/custom_views/suspend_fraudulent_users_by_ids.py
@@ -22,7 +22,7 @@ ALLOWED_EXTENSIONS = {".csv"}
 
 
 def allowed_file(filename):
-    return pathlib.Path(filename).suffix in ALLOWED_EXTENSIONS
+    return pathlib.Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
 
 
 class SuspendFraudulentUsersByIdsForm(SecureForm):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11486


## But de la pull request
Pour les logiciels de tableur qui créent un fichier csv avec extension en majuscule

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
