### PR TITLE
(PC-11807) Compute eligibility start datetime with generalisation rules

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -4,6 +4,7 @@ import re
 import typing
 
 import pydantic
+import pytz
 import sqlalchemy
 
 from pcapi.connectors.beneficiaries import jouve_backend
@@ -267,7 +268,7 @@ def get_eligibility_type(
         registration_datetime = data.registration_datetime
         birth_date = data.birth_date
     elif isinstance(data, models.DMSContent):
-        registration_datetime = data.registration_datetime
+        registration_datetime = data.registration_datetime.astimezone(pytz.utc).replace(tzinfo=None)
         birth_date = data.birth_date
     else:
         raise exceptions.InvalidContentTypeException()

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -423,7 +423,11 @@ def _check_user_not_already_beneficiary(
     if not user.is_eligible_for_beneficiary_upgrade(eligibility):
         return models.FraudItem(
             status=models.FraudStatus.KO,
-            detail=(f"L’utilisateur est déjà bénéfiaire du pass {eligibility.name if eligibility is not None else ''}"),
+            detail=(
+                f"L’utilisateur est déjà bénéfiaire du pass {eligibility.name}"
+                if eligibility
+                else "L'utilisateur n'est pas éligible"
+            ),
             reason_code=models.FraudReasonCode.ALREADY_BENEFICIARY,
         )
     return models.FraudItem(status=models.FraudStatus.OK, detail="L'utilisateur n'est pas déjà bénéficaire")

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -7,6 +7,7 @@ import uuid
 from dateutil.relativedelta import relativedelta
 from factory.declarations import LazyAttribute
 import factory.fuzzy
+import pytz
 
 from pcapi.core import testing
 import pcapi.core.users.factories as users_factories
@@ -105,7 +106,9 @@ class DMSContentFactory(factory.Factory):
     activity = "Étudiant"
     address = factory.Faker("address")
     id_piece_number = factory.Sequence(lambda _: "".join(random.choices(string.digits, k=12)))
-    registration_datetime = datetime.utcnow()
+    registration_datetime = LazyAttribute(
+        lambda _: datetime.utcnow().replace(tzinfo=pytz.utc).strftime("%Y-%m-%dT%H:%M:%S%z")
+    )
 
 
 class UbbleContentFactory(factory.Factory):

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -48,7 +48,7 @@ class JouveContentFactory(factory.Factory):
     postalCode = "75008"
     posteCodeCtrl = "75"
     serviceCodeCtrl = factory.Faker("pystr")
-    registrationDate = datetime.utcnow()
+    registrationDate = LazyAttribute(lambda _: (datetime.utcnow()).strftime("%d/%m/%Y %H:%M"))
 
 
 USERPROFILING_RATING = [rating.value for rating in models.UserProfilingRiskRating]

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -49,7 +49,7 @@ def _parse_level(level: typing.Optional[str]) -> typing.Optional[int]:
         return None
 
 
-def _parse_date(date: typing.Optional[str]) -> typing.Optional[datetime.datetime]:
+def _parse_jouve_date(date: typing.Optional[str]) -> typing.Optional[datetime.datetime]:
     if not date:
         return None
     # this function has to support two parsings string format:
@@ -61,6 +61,19 @@ def _parse_date(date: typing.Optional[str]) -> typing.Optional[datetime.datetime
         pass
     try:
         return datetime.datetime.strptime(date, "%d/%m/%Y")
+    except ValueError:
+        return None
+
+
+def _parse_jouve_datetime(date: typing.Optional[str]) -> typing.Optional[datetime.datetime]:
+    if not date:
+        return None
+    try:
+        return pydantic.datetime_parse.parse_datetime(date)
+    except pydantic.DateTimeError:
+        pass
+    try:
+        return datetime.datetime.strptime(date, "%d/%m/%Y %H:%M")
     except ValueError:
         return None
 
@@ -110,8 +123,8 @@ class JouveContent(pydantic.BaseModel):
     _parse_body_first_name_level = validator("bodyFirstnameLevel", pre=True, allow_reuse=True)(_parse_level)
     _parse_body_name_level = validator("bodyNameLevel", pre=True, allow_reuse=True)(_parse_level)
     _parse_body_piece_number_level = validator("bodyPieceNumberLevel", pre=True, allow_reuse=True)(_parse_level)
-    _parse_birth_date = validator("birthDateTxt", pre=True, allow_reuse=True)(_parse_date)
-    _parse_registration_date = validator("registrationDate", pre=True, allow_reuse=True)(_parse_date)
+    _parse_birth_date = validator("birthDateTxt", pre=True, allow_reuse=True)(_parse_jouve_date)
+    _parse_registration_date = validator("registrationDate", pre=True, allow_reuse=True)(_parse_jouve_datetime)
 
 
 class IdentificationStatus(enum.Enum):

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -1,18 +1,26 @@
-from datetime import timedelta
+import datetime
 from enum import Enum
 
 from pcapi import settings
 
 
-RESET_PASSWORD_TOKEN_LIFE_TIME = timedelta(hours=24)
-RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED = timedelta(days=30)
-EMAIL_VALIDATION_TOKEN_LIFE_TIME = timedelta(hours=24)
-EMAIL_CHANGE_TOKEN_LIFE_TIME = timedelta(hours=24)
-ID_CHECK_TOKEN_LIFE_TIME = timedelta(hours=settings.ID_CHECK_TOKEN_LIFE_TIME_HOURS)
-PHONE_VALIDATION_TOKEN_LIFE_TIME = timedelta(minutes=10)
+RESET_PASSWORD_TOKEN_LIFE_TIME = datetime.timedelta(hours=24)
+RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED = datetime.timedelta(days=30)
+EMAIL_VALIDATION_TOKEN_LIFE_TIME = datetime.timedelta(hours=24)
+EMAIL_CHANGE_TOKEN_LIFE_TIME = datetime.timedelta(hours=24)
+ID_CHECK_TOKEN_LIFE_TIME = datetime.timedelta(hours=settings.ID_CHECK_TOKEN_LIFE_TIME_HOURS)
+PHONE_VALIDATION_TOKEN_LIFE_TIME = datetime.timedelta(minutes=10)
 
 ELIGIBILITY_AGE_18 = 18
 ELIGIBILITY_UNDERAGE_RANGE = [15, 16, 17]
+
+UNDERAGE_GENERALISATION_BROAD_OPENING_DATETIME = datetime.datetime(2022, 1, 31)
+UNDERAGE_GENERALISATION_EARLY_OPENING_DATETIME = datetime.datetime(2022, 1, 3)
+UNDERAGE_GENERALISATION_OPENING_DATETIMES_BY_AGE = {
+    15: UNDERAGE_GENERALISATION_BROAD_OPENING_DATETIME,
+    16: datetime.datetime(2022, 1, 20),
+    17: datetime.datetime(2022, 1, 10),
+}
 
 ACCOUNT_CREATION_MINIMUM_AGE = 15
 

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -1,5 +1,6 @@
 from datetime import date
 from datetime import datetime
+from datetime import time
 import logging
 from typing import Optional
 from typing import Union
@@ -117,9 +118,11 @@ def get_object(storage_path: str) -> Blob:
         raise exception
 
 
-def get_age_at_date(birth_date: Union[date, datetime], specified_datetime: datetime) -> int:
+def get_age_at_date(birth_date: Union[date, datetime], specified_datetime: datetime) -> Optional[int]:
+    if datetime.combine(birth_date, time(0, 0)) > specified_datetime:
+        return None
     return relativedelta(specified_datetime, birth_date).years
 
 
-def get_age_from_birth_date(birth_date: Union[date, datetime]) -> int:
-    return get_age_at_date(birth_date, date.today())
+def get_age_from_birth_date(birth_date: Union[date, datetime]) -> Optional[int]:
+    return get_age_at_date(birth_date, datetime.now())

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -1,7 +1,10 @@
+from datetime import date
 from datetime import datetime
 import logging
 from typing import Optional
+from typing import Union
 
+from dateutil.relativedelta import relativedelta
 from google.cloud.storage import Client
 from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
@@ -11,14 +14,15 @@ from pcapi import settings
 from pcapi.core.users.constants import METROPOLE_PHONE_PREFIX
 from pcapi.core.users.constants import PHONE_PREFIX_BY_DEPARTEMENT_CODE
 from pcapi.core.users.exceptions import UserWithoutPhoneNumberException
-from pcapi.core.users.models import ALGORITHM_HS_256
-from pcapi.core.users.models import ALGORITHM_RS_256
-from pcapi.core.users.models import User
 from pcapi.domain.postal_code.postal_code import PostalCode
 
 
 logger = logging.getLogger(__name__)
 JWT_ADAGE_PUBLIC_KEY_PATH = f"src/pcapi/routes/adage_iframe/public_key/{settings.JWT_ADAGE_PUBLIC_KEY_FILENAME}"
+
+
+ALGORITHM_HS_256 = "HS256"
+ALGORITHM_RS_256 = "RS256"
 
 
 def encode_jwt_payload(token_payload: dict, expiration_date: Optional[datetime] = None) -> str:
@@ -47,12 +51,12 @@ def sanitize_email(email: str) -> str:
     return email.strip().lower()
 
 
-def build_internationalized_phone_number(user: User, phone_number: str) -> str:
+def build_internationalized_phone_number(user, phone_number: str) -> str:
     country_code = PHONE_PREFIX_BY_DEPARTEMENT_CODE.get(user.departementCode, METROPOLE_PHONE_PREFIX)
     return country_code + phone_number[1:]
 
 
-def format_phone_number_with_country_code(user: User) -> str:
+def format_phone_number_with_country_code(user) -> str:
     if not user.phoneNumber:
         raise UserWithoutPhoneNumberException()
 
@@ -111,3 +115,11 @@ def get_object(storage_path: str) -> Blob:
             str(exception),
         )
         raise exception
+
+
+def get_age_at_date(birth_date: Union[date, datetime], specified_datetime: datetime) -> int:
+    return relativedelta(specified_datetime, birth_date).years
+
+
+def get_age_from_birth_date(birth_date: Union[date, datetime]) -> int:
+    return get_age_at_date(birth_date, date.today())

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -25,6 +25,8 @@ from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users.api import BeneficiaryValidationStep
 from pcapi.core.users.api import get_domains_credit
+from pcapi.core.users.api import get_eligibility_end_datetime
+from pcapi.core.users.api import get_eligibility_start_datetime
 from pcapi.core.users.api import get_next_beneficiary_validation_step
 from pcapi.core.users.models import ActivityEnum
 from pcapi.core.users.models import EligibilityCheckMethods
@@ -233,6 +235,8 @@ class UserProfileResponse(BaseModel):
         user.booked_offers = cls._get_booked_offers(user)
         user.next_beneficiary_validation_step = get_next_beneficiary_validation_step(user)
         user.isEligibleForBeneficiaryUpgrade = user.is_eligible_for_beneficiary_upgrade()
+        user.eligibility_end_datetime = get_eligibility_end_datetime(user.dateOfBirth)
+        user.eligibility_start_datetime = get_eligibility_start_datetime(user.dateOfBirth)
         result = super().from_orm(user)
         result.subscriptionMessage = SubscriptionMessage.from_model(
             subscription_api.get_latest_subscription_message(user)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -53,7 +53,7 @@ class JouveFraudCheckTest:
         "postalCode": "",
         "posteCode": "678083",
         "posteCodeCtrl": "OK",
-        "registrationDate": "10/06/2021 21:00",
+        "registrationDate": f"{datetime.datetime.now():%d/%m/%Y %H%M}",
         "serviceCode": "1",
         "serviceCodeCtrl": "OK",
     }
@@ -84,6 +84,8 @@ class JouveFraudCheckTest:
 
         db.session.refresh(user)
         assert user.has_beneficiary_role
+        assert user.firstName == "CHRISTOPHE"
+        assert user.lastName == "DUPO"
 
     @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
     def test_jouve_update_duplicate_user(self, _get_raw_content, client):

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -234,20 +234,6 @@ class UserTest:
             with freeze_time(today):
                 assert user_models._get_latest_birthday(birth_date) == latest_birthday
 
-        @pytest.mark.parametrize(
-            "age,eligibility_type",
-            [
-                (19, None),
-                (18, user_models.EligibilityType.AGE18),
-                (17, user_models.EligibilityType.UNDERAGE),
-                (16, user_models.EligibilityType.UNDERAGE),
-                (15, user_models.EligibilityType.UNDERAGE),
-                (14, None),
-            ],
-        )
-        def test_get_eligibility(self, age, eligibility_type):
-            assert user_models.get_eligibility(age) == eligibility_type
-
 
 @pytest.mark.usefixtures("db_session")
 class SuperAdminTest:

--- a/api/tests/core/users/test_users_sql_entity.py
+++ b/api/tests/core/users/test_users_sql_entity.py
@@ -11,7 +11,6 @@ import sqlalchemy.exc
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.payments import api as payments_api
-from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as user_models
 from pcapi.model_creators.generic_creators import create_offerer
@@ -259,38 +258,6 @@ class CalculateAgeTest:
         assert users_factories.UserFactory.build(dateOfBirth=datetime(1999, 7, 1)).age == 18
         assert users_factories.UserFactory.build(dateOfBirth=datetime(2000, 7, 1)).age == 17
         assert users_factories.UserFactory.build(dateOfBirth=datetime(1999, 5, 1)).age == 19
-
-    @freeze_time("2018-06-01")
-    @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=False)
-    def test_eligibility_start_end_datetime_beneficiary(self):
-        assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_start_datetime is None
-        assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2000, 6, 1, 5, 1)
-        ).eligibility_start_datetime == datetime(2018, 6, 1, 0, 0)
-
-        assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_end_datetime is None
-        assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2000, 6, 1, 5, 1)
-        ).eligibility_end_datetime == datetime(2019, 6, 1, 0, 0)
-        assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2001, 6, 1, 5, 1)
-        ).eligibility_end_datetime == datetime(2020, 6, 1, 0, 0)
-
-    @freeze_time("2018-06-01")
-    @override_features(ENABLE_NATIVE_EAC_INDIVIDUAL=True)
-    def test_eligibility_start_end_datetime_underage_beneficiary(self):
-        assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_start_datetime is None
-        assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2000, 6, 1, 5, 1)
-        ).eligibility_start_datetime == datetime(2015, 6, 1, 0, 0)
-
-        assert users_factories.UserFactory.build(dateOfBirth=None).eligibility_end_datetime is None
-        assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2000, 6, 1, 5, 1)
-        ).eligibility_end_datetime == datetime(2019, 6, 1, 0, 0)
-        assert users_factories.UserFactory.build(
-            dateOfBirth=datetime(2001, 6, 1, 5, 1)
-        ).eligibility_end_datetime == datetime(2019, 6, 1, 0, 0)
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/core/users/test_utils.py
+++ b/api/tests/core/users/test_utils.py
@@ -5,8 +5,8 @@ import pytest
 
 from pcapi import settings
 from pcapi.core.users.factories import UserFactory
