### PR TITLE
[PC-12266][API] Don't show tokens for non-event booked goods

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -805,6 +805,19 @@ def _get_booking_status(status: BookingStatus, is_confirmed: bool) -> str:
     return BOOKING_STATUS_LABELS[status]
 
 
+# TODO: merge this with BookingRecap._get_booking_token
+def _get_booking_token(
+    booking_token: str, booking_status: BookingStatus, event_beginning_datetime: Optional[datetime]
+) -> Optional[str]:
+    if not event_beginning_datetime and booking_status not in [
+        BookingStatus.REIMBURSED,
+        BookingStatus.CANCELLED,
+        BookingStatus.USED,
+    ]:
+        return None
+    return booking_token
+
+
 def _serialize_csv_report(query: Query) -> str:
     output = StringIO()
     writer = csv.writer(output, dialect=csv.excel, delimiter=";", quoting=csv.QUOTE_NONNUMERIC)
@@ -837,7 +850,7 @@ def _serialize_csv_report(query: Query) -> str:
                 booking.beneficiaryPhoneNumber,
                 _serialize_date_with_timezone(booking.bookedAt, booking),
                 _serialize_date_with_timezone(booking.usedAt, booking),
-                booking.token,
+                _get_booking_token(booking.token, booking.status, booking.stockBeginningDatetime),
                 booking.amount,
                 _get_booking_status(booking.status, booking.isConfirmed),
                 _serialize_date_with_timezone(booking.reimbursedAt, booking),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12266

## But de la pull request

Ne pas montrer les contre-marques pour les biens culturels réservés.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
