### PR TITLE
[API] refactor(settings): remove unused settings fields

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/settings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/settings.py
@@ -1,5 +1,3 @@
-from pydantic.class_validators import validator
-
 from pcapi.core.payments import conf as payments_conf
 from pcapi.routes.native.utils import convert_to_cent
 from pcapi.serialization.utils import to_camel
@@ -17,22 +15,17 @@ class DepositAmountsByAge(BaseModel):
 class SettingsResponse(BaseModel):
     account_creation_minimum_age: int
     auto_activate_digital_bookings: bool
-    allow_id_check_registration: bool
-    deposit_amount: int
     deposit_amounts_by_age = DepositAmountsByAge()
     display_dms_redirection: bool
-    enable_native_id_check_verbose_debugging: bool
     enable_id_check_retention: bool
-    enable_cultural_survey: bool
     enable_native_eac_individual: bool
+    enable_native_id_check_verbose_debugging: bool
     enable_phone_validation: bool
     enable_underage_generalisation: bool
     id_check_address_autocompletion: bool
     is_recaptcha_enabled: bool
     is_webapp_v2_enabled: bool
     object_storage_url: str
-
-    _convert_deposit_amount = validator("deposit_amount", pre=True, allow_reuse=True)(convert_to_cent)
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -1,4 +1,3 @@
-from pcapi.core.payments import conf as deposits_conf
 from pcapi.core.users import constants
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository import feature_queries
@@ -23,16 +22,13 @@ def _get_features(*requested_features: FeatureToggle):
 def get_settings() -> serializers.SettingsResponse:
 
     features = _get_features(
-        FeatureToggle.ALLOW_IDCHECK_REGISTRATION,
         FeatureToggle.AUTO_ACTIVATE_DIGITAL_BOOKINGS,
         FeatureToggle.DISPLAY_DMS_REDIRECTION,
-        FeatureToggle.ENABLE_CULTURAL_SURVEY,
         FeatureToggle.ENABLE_ID_CHECK_RETENTION,
         FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA,
         FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL,
         FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,
         FeatureToggle.ENABLE_PHONE_VALIDATION,
-        FeatureToggle.ENABLE_UBBLE,
         FeatureToggle.ENABLE_UNDERAGE_GENERALISATION,
         FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
         FeatureToggle.WEBAPP_V2_ENABLED,
@@ -40,19 +36,17 @@ def get_settings() -> serializers.SettingsResponse:
 
     return serializers.SettingsResponse(
         account_creation_minimum_age=constants.ACCOUNT_CREATION_MINIMUM_AGE,
-        allow_id_check_registration=features[FeatureToggle.ALLOW_IDCHECK_REGISTRATION],
         auto_activate_digital_bookings=features[FeatureToggle.AUTO_ACTIVATE_DIGITAL_BOOKINGS],
-        deposit_amount=deposits_conf.GRANTED_DEPOSIT_AMOUNT_18_v2,
         display_dms_redirection=features[FeatureToggle.DISPLAY_DMS_REDIRECTION],
-        enable_cultural_survey=features[FeatureToggle.ENABLE_CULTURAL_SURVEY],
         enable_id_check_retention=features[FeatureToggle.ENABLE_ID_CHECK_RETENTION],
         enable_native_eac_individual=features[FeatureToggle.ENABLE_NATIVE_EAC_INDIVIDUAL],
         enable_native_id_check_verbose_debugging=features[FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING],
         enable_phone_validation=features[FeatureToggle.ENABLE_PHONE_VALIDATION],
-        enable_ubble=features[FeatureToggle.ENABLE_UBBLE],
         enable_underage_generalisation=features[FeatureToggle.ENABLE_UNDERAGE_GENERALISATION],
         id_check_address_autocompletion=features[FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION],
         is_recaptcha_enabled=features[FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA],
+        # TODO(antoinewg): remove this after next forced release (> v1.166.3)
+        # the last forced release v1.166.3 was not future proof enough to delete yet in this PR.
         is_webapp_v2_enabled=features[FeatureToggle.WEBAPP_V2_ENABLED],
         object_storage_url=OBJECT_STORAGE_URL,
     )

--- a/api/tests/routes/native/v1/settings_test.py
+++ b/api/tests/routes/native/v1/settings_test.py
@@ -10,10 +10,8 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 class SettingsTest:
     @override_features(
-        ALLOW_IDCHECK_REGISTRATION=True,
         AUTO_ACTIVATE_DIGITAL_BOOKINGS=False,
         DISPLAY_DMS_REDIRECTION=True,
-        ENABLE_CULTURAL_SURVEY=True,
         ENABLE_ID_CHECK_RETENTION=False,
         ENABLE_NATIVE_APP_RECAPTCHA=True,
         ENABLE_NATIVE_EAC_INDIVIDUAL=False,
@@ -27,9 +25,7 @@ class SettingsTest:
         assert response.status_code == 200
         assert response.json == {
             "accountCreationMinimumAge": 15,
-            "allowIdCheckRegistration": True,
             "autoActivateDigitalBookings": False,
-            "depositAmount": 30000,
             "depositAmountsByAge": {"age_15": 2000, "age_16": 3000, "age_17": 3000, "age_18": 30000},
             "displayDmsRedirection": True,
             "enableIdCheckRetention": False,
@@ -37,7 +33,6 @@ class SettingsTest:
             "enableNativeIdCheckVerboseDebugging": False,
             "enablePhoneValidation": True,
             "enableUnderageGeneralisation": False,
-            "enableCulturalSurvey": True,
             "idCheckAddressAutocompletion": True,
             "isRecaptchaEnabled": True,
             "isWebappV2Enabled": False,
@@ -45,29 +40,24 @@ class SettingsTest:
         }
 
     @override_features(
-        ALLOW_IDCHECK_REGISTRATION=False,
-        ENABLE_NATIVE_APP_RECAPTCHA=False,
-        ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING=True,
-        ENABLE_ID_CHECK_RETENTION=True,
         AUTO_ACTIVATE_DIGITAL_BOOKINGS=True,
-        ENABLE_CULTURAL_SURVEY=False,
-        WEBAPP_V2_ENABLED=True,
-        ENABLE_PHONE_VALIDATION=False,
         DISPLAY_DMS_REDIRECTION=False,
-        ID_CHECK_ADDRESS_AUTOCOMPLETION=False,
+        ENABLE_ID_CHECK_RETENTION=True,
+        ENABLE_NATIVE_APP_RECAPTCHA=False,
         ENABLE_NATIVE_EAC_INDIVIDUAL=True,
+        ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING=True,
+        ENABLE_PHONE_VALIDATION=False,
+        ID_CHECK_ADDRESS_AUTOCOMPLETION=False,
+        WEBAPP_V2_ENABLED=True,
     )
     def test_get_settings_feature_combination_2(self, app):
         response = TestClient(app.test_client()).get("/native/v1/settings")
         assert response.status_code == 200
         assert response.json == {
             "accountCreationMinimumAge": 15,
-            "allowIdCheckRegistration": False,
             "autoActivateDigitalBookings": True,
-            "depositAmount": 30000,
             "depositAmountsByAge": {"age_15": 2000, "age_16": 3000, "age_17": 3000, "age_18": 30000},
             "displayDmsRedirection": False,
-            "enableCulturalSurvey": False,
             "enableIdCheckRetention": True,
             "enableNativeEacIndividual": True,
             "enableNativeIdCheckVerboseDebugging": True,


### PR DESCRIPTION
Pas de ticket

https://github.com/pass-culture/pass-culture-app-native/pull/2405

## But de la PR

enlever les champs qui ne sont pas ou plus utilisé par l'app native: `allowIdCheckRegistration`, `depositAmount` et `enableCulturalSurvey`.

C'est possible car on a fait une màj de la version `10166003` et elle n'utilise plus ces champs.