### PR TITLE
(PC-12099) email history UI

### DIFF
--- a/api/src/pcapi/admin/custom_views/user_email_history_view.py
+++ b/api/src/pcapi/admin/custom_views/user_email_history_view.py
@@ -1,0 +1,41 @@
+from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.admin.custom_views.mixins.suspension_mixin import SuspensionMixin
+
+
+class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
+    column_list = [
+        "userId",
+        "oldEmail",
+        "newEmail",
+        "creationDate",
+        "eventType",
+        "deviceId",
+    ]
+    column_labels = dict(
+        userId="User ID",
+        oldEmail="Ancienne adresse email",
+        oldDomainEmail="Ancien nom de domaine d'adresse email",
+        newEmail="Nouvelle adresse email",
+        newDomainEmail="Nouveau nom de domaine d'adresse email",
+        creationDate="Date de création",
+        eventType="Type d'événement",
+        deviceId="Device ID",
+    )
+    column_searchable_list = [
+        "userId",
+        "oldEmail",
+        "newEmail",
+        "deviceId",
+    ]
+    column_filters = [
+        "userId",
+        "oldEmail",
+        "oldDomainEmail",
+        "newEmail",
+        "newDomainEmail",
+        "eventType",
+        "deviceId",
+    ]
+
+    def is_accessible(self):
+        return super().is_accessible() and self.check_super_admins()

--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -25,6 +25,7 @@ from pcapi.admin.custom_views.pro_user_view import ProUserView
 from pcapi.admin.custom_views.suspend_fraudulent_users_by_email_providers import (
     SuspendFraudulentUsersByEmailProvidersView,
 )
+from pcapi.admin.custom_views.user_email_history_view import UserEmailHistoryView
 from pcapi.admin.custom_views.user_offerer_view import UserOffererView
 from pcapi.admin.custom_views.venue_provider_view import VenueProviderView
 from pcapi.admin.custom_views.venue_view import VenueView
@@ -35,6 +36,7 @@ from pcapi.core.payments.models import CustomReimbursementRule
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users.models import User
+from pcapi.core.users.models import UserEmailHistory
 from pcapi.models.allocine_pivot import AllocinePivot
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.criterion import Criterion
@@ -124,6 +126,15 @@ def install_admin_views(admin: Admin, session: Session) -> None:
     admin.add_view(FeatureView(Feature, session, name="Feature Flipping", category=None))
     admin.add_view(BeneficiaryImportView(BeneficiaryImport, session, name="Imports DMS", category=Category.USERS))
     admin.add_view(ApiKeyView(offerers_models.ApiKey, session, name="Clés API", category=Category.USERS))
+    admin.add_view(
+        UserEmailHistoryView(
+            UserEmailHistory,
+            session,
+            name="Historique des modifications emails",
+            category=Category.USERS,
+            endpoint="/user_email_history",
+        )
+    )
     admin.add_view(
         AllocinePivotView(AllocinePivot, session, name="Pivot Allocine", category=Category.OFFRES_STRUCTURES_LIEUX)
     )

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -467,7 +467,6 @@ def change_user_email(current_email: str, new_email: str, device_id: typing.Opti
 
     email_history = UserEmailHistory.build_validation(
         user=current_user,
-        old_email=current_email,
         new_email=new_email,
         device_id=device_id,
     )

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -31,7 +31,6 @@ def request_email_update(user: User, email: str, password: str, device_id: typin
 
     email_history = UserEmailHistory.build_update_request(
         user=user,
-        old_email=user.email,
         new_email=email,
         device_id=device_id,
     )

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -599,12 +599,11 @@ class UserEmailHistory(PcObject, Model):
     def _build(
         cls,
         user: User,
-        old_email: str,
         new_email: str,
         device_id: Optional[str],
         event_type: EmailHistoryEventTypeEnum,
     ) -> "UserEmailHistory":
-        old_user_email, old_domain_email = split_email(old_email)
+        old_user_email, old_domain_email = split_email(user.email)
         new_user_email, new_domain_email = split_email(new_email)
         return cls(
             user=user,
@@ -617,16 +616,12 @@ class UserEmailHistory(PcObject, Model):
         )
 
     @classmethod
-    def build_update_request(
-        cls, user: User, old_email: str, new_email: str, device_id: Optional[str]
-    ) -> "UserEmailHistory":
-        return cls._build(user, old_email, new_email, device_id, event_type=EmailHistoryEventTypeEnum.UPDATE_REQUEST)
+    def build_update_request(cls, user: User, new_email: str, device_id: Optional[str]) -> "UserEmailHistory":
+        return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.UPDATE_REQUEST)
 
     @classmethod
-    def build_validation(
-        cls, user: User, old_email: str, new_email: str, device_id: Optional[str]
-    ) -> "UserEmailHistory":
-        return cls._build(user, old_email, new_email, device_id, event_type=EmailHistoryEventTypeEnum.VALIDATION)
+    def build_validation(cls, user: User, new_email: str, device_id: Optional[str]) -> "UserEmailHistory":
+        return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.VALIDATION)
 
     @property
     def oldEmail(self) -> str:

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.sql import expression
+from sqlalchemy.sql.functions import func
 import transitions
 
 from pcapi import settings
