### PR TITLE
(PC-11121) Refacto next step

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view.py
+++ b/api/src/pcapi/admin/custom_views/support_view.py
@@ -335,6 +335,9 @@ class BeneficiaryView(base_configuration.BaseAdminView):
                 pre_subscription = subscription_models.BeneficiaryPreSubscription.from_dms_source(
                     fraud_check.source_data()
                 )
+                fraud_api.create_honor_statement_fraud_check(
+                    user, "honor statement contained in DMS application after admin review"
+                )
             beneficiary_repository.BeneficiarySQLRepository.save(pre_subscription, user)
 
         flask.flash(f"N° de pièce d'identitée modifiée sur le bénéficiaire {user.firstName} {user.lastName}")

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -1,0 +1,835 @@
+import datetime
+import logging
+import re
+import typing
+
+import pydantic
+import pytz
+import sqlalchemy
+
+from pcapi.connectors.beneficiaries import jouve_backend
+from pcapi.core.fraud import exceptions
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.exceptions import BeneficiaryFraudResultCannotBeDowngraded
+from pcapi.core.users import constants
+from pcapi.core.users import models as users_models
+from pcapi.core.users import utils as users_utils
+from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
+from pcapi.repository import repository
+from pcapi.repository.user_queries import matching
+
+from . import models
+from . import repository as fraud_repository
+
+
+logger = logging.getLogger(__name__)
+
+FRAUD_RESULT_REASON_SEPARATOR = ";"
+
+USER_PROFILING_RISK_MAPPING = {
+    models.UserProfilingRiskRating.TRUSTED: models.FraudStatus.OK,
+    models.UserProfilingRiskRating.NEUTRAL: models.FraudStatus.OK,
+    models.UserProfilingRiskRating.LOW: models.FraudStatus.OK,
+    models.UserProfilingRiskRating.MEDIUM: models.FraudStatus.SUSPICIOUS,
+    models.UserProfilingRiskRating.HIGH: models.FraudStatus.KO,
+}
+
+
+def on_educonnect_result(user: users_models.User, educonnect_content: models.EduconnectContent) -> None:
+    fraud_check = models.BeneficiaryFraudCheck.query.filter(
+        models.BeneficiaryFraudCheck.user == user,
+        models.BeneficiaryFraudCheck.type == models.FraudCheckType.EDUCONNECT,
+    ).one_or_none()
+
+    if fraud_check:
+        fraud_check.thirdPartyId = str(educonnect_content.educonnect_id)
+        fraud_check.resultContent = educonnect_content.dict()
+    else:
+        fraud_check = models.BeneficiaryFraudCheck(
+            user=user,
+            type=models.FraudCheckType.EDUCONNECT,
+            thirdPartyId=str(educonnect_content.educonnect_id),
+            resultContent=educonnect_content.dict(),
+        )
+    on_identity_fraud_check_result(user, fraud_check)
+    repository.save(fraud_check)
+
+
+def on_jouve_result(user: users_models.User, jouve_content: models.JouveContent) -> None:
+    if (
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.type.in_([models.FraudCheckType.JOUVE, models.FraudCheckType.DMS]),
+        ).count()
+        > 0
+    ):
+        # TODO: raise error and do not allow 2 DMS/Jouve FraudChecks
+        return
+
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.JOUVE,
+        thirdPartyId=str(jouve_content.id),
+        resultContent=jouve_content.dict(),
+    )
+    repository.save(fraud_check)
+
+    # TODO: save user fields from jouve_content
+    on_identity_fraud_check_result(user, fraud_check)
+
+
+def on_ubble_result(fraud_check: fraud_models.BeneficiaryFraudCheck) -> None:
+    on_identity_fraud_check_result(fraud_check.user, fraud_check)
+
+
+def on_dms_fraud_result(
+    user: users_models.User,
+    dms_content: models.DMSContent,
+) -> models.BeneficiaryFraudResult:
+
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.DMS,
+        thirdPartyId=str(dms_content.application_id),
+        resultContent=dms_content,
+    )
+
+    db.session.add(fraud_check)
+    db.session.commit()
+    return on_identity_fraud_check_result(user, fraud_check)
+
+
+def admin_update_identity_fraud_check_result(
+    user: users_models.User, id_piece_number: str
+) -> typing.Union[models.BeneficiaryFraudCheck, None]:
+    fraud_check = (
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.userId == user.id,
+            models.BeneficiaryFraudCheck.type.in_(
+                [
+                    models.FraudCheckType.JOUVE,
+                    models.FraudCheckType.DMS,
+                ]
+            ),
+        )
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .first()
+    )
+    if not fraud_check:
+        return None
+    content = fraud_check.source_data()
+    if fraud_check.type == models.FraudCheckType.JOUVE:
+        content.bodyPieceNumber = id_piece_number
+        content.bodyPieceNumberCtrl = "OK"
+        content.bodyPieceNumberLevel = 100
+    if fraud_check.type == models.FraudCheckType.DMS:
+        content.id_piece_number = id_piece_number
+    fraud_check.resultContent = content.dict()
+    repository.save(fraud_check)
+    return fraud_check
+
+
+def educonnect_fraud_checks(
+    user: users_models.User, beneficiary_fraud_check: models.BeneficiaryFraudCheck
+) -> list[models.FraudItem]:
+    educonnect_content = beneficiary_fraud_check.source_data()
+    fraud_items = []
+    # TODO: factorise in on_identity_fraud_check_result for the 4 *_fraud_checks
+    fraud_items.append(
+        _duplicate_user_fraud_item(
+            first_name=educonnect_content.first_name,
+            last_name=educonnect_content.last_name,
+            birth_date=educonnect_content.birth_date,
+            excluded_user_id=user.id,
+        )
+    )
+    fraud_items.append(_underage_user_fraud_item(educonnect_content.birth_date))
+    fraud_items.append(_duplicate_ine_hash_fraud_item(educonnect_content.ine_hash, user.id))
+    if FeatureToggle.ENABLE_INE_WHITELIST_FILTER.is_active():
+        fraud_items.append(_whitelisted_ine_fraud_item(educonnect_content.ine_hash))
+
+    return fraud_items
+
+
+def jouve_fraud_checks(
+    user: users_models.User, beneficiary_fraud_check: models.BeneficiaryFraudCheck
+) -> list[models.FraudItem]:
+    jouve_content = models.JouveContent(**beneficiary_fraud_check.resultContent)
+
+    fraud_items = []
+    fraud_items.append(_check_user_phone_is_validated(user))
+    # TODO: factorise in on_identity_fraud_check_result for the 4 *_fraud_checks
+    fraud_items.append(
+        _duplicate_user_fraud_item(
+            first_name=jouve_content.firstName,
+            last_name=jouve_content.lastName,
+            birth_date=jouve_content.birthDateTxt,
+            excluded_user_id=user.id,
+        )
+    )
+
+    fraud_items.append(validate_id_piece_number_format_fraud_item(jouve_content.bodyPieceNumber))
+    fraud_items.append(_duplicate_id_piece_number_fraud_item(user, jouve_content.bodyPieceNumber))
+    fraud_items.extend(_id_check_fraud_items(jouve_content))
+    return fraud_items
+
+
+def _ubble_result_fraud_item(content: fraud_models.UbbleContent) -> fraud_models.FraudItem:
+    if content.score == fraud_models.UbbleScore.VALID.value:
+        return fraud_models.FraudItem(status=fraud_models.FraudStatus.OK, detail=f"Ubble score {content.score}")
+
+    return fraud_models.FraudItem(
+        status=fraud_models.FraudStatus.KO,
+        detail=f"Ubble score {content.score}: {content.comment}",
+        reason_code=(
+            fraud_models.FraudReasonCode.ID_CHECK_INVALID
+            if content.score == fraud_models.UbbleScore.INVALID.value
+            else fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE
+        ),
+    )
+
+
+def ubble_fraud_checks(
+    user: users_models.User, beneficiary_fraud_check: models.BeneficiaryFraudCheck
+) -> list[models.FraudItem]:
+    content = fraud_models.UbbleContent(**beneficiary_fraud_check.resultContent)
+
+    fraud_items = [
+        _ubble_result_fraud_item(content),
+        # TODO: factorise in on_identity_fraud_check_result for the 4 *_fraud_checks
+        _duplicate_user_fraud_item(
+            first_name=content.first_name,
+            last_name=content.last_name,
+            birth_date=content.birth_date,
+            excluded_user_id=user.id,
+        ),
+        # TODO: décommenter cette ligne après avoir vérifié la regex qui vérifie
+        #  le format de numéro de pièce d'identité
+        # validate_id_piece_number_format_fraud_item(content.id_document_number),
+        _duplicate_id_piece_number_fraud_item(user, content.id_document_number),
+    ]
+
+    return fraud_items
+
+
+def dms_fraud_checks(
+    user: users_models.User, beneficiary_fraud_check: models.BeneficiaryFraudCheck
+) -> list[models.FraudItem]:
+    dms_content = models.DMSContent(**beneficiary_fraud_check.resultContent)
+
+    fraud_items = []
+    fraud_items.append(_check_user_phone_is_validated(user))
+    # TODO: factorise in on_identity_fraud_check_result for the 4 *_fraud_checks
+    fraud_items.append(
+        _duplicate_user_fraud_item(
+            first_name=dms_content.first_name,
+            last_name=dms_content.last_name,
+            birth_date=dms_content.birth_date,
+            excluded_user_id=user.id,
+        )
+    )
+    fraud_items.append(_duplicate_id_piece_number_fraud_item(user, dms_content.id_piece_number))
+    return fraud_items
+
+
+def start_ubble_fraud_check(user: users_models.User, ubble_content: models.UbbleContent) -> None:
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.UBBLE,
+        thirdPartyId=str(ubble_content.identification_id),
+        resultContent=ubble_content,
+    )
+    db.session.add(fraud_check)
+    db.session.commit()
+
+
+def get_ubble_fraud_check(identification_id: str) -> typing.Optional[models.BeneficiaryFraudCheck]:
+    fraud_check = (
+        models.BeneficiaryFraudCheck.query.filter(models.BeneficiaryFraudCheck.type == models.FraudCheckType.UBBLE)
+        .filter(models.BeneficiaryFraudCheck.thirdPartyId == identification_id)
+        .one_or_none()
+    )
+    return fraud_check
+
+
+def get_eligibility_type(data: models.SubscriptionContentType) -> typing.Optional[users_models.EligibilityType]:
+    from pcapi.core.users import api as users_api
+
+    if isinstance(data, models.EduconnectContent):
+        registration_datetime = data.registration_datetime
+        birth_date = data.birth_date
+    elif isinstance(data, models.JouveContent):
+        registration_datetime = data.registrationDate
+        birth_date = data.birthDateTxt.date() if data.birthDateTxt else None
+    elif isinstance(data, models.UbbleContent):
+        registration_datetime = data.registration_datetime
+        birth_date = data.birth_date
+    elif isinstance(data, models.DMSContent):
+        registration_datetime = data.registration_datetime.astimezone(pytz.utc).replace(tzinfo=None)
+        birth_date = data.birth_date
+    else:
+        raise exceptions.InvalidContentTypeException()
+
+    if registration_datetime is None or birth_date is None:
+        return None
+
+    return users_api.get_eligibility_at_date(birth_date, registration_datetime)
+
+
+def on_identity_fraud_check_result(
+    user: users_models.User,
+    beneficiary_fraud_check: models.BeneficiaryFraudCheck,
+) -> models.BeneficiaryFraudResult:
+    fraud_items: list[models.FraudItem] = []
+
+    eligibilityType = get_eligibility_type(beneficiary_fraud_check.source_data())
+
+    if beneficiary_fraud_check.type == models.FraudCheckType.JOUVE:
+        fraud_items += jouve_fraud_checks(user, beneficiary_fraud_check)
+
+    elif beneficiary_fraud_check.type == models.FraudCheckType.UBBLE:
+        fraud_items += ubble_fraud_checks(user, beneficiary_fraud_check)
+
+    elif beneficiary_fraud_check.type == models.FraudCheckType.DMS:
+        fraud_items += dms_fraud_checks(user, beneficiary_fraud_check)
+
+    elif beneficiary_fraud_check.type == models.FraudCheckType.EDUCONNECT:
+        fraud_items += educonnect_fraud_checks(user, beneficiary_fraud_check)
+
+    else:
+        raise Exception("The fraud_check type is not known")
+
+    fraud_items.append(_check_user_has_no_active_deposit(user, eligibilityType))
+    fraud_items.append(_check_user_email_is_validated(user))
+    fraud_items.append(_check_user_not_already_beneficiary(user, eligibilityType))
+
+    fraud_result = validate_frauds(user, fraud_items, beneficiary_fraud_check, eligibilityType)
+    if (
+        beneficiary_fraud_check.type == models.FraudCheckType.JOUVE
+        and FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION.is_active()
+    ):
+        fraud_result.status = models.FraudStatus.SUBSCRIPTION_ON_HOLD
+    repository.save(fraud_result)
+
+    return fraud_result
+
+
+def validate_id_piece_number_format_fraud_item(id_piece_number: str) -> models.FraudItem:
+    if not id_piece_number or not id_piece_number.strip():
+        return models.FraudItem(
+            status=models.FraudStatus.SUSPICIOUS,
+            detail="Le numéro de la pièce d'identité est vide",
+            reason_code=models.FraudReasonCode.EMPTY_ID_PIECE_NUMBER,
+        )
+
+    regexp = "|".join(
+        (
+            r"(^\d{18}$)",  # ID Algérienne
+            r"(^[\w]{8,12}|[\s\w]{14}$)",  # ID Europeene ID Française
+            r"(^\w{1}\d{6}$)",  # ID Tunisienne
+            r"(^\w{1}\ *\d{8}$)",  # ID Turque
+            r"(^\w{2}\ *\d{7}$)",  # Ancienne ID Italienne
+            r"(^\d{3}\-\d{7}\-\d{2}$)",  # ID Belge
+            r"(^\d{7}$)",  # ID Congolaise, Camerounaise, Mauricienne
+        )
+    )
+
+    if not re.fullmatch(
+        regexp,
+        id_piece_number,
+    ):
+        return models.FraudItem(
+            status=models.FraudStatus.SUSPICIOUS,
+            detail="Le format du numéro de la pièce d'identité n'est pas valide",
+            reason_code=models.FraudReasonCode.INVALID_ID_PIECE_NUMBER,
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail="Le numéro de pièce d'identité est valide")
+
+
+def _duplicate_user_fraud_item(
+    first_name: str, last_name: str, birth_date: datetime.date, excluded_user_id: int
+) -> models.FraudItem:
+    duplicate_user = users_models.User.query.filter(
+        matching(users_models.User.firstName, first_name)
+        & (matching(users_models.User.lastName, last_name))
+        & (sqlalchemy.func.DATE(users_models.User.dateOfBirth) == birth_date)
+        & (users_models.User.is_beneficiary == True)
+        & (users_models.User.id != excluded_user_id)
+    ).first()
+
+    return models.FraudItem(
+        status=models.FraudStatus.SUSPICIOUS if duplicate_user else models.FraudStatus.OK,
+        detail=f"Duplicat de l'utilisateur {duplicate_user.id}" if duplicate_user else "Utilisateur non dupliqué",
+        reason_code=models.FraudReasonCode.DUPLICATE_USER if duplicate_user else None,
+    )
+
+
+def _duplicate_id_piece_number_fraud_item(user: users_models.User, document_id_number: str) -> models.FraudItem:
+    duplicate_user = users_models.User.query.filter(
+        users_models.User.id != user.id, users_models.User.idPieceNumber == document_id_number
+    ).first()
+    return models.FraudItem(
+        status=models.FraudStatus.SUSPICIOUS if duplicate_user else models.FraudStatus.OK,
+        detail=f"Le n° de cni {document_id_number} est déjà pris par l'utilisateur {duplicate_user.id}"
+        if duplicate_user
+        else "Le numéro de CNI n'est pas déjà utilisé",
+        reason_code=models.FraudReasonCode.DUPLICATE_ID_PIECE_NUMBER if duplicate_user else None,
+    )
+
+
+def _duplicate_ine_hash_fraud_item(ine_hash: str, excluded_user_id: int) -> models.FraudItem:
+    duplicate_user = users_models.User.query.filter(
+        users_models.User.ineHash == ine_hash, users_models.User.id != excluded_user_id
+    ).first()
+    return models.FraudItem(
+        status=models.FraudStatus.SUSPICIOUS if duplicate_user else models.FraudStatus.OK,
+        detail=f"L'INE {ine_hash} est déjà pris par l'utilisateur {duplicate_user.id}"
+        if duplicate_user
+        else "L'INE est OK",
+        reason_code=models.FraudReasonCode.DUPLICATE_INE if duplicate_user else None,
+    )
+
+
+def _whitelisted_ine_fraud_item(ine_hash: str) -> models.FraudItem:
+    is_ine_whitelisted = db.session.query(models.IneHashWhitelist.query.filter_by(ine_hash=ine_hash).exists()).scalar()
+
+    return models.FraudItem(
+        # TODO: ask if it is considered as KO or SUSPICIOUS
+        status=models.FraudStatus.OK if is_ine_whitelisted else models.FraudStatus.SUSPICIOUS,
+        detail=f"L'INE {ine_hash} n'est pas whitelisté" if not is_ine_whitelisted else "L'INE est whitelisté",
+        reason_code=models.FraudReasonCode.INE_NOT_WHITELISTED if not is_ine_whitelisted else None,
+    )
+
+
+def _check_user_has_no_active_deposit(
+    user: users_models.User, eligibility: users_models.EligibilityType
+) -> models.FraudItem:
+    if user.has_active_deposit:
+        return models.FraudItem(
+            status=models.FraudStatus.KO,
+            detail=(
+                "L’utilisateur est déjà bénéfiaire, avec un portefeuille non expiré. "
+                f"Il ne peut pas prétendre au pass culture {'15-17 ans' if eligibility == users_models.EligibilityType.UNDERAGE else '18 ans'}"
+            ),
+            reason_code=models.FraudReasonCode.ALREADY_HAS_ACTIVE_DEPOSIT,
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail="L'utilisateur n'a pas déjà un deposit actif")
+
+
+def _check_user_not_already_beneficiary(
+    user: users_models.User, eligibility: users_models.EligibilityType
+) -> models.FraudItem:
+    if not user.is_eligible_for_beneficiary_upgrade(eligibility):
+        return models.FraudItem(
+            status=models.FraudStatus.KO,
+            detail=(
+                f"L’utilisateur est déjà bénéfiaire du pass {eligibility.name}"
+                if eligibility
+                else "L'utilisateur n'est pas éligible"
+            ),
+            reason_code=models.FraudReasonCode.ALREADY_BENEFICIARY,
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail="L'utilisateur n'est pas déjà bénéficaire")
+
+
+def _check_user_email_is_validated(user: users_models.User) -> models.FraudItem:
+    if not user.isEmailValidated:
+        return models.FraudItem(
+            status=models.FraudStatus.KO,
+            detail="L'email de l'utilisateur n'est pas validé",
+            reason_code=models.FraudReasonCode.EMAIL_NOT_VALIDATED,
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail="L'email est validé")
+
+
+def _check_user_phone_is_validated(user: users_models.User) -> models.FraudItem:
+    if FeatureToggle.FORCE_PHONE_VALIDATION.is_active() and not user.is_phone_validated:
+        return models.FraudItem(
+            status=models.FraudStatus.KO,
+            detail="Le n° de téléphone de l'utilisateur n'est pas validé",
+            reason_code=models.FraudReasonCode.PHONE_NOT_VALIDATED,
+        )
+    return models.FraudItem(status=models.FraudStatus.OK, detail="Le numéro de téléphone est validé")
+
+
+def _id_check_fraud_items(content: models.JouveContent) -> list[models.FraudItem]:
+    if not FeatureToggle.ENABLE_IDCHECK_FRAUD_CONTROLS.is_active():
+        return []
+
+    fraud_items = []
+    fraud_items.append(
+        _get_boolean_id_fraud_item(
+            content.birthLocationCtrl, "birthLocationCtrl", models.FraudReasonCode.ID_CHECK_INVALID, False
+        )
+    )
+    fraud_items.append(
+        _get_boolean_id_fraud_item(
+            content.bodyBirthDateCtrl, "bodyBirthDateCtrl", models.FraudReasonCode.ID_CHECK_INVALID, False
+        )
+    )
+    fraud_items.append(
+        _get_boolean_id_fraud_item(content.bodyNameCtrl, "bodyNameCtrl", models.FraudReasonCode.ID_CHECK_INVALID, False)
+    )
+    fraud_items.append(
+        _get_boolean_id_fraud_item(
+            content.bodyPieceNumberCtrl, "bodyPieceNumberCtrl", models.FraudReasonCode.ID_CHECK_INVALID, False
+        )
+    )
+
+    fraud_items.append(
+        _get_threshold_id_fraud_item(
+            content.bodyBirthDateLevel, "bodyBirthDateLevel", 100, models.FraudReasonCode.ID_CHECK_INVALID, False
+        )
+    )
+    fraud_items.append(
+        _get_threshold_id_fraud_item(
+            content.bodyNameLevel, "bodyNameLevel", 50, models.FraudReasonCode.ID_CHECK_INVALID, False
+        )
+    )
+    fraud_items.append(
+        _get_threshold_id_fraud_item(
+            content.bodyPieceNumberLevel, "bodyPieceNumberLevel", 50, models.FraudReasonCode.ID_CHECK_INVALID, False
+        )
+    )
+
+    return fraud_items
+
+
+def _get_boolean_id_fraud_item(
+    value: typing.Optional[str], key: str, fail_reason: models.FraudReasonCode, is_strict_ko: bool
+) -> models.FraudItem:
+    # TODO: move those functions when using fraud v2 journey only
+    item = jouve_backend.get_boolean_fraud_detection_item(value, key)
+
+    if item.valid:
+        status = models.FraudStatus.OK
+    elif is_strict_ko:
+        status = models.FraudStatus.KO
+    else:
+        status = models.FraudStatus.SUSPICIOUS
+
+    return models.FraudItem(
+        status=status,
+        detail=f"Le champ {key} est {value}",
+        reason_code=None if status == models.FraudStatus.OK else fail_reason,
+    )
+
+
+def _get_threshold_id_fraud_item(
+    value: typing.Optional[int], key: str, threshold: int, fail_reason: models.FraudReasonCode, is_strict_ko: bool
+) -> models.FraudItem:
+    # TODO: move those functions when using fraud v2 journey only
+    item = jouve_backend.get_threshold_fraud_detection_item(value, key, threshold)
+    if item.valid:
+        status = models.FraudStatus.OK
+    elif is_strict_ko:
+        status = models.FraudStatus.KO
+    else:
+        status = models.FraudStatus.SUSPICIOUS
+
+    return models.FraudItem(
+        status=status,
+        detail=f"Le champ {key} a le score {value} (minimum {threshold})",
+        reason_code=None if status == models.FraudStatus.OK else fail_reason,
+    )
+
+
+def _underage_user_fraud_item(birth_date: datetime.date) -> models.FraudItem:
+    age = users_utils.get_age_from_birth_date(birth_date)
+    if age in constants.ELIGIBILITY_UNDERAGE_RANGE:
+        return models.FraudItem(
+            status=models.FraudStatus.OK,
+            detail=f"L'age de l'utilisateur est valide ({age} ans).",
+        )
+    return models.FraudItem(
+        status=models.FraudStatus.KO,
+        detail=f"L'age de l'utilisateur est invalide ({age} ans). Il devrait être parmi {constants.ELIGIBILITY_UNDERAGE_RANGE}",
+        reason_code=models.FraudReasonCode.AGE_NOT_VALID,
+    )
+
+
+def on_user_profiling_result(
+    user: users_models.User, profiling_infos: models.UserProfilingFraudData
+) -> models.BeneficiaryFraudCheck:
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.USER_PROFILING,
+        thirdPartyId=profiling_infos.session_id,
+        resultContent=profiling_infos,
+    )
+    repository.save(fraud_check)
+    on_user_profiling_check_result(user, profiling_infos)
+    return fraud_check
+
+
+def on_user_profiling_check_result(
+    user: users_models.User,
+    tmx_content: models.UserProfilingFraudData,
+) -> None:
+    risk_rating = tmx_content.risk_rating
+    user_profiling_status = USER_PROFILING_RISK_MAPPING[risk_rating]
+    if not user_profiling_status == models.FraudStatus.OK:
+        upsert_fraud_result(
+            user, user_profiling_status, user.eligibility, f"threat-metrix risk rating is {risk_rating.value}"
+        )
+
+        from pcapi.core.subscription import messages as subscription_messages
+
+        subscription_messages.on_user_subscription_journey_stopped(user)
+
+
+def get_source_data(user: users_models.User) -> pydantic.BaseModel:
+    mapped_class = {models.FraudCheckType.DMS: models.DMSContent, models.FraudCheckType.JOUVE: models.JouveContent}
+    fraud_check_type = (
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.userId == user.id,
+            models.BeneficiaryFraudCheck.type.in_([models.FraudCheckType.JOUVE, models.FraudCheckType.DMS]),
+        )
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .first()
+    )
+    return mapped_class[fraud_check_type.type](**fraud_check_type.resultContent)
+
+
+def upsert_fraud_result(
+    user: users_models.User,
+    status: models.FraudStatus,
+    eligibilityType: typing.Optional[users_models.EligibilityType],
+    reason: str = None,
+) -> models.BeneficiaryFraudResult:
+    """
+    If the user has no fraud result: create one fraud result with status and the given reason.
+    If it already has one: append the reason to the already recorded ones.
+    """
+    if not eligibilityType:
+        eligibilityType = users_models.EligibilityType.AGE18
+    reason = reason or ""
+    if status != models.FraudStatus.OK and not reason:
+        raise ValueError(f"a reason should be provided when setting fraud result to {status.value}")
+
+    fraud_result = fraud_repository.get_current_beneficiary_fraud_result(user, eligibilityType)
+
+    if not fraud_result:
+        fraud_result = models.BeneficiaryFraudResult(
+            user=user, status=status, reason=reason, eligibilityType=eligibilityType
+        )
+    else:
+        fraud_result.status = status
+        # if this function is called twice (or more) in a row with the same
+        # reason, do not update the reason column with the same reason repeated
+        # over and over. It makes the reason less readable and therefore less
+        # useful.
+        last_reason = fraud_result.reason.split(FRAUD_RESULT_REASON_SEPARATOR)[-1].strip() if fraud_result else None
+        if last_reason != reason:
+            fraud_result.reason = f"{fraud_result.reason} {FRAUD_RESULT_REASON_SEPARATOR} {reason}"
+
+    repository.save(fraud_result)
+    return fraud_result
+
+
+def create_internal_review_fraud_check(
+    user: users_models.User, fraud_check_data: models.InternalReviewFraudData
+) -> models.BeneficiaryFraudCheck:
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.INTERNAL_REVIEW,
+        thirdPartyId=f"PC-{user.id}",
+        resultContent=fraud_check_data,
+    )
+
+    repository.save(fraud_check)
+    return fraud_check
+
+
+def handle_phone_already_exists(user: users_models.User, phone_number: str) -> models.BeneficiaryFraudCheck:
+    orig_user_id = (
+        users_models.User.query.filter(
+            users_models.User.phoneNumber == phone_number, users_models.User.is_phone_validated
+        )
+        .one()
+        .id
+    )
+    reason = f"Le numéro est déjà utilisé par l'utilisateur {orig_user_id}"
+    fraud_check_data = models.InternalReviewFraudData(
+        source=models.InternalReviewSource.PHONE_ALREADY_EXISTS, message=reason, phone_number=phone_number
+    )
+
+    return create_internal_review_fraud_check(user, fraud_check_data)
+
+
+def handle_blacklisted_sms_recipient(user: users_models.User, phone_number: str) -> models.BeneficiaryFraudCheck:
+    reason = "Le numéro saisi est interdit"
+    fraud_check_data = models.InternalReviewFraudData(
+        source=models.InternalReviewSource.BLACKLISTED_PHONE_NUMBER, message=reason, phone_number=phone_number
+    )
+
+    return create_internal_review_fraud_check(user, fraud_check_data)
+
+
+def handle_sms_sending_limit_reached(user: users_models.User) -> models.BeneficiaryFraudResult:
+    reason = "Le nombre maximum de sms envoyés est atteint"
+    fraud_check_data = models.InternalReviewFraudData(
+        source=models.InternalReviewSource.SMS_SENDING_LIMIT_REACHED,
+        message=reason,
+        phone_number=user.phoneNumber,
+    )
+
+    create_internal_review_fraud_check(user, fraud_check_data)
+    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, user.eligibility, reason)
+
+
+def handle_phone_validation_attempts_limit_reached(
+    user: users_models.User, attempts_count: int
+) -> models.BeneficiaryFraudResult:
+    reason = f"Le nombre maximum de tentatives de validation est atteint: {attempts_count}"
+    fraud_check_data = models.InternalReviewFraudData(
+        source=models.InternalReviewSource.PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED,
+        message=reason,
+        phone_number=user.phoneNumber,
+    )
+
+    create_internal_review_fraud_check(user, fraud_check_data)
+    return upsert_fraud_result(user, models.FraudStatus.SUSPICIOUS, user.eligibility, reason)
+
+
+def handle_document_validation_error(email: str, code: str) -> None:
+    user = users_models.User.query.filter(users_models.User.email == email).one_or_none()
+    if user:
+        fraud_check_data = models.InternalReviewFraudData(
+            source=models.InternalReviewSource.DOCUMENT_VALIDATION_ERROR,
+            message=f"Erreur de lecture du document : {code}",
+        )
+        create_internal_review_fraud_check(user, fraud_check_data)
+    else:
+        logger.warning("fraud internal validation : Cannot find user with email %s", email)
+
+
+def validate_frauds(
+    user: users_models.User,
+    fraud_items: list[models.FraudItem],
+    fraud_check: models.BeneficiaryFraudCheck,
+    eligibilityType: users_models.EligibilityType,
+) -> models.BeneficiaryFraudResult:
+    if all(fraud_item.status == models.FraudStatus.OK for fraud_item in fraud_items):
+        status = models.FraudStatus.OK
+        fraud_check_status = models.FraudCheckStatus.OK
+    elif any(fraud_item.status == models.FraudStatus.KO for fraud_item in fraud_items):
+        status = models.FraudStatus.KO
+        fraud_check_status = models.FraudCheckStatus.KO
+    else:
+        status = models.FraudStatus.SUSPICIOUS
+        fraud_check_status = models.FraudCheckStatus.SUSPICIOUS
+
+    reason = f" {FRAUD_RESULT_REASON_SEPARATOR} ".join(
+        fraud_item.detail for fraud_item in fraud_items if fraud_item.status != models.FraudStatus.OK
+    )
+    reason_codes = [
+        fraud_item.reason_code
+        for fraud_item in fraud_items
+        if fraud_item.status != models.FraudStatus.OK and fraud_item.reason_code is not None
+    ]
+
+    fraud_check.status = fraud_check_status
+    fraud_check.reason = reason
+    fraud_check.reasonCodes = reason_codes
+    repository.save(fraud_check)
+
+    fraud_result = update_or_create_fraud_result(user, status, reason, reason_codes, eligibilityType)
+
+    return fraud_result
+
+
+def update_or_create_fraud_result(
+    user: users_models.User,
+    status: models.FraudStatus,
+    reason: str,
+    reason_codes: list[models.FraudReasonCode],
+    eligibility_type: users_models.EligibilityType,
+):
+    existing_fraud_result = fraud_repository.get_current_beneficiary_fraud_result(user, eligibility_type)
+    if existing_fraud_result:
+        fraud_result = existing_fraud_result
+
+        if fraud_result.status == models.FraudStatus.OK and status != models.FraudStatus.OK:
+            raise BeneficiaryFraudResultCannotBeDowngraded()
+
+        fraud_result.status = status
+    else:
+        fraud_result = models.BeneficiaryFraudResult(user=user, status=status, eligibilityType=eligibility_type)
+    fraud_result.reason = reason
+    fraud_result.reason_codes = reason_codes
+    return fraud_result
+
+
+def has_user_performed_identity_check(user: users_models.User) -> bool:
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
+            models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
+        ).exists()
+    ).scalar()
+
+
+def has_user_performed_ubble_check(user: users_models.User) -> bool:
+    """
+    Look for any Ubble identification already started, processed or not, but not aborted.
+    There should not be more than one result in the database (later this function can count if limit is greater than 1).
+    """
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
+            models.BeneficiaryFraudCheck.type == models.FraudCheckType.UBBLE,
+        ).exists()
+    ).scalar()
+
+
+def is_risky_user_profile(user: users_models.User) -> bool:
+    user_profiling = (
+        models.BeneficiaryFraudCheck.query.filter(models.BeneficiaryFraudCheck.user == user)
+        .filter(models.BeneficiaryFraudCheck.type == models.FraudCheckType.USER_PROFILING)
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .first()
+    )
+
+    if user_profiling and user_profiling.source_data().risk_rating == models.UserProfilingRiskRating.HIGH:
+        return True
+
+    if not (user_profiling or FeatureToggle.ALLOW_EMPTY_USER_PROFILING.is_active()):
+        # unprofiled user and forbidden empty profiling -> risky
+        return True
+
+    return False
+
+
+def is_user_fraudster(user: users_models.User) -> bool:
+    return any(
+        beneficiary_fraud_result.status != models.FraudStatus.OK
+        for beneficiary_fraud_result in user.beneficiaryFraudResults
+    )
+
+
+def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> None:
+    # TODO(viconnex) add eligibility type
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.HONOR_STATEMENT,
+        status=models.FraudCheckStatus.OK,
+        reason=origin,
+        thirdPartyId=f"internal_check_{user.id}",
+    )
+    db.session.add(fraud_check)
+    db.session.commit()
+
+
+def has_performed_honor_statement(user: users_models.User) -> bool:
+    # TODO(viconnex) add eligibility type filter
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter_by(
+            user=user,
+            type=models.FraudCheckType.HONOR_STATEMENT,
+            status=models.FraudCheckStatus.OK,
+        ).exists()
+    ).scalar()

