### PR TITLE
(PC-12466) Fix ability for admin to submit a review on jouve cases

### DIFF
--- a/api/src/pcapi/core/fraud/api/__init__.py
+++ b/api/src/pcapi/core/fraud/api/__init__.py
@@ -733,7 +733,6 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
             models.BeneficiaryFraudCheck.user == user,
             models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
-            models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
         ).exists()
     ).scalar()
 

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -50,7 +50,7 @@ class JouveContentFactory(factory.Factory):
     postalCode = "75008"
     posteCodeCtrl = "75"
     serviceCodeCtrl = factory.Faker("pystr")
-    registrationDate = LazyAttribute(lambda _: (datetime.utcnow()).strftime("%d/%m/%Y %H:%M"))
+    registrationDate = LazyAttribute(lambda _: (datetime.utcnow()).strftime("%m/%d/%Y %H:%M %p"))
 
 
 USERPROFILING_RATING = [rating.value for rating in models.UserProfilingRiskRating]

--- a/api/src/pcapi/core/fraud/models/__init__.py
+++ b/api/src/pcapi/core/fraud/models/__init__.py
@@ -78,7 +78,7 @@ def _parse_jouve_datetime(date: typing.Optional[str]) -> typing.Optional[datetim
     except pydantic.DateTimeError:
         pass
     try:
-        return datetime.datetime.strptime(date, "%d/%m/%Y %H:%M")
+        return datetime.datetime.strptime(date, "%m/%d/%Y %H:%M %p")
     except ValueError:
         return None
 

--- a/api/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
+++ b/api/tests/connectors/beneficiaries/beneficiary_jouve_repository_test.py
@@ -20,7 +20,7 @@ def get_application_by_detail_response(application_id: int = 2, birth_date: str 
     return {
         "id": application_id,
         "birthDateTxt": birth_date,
-        "registrationDate": "04/06/2020 06:00",
+        "registrationDate": "06/04/2020 6:00 AM",
         "address": "18 avenue des fleurs",
         "city": "RENNES",
         "email": "rennes@example.org",

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -55,7 +55,7 @@ class JouveFraudCheckTest:
         "postalCode": "",
         "posteCode": "678083",
         "posteCodeCtrl": "OK",
-        "registrationDate": f"{datetime.datetime.now():%d/%m/%Y %H:%M}",
+        "registrationDate": f"{datetime.datetime.now():%m/%d/%Y %H:%M %p}",
         "serviceCode": "1",
         "serviceCodeCtrl": "OK",
     }
@@ -92,6 +92,7 @@ class JouveFraudCheckTest:
         assert jouve_fraud_content.bodyPieceNumber == "140767100016"
         assert fraud_check.dateCreated
         assert fraud_check.thirdPartyId == "35"
+        assert fraud_check.eligibilityType == users_models.EligibilityType.AGE18
         assert fraud_result.status == fraud_models.FraudStatus.OK
 
         db.session.refresh(user)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -844,7 +844,7 @@ class HasUserPerformedIdentityCheckTest:
             type=fraud_models.FraudCheckType.UBBLE, user=user, eligibilityType=users_models.EligibilityType.UNDERAGE
         )
 
-        assert not fraud_api.has_user_performed_identity_check(user)
+        assert fraud_api.has_user_performed_identity_check(user)
         assert not fraud_api.has_user_performed_ubble_check(user)
 
     def test_has_user_performed_identity_check_without_identity_fraud_check(self):

--- a/api/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/api/tests/use_cases/create_beneficiary_from_application_test.py
@@ -58,7 +58,7 @@ JOUVE_CONTENT = {
     "lastName": "DURAND",
     "phoneNumber": "0123456789",
     "postalCode": "35123",
-    "registrationDate": f"{datetime.now():%d/%m/%Y %H:%M}",
+    "registrationDate": f"{datetime.now():%m/%d/%Y %H:%M %p}",
     "serviceCodeCtrl": "OK",
 }
 


### PR DESCRIPTION
Résolution de 2 problèmes :
- Bug on flask admin : the operators cannot see the button 'Soumettre une revue manuelle' because old fraud_checks were created without eligibiltyType

- Enregistrer correctement le `registrationDate` des dossier jouve n’est pas enregistré, car on n’a pas le bon format de date
jouve envoie : ‘12/22/2021 5:00 PM’
nous on attend : ‘12/22/2021 17:00’

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX