### PR TITLE
(PC-12319) refactor: Rename /school_types route to profile_options

### DIFF
--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -55,7 +55,7 @@ def update_profile(user: users_models.User, body: serializers.ProfileUpdateReque
     )
 
 
-@blueprint.native_v1.route("/subscription/school_types", methods=["GET"])
+@blueprint.native_v1.route("/subscription/profile_options", methods=["GET"])
 @spectree_serialize(
     response_model=serializers.SchoolTypesResponse,
     on_success_status=200,

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -239,7 +239,7 @@ class UpdateProfileTest:
 
 class SchoolTypeTest:
     def test_get_all_school_types(self, client):
-        response = client.get("/native/v1/subscription/school_types")
+        response = client.get("/native/v1/subscription/profile_options")
 
         assert response.status_code == 200
         assert response.json == {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12319


## But de la pull request

Renommer la route pour plus de cohérence avec ce qu'elle expose

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
