### PR TITLE
[PC-11994][api][ubble] add a mechanism to bypass check of reference data

### DIFF
--- a/api/src/pcapi/core/fraud/models/ubble.py
+++ b/api/src/pcapi/core/fraud/models/ubble.py
@@ -72,15 +72,62 @@ class UbbleIdentificationDocuments(pydantic.BaseModel):
 
 
 class UbbleIdentificationDocumentChecks(pydantic.BaseModel):
-    expiry_date_score: float = pydantic.Field(None, alias="expiry-date-score")
-    supported: float
+    data_extracted_score: typing.Optional[float] = pydantic.Field(None, alias="data-extracted-score")
+    expiry_date_score: typing.Optional[float] = pydantic.Field(None, alias="expiry-date-score")
+    issue_date_score: typing.Optional[float] = pydantic.Field(None, alias="issue-date-score")
+    live_video_capture_score: typing.Optional[float] = pydantic.Field(None, alias="live-video-capture-score")
+    mrz_validity_score: typing.Optional[float] = pydantic.Field(None, alias="mrz-validity-score")
+    mrz_viz_score: typing.Optional[float] = pydantic.Field(None, alias="mrz-viz-score")
+    ove_back_score: typing.Optional[float] = pydantic.Field(None, alias="ove-back-score")
+    ove_front_score: typing.Optional[float] = pydantic.Field(None, alias="ove-front-score")
+    ove_score: typing.Optional[float] = pydantic.Field(None, alias="ove-score")
+    quality_score: typing.Optional[float] = pydantic.Field(None, alias="quality-score")
+    score: typing.Optional[float] = pydantic.Field(None, alias="score")
+    supported: typing.Optional[float] = None
+    visual_back_score: typing.Optional[float] = pydantic.Field(None, alias="visual-back-score")
+    visual_front_score: typing.Optional[float] = pydantic.Field(None, alias="visual-front-score")
+
+
+class UbbleIdentificationFaceChecks(pydantic.BaseModel):
+    active_liveness_score: typing.Optional[float] = pydantic.Field(None, alias="active-liveness-score")
+    live_video_capture_score: typing.Optional[float] = pydantic.Field(None, alias="live-video-capture-score")
+    quality_score: typing.Optional[float] = pydantic.Field(None, alias="quality-score")
+    score: typing.Optional[float] = None
+
+
+class UbbleIdentificationReferenceDataChecks(pydantic.BaseModel):
+    score: typing.Optional[float] = None
+
+
+class UbbleIdentificationDocFaceMatches(pydantic.BaseModel):
+    score: typing.Optional[float] = None
 
 
 class UbbleIdentificationIncluded(pydantic.BaseModel):
     type: str
     id: int
-    attributes: typing.Union[UbbleIdentificationDocumentChecks, UbbleIdentificationDocuments]
+    attributes: typing.Any
     relationships: typing.Optional[dict]
+
+
+class UbbleIdentificationIncludedDocuments(UbbleIdentificationIncluded):
+    attributes: UbbleIdentificationDocuments
+
+
+class UbbleIdentificationIncludedDocumentChecks(UbbleIdentificationIncluded):
+    attributes: UbbleIdentificationDocumentChecks
+
+
+class UbbleIdentificationIncludedFaceChecks(UbbleIdentificationIncluded):
+    attributes: UbbleIdentificationFaceChecks
+
+
+class UbbleIdentificationIncludedReferenceDataChecks(UbbleIdentificationIncluded):
+    attributes: UbbleIdentificationReferenceDataChecks
+
+
+class UbbleIdentificationIncludedDocFaceMatches(UbbleIdentificationIncluded):
+    attributes: UbbleIdentificationDocFaceMatches
 
 
 class UbbleIdentificationResponse(pydantic.BaseModel):

