### PR TITLE
(PC-12111) api: Fix id check already performed when BeneficiaryFraudCheck.status is null

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -764,7 +764,7 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
     return db.session.query(
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.user == user,
-            models.BeneficiaryFraudCheck.status != models.FraudCheckStatus.CANCELED,
+            models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
         ).exists()
     ).scalar()
@@ -778,7 +778,7 @@ def has_user_performed_ubble_check(user: users_models.User) -> bool:
     return db.session.query(
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.user == user,
-            models.BeneficiaryFraudCheck.status != models.FraudCheckStatus.CANCELED,
+            models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
             models.BeneficiaryFraudCheck.type == models.FraudCheckType.UBBLE,
         ).exists()
     ).scalar()

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -360,6 +360,9 @@ class AccountTest:
             (fraud_models.FraudCheckStatus.OK, fraud_models.IdentificationStatus.PROCESSED, None),
             (fraud_models.FraudCheckStatus.KO, fraud_models.IdentificationStatus.PROCESSED, None),
             (fraud_models.FraudCheckStatus.CANCELED, fraud_models.IdentificationStatus.ABORTED, "id-check"),
+            (None, fraud_models.IdentificationStatus.INITIATED, None),
+            (None, fraud_models.IdentificationStatus.PROCESSING, None),
+            (None, fraud_models.IdentificationStatus.PROCESSED, None),
         ],
     )
     @override_features(ENABLE_UBBLE=True)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -64,6 +64,9 @@ class NextStepTest:
             (fraud_models.FraudCheckStatus.OK, fraud_models.IdentificationStatus.PROCESSED, None),
             (fraud_models.FraudCheckStatus.KO, fraud_models.IdentificationStatus.PROCESSED, None),
             (fraud_models.FraudCheckStatus.CANCELED, fraud_models.IdentificationStatus.ABORTED, "identity-check"),
+            (None, fraud_models.IdentificationStatus.INITIATED, None),
+            (None, fraud_models.IdentificationStatus.PROCESSING, None),
+            (None, fraud_models.IdentificationStatus.PROCESSED, None),
         ],
     )
     @override_features(ENABLE_UBBLE=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12111


## But de la pull request

Le cas BeneficiaryFraudCheck.status vide (null dans la base de données) n'était pas pris en compte lorsqu'on vérifie si un check a déjà été fait. Pour Ubble il ne devrait cependant pas être vide (en cours de correction dans une autre PR)

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
