### PR TITLE
(PC-11947) Stop updating hasCompletedIdCheck in new profile completion route

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -243,6 +243,10 @@ def update_ubble_workflow(
     return fraud_check
 
 
+def has_completed_profile(user: users_models.User) -> bool:
+    return user.city is not None
+
+
 # pylint: disable=too-many-return-statements
 def get_next_subscription_step(user: users_models.User) -> Optional[models.SubscriptionStep]:
     # TODO(viconnex): base the next step on the user.subscriptionState that will be added later on
@@ -271,7 +275,7 @@ def get_next_subscription_step(user: users_models.User) -> Optional[models.Subsc
         if user_profiling.source_data().risk_rating == fraud_models.UserProfilingRiskRating.HIGH:
             return None
 
-    if not user.address:
+    if not has_completed_profile(user):
         return models.SubscriptionStep.PROFILE_COMPLETION
 
     if (

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -196,6 +196,11 @@ def create_beneficiary_import(user: users_models.User, eligibilityType: users_mo
 
     users_api.update_user_information_from_external_source(user, fraud_check.source_data(), commit=True)
 
+    if not users_api.steps_to_become_beneficiary(user):
+        activate_beneficiary(user)
+    else:
+        users_external.update_external_user(user)
+
 
 def _send_beneficiary_activation_email(user: users_models.User, has_activated_account: bool):
     if not has_activated_account:

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -295,6 +295,7 @@ def update_user_profile(
     last_name: Optional[str] = None,
     school_type: Optional[users_models.SchoolTypeEnum] = None,
     phone_number: Optional[str] = None,
+    has_completed_id_check: Optional[bool] = None,
 ) -> None:
     user_initial_roles = user.roles
 
@@ -304,7 +305,6 @@ def update_user_profile(
         "postalCode": postal_code,
         "departementCode": PostalCode(postal_code).get_departement_code(),
         "activity": activity,
-        "hasCompletedIdCheck": True,
         "schoolType": school_type,
     }
 
@@ -317,6 +317,9 @@ def update_user_profile(
     # TODO (viconnex): remove phone number update after app native mandatory version is >= 164
     if not FeatureToggle.ENABLE_PHONE_VALIDATION.is_active() and not user.phoneNumber and phone_number:
         update_payload["phoneNumber"] = phone_number
+
+    if has_completed_id_check:
+        update_payload["hasCompletedIdCheck"] = True
 
     with transaction():
         users_models.User.query.filter(users_models.User.id == user.id).update(update_payload)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -247,9 +247,6 @@ def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
     ):
         missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
 
-    if not user.hasCompletedIdCheck:
-        missing_steps.append(BeneficiaryValidationStep.BENEFICIARY_INFORMATION)
-
     return missing_steps
 
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -150,6 +150,7 @@ def update_beneficiary_mandatory_information(user: User, body: serializers.Benef
         postal_code=body.postal_code,
         activity=body.activity,
         phone_number=body.phone,
+        has_completed_id_check=True,
     )
 
 

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -118,6 +118,7 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
         return redirect(ERROR_PAGE_URL, code=302)
 
     try:
+        # TODO(viconnex): use generic subscription_api.on_successful_application
         subscription_api.create_beneficiary_import(user, fraud_api.get_eligibility_type(educonnect_content))
     except fraud_exceptions.UserAgeNotValid:
         logger.warning(

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -284,7 +284,7 @@ class NextSubscriptionStepTest:
     def test_next_subscription_step_underage(self):
         user = users_factories.UserFactory(
             dateOfBirth=self.fifteen_years_ago,
-            address=None,
+            city=None,
         )
         assert (
             subscription_api.get_next_subscription_step(user) == subscription_models.SubscriptionStep.PROFILE_COMPLETION
@@ -294,7 +294,7 @@ class NextSubscriptionStepTest:
         user = users_factories.UserFactory(
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            address=None,
+            city=None,
         )
         assert subscription_api.get_next_subscription_step(user) == subscription_models.SubscriptionStep.USER_PROFILING
 
@@ -302,7 +302,7 @@ class NextSubscriptionStepTest:
         user = users_factories.UserFactory(
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            address=None,
+            city=None,
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="high")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -315,7 +315,7 @@ class NextSubscriptionStepTest:
         user = users_factories.UserFactory(
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            address=None,
+            city=None,
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -330,7 +330,7 @@ class NextSubscriptionStepTest:
         user = users_factories.UserFactory(
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            address="3 rue du quai",
+            city="Zanzibar",
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -471,7 +471,6 @@ class StepsToBecomeBeneficiaryTest:
         expected = [
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
-            BeneficiaryValidationStep.BENEFICIARY_INFORMATION,
         ]
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role
@@ -483,7 +482,6 @@ class StepsToBecomeBeneficiaryTest:
         expected = [
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
-            BeneficiaryValidationStep.BENEFICIARY_INFORMATION,
         ]
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -698,6 +698,7 @@ class UpdateBeneficiaryMandatoryInformationTest:
             city=new_city,
             postal_code="93000",
             activity=user.activity,
+            has_completed_id_check=True,
         )
 
         user = User.query.get(user.id)
@@ -737,7 +738,6 @@ class UpdateBeneficiaryMandatoryInformationTest:
         assert user.address == new_address
         assert user.city == new_city
 
-        assert user.hasCompletedIdCheck
         assert not user.has_beneficiary_role
         assert not user.deposit
 

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -150,6 +150,7 @@ class EduconnectTest:
         assert user.lastName == "SENS"
         assert user.dateOfBirth == datetime.datetime(2006, 8, 18, 0, 0)
         assert user.ineHash == ine_hash
+        assert user.roles == [user_models.UserRole.UNDERAGE_BENEFICIARY]
 
     @patch("pcapi.core.users.external.educonnect.api.get_saml_client")
     def test_user_type_not_student(self, mock_get_educonnect_saml_client, client, caplog, app):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11947

### But de la PR

Dans le nouveau parcours, la route `subscription/profile` est appelée *avant* la vérification de l'identité.

Du coup on peut brûler le hack qui consistait à passer le `hasCompletedIdCheck`.

Et doit le brûler car le ticket des nextSteps (PC-11947) était KO : on ne renvoyait pas nextStep = IdentityCheck dès lors que la route `subscription/profile` avait été appelée.

Autre conséquence : il faut activer le compte bénéficiaire juste après avoir fait educonnect. Plus tard, on attendra une autre étape qui consiste à la confirmation sur l'honneur que les données indiquées sont exactes.

Cela résout un autre bug : 
- educonnect réussi
- enregistrement INE hash, prénom, nom sur l'utilisateur
- l'utilisateur ne remplit pas son profil (interruption volontaire par exemple)
- l'utilisateur revient plus tard, on le redirige vers educonnect
- educonnect échoué car l'INE hash existe déjà -----> car il a été enregistré sur lui même

Maintenant, on enregistre les infos puis on active l'utilisateur directement après.
Il faudra quand même exclure l'userId de la vérif sur le doublon INE