### PR TITLE
[PC-12589][API] Fix OOM on scheduled tasks

### DIFF
--- a/api/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -147,26 +147,22 @@ def notify_users_of_expired_individual_bookings(expired_on: datetime.date = None
     expired_on = expired_on or datetime.date.today()
 
     logger.info("[notify_users_of_expired_bookings] Start")
-    expired_individual_bookings_ordered_by_user = bookings_repository.find_expired_individual_bookings_ordered_by_user(
-        expired_on
-    )
-
-    expired_bookings_grouped_by_user = dict()
-    for user, individual_bookings in groupby(expired_individual_bookings_ordered_by_user, attrgetter("user")):
-        expired_bookings_grouped_by_user[user] = list(individual_bookings)
-
-    notified_users = []
-
-    for user, individual_bookings in expired_bookings_grouped_by_user.items():
+    users = bookings_repository.find_users_with_expired_individual_bookings(expired_on)
+    notified_users_str = []
+    for user in users:
         send_expired_bookings_to_beneficiary_email(
-            user, [individual_booking.booking for individual_booking in individual_bookings]
+            user,
+            [
+                individual_booking.booking
+                for individual_booking in bookings_repository.get_expired_individual_bookings_for_user(user)
+            ],
         )
-        notified_users.append(user)
+        notified_users_str.append(user.id)
 
     logger.info(
         "[notify_users_of_expired_bookings] %d Users have been notified: %s",
-        len(notified_users),
-        notified_users,
+        len(notified_users_str),
+        notified_users_str,
     )
 
     logger.info("[notify_users_of_expired_bookings] End")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12589

## But de la pull request

The scheduled tasks was pulling way too many objects from the DB
at once. This is reworked to proceed on a per user basis and
get the associated data for each user.
This is a bit less efficient than using a unique query and yield_per
but the later is much less readable as we'll need to regroup the
objects per user.

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