--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -748,3 +748,16 @@ def is_user_fraudster(user: users_models.User) -> bool:
         beneficiary_fraud_result.status != models.FraudStatus.OK
         for beneficiary_fraud_result in user.beneficiaryFraudResults
     )
+
+
+def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> None:
+    # TODO(viconnex) -> add eligibility type
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.HONOR_STATEMENT,
+        status=models.FraudCheckStatus.OK,
+        reason=origin,
+        thirdPartyId=f"internal_check_{user.id}",
+    )
+    db.session.add(fraud_check)
+    db.session.commit()

--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -751,7 +751,7 @@ def is_user_fraudster(user: users_models.User) -> bool:
 
 
 def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> None:
-    # TODO(viconnex) -> add eligibility type
+    # TODO(viconnex) add eligibility type
     fraud_check = models.BeneficiaryFraudCheck(
         user=user,
         type=models.FraudCheckType.HONOR_STATEMENT,
@@ -761,3 +761,14 @@ def create_honor_statement_fraud_check(user: users_models.User, origin: str) -> 
     )
     db.session.add(fraud_check)
     db.session.commit()
+
+
+def has_performed_honor_statement(user: users_models.User) -> bool:
+    # TODO(viconnex) add eligibility type filter
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter_by(
+            user=user,
+            type=models.FraudCheckType.HONOR_STATEMENT,
+            status=models.FraudCheckStatus.OK,
+        ).exists()
+    ).scalar()

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -152,6 +152,7 @@ FRAUD_CHECK_TYPE_MODEL_ASSOCIATION = {
     models.FraudCheckType.USER_PROFILING: UserProfilingFraudDataFactory,
     models.FraudCheckType.UBBLE: UbbleContentFactory,
     models.FraudCheckType.EDUCONNECT: EduconnectContentFactory,
+    models.FraudCheckType.HONOR_STATEMENT: None,
 }
 
 
