### PR TITLE
(PC-12022) add feature flag enable cultural survey

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -35,7 +35,7 @@ class FeatureToggle(enum.Enum):
     BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS = "Active la validation d'un bénéficiaire via les contrôles de sécurité"
     DISPLAY_DMS_REDIRECTION = "Affiche une redirection vers DMS si ID Check est KO"
     ENABLE_ACTIVATION_CODES = "Permet la création de codes d'activation"
-    ENABLE_CULTURAL_SURVEY = "Conditionner l'apparition du questionnaire des pratiques initiales (cultural study) afin d'éviter de bloquer les utilisateurs si notre prestataire Typeform ne tient pas la charge"
+    ENABLE_CULTURAL_SURVEY = "Activer l'affichage du questionnaire des pratiques initiales pour les bénéficiaires"
     ENABLE_DMS_GRAPHQL_API = "Utilise l'API GraphQL de DMS"
     ENABLE_DMS_LINK_ON_MAINTENANCE_PAGE_FOR_AGE_18 = (
         "Permet l'affichage du lien vers DMS sur la page de maintenance pour les 18 ans"

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -36,6 +36,7 @@ from pcapi.core.users.models import User
 from pcapi.core.users.models import UserRole
 from pcapi.core.users.models import VOID_FIRST_NAME
 from pcapi.core.users.models import VOID_PUBLIC_NAME
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.native.utils import convert_to_cent
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
@@ -264,6 +265,10 @@ class UserProfileResponse(BaseModel):
         user.allowed_eligibility_check_methods = user.legacy_allowed_eligibility_check_methods
         result = super().from_orm(user)
         result.subscriptionMessage = cls._get_subscription_message(user)
+
+        if not (FeatureToggle.ENABLE_CULTURAL_SURVEY.is_active() and user.is_beneficiary):
+            result.needsToFillCulturalSurvey = False
+
         # FIXME: (Lixxday) Remove after isBeneficiary column has been deleted
         result.isBeneficiary = user.is_beneficiary
         return result


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12022

## But de la pull request

Désactive le `needsToFillCulturalSurvey` lorsque l'utilisateur n'est pas bénéficiaire ou lorsque le feature flag est désactivé

##  Informations supplémentaires

- Renommage de la description du feature flag pour un texte plus concis fourni par Mathieu

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
