### PR TITLE
(PC-11121) Add can_activate_beneficiary method

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -105,7 +105,11 @@ def create_successfull_beneficiary_import(
     return beneficiary_import
 
 
-def can_activate_beneficiary(user: users_models.User, eligibilityType: users_models.EligibilityType) -> bool:
+def can_activate_beneficiary(
+    user: users_models.User, eligibilityType: typing.Optional[users_models.EligibilityType] = None
+) -> bool:
+    if not eligibilityType:
+        eligibilityType = user.eligibility
     return user.is_eligible_for_beneficiary_upgrade(eligibilityType) and not get_missing_subscription_steps(
         user, eligibilityType
     )

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -31,7 +31,6 @@ import pcapi.core.payments.api as payment_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import exceptions as subscription_exceptions
 from pcapi.core.subscription import messages as subscription_messages
-import pcapi.core.subscription.repository as subscription_repository
 from pcapi.core.users import utils as users_utils
 from pcapi.core.users.constants import UNDERAGE_GENERALISATION_BROAD_OPENING_DATETIME
 from pcapi.core.users.constants import UNDERAGE_GENERALISATION_EARLY_OPENING_DATETIME
@@ -234,35 +233,10 @@ def initialize_account(
     return user
 
 
-def steps_to_become_beneficiary(user: User) -> list[BeneficiaryValidationStep]:
-    missing_steps = []
-
-    if (
-        not user.is_phone_validated
-        and user.eligibility != EligibilityType.UNDERAGE
-        and FeatureToggle.FORCE_PHONE_VALIDATION.is_active()
-    ):
-        missing_steps.append(BeneficiaryValidationStep.PHONE_VALIDATION)
-
-    beneficiary_import = subscription_repository.get_beneficiary_import_for_beneficiary(user)
-    if not beneficiary_import or (
-        beneficiary_import.eligibilityType == EligibilityType.UNDERAGE and user.has_underage_beneficiary_role
-    ):
-        missing_steps.append(BeneficiaryValidationStep.ID_CHECK)
-
-    if not fraud_api.has_performed_honor_statement(user):
-        if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
-            logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})
-        else:
-            missing_steps.append(BeneficiaryValidationStep.HONOR_STATEMENT)
-
-    return missing_steps
-
-
 def validate_phone_number_and_activate_user(user: User, code: str) -> User:
     validate_phone_number(user, code)
 
-    if not steps_to_become_beneficiary(user):
+    if subscription_api.can_activate_beneficiary(user, user.eligibility):
         try:
             subscription_api.activate_beneficiary(user)
         except subscription_exceptions.CannotUpgradeBeneficiaryRole:

--- a/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
+++ b/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription.models import BeneficiaryPreSubscription
-from pcapi.core.users import api as users_api
 from pcapi.core.users.external import update_external_user
 from pcapi.core.users.models import User
 from pcapi.infrastructure.repository.beneficiary import beneficiary_pre_subscription_sql_converter
@@ -28,7 +27,7 @@ class BeneficiarySQLRepository:
         )
         repository.save(user_sql_entity)
 
-        if not users_api.steps_to_become_beneficiary(user_sql_entity):
+        if subscription_api.can_activate_beneficiary(user, beneficiary_pre_subscription.eligibility_type):
             user_sql_entity = subscription_api.check_and_activate_beneficiary(
                 user_sql_entity.id, has_activated_account=user is not None
             )

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -4,7 +4,6 @@ from typing import Optional
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import school_types
-from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
 from pcapi.routes.native.security import authenticated_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -76,5 +75,5 @@ def get_school_types() -> serializers.SchoolTypesResponse:
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
 
-    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user):
+    if subscription_api.can_activate_beneficiary(user, user.eligibility):
         subscription_api.activate_beneficiary(user)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -54,7 +54,7 @@ class JouveFraudCheckTest:
         "postalCode": "",
         "posteCode": "678083",
         "posteCodeCtrl": "OK",
