### PR TITLE
[PC-11628][api][finance] Utilisation de Pricing et Cashflow à la place de Payment

### DIFF
--- a/api/src/pcapi/core/bookings/validation.py
+++ b/api/src/pcapi/core/bookings/validation.py
@@ -7,6 +7,7 @@ from pcapi.core.bookings import exceptions
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.bookings.models import IndividualBooking
+import pcapi.core.finance.repository as finance_repository
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -15,7 +16,6 @@ from pcapi.core.users.models import User
 from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
-from pcapi.repository import payment_queries
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 from ..educational.models import EducationalBookingStatus
@@ -125,7 +125,7 @@ def check_booking_can_be_cancelled(booking: Booking) -> None:
 # desired HTTP-related exception (such as ResourceGone and Forbidden)
 # See also functions below.
 def check_is_usable(booking: Booking) -> None:
-    if payment_queries.has_payment(booking):
+    if finance_repository.has_reimbursement(booking):
         forbidden = api_errors.ForbiddenError()
         forbidden.add_error("payment", "Cette réservation a été remboursée")
         raise forbidden
@@ -193,7 +193,7 @@ def check_can_be_mark_as_unused(booking: Booking) -> None:
         forbidden.add_error("booking", "Cette réservation a été annulée")
         raise forbidden
 
