### PR TITLE
(PC-12188)[PRO]: Reset bank info input value on form submit cancellation, fix css & wording

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/DeleteBusinessUnitConfirmationDialog/DeleteBusinessUnitConfirmationDialog.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/DeleteBusinessUnitConfirmationDialog/DeleteBusinessUnitConfirmationDialog.tsx
@@ -17,13 +17,14 @@ const DeleteBusinessUnitConfirmationDialog = ({
       confirmText="Continuer"
       onCancel={onCancel}
       onConfirm={onConfirm}
-      title="Vous avez modifié les coordonnées bancaires associées à ce lieu"
+      title="Vous allez modifier les coordonnées bancaires associées à ce lieu"
     >
       <p>
         En modifiant ces coordonnées, vous les supprimez des autres lieux
         auxquels elles sont associées. Vous devrez associer à nouveau des
         coordonnées à ces lieux pour percevoir vos remboursements.
       </p>
+      <br />
       <p>Souhaitez-vous continuer ?</p>
     </ConfirmDialog>
   )

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
@@ -143,6 +143,11 @@ const VenueEdition = ({
       venueLabelId,
     } = values
 
+    const cancelBusinessUnitModification = form => {
+      form.change('businessUnitId', venue.businessUnitId)
+      setShowConfirmationDialog(false)
+    }
+
     const isDirtyFieldBookingEmail = bookingEmail !== venue.bookingEmail
     const siretValidOnModification = initialSiret !== null
     const fieldReadOnlyBecauseFrozenFormSiret =
@@ -232,7 +237,7 @@ const VenueEdition = ({
         </form>
         {showConfirmationDialog && (
           <DeleteBusinessUnitConfirmationDialog
-            onCancel={() => setShowConfirmationDialog(false)}
+            onCancel={() => cancelBusinessUnitModification(form)}
             onConfirm={() => onConfirmDeleteBusinessUnit(handleSubmit)}
           />
         )}

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/__specs__/VenueEdition.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/__specs__/VenueEdition.spec.jsx
@@ -196,7 +196,7 @@ describe('test page : VenueEdition', () => {
 
       expect(screen.getByText('Informations lieu')).toBeInTheDocument()
       expect(
-        screen.getByText('Coordonnées bancaires du lieu (remboursement)')
+        screen.getByText('Coordonnées bancaires du lieu')
       ).toBeInTheDocument()
 
       expect(screen.getByLabelText('Nom du lieu :')).toBeDisabled()
@@ -502,7 +502,7 @@ describe('test page : VenueEdition', () => {
 
         expect(
           screen.getByText(
-            'Vous avez modifié les coordonnées bancaires associées à ce lieu'
+            'Vous allez modifier les coordonnées bancaires associées à ce lieu'
           )
         ).toBeInTheDocument()
         fireEvent.click(screen.getByRole('button', { name: 'Continuer' }))
@@ -528,7 +528,7 @@ describe('test page : VenueEdition', () => {
         fireEvent.click(screen.queryByRole('button', { name: 'Valider' }))
         expect(
           screen.getByText(
-            'Vous avez modifié les coordonnées bancaires associées à ce lieu'
+            'Vous allez modifier les coordonnées bancaires associées à ce lieu'
           )
         ).toBeInTheDocument()
 

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/BusinessUnitFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/BusinessUnitFields.jsx
@@ -77,9 +77,7 @@ const BankInformationWithBusinessUnit = ({ readOnly, offerer, venue }) => {
   return (
     <div className="section vp-content-section bank-information">
       <div className="main-list-title title-actions-container">
-        <h2 className="main-list-title-text">
-          Coordonnées bancaires du lieu (remboursement)
-        </h2>
+        <h2 className="main-list-title-text">Coordonnées bancaires du lieu</h2>
         {displayedBanners[REPLACE_DMS_FILE_BUTTON] && (
           <a
             className="tertiary-link"

--- a/pro/src/styles/components/pages/Offerer/BankInformation/_BankInformation.scss
+++ b/pro/src/styles/components/pages/Offerer/BankInformation/_BankInformation.scss
@@ -26,6 +26,9 @@
     width: initial;
   }
   .select {
+    position: relative;
+    width: fit-content;
+
     select {
       @include body-important();
 
@@ -36,7 +39,7 @@
       height: rem(36px);
       max-width: 100%;
       outline: none;
-      padding: rem(4px) rem(40px) rem(4px) rem(16px);
+      padding: rem(4px) rem(46px) rem(4px) rem(16px);
     }
 
     &::after {
@@ -44,11 +47,11 @@
       border-radius: rem(2px);
       border-right: 0;
       border-top: 0;
-      content: " ";
+      content: "";
       height: rem(10px);
       margin-top: rem(-19px);
       position: absolute;
-      right: rem(460px);
+      right: rem(20px);
       top: 75%;
       transform: rotate(-45deg);
       transform-origin: center;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12188


## But de la pull request

Remettre la valeur précédente à l'input informations bancaires sur le formulaire d'édition de lieu quand l'utilisateur annule ses modifications suite à la pop up. Mise à jour de wording et css.


