### PR TITLE
(PC-12346) Add logout url in educonnect error redirections

### DIFF
--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -233,7 +233,7 @@ class EduconnectTest:
     @patch("pcapi.core.users.external.educonnect.api.get_educonnect_user")
     def test_educonnect_redirects_to_error_page_too_old(self, mock_get_educonnect_user, client, app):
         _, request_id = self.connect_to_educonnect(client, app)
-        age = 18
+        age = 20
         mock_get_educonnect_user.return_value = users_factories.EduconnectUserFactory(
             saml_request_id=request_id, age=age
         )
@@ -242,7 +242,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid18YearsOld&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
     @patch("pcapi.core.users.external.educonnect.api.get_educonnect_user")

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -211,8 +211,8 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith(
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid"
+        assert response.location == (
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
     @patch("pcapi.core.users.external.educonnect.api.get_educonnect_user")
@@ -226,8 +226,8 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith(
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid18YearsOld"
+        assert response.location == (
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid18YearsOld&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
     @patch("pcapi.core.users.external.educonnect.api.get_educonnect_user")
@@ -241,8 +241,8 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith(
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid"
+        assert response.location == (
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid18YearsOld&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
     @patch("pcapi.core.users.external.educonnect.api.get_educonnect_user")
@@ -281,8 +281,8 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith(
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserNotWhitelisted"
+        assert response.location == (
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserNotWhitelisted&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
     @override_features(ENABLE_INE_WHITELIST_FILTER=False)
@@ -310,13 +310,14 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith(
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid"
+        assert response.location == (
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
+
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.KO
 
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
         assert response.status_code == 302
-        assert response.location.startswith(
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid"
+        assert response.location == (
+            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12346


## But de la pull request

Pour que le front puisse logout l'utilisateur en cas d'erreur

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
