### PR TITLE
[PC-11728][api] add subscription message for Ubble

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -249,6 +249,7 @@ def update_ubble_workflow(
     if status == fraud_models.ubble.UbbleIdentificationStatus.PROCESSING:
         user.hasCompletedIdCheck = True
         pcapi_repository.repository.save(user)
+        subscription_messages.on_review_pending(user)
 
     elif status == fraud_models.ubble.UbbleIdentificationStatus.PROCESSED:
         try:
@@ -268,6 +269,7 @@ def update_ubble_workflow(
                     user=user,
                     reason_codes=fraud_check.reasonCodes,
                 )
+                subscription_messages.on_ubble_journey_cannot_continue(user)
                 return
 
             try:

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -7,6 +7,7 @@ from . import models
 
 
 INBOX_URL = "passculture://openInbox"
+REDIRECT_TO_DMS_VIEW = "passculture://verification-identite/demarches-simplifiees"
 
 DMS_ERROR_MESSAGE_USER_NOT_FOUND = """Bonjour,
                 
@@ -77,6 +78,25 @@ def create_message_jouve_manual_review(user: users_models.User, application_id: 
         user=user,
         userMessage=f"Nous avons reçu ton dossier le {today:%d/%m/%Y} et son analyse est en cours. Cela peut prendre jusqu'à 5 jours.",
         popOverIcon=models.PopOverIcon.CLOCK,
+    )
+    repository.save(message)
+
+
+def on_review_pending(user: users_models.User) -> None:
+    message = models.SubscriptionMessage(
+        user=user,
+        userMessage="Ton document d'identité est en cours de vérification.",
+        popOverIcon=models.PopOverIcon.CLOCK,
+    )
+    repository.save(message)
+
+
+def on_ubble_journey_cannot_continue(user: users_models.User) -> None:
+    message = models.SubscriptionMessage(
+        user=user,
+        userMessage="Désolé, la vérification de ton identité n'a pas pu aboutir. Nous t'invitons à passer par le site Démarches-Simplifiées.",
+        callToActionLink=REDIRECT_TO_DMS_VIEW,
+        callToActionIcon=models.CallToActionIcon.EXTERNAL,
     )
     repository.save(message)
 

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -111,6 +111,7 @@ class BeneficiaryPreSubscription:
 class CallToActionIcon(enum.Enum):
     EMAIL = "EMAIL"
     RETRY = "RETRY"
+    EXTERNAL = "EXTERNAL"
 
 
 class PopOverIcon(enum.Enum):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11728


## But de la pull request

Ajouter les messages de com in app sur le parcours d'inscription Ubble

##  Implémentation

- Ajout d'un type d'icône CTA External pour les liens de type externes
​
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
