### PR TITLE
(PC-12396) make offer type screen accessible

### DIFF
--- a/pro/src/screens/OfferType/OfferTypeButton/OfferTypeButton.module.scss
+++ b/pro/src/screens/OfferType/OfferTypeButton/OfferTypeButton.module.scss
@@ -1,53 +1,57 @@
 .button {
-    background-color: transparent;
-    border: 1px solid $black;
-    border-radius: 8px;
-    padding: rem(32px) rem(16px) rem(16px);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    position: relative;
-    width: rem(231px);
-    font-size: rem(15px);
+  background-color: transparent;
+  border: 1px solid $black;
+  border-radius: 8px;
+  padding: rem(32px) rem(16px) rem(16px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: rem(231px);
+  font-size: rem(15px);
 
-    &-radio {
-        display: none;
+  &-radio {
+    z-index: -1;
+  }
+
+  &-check-mark {
+    position: absolute;
+    top: rem(16px);
+    left: rem(16px);
+    fill: $primary;
+  }
+
+  &-icon {
+    fill: $black;
+    margin-bottom: rem(12px);
+  }
+
+  &.is-selected {
+    border: 1px solid $primary;
+    font-weight: 700;
+    color: $primary;
+
+    .button-icon {
+      fill: $primary;
+    }
+  }
+
+  &.is-disabled {
+    background-color: $grey-light;
+    color: $grey-dark;
+    border-color: $grey-dark;
+
+    .button-icon {
+      fill: $grey-dark;
     }
 
-    &-check-mark {
-        position: absolute;
-        top: rem(16px);
-        left: rem(16px);
-        fill: $primary
+    .button-check-mark {
+      fill: $grey-dark;
     }
+  }
+}
 
-    &-icon {
-        fill: $black;
-        margin-bottom: rem(12px);
-    }
-
-    &.is-selected {
-        border: 1px solid $primary;
-        font-weight: 700;
-        color: $primary;
-
-        .button-icon {
-            fill: $primary;
-        }
-    }
-
-    &.is-disabled {
-        background-color: $grey-light;
-        color: $grey-dark;
-        border-color: $grey-dark;
-
-        .button-icon {
-            fill: $grey-dark;
-        }
-
-        .button-check-mark {
-            fill: $grey-dark;
-        }
-    }
+.button.is-selected:focus-within {
+  border-width: 2px;
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX


## But de la pull request

rendre les boutons de choix du type d'offre accessibles au clavier

##  Implémentation

- supression du display: none sur les radio button (qui empêchent la sélection clavier)
- ajout d'une bordure au focus pour que le focus soit visible par l'utilisateur
​

https://user-images.githubusercontent.com/35567446/146741904-10498538-a5e3-443b-ba64-73de42a9e3d7.mov


