### PR TITLE
(PC-12433) (Backend) Ne plus utiliser le vieu endpoint idcheck/validation coté back

### DIFF
--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -158,7 +158,7 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
         logger.exception("Error while creating BeneficiaryImport from Educonnect: %s", e, extra={"user_id": user.id})
         return redirect(ERROR_PAGE_URL, code=302)
 
-    user_information_validation_base_url = f"{settings.WEBAPP_V2_URL}/idcheck/validation?"
+    user_information_validation_base_url = f"{settings.WEBAPP_V2_URL}/validation?"
     query_params = {
         "firstName": educonnect_user.first_name,
         "lastName": educonnect_user.last_name,

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -176,7 +176,7 @@ class EduconnectFlowTest:
         assert response.status_code == 302
         assert (
             response.location
-            == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            == "https://webapp-v2.example.com/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
         assert len(user.beneficiaryFraudResults) == 1
@@ -266,7 +266,7 @@ class EduconnectFlowTest:
         assert response.status_code == 302
         assert (
             response.location
-            == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            == "https://webapp-v2.example.com/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
         assert len(user.beneficiaryFraudResults) == 1

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -111,7 +111,7 @@ class EduconnectTest:
         assert response.status_code == 302
         assert (
             response.location
-            == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            == "https://webapp-v2.example.com/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
         assert caplog.records[0].extra == {
@@ -199,7 +199,7 @@ class EduconnectTest:
             response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith("https://webapp-v2.example.com/idcheck/validation")
+        assert response.location.startswith("https://webapp-v2.example.com/validation")
         assert caplog.messages == ["Fraud suspicion after Educonnect authentication: "]
         assert caplog.records[0].extra == {"userId": user.id, "educonnectId": educonnect_user.educonnect_id}
 
@@ -321,7 +321,7 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith("https://webapp-v2.example.com/idcheck/validation")
+        assert response.location.startswith("https://webapp-v2.example.com/validation")
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
 
     @override_features(ENABLE_INE_WHITELIST_FILTER=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12433


## But de la pull request

Supprimer des endpoints deprecated obligeant le front à gérer des alias avec une feature de screen detection incompatible avec les besoins du pass

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
