### PR TITLE
[pc-12219][api] Add ''hasIdentityCheckPending' in NextStep

### DIFF
--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -717,6 +717,17 @@ def update_or_create_fraud_result(
     return fraud_result
 
 
+def has_user_pending_identity_check(user: users_models.User) -> bool:
+    return db.session.query(
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.PENDING,
+            models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
+            models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
+        ).exists()
+    ).scalar()
+
+
 def has_user_performed_identity_check(user: users_models.User) -> bool:
     return db.session.query(
         models.BeneficiaryFraudCheck.query.filter(

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -197,6 +197,7 @@ class BeneficiaryGrant18Factory(BaseFactory):
 
         return fraud_factories.BeneficiaryFraudCheckFactory(
             user=obj,
+            status=fraud_models.FraudCheckStatus.OK,
             type=fraud_models.FraudCheckType.EDUCONNECT
             if obj.eligibility == users_models.EligibilityType.UNDERAGE
             else fraud_models.FraudCheckType.JOUVE,

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -12,6 +12,7 @@ class NextSubscriptionStepResponse(BaseModel):
     next_subscription_step: Optional[subscription_models.SubscriptionStep]
     maintenance_page_type: Optional[subscription_models.MaintenancePageType]
     allowed_identity_check_methods: list[subscription_models.IdentityCheckMethod]
+    has_identity_check_pending: bool
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -30,6 +30,7 @@ def next_subscription_step(
         next_subscription_step=subscription_api.get_next_subscription_step(user),
         allowed_identity_check_methods=subscription_api.get_allowed_identity_check_methods(user),
         maintenance_page_type=subscription_api.get_maintenance_page_type(user),
+        has_identity_check_pending=fraud_api.has_user_pending_identity_check(user),
     )
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12219


## But de la pull request

Ajout d'un champs 'hasIdentityCheckPending' dans le résultat de la route /subscription/next_step
pour aider l'application lorsque le retour d'Ubble n'est pas encore fait

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)