### PR TITLE
[PC-11705] make user beneficiary on valid Ubble check

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -7,7 +7,7 @@ import requests
 
 from pcapi import settings
 from pcapi.connectors.beneficiaries import exceptions
-from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.models import ubble as ubble_models
 
 
 logger = logging.getLogger(__name__)
@@ -31,28 +31,28 @@ def build_url(path: str) -> str:
 
 
 INCLUDED_MODELS = {
-    "documents": fraud_models.UbbleIdentificationDocuments,
-    "document-checks": fraud_models.UbbleIdentificationDocumentChecks,
+    "documents": ubble_models.UbbleIdentificationDocuments,
+    "document-checks": ubble_models.UbbleIdentificationDocumentChecks,
 }
 
 
 def _get_included_attributes(
-    response: fraud_models.UbbleIdentificationResponse, type_: str
-) -> typing.Union[fraud_models.UbbleIdentificationDocuments, fraud_models.UbbleIdentificationDocumentChecks]:
+    response: ubble_models.UbbleIdentificationResponse, type_: str
+) -> typing.Union[ubble_models.UbbleIdentificationDocuments, ubble_models.UbbleIdentificationDocumentChecks,]:
     filtered = list(filter(lambda included: included["type"] == type_, response["included"]))
     attributes = INCLUDED_MODELS[type_](**filtered[0].get("attributes")) if filtered else None
     return attributes
 
 
-def _get_data_attribute(response: fraud_models.UbbleIdentificationResponse, name: str) -> typing.Any:
+def _get_data_attribute(response: ubble_models.UbbleIdentificationResponse, name: str) -> typing.Any:
     return response["data"]["attributes"].get(name)
 
 
 def _extract_useful_content_from_response(
-    response: fraud_models.UbbleIdentificationResponse,
-) -> fraud_models.UbbleContent:
-    documents: fraud_models.UbbleIdentificationDocuments = _get_included_attributes(response, "documents")
-    document_checks: fraud_models.UbbleIdentificationDocumentChecks = _get_included_attributes(
+    response: ubble_models.UbbleIdentificationResponse,
+) -> ubble_models.UbbleContent:
+    documents: ubble_models.UbbleIdentificationDocuments = _get_included_attributes(response, "documents")
+    document_checks: ubble_models.UbbleIdentificationDocumentChecks = _get_included_attributes(
         response, "document-checks"
     )
     score = _get_data_attribute(response, "score")
