### PR TITLE
(pc-11987)(API)(FA) Fix Suspension Reason display if None

### DIFF
--- a/api/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
+++ b/api/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
@@ -43,9 +43,13 @@ def _action_links(view, context, model, name):
         text = "Suspendre…"
     else:
         url = url_for(".unsuspend_user_view")
-        text = "Réactiver…({})".format(
-            dict(users_constants.SUSPENSION_REASON_CHOICES)[users_constants.SuspensionReason(model.suspensionReason)]
-        )
+        text = "Réactiver…"
+        if model.suspensionReason:
+            text += "({})".format(
+                dict(users_constants.SUSPENSION_REASON_CHOICES)[
+                    users_constants.SuspensionReason(model.suspensionReason)
+                ]
+            )
 
     return Markup('<a href="{url}?user_id={model_id}">{text}</a>').format(
         url=url,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11987


## But de la pull request

En tant que contrôleur de la fraudeJ'aimerais ajouter un motif de suspension mieux défini sur le profil utilisateur dans FAAfin d’avoir un suivi précis sur les raisons de blocage et des statistiques 

##  Implémentation

- Sur FA, lorsque le compte utilisateur (Jeune, Pro, GP) est suspendu, on affiche la liste déroulante des raisons de suspension qui suit (dans l’ordre de la liste, et en remplacement da la liste actuelle) : 
    - Fraude faux document
    - Fraude revente produit
    - Fraude revente pass
    - Fraude usurpation
    - Fraude suspicion
    - Fraude doublon
    - Fraude hacking
    - Fraude annulation réservation
    - Fin de contrat
    - Fin d'éligibilité
    - Demande de l'utilisateur
    - Fraude PRO usurpation
    - Fraude PRO création
    - Structure définitivement fermée
    - Structure fermée provisoirement

- Afficher le motif de suspension dans la colonne de l’onglet principal FA “Utilisateurs > PRO/Jeunes/GP”​
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
![Capture d’écran 2021-12-01 à 14 51 20](https://user-images.githubusercontent.com/9610732/144247818-67676468-0185-492b-b7fd-ad66e47712ff.png)
![Capture d’écran 2021-12-01 à 14 51 32](https://user-images.githubusercontent.com/9610732/144247822-676f55db-a511-4f73-bbcc-abc26dabd445.png)

- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)