### PR TITLE
(PC-11208)[API] sendinblue: fix underage recredit transactional email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
@@ -1,27 +1,28 @@
+from decimal import Decimal
+
 from pcapi.core import mails
 from pcapi.core.mails.transactional.sendinblue_template_ids import SendinblueTransactionalEmailData
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
-from pcapi.core.payments.api import get_granted_deposit
 from pcapi.core.users import models as users_models
 from pcapi.core.users.api import get_domains_credit
 
 
 def get_recredit_to_underage_beneficiary_email_data(
     user: users_models.User,
+    recredit_amount: Decimal,
 ) -> SendinblueTransactionalEmailData:
-    granted_deposit = get_granted_deposit(user, user.eligibility)
     domains_credit = get_domains_credit(user)
 
     return SendinblueTransactionalEmailData(
         template=TransactionalEmail.RECREDIT_TO_UNDERAGE_BENEFICIARY.value,
         params={
             "FIRSTNAME": user.firstName,
-            "NEW_CREDIT": granted_deposit.amount,
+            "NEW_CREDIT": recredit_amount,
             "CREDIT": int(domains_credit.all.remaining),
         },
     )
 
 
-def send_recredit_email_to_underage_beneficiary(user: users_models.User) -> bool:
-    data = get_recredit_to_underage_beneficiary_email_data(user)
+def send_recredit_email_to_underage_beneficiary(user: users_models.User, recredit_amount: Decimal) -> bool:
+    data = get_recredit_to_underage_beneficiary_email_data(user, recredit_amount)
     return mails.send(recipients=[user.email], data=data)

--- a/api/src/pcapi/scheduled_tasks/clock.py
+++ b/api/src/pcapi/scheduled_tasks/clock.py
@@ -294,7 +294,7 @@ def clock() -> None:
 
     scheduler.add_job(pc_send_withdrawal_terms_to_offerers_validated_yesterday, "cron", day="*", hour="6")
 
-    scheduler.add_job(pc_recredit_underage_users, "cron", day="*", hour="0")
+    scheduler.add_job(pc_recredit_underage_users, "cron", day="*", hour="7")
 
     scheduler.add_job(price_bookings, "cron", day="*", minute="5,15,25,35,45,55")
 

--- a/api/tests/core/mails/transactional/users/recredit_to_underage_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/users/recredit_to_underage_beneficiary_test.py
@@ -7,7 +7,6 @@ from pcapi.core.mails.transactional.users.recredit_to_underage_beneficiary impor
 from pcapi.core.mails.transactional.users.recredit_to_underage_beneficiary import (
     send_recredit_email_to_underage_beneficiary,
 )
-from pcapi.core.payments.api import get_granted_deposit
 from pcapi.core.testing import override_features
 from pcapi.core.users.api import get_domains_credit
 import pcapi.core.users.factories as users_factories
@@ -21,9 +20,10 @@ class SendinblueSendNewlyEligibleUserEmailTest:
     def test_send_recredit_email_to_underage_beneficiary(self):
         # given
         user = users_factories.UnderageBeneficiaryFactory()
+        recredit_amount = 30
 
         # when
-        send_recredit_email_to_underage_beneficiary(user)
+        send_recredit_email_to_underage_beneficiary(user, recredit_amount)
 
         # then
         assert len(mails_testing.outbox) == 1  # test number of emails sent
@@ -35,35 +35,18 @@ class SendinblueSendNewlyEligibleUserEmailTest:
         }
 
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_return_correct_recredit_email_to_underage_beneficiary_email_data_16yo(
+    def test_return_correct_recredit_email_to_underage_beneficiary_email_data(
         self,
     ):
         # given
         user = users_factories.UnderageBeneficiaryFactory(subscription_age=16)
-        granted_deposit = get_granted_deposit(user, user.eligibility)
         domains_credit = get_domains_credit(user)
+        recredit_amount = 30
 
         # when
-        data = get_recredit_to_underage_beneficiary_email_data(user)
+        data = get_recredit_to_underage_beneficiary_email_data(user, recredit_amount)
 
         # then
         assert data.params["FIRSTNAME"] == user.firstName
-        assert data.params["NEW_CREDIT"] == granted_deposit.amount
-        assert data.params["CREDIT"] == domains_credit.all.remaining
-
-    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_return_correct_recredit_email_to_underage_beneficiary_email_data_17yo(
-        self,
-    ):
-        # given
-        user = users_factories.UnderageBeneficiaryFactory(subscription_age=17)
-        granted_deposit = get_granted_deposit(user, user.eligibility)
-        domains_credit = get_domains_credit(user)
-
-        # when
-        data = get_recredit_to_underage_beneficiary_email_data(user)
-
-        # then
-        assert data.params["FIRSTNAME"] == user.firstName
-        assert data.params["NEW_CREDIT"] == granted_deposit.amount
+        assert data.params["NEW_CREDIT"] == recredit_amount
         assert data.params["CREDIT"] == domains_credit.all.remaining


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11208


## But de la pull request

- Corriger le montant recrédité à l'utilisateur dans l'email transactionnel
- Programmer le cron de rechargement des utilisateurs à 7 heure (utc) tous les jours (au lieu de minuit)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
