### PR TITLE
(PC-12269)[PRO] Improve adapter typing

### DIFF
--- a/pro/src/core/OfferEducational/adapters/getCategoriesAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getCategoriesAdapter.ts
@@ -13,7 +13,7 @@ interface IPayload {
   educationalSubCategories: IEducationalSubCategory[]
 }
 
-type GetCategoriesAdapter = Adapter<Params, IPayload>
+type GetCategoriesAdapter = Adapter<Params, IPayload, IPayload>
 
 const FAILING_RESPONSE = {
   isOk: false,

--- a/pro/src/core/OfferEducational/adapters/getOfferAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getOfferAdapter.ts
@@ -1,9 +1,11 @@
 import { Offer } from 'custom_types/offer'
 import * as pcapi from 'repository/pcapi/pcapi'
 
-type GetOfferAdapter = Adapter<string, { offer: Offer | null }>
+type IPayloadSuccess = { offer: Offer }
+type IPayloadFailure = { offer: null }
+type GetOfferAdapter = Adapter<string, IPayloadSuccess, IPayloadFailure>
 
-const FAILING_RESPONSE = {
+const FAILING_RESPONSE: AdapterFailure<IPayloadFailure> = {
   isOk: false,
   message: 'Une erreur est survenue lors de la récupération de votre offre',
   payload: {

--- a/pro/src/core/OfferEducational/adapters/getOfferersAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getOfferersAdapter.ts
@@ -5,7 +5,7 @@ type Params = string | null
 
 type IPayload = IUserOfferer[]
 
-type GetOfferersAdapter = Adapter<Params, IPayload>
+type GetOfferersAdapter = Adapter<Params, IPayload, IPayload>
 
 const FAILING_RESPONSE = {
   isOk: false,

--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -76,7 +76,8 @@ export type IOfferEducationalFormValues = {
 
 export type GetIsOffererEligibleToEducationalOffer = Adapter<
   string,
-  { isOffererEligibleToEducationalOffer: boolean }
+  { isOffererEligibleToEducationalOffer: boolean },
+  { isOffererEligibleToEducationalOffer: false }
 >
 
 export enum Mode {

--- a/pro/src/custom_types/adapters.d.ts
+++ b/pro/src/custom_types/adapters.d.ts
@@ -1,5 +1,15 @@
-type Adapter<Params, Payload> = (params: Params) => Promise<{
-  isOk: boolean
+type AdapterSuccess<T> = {
+  isOk: true
   message: string | null
-  payload: Payload
-}>
+  payload: T
+}
+
+type AdapterFailure<T> = {
+  isOk: false
+  message: string
+  payload: T
+}
+
+type Adapter<Params, SuccessPayload, FailurePayload> = (
+  params: Params
+) => Promise<AdapterSuccess<SuccessPayload> | AdapterFailure<FailurePayload>>

--- a/pro/src/routes/OfferEducationalCreation/adapters/getIsOffererEligibleToEducationalOfferAdapter.ts
+++ b/pro/src/routes/OfferEducationalCreation/adapters/getIsOffererEligibleToEducationalOfferAdapter.ts
@@ -4,7 +4,9 @@ import {
 } from 'core/OfferEducational'
 import * as pcapi from 'repository/pcapi/pcapi'
 
-const FAILING_RESPONSE = {
+const FAILING_RESPONSE: AdapterFailure<{
+  isOffererEligibleToEducationalOffer: false
+}> = {
   isOk: false,
   message:
     "Une erreur est survenue lors de la vérification de votre éligibilité à la création d'offre collective",

--- a/pro/src/routes/OfferEducationalCreation/adapters/postOfferAdapter.ts
+++ b/pro/src/routes/OfferEducationalCreation/adapters/postOfferAdapter.ts
@@ -8,13 +8,12 @@ import { createOfferPayload } from '../utils/createOfferPayload'
 
 type Params = IOfferEducationalFormValues
 
-interface IPayload {
-  offerId: string | null
-}
+type IPayloadSuccess = { offerId: string }
+type IPayloadFailure = { offerId: null }
 
-type PostOfferAdapter = Adapter<Params, IPayload>
+type PostOfferAdapter = Adapter<Params, IPayloadSuccess, IPayloadFailure>
 
-const BAD_REQUEST_FAILING_RESPONSE = {
+const BAD_REQUEST_FAILING_RESPONSE: AdapterFailure<IPayloadFailure> = {
   isOk: false,
   message: 'Une ou plusieurs erreurs sont présentes dans le formulaire',
   payload: {
@@ -22,7 +21,7 @@ const BAD_REQUEST_FAILING_RESPONSE = {
   },
 }
 
-const UNKNOWN_FAILING_RESPONSE = {
+const UNKNOWN_FAILING_RESPONSE: AdapterFailure<IPayloadFailure> = {
   isOk: false,
   message: 'Une erreur est survenue lors de la création de votre offre',
   payload: {

--- a/pro/src/routes/OfferEducationalEdition/OfferEducationalEdition.tsx
+++ b/pro/src/routes/OfferEducationalEdition/OfferEducationalEdition.tsx
@@ -13,7 +13,6 @@ import {
   getOfferAdapter,
   setInitialFormValues,
 } from 'core/OfferEducational'
-import { Offer } from 'custom_types/offer'
 import OfferEducationalScreen from 'screens/OfferEducational'
 import { IOfferEducationalProps } from 'screens/OfferEducational/OfferEducational'
 import { Title } from 'ui-kit'
@@ -25,14 +24,6 @@ type AsyncScreenProps = Pick<
   IOfferEducationalProps,
   'educationalCategories' | 'educationalSubCategories' | 'userOfferers'
 >
-
-/* @debt mathilde: should remove this typeguard when Adapter has Success and Failure type */
-const isLoadOfferSuccess = (response: {
-  isOk: boolean
-  message: string | null
-  payload: { offer: Offer | null }
-}): response is { isOk: boolean; message: null; payload: { offer: Offer } } =>
-  response.isOk === true
 
 const OfferEducationalEdition = ({
   tracking,
@@ -69,7 +60,7 @@ const OfferEducationalEdition = ({
       const loadData = async () => {
         const offerResponse = await getOfferAdapter(offerId)
 
-        if (!isLoadOfferSuccess(offerResponse)) {
+        if (!offerResponse.isOk) {
           return notify.error(offerResponse.message)
         }
 

--- a/pro/src/routes/OfferEducationalEdition/adapters/patchOfferAdapter.ts
+++ b/pro/src/routes/OfferEducationalEdition/adapters/patchOfferAdapter.ts
@@ -12,7 +12,7 @@ type Params = {
   initialValues: IOfferEducationalFormValues
 }
 
-type PostOfferAdapter = Adapter<Params, null>
+type PostOfferAdapter = Adapter<Params, null, null>
 
 const BAD_REQUEST_FAILING_RESPONSE = {
   isOk: false,

--- a/pro/src/routes/OfferEducationalStockCreation/adapters/postEducationalStock.ts
+++ b/pro/src/routes/OfferEducationalStockCreation/adapters/postEducationalStock.ts
@@ -9,7 +9,7 @@ import { createStockPayload } from './utils/createStockPayload'
 
 type Params = { offer: Offer; values: OfferEducationalStockFormValues }
 
-type PostEducationalStockAdapter = Adapter<Params, null>
+type PostEducationalStockAdapter = Adapter<Params, null, null>
 
 const BAD_REQUEST_FAILING_RESPONSE = {
   isOk: false,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12269

## But de la pull request
Améliorer le typage de l'adapter pour différencier le typage d'erreur et de succès pour ne pas avoir à caster les types après vérification de la valeur de `isOk`

##  Implémentation

- Création de 2 types générique de succès et de failure
- Modification du type de retour d'Adapter -> Promise<Failure | success>
- Mise à jour des utilisation d'adapter dans le code
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
