### PR TITLE
[api][alembic] Fix business_unit.status column definition

### DIFF
--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -70,7 +70,9 @@ class BusinessUnit(Model):
     id = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
     name = sqla.Column(sqla.Text)
     siret = sqla.Column(sqla.String(14), unique=True)
-    status = sqla.Column(db_utils.MagicEnum(BusinessUnitStatus), nullable=False, default=BusinessUnitStatus.ACTIVE)
+    status = sqla.Column(
+        db_utils.MagicEnum(BusinessUnitStatus), nullable=False, server_default=BusinessUnitStatus.ACTIVE.value
+    )
 
     bankAccountId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("bank_information.id"), index=True, nullable=True)
     bankAccount = sqla_orm.relationship("BankInformation", foreign_keys=[bankAccountId])


### PR DESCRIPTION
## But de la pull request

Corriger la définition de la colonne `status` du modèle `BusinessUnit`.

En effet, la génération automatique de migration par alembic détectait une incohérence et proposait :
```
def upgrade():
    op.alter_column('business_unit', 'status',
               existing_type=sa.TEXT(),
               server_default=None,
               existing_nullable=False)
```

## Implémentation

- Remplacer `default` par `server_default`
- Fournir la valeur de l'enum, afin qu'alembic sache définir la bonne valeur de type `str`
