### PR TITLE
(PC-12371) api: Add logs to follow and debug Ubble identifications

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -156,6 +156,12 @@ def start_identification(
             "request_type": "start-identification",
         },
     )
+
+    logger.info(
+        "Ubble identification started",
+        extra={"identification_id": str(content.identification_id), "status": str(content.status)},
+    )
+
     return content
 
 

--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -109,6 +109,8 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
 def ubble_webhook_update_application_status(
     body: ubble_validation.WebhookRequest,
 ) -> ubble_validation.WebhookDummyReponse:
+    logger.info("Ubble webhook called", extra={"identification_id": body.identification_id, "status": str(body.status)})
+
     fraud_check = fraud_api.ubble.get_ubble_fraud_check(body.identification_id)
     if not fraud_check:
         raise ValueError(f"no Ubble fraud check found with identification_id {body.identification_id}")

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -37,7 +37,7 @@ class StartIdentificationTest:
         assert attributes["webhook"] == "http://webhook/url/"
         assert attributes["redirect_url"] == "http://redirect/url"
 
-        assert len(caplog.records) == 1
+        assert len(caplog.records) >= 1
         record = caplog.records[0]
         assert record.extra["status_code"] == 201
         assert record.extra["identification_id"] == str(response.identification_id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12371

## But de la pull request

Besoin de logs pour comprendre les bugs rencontrés dans le parcours Ubble

##  Implémentation

Log au démarrage de l'identification, log à chaque notification de Ubble
​
##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
