### PR TITLE
[PC-12451][API] educonnect: remove idcheck subpath from error and validation url

### DIFF
--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -24,8 +24,8 @@ from . import blueprint
 
 logger = logging.getLogger(__name__)
 
-ERROR_PAGE_URL = f"{settings.WEBAPP_V2_URL}/idcheck/educonnect/erreur?"
-SUCCESS_PAGE_URL = f"{settings.WEBAPP_V2_URL}/idcheck/validation?"
+ERROR_PAGE_URL = f"{settings.WEBAPP_V2_URL}/educonnect/erreur?"
+SUCCESS_PAGE_URL = f"{settings.WEBAPP_V2_URL}/educonnect/validation?"
 
 
 @blueprint.saml_blueprint.route("educonnect/login", methods=["GET"])

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -126,80 +126,6 @@ class AttachBenerificaryImportDetailsTest:
 class EduconnectFlowTest:
     @freeze_time("2021-10-10")
     @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_saml_client")
-    def test_legacy_educonnect_subscription(self, mock_get_educonnect_saml_client, client, app):
-        # TODO (viconnex): remove this journey after app native mandatory version is >= 164
-        ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
-        fraud_factories.IneHashWhitelistFactory(ine_hash=ine_hash)
-        user = users_factories.UserFactory(dateOfBirth=datetime(2004, 1, 1))
-        access_token = create_access_token(identity=user.email)
-        client.auth_header = {"Authorization": f"Bearer {access_token}"}
-        mock_saml_client = MagicMock()
-        mock_get_educonnect_saml_client.return_value = mock_saml_client
-        mock_saml_client.prepare_for_authenticate.return_value = (
-            "request_id_123",
-            {"headers": [("Location", "https://pr4.educonnect.phm.education.gouv.fr/idp")]},
-        )
-
-        # Get educonnect login form with saml protocol
-        response = client.get("/saml/educonnect/login")
-        assert response.status_code == 302
-        assert response.location.startswith("https://pr4.educonnect.phm.education.gouv.fr/idp")
-
-        prefixed_request_id = app.redis_client.keys("educonnect-saml-request-*")[0]
-        request_id = prefixed_request_id[len("educonnect-saml-request-") :]
-
-        mock_saml_response = MagicMock()
-        mock_saml_client.parse_authn_request_response.return_value = mock_saml_response
-        mock_saml_response.get_identity.return_value = {
-            "givenName": ["Max"],
-            "sn": ["SENS"],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.57": [
-                "e6759833fb379e0340322889f2a367a5a5150f1533f80dfe963d21e43e33f7164b76cc802766cdd33c6645e1abfd1875"
-            ],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.5": ["https://educonnect.education.gouv.fr/Logout"],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.67": ["2006-08-18"],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.73": ["2212"],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.6": ["2021-10-08 11:51:33.437"],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.64": [ine_hash],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.7": ["eleve1d"],
-            "urn:oid:1.3.6.1.4.1.20326.10.999.1.72": ["school_uai"],
-        }
-        mock_saml_response.in_response_to = request_id
-
-        response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
-
-        assert response.status_code == 302
-        assert (
-            response.location
-            == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
-        )
-
-        assert len(user.beneficiaryFraudResults) == 1
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
-
-        beneficiary_import = BeneficiaryImport.query.filter_by(beneficiaryId=user.id).one_or_none()
-        assert beneficiary_import is not None
-        assert beneficiary_import.currentStatus == ImportStatus.CREATED
-        assert user.firstName == "Max"
-        assert user.lastName == "SENS"
-        assert user.dateOfBirth == datetime(2006, 8, 18, 0, 0)
-        assert user.ineHash == ine_hash
-
-        profile_data = {
-            "address": "1 rue des rues",
-            "city": "Uneville",
-            "postalCode": "77000",
-            "activity": "Lycéen",
-        }
-
-        response = client.patch("/native/v1/beneficiary_information", profile_data)
-
-        assert response.status_code == 204
-        assert user.roles == [users_models.UserRole.UNDERAGE_BENEFICIARY]
-        assert user.deposit.amount == 20
-
-    @freeze_time("2021-10-10")
-    @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_saml_client")
     @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True, ENABLE_EDUCONNECT_AUTHENTICATION=True)
     def test_educonnect_subscription(self, mock_get_educonnect_saml_client, client, app):
         ine_hash = "5ba682c0fc6a05edf07cd8ed0219258f"
@@ -261,7 +187,7 @@ class EduconnectFlowTest:
         assert response.status_code == 302
         assert (
             response.location
-            == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            == "https://webapp-v2.example.com/educonnect/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
         assert len(user.beneficiaryFraudResults) == 1

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -111,7 +111,7 @@ class EduconnectTest:
         assert response.status_code == 302
         assert (
             response.location
-            == "https://webapp-v2.example.com/idcheck/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            == "https://webapp-v2.example.com/educonnect/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
         assert caplog.records[0].extra == {
@@ -177,7 +177,7 @@ class EduconnectTest:
         assert response.status_code == 302
         assert (
             response.location
-            == "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserTypeNotStudent&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            == "https://webapp-v2.example.com/educonnect/erreur?code=UserTypeNotStudent&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
         assert caplog.records[0].extra == {"saml_request_id": self.request_id, "user_id": str(user.id)}
         assert caplog.records[0].message == "Wrong user type of educonnect user"
@@ -199,7 +199,7 @@ class EduconnectTest:
             response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith("https://webapp-v2.example.com/idcheck/validation")
+        assert response.location.startswith("https://webapp-v2.example.com/educonnect/validation")
         assert caplog.messages == [
             "Fraud suspicion after educonnect authentication with codes: duplicate_user, ine_not_whitelisted"
         ]
@@ -224,7 +224,7 @@ class EduconnectTest:
 
         assert not BeneficiaryImport.query.filter_by(beneficiary=user).first()
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
         assert len(user.subscriptionMessages) == 1
         assert (
@@ -246,7 +246,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
         assert len(user.subscriptionMessages) == 1
         assert (
@@ -268,7 +268,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid18YearsOld&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid18YearsOld&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
         assert len(user.subscriptionMessages) == 1
         assert (
@@ -290,7 +290,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
         assert len(user.subscriptionMessages) == 1
         assert (
@@ -335,7 +335,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserNotWhitelisted&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserNotWhitelisted&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
         assert len(user.subscriptionMessages) == 1
         assert (
@@ -354,7 +354,7 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
         assert response.status_code == 302
-        assert response.location.startswith("https://webapp-v2.example.com/idcheck/validation")
+        assert response.location.startswith("https://webapp-v2.example.com/educonnect/validation")
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
 
     @override_features(ENABLE_INE_WHITELIST_FILTER=False)
@@ -369,7 +369,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
         assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.KO
@@ -377,5 +377,5 @@ class EduconnectTest:
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
         assert response.status_code == 302
         assert response.location == (
-            "https://webapp-v2.example.com/idcheck/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
+            "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12451


## But de la pull request

Standardiser les url de redirection d'educonnect
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
