### PR TITLE
[pc-12353][api] Add missing cta title in dms redirection

### DIFF
--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -95,6 +95,7 @@ def on_ubble_journey_cannot_continue(user: users_models.User) -> None:
     message = models.SubscriptionMessage(
         user=user,
         userMessage="Désolé, la vérification de ton identité n'a pas pu aboutir. Nous t'invitons à passer par le site Démarches-Simplifiées.",
+        callToActionTitle="Accéder au site Démarches-Simplifiées",
         callToActionLink=REDIRECT_TO_DMS_VIEW,
         callToActionIcon=models.CallToActionIcon.EXTERNAL,
     )

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -387,6 +387,7 @@ class UbbleWorkflowTest:
             )
             assert message.callToActionLink == "passculture://verification-identite/demarches-simplifiees"
             assert message.callToActionIcon == subscription_models.CallToActionIcon.EXTERNAL
+            assert message.callToActionTitle == "Accéder au site Démarches-Simplifiées"
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12353


## But de la pull request
Corriger le message inapp de redirection vers DMS : il manquait le titre du CTA
pour voir afficher le lien

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)