@@ -169,9 +170,9 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
         """Override the default ``_create`` with our custom call."""
         factory_class = FRAUD_CHECK_TYPE_MODEL_ASSOCIATION.get(kwargs["type"])
         content = {}
-        if "resultContent" not in kwargs:
+        if factory_class and "resultContent" not in kwargs:
             content = factory_class().dict(by_alias=True)
-        if isinstance(kwargs.get("resultContent"), factory_class._meta.get_model_class()):
+        if factory_class and isinstance(kwargs.get("resultContent"), factory_class._meta.get_model_class()):
             content = kwargs["resultContent"].dict(by_alias=True)
 
         kwargs["resultContent"] = content

--- a/api/src/pcapi/core/fraud/models/__init__.py
+++ b/api/src/pcapi/core/fraud/models/__init__.py
@@ -24,6 +24,7 @@ class FraudCheckType(enum.Enum):
     INTERNAL_REVIEW = "internal_review"
     EDUCONNECT = "educonnect"
     UBBLE = "ubble"
+    HONOR_STATEMENT = "honor_statement"
 
 
 IDENTITY_CHECK_TYPES = [FraudCheckType.JOUVE, FraudCheckType.DMS, FraudCheckType.UBBLE, FraudCheckType.EDUCONNECT]

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -337,6 +337,9 @@ def get_next_subscription_step(user: users_models.User) -> typing.Optional[model
     ):
         return models.SubscriptionStep.IDENTITY_CHECK
 
