### PR TITLE
[pc-12226][api] Use Valid userprofiling data

### DIFF
--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -319,10 +319,14 @@ class NextStepTest:
             phoneNumber="+33609080706",
         )
 
+        user_profiling = fraud_factories.UserProfilingFraudDataFactory(
+            risk_rating=fraud_models.UserProfilingRiskRating.TRUSTED
+        )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user_approching_birthday,
             type=fraud_models.FraudCheckType.USER_PROFILING,
             status=fraud_models.FraudCheckStatus.OK,
+            resultContent=user_profiling,
         )
         client.with_token(user_approching_birthday.email)
         response = client.get("/native/v1/subscription/next_step")
@@ -350,6 +354,7 @@ class NextStepTest:
             user=user_not_eligible_for_ubble,
             type=fraud_models.FraudCheckType.USER_PROFILING,
             status=fraud_models.FraudCheckStatus.OK,
+            resultContent=user_profiling,
         )
 
         client.with_token(user_not_eligible_for_ubble.email)


### PR DESCRIPTION
The factory UserProfiling is very unstable leading to possible
flacky test: the fonction verifies the potential risk of a user,
depending on the userprofiling response.

This commit ensure the userprofilig response is not risky


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12226


## But de la pull request
Correction d'un test flacky lorsque la factory retourne un risque potentiel sur le profil utilisateur

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)