### PR TITLE
[PC-11623][api][finance] Exclude free bookings from payments CSV file

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -552,6 +552,7 @@ def _generate_payments_file(batch_id: int) -> pathlib.Path:
         models.Pricing.query.filter_by(status=models.PricingStatus.VALIDATED)
         .join(models.Pricing.cashflows)
         .join(models.Pricing.booking)
+        .filter(bookings_models.Booking.amount != 0)
         .join(models.Pricing.businessUnit)
         .join(
             BusinessUnitVenue,

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -451,6 +451,15 @@ def test_generate_payments_file():
         booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         booking__stock__offer__venue=venue1,
     )
+    # A free booking that should not appear in the CSV file.
+    factories.PricingFactory(
+        amount=0,
+        booking__amount=0,
+        booking__dateUsed=used_date,
+        booking__stock__offer__name="Une histoire gratuite",
+        booking__stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+        booking__stock__offer__venue=venue1,
+    )
     # These other pricings belong to a business unit whose venue is
     # NOT the venue of the offers.
     business_unit_venue2 = offers_factories.VenueFactory(


### PR DESCRIPTION
They are not included in the "old-style" CSV file, there is no reason
to include them in the "new-style" one.


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11623