### PR TITLE
(PC-12249) api: Add eligibilityType to BeneficiaryFraudCheck

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-b5eab9709bdd (head)
+608d334310cd (head)

--- a/api/src/pcapi/admin/custom_views/support_view.py
+++ b/api/src/pcapi/admin/custom_views/support_view.py
@@ -249,7 +249,7 @@ class BeneficiaryView(base_configuration.BaseAdminView):
             flask.flash("Fonctionnalité non activée", "error")
             return flask.redirect(flask.url_for(".details_view", id=user_id))
         if not self.check_super_admins() and not flask_login.current_user.has_jouve_role:
-            flask.flash("Vous n'avez pas les droits suffisant pour activer ce bénéficiaire", "error")
+            flask.flash("Vous n'avez pas les droits suffisants pour activer ce bénéficiaire", "error")
             return flask.redirect(flask.url_for(".details_view", id=user_id))
         form = FraudReviewForm(flask.request.form)
         if not form.validate():
@@ -304,7 +304,7 @@ class BeneficiaryView(base_configuration.BaseAdminView):
     @flask_admin.expose("/update/beneficiary/id_piece_number/<user_id>", methods=["POST"])
     def update_beneficiary_id_piece_number(self, user_id: int) -> Response:
         if not self.check_super_admins() and not flask_login.current_user.has_jouve_role:
-            flask.flash("Vous n'avez pas les droits suffisant pour activer ce bénéficiaire", "error")
+            flask.flash("Vous n'avez pas les droits suffisants pour activer ce bénéficiaire", "error")
             return flask.redirect(flask.url_for(".details_view", id=user_id))
 
         form = IDPieceNumberForm(flask.request.form)
@@ -338,18 +338,20 @@ class BeneficiaryView(base_configuration.BaseAdminView):
                     fraud_check.source_data()
                 )
                 fraud_api.create_honor_statement_fraud_check(
-                    user, "honor statement contained in DMS application after admin review"
+                    user,
+                    "honor statement contained in DMS application after admin review",
+                    fraud_api.get_eligibility_type(fraud_check.source_data()),
                 )
             beneficiary_repository.BeneficiarySQLRepository.save(pre_subscription, user)
 
-        flask.flash(f"N° de pièce d'identitée modifiée sur le bénéficiaire {user.firstName} {user.lastName}")
+        flask.flash(f"N° de pièce d'identité modifiée sur le bénéficiaire {user.firstName} {user.lastName}")
         return flask.redirect(flask.url_for(".details_view", id=user_id))
 
     @flask_admin.expose("/validate/beneficiary/phone_number/<user_id>", methods=["POST"])
     def validate_phone_number(self, user_id: int) -> Response:
         if not flask_login.current_user.has_admin_role:
             flask.flash(
-                "Vous n'avez pas les droits suffisant pour valider le numéro de téléphone de cet utilisateur", "error"
+                "Vous n'avez pas les droits suffisants pour valider le numéro de téléphone de cet utilisateur", "error"
             )
             return flask.redirect(flask.url_for(".details_view", id=user_id))
 

