### PR TITLE
[api][requirements] Bump version of lxml

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -30,7 +30,7 @@ ipaddress
 isort==5.6.4
 itsdangerous==1.1.0
 Jinja2==2.11.3
-lxml==4.6.3
+lxml
 mailjet-rest==1.3.3
 MarkupSafe==1.1.1
 mypy==0.812


### PR DESCRIPTION
lxml 4.6.5 and 4.7.1 have been released with a security fix:

    https://lxml.de/4.7/changes-4.7.1.html#id3

Our only direct use of lxml is to generate banking XML files
(which we actually don't send to the bank). Our indirect uses are less
clear. I don't think that we could be affected by the security bug.
Nevertheless, it looks easy enough to be up-to-date.