### PR TITLE
(BSR) Fix user statemachine initialization

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -496,11 +496,12 @@ class User(PcObject, Model, NeedsValidationMixin):
         )
 
     @classmethod
-    def init_subscription_state_machine(cls, obj, *args, **kwargs):
+    def init_subscription_state_machine(cls, obj, *args, **kwargs) -> None:
         from pcapi.core.subscription import transitions as subscription_transitions
 
         if not kwargs:
-            kwargs = args[-1]
+            if isinstance(args[-1], dict):
+                kwargs = args[-1]
 
         initial_state = obj.subscriptionState or kwargs.get("subscriptionState", SubscriptionState.account_created)
 

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -11,6 +11,9 @@ from pcapi.core.testing import override_settings
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as user_models
 from pcapi.core.users.exceptions import InvalidUserRoleException
+from pcapi.models import db
+
+from tests.conftest import clean_database
 
 
 @pytest.mark.usefixtures("db_session")
@@ -256,3 +259,24 @@ class SuperAdminTest:
     def test_super_user_not_prod_is_admin_is_super_admin(self):
         user = users_factories.AdminFactory()
         assert user.is_super_admin()
+
+
+class SubscriptionStateTest:
+    @pytest.mark.usefixtures("db_session")
+    def test_trigger_init_event(self):
+        user = users_factories.UserFactory(subscriptionState=user_models.SubscriptionState.user_profiling_validated)
+        assert user.subscriptionState == user_models.SubscriptionState.user_profiling_validated
+
+    @pytest.mark.usefixtures("db_session")
+    def test_trigger_default_state(self):
+        user = users_factories.UserFactory()
+        assert user.subscriptionState == user_models.SubscriptionState.account_created
+
+    @clean_database
+    def test_trigger_load_event(self):
+        user = users_factories.UserFactory.build()
+        new_session = db.create_scoped_session()
+        new_session.add(user)
+        new_session.commit()
+        new_user = user_models.User.query.get(user.id)
+        assert hasattr(new_user, "_subscriptionStateMachine")


### PR DESCRIPTION
SQLAlchemy events are quite ambigous, and callback does not have the same
signature.

This ensure we carefully loads data from guessed kwargs when creating an ORM object
(such as init event) from a dict.

On a load event (when data is fetched from the database), the callback signature slightly differs
but we do not need to look for data : the object is already filled from a row result.

## But de la pull request

Corriger l'initialisation de la machine a état de l'attribut SubscriptionState
dans le cas ou on récupère des données "User" qui ne sont pas dans la session.

le bug n'a pu être déduit facilement dans les tests: la session SQLA masquait le pb

##  Implémentation

Le test utilise une 2e session pour éviter qu'une requete get() ne requete le cache

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)