### PR TITLE
(PC-11581)[api]: eac stock edition : add numberOfTickets and isEducat…

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -190,7 +190,8 @@ def get_stocks_for_offers(offer_ids: list[int]) -> list[Stock]:
 
 def get_stocks_for_offer(offer_id: int) -> list[Stock]:
     return (
-        Stock.query.options(joinedload(Stock.offer).load_only(Offer.url))
+        Stock.query.options(joinedload(Stock.offer).load_only(Offer.url, Offer.isEducational))
+        .options(joinedload(Stock.bookings).load_only(Booking.status, Booking.isCancelled))
         .filter(Stock.offerId == offer_id)
         .filter(Stock.isSoftDeleted.is_(False))
         .all()

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -8,6 +8,7 @@ from pydantic import condecimal
 from pydantic import validator
 from pydantic.types import NonNegativeInt
 
+from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers.models import ActivationCode
 from pcapi.core.offers.models import Stock
 from pcapi.serialization.utils import dehumanize_field
@@ -30,6 +31,8 @@ class StockResponseModel(BaseModel):
     offerId: str
     price: float
     quantity: Optional[int]
+    numberOfTickets: Optional[int]
+    isEducationalStockEditable: Optional[bool]
 
     _humanize_id = humanize_field("id")
     _humanize_offer_id = humanize_field("offerId")
@@ -43,6 +46,11 @@ class StockResponseModel(BaseModel):
         )
         stock.hasActivationCodes = bool(activation_code)
         stock.activationCodesExpirationDatetime = activation_code.expirationDate if activation_code else None
+        stock.isEducationalStockEditable = False
+        if stock.offer.isEducational:
+            stock.isEducationalStockEditable = all(
+                booking.status in (BookingStatus.PENDING, BookingStatus.CANCELLED) for booking in stock.bookings
+            )
         return super().from_orm(stock)
 
     class Config:


### PR DESCRIPTION
…ionalStockEditable in get_stocks response model

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11581


## But de la pull request

- Pendant le parcours d'édition d'un stock eac, le front pro a besoin de récupérer l'attribut `numberOfTickets` du stock, ainsi que l'information s'il est éditable ou non. Le stock eac est éditable si il n'a pas de réservation, ou si la réservation courante (i.e. non-annulée) est au statut PENDING

##  Implémentation

- Ajout d'un joinedload bookings sur la query getStocks
- calcul du booléen isEducationalStockEditable directement dans le serializer pydantic
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
