### PR TITLE
[PC-12355][api][offers] Disallow stock creation with incoherent stock price if reimbursement rule exists

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -385,16 +385,14 @@ def _edit_stock(
         "bookingLimitDatetime": booking_limit_datetime,
     }
 
-    # fmt: off
-    updated_fields = {
-        attr
-        for attr, new_value in updates.items()
-        if new_value != getattr(stock, attr)
-    }
-    # fmt: on
-    if "price" in updated_fields:
-        validation.check_stock_has_no_custom_reimbursement_rule(stock)
     if stock.offer.isFromAllocine:
+        # fmt: off
+        updated_fields = {
+            attr
+            for attr, new_value in updates.items()
+            if new_value != getattr(stock, attr)
+        }
+        # fmt: on
         validation.check_update_only_allowed_stock_fields_for_allocine_offer(updated_fields)
         stock.fieldsUpdated = list(updated_fields)
 

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -9,7 +9,6 @@ from pcapi.core.offers import exceptions
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import validation
 from pcapi.core.offers.models import OfferValidationStatus
-import pcapi.core.payments.factories as payments_factories
 from pcapi.models.api_errors import ApiErrors
 
 import tests
@@ -433,14 +432,3 @@ class CheckValidationStatusTest:
         assert error.value.errors["global"] == [
             "Les offres refusées ou en attente de validation ne sont pas modifiables"
         ]
-
-
-@pytest.mark.usefixtures("db_session")
-def test_check_stock_has_no_custom_reimbursement_rule():
-    stock = offers_factories.StockFactory()
-    validation.check_stock_has_no_custom_reimbursement_rule(stock)  # should not raise
-
-    payments_factories.CustomReimbursementRuleFactory(offer=stock.offer)
-    with pytest.raises(ApiErrors) as error:
-        validation.check_stock_has_no_custom_reimbursement_rule(stock)
-    assert error.value.errors["price"] == ["Vous ne pouvez pas modifier le prix de cette offre"]


### PR DESCRIPTION
When a reimbursement rule exists for an offer, we disallowed to change
the price of a stock. Now we also disallow to *create* a new stock
with a price that is different from exiting stocks.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12355