### PR TITLE
(PC-12483)[api]: correct wrong status in csv that lists bookings

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -828,15 +828,9 @@ def _serialize_booking_recap_legacy(booking: AbstractKeyedTuple) -> BookingRecap
 
 
 def _get_booking_status(status: BookingStatus, is_confirmed: bool) -> str:
-    if status in [
-        BookingStatus.CANCELLED,
-        BookingStatus.USED,
-        BookingStatus.REIMBURSED,
-    ]:
-        return BOOKING_STATUS_LABELS[status]
-    if is_confirmed:
+    cancellation_limit_date_exists_and_past = is_confirmed
+    if cancellation_limit_date_exists_and_past and status == BookingStatus.CONFIRMED:
         return BOOKING_STATUS_LABELS["confirmed"]
-
     return BOOKING_STATUS_LABELS[status]
 
 


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12483


## But de la pull request

Certaines réservations eac en statut "préréservé" remontée en statut "confirmé" dans le csv des réservations.
En effet, la détermination des statuts dans la construction du csv ne tenait pas compte du cas spécial pour les réservations eac : 
- Pour les réservations individuelles, l'une d'entre elles à le statut "confirmé" dès lors que la date limite d'annulation est dépassée
- Pour les réservations eac, ceci est vrai uniquement si la réservation a été validée par le chef d'établissement. Dans le cas contraire, son statut reste en "préréservé" même après la date limite d'annulation

##  Implémentation

Adaptation de la logique dans la fonction `_get_booking_status`
​
##  Informations supplémentaires

J'ai ajouté une bonne batterie de tests spécifiques aux statuts, pour les réservations individuelles et collectives, pour bien appréhender la logique, et ne pas compromettre l'existant sur l'individuel
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
