### PR TITLE
(PC-12240) Add honor mandatory statement step

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view.py
+++ b/api/src/pcapi/admin/custom_views/support_view.py
@@ -335,6 +335,9 @@ class BeneficiaryView(base_configuration.BaseAdminView):
                 pre_subscription = subscription_models.BeneficiaryPreSubscription.from_dms_source(
                     fraud_check.source_data()
                 )
+                fraud_api.create_honor_statement_fraud_check(
+                    user, "honor statement contained in DMS application after admin review"
+                )
             beneficiary_repository.BeneficiarySQLRepository.save(pre_subscription, user)
 
         flask.flash(f"N° de pièce d'identitée modifiée sur le bénéficiaire {user.firstName} {user.lastName}")

--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -813,3 +813,16 @@ def mark_fraud_check_failed(
     fraud_check.reasonCodes = reasons
 
     repository.save(fraud_check)
+
+
+def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> None:
+    # TODO(viconnex) -> add eligibility type
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.HONOR_STATEMENT,
+        status=models.FraudCheckStatus.OK,
+        reason=origin,
+        thirdPartyId=f"internal_check_{user.id}",
+    )
+    db.session.add(fraud_check)
+    db.session.commit()

--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -816,7 +816,7 @@ def mark_fraud_check_failed(
 
 
 def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> None:
-    # TODO(viconnex) -> add eligibility type
+    # TODO(viconnex) add eligibility type
     fraud_check = models.BeneficiaryFraudCheck(
         user=user,
         type=models.FraudCheckType.HONOR_STATEMENT,
@@ -826,3 +826,14 @@ def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> 
     )
     db.session.add(fraud_check)
     db.session.commit()
+
+
+def has_performed_honor_statement(user: users_models.User) -> bool:
+    # TODO(viconnex) add eligibility type filter
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter_by(
+            user=user,
+            type=models.FraudCheckType.HONOR_STATEMENT,
+            status=models.FraudCheckStatus.OK,
+        ).exists()
+    ).scalar()

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -152,6 +152,7 @@ FRAUD_CHECK_TYPE_MODEL_ASSOCIATION = {
     models.FraudCheckType.USER_PROFILING: UserProfilingFraudDataFactory,
     models.FraudCheckType.UBBLE: UbbleContentFactory,
     models.FraudCheckType.EDUCONNECT: EduconnectContentFactory,
+    models.FraudCheckType.HONOR_STATEMENT: None,
 }
 
 
@@ -169,9 +170,9 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
         """Override the default ``_create`` with our custom call."""
         factory_class = FRAUD_CHECK_TYPE_MODEL_ASSOCIATION.get(kwargs["type"])
         content = {}
-        if "resultContent" not in kwargs:
+        if factory_class and "resultContent" not in kwargs:
             content = factory_class().dict(by_alias=True)
-        if isinstance(kwargs.get("resultContent"), factory_class._meta.get_model_class()):
+        if factory_class and isinstance(kwargs.get("resultContent"), factory_class._meta.get_model_class()):
             content = kwargs["resultContent"].dict(by_alias=True)
 
         kwargs["resultContent"] = content

--- a/api/src/pcapi/core/fraud/models/__init__.py
+++ b/api/src/pcapi/core/fraud/models/__init__.py
@@ -24,6 +24,7 @@ class FraudCheckType(enum.Enum):
     INTERNAL_REVIEW = "internal_review"
     EDUCONNECT = "educonnect"
     UBBLE = "ubble"
+    HONOR_STATEMENT = "honor_statement"
 
 
 IDENTITY_CHECK_TYPES = [FraudCheckType.JOUVE, FraudCheckType.DMS, FraudCheckType.UBBLE, FraudCheckType.EDUCONNECT]

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -339,6 +339,9 @@ def get_next_subscription_step(user: users_models.User) -> typing.Optional[model
     ):
         return models.SubscriptionStep.IDENTITY_CHECK
 
