### PR TITLE
(PC-12317) do not call /offers/offerid when offer is set

### DIFF
--- a/pro/src/components/hooks/useNotification.js
+++ b/pro/src/components/hooks/useNotification.js
@@ -1,24 +1,31 @@
+import { useCallback, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 
 import { showNotification } from 'store/reducers/notificationReducer'
 
 const useNotification = () => {
   const dispatch = useDispatch()
-  const dispatchNotification = (textMessage, type) => {
-    dispatch(
-      showNotification({
-        text: textMessage,
-        type: type,
-      })
-    )
-  }
+  const dispatchNotification = useCallback(
+    (textMessage, type) => {
+      dispatch(
+        showNotification({
+          text: textMessage,
+          type: type,
+        })
+      )
+    },
+    [dispatch]
+  )
 
-  return {
-    success: msg => dispatchNotification(msg, 'success'),
-    error: msg => dispatchNotification(msg, 'error'),
-    pending: msg => dispatchNotification(msg, 'pending'),
-    information: msg => dispatchNotification(msg, 'information'),
-  }
+  return useMemo(
+    () => ({
+      success: msg => dispatchNotification(msg, 'success'),
+      error: msg => dispatchNotification(msg, 'error'),
+      pending: msg => dispatchNotification(msg, 'pending'),
+      information: msg => dispatchNotification(msg, 'information'),
+    }),
+    [dispatchNotification]
+  )
 }
 
 export default useNotification

--- a/pro/src/routes/OfferEducationalStockCreation/OfferEducationalStockCreation.tsx
+++ b/pro/src/routes/OfferEducationalStockCreation/OfferEducationalStockCreation.tsx
@@ -44,18 +44,20 @@ const OfferEducationalStockCreation = (): JSX.Element => {
   }
 
   useEffect(() => {
-    const loadOffer = async () => {
-      const { payload, message, isOk } = await getOfferAdapter(offerId)
-      if (isOk) {
-        setOffer(payload.offer)
-        setIsReady(true)
-        return
+    if (!isReady) {
+      const loadOffer = async () => {
+        const { payload, message, isOk } = await getOfferAdapter(offerId)
+        if (isOk) {
+          setOffer(payload.offer)
+          setIsReady(true)
+          return
+        }
+        notify.error(message)
       }
-      notify.error(message)
-    }
 
-    loadOffer()
-  }, [offerId, notify])
+      loadOffer()
+    }
+  }, [offerId, notify, isReady])
 
   return (
     <OfferEducationalLayout


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12317


## But de la pull request

Eviter les appels répétitifs à /offers/offerid

##  Implémentation

- Le hook useNotification provoquait trop de rerender à cause de sa dépendance dans le useEffect. Pour éviter ca, j'ai wrappé la fonction utilisée dans le useNptification dans un useCallback pour mémoiser cette fonction et éviter qu'elle change de référence
- Dans le useEffect, on ne fait l'appel à getOfferAdapter que si on n'a pas déjà fait cet appel (utilisation du state `isReady`, setté à true après l'appel)
​
