### PR TITLE
[PC-12389] (WebApp) expose version.txt when v1 to v2 redirect is on

### DIFF
--- a/webapp/scripts/build_redirects.js
+++ b/webapp/scripts/build_redirects.js
@@ -57,6 +57,7 @@ function createRedirectFile() {
     const v1 = publicRedirectFileContent.match(/.*\n/g, '').map((line) => line.replace(/\n/, '').split(' ').filter((arr) => arr.length > 1))
 
     const v1tov2 = [
+      ['/version.txt', '/version.txt', '200'],
       ['/accueil/details/:offerId', '/accueil/details/:offerId', '200'],
       ['/*', process.env.WEBAPP_V2_URL, '302!'],
     ]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12389


## But de la pull request

Exposé `/version.txt` lorsque le la redirection v1 to v2 est ON

##  Implémentation

- Ajout d'un redirect rule netlify
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