@@ -62,7 +62,7 @@ def _extract_useful_content_from_response(
     status = _get_data_attribute(response, "status")
     registered_at = _get_data_attribute(response, "created-at")
 
-    content = fraud_models.UbbleContent(
+    content = ubble_models.UbbleContent(
         status=status,
         birth_date=getattr(documents, "birth_date", None),
         first_name=getattr(documents, "first_name", None),
@@ -88,7 +88,7 @@ def start_identification(
     last_name: str,
     webhook_url: str,
     redirect_url: str,
-) -> fraud_models.UbbleContent:
+) -> ubble_models.UbbleContent:
     session = configure_session()
 
     data = {
@@ -134,7 +134,7 @@ def start_identification(
     return content
 
 
-def get_content(identification_id: str) -> fraud_models.UbbleContent:
+def get_content(identification_id: str) -> ubble_models.UbbleContent:
     session = configure_session()
     response = session.get(
         build_url(f"/identifications/{identification_id}/"),

--- a/api/src/pcapi/core/fraud/api/ubble.py
+++ b/api/src/pcapi/core/fraud/api/ubble.py
@@ -1,0 +1,69 @@
+import typing
+
+from pcapi.core.fraud import api as fraud_api
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import models as users_models
+from pcapi.models import db
+
+
+def on_ubble_result(fraud_check: fraud_models.BeneficiaryFraudCheck) -> None:
+    fraud_api.on_identity_fraud_check_result(fraud_check.user, fraud_check)
+
+
+def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_models.FraudItem:
+    if content.score == fraud_models.ubble.UbbleScore.VALID.value:
+        return fraud_models.FraudItem(status=fraud_models.FraudStatus.OK, detail=f"Ubble score {content.score}")
+
+    return fraud_models.FraudItem(
+        status=fraud_models.FraudStatus.KO,
+        detail=f"Ubble score {content.score}: {content.comment}",
+        reason_code=(
+            fraud_models.FraudReasonCode.ID_CHECK_INVALID
+            if content.score == fraud_models.ubble.UbbleScore.INVALID.value
+            else fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE
+        ),
+    )
+
+
+def ubble_fraud_checks(
+    user: users_models.User, beneficiary_fraud_check: fraud_models.BeneficiaryFraudCheck
+) -> list[fraud_models.FraudItem]:
+    content = fraud_models.ubble.UbbleContent(**beneficiary_fraud_check.resultContent)
+
+    fraud_items = [
+        _ubble_result_fraud_item(content),
+        # TODO: factorise in fraud_api.on_identity_fraud_check_result for the 4 *_fraud_checks
+        fraud_api._duplicate_user_fraud_item(
+            first_name=content.first_name,
+            last_name=content.last_name,
+            birth_date=content.birth_date,
+            excluded_user_id=user.id,
+        ),
+        fraud_api.validate_id_piece_number_format_fraud_item(content.id_document_number),
+        fraud_api._duplicate_id_piece_number_fraud_item(user, content.id_document_number),
+    ]
+
+    return fraud_items
+
+
+def start_ubble_fraud_check(user: users_models.User, ubble_content: fraud_models.ubble.UbbleContent) -> None:
+    fraud_check = fraud_models.BeneficiaryFraudCheck(
+        user=user,
+        type=fraud_models.FraudCheckType.UBBLE,
+        thirdPartyId=str(ubble_content.identification_id),
+        resultContent=ubble_content,
+        status=fraud_models.FraudCheckStatus.PENDING,
+    )
+    db.session.add(fraud_check)
+    db.session.commit()
+
+
+def get_ubble_fraud_check(identification_id: str) -> typing.Optional[fraud_models.BeneficiaryFraudCheck]:
+    fraud_check = (
+        fraud_models.BeneficiaryFraudCheck.query.filter(
+            fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE
+        )
+        .filter(fraud_models.BeneficiaryFraudCheck.thirdPartyId == identification_id)
+        .one_or_none()
+    )
+    return fraud_check

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -10,6 +10,7 @@ import factory.fuzzy
 import pytz
 
 from pcapi.core import testing
+import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.factories as users_factories
 
 from . import models
@@ -113,7 +114,7 @@ class DMSContentFactory(factory.Factory):
 
 class UbbleContentFactory(factory.Factory):
     class Meta:
-        model = models.UbbleContent
+        model = fraud_models.ubble.UbbleContent
 
     status = None
     birth_date = None

--- a/api/src/pcapi/core/fraud/models/__init__.py
+++ b/api/src/pcapi/core/fraud/models/__init__.py
@@ -14,6 +14,8 @@ from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 
+from . import ubble as ubble_models
+
 
 class FraudCheckType(enum.Enum):
     JOUVE = "jouve"
@@ -127,89 +129,6 @@ class JouveContent(pydantic.BaseModel):
     _parse_registration_date = validator("registrationDate", pre=True, allow_reuse=True)(_parse_jouve_datetime)
 
 
-class IdentificationStatus(enum.Enum):
-    UNINITIATED = "uninitiated"
-    INITIATED = "initiated"
-    PROCESSING = "processing"
-    PROCESSED = "processed"
-    ABORTED = "aborted"
-
-
-class UbbleScore(enum.Enum):
-    VALID = 1.0
-    INVALID = 0.0
-    UNDECIDABLE = -1.0
-
-
-class UbbleContent(pydantic.BaseModel):
-    birth_date: typing.Optional[datetime.date]
-    comment: typing.Optional[str]
-    document_type: typing.Optional[str]
-    expiry_date_score: typing.Optional[float]
-    first_name: typing.Optional[str]
-    id_document_number: typing.Optional[str]
-    identification_id: typing.Optional[pydantic.UUID4]
-    identification_url: typing.Optional[pydantic.HttpUrl]
-    last_name: typing.Optional[str]
-    registration_datetime: typing.Optional[datetime.datetime]
-    score: typing.Optional[float]
-    status: typing.Optional[IdentificationStatus]
-    supported: typing.Optional[float]
-
-    _parse_birth_date = validator("birth_date", pre=True, allow_reuse=True)(
-        lambda d: datetime.datetime.strptime(d, "%Y-%m-%d").date() if d is not None else None
-    )
-
-
-class UbbleIdentificationAttributes(pydantic.BaseModel):
-    comment: typing.Optional[str]
-    created_at: datetime.datetime = pydantic.Field(alias="created-at")
-    ended_at: typing.Optional[datetime.datetime] = pydantic.Field(None, alias="ended-at")
-    identification_id: str = pydantic.Field(alias="identification-id")
-    identification_url: str = pydantic.Field(alias="identification-url")
-    number_of_attempts: int = pydantic.Field(alias="number-of-attempts")
-    redirect_url: str = pydantic.Field(alias="redirect-url")
-    score: typing.Optional[float]
-    started_at: typing.Optional[datetime.datetime] = pydantic.Field(None, alias="started-at")
-    status: IdentificationStatus
-    status_updated_at: datetime.datetime = pydantic.Field(alias="status-updated-at")
-    updated_at: datetime.datetime = pydantic.Field(alias="updated-at")
-    user_agent: typing.Optional[str] = pydantic.Field(None, alias="user-agent")
-    user_ip_address: typing.Optional[str] = pydantic.Field(None, alias="user-ip-address")
-    webhook: str
-
-
-class UbbleIdentificationData(pydantic.BaseModel):
-    type: str
-    id: int
-    attributes: UbbleIdentificationAttributes
-
-
-class UbbleIdentificationDocuments(pydantic.BaseModel):
-    birth_date: str = pydantic.Field(None, alias="birth-date")
-    document_number: str = pydantic.Field(None, alias="document-number")
-    document_type: str = pydantic.Field(None, alias="document-type")
-    first_name: str = pydantic.Field(None, alias="first-name")
-    last_name: str = pydantic.Field(None, alias="last-name")
-
-
-class UbbleIdentificationDocumentChecks(pydantic.BaseModel):
-    expiry_date_score: float = pydantic.Field(None, alias="expiry-date-score")
-    supported: float
-
-
-class UbbleIdentificationIncluded(pydantic.BaseModel):
-    type: str
-    id: int
-    attributes: typing.Union[UbbleIdentificationDocumentChecks, UbbleIdentificationDocuments]
-    relationships: typing.Optional[dict]
-
-
-class UbbleIdentificationResponse(pydantic.BaseModel):
-    data: UbbleIdentificationData
-    included: list[UbbleIdentificationIncluded]
-
-
 class DMSContent(pydantic.BaseModel):
     last_name: str
     first_name: str
@@ -268,6 +187,16 @@ class UserProfilingFraudData(pydantic.BaseModel):
     unknown_session: typing.Optional[str]
 
 
+IdCheckContent = typing.TypeVar(
+    "IdCheckContent",
+    DMSContent,
+    EduconnectContent,
+    JouveContent,
+    ubble_models.UbbleContent,
+    UserProfilingFraudData,
+)
+
+
 class InternalReviewSource(enum.Enum):
     SMS_SENDING_LIMIT_REACHED = "sms_sending_limit_reached"
     PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED = "phone_validation_attempts_limit_reached"
@@ -282,7 +211,7 @@ class InternalReviewFraudData(pydantic.BaseModel):
     phone_number: typing.Optional[str]
 
 
-SubscriptionContentType = typing.Union[EduconnectContent, JouveContent, UbbleContent, DMSContent]
+SubscriptionContentType = typing.Union[EduconnectContent, JouveContent, ubble_models.UbbleContent, DMSContent]
 
 
 FRAUD_CHECK_MAPPING = {
@@ -291,7 +220,7 @@ FRAUD_CHECK_MAPPING = {
     FraudCheckType.JOUVE: JouveContent,
     FraudCheckType.INTERNAL_REVIEW: InternalReviewFraudData,
     FraudCheckType.EDUCONNECT: EduconnectContent,
-    FraudCheckType.UBBLE: UbbleContent,
+    FraudCheckType.UBBLE: ubble_models.UbbleContent,
 }
 
 

--- a/api/src/pcapi/core/fraud/models/ubble.py
+++ b/api/src/pcapi/core/fraud/models/ubble.py
@@ -1,0 +1,88 @@
+import datetime
+import enum
+import typing
+
+import pydantic
+
+
+class UbbleIdentificationStatus(enum.Enum):
+    UNINITIATED = "uninitiated"
+    INITIATED = "initiated"
+    PROCESSING = "processing"
+    PROCESSED = "processed"
+    ABORTED = "aborted"
+
+
+class UbbleScore(enum.Enum):
+    VALID = 1.0
+    INVALID = 0.0
+    UNDECIDABLE = -1.0
+
+
+class UbbleContent(pydantic.BaseModel):
+    birth_date: typing.Optional[datetime.date]
+    comment: typing.Optional[str]
+    document_type: typing.Optional[str]
+    expiry_date_score: typing.Optional[float]
+    first_name: typing.Optional[str]
+    id_document_number: typing.Optional[str]
+    identification_id: typing.Optional[pydantic.UUID4]
+    identification_url: typing.Optional[pydantic.HttpUrl]
+    last_name: typing.Optional[str]
+    registration_datetime: typing.Optional[datetime.datetime]
+    score: typing.Optional[float]
+    status: typing.Optional[UbbleIdentificationStatus]
+    supported: typing.Optional[float]
+
+    _parse_birth_date = pydantic.validator("birth_date", pre=True, allow_reuse=True)(
+        lambda d: datetime.datetime.strptime(d, "%Y-%m-%d").date() if d is not None else None
+    )
+
+
+class UbbleIdentificationAttributes(pydantic.BaseModel):
+    comment: typing.Optional[str]
+    created_at: datetime.datetime = pydantic.Field(alias="created-at")
+    ended_at: typing.Optional[datetime.datetime] = pydantic.Field(None, alias="ended-at")
+    identification_id: str = pydantic.Field(alias="identification-id")
+    identification_url: str = pydantic.Field(alias="identification-url")
+    number_of_attempts: int = pydantic.Field(alias="number-of-attempts")
+    redirect_url: str = pydantic.Field(alias="redirect-url")
+    score: typing.Optional[float]
+    started_at: typing.Optional[datetime.datetime] = pydantic.Field(None, alias="started-at")
+    status: UbbleIdentificationStatus
+    status_updated_at: datetime.datetime = pydantic.Field(alias="status-updated-at")
+    updated_at: datetime.datetime = pydantic.Field(alias="updated-at")
+    user_agent: typing.Optional[str] = pydantic.Field(None, alias="user-agent")
+    user_ip_address: typing.Optional[str] = pydantic.Field(None, alias="user-ip-address")
+    webhook: str
+
+
+class UbbleIdentificationData(pydantic.BaseModel):
+    type: str
+    id: int
+    attributes: UbbleIdentificationAttributes
+
+
+class UbbleIdentificationDocuments(pydantic.BaseModel):
+    birth_date: str = pydantic.Field(None, alias="birth-date")
+    document_number: str = pydantic.Field(None, alias="document-number")
+    document_type: str = pydantic.Field(None, alias="document-type")
+    first_name: str = pydantic.Field(None, alias="first-name")
+    last_name: str = pydantic.Field(None, alias="last-name")
+
+
+class UbbleIdentificationDocumentChecks(pydantic.BaseModel):
+    expiry_date_score: float = pydantic.Field(None, alias="expiry-date-score")
+    supported: float
+
+
+class UbbleIdentificationIncluded(pydantic.BaseModel):
+    type: str
+    id: int
+    attributes: typing.Union[UbbleIdentificationDocumentChecks, UbbleIdentificationDocuments]
+    relationships: typing.Optional[dict]
+
+
+class UbbleIdentificationResponse(pydantic.BaseModel):
+    data: UbbleIdentificationData
+    included: list[UbbleIdentificationIncluded]

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -193,6 +193,15 @@ def on_duplicate_user(user: users_models.User) -> None:
     repository.save(message)
 
 
+def on_already_beneficiary(user: users_models.User) -> None:
+    message = models.SubscriptionMessage(
+        user=user,
+        userMessage="Tu es déjà bénéficaire.",
+        popOverIcon=models.PopOverIcon.ERROR,
+    )
+    repository.save(message)
+
+
 def _generate_form_field_error(error_text_singular: str, error_text_plural: str, error_fields: list[str]) -> str:
     french_field_name = {
         "id_piece_number": "ta pièce d'identité",

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -322,6 +322,11 @@ def update_user_information_from_external_source(
         user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0))
         user.ineHash = data.ine_hash
 
+    elif isinstance(data, fraud_models.ubble.UbbleContent):
+        user.firstName = data.first_name
+        user.lastName = data.last_name
+        user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0))
+
     # update user fields to be correctly initialized
     user.hasSeenTutorials = False
     user.remove_admin_role()

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -22,6 +22,7 @@ class BeneficiaryImportSources(Enum):
     demarches_simplifiees = "demarches_simplifiees"
     jouve = "jouve"
     educonnect = "educonnect"
+    ubble = "ubble"
 
 
 class BeneficiaryImport(PcObject, Model):

--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -106,7 +106,7 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
 def ubble_webhook_update_application_status(
     body: ubble_validation.WebhookRequest,
 ) -> ubble_validation.WebhookDummyReponse:
-    fraud_check = fraud_api.get_ubble_fraud_check(body.identification_id)
+    fraud_check = fraud_api.ubble.get_ubble_fraud_check(body.identification_id)
     if not fraud_check:
         raise ValueError(f"no Ubble fraud check found with identification_id {body.identification_id}")
 

--- a/api/src/pcapi/scripts/beneficiary/import_dms_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_dms_users.py
@@ -201,6 +201,7 @@ def process_application(
                 source_data=information,
                 application_id=application_id,
                 source_id=procedure_id,
+                source=BeneficiaryImportSources.demarches_simplifiees,
             )
         except ApiErrors as api_errors:
             logger.warning(

--- a/api/src/pcapi/use_cases/create_beneficiary_from_application.py
+++ b/api/src/pcapi/use_cases/create_beneficiary_from_application.py
@@ -60,8 +60,8 @@ class CreateBeneficiaryFromApplication:
         preexisting_account = find_user_by_email(beneficiary_pre_subscription.email)
         if not preexisting_account:
             save_beneficiary_import_with_status(
-                ImportStatus.ERROR,
-                application_id,
+                status=ImportStatus.ERROR,
+                application_id=application_id,
                 source=BeneficiaryImportSources.demarches_simplifiees,
                 source_id=jouve_backend.DEFAULT_JOUVE_SOURCE_ID,
                 detail=f"Aucun utilisateur trouvé pour l'email {beneficiary_pre_subscription.email}",

--- a/api/src/pcapi/validation/routes/ubble.py
+++ b/api/src/pcapi/validation/routes/ubble.py
@@ -9,7 +9,7 @@ import flask
 import pydantic
 
 from pcapi import settings
-from pcapi.core.fraud.models import IdentificationStatus
+from pcapi.core.fraud import models as fraud_models
 from pcapi.models.api_errors import ForbiddenError
 
 
@@ -23,7 +23,7 @@ class Configuration(pydantic.BaseModel):
 
 class WebhookRequest(pydantic.BaseModel):
     identification_id: str
-    status: IdentificationStatus
+    status: fraud_models.ubble.UbbleIdentificationStatus
     configuration: Configuration
 
 

--- a/api/tests/connectors/beneficiaries/ubble_fixtures.py
+++ b/api/tests/connectors/beneficiaries/ubble_fixtures.py
@@ -1,4 +1,4 @@
-from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.models import ubble as ubble_models
 
 
 UBBLE_IDENTIFICATION_RESPONSE = {
@@ -6,7 +6,7 @@ UBBLE_IDENTIFICATION_RESPONSE = {
         "type": "identifications",
         "id": "3191295",
         "attributes": {
-            "score": fraud_models.UbbleScore.INVALID.value,
+            "score": ubble_models.UbbleScore.INVALID.value,
             "anonymized-at": None,
             "comment": None,
             "created-at": "2021-11-18T18:59:59.273402Z",
@@ -50,20 +50,20 @@ UBBLE_IDENTIFICATION_RESPONSE = {
             "type": "document-checks",
             "id": "4997875",
             "attributes": {
-                "data-extracted-score": fraud_models.UbbleScore.INVALID.value,
-                "expiry-date-score": fraud_models.UbbleScore.INVALID.value,
+                "data-extracted-score": ubble_models.UbbleScore.INVALID.value,
+                "expiry-date-score": ubble_models.UbbleScore.INVALID.value,
                 "issue-date-score": None,
                 "live-video-capture-score": None,
-                "mrz-validity-score": fraud_models.UbbleScore.INVALID.value,
-                "mrz-viz-score": fraud_models.UbbleScore.INVALID.value,
-                "ove-back-score": fraud_models.UbbleScore.INVALID.value,
-                "ove-front-score": fraud_models.UbbleScore.INVALID.value,
-                "ove-score": fraud_models.UbbleScore.INVALID.value,
-                "quality-score": fraud_models.UbbleScore.INVALID.value,
-                "score": fraud_models.UbbleScore.INVALID.value,
-                "supported": fraud_models.UbbleScore.INVALID.value,
-                "visual-back-score": fraud_models.UbbleScore.INVALID.value,
-                "visual-front-score": fraud_models.UbbleScore.INVALID.value,
+                "mrz-validity-score": ubble_models.UbbleScore.INVALID.value,
+                "mrz-viz-score": ubble_models.UbbleScore.INVALID.value,
+                "ove-back-score": ubble_models.UbbleScore.INVALID.value,
+                "ove-front-score": ubble_models.UbbleScore.INVALID.value,
+                "ove-score": ubble_models.UbbleScore.INVALID.value,
+                "quality-score": ubble_models.UbbleScore.INVALID.value,
+                "score": ubble_models.UbbleScore.INVALID.value,
+                "supported": ubble_models.UbbleScore.INVALID.value,
+                "visual-back-score": ubble_models.UbbleScore.INVALID.value,
+                "visual-front-score": ubble_models.UbbleScore.INVALID.value,
             },
             "relationships": {},
         },

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from pcapi.connectors.beneficiaries import exceptions
 from pcapi.connectors.beneficiaries import ubble
-from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.models import ubble as ubble_models
 
 
 class StartIdentificationTest:
@@ -20,7 +20,7 @@ class StartIdentificationTest:
             redirect_url="http://redirect/url",
         )
 
-        assert isinstance(response, fraud_models.UbbleContent)
+        assert isinstance(response, ubble_models.UbbleContent)
         assert ubble_mock.call_count == 1
 
         attributes = ubble_mock.last_request.json()["data"]["attributes"]

--- a/api/tests/core/fraud/test_factories.py
+++ b/api/tests/core/fraud/test_factories.py
@@ -14,7 +14,7 @@ class FactoriesTest:
             (fraud_models.FraudCheckType.DMS, fraud_models.DMSContent),
             (fraud_models.FraudCheckType.JOUVE, fraud_models.JouveContent),
             (fraud_models.FraudCheckType.USER_PROFILING, fraud_models.UserProfilingFraudData),
-            (fraud_models.FraudCheckType.UBBLE, fraud_models.UbbleContent),
+            (fraud_models.FraudCheckType.UBBLE, fraud_models.ubble.UbbleContent),
         ],
     )
     def test_database_serialization(self, check_type, model_class):

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -8,26 +8,19 @@ import pytest
 from pcapi import settings
 from pcapi.connectors.api_demarches_simplifiees import DMSGraphQLClient
 from pcapi.connectors.api_demarches_simplifiees import GraphQLApplicationStates
+from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
-from pcapi.core.fraud.api import get_ubble_fraud_check
-from pcapi.core.fraud.models import FraudCheckStatus
-from pcapi.core.fraud.models import FraudCheckType
-from pcapi.core.fraud.models import FraudReasonCode
-from pcapi.core.fraud.models import UbbleContent
+import pcapi.core.mails.testing as mails_testing
 from pcapi.core.subscription import messages as subscription_messages
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import factories as users_factories
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import import BeneficiaryImportSources
 from pcapi.models.beneficiary_import_status import ImportStatus
-from pcapi.validation.routes.ubble import Configuration
-from pcapi.validation.routes.ubble import WebhookRequest
-from pcapi.validation.routes.ubble import compute_signature
+from pcapi.validation.routes import ubble as ubble_routes
 
-from tests.core.subscription.test_factories import IdentificationState
-from tests.core.subscription.test_factories import STATE_STATUS_MAPPING
-from tests.core.subscription.test_factories import UbbleIdentificationResponseFactory
+from tests.core.subscription import test_factories
 from tests.scripts.beneficiary.fixture import make_single_application
 from tests.test_utils import json_default
 
@@ -256,10 +249,10 @@ class DmsWebhookApplicationTest:
 @pytest.mark.usefixtures("db_session")
 class UbbleWebhookTest:
     def _get_request_body(self, fraud_check, status):
-        return WebhookRequest(
+        return ubble_routes.WebhookRequest(
             identification_id=fraud_check.thirdPartyId,
             status=status,
-            configuration=Configuration(
+            configuration=ubble_routes.Configuration(
                 id=fraud_check.user.id,
                 name="Pass Culture",
             ),
@@ -267,7 +260,7 @@ class UbbleWebhookTest:
 
     def _get_signature(self, payload):
         timestamp = str(int(time.time()))
-        token = compute_signature(timestamp.encode("utf-8"), payload.encode("utf-8"))
+        token = ubble_routes.compute_signature(timestamp.encode("utf-8"), payload.encode("utf-8"))
         return f"ts={timestamp},v1={token}"
 
     def _init_test(self, current_identification_state, notified_identification_state):
@@ -275,22 +268,24 @@ class UbbleWebhookTest:
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             resultContent=fraud_factories.UbbleContentFactory(
-                status=STATE_STATUS_MAPPING[current_identification_state].value,
+                status=test_factories.STATE_STATUS_MAPPING[current_identification_state].value,
             ),
             user=user,
         )
-        request_data = self._get_request_body(fraud_check, STATE_STATUS_MAPPING[notified_identification_state])
+        request_data = self._get_request_body(
+            fraud_check, test_factories.STATE_STATUS_MAPPING[notified_identification_state]
+        )
         payload = json.dumps(request_data.dict(by_alias=True), default=json_default)
         signature = self._get_signature(payload)
-        ubble_identification_response = UbbleIdentificationResponseFactory(
+        ubble_identification_response = test_factories.UbbleIdentificationResponseFactory(
             identification_state=notified_identification_state,
             data__attributes__identification_id=str(request_data.identification_id),
         )
         return payload, request_data, signature, ubble_identification_response
 
     def test_webhook_signature_ok(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.INITIATED
-        notified_identification_state = IdentificationState.PROCESSING
+        current_identification_state = test_factories.IdentificationState.INITIATED
+        notified_identification_state = test_factories.IdentificationState.PROCESSING
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -309,8 +304,8 @@ class UbbleWebhookTest:
         assert response.json == {"status": "ok"}
 
     def test_webhook_signature_bad(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.INITIATED
-        notified_identification_state = IdentificationState.PROCESSING
+        current_identification_state = test_factories.IdentificationState.INITIATED
+        notified_identification_state = test_factories.IdentificationState.PROCESSING
         payload, request_data, _, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -329,8 +324,8 @@ class UbbleWebhookTest:
         assert response.json == {"signature": ["Invalid signature"]}
 
     def test_webhook_signature_missing(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.INITIATED
-        notified_identification_state = IdentificationState.PROCESSING
+        current_identification_state = test_factories.IdentificationState.INITIATED
+        notified_identification_state = test_factories.IdentificationState.PROCESSING
         payload, request_data, _, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -348,8 +343,8 @@ class UbbleWebhookTest:
         assert response.json == {"signature": ["Invalid signature"]}
 
     def test_fraud_check_intiated(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.NEW
-        notified_identification_state = IdentificationState.INITIATED
+        current_identification_state = test_factories.IdentificationState.NEW
+        notified_identification_state = test_factories.IdentificationState.INITIATED
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -364,15 +359,17 @@ class UbbleWebhookTest:
                 raw_json=payload,
             )
 
-        fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
+        fraud_check = fraud_api.ubble.get_ubble_fraud_check(
+            ubble_identification_response.data.attributes.identification_id
+        )
         assert fraud_check.reason is None
         assert fraud_check.reasonCodes is None
-        assert fraud_check.status is FraudCheckStatus.PENDING
-        assert fraud_check.type == FraudCheckType.UBBLE
+        assert fraud_check.status is fraud_models.FraudCheckStatus.PENDING
+        assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
-        content = UbbleContent(**fraud_check.resultContent)
+        content = fraud_models.ubble.UbbleContent(**fraud_check.resultContent)
         assert content.score is None
-        assert content.status == STATE_STATUS_MAPPING[notified_identification_state]
+        assert content.status == test_factories.STATE_STATUS_MAPPING[notified_identification_state]
         assert content.comment is None
         assert content.last_name is None
         assert content.first_name is None
@@ -387,8 +384,8 @@ class UbbleWebhookTest:
         )
 
     def test_fraud_check_aborted(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.INITIATED
-        notified_identification_state = IdentificationState.ABORTED
+        current_identification_state = test_factories.IdentificationState.INITIATED
+        notified_identification_state = test_factories.IdentificationState.ABORTED
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -403,15 +400,17 @@ class UbbleWebhookTest:
                 raw_json=payload,
             )
 
-        fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
+        fraud_check = fraud_api.ubble.get_ubble_fraud_check(
+            ubble_identification_response.data.attributes.identification_id
+        )
         assert fraud_check.reason is None
         assert fraud_check.reasonCodes is None
-        assert fraud_check.status is FraudCheckStatus.CANCELED
-        assert fraud_check.type == FraudCheckType.UBBLE
+        assert fraud_check.status is fraud_models.FraudCheckStatus.CANCELED
+        assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
-        content = UbbleContent(**fraud_check.resultContent)
+        content = fraud_models.ubble.UbbleContent(**fraud_check.resultContent)
         assert content.score is None
-        assert content.status == STATE_STATUS_MAPPING[notified_identification_state]
+        assert content.status == test_factories.STATE_STATUS_MAPPING[notified_identification_state]
         assert content.comment is None
         assert content.last_name is None
         assert content.first_name is None
@@ -426,8 +425,8 @@ class UbbleWebhookTest:
         )
 
     def test_fraud_check_processing(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.INITIATED
-        notified_identification_state = IdentificationState.PROCESSING
+        current_identification_state = test_factories.IdentificationState.INITIATED
+        notified_identification_state = test_factories.IdentificationState.PROCESSING
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -442,19 +441,21 @@ class UbbleWebhookTest:
                 raw_json=payload,
             )
 
-        fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
+        fraud_check = fraud_api.ubble.get_ubble_fraud_check(
+            ubble_identification_response.data.attributes.identification_id
+        )
         assert fraud_check.reason is None
         assert fraud_check.reasonCodes is None
-        assert fraud_check.status is FraudCheckStatus.PENDING
-        assert fraud_check.type == FraudCheckType.UBBLE
+        assert fraud_check.status is fraud_models.FraudCheckStatus.PENDING
+        assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
         assert fraud_check.user.hasCompletedIdCheck is True
-        content = UbbleContent(**fraud_check.resultContent)
+        content = fraud_models.ubble.UbbleContent(**fraud_check.resultContent)
         document = list(filter(lambda included: included.type == "documents", ubble_identification_response.included))[
             0
         ].attributes
         assert content.score is None
-        assert content.status == STATE_STATUS_MAPPING[notified_identification_state]
+        assert content.status == test_factories.STATE_STATUS_MAPPING[notified_identification_state]
         assert content.comment == ubble_identification_response.data.attributes.comment
         assert content.last_name == document.last_name
         assert content.first_name == document.first_name
@@ -468,9 +469,9 @@ class UbbleWebhookTest:
             content.identification_url == f"{settings.UBBLE_API_URL}/identifications/{str(content.identification_id)}"
         )
 
-    def test_fraud_check_valid(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.PROCESSING
-        notified_identification_state = IdentificationState.VALID
+    def test_fraud_check_valid(self, client, ubble_mocker, mocker):
+        current_identification_state = test_factories.IdentificationState.PROCESSING
+        notified_identification_state = test_factories.IdentificationState.VALID
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -485,34 +486,45 @@ class UbbleWebhookTest:
                 raw_json=payload,
             )
 
-        fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
+        fraud_check = fraud_api.ubble.get_ubble_fraud_check(
+            ubble_identification_response.data.attributes.identification_id
+        )
         assert fraud_check.reason == ""
         assert fraud_check.reasonCodes == []
-        assert fraud_check.status is FraudCheckStatus.OK
-        assert fraud_check.type == FraudCheckType.UBBLE
+        assert fraud_check.status is fraud_models.FraudCheckStatus.OK
+        assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
-        content = UbbleContent(**fraud_check.resultContent)
+
+        assert fraud_check.user.has_beneficiary_role
+        assert len(fraud_check.user.deposits) == 1
+        assert len(fraud_check.user.beneficiaryImports) == 1
+        assert fraud_check.user.beneficiaryImports[0].source == BeneficiaryImportSources.ubble.value
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0].sent_data["To"] == fraud_check.user.email
+
+        content = fraud_models.ubble.UbbleContent(**fraud_check.resultContent)
         document = list(filter(lambda included: included.type == "documents", ubble_identification_response.included))[
             0
         ].attributes
-        assert content.score == fraud_models.UbbleScore.VALID.value
-        assert content.status == STATE_STATUS_MAPPING[notified_identification_state]
+        assert content.score == fraud_models.ubble.UbbleScore.VALID.value
+        assert content.status == test_factories.STATE_STATUS_MAPPING[notified_identification_state]
         assert content.comment == ubble_identification_response.data.attributes.comment
         assert content.last_name == document.last_name
         assert content.first_name == document.first_name
         assert str(content.birth_date) == document.birth_date
-        assert content.supported == fraud_models.UbbleScore.VALID.value
+        assert content.supported == fraud_models.ubble.UbbleScore.VALID.value
         assert content.document_type == document.document_type
-        assert content.expiry_date_score == fraud_models.UbbleScore.VALID.value
+        assert content.expiry_date_score == fraud_models.ubble.UbbleScore.VALID.value
         assert str(content.identification_id) == ubble_identification_response.data.attributes.identification_id
         assert content.id_document_number == document.document_number
         assert (
             content.identification_url == f"{settings.UBBLE_API_URL}/identifications/{str(content.identification_id)}"
         )
 
-    def test_fraud_check_invalid(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.PROCESSING
-        notified_identification_state = IdentificationState.INVALID
+    def test_fraud_check_invalid(self, client, ubble_mocker, mocker):
+        current_identification_state = test_factories.IdentificationState.PROCESSING
+        notified_identification_state = test_factories.IdentificationState.INVALID
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -527,21 +539,29 @@ class UbbleWebhookTest:
                 raw_json=payload,
             )
 
-        fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
+        fraud_check = fraud_api.ubble.get_ubble_fraud_check(
+            ubble_identification_response.data.attributes.identification_id
+        )
         assert fraud_check.reason is not None
         assert fraud_check.reasonCodes is not None
-        assert fraud_check.status is FraudCheckStatus.KO
-        assert fraud_check.type == FraudCheckType.UBBLE
+        assert fraud_check.status is fraud_models.FraudCheckStatus.KO
+        assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
-        content = UbbleContent(**fraud_check.resultContent)
+
+        assert not fraud_check.user.has_beneficiary_role
+        assert len(fraud_check.user.deposits) == 0
+
+        assert len(mails_testing.outbox) == 0
+
+        content = fraud_models.ubble.UbbleContent(**fraud_check.resultContent)
         document = list(filter(lambda included: included.type == "documents", ubble_identification_response.included))[
             0
         ].attributes
         document_check = list(
             filter(lambda included: included.type == "document-checks", ubble_identification_response.included)
         )[0].attributes
-        assert content.score == fraud_models.UbbleScore.INVALID.value
-        assert content.status == STATE_STATUS_MAPPING[notified_identification_state]
+        assert content.score == fraud_models.ubble.UbbleScore.INVALID.value
+        assert content.status == test_factories.STATE_STATUS_MAPPING[notified_identification_state]
         assert content.comment == ubble_identification_response.data.attributes.comment
         assert content.last_name == document.last_name
         assert content.first_name == document.first_name
@@ -555,9 +575,9 @@ class UbbleWebhookTest:
             content.identification_url == f"{settings.UBBLE_API_URL}/identifications/{str(content.identification_id)}"
         )
 
-    def test_fraud_check_unprocessable(self, client, ubble_mocker):
-        current_identification_state = IdentificationState.PROCESSING
-        notified_identification_state = IdentificationState.UNPROCESSABLE
+    def test_fraud_check_unprocessable(self, client, ubble_mocker, mocker):
+        current_identification_state = test_factories.IdentificationState.PROCESSING
+        notified_identification_state = test_factories.IdentificationState.UNPROCESSABLE
         payload, request_data, signature, ubble_identification_response = self._init_test(
             current_identification_state, notified_identification_state
         )
@@ -572,21 +592,29 @@ class UbbleWebhookTest:
                 raw_json=payload,
             )
 
-        fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
+        fraud_check = fraud_api.ubble.get_ubble_fraud_check(
+            ubble_identification_response.data.attributes.identification_id
+        )
         assert fraud_check.reason == "Ubble score -1.0: None"
-        assert fraud_check.reasonCodes == [FraudReasonCode.ID_CHECK_UNPROCESSABLE]
-        assert fraud_check.status is FraudCheckStatus.KO
-        assert fraud_check.type == FraudCheckType.UBBLE
+        assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE]
+        assert fraud_check.status is fraud_models.FraudCheckStatus.KO
+        assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
-        content = UbbleContent(**fraud_check.resultContent)
+
+        assert not fraud_check.user.has_beneficiary_role
+        assert len(fraud_check.user.deposits) == 0
+
+        assert len(mails_testing.outbox) == 0
+
+        content = fraud_models.ubble.UbbleContent(**fraud_check.resultContent)
         document = list(filter(lambda included: included.type == "documents", ubble_identification_response.included))[
             0
         ].attributes
         document_check = list(
             filter(lambda included: included.type == "document-checks", ubble_identification_response.included)
         )[0].attributes
-        assert content.score == fraud_models.UbbleScore.UNDECIDABLE.value
-        assert content.status == STATE_STATUS_MAPPING[notified_identification_state]
+        assert content.score == fraud_models.ubble.UbbleScore.UNDECIDABLE.value
+        assert content.status == test_factories.STATE_STATUS_MAPPING[notified_identification_state]
         assert content.comment == ubble_identification_response.data.attributes.comment
         assert content.last_name == document.last_name
         assert content.first_name == document.first_name

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -355,14 +355,14 @@ class AccountTest:
     @pytest.mark.parametrize(
         "fraud_check_status,ubble_status,next_step",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.IdentificationStatus.INITIATED, None),
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.IdentificationStatus.PROCESSING, None),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.IdentificationStatus.PROCESSED, None),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.IdentificationStatus.PROCESSED, None),
-            (fraud_models.FraudCheckStatus.CANCELED, fraud_models.IdentificationStatus.ABORTED, "id-check"),
-            (None, fraud_models.IdentificationStatus.INITIATED, None),
-            (None, fraud_models.IdentificationStatus.PROCESSING, None),
-            (None, fraud_models.IdentificationStatus.PROCESSED, None),
+            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
+            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
+            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (fraud_models.FraudCheckStatus.CANCELED, fraud_models.ubble.UbbleIdentificationStatus.ABORTED, "id-check"),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
         ],
     )
     @override_features(ENABLE_UBBLE=True)
