### PR TITLE
(PC-10848) Add status in error log message to separate exceptions types in sentry

### DIFF
--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -30,13 +30,14 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
         api_instance.send_transac_email(send_smtp_email)
         return True
     except ApiException as e:
-        logger.error(
-            "Exception when calling SMTPApi->send_transac_email (status=%s): %s\n",
-            e.status,
-            e,
-            extra={"status": e.status, "template_id": payload.template_id, "recipients": payload.recipients},
+        logger.exception(  # pylint: disable=logging-fstring-interpolation
+            f"Exception when calling SMTPApi->send_transac_email with status={e.status}",
+            extra={"template_id": payload.template_id, "recipients": payload.recipients},
         )
         return False
     except Exception as e:  # pylint: disable=broad-except
-        logger.error("Unknown exception occurred when calling SMTPApi->send_transac_email: %s\n", e)
+        logger.exception(
+            "Unknown exception occurred when calling SMTPApi->send_transac_email",
+            extra={"template_id": payload.template_id, "recipients": payload.recipients},
+        )
         return False

--- a/api/src/pcapi/core/users/external/sendinblue.py
+++ b/api/src/pcapi/core/users/external/sendinblue.py
@@ -161,9 +161,8 @@ def make_update_request(payload: UpdateSendinblueContactRequest) -> bool:
 
     except SendinblueApiException as exception:
         if exception.status == 524:
-            logger.warning(
-                "Timeout when calling ContactsApi->create_contact: %s",
-                exception,
+            logger.exception(
+                "Timeout when calling ContactsApi->create_contact",
                 extra={
                     "email": payload.email,
                     "attributes": payload.attributes,
@@ -171,15 +170,25 @@ def make_update_request(payload: UpdateSendinblueContactRequest) -> bool:
                 },
             )
         else:
-            logger.exception(
-                "Exception when calling ContactsApi->create_contact: %s",
-                exception,
+            logger.exception(  # pylint: disable=logging-fstring-interpolation
+                f"Exception when calling ContactsApi->create_contact with status={exception.status}",
                 extra={
                     "email": payload.email,
                     "attributes": payload.attributes,
                     "emailBlacklisted": payload.emailBlacklisted,
                 },
             )
+        return False
+
+    except Exception as exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Exception when calling ContactsApi->create_contact",
+            extra={
+                "email": payload.email,
+                "attributes": payload.attributes,
+                "emailBlacklisted": payload.emailBlacklisted,
+            },
+        )
         return False
 
 


### PR DESCRIPTION
Sentry remonte bien les erreurs Sendinblue. Cependant, elles sont groupées dans la même issue sentry alors qu’elles peuvent être de nature différentes :

Exemple ici une [erreur 500](https://sentry.internal-passculture.app/organizations/sentry/issues/237466/events/5e986b11c6c04be59a976acdd57124a3/?environment=production&project=5&query=sendinblue&statsPeriod=14d)

Ici une [erreur 503](https://sentry.internal-passculture.app/organizations/sentry/issues/237466/events/994cddbc844c4a3cadaf2199e8708974/?environment=production&project=5&query=sendinblue&statsPeriod=14d)

On va donc utiliser un f-string pour différencier par status code `logger.error(f"Exception when calling SMTPApi->send_transac_email with status={e.status}")`