### PR TITLE
(PC-12111) api: Block Ubble after identification has already been tried once

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -766,7 +766,22 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
     return db.session.query(
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status != models.FraudCheckStatus.CANCELED,
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
+        ).exists()
+    ).scalar()
+
+
+def has_user_performed_ubble_check(user: users_models.User) -> bool:
+    """
+    Look for any Ubble identification already started, processed or not, but not aborted.
+    There should not be more than one result in the database (later this function can count if limit is greater than 1).
+    """
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status != models.FraudCheckStatus.CANCELED,
+            models.BeneficiaryFraudCheck.type == models.FraudCheckType.UBBLE,
         ).exists()
     ).scalar()
 

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -316,6 +316,7 @@ class FraudCheckStatus(enum.Enum):
     OK = "ok"
     SUSPICIOUS = "suspiscious"
     PENDING = "pending"
+    CANCELED = "canceled"
 
 
 class BeneficiaryFraudCheck(PcObject, Model):

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -407,6 +407,13 @@ def profiling_session_id(user: User) -> serializers.UserProfilingSessionIdRespon
 def start_identification_session(
     user: User, body: serializers.IdentificationSessionRequest
 ) -> serializers.IdentificationSessionResponse:
+
+    if fraud_api.has_user_performed_ubble_check(user):
+        raise ApiErrors(
+            {"code": "IDCHECK_ALREADY_PROCESSED", "message": "Une identification a déjà été traitée"},
+            status_code=400,
+        )
+
     try:
         identification_url = subscription_api.start_ubble_workflow(user, body.redirectUrl)
         return serializers.IdentificationSessionResponse(identificationUrl=identification_url)

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -406,7 +406,7 @@ class UbbleWebhookTest:
         fraud_check = get_ubble_fraud_check(ubble_identification_response.data.attributes.identification_id)
         assert fraud_check.reason is None
         assert fraud_check.reasonCodes is None
-        assert fraud_check.status is FraudCheckStatus.PENDING
+        assert fraud_check.status is FraudCheckStatus.CANCELED
         assert fraud_check.type == FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
         content = UbbleContent(**fraud_check.resultContent)


### PR DESCRIPTION
…

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12111

## But de la pull request

Bloquer toute demande d'identification Ubble pour un jeune qui a déjà demandé une première identification Ubble, sauf si celle-ci a été annulée (retour "aborted" de Ubble).

##  Implémentation

##  Informations supplémentaires

Un état CANCELED a été ajouté pour ne pas rester en PENDING dans notre modèle.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
