### PR TITLE
(PC-11121) Fix next step after educonnect success

### DIFF
--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -732,6 +732,16 @@ def has_user_performed_ubble_check(user: users_models.User) -> bool:
     ).scalar()
 
 
+def has_passed_educonnect(user: users_models.User) -> bool:
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.OK,
+            models.BeneficiaryFraudCheck.type == models.FraudCheckType.EDUCONNECT,
+        ).exists()
+    ).scalar()
+
+
 def is_risky_user_profile(user: users_models.User) -> bool:
     user_profiling = (
         models.BeneficiaryFraudCheck.query.filter(models.BeneficiaryFraudCheck.user == user)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -306,6 +306,7 @@ def needs_to_perform_identity_check(user: users_models.User) -> bool:
         not user.hasCompletedIdCheck
         and not (fraud_api.has_user_performed_ubble_check(user) and FeatureToggle.ENABLE_UBBLE.is_active())
         and not user.extraData.get("is_identity_document_uploaded")  # Jouve
+        and not (fraud_api.has_passed_educonnect(user) and user.eligibility == users_models.EligibilityType.UNDERAGE)
     )
 
 

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -300,6 +300,15 @@ def has_completed_profile(user: users_models.User) -> bool:
     return user.city is not None
 
 
+def needs_to_perform_identity_check(user: users_models.User) -> bool:
+    # TODO (viconnex) refacto this method to base result on fraud_checks made
+    return (
+        not user.hasCompletedIdCheck
+        and not (fraud_api.has_user_performed_ubble_check(user) and FeatureToggle.ENABLE_UBBLE.is_active())
+        and not user.extraData.get("is_identity_document_uploaded")  # Jouve
+    )
+
+
 # pylint: disable=too-many-return-statements
 def get_next_subscription_step(user: users_models.User) -> typing.Optional[models.SubscriptionStep]:
     # TODO(viconnex): base the next step on the user.subscriptionState that will be added later on
@@ -331,12 +340,7 @@ def get_next_subscription_step(user: users_models.User) -> typing.Optional[model
     if not has_completed_profile(user):
         return models.SubscriptionStep.PROFILE_COMPLETION
 
-    if (
-        not user.hasCompletedIdCheck
-        and allowed_identity_check_methods
-        and not (fraud_api.has_user_performed_ubble_check(user) and FeatureToggle.ENABLE_UBBLE.is_active())
-        and not user.extraData.get("is_identity_document_uploaded")  # Jouve
-    ):
+    if needs_to_perform_identity_check(user) and allowed_identity_check_methods:
         return models.SubscriptionStep.IDENTITY_CHECK
 
     if not fraud_api.has_performed_honor_statement(user):

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -203,7 +203,7 @@ class EduconnectFlowTest:
 
     @freeze_time("2021-10-10")
     @patch("pcapi.core.users.external.educonnect.api.get_saml_client")
-    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True, ENABLE_EDUCONNECT_AUTHENTICATION=True)
     def test_educonnect_subscription(self, mock_get_educonnect_saml_client, client, app):
         ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
         fraud_factories.IneHashWhitelistFactory(ine_hash=ine_hash)
@@ -279,6 +279,7 @@ class EduconnectFlowTest:
         assert user.ineHash == ine_hash
 
         assert not user.is_beneficiary
+        assert subscription_api.get_next_subscription_step(user) == subscription_models.SubscriptionStep.HONOR_STATEMENT
 
         response = client.post("/native/v1/subscription/honor_statement")
 

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -10,6 +10,7 @@ import freezegun
 import pytest
 
 from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud.api import has_passed_educonnect
 import pcapi.core.fraud.models as fraud_models
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
@@ -143,6 +144,7 @@ class EduconnectTest:
             "student_level": "2212",
         }
         assert len(user.beneficiaryFraudResults) == 1
+        assert has_passed_educonnect(user)
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
         beneficiary_import = BeneficiaryImport.query.filter_by(beneficiaryId=user.id).one_or_none()
         assert beneficiary_import.currentStatus == ImportStatus.CREATED


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11121

Lié au ticket 11121 car il y a un bug avec Educonnect : on renvoie toujours nextStep = "IDENTITY_CHECK" même si un dossier educonnect a été déposé.
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
