### PR TITLE
(PC-11477)[PRO] venue creation: add business unit fields

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
@@ -21,6 +21,7 @@ import AccessibilityFields, {
   autoFillNoDisabilityCompliantDecorator,
 } from '../fields/AccessibilityFields'
 import BankInformation from '../fields/BankInformationFields'
+import BusinessUnitFields from '../fields/BankInformationFields/BusinessUnitFields'
 import ContactInfosFields from '../fields/ContactInfosFields'
 import IdentifierFields, {
   bindGetSiretInformationToSiret,
@@ -103,6 +104,7 @@ class VenueCreation extends PureComponent {
       venueLabels,
       offerer,
       withdrawalDetailActive,
+      isBankInformationWithSiretActive,
     } = this.props
     const { isRequestPending } = this.state
     const readOnly = false
@@ -118,7 +120,6 @@ class VenueCreation extends PureComponent {
 
     const siretValidOnCreation =
       formSiret && formatSiret(formSiret).length === 14
-
     return (
       <form name="venue" onSubmit={handleSubmit}>
         <IdentifierFields
@@ -132,7 +133,11 @@ class VenueCreation extends PureComponent {
         {withdrawalDetailActive && (
           <WithdrawalDetailsFields isCreatedEntity readOnly={readOnly} />
         )}
-        <BankInformation offerer={offerer} />
+        {isBankInformationWithSiretActive ? (
+          <BusinessUnitFields offerer={offerer} />
+        ) : (
+          <BankInformation offerer={offerer} />
+        )}
         <LocationFields
           fieldReadOnlyBecauseFrozenFormSiret={siretValidOnCreation}
           form={form}
@@ -224,6 +229,7 @@ VenueCreation.propTypes = {
   handleSubmitRequestFail: PropTypes.func.isRequired,
   handleSubmitRequestSuccess: PropTypes.func.isRequired,
   history: PropTypes.shape().isRequired,
+  isBankInformationWithSiretActive: PropTypes.bool.isRequired,
   match: PropTypes.shape().isRequired,
   offerer: PropTypes.shape().isRequired,
   trackCreateVenue: PropTypes.func.isRequired,

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreationContainer.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreationContainer.js
@@ -49,6 +49,10 @@ export const mapStateToProps = (state, ownProps) => {
       state,
       'ENABLE_VENUE_WITHDRAWAL_DETAILS'
     ),
+    isBankInformationWithSiretActive: isFeatureActive(
+      state,
+      'ENFORCE_BANK_INFORMATION_WITH_SIRET'
+    ),
   }
 }
 

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreationContainer.spec.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreationContainer.spec.js
@@ -66,6 +66,7 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
       // then
       expect(result).toStrictEqual({
         currentUser: currentUser,
+        isBankInformationWithSiretActive: false,
         offerer: { id: 1 },
         formInitialValues: {
           bookingEmail: 'john.doe@email.com',

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/BusinessUnitFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/BusinessUnitFields.jsx
@@ -150,11 +150,12 @@ const BankInformationWithBusinessUnit = ({ readOnly, offerer, venue }) => {
 }
 
 BankInformationWithBusinessUnit.defaultProps = {
+  readOnly: false,
   venue: {},
 }
 BankInformationWithBusinessUnit.propTypes = {
   offerer: PropTypes.shape().isRequired,
-  readOnly: PropTypes.bool.isRequired,
+  readOnly: PropTypes.bool,
   venue: PropTypes.shape(),
 }
 

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
@@ -6,6 +6,7 @@ const creation_authorized_input_field = [
   'address',
   'bic',
   'bookingEmail',
+  'businessUnitId',
   'city',
   'comment',
   'description',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11477


## But de la pull request

Ajouter la section business unit au formulaire de création de lieu lorsque le FF ENFORCE_BANK_INFORMATION_WITH_SIRET est activé
​
![image](https://user-images.githubusercontent.com/77629406/146578822-9a6db43c-9d0a-4c56-90b1-3d0a8fce7b37.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