--- a/api/tests/core/subscription/test_factories.py
+++ b/api/tests/core/subscription/test_factories.py
@@ -36,6 +36,9 @@ STATE_STATUS_MAPPING = {
 class IdentificationIncludedType(Enum):
     DOCUMENT_CHECKS = "document-checks"
     DOCUMENTS = "documents"
+    FACE_CHECKS = "face-checks"
+    REFERENCE_DATA_CHECKS = "reference-data-checks"
+    DOC_FACE_MATCHES = "doc-face-matches"
 
 
 class UbbleIdentificationDataAttributesFactory(factory.Factory):
@@ -259,6 +262,41 @@ class UbbleIdentificationIncludedDocumentChecksAttributesFactory(factory.Factory
         }.get(self.identification_state)
 
 
+class UbbleIdentificationIncludedDocFaceMatchesAttributesFactory(factory.Factory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationDocFaceMatches
+
+    class Params:
+        identification_state = IdentificationState.VALID
+
+    score = ubble_models.UbbleScore.VALID.value
+
+
+class UbbleIdentificationIncludedFaceChecksAttributesFactory(factory.Factory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationFaceChecks
+        rename = {
+            "active_liveness_score": "active-liveness-score",
+            "live_video_capture_score": "live-video-capture-score",
+            "quality_score": "quality-score",
+        }
+
+    class Params:
+        identification_state = IdentificationState.VALID
+
+    active_liveness_score = None
+    live_video_capture_score = None
+    quality_score = None
+    score = ubble_models.UbbleScore.VALID.value
+
+
+class UbbleIdentificationIncludedReferenceDataChecksAttributesFactory(factory.Factory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationReferenceDataChecks
+
+    score = ubble_models.UbbleScore.VALID.value
+
+
 class UbbleIdentificationIncludedFactory(factory.Factory):
     class Meta:
         model = ubble_models.UbbleIdentificationIncluded
@@ -269,14 +307,44 @@ class UbbleIdentificationIncludedFactory(factory.Factory):
     attributes = None
 
 
-class UbbleUbbleIdentificationIncludedDocumentsFactory(UbbleIdentificationIncludedFactory):
+class UbbleIdentificationIncludedDocumentsFactory(UbbleIdentificationIncludedFactory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationIncludedDocuments
+
     type = IdentificationIncludedType.DOCUMENTS.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedDocumentsAttributesFactory)
 
 
-class UbbleUbbleIdentificationIncludedDocumentChecksFactory(UbbleIdentificationIncludedFactory):
+class UbbleIdentificationIncludedDocumentChecksFactory(UbbleIdentificationIncludedFactory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationIncludedDocumentChecks
+
     type = IdentificationIncludedType.DOCUMENT_CHECKS.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedDocumentChecksAttributesFactory)
+
+
+class UbbleIdentificationIncludedFaceChecksFactory(UbbleIdentificationIncludedFactory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationIncludedFaceChecks
+
+    type = IdentificationIncludedType.FACE_CHECKS.value
+    attributes = factory.SubFactory(UbbleIdentificationIncludedFaceChecksAttributesFactory)
+
+
+class UbbleIdentificationIncludedReferenceDataChecksFactory(UbbleIdentificationIncludedFactory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationIncludedReferenceDataChecks
+
+    type = IdentificationIncludedType.REFERENCE_DATA_CHECKS.value
+    attributes = factory.SubFactory(UbbleIdentificationIncludedReferenceDataChecksAttributesFactory)
+
+
+class UbbleIdentificationIncludedDocFaceMatchesFactory(UbbleIdentificationIncludedFactory):
+    class Meta:
+        model = ubble_models.UbbleIdentificationIncludedDocFaceMatches
+
+    type = IdentificationIncludedType.DOC_FACE_MATCHES.value
+    attributes = factory.SubFactory(UbbleIdentificationIncludedDocFaceMatchesAttributesFactory)
 
 
 class UbbleIdentificationResponseFactory(factory.Factory):
@@ -296,21 +364,31 @@ class UbbleIdentificationResponseFactory(factory.Factory):
             list,
             {
                 IdentificationState.PROCESSING: [
-                    UbbleUbbleIdentificationIncludedDocumentsFactory,
+                    UbbleIdentificationIncludedDocumentsFactory,
                 ],
                 IdentificationState.VALID: [
-                    UbbleUbbleIdentificationIncludedDocumentsFactory,
-                    UbbleUbbleIdentificationIncludedDocumentChecksFactory,
+                    UbbleIdentificationIncludedDocumentsFactory,
+                    UbbleIdentificationIncludedDocumentChecksFactory,
+                    UbbleIdentificationIncludedFaceChecksFactory,
+                    UbbleIdentificationIncludedDocFaceMatchesFactory,
+                    UbbleIdentificationIncludedReferenceDataChecksFactory,
                 ],
                 IdentificationState.INVALID: [
-                    UbbleUbbleIdentificationIncludedDocumentsFactory,
-                    UbbleUbbleIdentificationIncludedDocumentChecksFactory,
+                    UbbleIdentificationIncludedDocumentsFactory,
+                    UbbleIdentificationIncludedDocumentChecksFactory,
+                    UbbleIdentificationIncludedFaceChecksFactory,
+                    UbbleIdentificationIncludedDocFaceMatchesFactory,
+                    UbbleIdentificationIncludedReferenceDataChecksFactory,
                 ],
                 IdentificationState.UNPROCESSABLE: [
-                    UbbleUbbleIdentificationIncludedDocumentsFactory,
-                    UbbleUbbleIdentificationIncludedDocumentChecksFactory,
+                    UbbleIdentificationIncludedDocumentsFactory,
+                    UbbleIdentificationIncludedDocumentChecksFactory,
+                    UbbleIdentificationIncludedFaceChecksFactory,
+                    UbbleIdentificationIncludedDocFaceMatchesFactory,
+                    UbbleIdentificationIncludedReferenceDataChecksFactory,
                 ],
             },
         )[self.identification_state]
 
-        return [sf(identification_state=self.identification_state) for sf in included_data]
+        included_data = [sf(identification_state=self.identification_state) for sf in included_data]
+        return included_data


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11994


## But de la pull request

Ajouter un mécanisme permettant de valider de bout en bout le parcours Ubble sans avoir un jeune de 18 ans sous la main.
Pour un utilisateur (hors production) dont l'email se termine par `@ubble.test`, la réponse Ubble est modifiée avant traitement pour mettre des valeurs valides pour la vérification des données de référence.

##  Implémentation

- ajout d'un traitement (`_discard_reference_data_error`) qui change le score `reference-data-checks` de la réponse Ubble et le score global si nécessaire pour simuler une vérification OK des données de référence.
- ce traitement est conditionné par l'email de l'utilisateur et l'environnement d'exécution:
  - l'email de l'utilisateur doit se terminer par `@ubble.test`
  - `settings.IS_PROD` doit être `False`
​
##  Informations supplémentaires

- ajouts/modifications de factory et modèles pydantic
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)~~ N/A
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] ~~J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)~~ N/A
