### PR TITLE
[PC-12197] handle dms registration with no registration date

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -253,9 +253,7 @@ def get_ubble_fraud_check(identification_id: str) -> typing.Optional[models.Bene
     return fraud_check
 
 
-def get_eligibility_type(
-    data: typing.Union[models.EduconnectContent, models.JouveContent, models.DMSContent]
-) -> typing.Optional[users_models.EligibilityType]:
+def get_eligibility_type(data: models.SubscriptionContentType) -> typing.Optional[users_models.EligibilityType]:
     from pcapi.core.users import api as users_api
 
     if isinstance(data, models.EduconnectContent):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -224,7 +224,7 @@ class DMSContent(pydantic.BaseModel):
     activity: typing.Optional[str]
     address: typing.Optional[str]
     id_piece_number: typing.Optional[str]
-    registration_datetime: datetime.datetime
+    registration_datetime: typing.Optional[datetime.datetime]
 
 
 class UserProfilingRiskRating(enum.Enum):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -282,6 +282,9 @@ class InternalReviewFraudData(pydantic.BaseModel):
     phone_number: typing.Optional[str]
 
 
+SubscriptionContentType = typing.Union[EduconnectContent, JouveContent, UbbleContent, DMSContent]
+
+
 FRAUD_CHECK_MAPPING = {
     FraudCheckType.DMS: DMSContent,
     FraudCheckType.USER_PROFILING: UserProfilingFraudData,
@@ -344,7 +347,7 @@ class BeneficiaryFraudCheck(PcObject, Model):
         nullable=True,
     )
 
-    def source_data(self) -> typing.Union[JouveContent, DMSContent, UserProfilingFraudData, EduconnectContent]:
+    def source_data(self) -> typing.Union[SubscriptionContentType, UserProfilingFraudData]:
         if self.type not in FRAUD_CHECK_MAPPING:
             raise NotImplementedError(f"Cannot unserialize type {self.type}")
         return FRAUD_CHECK_MAPPING[self.type](**self.resultContent)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -266,7 +266,7 @@ def validate_phone_number_and_activate_user(user: User, code: str) -> User:
 
 def update_user_information_from_external_source(
     user: User,
-    data: Union[fraud_models.DMSContent, fraud_models.JouveContent, fraud_models.EduconnectContent],
+    data: fraud_models.SubscriptionContentType,
     commit=False,
 ) -> User:
     if isinstance(data, fraud_models.DMSContent):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12197


## But de la pull request

Accepter des `registration_datetime` vides de DMS 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