@@ -2001,10 +2001,10 @@ class IdentificationSessionTest:
     @pytest.mark.parametrize(
         "fraud_check_status,ubble_status",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.IdentificationStatus.INITIATED),
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.IdentificationStatus.PROCESSING),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.IdentificationStatus.PROCESSED),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.IdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.INITIATED),
+            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING),
+            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
         ],
     )
     def test_request_ubble_second_check_blocked(self, client, ubble_mock, fraud_check_status, ubble_status):
@@ -2056,7 +2056,9 @@ class IdentificationSessionTest:
             user=user,
             type=fraud_models.FraudCheckType.UBBLE,
             status=fraud_models.FraudCheckStatus.CANCELED,
-            resultContent=fraud_factories.UbbleContentFactory(status=fraud_models.IdentificationStatus.ABORTED),
+            resultContent=fraud_factories.UbbleContentFactory(
+                status=fraud_models.ubble.UbbleIdentificationStatus.ABORTED
+            ),
         )
 
         # Initiate second id check with Ubble

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -57,14 +57,18 @@ class NextStepTest:
     @pytest.mark.parametrize(
         "fraud_check_status,ubble_status,next_step",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.IdentificationStatus.INITIATED, None),
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.IdentificationStatus.PROCESSING, None),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.IdentificationStatus.PROCESSED, None),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.IdentificationStatus.PROCESSED, None),
-            (fraud_models.FraudCheckStatus.CANCELED, fraud_models.IdentificationStatus.ABORTED, "identity-check"),
-            (None, fraud_models.IdentificationStatus.INITIATED, None),
-            (None, fraud_models.IdentificationStatus.PROCESSING, None),
-            (None, fraud_models.IdentificationStatus.PROCESSED, None),
+            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
+            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
+            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (
+                fraud_models.FraudCheckStatus.CANCELED,
+                fraud_models.ubble.UbbleIdentificationStatus.ABORTED,
+                "identity-check",
+            ),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
         ],
     )
     @override_features(ENABLE_UBBLE=True)

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -22,6 +22,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users.constants import ELIGIBILITY_AGE_18
 from pcapi.models.beneficiary_import import BeneficiaryImport
+from pcapi.models.beneficiary_import import BeneficiaryImportSources
 from pcapi.models.beneficiary_import_status import ImportStatus
 import pcapi.notifications.push.testing as push_testing
 from pcapi.scripts.beneficiary import import_dms_users
@@ -323,6 +324,7 @@ class RunTest:
             ),
             application_id=123,
             source_id=6712558,
+            source=BeneficiaryImportSources.demarches_simplifiees,
         )
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11705


## But de la pull request

Passer l'utilisateur en bénéficiaire quand celui-ci a reussi sa vérification d'identité via Ubble.

##  Implémentation

- généralisation des fonctions de vérification et validation de l'utilisateur utilisé pour DMS pour pouvoir les utiliser aussi avec Ubble
​
##  Informations supplémentaires

- migration du code spécifique Ubble dans des modules `ubble`, là ou c'était pertinent

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [ x PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)~~ N/A
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] ~~J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)~~ N/A
