### PR TITLE
(PC-11581)[pro]: eac stock edition : make offerbreadcrumb clickable o…

### DIFF
--- a/pro/src/routes/OfferEducationalStockEdition/OfferEducationalStockEdition.tsx
+++ b/pro/src/routes/OfferEducationalStockEdition/OfferEducationalStockEdition.tsx
@@ -10,6 +10,8 @@ import {
   OfferEducationalStockFormValues,
 } from 'core/OfferEducational'
 import { Offer } from 'custom_types/offer'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
+import OfferEducationalLayout from 'new_components/OfferEducationalLayout'
 import OfferEducationalStockScreen from 'screens/OfferEducationalStock'
 
 import { getEducationalStockAdapter } from './adapters/getEducationalStockAdapter'
@@ -72,15 +74,26 @@ const OfferEducationalStockEdition = (): JSX.Element => {
     }
   }, [offerId, isReady, notify])
 
-  return offer && isReady ? (
-    <OfferEducationalStockScreen
-      initialValues={initialValues}
-      mode={stock?.isEducationalStockEditable ? Mode.EDITION : Mode.READ_ONLY}
-      offer={offer}
-      onSubmit={handleSubmitStock}
-    />
-  ) : (
-    <Spinner />
+  return (
+    <OfferEducationalLayout
+      activeStep={OfferBreadcrumbStep.STOCKS}
+      isCreatingOffer={false}
+      offerId={offerId}
+      title="Éditer une offre"
+    >
+      {offer && isReady ? (
+        <OfferEducationalStockScreen
+          initialValues={initialValues}
+          mode={
+            stock?.isEducationalStockEditable ? Mode.EDITION : Mode.READ_ONLY
+          }
+          offer={offer}
+          onSubmit={handleSubmitStock}
+        />
+      ) : (
+        <Spinner />
+      )}
+    </OfferEducationalLayout>
   )
 }
 


### PR DESCRIPTION
…n stock edition page

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11581


## But de la pull request

- Retour PO sur ce ticket : le breadcrumb n'était pas clickable depuis la page d'édition 'Détail et prix'

##  Implémentation

- Wrapper le OfferEducationalStockEdition screen dans le OfferLayout
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