@@ -623,10 +624,18 @@ class UserEmailHistory(PcObject, Model):
     def build_validation(cls, user: User, new_email: str, device_id: Optional[str]) -> "UserEmailHistory":
         return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.VALIDATION)
 
-    @property
+    @hybrid_property
     def oldEmail(self) -> str:
         return f"{self.oldUserEmail}@{self.oldDomainEmail}"
 
-    @property
+    @oldEmail.expression
+    def oldEmail(cls):  # pylint: disable=no-self-argument # type: ignore[no-redef]
+        return func.concat(cls.oldUserEmail, "@", cls.oldDomainEmail)
+
+    @hybrid_property
     def newEmail(self) -> str:
         return f"{self.newUserEmail}@{self.newDomainEmail}"
+
+    @newEmail.expression
+    def newEmail(cls):  # pylint: disable=no-self-argument # type: ignore[no-redef]
+        return func.concat(cls.newUserEmail, "@", cls.newDomainEmail)

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -250,6 +250,46 @@
   </div>
   {% endif %}
 </div>
+
+<h3>Historique des changements d'adresse email</h3>
+<div class="row">
+  <div class="col-lg-12">
+    {% if model.email_history|length == 0 %}
+    <p class="card card-body">
+        Pas de changement d'adresse email pour le moment
+    </p>
+    {% elif current_user.is_super_admin() %}
+    <a href="/pc/back-office/user_email_history/?search=pctest&flt1_0={{ model.id }}">Vue détaillée</a>
+    <table class="table table-striped table-hover">
+      <thead>
+        <tr>
+          <th scope="col">Ancienne adresse email</th>
+          <th scope="col">Nouvelle adresse email</th>
+          <th scope="col">Date</th>
+          <th scope="col">Type d'événement</th>
+          <th scope="col">Device ID</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for email_history in model.email_history %}
+        <tr>
+          <td>{{ email_history.oldEmail }}</td>
+          <td>{{ email_history.newEmail }}</td>
+          <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+          <td>{{ email_history.eventType.value }}</td>
+          <td>{{ email_history.deviceId }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p class="card card-body">
+        L'utilisateur a changé d'adresse email depuis la création de son compte
+    </p>
+    {% endif %}
+  </div>
+</div>
+
 <h3>Beneficiary Imports</h3>
 <div class="row">
   {% for import in model.beneficiaryImports %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12099


## But de la pull request

Ajout d'une interface utilisateur dans l'admin pour afficher l'historique des changements d'adresse email

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)

Dans l'onglet `Support`, dans la page de détail d'un bénéficiaire, lorsqu'il y a eu des changements d'adresse email et que l'user connecté est super admin
![image](https://user-images.githubusercontent.com/95220086/146778195-d0c13032-3e07-4907-ab88-a6b134585e2d.png)

Dans l'onglet `Support`, dans la page de détail d'un bénéficiaire, lorsqu'il y a eu des changements d'adresse email et que l'user connecté est seulement admin
![image](https://user-images.githubusercontent.com/95220086/146937199-c1b8a578-f9fd-4ead-850f-debeda641b7c.png)

Dans l'onglet `Support`, dans la page de détail d'un bénéficiaire, lorsqu'il **n'y a pas** eu de changements d'adresse email
![image](https://user-images.githubusercontent.com/95220086/146937345-c8bb1a35-3b08-4595-aa18-043e3230f7bd.png)

Dans l'onglet `Utilisateurs`, nouvelle page dédiée à l'historique de changements d'adresse email
![image](https://user-images.githubusercontent.com/95220086/146769348-6062a03e-daa6-4fbf-b4bd-52d5c8c7bbd8.png)