+    if not fraud_api.has_performed_honor_statement(user):
+        return models.SubscriptionStep.HONOR_STATEMENT
+
     return None
 
 

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -105,6 +105,12 @@ def create_successfull_beneficiary_import(
     return beneficiary_import
 
 
+def can_activate_beneficiary(user: users_models.User, eligibilityType: users_models.EligibilityType) -> bool:
+    return user.is_eligible_for_beneficiary_upgrade(eligibilityType) and not get_missing_subscription_steps(
+        user, eligibilityType
+    )
+
+
 def activate_beneficiary(
     user: users_models.User, deposit_source: str = None, has_activated_account: typing.Optional[bool] = True
 ) -> users_models.User:
@@ -166,7 +172,6 @@ def check_and_activate_beneficiary(
 def create_beneficiary_import(user: users_models.User, eligibilityType: users_models.EligibilityType) -> None:
     fraud_result = fraud_models.BeneficiaryFraudResult.query.filter_by(
         user=user,
-        # find fraud result by eligibility. If eligibilityType is None, the FraudResult has the default value AGE18
         eligibilityType=eligibilityType or users_models.EligibilityType.AGE18,
     ).one_or_none()
     if not fraud_result:
@@ -206,7 +211,7 @@ def create_beneficiary_import(user: users_models.User, eligibilityType: users_mo
 
     users_api.update_user_information_from_external_source(user, fraud_check.source_data(), commit=True)
 
-    if not users_api.steps_to_become_beneficiary(user):
+    if can_activate_beneficiary(user, eligibilityType):
         activate_beneficiary(user)
     else:
         users_external.update_external_user(user)
@@ -298,6 +303,39 @@ def has_completed_profile(user: users_models.User) -> bool:
     return user.city is not None
 
 
+def needs_to_validate_phone_number(user: users_models.User, eligibilityType: users_models.EligibilityType):
+    return (
+        eligibilityType == users_models.EligibilityType.AGE18
+        and not user.is_phone_validated
+        and FeatureToggle.FORCE_PHONE_VALIDATION.is_active()
+    )
+
+
+def get_missing_subscription_steps(
+    user: users_models.User, eligibilityType: users_models.EligibilityType
+) -> list[models.SubscriptionStep]:
+    missing_steps = []
+
+    if not user.isEmailValidated:
+        missing_steps.append(models.SubscriptionStep.EMAIL_VALIDATION)
+
+    if needs_to_validate_phone_number(user, eligibilityType):
+        missing_steps.append(models.SubscriptionStep.PHONE_VALIDATION)
+
+    beneficiary_import = subscription_repository.get_beneficiary_import_for_beneficiary(user)
+    if not beneficiary_import or (beneficiary_import.eligibilityType != eligibilityType):
+        missing_steps.append(models.SubscriptionStep.IDENTITY_CHECK)
+
+    if not fraud_api.has_performed_honor_statement(user):
+        if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
+            logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})
+        else:
+            missing_steps.append(models.SubscriptionStep.HONOR_STATEMENT)
+        missing_steps.append(models.SubscriptionStep.HONOR_STATEMENT)
+
+    return missing_steps
+
+
 # pylint: disable=too-many-return-statements
 def get_next_subscription_step(user: users_models.User) -> typing.Optional[models.SubscriptionStep]:
     # TODO(viconnex): base the next step on the user.subscriptionState that will be added later on
@@ -310,11 +348,7 @@ def get_next_subscription_step(user: users_models.User) -> typing.Optional[model
     if not user.is_eligible_for_beneficiary_upgrade():
         return None
 
-    if (
-        not user.is_phone_validated
-        and user.eligibility == users_models.EligibilityType.AGE18
-        and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active()
-    ):
+    if needs_to_validate_phone_number(user, user.eligibility):
         return models.SubscriptionStep.PHONE_VALIDATION
 
     if user.eligibility == users_models.EligibilityType.AGE18:
@@ -383,12 +417,7 @@ def update_user_profile(
         users_models.User.query.filter(users_models.User.id == user.id).update(update_payload)
     db.session.refresh(user)
 
-    if (
-        not users_api.steps_to_become_beneficiary(user)
-        # the 2 following checks should be useless
-        and fraud_api.has_user_performed_identity_check(user)
-        and not fraud_api.is_user_fraudster(user)
-    ):
+    if can_activate_beneficiary(user, user.eligibility):
         check_and_activate_beneficiary(user.id)
     else:
         users_api.update_external_user(user)
@@ -479,16 +508,18 @@ def on_successful_application(
     user.hasCompletedIdCheck = True
     pcapi_repository.repository.save(user)
 
+    eligibility = fraud_api.get_eligibility_type(source_data)
+
     create_successfull_beneficiary_import(
         user=user,
         source=source,
         source_id=source_id,
         application_id=application_id,
-        eligibility_type=fraud_api.get_eligibility_type(source_data),
+        eligibility_type=eligibility,
         third_party_id=third_party_id,
     )
 
-    if not users_api.steps_to_become_beneficiary(user):
+    if can_activate_beneficiary(user, eligibility):
         activate_beneficiary(user)
     else:
         users_external.update_external_user(user)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -152,7 +152,7 @@ def activate_beneficiary(
     return user
 
 
-def check_and_activate_beneficiary(
+def lock_user_to_activate_beneficiary(
     userId: int, deposit_source: str = None, has_activated_account: typing.Optional[bool] = True
 ) -> users_models.User:
     with pcapi_repository.transaction():
@@ -418,7 +418,7 @@ def update_user_profile(
     db.session.refresh(user)
 
     if can_activate_beneficiary(user, user.eligibility):
-        check_and_activate_beneficiary(user.id)
+        lock_user_to_activate_beneficiary(user.id)
     else:
         users_api.update_external_user(user)
 

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -350,7 +350,7 @@ def update_user_profile(
     last_name: typing.Optional[str] = None,
     school_type: typing.Optional[users_models.SchoolTypeEnum] = None,
     phone_number: typing.Optional[str] = None,
-    has_completed_id_check: typing.Optional[bool] = None,
+    is_legacy_behaviour: typing.Optional[bool] = False,
 ) -> None:
     user_initial_roles = user.roles
 
@@ -369,12 +369,12 @@ def update_user_profile(
     if last_name and not user.lastName:
         update_payload["lastName"] = last_name
 
-    # TODO (viconnex): remove phone number update after app native mandatory version is >= 164
-    if not FeatureToggle.ENABLE_PHONE_VALIDATION.is_active() and not user.phoneNumber and phone_number:
-        update_payload["phoneNumber"] = phone_number
-
-    if has_completed_id_check:
+    if is_legacy_behaviour:
+        # TODO (viconnex): remove phone number update after app native mandatory version is >= 164
+        if not user.phoneNumber and phone_number and not FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
+            update_payload["phoneNumber"] = phone_number
         update_payload["hasCompletedIdCheck"] = True
+        fraud_api.create_honor_statement_fraud_check(user, "legacy /beneficiary_information route")
 
     with pcapi_repository.transaction():
         users_models.User.query.filter(users_models.User.id == user.id).update(update_payload)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -116,7 +116,7 @@ def activate_beneficiary(
     eligibility = beneficiary_import.eligibilityType
     deposit_source = beneficiary_import.get_detailed_source()
 
-    if not user.is_eligible_for_beneficiary_upgrade:
+    if not user.is_eligible_for_beneficiary_upgrade(eligibility):
         raise exceptions.CannotUpgradeBeneficiaryRole()
 
     if eligibility == users_models.EligibilityType.UNDERAGE:

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -25,6 +25,7 @@ class SubscriptionStep(enum.Enum):
     PROFILE_COMPLETION = "profile-completion"
     IDENTITY_CHECK = "identity-check"
     USER_PROFILING = "user-profiling"
+    HONOR_STATEMENT = "honor-statement"
 
 
 class IdentityCheckMethod(enum.Enum):

--- a/api/src/pcapi/core/subscription/repository.py
+++ b/api/src/pcapi/core/subscription/repository.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from pcapi.core.users import models as users_models
+from pcapi.models import db
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
 from pcapi.models.beneficiary_import_status import ImportStatus
@@ -14,3 +15,15 @@ def get_beneficiary_import_for_beneficiary(user: users_models.User) -> Optional[
         .order_by(BeneficiaryImportStatus.date.desc())
         .first()
     )
+
+
+def has_created_beneficiary_import_of_eligibility(
+    user: users_models.User, eligibility: users_models.EligibilityType
+) -> bool:
+    return db.session.query(
+        BeneficiaryImport.query.join(BeneficiaryImportStatus)
+        .filter(BeneficiaryImport.beneficiaryId == user.id)
+        .filter(BeneficiaryImport.eligibilityType == eligibility)
+        .filter(BeneficiaryImportStatus.status == ImportStatus.CREATED)
+        .exists()
+    ).scalar()

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -249,7 +249,10 @@ def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
         missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
 
     if not fraud_api.has_performed_honor_statement(user):
-        missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
+        if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
+            logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})
+        else:
+            missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
 
     return missing_steps
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -90,6 +90,7 @@ class BeneficiaryValidationStep(Enum):
     PHONE_VALIDATION = "phone-validation"
     ID_CHECK = "id-check"
     BENEFICIARY_INFORMATION = "beneficiary-information"
+    HONOR_STATEMENT = "honor-statement"
 
 
 def create_email_validation_token(user: User) -> Token:
@@ -246,6 +247,9 @@ def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
         beneficiary_import.eligibilityType == EligibilityType.UNDERAGE and user.has_underage_beneficiary_role
     ):
         missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
+
+    if not fraud_api.has_performed_honor_statement(user):
+        missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
 
     return missing_steps
 

--- a/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
+++ b/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
@@ -28,7 +28,7 @@ class BeneficiarySQLRepository:
         repository.save(user_sql_entity)
 
         if subscription_api.can_activate_beneficiary(user, beneficiary_pre_subscription.eligibility_type):
-            user_sql_entity = subscription_api.check_and_activate_beneficiary(
+            user_sql_entity = subscription_api.lock_user_to_activate_beneficiary(
                 user_sql_entity.id, has_activated_account=user is not None
             )
         else:

--- a/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
+++ b/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription.models import BeneficiaryPreSubscription
-from pcapi.core.users import api as users_api
 from pcapi.core.users.external import update_external_user
 from pcapi.core.users.models import User
 from pcapi.infrastructure.repository.beneficiary import beneficiary_pre_subscription_sql_converter
@@ -28,7 +27,7 @@ class BeneficiarySQLRepository:
         )
         repository.save(user_sql_entity)
 
-        if not users_api.steps_to_become_beneficiary(user_sql_entity):
+        if subscription_api.can_activate_beneficiary(user, beneficiary_pre_subscription.eligibility_type):
             user_sql_entity = subscription_api.check_and_activate_beneficiary(
                 user_sql_entity.id, has_activated_account=user is not None
             )

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -72,6 +72,7 @@ class FeatureToggle(enum.Enum):
     ENFORCE_BANK_INFORMATION_WITH_SIRET = "Forcer les informations banquaires à être liées à un SIRET."
     FORCE_PHONE_VALIDATION = "Forcer la validation du numéro de téléphone pour devenir bénéficiaire"
     ID_CHECK_ADDRESS_AUTOCOMPLETION = "Autocomplétion de l'adresse lors du parcours IDCheck"
+    IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY = "Vérifier que l'utilisateur a bien rempli l'étape de confirmation sur l'honneur avant d'activer son compte bénéficiaire"  # TODO (vionnex) remove after v164 is forced on native app
     IMPROVE_BOOKINGS_PERF = "Améliore les performances pour la page pro des réservations"
     OFFER_VALIDATION_MOCK_COMPUTATION = "Active le calcul automatique de validation d'offre depuis le nom de l'offre"
     PAUSE_JOUVE_SUBSCRIPTION = "Mettre en pause les inscriptions depuis JOUVE"
@@ -142,6 +143,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.IMPROVE_BOOKINGS_PERF,
     FeatureToggle.FORCE_PHONE_VALIDATION,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
+    FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY,
     FeatureToggle.PAUSE_JOUVE_SUBSCRIPTION,
     FeatureToggle.PERF_VENUE_STATS,
     FeatureToggle.PRICE_BOOKINGS,

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -150,7 +150,7 @@ def update_beneficiary_mandatory_information(user: User, body: serializers.Benef
         postal_code=body.postal_code,
         activity=body.activity,
         phone_number=body.phone,
-        has_completed_id_check=True,
+        is_legacy_behaviour=True,
     )
 
 

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import school_types
+from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
 from pcapi.routes.native.security import authenticated_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -74,3 +75,6 @@ def get_school_types() -> serializers.SchoolTypesResponse:
 @authenticated_user_required
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
+
+    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user):
+        subscription_api.activate_beneficiary(user)

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -4,7 +4,6 @@ from typing import Optional
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import school_types
-from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
 from pcapi.routes.native.security import authenticated_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -76,5 +75,5 @@ def get_school_types() -> serializers.SchoolTypesResponse:
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
 
-    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user):
+    if subscription_api.can_activate_beneficiary(user, user.eligibility):
         subscription_api.activate_beneficiary(user)

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import school_types
 from pcapi.core.users import models as users_models
@@ -66,3 +67,10 @@ def get_school_types() -> serializers.SchoolTypesResponse:
         ],
         activities=[serializers.ActivityResponseModel.from_orm(activity) for activity in school_types.ALL_ACTIVITIES],
     )
+
+
+@blueprint.native_v1.route("/subscription/honor_statement", methods=["POST"])
+@spectree_serialize(on_success_status=204, api=blueprint.api)
+@authenticated_user_required
+def create_honor_statement_fraud_check(user: users_models.User) -> None:
+    fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")

--- a/api/src/pcapi/scripts/beneficiary/import_dms_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_dms_users.py
@@ -196,6 +196,7 @@ def process_application(
             return
 
         try:
+            fraud_api.create_honor_statement_fraud_check(user, "honor statement contained in DMS application")
             subscription_api.on_successful_application(
                 user=user,
                 source_data=information,

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -332,6 +332,9 @@ class UpdateIDPieceNumberTest:
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.JOUVE, resultContent=content
         )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
         id_piece_number = "123123123123"
         client.with_session_auth(self.jouve_admin.email)
@@ -356,6 +359,9 @@ class UpdateIDPieceNumberTest:
     def test_update_beneficiary_id_piece_number_from_dms_data(self, client):
         user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
         client.with_session_auth(self.jouve_admin.email)
         id_piece_number = "123123123123"
@@ -377,6 +383,9 @@ class UpdateIDPieceNumberTest:
         user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
         dms_data = fraud_check.source_data()
         beneficiary_import = users_factories.BeneficiaryImportFactory(
             beneficiary=user,
@@ -430,6 +439,9 @@ class UpdateIDPieceNumberTest:
             user=user, type=fraud_models.FraudCheckType.JOUVE, resultContent=content
         )
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         client.with_session_auth(admin.email)
         client.post(

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -99,6 +99,7 @@ class BeneficiaryValidationViewTest:
         assert response.headers["Location"] == "http://localhost/pc/back-office/"
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_validation_view_validate_user_from_jouve_data_staging(self, client):
         user = users_factories.UserFactory(isBeneficiary=False, dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE)
 
@@ -132,6 +133,7 @@ class BeneficiaryValidationViewTest:
         assert user.lastName == jouve_content.lastName
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_validation_view_validate_user_from_dms_data_staging(self, client):
         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
@@ -379,13 +381,11 @@ class UpdateIDPieceNumberTest:
         assert len(user.beneficiaryImports) == 1
         assert user.beneficiaryImports[0].currentStatus == ImportStatus.CREATED
 
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_update_beneficiary_id_piece_number_from_dms_data_with_existing_beneficiary_import(self, client):
         user = users_factories.UserFactory()
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         fraud_factories.BeneficiaryFraudResultFactory(user=user, status=fraud_models.FraudStatus.SUSPICIOUS)
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
-        )
         dms_data = fraud_check.source_data()
         beneficiary_import = users_factories.BeneficiaryImportFactory(
             beneficiary=user,

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -203,6 +203,7 @@ class EduconnectFlowTest:
 
     @freeze_time("2021-10-10")
     @patch("pcapi.core.users.external.educonnect.api.get_saml_client")
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_educonnect_subscription(self, mock_get_educonnect_saml_client, client, app):
         ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
         fraud_factories.IneHashWhitelistFactory(ine_hash=ine_hash)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -696,7 +696,7 @@ class UpdateBeneficiaryMandatoryInformationTest:
             city=new_city,
             postal_code="93000",
             activity=user.activity,
-            has_completed_id_check=True,
+            is_legacy_behaviour=True,
         )
 
         user = User.query.get(user.id)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -484,7 +484,7 @@ class StepsToBecomeBeneficiaryTest:
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role
 
-    @override_features(FORCE_PHONE_VALIDATION=True)
+    @override_features(FORCE_PHONE_VALIDATION=True, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
     def test_missing_all(self):
         user = self.eligible_user(validate_phone=False)
 
@@ -492,6 +492,17 @@ class StepsToBecomeBeneficiaryTest:
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
             BeneficiaryValidationStep.HONOR_STATEMENT,
+        ]
+        assert steps_to_become_beneficiary(user) == expected
+        assert not user.has_beneficiary_role
+
+    @override_features(FORCE_PHONE_VALIDATION=True, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=False)
+    def test_missing_all_honor_statement_optional(self):
+        user = self.eligible_user(validate_phone=False)
+
+        expected = [
+            BeneficiaryValidationStep.PHONE_VALIDATION,
+            BeneficiaryValidationStep.ID_CHECK,
         ]
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -447,6 +447,9 @@ class StepsToBecomeBeneficiaryTest:
         )
         beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
         user.hasCompletedIdCheck = True
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         assert steps_to_become_beneficiary(user) == []
 
@@ -457,6 +460,9 @@ class StepsToBecomeBeneficiaryTest:
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
         user.hasCompletedIdCheck = True
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         assert steps_to_become_beneficiary(user) == [BeneficiaryValidationStep.PHONE_VALIDATION]
         assert not user.has_beneficiary_role
@@ -467,6 +473,9 @@ class StepsToBecomeBeneficiaryTest:
 
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.REJECTED, author=user)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         expected = [
             BeneficiaryValidationStep.PHONE_VALIDATION,
@@ -482,6 +491,7 @@ class StepsToBecomeBeneficiaryTest:
         expected = [
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
+            BeneficiaryValidationStep.HONOR_STATEMENT,
         ]
         assert steps_to_become_beneficiary(user) == expected
         assert not user.has_beneficiary_role

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1407,6 +1407,9 @@ class ValidatePhoneNumberTest:
 
         beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
         beneficiary_import.setStatus(ImportStatus.CREATED)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
 
         client.with_token(email=user.email)
         token = create_phone_validation_token(user)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -57,18 +57,34 @@ class NextStepTest:
     @pytest.mark.parametrize(
         "fraud_check_status,ubble_status,next_step",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (
+                fraud_models.FraudCheckStatus.PENDING,
+                fraud_models.ubble.UbbleIdentificationStatus.INITIATED,
+                "honor-statement",
+            ),
+            (
+                fraud_models.FraudCheckStatus.PENDING,
+                fraud_models.ubble.UbbleIdentificationStatus.PROCESSING,
+                "honor-statement",
+            ),
+            (
+                fraud_models.FraudCheckStatus.OK,
+                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                "honor-statement",
+            ),
+            (
+                fraud_models.FraudCheckStatus.KO,
+                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                "honor-statement",
+            ),
             (
                 fraud_models.FraudCheckStatus.CANCELED,
                 fraud_models.ubble.UbbleIdentificationStatus.ABORTED,
                 "identity-check",
             ),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, None),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, None),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, None),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, "honor-statement"),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, "honor-statement"),
