### PR TITLE
(PC-11581)[api] edit educational stock

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -157,6 +157,10 @@ def find_by_pro_user(
     )
 
 
+def find_bookings_by_stock_id(stock_id: int) -> list[Booking]:
+    return Booking.query.filter_by(stockId=stock_id).all()
+
+
 def find_ongoing_bookings_by_stock(stock_id: int) -> list[Booking]:
     return Booking.query.filter_by(stockId=stock_id, isCancelled=False, isUsed=False).all()
 

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -158,10 +158,10 @@ def find_by_pro_user(
     )
 
 
-def find_non_cancelled_bookings_by_stock_id(stock_id: int) -> list[Booking]:
+def find_unique_eac_booking_if_any(stock_id: int) -> list[Booking]:
     return Booking.query.filter(
         Booking.stockId == stock_id, Booking.isCancelled.is_(False), not_(Booking.status == BookingStatus.CANCELLED)
-    ).all()
+    ).one_or_none()
 
 
 def find_ongoing_bookings_by_stock(stock_id: int) -> list[Booking]:

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Query
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql.elements import not_
 from sqlalchemy.sql.functions import coalesce
 from sqlalchemy.util._collections import AbstractKeyedTuple
 
@@ -157,8 +158,10 @@ def find_by_pro_user(
     )
 
 
-def find_bookings_by_stock_id(stock_id: int) -> list[Booking]:
-    return Booking.query.filter_by(stockId=stock_id).all()
+def find_non_cancelled_bookings_by_stock_id(stock_id: int) -> list[Booking]:
+    return Booking.query.filter(
+        Booking.stockId == stock_id, Booking.isCancelled.is_(False), not_(Booking.status == BookingStatus.CANCELLED)
+    ).all()
 
 
 def find_ongoing_bookings_by_stock(stock_id: int) -> list[Booking]:

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -73,7 +73,6 @@ from pcapi.utils import mailing
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.utils.rest import load_or_raise_error
-from pcapi.validation.models import entity_validator
 from pcapi.workers.push_notification_job import send_cancel_booking_notification
 
 from .exceptions import ThumbnailStorageError

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -581,10 +581,6 @@ def edit_educational_stock(stock: Stock, stock_data: dict) -> None:
         for attribute, new_value in updatable_fields.items():
             if new_value is not None and getattr(stock, attribute) != new_value:
                 setattr(stock, attribute, new_value)
