### PR TITLE
(PC-12508)[API] sendinblue transac email recredit anniversary underage beneficiary

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -49,6 +49,7 @@ class TransactionalEmail(Enum):
     EXPIRED_BOOKINGS_TO_BENEFICIARY = Template(id_prod=145, id_not_prod=34, tags=["jeunes_resa_expiree"])
     FRAUD_SUSPICION = Template(id_prod=82, id_not_prod=24, tags=["jeunes_compte_en_cours_d_analyse"])
     NEW_PASSWORD_REQUEST = Template(id_prod=141, id_not_prod=26, tags=["jeunes_nouveau_mdp"], use_priority_queue=True)
+    RECREDIT_TO_UNDERAGE_BENEFICIARY = Template(id_prod=303, id_not_prod=31, tags=["anniversaire_16_17_ans"])
     SUBSCRIPTION_FOREIGN_DOCUMENT_ERROR = Template(
         id_prod=385,
         id_not_prod=40,

--- a/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
@@ -1,0 +1,27 @@
+from pcapi.core import mails
+from pcapi.core.mails.transactional.sendinblue_template_ids import SendinblueTransactionalEmailData
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.payments.api import get_granted_deposit
+from pcapi.core.users import models as users_models
+from pcapi.core.users.api import get_domains_credit
+
+
+def get_recredit_to_underage_beneficiary_email_data(
+    user: users_models.User,
+) -> SendinblueTransactionalEmailData:
+    granted_deposit = get_granted_deposit(user, user.eligibility)
+    domains_credit = get_domains_credit(user)
+
+    return SendinblueTransactionalEmailData(
+        template=TransactionalEmail.RECREDIT_TO_UNDERAGE_BENEFICIARY.value,
+        params={
+            "FIRSTNAME": user.firstName,
+            "NEW_CREDIT": granted_deposit.amount,
+            "CREDIT": int(domains_credit.all.remaining),
+        },
+    )
+
+
+def send_recredit_email_to_underage_beneficiary(user: users_models.User) -> bool:
+    data = get_recredit_to_underage_beneficiary_email_data(user)
+    return mails.send(recipients=[user.email], data=data)

--- a/api/src/pcapi/scheduled_tasks/clock.py
+++ b/api/src/pcapi/scheduled_tasks/clock.py
@@ -145,7 +145,7 @@ def pc_notify_soon_to_be_expired_individual_bookings() -> None:
 
 @cron_context
 @log_cron_with_transaction
-def pc_notify_newly_eligible_users() -> None:
+def pc_notify_newly_eligible_age_18_users() -> None:
     if not settings.IS_PROD and not settings.IS_TESTING:
         return
     yesterday = datetime.date.today() - datetime.timedelta(days=1)
@@ -282,7 +282,7 @@ def clock() -> None:
         minute="30",
     )
 
-    scheduler.add_job(pc_notify_newly_eligible_users, "cron", day="*", hour="3")
+    scheduler.add_job(pc_notify_newly_eligible_age_18_users, "cron", day="*", hour="3")
 
     scheduler.add_job(pc_clean_expired_tokens, "cron", day="*", hour="2")
 

--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -4,6 +4,9 @@ import logging
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import joinedload
 
+from pcapi.core.mails.transactional.users.recredit_to_underage_beneficiary import (
+    send_recredit_email_to_underage_beneficiary,
+)
 from pcapi.core.payments import models as payments_models
 import pcapi.core.payments.conf as deposit_conf
 from pcapi.core.users import models as users_models
@@ -56,3 +59,6 @@ def recredit_underage_users() -> None:
             db.session.add(recredit)
 
     logger.info("Recredited %s underage users deposits", len(users_to_recredit))
+    for user in users_to_recredit:
+        if not send_recredit_email_to_underage_beneficiary(user):
+            logger.error("Failed to send recredit email to: %s", user.email)

--- a/api/tests/core/mails/transactional/users/anniversary_to_newly_eligible_user_test.py
+++ b/api/tests/core/mails/transactional/users/anniversary_to_newly_eligible_user_test.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 class MailjetSendNewlyEligibleUserEmailTest:
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
-    def test_send_anniversary_email(self):
+    def test_send_anniversary_age_18_email(self):
         # given
         user = users_factories.UserFactory(
             dateOfBirth=(datetime.now() - relativedelta(years=18, days=5)), departementCode="93"
@@ -39,7 +39,7 @@ class MailjetSendNewlyEligibleUserEmailTest:
 
 class SendinblueSendNewlyEligibleUserEmailTest:
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_send_anniversary_email(self):
+    def test_send_anniversary_age_18_email(self):
         # given
         user = users_factories.UserFactory()
 

--- a/api/tests/core/mails/transactional/users/recredit_to_underage_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/users/recredit_to_underage_beneficiary_test.py
@@ -1,0 +1,69 @@
+import pytest
+
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.mails.transactional.users.recredit_to_underage_beneficiary import (
+    get_recredit_to_underage_beneficiary_email_data,
+)
+from pcapi.core.mails.transactional.users.recredit_to_underage_beneficiary import (
+    send_recredit_email_to_underage_beneficiary,
+)
+from pcapi.core.payments.api import get_granted_deposit
+from pcapi.core.testing import override_features
+from pcapi.core.users.api import get_domains_credit
+import pcapi.core.users.factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class SendinblueSendNewlyEligibleUserEmailTest:
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_send_recredit_email_to_underage_beneficiary(self):
+        # given
+        user = users_factories.UnderageBeneficiaryFactory()
+
+        # when
+        send_recredit_email_to_underage_beneficiary(user)
+
+        # then
+        assert len(mails_testing.outbox) == 1  # test number of emails sent
+        assert mails_testing.outbox[0].sent_data["template"] == {
+            "id_prod": 303,
+            "id_not_prod": 31,
+            "tags": ["anniversaire_16_17_ans"],
+            "use_priority_queue": False,
+        }
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_return_correct_recredit_email_to_underage_beneficiary_email_data_16yo(
+        self,
+    ):
+        # given
+        user = users_factories.UnderageBeneficiaryFactory(subscription_age=16)
+        granted_deposit = get_granted_deposit(user, user.eligibility)
+        domains_credit = get_domains_credit(user)
+
+        # when
+        data = get_recredit_to_underage_beneficiary_email_data(user)
+
+        # then
+        assert data.params["FIRSTNAME"] == user.firstName
+        assert data.params["NEW_CREDIT"] == granted_deposit.amount
+        assert data.params["CREDIT"] == domains_credit.all.remaining
+
+    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
+    def test_return_correct_recredit_email_to_underage_beneficiary_email_data_17yo(
+        self,
+    ):
+        # given
+        user = users_factories.UnderageBeneficiaryFactory(subscription_age=17)
+        granted_deposit = get_granted_deposit(user, user.eligibility)
+        domains_credit = get_domains_credit(user)
+
+        # when
+        data = get_recredit_to_underage_beneficiary_email_data(user)
+
+        # then
+        assert data.params["FIRSTNAME"] == user.firstName
+        assert data.params["NEW_CREDIT"] == granted_deposit.amount
+        assert data.params["CREDIT"] == domains_credit.all.remaining


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12508


## But de la pull request

Envoi un email transactionnel par sendinblue 
lorsqu'un bénéficiaire mineur obtient un recredit durant son anniversaire
(exemple: obtention d'un jeune d'un nouveau crédit à 16 ans et 17 ans déclenche l'envoi de cet email)

##  Implémentation
N/A
​
##  Informations supplémentaires
N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
