### PR TITLE
[PC-12061][API] fix flaky test

### DIFF
--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -838,7 +838,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=10, status="SOLD_OUT"
             )
 
             # then


### PR DESCRIPTION
Prior to #617 the results were sorted whenever they were over the
limit. Since it had an impact on performances, the results are not
sorted any longer which means that from time to time the test would
fail.
Since the test is about making sure some offers are correctly
included, I don't see any reason not to increase the result limit
to include all the results.
