### PR TITLE
(PC-11880) Add isForbiddenToUnderage in offer response

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -195,6 +195,7 @@ class OfferResponse(BaseModel):
     externalTicketOfficeUrl: Optional[str]
     extraData: Optional[OfferExtraData]
     isExpired: bool
+    is_forbidden_to_underage: bool
     isReleased: bool
     isSoldOut: bool
     isDigital: bool

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -136,6 +136,7 @@ class OffersTest:
             },
             "image": {"url": "http://localhost/storage/thumbs/mediations/N4", "credit": "street credit"},
             "isExpired": False,
+            "isForbiddenToUnderage": False,
             "isSoldOut": False,
             "isDuo": True,
             "isEducational": False,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11880


## But de la pull request

L'info est déjà présente sur le stock et permet au front de gérer l'affichage du bouton "Confirmer ma réservation"

On rajoute l'info sur l'offre pour que le front gère aussi l'affichage du premier CTA "Réserver cette offre" qui arrive plus en amont.