-        "registrationDate": f"{datetime.datetime.now():%d/%m/%Y %H%M}",
+        "registrationDate": f"{datetime.datetime.now():%d/%m/%Y %H:%M}",
         "serviceCode": "1",
         "serviceCodeCtrl": "OK",
     }

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -800,3 +800,81 @@ class DMSSubscriptionTest:
         assert user.subscriptionState == users_models.SubscriptionState.identity_check_pending
         assert fraud_check.user == user
         assert fraud_check.status == fraud_models.FraudCheckStatus.PENDING
+
+
+@pytest.mark.usefixtures("db_session")
+class MissingSubscriptionStepsTest:
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+
+    def eligible_user(self, validate_phone: bool):
+        phone_validation_status = users_models.PhoneValidationStatusType.VALIDATED if validate_phone else None
+        return users_factories.UserFactory(
+            dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE, phoneValidationStatus=phone_validation_status
+        )
+
+    def set_beneficiary_import(self, user, status: str = ImportStatus.CREATED) -> BeneficiaryImport:
+        beneficiary_import = users_factories.BeneficiaryImportFactory(
+            beneficiary=user, source=BeneficiaryImportSources.jouve
+        )
+        beneficiary_import.setStatus(status, author=user)
+
+        return beneficiary_import
+
+    def test_no_missing_step(self):
+        user = self.eligible_user(validate_phone=True)
+
+        beneficiary_import = users_factories.BeneficiaryImportFactory(
+            applicationId=0, beneficiary=user, source=BeneficiaryImportSources.jouve.value
+        )
+        beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
+        user.hasCompletedIdCheck = True
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
+
+        assert subscription_api.get_missing_subscription_steps(user, user.eligibility) == []
+
+    @override_features(FORCE_PHONE_VALIDATION=True)
+    def test_missing_step(self):
+        user = self.eligible_user(validate_phone=False)
+
+        beneficiary_import = users_factories.BeneficiaryImportFactory(beneficiary=user)
+        beneficiary_import.setStatus(ImportStatus.CREATED, author=user)
+        user.hasCompletedIdCheck = True
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
+
+        assert subscription_api.get_missing_subscription_steps(user, user.eligibility) == [
+            subscription_models.SubscriptionStep.PHONE_VALIDATION
+        ]
+        assert not user.has_beneficiary_role
+
+    @override_features(FORCE_PHONE_VALIDATION=True)
+    def test_rejected_import(self):
+        user = self.eligible_user(validate_phone=False)
+
+        beneficiary_import = users_factories.BeneficiaryImportFactory(beneficiary=user)
+        beneficiary_import.setStatus(ImportStatus.REJECTED, author=user)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
+
+        expected = [
+            subscription_models.SubscriptionStep.PHONE_VALIDATION,
+            subscription_models.SubscriptionStep.IDENTITY_CHECK,
+        ]
+        assert subscription_api.get_missing_subscription_steps(user, user.eligibility) == expected
+        assert not user.has_beneficiary_role
+
+    @override_features(FORCE_PHONE_VALIDATION=True)
+    def test_missing_all(self):
+        user = self.eligible_user(validate_phone=False)
+
+        expected = [
+            subscription_models.SubscriptionStep.PHONE_VALIDATION,
+            subscription_models.SubscriptionStep.IDENTITY_CHECK,
+            subscription_models.SubscriptionStep.HONOR_STATEMENT,
+        ]
+        assert subscription_api.get_missing_subscription_steps(user, user.eligibility) == expected
+        assert not user.has_beneficiary_role


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11121

Lié au ticket 11121 car il y a un bug avec Educonnect : on renvoie toujours nextStep = "IDENTITY_CHECK" même si un dossier educonnect a été déposé.

J'en ai profité pour refacto :
- missing_steps -> déplacement dans subscription.api
- ajout d'une méthode un peu plus claire needs_to_perform_identity_check(user)



## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
