### PR TITLE
(PC-12112) feat:email_update: add validate button

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view.py
+++ b/api/src/pcapi/admin/custom_views/support_view.py
@@ -241,6 +241,7 @@ class BeneficiaryView(base_configuration.BaseAdminView):
             get_value=self.get_detail_value,
             return_url=return_url,
             has_performed_identity_check=fraud_api.has_user_performed_identity_check(user),
+            enum_update_request_value=users_models.EmailHistoryEventTypeEnum.UPDATE_REQUEST.value,
         )
 
     @flask_admin.expose(

--- a/api/src/pcapi/admin/custom_views/user_email_history_view.py
+++ b/api/src/pcapi/admin/custom_views/user_email_history_view.py
@@ -1,8 +1,25 @@
+from flask import redirect
+from flask import request
+from flask import url_for
+from flask.helpers import flash
+from flask_admin import expose
+from flask_login import current_user
+from werkzeug import Response
+from werkzeug.exceptions import BadRequestKeyError
+from werkzeug.routing import BuildError
+
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.admin.custom_views.mixins.suspension_mixin import SuspensionMixin
+from pcapi.core.users import api as users_api
+from pcapi.core.users import exceptions as users_exceptions
+from pcapi.core.users import models as users_models
+from pcapi.core.users.email import repository as email_repository
+from pcapi.core.users.models import UserEmailHistory
 
 
 class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
+    list_template = "admin/list_user_email_history.html"
+
     column_list = [
         "userId",
         "oldEmail",
@@ -11,6 +28,7 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
         "eventType",
         "deviceId",
     ]
+
     column_labels = dict(
         userId="User ID",
         oldEmail="Ancienne adresse email",
@@ -21,12 +39,14 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
         eventType="Type d'événement",
         deviceId="Device ID",
     )
+
     column_searchable_list = [
         "userId",
         "oldEmail",
         "newEmail",
         "deviceId",
     ]
+
     column_filters = [
         "userId",
         "oldEmail",
@@ -36,3 +56,50 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
         "eventType",
         "deviceId",
     ]
+
+    @expose("/")
+    def index(self):
+        self._template_args["enum_update_request_value"] = users_models.EmailHistoryEventTypeEnum.UPDATE_REQUEST.value
+        return super().index_view()
+
+    @expose("/validate_user_email/<int:entry_id>", methods=["POST"])
+    def validate_user_email(self, entry_id: int) -> Response:
+        """
+        Manually validate a user's email update request, only if it has
+        not already been validated (by the user himself or another
+        superadmin).
+
+        One can pass query parameters to set another redirect:
+          * next (mandatory) ;
+          * extra parameters (non mandatory).
+        """
+        if not self.check_super_admins():
+            flash("Vous n'avez pas les droits suffisants pour effectuer cette action", "error")
+            return redirect(url_for(".index_view"))
+
+        entry = UserEmailHistory.query.get(entry_id)
+
+        if email_repository.has_been_validated(entry):
+            flash(
+                f"L'adresse email {entry.newEmail} de l'utilisateur {entry.userId} avait déjà été validée",
+                category="warning",
+            )
+        else:
+            try:
+                users_api.change_user_email(
+                    current_email=entry.oldEmail, new_email=entry.newEmail, admin=True, device_id=current_user.email
+                )
+            except users_exceptions.UserDoesNotExist:
+                flash(f"L'utilisateur avec l'adresse email {entry.oldEmail} n'a pas été trouvé", category="error")
+            except users_exceptions.EmailExistsError:
+                flash(f"L'adresse {entry.newEmail} est déjà utilisée", category="error")
+            else:
+                flash(f"L'adresse email {entry.newEmail} de l'utilisateur {entry.userId} a bien été validée")
+
+        try:
+            extra = {param: value for param, value in request.args.items() if param != "next"}
+            next_url = url_for(request.args["next"], **extra)
+        except (BadRequestKeyError, BuildError):
+            next_url = url_for(".index_view")
+
+        return redirect(next_url)

--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -320,3 +320,15 @@ def clean_temporary_files(test_function):
             cleanup()
 
     return wrapper
+
+
+@contextlib.contextmanager
+def assert_model_count_delta(model, delta):
+    start_count = model.query.count()
+    expected_count = start_count + delta
+
+    yield
+
+    end_count = model.query.count()
+    if end_count != expected_count:
+        pytest.fail(f"Got {end_count} {model.__class__.__name__} instead of {expected_count}")

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -460,15 +460,18 @@ def bulk_unsuspend_account(user_ids: list[int], actor: User) -> None:
     )
 
 
-def change_user_email(current_email: str, new_email: str, device_id: typing.Optional[str] = None) -> None:
+def change_user_email(
+    current_email: str,
+    new_email: str,
+    device_id: typing.Optional[str] = None,
+    admin: bool = False,
+) -> None:
     current_user = user_queries.find_user_by_email(current_email)
     if not current_user:
         raise exceptions.UserDoesNotExist()
 
     email_history = UserEmailHistory.build_validation(
-        user=current_user,
-        new_email=new_email,
-        device_id=device_id,
+        user=current_user, new_email=new_email, device_id=device_id, admin=admin
     )
 
     try:

