### PR TITLE
(PC-12369) Add check on eligibility type before creating educonnect beneficiary import

### DIFF
--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -372,7 +372,7 @@ def _check_user_has_no_active_deposit(
 
 
 def _check_user_eligibility(user: users_models.User, eligibility: users_models.EligibilityType) -> models.FraudItem:
-    if not user.is_eligible_for_beneficiary_upgrade(eligibility):
+    if not eligibility or not user.is_eligible_for_beneficiary_upgrade(eligibility):
         return models.FraudItem(
             status=models.FraudStatus.KO,
             detail=(

--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -541,7 +541,7 @@ def on_user_profiling_check_result(
 
 def get_source_data(user: users_models.User) -> pydantic.BaseModel:
     mapped_class = {models.FraudCheckType.DMS: models.DMSContent, models.FraudCheckType.JOUVE: models.JouveContent}
-    fraud_check_type = (
+    fraud_check = (
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.userId == user.id,
             models.BeneficiaryFraudCheck.type.in_([models.FraudCheckType.JOUVE, models.FraudCheckType.DMS]),
@@ -549,7 +549,7 @@ def get_source_data(user: users_models.User) -> pydantic.BaseModel:
         .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
         .first()
     )
-    return mapped_class[fraud_check_type.type](**fraud_check_type.resultContent)
+    return mapped_class[fraud_check.type](**fraud_check.resultContent)
 
 
 def upsert_fraud_result(

--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -256,7 +256,7 @@ def on_identity_fraud_check_result(
 
     fraud_items.append(_check_user_has_no_active_deposit(user, beneficiary_fraud_check.eligibilityType))
     fraud_items.append(_check_user_email_is_validated(user))
-    fraud_items.append(_check_user_not_already_beneficiary(user, beneficiary_fraud_check.eligibilityType))
+    fraud_items.append(_check_user_eligibility(user, beneficiary_fraud_check.eligibilityType))
 
     fraud_result = validate_frauds(user, fraud_items, beneficiary_fraud_check, beneficiary_fraud_check.eligibilityType)
     if (
@@ -371,9 +371,7 @@ def _check_user_has_no_active_deposit(
     return models.FraudItem(status=models.FraudStatus.OK, detail="L'utilisateur n'a pas déjà un deposit actif")
 
 
-def _check_user_not_already_beneficiary(
-    user: users_models.User, eligibility: users_models.EligibilityType
-) -> models.FraudItem:
+def _check_user_eligibility(user: users_models.User, eligibility: users_models.EligibilityType) -> models.FraudItem:
     if not user.is_eligible_for_beneficiary_upgrade(eligibility):
         return models.FraudItem(
             status=models.FraudStatus.KO,

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -15,7 +15,6 @@ from pcapi.core.payments import api as payments_api
 from pcapi.core.subscription import messages as subscription_messages
 from pcapi.core.users import api as users_api
 from pcapi.core.users import constants as users_constants
-from pcapi.core.users import exceptions as users_exception
 from pcapi.core.users import external as users_external
 from pcapi.core.users import models as users_models
 from pcapi.core.users import repository as users_repository
@@ -119,7 +118,7 @@ def activate_beneficiary(
     eligibility = beneficiary_import.eligibilityType
     deposit_source = beneficiary_import.get_detailed_source()
 
-    if not user.is_eligible_for_beneficiary_upgrade(eligibility):
+    if not eligibility or not user.is_eligible_for_beneficiary_upgrade(eligibility):
         raise exceptions.CannotUpgradeBeneficiaryRole()
 
     if eligibility == users_models.EligibilityType.UNDERAGE:
@@ -130,7 +129,7 @@ def activate_beneficiary(
         user.add_beneficiary_role()
         user.remove_underage_beneficiary_role()
     else:
-        raise users_exception.InvalidEligibilityTypeException()
+        raise exceptions.InvalidEligibilityTypeException()
 
     if "apps_flyer" in user.externalIds:
         apps_flyer_job.log_user_becomes_beneficiary_event_job.delay(user.id)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -168,7 +168,12 @@ def check_and_activate_beneficiary(
         return user
 
 
-def create_beneficiary_import(user: users_models.User, eligibilityType: users_models.EligibilityType) -> None:
+def create_beneficiary_import_after_educonnect(
+    user: users_models.User, eligibilityType: typing.Optional[users_models.EligibilityType]
+) -> None:
+    if not eligibilityType:
+        raise fraud_exceptions.UserAgeNotValid()
+
     fraud_result = fraud_models.BeneficiaryFraudResult.query.filter_by(
         user=user, eligibilityType=eligibilityType
     ).one_or_none()

--- a/api/src/pcapi/core/subscription/exceptions.py
+++ b/api/src/pcapi/core/subscription/exceptions.py
@@ -2,6 +2,10 @@ class SubscriptionException(Exception):
     pass
 
 
+class InvalidEligibilityTypeException(SubscriptionException):
+    pass
+
+
 class BeneficiaryImportMissingException(SubscriptionException):
     pass
 

--- a/api/src/pcapi/core/users/exceptions.py
+++ b/api/src/pcapi/core/users/exceptions.py
@@ -116,10 +116,6 @@ class InvalidUserRoleException(Exception):
     pass
 
 
-class InvalidEligibilityTypeException(Exception):
-    pass
-
-
 class EmailUpdateLimitReached(Exception):
     pass
 

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -39,8 +39,8 @@ class BeneficiaryImport(PcObject, Model):
     eligibilityType = sa.Column(
         sa.Enum(EligibilityType, create_constraint=False),
         nullable=False,
-        default=EligibilityType.AGE18,
-        server_default=sa.text(EligibilityType.AGE18.name),
+        default=EligibilityType.AGE18,  # TODO (viconnex) remove default values
+        server_default=sa.text(EligibilityType.AGE18.name),  # TODO (viconnex) remove default values
     )
     beneficiary = relationship("User", foreign_keys=[beneficiaryId], backref="beneficiaryImports")
 

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -120,7 +120,9 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
 
     try:
         # TODO(viconnex): use generic subscription_api.on_successful_application
-        subscription_api.create_beneficiary_import(user, fraud_api.get_eligibility_type(educonnect_content))
+        subscription_api.create_beneficiary_import_after_educonnect(
+            user, fraud_api.get_eligibility_type(educonnect_content)
+        )
     except fraud_exceptions.UserAgeNotValid:
         logger.warning(
             "User age not valid",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX


## But de la pull request

Bug : un utilisateur de 16 ans se voit attribuer un crédit de 18 ans

Comment reproduire (reproduit dans les tests):
- `user.dateOfBirth` déclaré à l'inscription de façon à être éligible
- date de naissance éduconnect avec un âge éligible **mais** avant la généralisation (ouverture 1er janvier 2022)

Pourquoi ? 2 problèmes : 

- `user.is_eligible_for_beneficiary_upgrade(eligibility)`
si eligibility est null (qui se base sur la date de naissance du dossier), on va prendre user.eligibility qui peut ne pas être null !
Donc on réussit le check de fraud `_check_user_not_already_beneficiary`
(que je vais renommer check_user_eligibility ) et on enregistre un eligibilityTYpe null sur le FraudCheck

- ensuite on enregistre un BeneficiaryImport avec un eligibilityType à null du coup il prend la valeur par défaut (“pass 18”)

##  Implémentation

- Rajout d'un check sur eligibility
- Ne pas enregistrer de BeneficiairytImport avec un EligibilitType null 
  - j'ai géré le cas educonnect et admin
  - j'ai pas géré jouve et dms car 
    - trop de tests cassent
    - les dates d'éligibilité sont vérifiées par JouveMiddleWear ou par les opérateurs DMS
​
## Checklist :

- [ x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