+            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, "honor-statement"),
         ],
     )
     @override_features(ENABLE_UBBLE=True)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -290,3 +290,22 @@ class SchoolTypeTest:
                 {"id": "PUBLIC_SECONDARY_SCHOOL", "label": "Collège public"},
             ],
         }
+
+
+class HonorStatementTest:
+    def test_create_honor_statement_fraud_check(self, client):
+        user = users_factories.UserFactory()
+
+        client.with_token(user.email)
+
+        response = client.post("/native/v1/subscription/honor_statement")
+
+        assert response.status_code == 204
+
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT
+        ).first()
+
+        assert fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert fraud_check.reason == "statement from /subscription/honor_statement endpoint"
+        # TODO(viconnex) add eligibility type -- assert fraud_check.eligibilityType == eligibilityType

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -150,7 +150,6 @@ class EduconnectTest:
         assert user.lastName == "SENS"
         assert user.dateOfBirth == datetime.datetime(2006, 8, 18, 0, 0)
         assert user.ineHash == ine_hash
-        assert user.roles == [user_models.UserRole.UNDERAGE_BENEFICIARY]
 
     @patch("pcapi.core.users.external.educonnect.api.get_saml_client")
     def test_user_type_not_student(self, mock_get_educonnect_saml_client, client, caplog, app):