+    if not fraud_api.has_performed_honor_statement(user):
+        return models.SubscriptionStep.HONOR_STATEMENT
+
     return None
 
 

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -116,7 +116,7 @@ def activate_beneficiary(
     eligibility = beneficiary_import.eligibilityType
     deposit_source = beneficiary_import.get_detailed_source()
 
-    if not user.is_eligible_for_beneficiary_upgrade:
+    if not user.is_eligible_for_beneficiary_upgrade(eligibility):
         raise exceptions.CannotUpgradeBeneficiaryRole()
 
     if eligibility == users_models.EligibilityType.UNDERAGE:

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -25,6 +25,7 @@ class SubscriptionStep(enum.Enum):
     PROFILE_COMPLETION = "profile-completion"
     IDENTITY_CHECK = "identity-check"
     USER_PROFILING = "user-profiling"
+    HONOR_STATEMENT = "honor-statement"
 
 
 class IdentityCheckMethod(enum.Enum):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -251,7 +251,10 @@ def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
         missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
 
     if not fraud_api.has_performed_honor_statement(user):
-        missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
+        if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
+            logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})
+        else:
+            missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
 
     return missing_steps
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -91,6 +91,7 @@ class BeneficiaryValidationStep(Enum):
     PHONE_VALIDATION = "phone-validation"
     ID_CHECK = "id-check"
     BENEFICIARY_INFORMATION = "beneficiary-information"
+    HONOR_STATEMENT = "honor-statement"
 
 
 def create_email_validation_token(user: User) -> Token:
@@ -248,6 +249,9 @@ def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
         beneficiary_import.eligibilityType == EligibilityType.UNDERAGE and user.has_underage_beneficiary_role
     ):
         missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
+
+    if not fraud_api.has_performed_honor_statement(user):
+        missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
 
     return missing_steps
 

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -72,6 +72,7 @@ class FeatureToggle(enum.Enum):
     ENFORCE_BANK_INFORMATION_WITH_SIRET = "Forcer les informations banquaires à être liées à un SIRET."
     FORCE_PHONE_VALIDATION = "Forcer la validation du numéro de téléphone pour devenir bénéficiaire"
     ID_CHECK_ADDRESS_AUTOCOMPLETION = "Autocomplétion de l'adresse lors du parcours IDCheck"
+    IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY = "Vérifier que l'utilisateur a bien rempli l'étape de confirmation sur l'honneur avant d'activer son compte bénéficiaire"  # TODO (vionnex) remove after v164 is forced on native app
     IMPROVE_BOOKINGS_PERF = "Améliore les performances pour la page pro des réservations"
     OFFER_VALIDATION_MOCK_COMPUTATION = "Active le calcul automatique de validation d'offre depuis le nom de l'offre"
     PAUSE_JOUVE_SUBSCRIPTION = "Mettre en pause les inscriptions depuis JOUVE"
@@ -142,6 +143,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.IMPROVE_BOOKINGS_PERF,
     FeatureToggle.FORCE_PHONE_VALIDATION,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
+    FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY,
     FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION,
     FeatureToggle.PERF_VENUE_STATS,
     FeatureToggle.PRICE_BOOKINGS,

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -150,7 +150,7 @@ def update_beneficiary_mandatory_information(user: User, body: serializers.Benef
         postal_code=body.postal_code,
         activity=body.activity,
         phone_number=body.phone,
-        has_completed_id_check=True,
+        is_legacy_behaviour=True,
     )
 
 

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import school_types
+from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
 from pcapi.routes.native.security import authenticated_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -74,3 +75,6 @@ def get_school_types() -> serializers.SchoolTypesResponse:
 @authenticated_user_required
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
+
+    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user):
+        subscription_api.activate_beneficiary(user)

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import school_types
 from pcapi.core.users import models as users_models
@@ -66,3 +67,10 @@ def get_school_types() -> serializers.SchoolTypesResponse:
         ],
         activities=[serializers.ActivityResponseModel.from_orm(activity) for activity in school_types.ALL_ACTIVITIES],
     )
+
+
+@blueprint.native_v1.route("/subscription/honor_statement", methods=["POST"])
+@spectree_serialize(on_success_status=204, api=blueprint.api)
+@authenticated_user_required
+def create_honor_statement_fraud_check(user: users_models.User) -> None:
+    fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")