-
-        api_errors = entity_validator.validate(stock)
-        if api_errors.errors.keys():
-            raise api_errors
         db.session.add(stock)
         db.session.commit()
 

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -529,9 +529,7 @@ def create_educational_stock(stock_data: EducationalStockCreationBodyModel, user
     if not offer.isEducational:
         raise educational_exceptions.OfferIsNotEducational(offer_id)
     validation.check_validation_status(offer)
-    if booking_limit_datetime is not None:
-        validation.check_booking_limit_datetime(beginning, booking_limit_datetime)
-    else:
+    if booking_limit_datetime is None:
         booking_limit_datetime = beginning
 
     stock = Stock(

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -562,9 +562,8 @@ def edit_educational_stock(stock: Stock, stock_data: dict) -> None:
     booking_limit_datetime = as_utc_without_timezone(booking_limit_datetime) if booking_limit_datetime else None
     validation.check_booking_limit_datetime(stock, beginning, booking_limit_datetime)
 
-    associated_bookings = bookings_repository.find_non_cancelled_bookings_by_stock_id(stock.id)
-    if associated_bookings:
-        educational_stock_unique_booking = associated_bookings[0]
+    educational_stock_unique_booking = bookings_repository.find_unique_eac_booking_if_any(stock.id)
+    if educational_stock_unique_booking:
         validation.check_stock_booking_status(educational_stock_unique_booking)
         if beginning:
             updated_booking = _update_educational_booking_cancellation_limit_date(

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -100,9 +100,4 @@ class ReportMalformed(OfferReportError):
     code = "REPORT_MALFORMED"
 
 
-class BookingLimitDatetimeTooLate(ClientError):
-    def __init__(self):
-        super().__init__(
-            "bookingLimitDatetime",
-            "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement",
-        )
+class EducationalOfferStockBookedAndBookingUsed(Exception):

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -100,16 +100,10 @@ class ReportMalformed(OfferReportError):
     code = "REPORT_MALFORMED"
 
 
-class EducationalOfferStockBookedAndBookingUsed(Exception):
-    pass
-
-
-class EducationalOfferStockBookedAndBookingConfirmed(Exception):
-    pass
-
-
-class EducationalOfferStockBookedAndBookingReimbursed(Exception):
-    pass
+class EducationalOfferStockBookedAndBookingNotPending(Exception):
+    def __init__(self, status, booking_id):
+        self.booking_status = status
+        super().__init__()
 
 
 class CannotModifiedPastEventStock(Exception):

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -101,3 +101,24 @@ class ReportMalformed(OfferReportError):
 
 
 class EducationalOfferStockBookedAndBookingUsed(Exception):
+    pass
+
+
+class EducationalOfferStockBookedAndBookingConfirmed(Exception):
+    pass
+
+
+class EducationalOfferStockBookedAndBookingReimbursed(Exception):
+    pass
+
+
+class CannotModifiedPastEventStock(Exception):
+    pass
+
+
+class CannotUpdateStockRelatedToNonApprovedOffer(Exception):
+    pass
+
+
+class BookingLimitDatetimeTooLate(Exception):
+    pass

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -3,6 +3,7 @@ from datetime import time
 from datetime import timedelta
 from operator import attrgetter
 from typing import Optional
+from typing import Union
 
 from sqlalchemy import and_
 from sqlalchemy import func
@@ -316,7 +317,7 @@ def get_current_offer_validation_config() -> Optional[OfferValidationConfig]:
     return OfferValidationConfig.query.order_by(OfferValidationConfig.id.desc()).first()
 
 
-def get_expired_offers(interval: [datetime, datetime]) -> Query:
+def get_expired_offers(interval: Union[datetime, datetime]) -> Query:
     """Return a query of offers whose latest booking limit occurs within
     the given interval.
 
@@ -360,3 +361,10 @@ def get_available_activation_code(stock: Stock) -> Optional[ActivationCode]:
 
 def get_educational_offer_by_id(offer_id: str) -> Offer:
     return Offer.query.filter(Offer.isEducational == True, Offer.id == offer_id).one()
+
+
+def get_non_deleted_stock_by_id(stock_id: int):
+    stock = Stock.queryNotSoftDeleted().filter_by(id=stock_id).first()
+    if stock is None:
+        raise StockDoesNotExist()
+    return stock

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from operator import attrgetter
+from typing import List
 from typing import Optional
-from typing import Union
 
 from sqlalchemy import and_
 from sqlalchemy import func
@@ -317,7 +317,7 @@ def get_current_offer_validation_config() -> Optional[OfferValidationConfig]:
     return OfferValidationConfig.query.order_by(OfferValidationConfig.id.desc()).first()
 
 
-def get_expired_offers(interval: Union[datetime, datetime]) -> Query:
+def get_expired_offers(interval: List[datetime]) -> Query:
     """Return a query of offers whose latest booking limit occurs within
     the given interval.
 

--- a/api/src/pcapi/core/offers/utils.py
+++ b/api/src/pcapi/core/offers/utils.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+import pytz
+
 from pcapi import settings
 from pcapi.core.offers.models import Offer
 from pcapi.models.feature import FeatureToggle
@@ -9,3 +13,7 @@ def offer_webapp_link(offer: Offer) -> str:
     if FeatureToggle.WEBAPP_V2_ENABLED.is_active():
         return generate_firebase_dynamic_link(path=f"offre/{offer.id}", params=None)
     return f"{settings.WEBAPP_URL}/offre/details/{humanize(offer.id)}"
+
+
+def as_utc_without_timezone(d: datetime) -> datetime:
+    return d.astimezone(pytz.utc).replace(tzinfo=None)

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -350,12 +350,8 @@ def check_offer_subcategory_is_valid(offer_subcategory_id):
 
 
 def check_stock_booking_status(booking: Booking) -> Union[None, Exception]:
-    if booking.status is BookingStatus.CONFIRMED:
-        raise exceptions.EducationalOfferStockBookedAndBookingConfirmed()
-    if booking.status is BookingStatus.REIMBURSED:
-        raise exceptions.EducationalOfferStockBookedAndBookingReimbursed()
-    if booking.status is BookingStatus.USED or booking.isUsed:
-        raise exceptions.EducationalOfferStockBookedAndBookingUsed()
+    if booking.status is not BookingStatus.PENDING:
+        raise exceptions.EducationalOfferStockBookedAndBookingNotPending(booking.status, booking.id)
 
 
 def check_booking_limit_datetime(

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -169,13 +169,15 @@ def edit_educational_stock(stock_id: str, body: EducationalStockEditionBodyModel
             {"educationalStock": ["La date limite de confirmation ne peut être fixée après la date de l évènement"]},
             status_code=400,
         )
-    except (
-        offers_exceptions.EducationalOfferStockBookedAndBookingConfirmed,
-        offers_exceptions.EducationalOfferStockBookedAndBookingReimbursed,
-        offers_exceptions.EducationalOfferStockBookedAndBookingUsed,
-    ):
+    except offers_exceptions.EducationalOfferStockBookedAndBookingNotPending as error:
         raise ApiErrors(
             {
+                "educationalStockEdition": [
+                    f"Un stock lié à une offre éducationnelle, dont la réservation associée a le statut {error.booking_status.value}, ne peut être édité "
+                ]
+            },
+            status_code=400,
+        )
     except SQLAMultipleResultsFound:
         logger.exception(
             "Several non cancelled bookings found while trying to edit related educational stock",

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -133,8 +133,5 @@ def create_educational_stock(body: EducationalStockCreationBodyModel) -> StockId
         raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
     check_user_has_access_to_offerer(current_user, offerer.id)
 
-    try:
         stock = offers_api.create_educational_stock(body, current_user)
-    except offers_exceptions.BookingLimitDatetimeTooLate as error:
-        raise ApiErrors(error.errors, status_code=400)
     return StockIdResponseModel.from_orm(stock)

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -139,7 +139,7 @@ class EducationalStockEditionBodyModel(BaseModel):
     @validator("booking_limit_datetime")
     def validate_booking_limit_datetime(cls, booking_limit_datetime, values):  # pylint: disable=no-self-argument
         if (
-            all({booking_limit_datetime, values["beginning_datetime"]})
+            all([booking_limit_datetime, values["beginning_datetime"]])
             and booking_limit_datetime > values["beginning_datetime"]
         ):
             raise ValueError("La date limite de réservation ne peut être postérieure à la date de début de l'évènement")

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -103,6 +103,39 @@ class EducationalStockCreationBodyModel(BaseModel):
             raise ValueError("La date limite de réservation ne peut être postérieure à la date de début de l'évènement")
         return booking_limit_datetime
 
+
+class EducationalStockEditionBodyModel(BaseModel):
+    beginning_datetime: Optional[datetime]
+    booking_limit_datetime: Optional[datetime]
+    total_price: Optional[float]
+    number_of_tickets: Optional[int]
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
+
+    @validator("number_of_tickets", pre=True)
+    def validate_number_of_tickets(cls, number_of_tickets):  # pylint: disable=no-self-argument
+        if number_of_tickets < 0:
+            raise ValueError("Le nombre de places ne peut pas être négatif.")
+        return number_of_tickets
+
+    @validator("total_price", pre=True)
+    def validate_price(cls, price):  # pylint: disable=no-self-argument
+        if price < 0:
+            raise ValueError("Le prix ne peut pas être négatif.")
+        return price
+
+    @validator("booking_limit_datetime")
+    def validate_booking_limit_datetime(cls, booking_limit_datetime, values):  # pylint: disable=no-self-argument
+        if (
+            all({booking_limit_datetime, values["beginning_datetime"]})
+            and booking_limit_datetime > values["beginning_datetime"]
+        ):
+            raise ValueError("La date limite de réservation ne peut être postérieure à la date de début de l'évènement")
+        return booking_limit_datetime
+
+
 class StockEditionBodyModel(BaseModel):
     beginning_datetime: Optional[datetime]
     booking_limit_datetime: Optional[datetime]

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -91,6 +91,17 @@ class EducationalStockCreationBodyModel(BaseModel):
             raise ValueError("Le nombre de places ne peut pas être négatif.")
         return number_of_tickets
 
+    @validator("total_price", pre=True)
+    def validate_price(cls, price):  # pylint: disable=no-self-argument
+        if price < 0:
+            raise ValueError("Le prix ne peut pas être négatif.")
+        return price
+
+    @validator("booking_limit_datetime")
+    def validate_booking_limit_datetime(cls, booking_limit_datetime, values):  # pylint: disable=no-self-argument
+        if booking_limit_datetime and booking_limit_datetime > values["beginning_datetime"]:
+            raise ValueError("La date limite de réservation ne peut être postérieure à la date de début de l'évènement")
+        return booking_limit_datetime
 
 class StockEditionBodyModel(BaseModel):
     beginning_datetime: Optional[datetime]

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -114,14 +114,24 @@ class EducationalStockEditionBodyModel(BaseModel):
         alias_generator = to_camel
         extra = "forbid"
 
+    @validator("beginning_datetime", pre=True)
+    def validate_beginning_datetime(cls, beginning_datetime):  # pylint: disable=no-self-argument
+        if beginning_datetime is None:
+            raise ValueError("La date d’évènement ne peut être nulle")
+        return beginning_datetime
+
     @validator("number_of_tickets", pre=True)
     def validate_number_of_tickets(cls, number_of_tickets):  # pylint: disable=no-self-argument
+        if number_of_tickets is None:
+            raise ValueError("Le nombre de places ne peut être nul")
         if number_of_tickets < 0:
             raise ValueError("Le nombre de places ne peut pas être négatif.")
         return number_of_tickets
 
     @validator("total_price", pre=True)
     def validate_price(cls, price):  # pylint: disable=no-self-argument
+        if price is None:
+            raise ValueError("Le prix ne peut être nul")
         if price < 0:
             raise ValueError("Le prix ne peut pas être négatif.")
         return price

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -695,31 +695,6 @@ class CreateEducationalOfferStocksTest:
         assert not draft_fraudulent_offer.isActive
         assert draft_fraudulent_offer.lastValidationDate == datetime(2020, 11, 17, 15, 0)
 
-    def test_does_not_allow_booking_limit_after_beginning_datetime(self):
-        # Given
-        user = users_factories.ProFactory()
-        offer = offer_factories.EducationalEventOfferFactory()
-        beginning_date = datetime.utcnow() + timedelta(days=4)
-        booking_limit = beginning_date + timedelta(days=4)
-        created_stock_data = stock_serialize.EducationalStockCreationBodyModel(
-            offerId=offer.id,
-            beginningDatetime=beginning_date,
-            bookingLimitDatetime=booking_limit,
-            totalPrice=1500,
-            numberOfTickets=38,
-        )
-
-        # When
-        with pytest.raises(offer_exceptions.BookingLimitDatetimeTooLate) as error:
-            api.create_educational_stock(stock_data=created_stock_data, user=user)
-
-        # Then
-        assert error.value.errors == {
-            "bookingLimitDatetime": [
-                "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement"
-            ]
-        }
-
     def test_create_stock_for_non_approved_offer_fails(self):
         # Given
         user = users_factories.ProFactory()

--- a/api/tests/routes/pro/edit_educational_offer_test.py
+++ b/api/tests/routes/pro/edit_educational_offer_test.py
@@ -1,0 +1,185 @@
+from datetime import datetime
+from datetime import timedelta
+
+import pytest
+
+from pcapi.core.offers import factories as offer_factories
+from pcapi.core.offers.models import Stock
+from pcapi.utils.human_ids import humanize
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class Return200Test:
+    def test_edit_educational_stock(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory(
+            beginningDatetime=datetime(2021, 12, 18),
+            price=1200,
+            numberOfTickets=32,
+            bookingLimitDatetime=datetime(2021, 12, 1),
+        )
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T20:00:00Z",
+            "totalPrice": 1500,
+            "numberOfTickets": 38,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 204
+        edited_stock = Stock.query.get(stock.id)
+        assert edited_stock.beginningDatetime == datetime(2022, 1, 17, 22)
+        assert edited_stock.bookingLimitDatetime == datetime(2021, 12, 31, 20)
+        assert edited_stock.price == 1500
+        assert edited_stock.numberOfTickets == 38
+
+    def test_edit_educational_stock_partially(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory(
+            beginningDatetime=datetime(2021, 12, 18),
+            price=1200,
+            numberOfTickets=32,
+            bookingLimitDatetime=datetime(2021, 12, 1),
+        )
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "totalPrice": 1500,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 204
+        edited_stock = Stock.query.get(stock.id)
+        assert edited_stock.beginningDatetime == datetime(2022, 1, 17, 22)
+        assert edited_stock.bookingLimitDatetime == stock.bookingLimitDatetime
+        assert edited_stock.price == 1500
+        assert edited_stock.numberOfTickets == 32
+
+
+class Return403Test:
+    def test_edit_educational_stocks_should_not_be_possible_when_user_not_linked_to_offerer(self, app, client):
+        stock = offer_factories.EducationalEventStockFactory(
+            beginningDatetime=datetime(2021, 12, 18),
+            price=1200,
+        )
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+        )
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "totalPrice": 1500,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json == {
+            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+        }
+
+
+class Return400Test:
+    def should_not_allow_number_of_tickets_to_be_negative_on_edition(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory(
+            beginningDatetime=datetime(2021, 12, 18),
+            price=1200,
+            numberOfTickets=32,
+            bookingLimitDatetime=datetime(2021, 12, 1),
+        )
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "numberOfTickets": -10,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400
+        edited_stock = Stock.query.get(stock.id)
+        assert edited_stock.numberOfTickets == 32
+
+    def should_not_allow_price_to_be_negative_on_creation(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory(
+            beginningDatetime=datetime(2021, 12, 18),
+            price=1200,
+            numberOfTickets=32,
+            bookingLimitDatetime=datetime(2021, 12, 1),
+        )
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "totalPrice": -10,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400
+        edited_stock = Stock.query.get(stock.id)
+        assert edited_stock.price == 1200
+
+    def should_not_accept_payload_with_bookingLimitDatetime_after_beginningDatetime(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory(
+            beginningDatetime=datetime(2021, 12, 18),
+            price=1200,
+            numberOfTickets=32,
+            bookingLimitDatetime=datetime(2021, 12, 1),
+        )
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": "2021-12-20T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T22:00:00Z",
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400
+        edited_stock = Stock.query.get(stock.id)
+        assert edited_stock.bookingLimitDatetime == stock.bookingLimitDatetime
+
+    def should_not_edit_stock_when_event_expired(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory(beginningDatetime=datetime.utcnow() - timedelta(minutes=1))
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "totalPrice": 1500,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400

--- a/api/tests/routes/pro/edit_educational_offer_test.py
+++ b/api/tests/routes/pro/edit_educational_offer_test.py
@@ -183,3 +183,54 @@ class Return400Test:
 
         # Then
         assert response.status_code == 400
+
+    def should_not_allow_stock_edition_when_numberOfTickets_has_been_set_to_none(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory()
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "numberOfTickets": None,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"numberOfTickets": ["Le nombre de places ne peut être nul"]}
+
+    def should_not_allow_stock_edition_when_totalPrice_has_been_set_to_none(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory()
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "totalPrice": None,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"totalPrice": ["Le prix ne peut être nul"]}
+
+    def should_not_allow_stock_edition_when_beginnningDatetime_has_been_set_to_none(self, app, client):
+        # Given
+        stock = offer_factories.EducationalEventStockFactory()
+        offer_factories.UserOffererFactory(user__email="user@example.com", offerer=stock.offer.venue.managingOfferer)
+
+        # When
+        stock_edition_payload = {
+            "beginningDatetime": None,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/stocks/educational/{humanize(stock.id)}", json=stock_edition_payload)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"beginningDatetime": ["La date d’évènement ne peut être nulle"]}

--- a/api/tests/routes/pro/post_educational_stock_test.py
+++ b/api/tests/routes/pro/post_educational_stock_test.py
@@ -39,7 +39,7 @@ class Return200Test:
 
 
 class Return400Test:
-    def test_upsert_educational_stocks_should_not_be_available_if_user_not_linked_to_offerer(self, app, client):
+    def test_create_educational_stocks_should_not_be_available_if_user_not_linked_to_offerer(self, app, client):
         # Given
         offer = offer_factories.EducationalEventOfferFactory()
         offer_factories.UserOffererFactory(
@@ -87,3 +87,55 @@ class Return400Test:
         # Then
         assert response.status_code == 400
         assert response.json == {"numberOfTickets": ["Le nombre de places ne peut pas être négatif."]}
+
+    def should_not_allow_price_to_be_negative_on_creation(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory()
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        stock_payload = {
+            "offerId": humanize(offer.id),
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T20:00:00Z",
+            "totalPrice": -1500,
+            "numberOfTickets": 30,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post("/stocks/educational/", json=stock_payload)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"totalPrice": ["Le prix ne peut pas être négatif."]}
+
+    def should_not_accept_payload_with_bookingLimitDatetime_after_beginningDatetime(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory()
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        stock_payload = {
+            "offerId": humanize(offer.id),
+            "beginningDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2022-01-18T20:00:00Z",
+            "totalPrice": 1500,
+            "numberOfTickets": 30,
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post("/stocks/educational/", json=stock_payload)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {
+            "bookingLimitDatetime": [
+                "La date limite de réservation ne peut être postérieure à la date de début de l'évènement"
+            ]
+        }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11581


## But de la pull request

Implémenter l'édition des stocks pour les offres éducationnelles dans le cadre de la création d'offres v0.1

##  Implémentation

Nouvelle route `/stocks/educational/<stock_id>` dans `routes/pro/stocks`
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
