### PR TITLE
[pc-12342][api] Ensure get_registration_datetime is datetime naive

### DIFF
--- a/api/src/pcapi/core/fraud/models/ubble.py
+++ b/api/src/pcapi/core/fraud/models/ubble.py
@@ -3,6 +3,7 @@ import enum
 import typing
 
 import pydantic
+import pytz
 
 from .common import IdentityCheckContent
 
@@ -41,7 +42,9 @@ class UbbleContent(IdentityCheckContent):
     )
 
     def get_registration_datetime(self) -> typing.Optional[datetime.datetime]:
-        return self.registration_datetime
+        return (
+            self.registration_datetime.astimezone(pytz.utc).replace(tzinfo=None) if self.registration_datetime else None
+        )
 
     def get_birth_date(self) -> typing.Optional[datetime.date]:
         return self.birth_date

--- a/api/tests/core/fraud/test_models.py
+++ b/api/tests/core/fraud/test_models.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+
+
+class GetRegistrationDatetimeTest:
+    @pytest.mark.parametrize(
+        "factory_class",
+        [
+            fraud_factories.UbbleContentFactory,
+            fraud_factories.DMSContentFactory,
+            fraud_factories.JouveContentFactory,
+            fraud_factories.EduconnectContentFactory,
+        ],
+    )
+    def test_has_no_timezone(self, factory_class):
+        content = factory_class()
+
+        datetime = content.get_registration_datetime()
+        assert not datetime.tzinfo


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12342


## But de la pull request

Corriger le sentry : notre base de code est "timezone non-aware" ou "sans timezone"

On s'assure que l'ensemble des données utilisées pour vérifier l'eligibilité utilise bien un "datetime naîf"
et on corrige la sortie pour Ubble.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)