### PR TITLE
(PC-12510)[API]sendinblue-transac-email-beneficiary-subscription-info-error

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -54,6 +54,12 @@ class TransactionalEmail(Enum):
         tags=["jeunes_document_etranger"],
         use_priority_queue=True,
     )
+    SUBSCRIPTION_INFORMATION_ERROR = Template(
+        id_prod=410,
+        id_not_prod=43,
+        tags=["jeunes_infos_erronees"],
+        use_priority_queue=True,
+    )
     SUBSCRIPTION_INVALID_DOCUMENT_ERROR = Template(
         id_prod=384,
         id_not_prod=39,

--- a/api/src/pcapi/core/mails/transactional/users/subscription_document_error_email.py
+++ b/api/src/pcapi/core/mails/transactional/users/subscription_document_error_email.py
@@ -30,31 +30,14 @@ def get_subscription_document_error_email_data(code: str) -> Union[dict, Sendinb
         return handler()
 
     error_codes_switch = {
-        "unread-document": _get_unread_document_sendinblue_email_data,
-        "invalid-document": _get_invalid_document_sendinblue_email_data,
-        "unread-mrz-document": _get_invalid_mrz_sendinblue_email_data,
+        "information-error": TransactionalEmail.SUBSCRIPTION_INFORMATION_ERROR,
+        "unread-document": TransactionalEmail.SUBSCRIPTION_UNREADABLE_DOCUMENT_ERROR,
+        "invalid-document": TransactionalEmail.SUBSCRIPTION_INVALID_DOCUMENT_ERROR,
+        "unread-mrz-document": TransactionalEmail.SUBSCRIPTION_FOREIGN_DOCUMENT_ERROR,
     }
 
-    handler = error_codes_switch.get(code, _get_unread_document_sendinblue_email_data)
-    return handler()
-
-
-def _get_unread_document_sendinblue_email_data() -> SendinblueTransactionalEmailData:
-    return SendinblueTransactionalEmailData(
-        template=TransactionalEmail.SUBSCRIPTION_UNREADABLE_DOCUMENT_ERROR.value,
-    )
-
-
-def _get_invalid_document_sendinblue_email_data() -> SendinblueTransactionalEmailData:
-    return SendinblueTransactionalEmailData(
-        template=TransactionalEmail.SUBSCRIPTION_INVALID_DOCUMENT_ERROR.value,
-    )
-
-
-def _get_invalid_mrz_sendinblue_email_data() -> SendinblueTransactionalEmailData:
-    return SendinblueTransactionalEmailData(
-        template=TransactionalEmail.SUBSCRIPTION_FOREIGN_DOCUMENT_ERROR.value,
-    )
+    template = error_codes_switch.get(code, TransactionalEmail.SUBSCRIPTION_INFORMATION_ERROR)
+    return SendinblueTransactionalEmailData(template=template.value)
 
 
 def _get_unread_document_email_data() -> dict:

--- a/api/tests/core/mails/transactional/users/subscription_document_error_email_test.py
+++ b/api/tests/core/mails/transactional/users/subscription_document_error_email_test.py
@@ -5,9 +5,75 @@ from pcapi.core.mails.transactional.users.subscription_document_error_email impo
 from pcapi.core.testing import override_features
 
 
-class SubscriptionUnreadableDocumentErrorEmailTest:
+class MailjetSubscriptionErrorEmailTest:
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
+    def test_send_unreadable_document_error_email_sendinblue_not_activated(self) -> None:
+        email = "123@test.com"
+        code = "unread-document"
+        send_subscription_document_error_email(email, code)
+
+        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 2958557
+        assert mails_testing.outbox[0].sent_data["To"] == email
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
+    def test_send_foreign_document_error_email_sendinblue_not_activated(self) -> None:
+        email = "123@test.com"
+        code = "unread-mrz-document"
+        send_subscription_document_error_email(email, code)
+
+        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 3188025
+        assert mails_testing.outbox[0].sent_data["To"] == email
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
+    def test_send_invalid_document_error_email_sendinblue_not_activated(self) -> None:
+        email = "123@test.com"
+        code = "invalid-document"
+        send_subscription_document_error_email(email, code)
+
+        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 2958584
+        assert mails_testing.outbox[0].sent_data["To"] == email
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
+    def test_send_unreadable_document_error_email_by_default_when_wrong_error_code(self) -> None:
+        email = "123@test.com"
+        code = "information-error"
+        send_subscription_document_error_email(email, code)
+
+        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 2958557
+        assert mails_testing.outbox[0].sent_data["To"] == email
+
+
+class SendinblueSubscriptionDocumentErrorEmailTest:
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_send_document_error_email(self) -> None:
+    def test_send_information_error_email_by_default_when_wrong_zerror_code(self) -> None:
+        email = "123@test.com"
+        code = "wrong-code"
+        send_subscription_document_error_email(email, code)
+
+        assert mails_testing.outbox[0].sent_data["template"] == {
+            "id_prod": 410,
+            "id_not_prod": 43,
+            "tags": ["jeunes_infos_erronees"],
+            "use_priority_queue": True,
+        }
+        assert mails_testing.outbox[0].sent_data["To"] == email
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_send_information_error_email(self) -> None:
+        email = "123@test.com"
+        code = "information-error"
+        send_subscription_document_error_email(email, code)
+
+        assert mails_testing.outbox[0].sent_data["template"] == {
+            "id_prod": 410,
+            "id_not_prod": 43,
+            "tags": ["jeunes_infos_erronees"],
+            "use_priority_queue": True,
+        }
+        assert mails_testing.outbox[0].sent_data["To"] == email
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_send_unreadable_document_error_email(self) -> None:
         email = "123@test.com"
         code = "unread-document"
         send_subscription_document_error_email(email, code)
@@ -20,19 +86,8 @@ class SubscriptionUnreadableDocumentErrorEmailTest:
         }
         assert mails_testing.outbox[0].sent_data["To"] == email
 
-    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
-    def test_send_document_error_email_sendinblue_not_activated(self) -> None:
-        email = "123@test.com"
-        code = "unread-document"
-        send_subscription_document_error_email(email, code)
-
-        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 2958557
-        assert mails_testing.outbox[0].sent_data["To"] == email
-
-
-class SubscriptionInvalidDocumentErrorEmailTest:
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_send_subscription_document_error_email(self) -> None:
+    def test_send_invalid_document_error_email(self) -> None:
         email = "123@test.com"
         code = "invalid-document"
         send_subscription_document_error_email(email, code)
@@ -45,19 +100,8 @@ class SubscriptionInvalidDocumentErrorEmailTest:
         }
         assert mails_testing.outbox[0].sent_data["To"] == email
 