--- a/api/tests/routes/webapp/phone_validation_test.py
+++ b/api/tests/routes/webapp/phone_validation_test.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pytest
 
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
 from pcapi.core.testing import override_settings
 from pcapi.core.users.api import create_phone_validation_token
 from pcapi.core.users.factories import BeneficiaryImportFactory
@@ -59,6 +61,9 @@ def test_send_phone_validation_and_become_beneficiary(app):
     )
     beneficiary_import = BeneficiaryImportFactory(beneficiary=user)
     beneficiary_import.setStatus(ImportStatus.CREATED)
+    fraud_factories.BeneficiaryFraudCheckFactory(
+        user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+    )
 
     client = TestClient(app.test_client()).with_session_auth(email=user.email)
 

--- a/api/tests/routes/webapp/post_id_check_application_update_test.py
+++ b/api/tests/routes/webapp/post_id_check_application_update_test.py
@@ -4,8 +4,6 @@ from unittest.mock import patch
 from dateutil.relativedelta import relativedelta
 import pytest
 
-from pcapi.core.fraud import factories as fraud_factories
-from pcapi.core.fraud import models as fraud_models
 from pcapi.core.payments.models import Deposit
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
@@ -82,13 +80,10 @@ class Returns200Test:
         application_id = 35
         _get_raw_content.return_value = JOUVE_CONTENT
 