--- a/api/src/pcapi/scripts/beneficiary/import_dms_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_dms_users.py
@@ -196,6 +196,7 @@ def process_application(
             return
 
         try:
+            fraud_api.create_honor_statement_fraud_check(user, "honor statement contained in DMS application")
             subscription_api.on_successful_application(
                 user=user,
                 source_data=information,

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -332,6 +332,9 @@ class UpdateIDPieceNumberTest:
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.JOUVE, resultContent=content
         )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
         id_piece_number = "123123123123"
         client.with_session_auth(self.jouve_admin.email)
@@ -356,6 +359,9 @@ class UpdateIDPieceNumberTest:
     def test_update_beneficiary_id_piece_number_from_dms_data(self, client):
         user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
         client.with_session_auth(self.jouve_admin.email)
         id_piece_number = "123123123123"
@@ -377,6 +383,9 @@ class UpdateIDPieceNumberTest:
         user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
         dms_data = fraud_check.source_data()
         beneficiary_import = users_factories.BeneficiaryImportFactory(
             beneficiary=user,
@@ -430,6 +439,9 @@ class UpdateIDPieceNumberTest:
             user=user, type=fraud_models.FraudCheckType.JOUVE, resultContent=content
         )
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         client.with_session_auth(admin.email)
         client.post(

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -99,6 +99,7 @@ class BeneficiaryValidationViewTest:
         assert response.headers["Location"] == "http://localhost/pc/back-office/"
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_validation_view_validate_user_from_jouve_data_staging(self, client):
         user = users_factories.UserFactory(isBeneficiary=False, dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE)
 
@@ -132,6 +133,7 @@ class BeneficiaryValidationViewTest:
         assert user.lastName == jouve_content.lastName
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_validation_view_validate_user_from_dms_data_staging(self, client):
         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
@@ -379,13 +381,11 @@ class UpdateIDPieceNumberTest:
         assert len(user.beneficiaryImports) == 1
         assert user.beneficiaryImports[0].currentStatus == ImportStatus.CREATED
 
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_update_beneficiary_id_piece_number_from_dms_data_with_existing_beneficiary_import(self, client):
         user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
-        )
         dms_data = fraud_check.source_data()
         beneficiary_import = users_factories.BeneficiaryImportFactory(
             beneficiary=user,

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -69,7 +69,56 @@ class JouveFraudCheckTest:
         )
         _get_raw_content.return_value = self.JOUVE_CONTENT
 
+        profile_data = {
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activity": "Lycéen",
+        }
+        client.with_token(email=user.email)
+        client.patch("/native/v1/beneficiary_information", profile_data)
+
         response = client.post("/beneficiaries/application_update", json={"id": self.application_id})
+
+        assert response.status_code == 200
+
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            user=user, type=fraud_models.FraudCheckType.JOUVE
+        ).first()
+        fraud_result = fraud_models.BeneficiaryFraudResult.query.filter_by(user=user).first()
+        jouve_fraud_content = fraud_models.JouveContent(**fraud_check.resultContent)
+
+        assert jouve_fraud_content.bodyPieceNumber == "140767100016"
+        assert fraud_check.dateCreated
+        assert fraud_check.thirdPartyId == "35"
+        assert fraud_result.status == fraud_models.FraudStatus.OK
+
+        db.session.refresh(user)
+        assert user.has_beneficiary_role
+        assert user.firstName == "CHRISTOPHE"
+        assert user.lastName == "DUPO"
+
+    @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
+    def test_jouve_update_before_profile_update(self, _get_raw_content, client):
+        user = users_factories.UserFactory(
+            hasCompletedIdCheck=True,
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE,
+            email=self.user_email,
+        )
+        _get_raw_content.return_value = self.JOUVE_CONTENT
+
+        response = client.post("/beneficiaries/application_update", json={"id": self.application_id})
+
+        profile_data = {
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activity": "Lycéen",
+        }
+        client.with_token(email=user.email)
+        client.patch("/native/v1/beneficiary_information", profile_data)
+
         assert response.status_code == 200
 
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -203,6 +203,7 @@ class EduconnectFlowTest:
 
     @freeze_time("2021-10-10")
     @patch("pcapi.core.users.external.educonnect.api.get_saml_client")
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_educonnect_subscription(self, mock_get_educonnect_saml_client, client, app):
         ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
         fraud_factories.IneHashWhitelistFactory(ine_hash=ine_hash)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -696,7 +696,7 @@ class UpdateBeneficiaryMandatoryInformationTest:
             city=new_city,
             postal_code="93000",
             activity=user.activity,
-            has_completed_id_check=True,
+            is_legacy_behaviour=True,
         )
 
         user = User.query.get(user.id)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -484,7 +484,7 @@ class StepsToBecomeBeneficiaryTest:
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role
 
