### PR TITLE
[PC-12327][api][finance] Adapt /finance/invoices endpoint

### DIFF
--- a/api/src/pcapi/routes/pro/finance.py
+++ b/api/src/pcapi/routes/pro/finance.py
@@ -12,26 +12,21 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import finance_serialize
 from pcapi.serialization.decorator import spectree_serialize
-from pcapi.utils import human_ids
 from pcapi.utils.rest import check_user_has_access_to_offerer
 
 
-@private_api.route("/finance/<humanized_offerer_id>/invoices", methods=["GET"])
+@private_api.route("/finance/invoices", methods=["GET"])
 @login_required
 @spectree_serialize(response_model=finance_serialize.InvoiceListResponseModel)
 def get_invoices(
-    humanized_offerer_id: str,
     query: finance_serialize.InvoiceListQueryModel,
 ) -> finance_serialize.InvoiceListResponseModel:
-    offerer_id = human_ids.dehumanize(humanized_offerer_id)
-    check_user_has_access_to_offerer(current_user, offerer_id)
-
     # Frontend sends a period with *inclusive* bounds, but
     # `get_invoices_query` expects the upper bound to be *exclusive*.
     if query.periodEndingDate:
         query.periodEndingDate += datetime.timedelta(days=1)
     invoices = finance_repository.get_invoices_query(
-        offerer_id,
+        current_user,
         business_unit_id=query.businessUnitId,
         date_from=query.periodBeginningDate,
         date_until=query.periodEndingDate,

--- a/api/tests/routes/pro/get_invoices_test.py
+++ b/api/tests/routes/pro/get_invoices_test.py
@@ -5,7 +5,6 @@ import pytest
 import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
-from pcapi.utils import human_ids
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -30,8 +29,7 @@ def test_get_invoices(client):
     pro = users_factories.ProFactory(offerers=[offerer])
 
     client = client.with_session_auth(pro.email)
-    humanized_offerer_id = human_ids.humanize(offerer.id)
-    response = client.get(f"/finance/{humanized_offerer_id}/invoices")
+    response = client.get("/finance/invoices")
 
     assert response.status_code == 200
     invoices = response.json
@@ -57,8 +55,7 @@ def test_get_invoices_specify_business_unit(client):
 
     client = client.with_session_auth(pro.email)
     params = {"businessUnitId": business_unit1.id}
-    humanized_offerer_id = human_ids.humanize(offerer.id)
-    response = client.get(f"/finance/{humanized_offerer_id}/invoices", params=params)
+    response = client.get("/finance/invoices", params=params)
 
     assert response.status_code == 200
     invoices = response.json
@@ -86,24 +83,12 @@ def test_get_invoices_specify_dates(client):
 
     client = client.with_session_auth(pro.email)
     params = {"periodBeginningDate": "2021-07-01", "periodEndingDate": "2021-07-31"}
-    humanized_offerer_id = human_ids.humanize(offerer.id)
-    response = client.get(f"/finance/{humanized_offerer_id}/invoices", params=params)
+    response = client.get("/finance/invoices", params=params)
 
     assert response.status_code == 200
     invoices = response.json
     assert len(invoices) == 1
     assert invoices[0]["reference"] == invoice_within.reference
-
-
-def test_get_invoices_unauthorized_offerer(client):
-    offerer = offerers_factories.OffererFactory()
-    pro = users_factories.ProFactory()
-
-    client = client.with_session_auth(pro.email)
-    humanized_offerer_id = human_ids.humanize(offerer.id)
-    response = client.get(f"/finance/{humanized_offerer_id}/invoices")
-
-    assert response.status_code == 403
 
 
 def test_get_invoices_unauthorized_business_unit(client):
@@ -113,9 +98,8 @@ def test_get_invoices_unauthorized_business_unit(client):
     other_business_unit = other_invoice.businessUnit
 
     client = client.with_session_auth(pro.email)
-    humanized_offerer_id = human_ids.humanize(offerer.id)
     params = {"businessUnitId": other_business_unit.id}
-    response = client.get(f"/finance/{humanized_offerer_id}/invoices", params=params)
+    response = client.get("/finance/invoices", params=params)
 
     assert response.status_code == 200
     invoices = response.json


### PR DESCRIPTION
This endpoint does not accept an offerer id anymore. It returns all
invoices that are available to the current user... unless the user is
an admin, in which case they must provide a business unit id to filter
on. We really don't want to return all invoices of all business units
to an admin.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12327