### PR TITLE
(PC-10114) fix no-user-found bug with pro login

### DIFF
--- a/api/src/pcapi/admin/base_configuration.py
+++ b/api/src/pcapi/admin/base_configuration.py
@@ -122,7 +122,7 @@ class AdminIndexView(AdminIndexBaseView):
     def no_user_found_view(self):
         from pcapi.utils import login_manager
 
-        if not session:
+        if current_user.is_authenticated:
             return redirect(url_for(".index"))
 
         rendered_view = self.render("admin/no_user_found.html", email=session["google_email"])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10114


## But de la pull request

Lors de l'accès à Flask Admin, si un utilisateur est connecté via le cookie "PRO" et visite la page `/no-user-found`, il recevait une 500.
Désormais, l'utilisateur est redirigé vers la page d'accueil de Flask Admin

##  Implémentation

- modification des conditions de redirection sur la route `/no-user-found`
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
