### PR TITLE
(PC-12507)[API]feat:sendinblue-transac-email-user-anniversary-age-18

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -24,6 +24,7 @@ class TransactionalEmail(Enum):
     ACCEPTED_AS_EAC_BENEFICIARY = Template(
         id_prod=257, id_not_prod=27, tags=["jeunes_pass_credite_eac"], use_priority_queue=True
     )
+    ANNIVERSARY_AGE_18 = Template(id_prod=78, id_not_prod=32, tags=["anniversaire_18_ans"])
     BOOKING_CANCELLATION_BY_BENEFICIARY = Template(id_prod=223, id_not_prod=33, tags=["jeunes_offre_annulee_jeune"])
     BOOKING_CANCELLATION_BY_PRO_TO_BENEFICIARY = Template(
         id_prod=225, id_not_prod=37, tags=["jeunes_offre_annulee_pros"]

--- a/api/src/pcapi/core/mails/transactional/users/anniversary_to_newly_eligible_user.py
+++ b/api/src/pcapi/core/mails/transactional/users/anniversary_to_newly_eligible_user.py
@@ -1,0 +1,31 @@
+from typing import Union
+
+from pcapi.core import mails
+from pcapi.core.mails.transactional.sendinblue_template_ids import SendinblueTransactionalEmailData
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.payments.api import get_granted_deposit
+from pcapi.core.users import models as users_models
+from pcapi.models.feature import FeatureToggle
+from pcapi.utils.urls import generate_firebase_dynamic_link
+
+
+def get_anniversary_age_18_user_email_data(user: users_models.User) -> Union[dict, SendinblueTransactionalEmailData]:
+    if not FeatureToggle.ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS.is_active():
+        email_link = generate_firebase_dynamic_link(path="id-check", params={"email": user.email})
+        granted_deposit = get_granted_deposit(user, user.eligibility)
+        return {
+            "Mj-TemplateID": 2030056,
+            "Mj-TemplateLanguage": True,
+            "Mj-trackclick": 1,
+            "Vars": {
+                "nativeAppLink": email_link,
+                "depositAmount": int(granted_deposit.amount),
+            },
+        }
+
+    return SendinblueTransactionalEmailData(template=TransactionalEmail.ANNIVERSARY_AGE_18.value)
+
+
+def send_newly_eligible_age_18_user_email(user: users_models.User) -> bool:
+    data = get_anniversary_age_18_user_email_data(user)
+    return mails.send(recipients=[user.email], data=data)

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -99,7 +99,7 @@ def get_id_check_token(token_value: str) -> models.Token:
     ).one_or_none()
 
 
-def get_newly_eligible_users(since: date) -> list[User]:
+def get_newly_eligible_age_18_users(since: date) -> list[User]:
     """get users that are eligible between `since` (excluded) and now (included) and that have
     created their account before `since`"""
     today = datetime.combine(datetime.today(), datetime.min.time())

--- a/api/src/pcapi/domain/user_emails.py
+++ b/api/src/pcapi/domain/user_emails.py
@@ -191,11 +191,6 @@ def send_rejection_email_to_beneficiary_pre_subscription(
     return send_duplicate_beneficiary_pre_subscription_rejected_data(beneficiary_pre_subscription.email)
 
 
-def send_newly_eligible_user_email(user: User) -> bool:
-    data = beneficiary_activation.get_newly_eligible_user_email_data(user)
-    return mails.send(recipients=[user.email], data=data)
-
-
 def send_reset_password_link_to_admin_email(created_user: User, admin_email: User, reset_password_link: str) -> bool:
     data = retrieve_data_for_reset_password_link_to_admin_email(created_user, reset_password_link)
     return mails.send(recipients=[admin_email], data=data)

--- a/api/src/pcapi/emails/beneficiary_activation.py
+++ b/api/src/pcapi/emails/beneficiary_activation.py
@@ -1,8 +1,6 @@
 from urllib.parse import quote
 
-from pcapi.core.payments.api import get_granted_deposit
 from pcapi.core.users import models as users_models
-from pcapi.utils.urls import generate_firebase_dynamic_link
 
 
 def get_activation_email_data(user: users_models.User, token: users_models.Token) -> dict:
@@ -16,24 +14,6 @@ def get_activation_email_data(user: users_models.User, token: users_models.Token
             "prenom_user": first_name,
             "token": token.value,
             "email": quote(email),
-        },
-    }
-
-
-def get_newly_eligible_user_email_data(user: users_models.User) -> dict:
-    email_link = generate_firebase_dynamic_link(
-        path="id-check",
-        params={"email": user.email},
-    )
-    granted_deposit = get_granted_deposit(user, user.eligibility)
-
-    return {
-        "Mj-TemplateID": 2030056,
-        "Mj-TemplateLanguage": True,
-        "Mj-trackclick": 1,
-        "Vars": {
-            "nativeAppLink": email_link,
-            "depositAmount": int(granted_deposit.amount),
         },
     }
 