--- a/api/src/pcapi/alembic/versions/20211210T142011_608d334310cd_add_fraud_check_eligibility_type.py
+++ b/api/src/pcapi/alembic/versions/20211210T142011_608d334310cd_add_fraud_check_eligibility_type.py
@@ -1,0 +1,23 @@
+"""
+Add eligilibilityType to BeneficiaryFraudCheck
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "608d334310cd"
+down_revision = "b5eab9709bdd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "beneficiary_fraud_check",
+        sa.Column("eligibilityType", sa.TEXT(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("beneficiary_fraud_check", "eligibilityType")

--- a/api/src/pcapi/core/fraud/api/ubble.py
+++ b/api/src/pcapi/core/fraud/api/ubble.py
@@ -53,6 +53,7 @@ def start_ubble_fraud_check(user: users_models.User, ubble_content: fraud_models
         thirdPartyId=str(ubble_content.identification_id),
         resultContent=ubble_content,
         status=fraud_models.FraudCheckStatus.PENDING,
+        eligibilityType=user.eligibility,
     )
     db.session.add(fraud_check)
     db.session.commit()
@@ -61,7 +62,7 @@ def start_ubble_fraud_check(user: users_models.User, ubble_content: fraud_models
 def get_ubble_fraud_check(identification_id: str) -> typing.Optional[fraud_models.BeneficiaryFraudCheck]:
     fraud_check = (
         fraud_models.BeneficiaryFraudCheck.query.filter(
-            fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE
+            fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE,
         )
         .filter(fraud_models.BeneficiaryFraudCheck.thirdPartyId == identification_id)
         .one_or_none()

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -11,6 +11,7 @@ import pytz
 
 from pcapi.core import testing
 import pcapi.core.fraud.models as fraud_models
+from pcapi.core.users import models as users_models
 import pcapi.core.users.factories as users_factories
 
 from . import models
@@ -117,9 +118,9 @@ class UbbleContentFactory(factory.Factory):
         model = fraud_models.ubble.UbbleContent
 
     status = None
-    birth_date = None
-    first_name = None
-    last_name = None
+    birth_date = (date.today() - relativedelta(years=18, months=4)).isoformat()
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
     document_type = None
     id_document_number = None
     score = None
@@ -128,7 +129,7 @@ class UbbleContentFactory(factory.Factory):
     supported = None
     identification_id = None
     identification_url = None
-    registration_datetime = None
+    registration_datetime = datetime.now()
 
 
 class EduconnectContentFactory(factory.Factory):
@@ -164,6 +165,7 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
     type = models.FraudCheckType.JOUVE
     thirdPartyId = factory.LazyFunction(lambda: str(uuid.uuid4()))
     status = models.FraudCheckStatus.PENDING
+    eligibilityType = users_models.EligibilityType.AGE18
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):

--- a/api/src/pcapi/core/fraud/models/__init__.py
+++ b/api/src/pcapi/core/fraud/models/__init__.py
@@ -299,6 +299,13 @@ class BeneficiaryFraudCheck(PcObject, Model):
         nullable=True,
     )
 
+    # Unlike BeneficiaryFraudResult, the eligibility is nullable here to support existing objects.
+    # A script may fill in this column for past objects.
+    eligibilityType = sqlalchemy.Column(
+        sqlalchemy.Enum(users_models.EligibilityType, create_constraint=False),
+        nullable=True,
+    )
+
     def source_data(self) -> typing.Union[IdentityCheckContent, UserProfilingFraudData]:
         if self.type not in FRAUD_CHECK_MAPPING:
             raise NotImplementedError(f"Cannot unserialize type {self.type}")

--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -15,9 +15,12 @@ def get_current_beneficiary_fraud_result(
 
 
 def get_last_user_profiling_fraud_check(user: users_models.User) -> Optional[models.BeneficiaryFraudCheck]:
+    # User profiling is not performed for UNDERAGE credit, no need to filter on eligibilityType here
     return (
-        models.BeneficiaryFraudCheck.query.filter(models.BeneficiaryFraudCheck.user == user)
-        .filter(models.BeneficiaryFraudCheck.type == models.FraudCheckType.USER_PROFILING)
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.type == models.FraudCheckType.USER_PROFILING,
+        )
         .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
         .first()
     )

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -208,6 +208,9 @@ class BeneficiaryGrant18Factory(BaseFactory):
             )
             if obj.eligibility == users_models.EligibilityType.UNDERAGE
             else fraud_factories.JouveContentFactory(firstName=obj.firstName, lastName=obj.lastName),
+            eligibilityType=users_models.EligibilityType.UNDERAGE
+            if obj.eligibility == users_models.EligibilityType.UNDERAGE
+            else users_models.EligibilityType.AGE18,
         )
 
     @factory.post_generation

--- a/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
+++ b/api/src/pcapi/infrastructure/repository/beneficiary/beneficiary_sql_repository.py
@@ -28,7 +28,7 @@ class BeneficiarySQLRepository:
         )
         repository.save(user_sql_entity)
 
-        if not users_api.steps_to_become_beneficiary(user_sql_entity):
+        if not users_api.steps_to_become_beneficiary(user_sql_entity, beneficiary_pre_subscription.eligibility_type):
             user_sql_entity = subscription_api.check_and_activate_beneficiary(
                 user_sql_entity.id, has_activated_account=user is not None
             )

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -418,6 +418,12 @@ def start_identification_session(
     user: User, body: serializers.IdentificationSessionRequest
 ) -> serializers.IdentificationSessionResponse:
 
+    if user.eligibility is None:
+        raise ApiErrors(
+            {"code": "IDCHECK_NOT_ELIGIBLE", "message": "Non éligible à un crédit"},
+            status_code=400,
+        )
+
     if fraud_api.has_user_performed_ubble_check(user):
         raise ApiErrors(
             {"code": "IDCHECK_ALREADY_PROCESSED", "message": "Une identification a déjà été traitée"},

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -79,5 +79,5 @@ def get_profile_options() -> serializers.ProfileOptionsResponse:
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
 
-    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user):
+    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user, user.eligibility):
         subscription_api.activate_beneficiary(user)

--- a/api/src/pcapi/scripts/beneficiary/import_dms_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_dms_users.py
@@ -196,10 +196,15 @@ def process_application(
             return
 
         try:
-            fraud_api.create_honor_statement_fraud_check(user, "honor statement contained in DMS application")
+            eligibility_type = fraud_api.get_eligibility_type(information)
+
+            fraud_api.create_honor_statement_fraud_check(
+                user, "honor statement contained in DMS application", eligibility_type
+            )
             subscription_api.on_successful_application(
                 user=user,
                 source_data=information,
+                eligibility_type=eligibility_type,
                 application_id=application_id,
                 source_id=procedure_id,
                 source=BeneficiaryImportSources.demarches_simplifiees,

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -305,6 +305,10 @@
   <div class="col-lg-4">
     <table class="table">
       <tr>
+        <th scope="row">Souscription</th>
+        <td>{{ "pass 15-17" if check.eligibilityType.value == "underage" else "pass 18 ans" if check.eligibilityType.value == "age-18" else "inconnu" }}</td>
+      </tr>
+      <tr>
         <th scope="row">Type</th>
         <td>{{ check.type.value }}</td>
       </tr>

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -402,6 +402,7 @@ class UpdateIDPieceNumberTest:
 
         assert len(user.beneficiaryFraudResults) == 1
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
+        assert user.beneficiaryFraudResults[0].eligibilityType == users_models.EligibilityType.AGE18
         assert fraud_check.resultContent["id_piece_number"] == id_piece_number
         assert user.idPieceNumber == id_piece_number
         assert user.has_beneficiary_role

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -476,7 +476,7 @@ class StepsToBecomeBeneficiaryTest:
             user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
         )
 
-        assert steps_to_become_beneficiary(user) == []
+        assert steps_to_become_beneficiary(user, EligibilityType.AGE18) == []
 
     @override_features(FORCE_PHONE_VALIDATION=True)
     def test_missing_step(self):
@@ -489,7 +489,7 @@ class StepsToBecomeBeneficiaryTest:
             user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
         )
 
-        assert steps_to_become_beneficiary(user) == [BeneficiaryValidationStep.PHONE_VALIDATION]
+        assert steps_to_become_beneficiary(user, EligibilityType.AGE18) == [BeneficiaryValidationStep.PHONE_VALIDATION]
         assert not user.has_beneficiary_role
 
     @override_features(FORCE_PHONE_VALIDATION=True)
@@ -506,7 +506,7 @@ class StepsToBecomeBeneficiaryTest:
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
         ]
-        assert steps_to_become_beneficiary(user) == expected
+        assert steps_to_become_beneficiary(user, EligibilityType.AGE18) == expected
         assert not user.has_beneficiary_role
 
     @override_features(FORCE_PHONE_VALIDATION=True, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
@@ -518,7 +518,7 @@ class StepsToBecomeBeneficiaryTest:
             BeneficiaryValidationStep.ID_CHECK,
             BeneficiaryValidationStep.HONOR_STATEMENT,
         ]
-        assert steps_to_become_beneficiary(user) == expected
+        assert steps_to_become_beneficiary(user, EligibilityType.AGE18) == expected
         assert not user.has_beneficiary_role
 
     @override_features(FORCE_PHONE_VALIDATION=True, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=False)
@@ -529,7 +529,7 @@ class StepsToBecomeBeneficiaryTest:
             BeneficiaryValidationStep.PHONE_VALIDATION,
             BeneficiaryValidationStep.ID_CHECK,
         ]
-        assert steps_to_become_beneficiary(user) == expected
+        assert steps_to_become_beneficiary(user, EligibilityType.AGE18) == expected
         assert not user.has_beneficiary_role
 
 

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -277,6 +277,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionState == users_models.SubscriptionState.identity_check_pending
         assert user.beneficiaryFraudChecks[0].status == fraud_models.FraudCheckStatus.PENDING
         assert user.beneficiaryFraudChecks[0].type == fraud_models.FraudCheckType.DMS
+        assert user.beneficiaryFraudChecks[0].eligibilityType == users_models.EligibilityType.AGE18
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -310,6 +310,7 @@ class RunTest:
                 registration_datetime=datetime(2020, 4, 17, 7, 18, 22, 534000, tzinfo=timezone.utc),
                 id_piece_number="123123121",
             ),
+            eligibility_type=users_models.EligibilityType.AGE18,
             application_id=123,
             source_id=6712558,
             source=BeneficiaryImportSources.demarches_simplifiees,

--- a/api/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/api/tests/use_cases/create_beneficiary_from_application_test.py
@@ -58,6 +58,8 @@ JOUVE_CONTENT = {
     "lastName": "DURAND",
     "phoneNumber": "0123456789",
     "postalCode": "35123",
+    "registrationDate": f"{datetime.now():%d/%m/%Y %H:%M}",
+    "serviceCodeCtrl": "OK",
 }
 
 
@@ -152,7 +154,7 @@ def test_application_for_native_app_user(_get_raw_content_mock, client):
     beneficiary = User.query.one()
 
     # the fake Jouve backend returns a default phone number. Since a User
-    # alredy exists, the phone number should not be updated during the import process
+    # already exists, the phone number should not be updated during the import process
     assert beneficiary.phoneNumber == "0607080900"
 
     deposit = Deposit.query.one()
@@ -171,7 +173,7 @@ def test_application_for_native_app_user(_get_raw_content_mock, client):
 
 @override_features(FORCE_PHONE_VALIDATION=False, IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=False)
 @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content", return_value=JOUVE_CONTENT)
-def test_application_for_native_app_user_honor_statemlent_optional(_get_raw_content_mock):
+def test_application_for_native_app_user_honor_statement_optional(_get_raw_content_mock):
     # Given
     users_api.create_account(
         email=JOUVE_CONTENT["email"],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12249

## But de la pull request

Associer un eligibilityType au BeneficiaryFraudCheck afin de pouvoir retrouver si une identification Ubble (ou autre) était faite pour le crédit 15-17 ou pour le crédit de 300€.

##  Implémentation

Stratégie tech : voir ticket Jira
​
##  Informations supplémentaires

Bien testé par les tests unitaires, mais mieux vaut re-tester toutes les procédures d'inscription une fois sur testing !
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