-    if payment_queries.has_payment(booking):
+    if finance_repository.has_reimbursement(booking):
         gone = api_errors.ResourceGoneError()
         gone.add_error("payment", "Le remboursement est en cours de traitement")
         raise gone

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -330,7 +330,7 @@ def _delete_dependent_pricings(booking: bookings_models.Booking, log_message: st
     logger.info(
         log_message,
         extra={
-            "booking_being_priced": booking.id,
+            "booking_being_priced_or_cancelled": booking.id,
             "bookings_already_priced": bookings_already_priced,
             "siret": siret,
         },

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -28,7 +28,12 @@ class PricingStatus(enum.Enum):
     CANCELLED = "cancelled"
     VALIDATED = "validated"
     REJECTED = "rejected"
-    BILLED = "billed"
+    # FIXME (dbaty, 2021-01-18): a "paid" status has been deployed on
+    # prod (through a hotfix). Once rows have been updated to use
+    # "processed" instead, we can remove this enum value.
+    PAID = "paid"
+    PROCESSED = "processed"  # has an associated cashflow
+    INVOICED = "invoiced"  # has an associated invoice (whose cashflows are "accepted")
 
 
 class BusinessUnitStatus(enum.Enum):

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -92,6 +92,9 @@ class FeatureToggle(enum.Enum):
     WEBAPP_HOMEPAGE = "Permettre l affichage de la nouvelle page d accueil de la webapp"
     WEBAPP_V2_ENABLED = "Utiliser la nouvelle web app (décli web/v2) au lieu de l'ancienne"
     SHOW_INVOICES_ON_PRO_PORTAL = "Activer l'affichage des remboursements sur le portail pro"
+    INCLUDE_LEGACY_PAYMENTS_FOR_REIMBURSEMENTS = (
+        "Inclure les anciens modèles de données pour le téléchargement des remboursements "
+    )
 
     def is_active(self) -> bool:
         if flask.has_request_context():

--- a/api/src/pcapi/repository/payment_queries.py
+++ b/api/src/pcapi/repository/payment_queries.py
@@ -1,6 +1,5 @@
 import datetime
 from typing import Iterable
-from typing import Optional
 
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
@@ -22,10 +21,6 @@ from pcapi.models.payment_status import TransactionStatus
 
 def find_payments_by_message(message_name: str) -> list[Payment]:
     return Payment.query.join(PaymentMessage).filter(PaymentMessage.name == message_name).all()
-
-
-def has_payment(booking: Booking) -> Optional[Payment]:
-    return db.session.query(Payment.query.filter_by(bookingId=booking.id).exists()).scalar()
 
 
 def find_not_processable_with_bank_information() -> list[Payment]:

--- a/api/src/pcapi/repository/reimbursement_queries.py
+++ b/api/src/pcapi/repository/reimbursement_queries.py
@@ -1,18 +1,20 @@
 from datetime import date
 from typing import Optional
 
-from sqlalchemy import Date
-from sqlalchemy import cast
+import sqlalchemy as sqla
 
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import IndividualBooking
 from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalRedactor
+import pcapi.core.finance.models as finance_models
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
 from pcapi.core.users.models import User
+from pcapi.models.bank_information import BankInformation
+from pcapi.models.feature import FeatureToggle
 from pcapi.models.payment import Payment
 from pcapi.models.payment_status import PaymentStatus
 from pcapi.models.payment_status import TransactionStatus
@@ -31,7 +33,7 @@ def find_all_offerer_payments(
 def find_all_offerers_payments(
     offerer_ids: list[int], reimbursement_period: tuple[date, date], venue_id: Optional[int] = None
 ) -> list[tuple]:
-    payment_date = cast(PaymentStatus.date, Date)
+    payment_date = sqla.cast(PaymentStatus.date, sqla.Date)
     sent_payments = (
         Payment.query.join(PaymentStatus)
         .join(Booking)
@@ -74,4 +76,57 @@ def find_all_offerers_payments(
         )
     )
 
-    return sent_payments.all()
+    sent_pricings = (
+        finance_models.Pricing.query.join(finance_models.Pricing.booking)
+        .join(finance_models.Pricing.cashflows)
+        .join(finance_models.Cashflow.bankAccount)
+        .outerjoin(finance_models.Pricing.customRule)
+        .filter(
+            finance_models.Pricing.status == finance_models.PricingStatus.INVOICED,
+            sqla.cast(finance_models.Cashflow.creationDate, sqla.Date).between(
+                *reimbursement_period,
+                symmetric=True,
+            ),
+            Booking.offererId.in_(offerer_ids),
+            (Booking.venueId == venue_id) if venue_id else sqla.true(),
+        )
+        .join(Booking.offerer)
+        .outerjoin(IndividualBooking)
+        .outerjoin(User)
+        .outerjoin(EducationalBooking)
+        .outerjoin(EducationalRedactor)
+        .join(Stock)
+        .join(Offer)
+        .join(Venue)
+        .order_by(finance_models.Cashflow.id.desc())
+        .with_entities(
+            User.lastName.label("user_lastName"),
+            User.firstName.label("user_firstName"),
+            EducationalRedactor.firstName.label("redactor_firstname"),
+            EducationalRedactor.lastName.label("redactor_lastname"),
+            Booking.token.label("booking_token"),
+            Booking.dateUsed.label("booking_dateUsed"),
+            Booking.quantity.label("booking_quantity"),
+            Booking.amount.label("booking_amount"),
+            Offer.name.label("offer_name"),
+            Offer.isEducational.label("offer_is_educational"),
+            Offerer.address.label("offerer_address"),
+            Venue.name.label("venue_name"),
+            Venue.siret.label("venue_siret"),
+            Venue.address.label("venue_address"),
+            # See note about `amount` in `core/finance/models.py`.
+            (-finance_models.Pricing.amount).label("amount"),
+            finance_models.Pricing.standardRule.label("rule_name"),
+            finance_models.Pricing.customRuleId.label("rule_id"),
+            finance_models.Cashflow.creationDate.label("cashflow_date"),
+            BankInformation.iban.label("iban"),
+        )
+    )
+
+    results = []
+    if FeatureToggle.INCLUDE_LEGACY_PAYMENTS_FOR_REIMBURSEMENTS.is_active():
+        results.extend(sent_payments.all())
+
+    results.extend(sent_pricings.all())
+
+    return results

--- a/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -40,40 +40,37 @@ class ReimbursementDetails:
         "Type d'offre",
     ]
 
-    def __init__(self, payment_info: namedtuple = None):
-        if payment_info is not None:
-            transfer_infos = payment_info.transactionLabel.replace("pass Culture Pro - ", "").split(" ")
-            transfer_label = " ".join(transfer_infos[:-1])
+    def __init__(self, payment_info: namedtuple):
+        transfer_infos = payment_info.transactionLabel.replace("pass Culture Pro - ", "").split(" ")
+        transfer_label = " ".join(transfer_infos[:-1])
 
-            transfer_date = transfer_infos[-1]
-            month_number, year = transfer_date.split("-")
-            month_name = MONTHS_IN_FRENCH[int(month_number)]
+        transfer_date = transfer_infos[-1]
+        month_number, year = transfer_date.split("-")
+        month_name = MONTHS_IN_FRENCH[int(month_number)]
 
-            self.year = year
-            self.transfer_name = "{} : {}".format(month_name, transfer_label)
-            self.venue_name = payment_info.venue_name
-            self.venue_siret = payment_info.venue_siret
-            self.venue_address = payment_info.venue_address or payment_info.offerer_address
-            self.payment_iban = payment_info.iban
-            self.venue_name = payment_info.venue_name
-            self.offer_name = payment_info.offer_name
-            self.user_last_name = payment_info.user_lastName or payment_info.redactor_lastname
-            self.user_first_name = payment_info.user_firstName or payment_info.redactor_firstname
-            self.booking_token = payment_info.booking_token
-            self.booking_used_date = payment_info.booking_dateUsed
-            self.booking_total_amount = format_number_as_french(
-                payment_info.booking_amount * payment_info.booking_quantity
-            )
-            if payment_info.reimbursement_rate:
-                reimbursement_rate = f"{int(payment_info.reimbursement_rate * 100)}%"
-            else:
-                reimbursement_rate = ""
-            self.reimbursement_rate = reimbursement_rate
-            self.reimbursed_amount = format_number_as_french(payment_info.amount)
-            # Backward compatibility to avoid changing the format of the CSV. This field
-            # used to show different statuses.
-            self.status = "Remboursement envoyé"
-            self.offer_type = serialize_offer_type_educational_or_individual(payment_info.offer_is_educational)
+        self.year = year
+        self.transfer_name = "{} : {}".format(month_name, transfer_label)
+        self.venue_name = payment_info.venue_name
+        self.venue_siret = payment_info.venue_siret
+        self.venue_address = payment_info.venue_address or payment_info.offerer_address
+        self.payment_iban = payment_info.iban
+        self.venue_name = payment_info.venue_name
+        self.offer_name = payment_info.offer_name
+        self.user_last_name = payment_info.user_lastName or payment_info.redactor_lastname
+        self.user_first_name = payment_info.user_firstName or payment_info.redactor_firstname
+        self.booking_token = payment_info.booking_token
+        self.booking_used_date = payment_info.booking_dateUsed
+        self.booking_total_amount = format_number_as_french(payment_info.booking_amount * payment_info.booking_quantity)
+        if payment_info.reimbursement_rate:
+            reimbursement_rate = f"{int(payment_info.reimbursement_rate * 100)}%"
+        else:
+            reimbursement_rate = ""
+        self.reimbursement_rate = reimbursement_rate
+        self.reimbursed_amount = format_number_as_french(payment_info.amount)
+        # Backward compatibility to avoid changing the format of the CSV. This field
+        # used to show different statuses.
+        self.status = "Remboursement envoyé"
+        self.offer_type = serialize_offer_type_educational_or_individual(payment_info.offer_is_educational)
 
     def as_csv_row(self):
         return [

--- a/api/tests/core/finance/test_integration.py
+++ b/api/tests/core/finance/test_integration.py
@@ -6,6 +6,7 @@ import pcapi.core.bookings.api as bookings_api
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.finance import api
 from pcapi.core.finance import models
+import pcapi.core.reference.factories as reference_factories
 from pcapi.models import db
 
 
@@ -24,4 +25,9 @@ def test_integration():
     cashflow = pricing.cashflows[0]
     assert cashflow.status == models.CashflowStatus.UNDER_REVIEW
     db.session.refresh(pricing)
-    assert pricing.status == models.PricingStatus.VALIDATED
+    assert pricing.status == models.PricingStatus.PROCESSED
+
+    reference_factories.ReferenceSchemeFactory()
+    api._generate_invoice(pricing.businessUnitId, [cashflow.id])
+    db.session.refresh(pricing)
+    assert pricing.status == models.PricingStatus.INVOICED

--- a/api/tests/core/finance/test_repository.py
+++ b/api/tests/core/finance/test_repository.py
@@ -2,11 +2,13 @@ import datetime
 
 import pytest
 
+import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.finance import factories
 from pcapi.core.finance import models
 from pcapi.core.finance import repository
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
+from pcapi.models import db
 from pcapi.models.bank_information import BankInformationStatus
 
 
@@ -178,3 +180,16 @@ class GetInvoicesQueryTest:
 
         invoices = repository.get_invoices_query(admin)
         assert list(invoices) == []
+
+
+def test_has_reimbursement():
+    booking = bookings_factories.UsedIndividualBookingFactory()
+    assert not repository.has_reimbursement(booking)
+
+    pricing = factories.PricingFactory(booking=booking, status=models.PricingStatus.VALIDATED)
+    assert not repository.has_reimbursement(booking)
+
+    pricing.status = models.PricingStatus.PROCESSED
+    db.session.add(pricing)
+    db.session.commit()
+    assert repository.has_reimbursement(booking)

--- a/api/tests/repository/payment_queries_test.py
+++ b/api/tests/repository/payment_queries_test.py
@@ -187,15 +187,6 @@ class FindNotProcessableWithBankInformationTest:
 
 
 @pytest.mark.usefixtures("db_session")
-def test_has_payment():
-    booking = bookings_factories.UsedIndividualBookingFactory()
-    assert not payment_queries.has_payment(booking)
-
-    factories.PaymentFactory(booking=booking)
-    assert payment_queries.has_payment(booking)
-
-
-@pytest.mark.usefixtures("db_session")
 def test_get_payment_count_by_status():
     batch_date = datetime.datetime.now()
     other_date = datetime.datetime.now()

--- a/api/tests/routes/serialization/reimbursement_csv_test.py
+++ b/api/tests/routes/serialization/reimbursement_csv_test.py
@@ -1,14 +1,17 @@
+from datetime import date
 from datetime import datetime
 from datetime import timedelta
 
 import pytest
 
-import pcapi.core.bookings.factories as booking_factories
+import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.finance.api as finance_api
+import pcapi.core.finance.factories as finance_factories
+import pcapi.core.finance.models as finance_models
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
-from pcapi.core.payments.factories import PaymentFactory
-from pcapi.core.payments.factories import PaymentWithCustomRuleFactory
 from pcapi.models.payment_status import TransactionStatus
+from pcapi.repository import repository
 from pcapi.repository.reimbursement_queries import find_all_offerer_payments
 from pcapi.routes.serialization.reimbursement_csv_serialize import ReimbursementDetails
 from pcapi.routes.serialization.reimbursement_csv_serialize import find_all_offerer_reimbursement_details
@@ -22,21 +25,28 @@ reimbursement_period = (today, in_two_days)
 
 @pytest.mark.usefixtures("db_session")
 class ReimbursementDetailsTest:
-    def test_reimbursementDetail_as_csv_individual_booking(self, app):
-        # given
-        payment = PaymentFactory(
+    def test_reimbursement_details_as_csv_individual_booking(self):
+        payment = payments_factories.PaymentFactory(
             transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
             booking__amount=10.5,
             booking__quantity=2,
+            booking__stock__offer__venue__businessUnit__bankAccount__iban="CF13QSDFGH456789",
         )
         payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
-
+        finance_factories.PricingFactory(
+            booking=payment.booking,
+            amount=-2100,
+            standardRule="Remboursement total pour les offres physiques",
+            status=finance_models.PricingStatus.VALIDATED,
+        )
+        finance_api.generate_cashflows(cutoff=datetime.utcnow())
+        finance_models.Pricing.query.update(
+            {"status": finance_models.PricingStatus.INVOICED},
+        )
         payments_info = find_all_offerer_payments(payment.booking.offerer.id, reimbursement_period)
 
-        # when
+        # legacy payment data
         raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
-
-        # then
         assert raw_csv[0] == "2019"
         assert raw_csv[1] == "Juillet : remboursement 1ère quinzaine"
         assert raw_csv[2] == payment.booking.venue.name
@@ -53,22 +63,54 @@ class ReimbursementDetailsTest:
         assert raw_csv[13] == f"{int(payment.reimbursementRate * 100)}%"
         assert raw_csv[14] == "21,00"
         assert raw_csv[15] == "Remboursement envoyé"
+        assert raw_csv[16] == "offre grand public"
 
-    def test_reimbursementDetail_as_csv_educational_booking(self, app):
+        # new pricing+cashflow data
+        row = ReimbursementDetails(payments_info[1]).as_csv_row()
+        # The first 2 cells are tested in a separate test below.
+        assert row[2] == payment.booking.venue.name
+        assert row[3] == payment.booking.venue.siret
+        assert row[4] == payment.booking.venue.address
+        assert row[5] == payment.iban
+        assert row[6] == payment.booking.venue.name
+        assert row[7] == payment.booking.stock.offer.name
+        assert row[8] == "Doux"
+        assert row[9] == "Jeanne"
+        assert row[10] == payment.booking.token
+        assert row[11] == payment.booking.dateUsed
+        assert row[12] == "21,00"
+        assert row[13] == f"{int(payment.reimbursementRate * 100)} %"
+        assert row[14] == "21,00"
+        assert row[15] == "Remboursement envoyé"
+        assert row[16] == "offre grand public"
+
+    def test_reimbursement_details_as_csv_educational_booking(self):
         # given
-        booking = booking_factories.UsedEducationalBookingFactory(amount=10.5, quantity=2)
-        payment = PaymentFactory(
+        booking = bookings_factories.UsedEducationalBookingFactory(
+            amount=10.5,
+            quantity=2,
+            stock__offer__venue__businessUnit__bankAccount__iban="CF13QSDFGH456789",
+        )
+        payment = payments_factories.PaymentFactory(
             booking=booking,
             transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
         )
         payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
-
+        finance_factories.PricingFactory(
+            booking=payment.booking,
+            amount=-2100,
+            standardRule="Remboursement total pour les offres physiques",
+            status=finance_models.PricingStatus.VALIDATED,
+        )
+        finance_api.generate_cashflows(cutoff=datetime.utcnow())
+        finance_models.Pricing.query.update(
+            {"status": finance_models.PricingStatus.INVOICED},
+            synchronize_session=False,
+        )
         payments_info = find_all_offerer_payments(payment.booking.offerer.id, reimbursement_period)
 
-        # when
+        # legacy payment data
         raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
-
-        # then
         assert raw_csv[0] == "2019"
         assert raw_csv[1] == "Juillet : remboursement 1ère quinzaine"
         assert raw_csv[2] == payment.booking.venue.name
@@ -85,45 +127,132 @@ class ReimbursementDetailsTest:
         assert raw_csv[13] == f"{int(payment.reimbursementRate * 100)}%"
         assert raw_csv[14] == "21,00"
         assert raw_csv[15] == "Remboursement envoyé"
+        assert raw_csv[16] == "offre scolaire"
 
-    def test_reimbursementDetail_with_custom_rule_as_csv(self, app):
+        # new pricing+cashflow data
+        row = ReimbursementDetails(payments_info[1]).as_csv_row()
+        # The first 2 cells are tested in a separate test below.
+        assert row[2] == payment.booking.venue.name
+        assert row[3] == payment.booking.venue.siret
+        assert row[4] == payment.booking.venue.address
+        assert row[5] == payment.iban
+        assert row[6] == payment.booking.venue.name
+        assert row[7] == payment.booking.stock.offer.name
+        assert row[8] == payment.booking.educationalBooking.educationalRedactor.lastName
+        assert row[9] == payment.booking.educationalBooking.educationalRedactor.firstName
+        assert row[10] == payment.booking.token
+        assert row[11] == payment.booking.dateUsed
+        assert row[12] == "21,00"
+        assert row[13] == f"{int(payment.reimbursementRate * 100)} %"
+        assert row[14] == "21,00"
+        assert row[15] == "Remboursement envoyé"
+        assert row[16] == "offre scolaire"
+
+    def test_reimbursement_details_with_custom_rule_as_csv(self):
         # given
-        payment = PaymentWithCustomRuleFactory(
+        custom_reimbursement_rule = payments_factories.CustomReimbursementRuleFactory(
+            amount=None,
+            rate=0.1234,
+        )
+        payment = payments_factories.PaymentWithCustomRuleFactory(
             transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
+            amount=2.71,
+            customReimbursementRule=custom_reimbursement_rule,
             booking__amount=10.5,
             booking__quantity=2,
+            booking__stock__offer__venue__businessUnit__bankAccount__iban="CF13QSDFGH456789",
         )
         payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
-
+        finance_factories.PricingFactory(
+            booking=payment.booking,
+            amount=-271,
+            standardRule="",
+            customRule=custom_reimbursement_rule,
+            status=finance_models.PricingStatus.VALIDATED,
+        )
+        finance_api.generate_cashflows(cutoff=datetime.utcnow())
+        finance_models.Pricing.query.update(
+            {"status": finance_models.PricingStatus.INVOICED},
+        )
         payments_info = find_all_offerer_payments(payment.booking.offererId, reimbursement_period)
 
-        # when
-        raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
+        # legacy payment data
+        row = ReimbursementDetails(payments_info[0]).as_csv_row()
+        assert row[13] == ""
 
-        # then
-        assert raw_csv[13] == ""
+        # new pricing+cashflow data
+        row = ReimbursementDetails(payments_info[1]).as_csv_row()
+        assert row[13] == "12,34 %"
+
+    def test_reimbursement_details_date_columns(self):
+        # Date columns of ReimbursementDetails are populated from
+        # `Cashflow.creationDate` which is generated by the
+        # database. They cannot be controlled with freezetime in the
+        # tests above.
+        booking = bookings_factories.UsedIndividualBookingFactory(
+            stock__offer__venue__businessUnit__bankAccount__iban="CF13QSDFGH456789",
+        )
+        finance_factories.PricingFactory(
+            booking=booking,
+            status=finance_models.PricingStatus.VALIDATED,
+        )
+        finance_api.generate_cashflows(cutoff=datetime.utcnow())
+        finance_models.Pricing.query.update(
+            {"status": finance_models.PricingStatus.INVOICED},
+            synchronize_session=False,
+        )
+        cashflow = finance_models.Cashflow.query.one()
+
+        cashflow.creationDate = datetime(2021, 1, 1, 4, 0)
+        repository.save(cashflow)
+        period = (cashflow.creationDate.date(), date.today() + timedelta(days=1))
+        payments = find_all_offerer_payments(booking.offererId, period)
+        row = ReimbursementDetails(payments[0]).as_csv_row()
+        assert row[0] == 2021
+        assert row[1] == "Janvier : remboursement 1ère quinzaine"
+
+        cashflow.creationDate = datetime(2021, 2, 16, 4, 0)
+        repository.save(cashflow)
+        payments = find_all_offerer_payments(booking.offererId, period)
+        row = ReimbursementDetails(payments[0]).as_csv_row()
+        assert row[0] == 2021
+        assert row[1] == "Février : remboursement 2nde quinzaine"
 
 
 @pytest.mark.usefixtures("db_session")
 def test_generate_reimbursement_details_csv():
     # given
-    payment = PaymentFactory(
+    payment = payments_factories.PaymentFactory(
         booking__stock__offer__name='Mon titre ; un peu "spécial"',
         booking__stock__offer__isEducational=False,
         booking__stock__offer__venue__name='Mon lieu ; un peu "spécial"',
         booking__stock__offer__venue__siret="siret-1234",
+        booking__stock__offer__venue__businessUnit__bankAccount__iban="CF13QSDFGH456789",
         booking__token="0E2722",
         booking__amount=10.5,
         booking__quantity=2,
         booking__dateUsed=datetime(2021, 1, 1, 12, 0),
-        iban="iban-1234",
+        iban="CF13QSDFGH456789",
         transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
     )
     payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
     offerer = payment.booking.offerer
-    reimbursement_details = find_all_offerer_reimbursement_details(offerer.id, reimbursement_period)
 
-    # when
+    finance_factories.PricingFactory(
+        booking=payment.booking,
+        amount=-2100,
+        standardRule="Remboursement total pour les offres physiques",
+        status=finance_models.PricingStatus.VALIDATED,
+    )
+    finance_api.generate_cashflows(cutoff=datetime.utcnow())
+    finance_models.Pricing.query.update(
+        {"status": finance_models.PricingStatus.INVOICED},
+        synchronize_session=False,
+    )
+    finance_models.Cashflow.query.update({"creationDate": datetime(2019, 7, 1, 4, 0)}, synchronize_session=False)
+
+    period = (datetime(2019, 7, 1, 4, 0).date(), datetime.utcnow().date())
+    reimbursement_details = find_all_offerer_reimbursement_details(offerer.id, period)
     csv = generate_reimbursement_details_csv(reimbursement_details)
 
     # then
@@ -132,46 +261,13 @@ def test_generate_reimbursement_details_csv():
         rows[0]
         == '"Année";"Virement";"Créditeur";"SIRET créditeur";"Adresse créditeur";"IBAN";"Raison sociale du lieu";"Nom de l\'offre";"Nom utilisateur";"Prénom utilisateur";"Contremarque";"Date de validation de la réservation";"Montant de la réservation";"Barème";"Montant remboursé";"Statut du remboursement";"Type d\'offre"'
     )
-    assert (
+    assert (  # legacy payment data
         rows[1]
-        == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"iban-1234";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"2021-01-01 12:00:00";"21,00";"100%";"21,00";"Remboursement envoyé";"offre grand public"'
+        == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"CF13QSDFGH456789";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"2021-01-01 12:00:00";"21,00";"100%";"21,00";"Remboursement envoyé";"offre grand public"'
     )
-
-
-@pytest.mark.usefixtures("db_session")
-def test_generate_reimbursement_details_csv_educational_booking():
-    # given
-    educational_booking = booking_factories.UsedEducationalBookingFactory(
-        stock__offer__name='Mon titre ; un peu "spécial"',
-        stock__offer__venue__name='Mon lieu ; un peu "spécial"',
-        stock__offer__venue__siret="siret-1234",
-        token="0E2722",
-        amount=10.5,
-        quantity=2,
-        dateUsed=datetime(2021, 1, 1, 12, 0),
-    )
-
-    payment = PaymentFactory(
-        booking=educational_booking,
-        iban="iban-1234",
-        transactionLabel="pass Culture Pro - remboursement 1ère quinzaine 07-2019",
-    )
-    payments_factories.PaymentStatusFactory(payment=payment, status=TransactionStatus.SENT)
-    offerer = payment.booking.offerer
-    reimbursement_details = find_all_offerer_reimbursement_details(offerer.id, reimbursement_period)
-
-    # when
-    csv = generate_reimbursement_details_csv(reimbursement_details)
-
-    # then
-    rows = csv.splitlines()
-    assert (
-        rows[0]
-        == '"Année";"Virement";"Créditeur";"SIRET créditeur";"Adresse créditeur";"IBAN";"Raison sociale du lieu";"Nom de l\'offre";"Nom utilisateur";"Prénom utilisateur";"Contremarque";"Date de validation de la réservation";"Montant de la réservation";"Barème";"Montant remboursé";"Statut du remboursement";"Type d\'offre"'
-    )
-    assert (
-        rows[1]
-        == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"iban-1234";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Khteur";"Reda";"0E2722";"2021-01-01 12:00:00";"21,00";"100%";"21,00";"Remboursement envoyé";"offre scolaire"'
+    assert (  # new pricing+cashflow data
+        rows[2]
+        == '2019;"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"CF13QSDFGH456789";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"2021-01-01 12:00:00";"21,00";"100 %";"21,00";"Remboursement envoyé";"offre grand public"'
     )
 
 
@@ -180,15 +276,28 @@ def test_find_all_offerer_reimbursement_details():
     offerer = offers_factories.OffererFactory()
     venue1 = offers_factories.VenueFactory(managingOfferer=offerer)
     venue2 = offers_factories.VenueFactory(managingOfferer=offerer)
-    educational_booking = booking_factories.UsedEducationalBookingFactory(stock__offer__venue=venue2)
+    booking1 = bookings_factories.UsedBookingFactory(stock__offer__venue=venue1)
+    booking2 = bookings_factories.UsedBookingFactory(stock__offer__venue=venue2)
+    booking3 = bookings_factories.UsedEducationalBookingFactory(stock__offer__venue=venue2)
     label = ("pass Culture Pro - remboursement 1ère quinzaine 07-2019",)
-    payment_1 = payments_factories.PaymentFactory(booking__stock__offer__venue=venue1, transactionLabel=label)
-    payment_2 = payments_factories.PaymentFactory(booking__stock__offer__venue=venue2, transactionLabel=label)
-    payment_3 = payments_factories.PaymentFactory(booking=educational_booking, transactionLabel=label)
+    payment_1 = payments_factories.PaymentFactory(booking=booking1, transactionLabel=label)
+    payment_2 = payments_factories.PaymentFactory(booking=booking2, transactionLabel=label)
+    payment_3 = payments_factories.PaymentFactory(booking=booking3, transactionLabel=label)
     payments_factories.PaymentStatusFactory(payment=payment_1, status=TransactionStatus.SENT)
     payments_factories.PaymentStatusFactory(payment=payment_2, status=TransactionStatus.SENT)
     payments_factories.PaymentStatusFactory(payment=payment_3, status=TransactionStatus.SENT)
 
+    for booking in (booking1, booking2, booking3):
+        finance_factories.PricingFactory(
+            booking=booking,
+            status=finance_models.PricingStatus.VALIDATED,
+        )
+    finance_api.generate_cashflows(cutoff=datetime.utcnow())
+    finance_models.Pricing.query.update(
+        {"status": finance_models.PricingStatus.INVOICED},
+        synchronize_session=False,
+    )
+
     reimbursement_details = find_all_offerer_reimbursement_details(offerer.id, reimbursement_period)
 
-    assert len(reimbursement_details) == 3
+    assert len(reimbursement_details) == 6


### PR DESCRIPTION
Adaptation du CSV des remboursements pour prendre en compte les anciens (Payment + PaymentStatus) et les nouveaux modèles (Pricing + Cashflow). **Commits à relire séparément.**

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11628