### PR TITLE
[PC-12475] fix optional bic/iban on business unit serialization

### DIFF
--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -21,8 +21,8 @@ class BusinessUnitResponseModel(BaseModel):
         orm_mode = True
 
     id: int
-    iban: str
-    bic: str
+    iban: Optional[str]
+    bic: Optional[str]
     name: str
     # FIXME (dbaty, 2021-12-15): SIRET may be NULL while we initialize
     # business units. In a few months, all business units should have


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12475

## But de la pull request

business unit may be created before the bic/iban are available.
This is required to be able to follow up a bic/iban procedure.