--- a/api/src/pcapi/scheduled_tasks/clock.py
+++ b/api/src/pcapi/scheduled_tasks/clock.py
@@ -8,6 +8,9 @@ from sentry_sdk import set_tag
 from pcapi import settings
 import pcapi.core.bookings.api as bookings_api
 import pcapi.core.finance.api as finance_api
+from pcapi.core.mails.transactional.users.anniversary_to_newly_eligible_user import (
+    send_newly_eligible_age_18_user_email,
+)
 from pcapi.core.offerers.repository import get_offerers_by_date_validated
 from pcapi.core.offers.repository import check_stock_consistency
 from pcapi.core.offers.repository import delete_past_draft_offers
@@ -22,8 +25,7 @@ from pcapi.core.users.external.user_automations import users_ex_beneficiary_auto
 from pcapi.core.users.external.user_automations import users_inactive_since_30_days_automation
 from pcapi.core.users.external.user_automations import users_one_year_with_pass_automation
 from pcapi.core.users.external.user_automations import users_turned_eighteen_automation
-from pcapi.core.users.repository import get_newly_eligible_users
-from pcapi.domain.user_emails import send_newly_eligible_user_email
+from pcapi.core.users.repository import get_newly_eligible_age_18_users
 from pcapi.domain.user_emails import send_withdrawal_terms_to_newly_validated_offerer
 from pcapi.local_providers.provider_api import provider_api_stocks
 from pcapi.local_providers.provider_manager import synchronize_venue_providers_for_provider
@@ -147,8 +149,8 @@ def pc_notify_newly_eligible_users() -> None:
     if not settings.IS_PROD and not settings.IS_TESTING:
         return
     yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    for user in get_newly_eligible_users(yesterday):
-        send_newly_eligible_user_email(user)
+    for user in get_newly_eligible_age_18_users(yesterday):
+        send_newly_eligible_age_18_user_email(user)
 
 
 @cron_context

--- a/api/src/pcapi/scripts/beneficiary/send_mail_after_idcheck_outage.py
+++ b/api/src/pcapi/scripts/beneficiary/send_mail_after_idcheck_outage.py
@@ -6,11 +6,13 @@ from dateutil.relativedelta import relativedelta
 from sqlalchemy import not_
 from sqlalchemy.orm import Query
 
+from pcapi.core.mails.transactional.users.anniversary_to_newly_eligible_user import (
+    send_newly_eligible_age_18_user_email,
+)
 from pcapi.core.users import constants
 from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
 from pcapi.domain.beneficiary_pre_subscription.validator import EXCLUDED_DEPARTMENTS
-from pcapi.domain.user_emails import send_newly_eligible_user_email
 from pcapi.models.user_offerer import UserOfferer
 
 