-    @override_features(FORCE_PHONE_VALIDATION=True)
+    @override_features(FORCE_PHONE_VALIDATION=True, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_missing_all(self):
         user = self.eligible_user(validate_phone=False)
 
@@ -492,6 +492,17 @@ class StepsToBecomeBeneficiaryTest:
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
             BeneficiaryValidationStep.HONOR_STATEMENT,
+        ]
+        assert steps_to_become_beneficiary(user) == expected
+        assert not user.has_beneficiary_role
+
+    @override_features(FORCE_PHONE_VALIDATION=True, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=False)
+    def test_missing_all_honor_statement_optional(self):
+        user = self.eligible_user(validate_phone=False)
+
+        expected = [
+            BeneficiaryValidationStep.PHONE_VALIDATION,
+            BeneficiaryValidationStep.ID_CHECK,
         ]
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -447,6 +447,9 @@ class StepsToBecomeBeneficiaryTest:
         )
         beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
         user.hasCompletedIdCheck = True
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         assert steps_to_become_beneficiary(user) == []
 
@@ -457,6 +460,9 @@ class StepsToBecomeBeneficiaryTest:
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
         user.hasCompletedIdCheck = True
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         assert steps_to_become_beneficiary(user) == [BeneficiaryValidationStep.PHONE_VALIDATION]
         assert not user.has_beneficiary_role
@@ -467,6 +473,9 @@ class StepsToBecomeBeneficiaryTest:
 
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.REJECTED, author=user)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         expected = [
             BeneficiaryValidationStep.PHONE_VALIDATION,
@@ -482,6 +491,7 @@ class StepsToBecomeBeneficiaryTest:
         expected = [
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
+            BeneficiaryValidationStep.HONOR_STATEMENT,
         ]
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1416,6 +1416,9 @@ class ValidatePhoneNumberTest:
 
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.CREATED)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         client.with_token(email=user.email)
         token = create_phone_validation_token(user)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -57,18 +57,34 @@ class NextStepTest:
     @pytest.mark.parametrize(
         "fraud_check_status,ubble_status,next_step",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (
+                fraud_models.FraudCheckStatus.PENDING,
+                fraud_models.ubble.UbbleIdentificationStatus.INITIATED,
+                "honor-statement",
+            ),
+            (
+                fraud_models.FraudCheckStatus.PENDING,
+                fraud_models.ubble.UbbleIdentificationStatus.PROCESSING,
+                "honor-statement",
+            ),
+            (
+                fraud_models.FraudCheckStatus.OK,
+                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                "honor-statement",
+            ),
+            (
+                fraud_models.FraudCheckStatus.KO,
+                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                "honor-statement",
+            ),
             (
                 fraud_models.FraudCheckStatus.CANCELED,
                 fraud_models.ubble.UbbleIdentificationStatus.ABORTED,
                 "identity-check",
             ),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, "honor-statement"),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, "honor-statement"),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, "honor-statement"),
         ],
     )
     @override_features(ENABLE_UBBLE=True)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -290,3 +290,22 @@ class SchoolTypeTest:
                 {"id": "PUBLIC_SECONDARY_SCHOOL", "label": "Collège public"},
             ],
         }
+
+
+class HonorStatementTest:
+    def test_create_honor_statement_fraud_check(self, client):
+        user = users_factories.UserFactory()
+
+        client.with_token(user.email)
+
+        response = client.post("/native/v1/subscription/honor_statement")
+
+        assert response.status_code == 204
+
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT
+        ).first()
+
+        assert fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert fraud_check.reason == "statement from /subscription/honor_statement endpoint"
+        # TODO(viconnex) add eligibility type -- assert fraud_check.eligibilityType == eligibilityType

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -150,7 +150,6 @@ class EduconnectTest:
         assert user.lastName == "SENS"
         assert user.dateOfBirth == datetime.datetime(2006, 8, 18, 0, 0)
         assert user.ineHash == ine_hash
-        assert user.roles == [user_models.UserRole.UNDERAGE_BENEFICIARY]
 
     @patch("pcapi.core.users.external.educonnect.api.get_saml_client")
     def test_user_type_not_student(self, mock_get_educonnect_saml_client, client, caplog, app):

--- a/api/tests/routes/webapp/phone_validation_test.py
+++ b/api/tests/routes/webapp/phone_validation_test.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pytest
 
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
 from pcapi.core.testing import override_settings
 from pcapi.core.users.api import create_phone_validation_token
 from pcapi.core.users.factories import BeneficiaryImportFactory
