### PR TITLE
[PC-11900] fix api contract types

### DIFF
--- a/api/src/pcapi/core/subscription/school_types.py
+++ b/api/src/pcapi/core/subscription/school_types.py
@@ -104,11 +104,5 @@ ALL_ACTIVITIES = [
     UNEMPLOYED,
 ]
 
-SCHOOL_TYPE_ID_ENUM = enum.Enum(
-    "SchoolTypesIdEnum", {school_type.name: school_type.name for school_type in users_models.SchoolTypeEnum}
-)
-SCHOOL_TYPE_LABEL_ENUM = enum.Enum(
-    "SchoolTypesLabelEnum", {school_type.value: school_type.value for school_type in users_models.SchoolTypeEnum}
-)
 ACTIVITY_ID_ENUM = enum.Enum("ActivityIdEnum", {activity.id: activity.id for activity in ALL_ACTIVITIES})
 ACTIVITY_LABEL_ENUM = enum.Enum("ActivityLabelEnum", {activity.label: activity.label for activity in ALL_ACTIVITIES})

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -19,13 +19,14 @@ class NextSubscriptionStepResponse(BaseModel):
 
 
 class ProfileUpdateRequest(BaseModel):
-    activity: users_models.ActivityEnum
+    activity_id: Optional[school_types.ACTIVITY_ID_ENUM]
+    activity: Optional[users_models.ActivityEnum]  # TODO: CorentinN: remove this field when frontend sends activity_id
     address: Optional[str]
     city: str
     first_name: str
     last_name: str
     postal_code: str
-    school_type: Optional[users_models.SchoolTypeEnum]
+    school_type_id: Optional[school_types.SCHOOL_TYPE_ID_ENUM]
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -33,7 +33,7 @@ class ProfileUpdateRequest(BaseModel):
 
 class SchoolTypeResponseModel(BaseModel):
     id: school_types.SCHOOL_TYPE_ID_ENUM
-    label: school_types.SCHOOL_TYPE_LABEL_ENUM
+    label: str
 
     class Config:
         alias_generator = to_camel
@@ -43,7 +43,7 @@ class SchoolTypeResponseModel(BaseModel):
 
 class ActivityResponseModel(BaseModel):
     id: school_types.ACTIVITY_ID_ENUM
-    label: school_types.ACTIVITY_LABEL_ENUM
+    label: str
     associated_school_types_ids: Optional[list[school_types.SCHOOL_TYPE_ID_ENUM]]
 
     class Config:

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -35,6 +35,12 @@ def next_subscription_step(
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_user_required
 def update_profile(user: users_models.User, body: serializers.ProfileUpdateRequest) -> None:
+    # TODO: Corentin: remove this when we send ids in the request body
+    if body.activity_id is not None:
+        activity = users_models.ActivityEnum[body.activity_id.value].value
+    else:
+        activity = body.activity.value
+
     subscription_api.update_user_profile(
         user,
         first_name=body.first_name,
@@ -42,8 +48,8 @@ def update_profile(user: users_models.User, body: serializers.ProfileUpdateReque
         address=body.address,
         city=body.city,
         postal_code=body.postal_code,
-        activity=body.activity.value,
-        school_type=body.school_type,
+        activity=activity,
+        school_type=users_models.SchoolTypeEnum[body.school_type_id.value] if body.school_type_id is not None else None,
     )
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11900

## But de la pull request

Typer correctement les response types du back pour que le front puisse générer les types TS sans erreurs et autres incongruitées

##  Implémentation

- Pour un Enum {clef: string_value}, les clefs sont typées comme ENUM, les values comme string
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
