### PR TITLE
[pc-12594][api] add dms script to force 19 yo beneficiaries

### DIFF
--- a/api/src/pcapi/scripts/force_19yo_dms_import.py
+++ b/api/src/pcapi/scripts/force_19yo_dms_import.py
@@ -1,0 +1,100 @@
+import logging
+
+import click
+from flask import Blueprint
+
+from pcapi.core.fraud import api as fraud_api
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.subscription import api as subscription_api
+from pcapi.core.users import models as users_models
+from pcapi.core.users import utils as users_utils
+from pcapi.models import db
+from pcapi.models.beneficiary_import import BeneficiaryImportSources
+
+
+blueprint = Blueprint(__name__, __name__)
+
+logger = logging.getLogger(__name__)
+
+
+@blueprint.cli.command("force_19yo_dms_import")
+@click.option("--dry-run/--no-dry-run", help="Dry run", default=True, type=bool)
+def force_19yo_dms_import_cli(dry_run: bool = True) -> None:
+    """Force the import of a user who had 18 yo at subscription time"""
+
+    force_19yo_dms_import(dry_run=dry_run)
+
+
+def force_19yo_dms_import(dry_run: bool = True) -> None:
+    users = (
+        users_models.User.query.join(fraud_models.BeneficiaryFraudCheck)
+        .join(fraud_models.BeneficiaryFraudResult)
+        .filter(
+            fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.DMS,
+            fraud_models.BeneficiaryFraudResult.status == fraud_models.FraudStatus.KO,
+        )
+    )
+    to_activate = []
+    for user in users:
+        if user.has_beneficiary_role:
+            continue
+        if (
+            user.dateOfBirth
+            and user.age == 19
+            and users_utils.get_age_at_date(user.dateOfBirth, user.dateCreated) == 18
+            and len(user.beneficiaryFraudResults) == 1
+        ):
+            fraud_result = user.beneficiaryFraudResults[0]
+            reasons = fraud_result.reason_codes
+            if len(reasons) == 1 and reasons[0] in (
+                fraud_models.FraudReasonCode.ALREADY_BENEFICIARY,
+                fraud_models.FraudReasonCode.NOT_ELIGIBLE,
+            ):
+                to_activate.append(user)
+    logger.info("Needs to reactivate %d users", len(to_activate))
+    if dry_run:
+        return
+    activated = []
+    for user in to_activate:
+        if user.has_beneficiary_role:
+            continue
+        fraud_check = (
+            fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user, type=fraud_models.FraudCheckType.DMS)
+            .order_by(fraud_models.BeneficiaryFraudCheck.id.desc())
+            .first()
+        )
+        fraud_result = user.beneficiaryFraudResults[0]
+        fraud_result.reason = ""
+        if fraud_result.reason_codes:
+            fraud_result.reason_codes.clear()
+        fraud_check.status = fraud_models.FraudCheckStatus.OK
+        if fraud_check.reasonCodes:
+            fraud_check.reasonCodes.clear()
+        eligibility_type = users_models.EligibilityType.AGE18
+        content = fraud_check.source_data()
+        fraud_api.create_honor_statement_fraud_check(
+            user, "honor statement contained in DMS application", eligibility_type
+        )
+        fraud_items = fraud_api.dms_fraud_checks(user, fraud_check)
+        if all(fraud_item.status == fraud_models.FraudStatus.OK for fraud_item in fraud_items):
+            try:
+                subscription_api.on_successful_application(
+                    user,
+                    fraud_check.source_data(),
+                    BeneficiaryImportSources.demarches_simplifiees,
+                    eligibility_type,
+                    application_id=content.application_id,
+                    source_id=content.procedure_id,
+                    third_party_id=fraud_check.thirdPartyId,
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.warning("Cannot activate user %d", user.id, exc_info=True)
+                continue
+            user.comment = "Inscription forcée : Utilisateur ayant 18 ans lors de son inscription et 19 ans lors de la validation DMS"
+            db.session.add(fraud_result)
+            db.session.add(fraud_check)
+            db.session.add(user)
+            db.session.commit()
+            logger.info("User %s is now activated", user.id)
+            activated.append(user)
+    logger.info("Users activated : %d", len(activated))

--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -1,13 +1,16 @@
 import importlib
 
+import flask
 
-def install_commands(app):
+
+def install_commands(app: flask.Flask) -> None:
     module_paths = (
         "pcapi.scheduled_tasks.algolia_clock",
         "pcapi.scheduled_tasks.clock",
         "pcapi.scheduled_tasks.titelive_clock",
         "pcapi.scripts.algolia_indexing.commands",
         "pcapi.scripts.clean_database",
+        "pcapi.scripts.force_19yo_dms_import",
         "pcapi.scripts.full_index_offers",
         "pcapi.scripts.install_data",
         "pcapi.scripts.offerer.commands",

--- a/api/tests/scripts/force_19_yo_dms_import_test.py
+++ b/api/tests/scripts/force_19_yo_dms_import_test.py
@@ -1,0 +1,75 @@
+import datetime
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import factories as users_factories
+from pcapi.scripts.force_19yo_dms_import import force_19yo_dms_import
+
+
+@pytest.mark.usefixtures("db_session")
+class User19YearOldActivationTest:
+    def test_user_should_be_activated(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.DMS,
+            status=fraud_models.FraudCheckStatus.KO,
+            reasonCodes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+        fraud_factories.BeneficiaryFraudResultFactory(
+            user=user,
+            status=fraud_models.FraudStatus.KO,
+            reason_codes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+
+        force_19yo_dms_import(dry_run=False)
+
+        assert user.has_beneficiary_role
+        assert user.has_active_deposit
+
+    def test_user_should_not_be_activated_dry_run(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.DMS,
+            status=fraud_models.FraudCheckStatus.KO,
+            reasonCodes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+        fraud_factories.BeneficiaryFraudResultFactory(
+            user=user,
+            status=fraud_models.FraudStatus.KO,
+            reason_codes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+
+        assert not user.has_beneficiary_role
+        assert not user.has_active_deposit
+
+    def test_user_should_not_be_activated(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.UBBLE,
+            status=fraud_models.FraudCheckStatus.KO,
+            reasonCodes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+        fraud_factories.BeneficiaryFraudResultFactory(
+            user=user,
+            status=fraud_models.FraudStatus.KO,
+            reason_codes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+
+        force_19yo_dms_import()
+        assert not user.has_beneficiary_role
+        assert not user.has_active_deposit


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12594


## But de la pull request

Forcer le passage beneficiaires d'utilisateur qui avaient 18 lors de leur creation de compte
mais dont le delais du traitement DMS a mis trop de temps.

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)