@@ -58,7 +60,7 @@ def send_mail_to_potential_beneficiaries(
     try:
         for i, user in enumerate(_get_eligible_users_created_between(start_date, end_date, max_number)):
             if user.eligibility == EligibilityType.AGE18:
-                if not send_newly_eligible_user_email(user):
+                if not send_newly_eligible_age_18_user_email(user):
                     print(f"Could not send mail to user {user.id}")
             if i % 100:
                 print(f"Processed {i} users")

--- a/api/tests/core/mails/transactional/users/anniversary_to_newly_eligible_user_test.py
+++ b/api/tests/core/mails/transactional/users/anniversary_to_newly_eligible_user_test.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.mails.transactional.users.anniversary_to_newly_eligible_user import (
+    send_newly_eligible_age_18_user_email,
+)
+from pcapi.core.testing import override_features
+import pcapi.core.users.factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class MailjetSendNewlyEligibleUserEmailTest:
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
+    def test_send_anniversary_email(self):
+        # given
+        user = users_factories.UserFactory(
+            dateOfBirth=(datetime.now() - relativedelta(years=18, days=5)), departementCode="93"
+        )
+
+        # when
+        send_newly_eligible_age_18_user_email(user)
+
+        # then
+        assert len(mails_testing.outbox) == 1  # test number of emails sent
+        assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2030056
+        assert (
+            mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"][:118]
+            == "https://passcultureapptestauto.page.link/?link=https%3A%2F%2F"
+            "app-native.testing.internal-passculture.app%2Fid-check%3F"
+        )
+        assert "email" in mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"]
+        assert mails_testing.outbox[0].sent_data["Vars"]["depositAmount"] == 300
+
+
+class SendinblueSendNewlyEligibleUserEmailTest:
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_send_anniversary_email(self):
+        # given
+        user = users_factories.UserFactory()
+
+        # when
+        send_newly_eligible_age_18_user_email(user)
+
+        # then
+        assert len(mails_testing.outbox) == 1  # test number of emails sent
+        assert mails_testing.outbox[0].sent_data["template"] == {
+            "id_prod": 78,
+            "id_not_prod": 32,
+            "tags": ["anniversaire_18_ans"],
+            "use_priority_queue": False,
+        }

--- a/api/tests/core/users/test_repository.py
+++ b/api/tests/core/users/test_repository.py
@@ -89,9 +89,9 @@ class GetNewlyEligibleUsersTest:
         users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 2), dateCreated=datetime(2017, 12, 1))
 
         # Users 18 on the day `since` should not appear, nor those that are not 18 yet
-        users = repository.get_newly_eligible_users(since=date(2017, 12, 31))
+        users = repository.get_newly_eligible_age_18_users(since=date(2017, 12, 31))
         assert set(users) == {user_just_18_in_eligible_area, user_just_18_in_ineligible_area}
-        users = repository.get_newly_eligible_users(since=date(2017, 12, 30))
+        users = repository.get_newly_eligible_age_18_users(since=date(2017, 12, 30))
         assert set(users) == {user_just_18_in_eligible_area, user_just_18_in_ineligible_area, user_already_18}
 
 

--- a/api/tests/domain/user_emails_test.py
+++ b/api/tests/domain/user_emails_test.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from unittest.mock import call
 from unittest.mock import patch
 
-from dateutil.relativedelta import relativedelta
 import pytest
 
 from pcapi.core.bookings import factories as booking_factories
@@ -26,7 +25,6 @@ from pcapi.domain.user_emails import send_activation_email
 from pcapi.domain.user_emails import send_admin_user_validation_email
 from pcapi.domain.user_emails import send_expired_individual_bookings_recap_email_to_offerer
 from pcapi.domain.user_emails import send_individual_booking_confirmation_email_to_offerer
-from pcapi.domain.user_emails import send_newly_eligible_user_email
 from pcapi.domain.user_emails import send_offer_validation_status_update_email
 from pcapi.domain.user_emails import send_offerer_bookings_recap_email_after_offerer_cancellation
 from pcapi.domain.user_emails import send_offerer_driven_cancellation_email_to_offerer
@@ -470,28 +468,6 @@ class SendSoonToBeExpiredBookingsRecapEmailToBeneficiaryTest:
         assert len(mails_testing.outbox) == 2  # test number of emails sent
         assert mails_testing.outbox[0].sent_data["MJ-TemplateID"] == 12345
         assert mails_testing.outbox[1].sent_data["MJ-TemplateID"] == 12345
-
-
-class SendNewlyEligibleUserEmailTest:
-    def test_send_activation_email(self):
-        # given
-        user = users_factories.UserFactory(
-            dateOfBirth=(datetime.now() - relativedelta(years=18, days=5)), departementCode="93"
-        )
-
-        # when
-        send_newly_eligible_user_email(user)
-
-        # then
-        assert len(mails_testing.outbox) == 1  # test number of emails sent
-        assert mails_testing.outbox[0].sent_data["Mj-TemplateID"] == 2030056
-        assert (
-            mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"][:118]
-            == "https://passcultureapptestauto.page.link/?link=https%3A%2F%2F"
-            "app-native.testing.internal-passculture.app%2Fid-check%3F"
-        )
-        assert "email" in mails_testing.outbox[0].sent_data["Vars"]["nativeAppLink"]
-        assert mails_testing.outbox[0].sent_data["Vars"]["depositAmount"] == 300
 
 
 class SendOfferValidationTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12507

## But de la pull request
Migration mailjet vers sendinblue : Envoi de mail pour devenir bénéficiaire lorsqu'un utilisateur non bénéficiaire atteint l'age de 18 ans

##  Implémentation
N/A​
##  Informations supplémentaires
N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