-        user = users_factories.UserFactory(
+        users_factories.UserFactory(
             email="rennes@example.org",
             isEmailValidated=True,
             phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
         )
 
         # When

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -121,9 +121,7 @@ class RunTest:
         ]
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         assert on_sucessful_application.call_count == 3
@@ -172,9 +170,7 @@ class RunTest:
         ]
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         assert on_sucessful_application.call_count == 3
@@ -198,9 +194,7 @@ class RunTest:
         mocked_parse_beneficiary_information.side_effect = [Exception()]
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         beneficiary_import = BeneficiaryImport.query.first()
@@ -231,9 +225,7 @@ class RunTest:
         get_details.return_value = make_new_beneficiary_application_details(123, "closed")
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         on_sucessful_application.assert_not_called()
@@ -259,9 +251,7 @@ class RunTest:
         initial_beneficiary_import_id = user.beneficiaryImports[0].id
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         beneficiary_import = BeneficiaryImport.query.filter(
@@ -299,9 +289,7 @@ class RunTest:
         applicant = users_factories.UserFactory(firstName="Doe", lastName="John", email="john.doe@test.com")
 
         # when
-        import_dms_users.run(
-            procedure_id=6712558,
-        )
+        import_dms_users.run(procedure_id=6712558)
 
         # then
         on_sucessful_application.assert_called_with(
@@ -786,12 +774,24 @@ class RunIntegrationTest:
         assert user.phoneNumber == "0102030405"
         assert user.idPieceNumber == "1234123412"
 
-        assert len(user.beneficiaryFraudChecks) == 1
-        fraud_check = user.beneficiaryFraudChecks[0]
-        assert fraud_check.type == fraud_models.FraudCheckType.DMS
-        fraud_content = fraud_models.DMSContent(**fraud_check.resultContent)
+        assert len(user.beneficiaryFraudChecks) == 2
+
+        dms_fraud_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.DMS
+        )
+        dms_fraud_check = user.beneficiaryFraudChecks[0]
+        assert dms_fraud_check.type == fraud_models.FraudCheckType.DMS
+        fraud_content = fraud_models.DMSContent(**dms_fraud_check.resultContent)
         assert fraud_content.birth_date == user.dateOfBirth.date()
         assert fraud_content.address == "11 Rue du Test"
+
+        assert next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.HONOR_STATEMENT
+        )
 
         assert BeneficiaryImport.query.count() == 1
         beneficiary_import = BeneficiaryImport.query.first()
