### PR TITLE
[api][finance] Do not price bookings whose business unit don't have a SIRET

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -106,6 +106,11 @@ class PriceBookingTest:
         pricing = api.price_booking(booking)
         assert pricing is None
 
+    def test_price_booking_checks_business_unit(self):
+        booking = bookings_factories.UsedBookingFactory(stock__offer__venue__businessUnit__siret=None)
+        pricing = api.price_booking(booking)
+        assert pricing is None
+
     def test_num_queries(self):
         booking = bookings_factories.UsedBookingFactory()
         booking = (


### PR DESCRIPTION
During the initialization phase, some business units will be created
as "empty shells" that do not have any SIRET until validated by the
offerer. Venues may be changed to link to a new business unit (with a
SIRET). If we price bookings related to the "empty shell" business
unit, we'll have a problem when we try to generate cashflows. We'd
rather not price those bookings in the first place.