### PR TITLE
(PC-12212)[PRO] update confirmation page with pending status

### DIFF
--- a/pro/src/routes/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
+++ b/pro/src/routes/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
@@ -1,17 +1,43 @@
-import React from 'react'
-import { useLocation } from 'react-router'
+import React, { useEffect, useState } from 'react'
+import { useLocation, useParams } from 'react-router'
 
+import useNotification from 'components/hooks/useNotification'
+import Spinner from 'components/layout/Spinner'
 import { queryParamsFromOfferer } from 'components/pages/Offers/utils/queryParamsFromOfferer'
+import { getOfferAdapter } from 'core/OfferEducational'
+import { OfferStatus } from 'custom_types/offer'
 import OfferEducationalConfirmationScreen from 'screens/OfferEducationalConfirmation'
 
 const OfferEducationalConfirmation = (): JSX.Element => {
   const location = useLocation<{ structure?: string; lieu?: string }>()
+  const { offerId } = useParams<{ offerId: string }>()
+  const [offerStatus, setOfferStatus] = useState<undefined | OfferStatus>()
+  const notify = useNotification()
 
   const { structure: offererId, lieu: venueId } =
     queryParamsFromOfferer(location)
 
+  useEffect(() => {
+    const loadOffer = async () => {
+      const offerResponse = await getOfferAdapter(offerId)
+
+      if (!offerResponse.isOk) {
+        return notify.error(offerResponse.message)
+      }
+
+      setOfferStatus(offerResponse.payload.offer.status)
+    }
+
+    loadOffer()
+  }, [offerId, notify])
+
+  if (!offerStatus) {
+    return <Spinner />
+  }
+
   return (
     <OfferEducationalConfirmationScreen
+      offerStatus={offerStatus}
       offererId={offererId}
       venueId={venueId}
     />

--- a/pro/src/routes/OfferEducationalStockCreation/OfferEducationalStockCreation.tsx
+++ b/pro/src/routes/OfferEducationalStockCreation/OfferEducationalStockCreation.tsx
@@ -36,7 +36,7 @@ const OfferEducationalStockCreation = (): JSX.Element => {
     if (!isOk) {
       return notify.error(message)
     }
-    history.push('/offre/scolaire/confirmation')
+    history.push(`/offre/${offer.id}/scolaire/confirmation`)
   }
 
   useEffect(() => {

--- a/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
+++ b/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
@@ -2,7 +2,9 @@ import cn from 'classnames'
 import React from 'react'
 import { Link } from 'react-router-dom'
 
+import { ReactComponent as PendingIcon } from 'components/pages/Offers/Offer/Confirmation/assets/pending.svg'
 import { ReactComponent as ValidateIcon } from 'components/pages/Offers/Offer/Confirmation/assets/validate.svg'
+import { OfferStatus } from 'custom_types/offer'
 import { Title } from 'ui-kit'
 
 import styles from './OfferEducationalConfirmation.module.scss'
@@ -10,11 +12,27 @@ import styles from './OfferEducationalConfirmation.module.scss'
 interface IOfferEducationalConfirmationProps {
   offererId: string | null
   venueId: string | null
+  offerStatus?: OfferStatus
+}
+
+const activeOffer = {
+  title: 'Offre créée avec succès !',
+  description:
+    "Votre offre est désormais disponible sur ADAGE (L'Application Dédiée À la Généralisation de l’Éducation artistique et culturelle) et visible par les enseignants et chefs d’établissement de l’Éducation nationale.",
+  Icon: ValidateIcon,
+}
+
+const pendingOffer = {
+  title: 'Offre en cours de validation !',
+  description:
+    'Votre offre est en cours de validation par l’équipe pass Culture, nous vérifions actuellement son éligibilité. Cette vérification pourra prendre jusqu’à 72h.',
+  Icon: PendingIcon,
 }
 
 const OfferEducationalConfirmation = ({
   offererId,
   venueId,
+  offerStatus,
 }: IOfferEducationalConfirmationProps): JSX.Element => {
   let queryString = ''
   if (offererId) {
@@ -25,19 +43,22 @@ const OfferEducationalConfirmation = ({
     queryString += `&lieu=${venueId}`
   }
 
+  const { title, description, Icon } =
+    offerStatus === OfferStatus.OFFER_STATUS_PENDING
+      ? pendingOffer
+      : activeOffer
+
   return (
     <div className={styles['confirmation']}>
-      <ValidateIcon className={styles['confirmation-icon']} />
+      <Icon className={styles['confirmation-icon']} />
       <div className={styles['confirmation-section']}>
         <div className={styles['confirmation-section-header']}>
           <Title as="h2" level={3}>
-            Offre créée avec succès !
+            {title}
           </Title>
         </div>
         <p className={styles['form-layout-section-description']}>
-          Votre offre est désormais disponible sur ADAGE (L'Application Dédiée À
-          la Généralisation de l’Éducation artistique et culturelle) et visible
-          par les enseignants et chefs d’établissement de l’Éducation nationale.
+          {description}
         </p>
       </div>
       <div className={styles['confirmation-actions']}>

--- a/pro/src/utils/routes_map.jsx
+++ b/pro/src/utils/routes_map.jsx
@@ -195,7 +195,7 @@ const routes = [
     component: OfferEducationalConfirmation,
     exact: true,
     featureName: 'ENABLE_NEW_EDUCATIONAL_OFFER_CREATION_FORM',
-    path: '/offre/scolaire/confirmation',
+    path: '/offre/:offerId([A-Z0-9]+)/scolaire/confirmation',
     title: 'Page de confirmation de création d’offre',
   },
   {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12212

## But de la pull request

Informer l'utilisateur sur le statut de son offre après sa création. Parfois, celle-ci peut-être PENDING si elle doit passer certains contrôle de fraude.

##  Implémentation

- Ajout de l'offerId dans l'url de la page de confirmation
- Récupération du statut de l'offre et affichage du screen avec des données différentes suivant le statut
​