--- a/api/src/pcapi/core/users/email/repository.py
+++ b/api/src/pcapi/core/users/email/repository.py
@@ -1,0 +1,21 @@
+from pcapi.core.users.models import EmailHistoryEventTypeEnum
+from pcapi.core.users.models import UserEmailHistory
+
+
+def has_been_validated(entry: UserEmailHistory) -> bool:
+    query = UserEmailHistory.query.filter_by(
+        userId=entry.userId,
+        oldUserEmail=entry.oldUserEmail,
+        oldDomainEmail=entry.oldDomainEmail,
+        newUserEmail=entry.newUserEmail,
+        newDomainEmail=entry.newDomainEmail,
+    ).filter(
+        UserEmailHistory.eventType.in_(
+            [
+                EmailHistoryEventTypeEnum.ADMIN_VALIDATION.value,
+                EmailHistoryEventTypeEnum.VALIDATION.value,
+            ]
+        ),
+    )
+
+    return query.first() is not None

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -379,3 +379,28 @@ class EduconnectUserFactory(factory.Factory):
     ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
     student_level = "2212"
     school_uai = "0910620E"
+
+
+class UserEmailHistoryFactory(BaseFactory):
+    class Meta:
+        model = users_models.UserEmailHistory
+        abstract = True
+
+    user = factory.SubFactory(UserFactory)
+    oldUserEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[0])
+    oldDomainEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[1])
+    newUserEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[0])
+    newDomainEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[1] + ".update")
+    deviceId = "deviceId"
+
+
+class EmailUpdateEntryFactory(UserEmailHistoryFactory):
+    eventType = users_models.EmailHistoryEventTypeEnum.UPDATE_REQUEST.value
+
+
+class EmailValidationEntryFactory(UserEmailHistoryFactory):
+    eventType = users_models.EmailHistoryEventTypeEnum.VALIDATION.value
+
+
+class EmailAdminValidationEntryFactory(UserEmailHistoryFactory):
+    eventType = users_models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION.value

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -574,6 +574,7 @@ def split_email(email: str) -> tuple[str, str]:
 class EmailHistoryEventTypeEnum(enum.Enum):
     UPDATE_REQUEST = "UPDATE_REQUEST"
     VALIDATION = "VALIDATION"
+    ADMIN_VALIDATION = "ADMIN_VALIDATION"
 
 
 class UserEmailHistory(PcObject, Model):
@@ -621,7 +622,9 @@ class UserEmailHistory(PcObject, Model):
         return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.UPDATE_REQUEST)
 
     @classmethod
-    def build_validation(cls, user: User, new_email: str, device_id: Optional[str]) -> "UserEmailHistory":
+    def build_validation(cls, user: User, new_email: str, device_id: Optional[str], admin: bool) -> "UserEmailHistory":
+        if admin:
+            return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.ADMIN_VALIDATION)
         return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.VALIDATION)
 
     @hybrid_property

--- a/api/src/pcapi/templates/admin/list_user_email_history.html
+++ b/api/src/pcapi/templates/admin/list_user_email_history.html
@@ -1,0 +1,14 @@
+{% extends 'admin/model/list.html' %}
+
+{% block list_row_actions %} 
+    {% if row.eventType.value == enum_update_request_value %}
+        <form action={{ url_for(".validate_user_email", entry_id=get_pk_value(row)) }} method="POST">
+            <button
+                class="btn btn-secondary"
+                onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ row.newEmail }}')"
+                title="Approve">
+                Valider
+            </button>
+        </form>
+    {% endif %}
+{% endblock %}

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -263,6 +263,9 @@
     <table class="table table-striped table-hover">
       <thead>
         <tr>
+          {% if current_user.is_super_admin() %}
+            <th scope="col">Validation</th>
+          {% endif %}
           <th scope="col">Ancienne adresse email</th>
           <th scope="col">Nouvelle adresse email</th>
           <th scope="col">Date</th>
@@ -273,6 +276,22 @@
       <tbody>
         {% for email_history in model.email_history %}
         <tr>
+          {% if current_user.is_super_admin() %}
+              <td>
+                {% if email_history.eventType.value == enum_update_request_value %}
+                    <form
+                        action={{ url_for("/user_email_history.validate_user_email", entry_id=email_history.id, next="support_beneficiary.details_view", id=model.id) }}
+                        method="POST">
+                        <button
+                            class="btn btn-secondary"
+                            onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
+                            title="Approve">
+                            Valider
+                        </button>
+                    </form>
+                {% endif %}
+              </td>
+          {% endif %}
           <td>{{ email_history.oldEmail }}</td>
           <td>{{ email_history.newEmail }}</td>
           <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>

