### PR TITLE
(PC-12367)[PRO] offerer page: dispaly invalid business unit banner

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/OffererDetails/BankInformation/BankInformation.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/OffererDetails/BankInformation/BankInformation.jsx
@@ -13,7 +13,7 @@ import { DEMARCHES_SIMPLIFIEES_OFFERER_RIB_UPLOAD_PROCEDURE_URL } from 'utils/co
 
 import { Offerer } from '../Offerer'
 
-const BankInformation = ({ offerer, hasBusinessUnitError = false }) => (
+const BankInformation = ({ offerer, hasBusinessUnitError }) => (
   <div className="section op-content-section bank-information">
     <div className="main-list-title title-actions-container">
       <h2 className="main-list-title-text">
@@ -68,9 +68,11 @@ const BankInformation = ({ offerer, hasBusinessUnitError = false }) => (
     />
   </div>
 )
-
+BankInformation.defaultProps = {
+  hasBusinessUnitError: false,
+}
 BankInformation.propTypes = {
-  hasBusinessUnitError: PropTypes.bool.isRequired,
+  hasBusinessUnitError: PropTypes.bool,
   offerer: PropTypes.instanceOf(Offerer).isRequired,
 }
 

--- a/pro/src/components/pages/Offerers/Offerer/OffererDetails/OffererDetailsContainer.js
+++ b/pro/src/components/pages/Offerers/Offerer/OffererDetails/OffererDetailsContainer.js
@@ -1,5 +1,4 @@
 /*
- * @debt deprecated "Gaël: deprecated usage of redux-saga-data"
  * @debt standard "Gaël: prefer hooks for routers (https://reactrouter.com/web/api/Hooks)"
  * @debt standard "Gaël: prefer useSelector hook vs connect for redux (https://react-redux.js.org/api/hooks)"
  */
@@ -7,16 +6,11 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { compose } from 'redux'
-import { requestData } from 'redux-saga-data'
 
 import withTracking from 'components/hocs/withTracking'
-import { selectOffererById } from 'store/selectors/data/offerersSelectors'
 import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-import { selectPhysicalVenuesByOffererId } from 'store/selectors/data/venuesSelectors'
-import { offererNormalizer } from 'utils/normalizers'
 
 import OffererDetails from './OffererDetails'
-import { makeOffererComponentValueObject } from './OffererFactory'
 
 export const mapStateToProps = (state, ownProps) => {
   const { match } = ownProps
@@ -26,34 +20,12 @@ export const mapStateToProps = (state, ownProps) => {
   const currentUser = selectCurrentUser(state)
   return {
     currentUser,
-    offerer: makeOffererComponentValueObject(
-      selectOffererById,
-      offererId,
-      state
-    ),
     offererId,
-    venues: selectPhysicalVenuesByOffererId(state, offererId),
-  }
-}
-
-/**
- * @debt standard "Annaëlle: Supprimer requestData"
- */
-export const mapDispatchToProps = dispatch => {
-  return {
-    loadOffererById: offererId => {
-      dispatch(
-        requestData({
-          apiPath: `/offerers/${offererId}`,
-          normalizer: offererNormalizer,
-        })
-      )
-    },
   }
 }
 
 export default compose(
   withRouter,
   withTracking('Offerer'),
-  connect(mapStateToProps, mapDispatchToProps)
+  connect(mapStateToProps)
 )(OffererDetails)

--- a/pro/src/components/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.jsx
@@ -1,56 +1,111 @@
 /*
  * @debt complexity "Gaël: file nested too deep in directory structure"
- * @debt rtl "Gaël: migration from enzyme to RTL"
  */
 
-import { shallow } from 'enzyme'
+import '@testing-library/jest-dom'
+import { act, render, screen } from '@testing-library/react'
 import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
 
-import BankInformation from '../BankInformation/BankInformation'
-import { Offerer } from '../Offerer'
+import * as pcapi from 'repository/pcapi/pcapi'
+import { configureTestStore } from 'store/testUtils'
+
 import OffererDetails from '../OffererDetails'
-import VenuesContainer from '../Venues/VenuesContainer'
+
+jest.mock('repository/pcapi/pcapi', () => ({
+  getOfferer: jest.fn(),
+  getBusinessUnits: jest.fn(),
+}))
+
+const renderOffererDetails = async ({ props, store }) => {
+  return await act(async () => {
+    await render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <OffererDetails {...props} />
+        </MemoryRouter>
+      </Provider>
+    )
+  })
+}
 
 describe('src | components | pages | Offerer | OffererDetails', () => {
   let props
+  let store
   beforeEach(() => {
     props = {
-      loadOffererById: () => {},
-      offerer: new Offerer({
-        id: 'AA',
-        name: 'fake offerer name',
-        address: 'fake address',
-        bic: 'ABC',
-        iban: 'DEF',
-      }),
       offererId: 'AA',
-      venues: [{}],
     }
+    store = configureTestStore()
+  })
+
+  pcapi.getOfferer.mockResolvedValue({
+    id: 'AA',
+    name: 'fake offerer name',
+    address: 'fake address',
+    bic: 'ABC',
+    iban: 'DEF',
+    managedVenues: [
+      {
+        address: '1 fake address',
+        name: 'fake venue',
+        publicName: 'fake venue',
+        postalCode: '75000',
+        city: 'Paris',
+      },
+    ],
   })
 
   describe('render', () => {
-    it('should render a bank instructions block if they are already provided', () => {
-      // given
-      props.offerer.bic = 'FR7630001001111111111111111'
-      props.offerer.iban = 'QS111111111'
+    it('should render a bank instructions block if they are already provided', async () => {
+      // When
+      renderOffererDetails({ props, store })
 
-      // when
-      const wrapper = shallow(<OffererDetails {...props} />)
-
-      // then
-      const bankInstructions = wrapper.find(BankInformation)
-      expect(bankInstructions).toHaveLength(1)
+      // Then
+      const bankInstructions = await screen.findByText(
+        'Les coordonnées bancaires ci-dessous seront attribuées à tous les lieux sans coordonnées bancaires propres :'
+      )
+      expect(bankInstructions).toBeInTheDocument()
     })
 
-    it('should render Venues', () => {
+    it('should render Venues', async () => {
       // when
-      const wrapper = shallow(<OffererDetails {...props} />)
-      const venuesComponent = wrapper.find(VenuesContainer)
+      await renderOffererDetails({ props, store })
 
       // then
-      expect(venuesComponent).toHaveLength(1)
-      expect(venuesComponent.prop('offererId')).toBe(props.offerer.id)
-      expect(venuesComponent.prop('venues')).toBe(props.venues)
+      expect(screen.getByText('Lieux')).toBeInTheDocument()
+      expect(screen.getByText('fake venue')).toBeInTheDocument()
+    })
+
+    it('should render business unit banner when offerer has invalid business unit', async () => {
+      // Given
+      store = configureTestStore({
+        features: {
+          list: [
+            { isActive: true, nameKey: 'ENFORCE_BANK_INFORMATION_WITH_SIRET' },
+          ],
+        },
+      })
+      pcapi.getBusinessUnits.mockResolvedValue([
+        {
+          name: 'Business Unit #2',
+          siret: null,
+          id: 2,
+          bic: 'BDFEFRPP',
+          iban: 'FR9410010000000000000000022',
+        },
+      ])
+
+      // When
+      await renderOffererDetails({ props, store })
+
+      // Then
+      expect(
+        screen.getByText(
+          'Certains de vos points de remboursement ne sont pas rattachés à un SIRET. Pour continuer à percevoir vos remboursements, veuillez renseigner un SIRET de référence.'
+        )
+      ).toBeInTheDocument()
     })
   })
 })

--- a/pro/src/components/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetailsContainer.spec.js
+++ b/pro/src/components/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetailsContainer.spec.js
@@ -3,18 +3,7 @@
  * @debt complexity "Gaël: file nested too deep in directory structure"
  */
 
-import {
-  mapStateToProps,
-  mapDispatchToProps,
-} from '../../OffererDetails/OffererDetailsContainer'
-
-jest.mock('redux-saga-data', () => {
-  const { requestData } = jest.requireActual('fetch-normalize-data')
-  return {
-    requestData,
-    createDataReducer: jest.fn(),
-  }
-})
+import { mapStateToProps } from '../OffererDetailsContainer'
 
 describe('src | components | pages | Offerer | OffererDetails | OffererDetailsContainer', () => {
   describe('mapStateToProps', () => {
@@ -64,16 +53,7 @@ describe('src | components | pages | Offerer | OffererDetails | OffererDetailsCo
         currentUser: {
           id: 'TY56er',
         },
-        offerer: expect.objectContaining({
-          id: 'AGH',
-          name: 'Gaumont cinéma',
-          bic: 'bic',
-          iban: 'iban',
-          address: '256, rue des mimosas',
-          siren: '256712456',
-        }),
         offererId: 'AGH',
-        venues: [],
       })
     })
 
@@ -121,36 +101,6 @@ describe('src | components | pages | Offerer | OffererDetails | OffererDetailsCo
       // then
       expect(props).toMatchObject({
         offererId: 'AGH',
-      })
-    })
-  })
-
-  describe('mapDispatchToProps', () => {
-    describe('loadOffererById', () => {
-      it('should load one offerer details', () => {
-        // given
-        const dispatch = jest.fn()
-        const offererId = 'B44'
-
-        // when
-        mapDispatchToProps(dispatch).loadOffererById(offererId)
-
-        // then
-        expect(dispatch).toHaveBeenCalledWith({
-          config: {
-            apiPath: '/offerers/B44',
-            method: 'GET',
-            normalizer: {
-              managedVenues: {
-                normalizer: {
-                  offers: 'offers',
-                },
-                stateKey: 'venues',
-              },
-            },
-          },
-          type: 'REQUEST_DATA_GET_/OFFERERS/B44',
-        })
       })
     })
   })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12367


## But de la pull request

Afficher un bandeau jaune sur la page structure, lorsqu’une structure a au moins un de ses lieux qui contient un point de remboursement invalide.

##  Informations supplémentaires

 - Migration de `OffererDetails.jsx` à un composant fonctionnel.
 - Migration de redux-saga-data à des appel via pcapi client pour le composant `OffererDetails.jsx`
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