-from pcapi.core.users.models import ALGORITHM_RS_256
 from pcapi.core.users.utils import ALGORITHM_HS_256
+from pcapi.core.users.utils import ALGORITHM_RS_256
 from pcapi.core.users.utils import decode_jwt_token_rs256
 from pcapi.core.users.utils import encode_jwt_payload
 from pcapi.core.users.utils import format_phone_number_with_country_code

--- a/api/tests/routes/adage_iframe/utils_create_test_token.py
+++ b/api/tests/routes/adage_iframe/utils_create_test_token.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import jwt
 
-from pcapi.core.users.models import ALGORITHM_RS_256
+from pcapi.core.users.utils import ALGORITHM_RS_256
 
 from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -989,7 +989,7 @@ class UploadIdentityDocumentTest:
     IMAGES_DIR = Path(tests.__path__[0]) / "files"
 
     @patch("pcapi.core.users.api.verify_identity_document")
-    @patch("pcapi.core.users.api.store_object")
+    @patch("pcapi.core.users.utils.store_object")
     @patch("secrets.token_urlsafe")
     def test_upload_identity_document_successful(
         self,

--- a/api/tests/tasks/account_test.py
+++ b/api/tests/tasks/account_test.py
@@ -17,7 +17,7 @@ class VerifyIdentityDocumentTest:
     IMAGES_DIR = Path(tests.__path__[0]) / "files"
 
     @override_settings(ID_CHECK_MIDDLEWARE_TOKEN="fake_token")
-    @patch("pcapi.core.users.api.delete_object")
+    @patch("pcapi.core.users.utils.delete_object")
     @patch("pcapi.core.users.api._get_identity_document_informations")
     @patch("pcapi.connectors.beneficiaries.id_check_middleware.requests.post")
     def test_ask_for_document_verification(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11807


## But de la pull request

Le but est de lisser le nombre d'utilisateurs éligibles sur le mois de janvier 2022.

A scaling phase is planned where users will become eligible after UNDERAGE_GENERALISATION_OPENING_DATETIMES_BY_AGE.
However, as the legal opening day is on january 3rd 2022, if user's birthday happens between these dates, we let it enjoy a credit as soon as possible because otherwise it would not be given.


##  Implémentation

L'éligibilité se base maintenant sur `eligibility_start_datetime` / `eligibility_end_datetime`

On change aussi la règle pour la date de fin d'éligibilité. Avant, pour un 15-17, on considérait que c'était le jour de ses 18 ans. Maintenant, on considère qu'il est éligible en continu sur les phases 15-17 et 18. La date de fin d'éligibilité est donc le jour de ses 19 ans.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
