### PR TITLE
(PC-12369) Set eligibility property as required in is_eligible_for_bneficiary_upgrade

### DIFF
--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -372,7 +372,9 @@ def _check_user_has_no_active_deposit(
 
 
 def _check_user_eligibility(user: users_models.User, eligibility: users_models.EligibilityType) -> models.FraudItem:
-    if not eligibility or not user.is_eligible_for_beneficiary_upgrade(eligibility):
+    from pcapi.core.users import api as users_api
+
+    if not users_api.is_eligible_for_beneficiary_upgrade(user, eligibility):
         return models.FraudItem(
             status=models.FraudStatus.KO,
             detail=(

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -118,7 +118,7 @@ def activate_beneficiary(
     eligibility = beneficiary_import.eligibilityType
     deposit_source = beneficiary_import.get_detailed_source()
 
-    if not eligibility or not user.is_eligible_for_beneficiary_upgrade(eligibility):
+    if not users_api.is_eligible_for_beneficiary_upgrade(user, eligibility):
         raise exceptions.CannotUpgradeBeneficiaryRole()
 
     if eligibility == users_models.EligibilityType.UNDERAGE:
@@ -327,7 +327,7 @@ def get_next_subscription_step(user: users_models.User) -> typing.Optional[model
     if not user.isEmailValidated:
         return models.SubscriptionStep.EMAIL_VALIDATION
 
-    if not user.is_eligible_for_beneficiary_upgrade():
+    if not users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility):
         return None
 
     if user.eligibility == users_models.EligibilityType.AGE18:

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -799,7 +799,7 @@ def get_next_beneficiary_validation_step(user: User) -> Optional[BeneficiaryVali
     """
     This function is for legacy use. Now replaced with pcapi.core.subscription.get_next_subscription_step
     """
-    if user.is_eligible_for_beneficiary_upgrade():
+    if is_eligible_for_beneficiary_upgrade(user, user.eligibility):
         if user.eligibility == EligibilityType.AGE18:
             if not user.is_phone_validated and FeatureToggle.ENABLE_PHONE_VALIDATION.is_active():
                 return BeneficiaryValidationStep.PHONE_VALIDATION
@@ -1024,3 +1024,9 @@ def get_eligibility_at_date(
         return EligibilityType.AGE18
 
     return None
+
+
+def is_eligible_for_beneficiary_upgrade(user: models.User, eligibility: Optional[EligibilityType]) -> bool:
+    return (eligibility == EligibilityType.UNDERAGE and not user.has_underage_beneficiary_role) or (
+        eligibility == EligibilityType.AGE18 and not user.has_beneficiary_role
+    )

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -487,14 +487,6 @@ class User(PcObject, Model, NeedsValidationMixin):
     def has_underage_beneficiary_role(cls) -> bool:  # pylint: disable=no-self-argument
         return cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
 
-    def is_eligible_for_beneficiary_upgrade(self, eligibility: Optional[EligibilityType] = None) -> bool:
-        if not eligibility:
-            eligibility = self.eligibility
-
-        return (eligibility == EligibilityType.UNDERAGE and not self.has_underage_beneficiary_role) or (
-            eligibility == EligibilityType.AGE18 and not self.has_beneficiary_role
-        )
-
     @classmethod
     def init_subscription_state_machine(cls, obj, *args, **kwargs) -> None:
         from pcapi.core.subscription import transitions as subscription_transitions

--- a/api/src/pcapi/domain/beneficiary_pre_subscription/validator.py
+++ b/api/src/pcapi/domain/beneficiary_pre_subscription/validator.py
@@ -104,13 +104,17 @@ def validate(
     ignore_id_piece_number_field: bool = False,
     eligibility: EligibilityType = EligibilityType.AGE18,
 ) -> None:
+    from pcapi.core.users import api as users_api
+
     _check_subscription_on_hold(beneficiary_pre_subscription)
     _check_department_is_eligible(beneficiary_pre_subscription)
     if not preexisting_account:
         _check_email_is_not_taken(beneficiary_pre_subscription)
     else:
         if (
-            not preexisting_account.is_eligible_for_beneficiary_upgrade(eligibility)
+            not users_api.is_eligible_for_beneficiary_upgrade(
+                preexisting_account, eligibility or preexisting_account.eligibility
+            )
             or not preexisting_account.isEmailValidated
         ):
             raise BeneficiaryIsADuplicate(f"Email {beneficiary_pre_subscription.email} is already taken.")

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -252,7 +252,7 @@ def resend_email_validation(body: serializers.ResendEmailValidationRequest) -> N
 @spectree_serialize(api=blueprint.api, response_model=serializers.GetIdCheckTokenResponse)
 @authenticated_user_required
 def get_id_check_token(user: User) -> serializers.GetIdCheckTokenResponse:
-    if not user.is_eligible_for_beneficiary_upgrade():
+    if not api.is_eligible_for_beneficiary_upgrade(user, user.eligibility):
         raise ApiErrors({"code": "USER_NOT_ELIGIBLE"})
     try:
         id_check_token = api.create_id_check_token(user)

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -22,12 +22,8 @@ from pcapi.core.offers.models import Stock
 from pcapi.core.payments.models import DepositType
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import models as subscription_models
+from pcapi.core.users import api as users_api
 from pcapi.core.users import constants as users_constants
-from pcapi.core.users.api import BeneficiaryValidationStep
-from pcapi.core.users.api import get_domains_credit
-from pcapi.core.users.api import get_eligibility_end_datetime
-from pcapi.core.users.api import get_eligibility_start_datetime
-from pcapi.core.users.api import get_next_beneficiary_validation_step
 from pcapi.core.users.models import ActivityEnum
 from pcapi.core.users.models import EligibilityCheckMethods
 from pcapi.core.users.models import EligibilityType
@@ -186,7 +182,7 @@ class UserProfileResponse(BaseModel):
     isEligibleForBeneficiaryUpgrade: bool
     lastName: Optional[str]
     needsToFillCulturalSurvey: bool
-    next_beneficiary_validation_step: Optional[BeneficiaryValidationStep]
+    next_beneficiary_validation_step: Optional[users_api.BeneficiaryValidationStep]
     phoneNumber: Optional[str]
     publicName: Optional[str] = Field(None, alias="pseudo")
     recreditAmountToShow: Optional[int]
@@ -256,12 +252,12 @@ class UserProfileResponse(BaseModel):
     def from_orm(cls, user: User):  # type: ignore
         user.show_eligible_card = cls._show_eligible_card(user)
         user.subscriptions = user.get_notification_subscriptions()
-        user.domains_credit = get_domains_credit(user)
+        user.domains_credit = users_api.get_domains_credit(user)
         user.booked_offers = cls._get_booked_offers(user)
-        user.next_beneficiary_validation_step = get_next_beneficiary_validation_step(user)
-        user.isEligibleForBeneficiaryUpgrade = user.is_eligible_for_beneficiary_upgrade()
-        user.eligibility_end_datetime = get_eligibility_end_datetime(user.dateOfBirth)
-        user.eligibility_start_datetime = get_eligibility_start_datetime(user.dateOfBirth)
+        user.next_beneficiary_validation_step = users_api.get_next_beneficiary_validation_step(user)
+        user.isEligibleForBeneficiaryUpgrade = users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility)
+        user.eligibility_end_datetime = users_api.get_eligibility_end_datetime(user.dateOfBirth)
+        user.eligibility_start_datetime = users_api.get_eligibility_start_datetime(user.dateOfBirth)
         user.allowed_eligibility_check_methods = user.legacy_allowed_eligibility_check_methods
         result = super().from_orm(user)
         result.subscriptionMessage = cls._get_subscription_message(user)

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -82,5 +82,7 @@ def get_profile_options() -> serializers.ProfileOptionsResponse:
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
 
-    if user.is_eligible_for_beneficiary_upgrade() and not users_api.steps_to_become_beneficiary(user, user.eligibility):
+    if users_api.is_eligible_for_beneficiary_upgrade(
+        user, user.eligibility
+    ) and not users_api.steps_to_become_beneficiary(user, user.eligibility):
         subscription_api.activate_beneficiary(user)


### PR DESCRIPTION
The code was misleading and had lead to bugs. Now the caller of the function knows exactly what eligibility will be used

Cf bug PC-12369
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12369