### PR TITLE
(PC-12414) Fix eligibility start datetime

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -504,9 +504,10 @@ def on_successful_application(
     third_party_id: typing.Optional[str] = None,
 ) -> None:
     users_api.update_user_information_from_external_source(user, source_data)
-    # unsure ?
-    # not needed for Ubble since it has been set to True on `processing` notif
+
+    # TODO (viconnex) remove when we also look for DMS files to know if the user has completed id check
     user.hasCompletedIdCheck = True
+
     pcapi_repository.repository.save(user)
 
     create_successfull_beneficiary_import(

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1375,6 +1375,21 @@ class EligibilityStartDateTest:
     def test_eligibility_start_datetime_generalisation(self, date_of_birth, expected_date):
         assert get_eligibility_start_datetime(date_of_birth) == expected_date
 
+    @override_features(ENABLE_UNDERAGE_GENERALISATION=True)
+    @override_settings(
+        UNDERAGE_BROAD_OPENING_DATETIME=datetime(2022, 1, 31),
+        UNDERAGE_EARLY_OPENING_DATETIME=datetime(2022, 1, 3),
+        UNDERAGE_16_YO_OPENING_DATETIME=datetime(2022, 1, 20),
+        UNDERAGE_17_YO_OPENING_DATETIME=datetime(2022, 1, 10),
+    )
+    @patch(
+        "pcapi.core.users.constants.UNDERAGE_OPENING_DATETIMES_BY_AGE",
+        {15: datetime(2022, 1, 31), 16: datetime(2022, 1, 20), 17: datetime(2022, 1, 10)},
+    )
+    @freeze_time("2021-01-09")
+    def test_eligibility_start_datetime_during_generalisation(self):
+        assert get_eligibility_start_datetime(datetime(2004, 1, 8)) == datetime(2022, 1, 3)
+
 
 class GetEligibilityTest:
     @override_features(ENABLE_UNDERAGE_GENERALISATION=True)


### PR DESCRIPTION
It must not depend on the date where it is computed, which was the case because the result was relying on a "current" age.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12414


## But de la pull request

Corriger le bug qui survient quand :

- la généralisation est activée (ENABLE_UNDERAGE_GENERALISATION)
- le dossier est déposé à 17 ans 
- le dossier est validé à 18 ans 
- l’anniversaire tombe pendant la phase de généralisation

`eligibility_start_datetime` calculé **avant** l'anniversaire de 18ans donnait le 3 janvier (ouverture)
`eligibility_start_datetime` calculé **après** l'anniversaire de 18ans donnait l'anniv de 18 ans

Cette donnée ne doit pas dépendre de la date à laquelle on le calcule

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