@@ -1232,10 +1232,21 @@ class GraphQLSourceProcessApplicationTest:
         import_status = BeneficiaryImport.query.one_or_none()
         assert import_status.currentStatus == ImportStatus.CREATED
         assert import_status.beneficiary == user
-        assert len(user.beneficiaryFraudChecks) == 1
-        fraud_check = user.beneficiaryFraudChecks[0]
-        assert not fraud_check.reasonCodes
-        assert fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert len(user.beneficiaryFraudChecks) == 2
+        dms_fraud_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.DMS
+        )
+        assert not dms_fraud_check.reasonCodes
+        assert dms_fraud_check.status == fraud_models.FraudCheckStatus.OK
+        statement_fraud_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.HONOR_STATEMENT
+        )
+        assert statement_fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert statement_fraud_check.reason == "honor statement contained in DMS application"
 
     @patch.object(DMSGraphQLClient, "get_applications_with_details")
     def test_run(self, get_applications_with_details):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11121

Ticket 11121 car il y a un bug avec Educonnect : on renvoie toujours nextStep = "IDENTITY_CHECK" même si un dossier educonnect a été déposé.

J'en ai profité pour refacto : 
- missing_steps -> déplacement dans `subscription.api`
- ajout d'une méthode un peu plus claire `needs_to_perform_identity_check(user)`

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