-    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
-    def test_send_document_error_email_sendinblue_not_activated(self) -> None:
-        email = "123@test.com"
-        code = "invalid-document"
-        send_subscription_document_error_email(email, code)
-
-        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 2958584
-        assert mails_testing.outbox[0].sent_data["To"] == email
-
-
-class SubscriptionForeignDocumentErrorEmailTest:
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_send_document_error_email(self) -> None:
+    def test_send_foreign_document_error_email(self) -> None:
         email = "123@test.com"
         code = "unread-mrz-document"
         send_subscription_document_error_email(email, code)
@@ -70,11 +114,16 @@ class SubscriptionForeignDocumentErrorEmailTest:
         }
         assert mails_testing.outbox[0].sent_data["To"] == email
 
-    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
-    def test_send_document_error_email_sendinblue_not_activated(self) -> None:
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_send_information_document_error_email(self) -> None:
         email = "123@test.com"
-        code = "unread-mrz-document"
+        code = "information-error"
         send_subscription_document_error_email(email, code)
 
-        assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 3188025
+        assert mails_testing.outbox[0].sent_data["template"] == {
+            "id_prod": 410,
+            "id_not_prod": 43,
+            "tags": ["jeunes_infos_erronees"],
+            "use_priority_queue": True,
+        }
         assert mails_testing.outbox[0].sent_data["To"] == email


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12510

## But de la pull request

déclenche l'envoi d'un email transactionnel lorsque une erreur d'information d'inscription est remontée à la fonction send_subscription_document_error_email avec le code erreur : “information-error”

##  Implémentation

N/A
​
##  Informations supplémentaires

N/A
 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
