### PR TITLE
Pc 12350 invalid data received from userprofiling

### DIFF
--- a/api/src/pcapi/core/fraud/models/__init__.py
+++ b/api/src/pcapi/core/fraud/models/__init__.py
@@ -182,10 +182,10 @@ class UserProfilingFraudData(pydantic.BaseModel):
     account_email_first_seen: typing.Optional[datetime.date]
     account_email_result: str
     account_email_score: typing.Optional[int]
-    account_telephone_result: str
+    account_telephone_result: typing.Optional[str]  # Optional because Phone Validation may be disabled by FF
     account_telephone_first_seen: typing.Optional[datetime.date]
     account_telephone_score: typing.Optional[int]
-    account_telephone_is_valid: str
+    account_telephone_is_valid: typing.Optional[str]  # Optional because Phone Validation may be disabled by FF
     bb_bot_rating: str
     bb_bot_score: float
     bb_fraud_rating: str

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -332,7 +332,7 @@ def get_next_subscription_step(user: users_models.User) -> typing.Optional[model
         if not user_profiling:
             return models.SubscriptionStep.USER_PROFILING
 
-        if user_profiling.source_data().risk_rating == fraud_models.UserProfilingRiskRating.HIGH:
+        if fraud_api.is_risky_user_profile(user):
             return None
 
     if not has_completed_profile(user):

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -374,6 +374,13 @@ def suspend_account(user: User) -> None:
 def profiling_fraud_score(user: User, body: serializers.UserProfilingFraudRequest) -> None:
     handler = user_profiling.UserProfilingClient()
 
+    # User Profiling step must be after Phone Validation
+    if not user.is_phone_validated and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
+        raise ApiErrors(
+            {"message": "Le numéro de téléphone est n'a pas été validé", "code": "MISSING_PHONE_VALIDATION"},
+            status_code=400,
+        )
+
     try:
         profiling_infos = handler.get_user_profiling_fraud_data(
             session_id=body.sessionId,

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -26,8 +26,10 @@ logger = logging.getLogger(__name__)
 def next_subscription_step(
     user: users_models.User,
 ) -> Optional[serializers.NextSubscriptionStepResponse]:
+    next_step = subscription_api.get_next_subscription_step(user)
+    logger.info("next_subscription_step: %s", next_step.value if next_step else None, extra={"user_id": user.id})
     return serializers.NextSubscriptionStepResponse(
-        next_subscription_step=subscription_api.get_next_subscription_step(user),
+        next_subscription_step=next_step,
         allowed_identity_check_methods=subscription_api.get_allowed_identity_check_methods(user),
         maintenance_page_type=subscription_api.get_maintenance_page_type(user),
         has_identity_check_pending=fraud_api.has_user_pending_identity_check(user),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12350


## But de la pull request

- Gérer le cas de User Profiling appelé sans Phone Validation (FF ENABLE_PHONE_VALIDATION désactivé)
- Ajouter un log pour mieux suivre les "next steps" renvoyées au front pour l'inscription
- Garder le status dans BeneficiaryFraudCheck pour un User Profiling, pour visualisation dans FA notamment

##  Implémentation

​
##  Informations supplémentaires

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
