### PR TITLE
(PC-12425)[PRO] add venue name in educational offerers response

### DIFF
--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -127,6 +127,7 @@ class GetEducationalOffererVenueResponseModel(BaseModel):
     id: str
     isVirtual: bool
     publicName: Optional[str]
+    name: str
     postalCode: Optional[str]
     audioDisabilityCompliant: Optional[bool]
     mentalDisabilityCompliant: Optional[bool]

--- a/api/tests/routes/pro/get_educational_offerers_test.py
+++ b/api/tests/routes/pro/get_educational_offerers_test.py
@@ -41,6 +41,7 @@ class GetEducationalOfferersTest:
                             "publicName": venue_offerer_1.publicName,
                             "postalCode": venue_offerer_1.postalCode,
                             "visualDisabilityCompliant": venue_offerer_1.visualDisabilityCompliant,
+                            "name": venue_offerer_1.name,
                         }
                     ],
                 },
@@ -59,6 +60,7 @@ class GetEducationalOfferersTest:
                             "publicName": venue_offerer_2.publicName,
                             "postalCode": venue_offerer_2.postalCode,
                             "visualDisabilityCompliant": venue_offerer_2.visualDisabilityCompliant,
+                            "name": venue_offerer_2.name,
                         }
                     ],
                 },
@@ -113,6 +115,7 @@ class GetEducationalOfferersTest:
                             "publicName": venue_offerer_2.publicName,
                             "postalCode": venue_offerer_2.postalCode,
                             "visualDisabilityCompliant": venue_offerer_2.visualDisabilityCompliant,
+                            "name": venue_offerer_2.name,
                         }
                     ],
                 },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12425


## But de la pull request

Côté front, on affiche le nom du lieu soit en utilisant la valeur publicName soit en utilisant la valeur name de l'entité Venue. En testing, tous les publicName étaient renseignés donc on n'a pas vu le bug, mais en staging, on fallback sur le name, or celui-ci n'était pas remonté dans la réponse de l'API
