### PR TITLE
Permettre de reprendre une identification UBBLE qui n'a pas pu être terminée

### DIFF
--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -721,6 +721,8 @@ def has_user_pending_identity_check(user: users_models.User) -> bool:
             models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.PENDING,
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
             models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
+            models.BeneficiaryFraudCheck.resultContent["status"]
+            != models.ubble_models.UbbleIdentificationStatus.INITIATED,
         ).exists()
     ).scalar()
 
@@ -736,19 +738,36 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
     ).scalar()
 
 
+def get_pending_identity_check(user: users_models.User) -> typing.Optional[models.BeneficiaryFraudCheck]:
+    return (
+        models.BeneficiaryFraudCheck.query.filter(
+            models.BeneficiaryFraudCheck.user == user,
+            models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.PENDING,
+            models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
+            models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
+        )
+        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
+        .one_or_none()
+    )
+
+
 def has_user_performed_ubble_check(user: users_models.User) -> bool:
     """
     Look for any Ubble identification already started, processed or not, but not aborted.
     There should not be more than one result in the database (later this function can count if limit is greater than 1).
     """
-    return db.session.query(
-        models.BeneficiaryFraudCheck.query.filter(
-            models.BeneficiaryFraudCheck.user == user,
-            models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
-            models.BeneficiaryFraudCheck.type == models.FraudCheckType.UBBLE,
-            models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
-        ).exists()
-    ).scalar()
+    fraud_check = models.BeneficiaryFraudCheck.query.filter(
+        models.BeneficiaryFraudCheck.user == user,
+        models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
+        models.BeneficiaryFraudCheck.type == models.FraudCheckType.UBBLE,
+        models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
+    ).one_or_none()
+    if not fraud_check:
+        return False
+
+    if fraud_check.source_data().status == models.ubble_models.UbbleIdentificationStatus.INITIATED:
+        return False
+    return True
 
 
 def has_passed_educonnect(user: users_models.User) -> bool:

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -242,6 +242,16 @@ def start_ubble_workflow(user: users_models.User, redirect_url: str) -> str:
     return content.identification_url
 
 
+def is_ubble_workflow_restartable(fraud_check: fraud_models.BeneficiaryFraudCheck) -> bool:
+    if fraud_check.type != fraud_models.FraudCheckType.UBBLE:
+        return False
+
+    ubble_content: fraud_models.ubble_models.UbbleContent = fraud_check.source_data()
+    if ubble_content.status == fraud_models.ubble_models.UbbleIdentificationStatus.INITIATED:
+        return True
+    return False
+
+
 def update_ubble_workflow(
     fraud_check: fraud_models.BeneficiaryFraudCheck, status: fraud_models.ubble.UbbleIdentificationStatus
 ) -> None:

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -437,6 +437,17 @@ def start_identification_session(
             status_code=400,
         )
 
+    fraud_check = fraud_api.get_pending_identity_check(user)
+    if fraud_check:
+        if subscription_api.is_ubble_workflow_restartable(fraud_check):
+            return serializers.IdentificationSessionResponse(
+                identificationUrl=fraud_check.source_data().identification_url
+            )
+        raise ApiErrors(
+            {"code": "IDCHECK_ALREADY_PROCESSED", "message": "Une identification a déjà été traitée"},
+            status_code=400,
+        )
+
     try:
         identification_url = subscription_api.start_ubble_workflow(user, body.redirectUrl)
         return serializers.IdentificationSessionResponse(identificationUrl=identification_url)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -853,6 +853,18 @@ class HasUserPerformedIdentityCheckTest:
 
         assert not fraud_api.has_user_performed_identity_check(user)
 
+    def test_has_user_performed_identity_check_status_initiated(self):
+        user = users_factories.UserFactory()
+        ubble_content = fraud_factories.UbbleContentFactory(
+            status=fraud_models.ubble_models.UbbleIdentificationStatus.INITIATED
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            type=fraud_models.FraudCheckType.UBBLE,
+            user=user,
+            resultContent=ubble_content,
+            status=fraud_models.FraudCheckStatus.PENDING,
+        )
+
 
 @pytest.mark.usefixtures("db_session")
 class FraudCheckLifeCycleTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12373


## But de la pull request

Reprendre un workflow d'identification si l'utiulisateur s'est arrêté et que celle-ci n'est pas marquee
comme annulée côté UBBLE

##  Implémentation

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)