### PR TITLE
(11987)(API)(FA) Fix Suspension Reason Choices Order

### DIFF
--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -66,21 +66,21 @@ class SuspensionReason(Enum):
 
 
 SUSPENSION_REASON_CHOICES = (
-    (SuspensionReason.CLOSED_STRUCTURE_DEFINITIVE, "Structure définitivement fermée"),
-    (SuspensionReason.CLOSED_STRUCTURE_TEMP, "Structure fermée provisoirement"),
+    (SuspensionReason.FRAUD_FAKE_DOCUMENT, "Fraude faux document"),
+    (SuspensionReason.FRAUD_RESELL_PRODUCT, "Fraude revente produit"),
+    (SuspensionReason.FRAUD_RESELL_PASS, "Fraude revente pass"),
+    (SuspensionReason.FRAUD_USURPATION, "Fraude usurpation"),
+    (SuspensionReason.FRAUD_SUSPICION, "Fraude suspicion"),
+    (SuspensionReason.FRAUD_DUPLICATE, "Fraude doublon"),
+    (SuspensionReason.FRAUD_HACK, "Fraude hacking"),
+    (SuspensionReason.FRAUD_BOOKING_CANCEL, "Fraude annulation réservation"),
     (SuspensionReason.END_OF_CONTRACT, "Fin de contrat"),
     (SuspensionReason.END_OF_ELIGIBILITY, "Fin d'éligibilité"),
-    (SuspensionReason.FRAUD_BOOKING_CANCEL, "Fraude annulation réservation"),
-    (SuspensionReason.FRAUD_CREATION_PRO, "Fraude PRO création"),
-    (SuspensionReason.FRAUD_DUPLICATE, "Fraude doublon"),
-    (SuspensionReason.FRAUD_FAKE_DOCUMENT, "Fraude faux document"),
-    (SuspensionReason.FRAUD_HACK, "Fraude hacking"),
-    (SuspensionReason.FRAUD_RESELL_PASS, "Fraude revente pass"),
-    (SuspensionReason.FRAUD_RESELL_PRODUCT, "Fraude revente produit"),
-    (SuspensionReason.FRAUD_SUSPICION, "Fraude suspicion"),
     (SuspensionReason.UPON_USER_REQUEST, "Demande de l'utilisateur"),
-    (SuspensionReason.FRAUD_USURPATION, "Fraude usurpation"),
     (SuspensionReason.FRAUD_USURPATION_PRO, "Fraude PRO usurpation"),
+    (SuspensionReason.FRAUD_CREATION_PRO, "Fraude PRO création"),
+    (SuspensionReason.CLOSED_STRUCTURE_DEFINITIVE, "Structure définitivement fermée"),
+    (SuspensionReason.CLOSED_STRUCTURE_TEMP, "Structure fermée provisoirement"),
 )
 
 assert set(_t[0] for _t in SUSPENSION_REASON_CHOICES) == set(SuspensionReason)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11987


## But de la pull request

En tant que contrôleur de la fraudeJ'aimerais ajouter un motif de suspension mieux défini sur le profil utilisateur dans FAAfin d’avoir un suivi précis sur les raisons de blocage et des statistiques 

##  Implémentation

- Sur FA, lorsque le compte utilisateur (Jeune, Pro, GP) est suspendu, on affiche la liste déroulante des raisons de suspension qui suit (dans l’ordre de la liste, et en remplacement da la liste actuelle) : 
    - Fraude faux document
    - Fraude revente produit
    - Fraude revente pass
    - Fraude usurpation
    - Fraude suspicion
    - Fraude doublon
    - Fraude hacking
    - Fraude annulation réservation
    - Fin de contrat
    - Fin d'éligibilité
    - Demande de l'utilisateur
    - Fraude PRO usurpation
    - Fraude PRO création
    - Structure définitivement fermée
    - Structure fermée provisoirement

- Afficher le motif de suspension dans la colonne de l’onglet principal FA “Utilisateurs > PRO/Jeunes/GP”​
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
![Capture d’écran 2021-12-01 à 14 51 20](https://user-images.githubusercontent.com/9610732/144247818-67676468-0185-492b-b7fd-ad66e47712ff.png)
![Capture d’écran 2021-12-01 à 14 51 32](https://user-images.githubusercontent.com/9610732/144247822-676f55db-a511-4f73-bbcc-abc26dabd445.png)

- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)