### PR TITLE
[PC-11636][API] BusinessUnit script : handle virtual venues

### DIFF
--- a/api/src/pcapi/scripts/business_unit/create_bu.py
+++ b/api/src/pcapi/scripts/business_unit/create_bu.py
@@ -51,6 +51,9 @@ staging >>> bi_val.validate = fake_val
 
 staging >>> from pcapi.scripts.create_bu import create_all_business_units
 staging >>> create_all_business_units()
+staging >>> from pcapi.scripts.purge_virtual_venue_business_units import purge_virtual_venue_business_units
+staging >>> # Clear some business unit with virtual venues
+staging >>> purge_virtual_venue_business_units()
 """
 
 

--- a/api/src/pcapi/scripts/business_unit/purge_virtual_venue_business_units.py
+++ b/api/src/pcapi/scripts/business_unit/purge_virtual_venue_business_units.py
@@ -1,0 +1,25 @@
+from pcapi.core.finance.models import BusinessUnit
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.models import Offer
+from pcapi.models import db
+from pcapi.repository import repository
+
+
+def venue_have_at_least_one_offer(venue: int) -> bool:
+    return db.session.query(
+        Venue.query.join(Offer, Venue.id == Offer.venueId).filter(Venue.id == venue.id).exists()
+    ).scalar()
+
+
+def purge_virtual_venue_business_units():
+    business_units = BusinessUnit.query.all()
+    for business_unit in business_units:
+        virtual_venues = [venue for venue in business_unit.venues if venue.isVirtual]
+        if len(virtual_venues) > 0:
+            virtual_venue = virtual_venues[0]
+            lonely_venue = len(business_unit.venues) == 1
+            have_offer = venue_have_at_least_one_offer(virtual_venue)
+            if lonely_venue or not have_offer:
+                virtual_venue.businessUnitId = None
+                if lonely_venue:
+                    repository.delete(business_unit)

--- a/api/tests/scripts/business_unit/purge_virtual_venue_business_units_test.py
+++ b/api/tests/scripts/business_unit/purge_virtual_venue_business_units_test.py
@@ -1,0 +1,60 @@
+import pytest
+
+from pcapi.core.finance.factories import BusinessUnitFactory
+from pcapi.core.finance.models import BusinessUnit
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.scripts.business_unit.purge_virtual_venue_business_units import purge_virtual_venue_business_units
+
+
+@pytest.mark.usefixtures("db_session")
+def test_purge_virtual_venue_business_units():
+    expected_existing_bu = []
+    expected_purged_bu = []
+    expected_venues_without_bu = []
+
+    # Delete business unit that containt a single virtual venue
+    business_unit = BusinessUnitFactory(name="Business unit 1")
+    virtual_venue = VenueFactory(isVirtual=True, siret=None, businessUnit=business_unit)
+    expected_purged_bu.append(business_unit)
+    expected_venues_without_bu.append(virtual_venue)
+
+    # Delete business unit that containt a single virtual venue.
+    # Even if it have a existing offer.
+    business_unit = BusinessUnitFactory(name="Business unit 2")
+    virtual_venue = VenueFactory(isVirtual=True, siret=None, businessUnit=business_unit)
+    OfferFactory(venue=virtual_venue)
+    expected_purged_bu.append(business_unit)
+    expected_venues_without_bu.append(virtual_venue)
+
+    # Do not delete business unit when it containe a least one physical venue.
+    # Virtual venue without offer should be removed from the business unit.
+    business_unit = BusinessUnitFactory(name="Business unit 3")
+    VenueFactory(isVirtual=False, businessUnit=business_unit)
+    virtual_venue = VenueFactory(isVirtual=True, siret=None, businessUnit=business_unit)
+    expected_existing_bu.append(business_unit)
+    expected_venues_without_bu.append(virtual_venue)
+
+    # Do not delete business unit when it containe a least one physical venue.
+    # Virtual venue with at least one offer can stay on the business unit.
+    business_unit = BusinessUnitFactory(name="Business unit 4")
+    VenueFactory(isVirtual=False, businessUnit=business_unit)
+    virtual_venue = VenueFactory(isVirtual=True, siret=None, businessUnit=business_unit)
+    OfferFactory(venue=virtual_venue)
+    expected_existing_bu.append(business_unit)
+
+    purge_virtual_venue_business_units()
+
+    all_business_units = BusinessUnit.query.all()
+    assert len(all_business_units) == len(expected_existing_bu)
+    for business_unit in expected_existing_bu:
+        assert business_unit.id in [bu.id for bu in all_business_units]
+
+    all_venues = Venue.query.all()
+    expected_venues_without_bu_ids = [v.id for v in expected_venues_without_bu]
+    for venue in all_venues:
+        if venue.id in expected_venues_without_bu_ids:
+            assert venue.businessUnitId is None
+        else:
+            assert venue.businessUnitId is not None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11636

Une fois le script de migration de business unit executer, nous avions quelques cas qui ne devaient pas exister:

* Un lieu virtuel sans offre ne doit pas avoir de BusinessUnit assignée.