--- a/api/tests/admin/custom_views/user_email_history_view_test.py
+++ b/api/tests/admin/custom_views/user_email_history_view_test.py
@@ -1,0 +1,97 @@
+from flask import url_for
+import pytest
+
+from pcapi.core.testing import assert_model_count_delta
+from pcapi.core.testing import override_settings
+import pcapi.core.users.factories as users_factories
+import pcapi.core.users.models as users_models
+
+
+@pytest.fixture(name="admin_client", scope="function")
+def admin_client_fixture(client):
+    users_factories.AdminFactory(email="admin@example.com")
+    return client.with_session_auth("admin@example.com")
+
+
+VALIDATE_EMAIL_PATH = "/user_email_history.validate_user_email"
+INDEX_PATH = "/user_email_history.index_view"
+BENEFICIARY_DETAILS_PATH = "support_beneficiary.details_view"
+
+
+@pytest.mark.usefixtures("db_session")
+class UserEmailHistoryViewTest:
+    def test_admin_validation(self, admin_client):
+        user = users_factories.BeneficiaryGrant18Factory()
+        entry = users_factories.EmailUpdateEntryFactory(user=user)
+
+        with assert_model_count_delta(users_models.UserEmailHistory, 1):
+            url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id)
+            response = admin_client.post(url)
+
+            assert response.status_code == 302
+            assert response.location == url_for(INDEX_PATH, _external=True)
+
+    @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
+    def test_only_super_admins_can_validate(self, admin_client):
+        """
+        Test that a regular admin cannot validate a user's new email
+        address.
+
+        Note: outside of production env, all admins are super admins.
+        """
+        user = users_factories.BeneficiaryGrant18Factory()
+        entry = users_factories.EmailUpdateEntryFactory(user=user)
+
+        with assert_model_count_delta(users_models.UserEmailHistory, 0):
+            url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id)
+            response = admin_client.post(url)
+
+            assert response.status_code == 302
+            assert response.location == url_for(INDEX_PATH, _external=True)
+
+    @pytest.mark.parametrize(
+        "validation_factory",
+        [
+            users_factories.EmailValidationEntryFactory,
+            users_factories.EmailAdminValidationEntryFactory,
+        ],
+    )
+    def test_already_validated(self, admin_client, validation_factory):
+        user = users_factories.BeneficiaryGrant18Factory()
+        update_entry = users_factories.EmailUpdateEntryFactory(user=user)
+        validation_factory(user=user)
+
+        with assert_model_count_delta(users_models.UserEmailHistory, 0):
+            url = url_for(VALIDATE_EMAIL_PATH, entry_id=update_entry.id)
+            response = admin_client.post(url)
+
+            assert response.status_code == 302
+            assert response.location == url_for(INDEX_PATH, _external=True)
+
+    def test_next_url(self, admin_client):
+        """
+        Test that the expected redirect happens when valid query
+        parameters are passed.
+        """
+        user = users_factories.BeneficiaryGrant18Factory()
+        entry = users_factories.EmailUpdateEntryFactory(user=user)
+
+        url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id, next=BENEFICIARY_DETAILS_PATH, id=user.id)
+        response = admin_client.post(url)
+
+        assert response.status_code == 302
+        assert response.location == url_for(BENEFICIARY_DETAILS_PATH, id=user.id, _external=True)
+
+    def test_next_url_broken(self, admin_client):
+        """
+        Test that the default redirect is used when the query parameters
+        are not valid.
+        """
+        user = users_factories.BeneficiaryGrant18Factory()
+        entry = users_factories.EmailUpdateEntryFactory(user=user)
+
+        url = url_for(VALIDATE_EMAIL_PATH, entry_id=entry.id, next="nope")
+        response = admin_client.post(url)
+
+        assert response.status_code == 302
+        assert response.location == url_for(INDEX_PATH, _external=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12112


## But de la pull request

Permettre à un admin (FA) de valider manuellement une demande de modification d'un email à deux endroits : 

1. sur la page d'index des demandes de modifications ;
2. sur la vue détaillée d'un bénéficiaire, dans la section des modifications d'email.

A chaque fois, le bouton n'apparaît que sur les lignes qui correspondent à un événement `UPDATE_REQUEST`.

On pourrait filtrer encore mieux et ne l'afficher que sur les lignes qui n'ont pas d’événements `VALIDATION` ou `ADMIN_VALIDATION` associés (même utilisateur, mêmes ancienne et nouvelle adresse) mais je n'ai pas trouvé comment passer du SQL à SQLAlchemy / FlaskAdmin 😭 

## Informations supplémentaires

Une fois l'adresse validée, l'utilisateur est redirigé par défaut sur l'index des demandes de modifications, ce qui peut être un peu déroutant lorsque l'on vient de la vue détaillée d'un bénéficiaire. La méthode de validation accepte donc des paramètres supplémentaires (url) qui permettent de définir une autre url de redirection.

Note : [pour des raisons de sécurité](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html), le paramètre `next` (obligatoire) ne correspond pas à une url mais à un nom de vue.