@@ -59,6 +61,9 @@ def test_send_phone_validation_and_become_beneficiary(app):
     )
     beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
     beneficiary_import.setStatus(ImportStatus.CREATED)
+    fraud_factories.BeneficiaryFraudCheckFactory(
+        user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+    )
 
     client = TestClient(app.test_client()).with_session_auth(email=user.email)
 

--- a/api/tests/routes/webapp/post_id_check_application_update_test.py
+++ b/api/tests/routes/webapp/post_id_check_application_update_test.py
@@ -4,8 +4,6 @@ from unittest.mock import patch
 from dateutil.relativedelta import relativedelta
 import pytest
 
-from pcapi.core.fraud import factories as fraud_factories
-from pcapi.core.fraud import models as fraud_models
 from pcapi.core.payments.models import Deposit
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
@@ -82,13 +80,10 @@ class Returns200Test:
         application_id = 35
         _get_raw_content.return_value = JOUVE_CONTENT
 
-        user = users_factories.UserFactory(
+        users_factories.UserFactory(
             email="rennes@example.org",
             isEmailValidated=True,
             phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
         )
 
         # When

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -121,9 +121,7 @@ class RunTest:
         ]
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         assert on_sucessful_application.call_count == 3
@@ -172,9 +170,7 @@ class RunTest:
         ]
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         assert on_sucessful_application.call_count == 3
@@ -198,9 +194,7 @@ class RunTest:
         mocked_parse_beneficiary_information.side_effect = [Exception()]
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         beneficiary_import = BeneficiaryImport.query.first()
@@ -231,9 +225,7 @@ class RunTest:
         get_details.return_value = make_new_beneficiary_application_details(123, "closed")
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         on_sucessful_application.assert_not_called()
@@ -259,9 +251,7 @@ class RunTest:
         initial_beneficiary_import_id = user.beneficiaryImports[0].id
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         beneficiary_import = BeneficiaryImport.query.filter(
@@ -299,9 +289,7 @@ class RunTest:
         applicant = users_factories.UserFactory(firstName="Doe", lastName="John", email="john.doe@test.com")
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         on_sucessful_application.assert_called_with(
@@ -786,12 +774,24 @@ class RunIntegrationTest:
         assert user.phoneNumber == "0102030405"
         assert user.idPieceNumber == "1234123412"
 
-        assert len(user.beneficiaryFraudChecks) == 1
-        fraud_check = user.beneficiaryFraudChecks[0]
-        assert fraud_check.type == fraud_models.FraudCheckType.DMS
-        fraud_content = fraud_models.DMSContent(**fraud_check.resultContent)
+        assert len(user.beneficiaryFraudChecks) == 2
+
+        dms_fraud_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.DMS
+        )
+        dms_fraud_check = user.beneficiaryFraudChecks[0]
+        assert dms_fraud_check.type == fraud_models.FraudCheckType.DMS
+        fraud_content = fraud_models.DMSContent(**dms_fraud_check.resultContent)
         assert fraud_content.birth_date == user.dateOfBirth.date()
         assert fraud_content.address == "11 Rue du Test"
+
+        assert next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.HONOR_STATEMENT
+        )
 
         assert BeneficiaryImport.query.count() == 1
         beneficiary_import = BeneficiaryImport.query.first()
@@ -1232,10 +1232,21 @@ class GraphQLSourceProcessApplicationTest:
         import_status = BeneficiaryImport.query.one_or_none()
         assert import_status.currentStatus == ImportStatus.CREATED
         assert import_status.beneficiary == user
-        assert len(user.beneficiaryFraudChecks) == 1
-        fraud_check = user.beneficiaryFraudChecks[0]
-        assert not fraud_check.reasonCodes
-        assert fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert len(user.beneficiaryFraudChecks) == 2
+        dms_fraud_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.DMS
+        )
+        assert not dms_fraud_check.reasonCodes
+        assert dms_fraud_check.status == fraud_models.FraudCheckStatus.OK
+        statement_fraud_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.HONOR_STATEMENT
+        )
+        assert statement_fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert statement_fraud_check.reason == "honor statement contained in DMS application"
 
     @patch.object(DMSGraphQLClient, "get_applications_with_details")
     def test_run(self, get_applications_with_details):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12240


## But de la pull request

Aujourd'hui, l'étape de confirmation sur l'honneur qui arrive à la fin du parcours n'est pas prise en compte côté back.
Le but est d'en faire une étape obligatoire.

Commits à lire séparément.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
