### PR TITLE
[bsr][api][admin] Do not show the user password in details page

### DIFF
--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -165,7 +165,6 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "lastName",
         "needsToFillCulturalSurvey",
         "notificationSubscriptions",
-        "password",
         "phoneNumber",
         "phoneValidationStatus",
         "postalCode",


### PR DESCRIPTION
It's hashed, but still.

![password](https://user-images.githubusercontent.com/471321/148259725-eb2cd0b9-a70c-4fd6-b8c4-44dc542da2a9.png)
