### PR TITLE
[API] (PC-9822) rm:account: rm postal code validation

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -166,7 +166,6 @@ def create_account(
     is_email_validated: bool = False,
     send_activation_mail: bool = True,
     remote_updates: bool = True,
-    postal_code: str = None,
     phone_number: str = None,
     apps_flyer_user_id: str = None,
     apps_flyer_platform: str = None,
@@ -175,8 +174,6 @@ def create_account(
     if find_user_by_email(email):
         raise exceptions.UserAlreadyExistsException()
 
-    departement_code = PostalCode(postal_code).get_departement_code() if postal_code else None
-
     user = User(
         email=email,
         dateOfBirth=datetime.combine(birthdate, datetime.min.time()),
@@ -184,8 +181,6 @@ def create_account(
         publicName=VOID_PUBLIC_NAME,  # Required because model validation requires 3+ chars
         hasSeenTutorials=False,
         notificationSubscriptions=asdict(NotificationSubscriptions(marketing_email=marketing_email_subscription)),
-        postalCode=postal_code,
-        departementCode=departement_code,
         phoneNumber=phone_number,
         lastConnectionDate=datetime.now(),
         subscriptionState=models.SubscriptionState.account_created,

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -59,7 +59,6 @@ class UserFactory(BaseFactory):
     address = factory.Sequence("{} place des noces rouges".format)
     city = "La Rochelle"
     dateOfBirth = datetime.combine(date(1980, 1, 1), time(0, 0))
-    departementCode = "75"
     firstName = "Jean"
     lastName = "Neige"
     publicName = "Jean Neige"
@@ -131,7 +130,6 @@ class BeneficiaryGrant18Factory(BaseFactory):
         lambda _: datetime.combine(date.today(), time(0, 0))
         - relativedelta(years=users_constants.ELIGIBILITY_AGE_18, months=1)
     )
-    departementCode = "75"
     firstName = "Jeanne"
     lastName = "Doux"
     hasCompletedIdCheck = False

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -382,10 +382,6 @@ class User(PcObject, Model, NeedsValidationMixin):
     @property
     def eligibility(self) -> Optional[EligibilityType]:
         from pcapi.core.users import api as users_api
-        from pcapi.domain.beneficiary_pre_subscription.validator import _is_postal_code_eligible
-
-        if not _is_postal_code_eligible(self.departementCode):
-            return None
 
         return users_api.get_eligibility_at_date(self.dateOfBirth, datetime.now())
 

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -16,7 +16,6 @@ from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
 from pcapi.core.users.utils import sanitize_email
-from pcapi.domain.beneficiary_pre_subscription.validator import _is_postal_code_eligible
 from pcapi.domain.favorite.favorite import FavoriteDomain
 from pcapi.infrastructure.repository.favorite import favorite_domain_converter
 from pcapi.models.user_offerer import UserOfferer
@@ -128,7 +127,6 @@ def get_newly_eligible_age_18_users(since: date) -> list[User]:
         )
         .all()
     )
-    eligible_users = [user for user in eligible_users if _is_postal_code_eligible(user.departementCode)]
     return eligible_users
 
 

--- a/api/src/pcapi/domain/beneficiary_pre_subscription/exceptions.py
+++ b/api/src/pcapi/domain/beneficiary_pre_subscription/exceptions.py
@@ -6,10 +6,6 @@ class BeneficiaryIsADuplicate(CantRegisterBeneficiary):
     pass
 
 
-class BeneficiaryIsNotEligible(CantRegisterBeneficiary):
-    pass
-
-
 class SubscriptionJourneyOnHold(CantRegisterBeneficiary):
     pass
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -198,7 +198,6 @@ def create_account(body: serializers.AccountRequest) -> None:
             birthdate=body.birthdate,
             marketing_email_subscription=body.marketing_email_subscription,
             is_email_validated=False,
-            postal_code=body.postal_code,
             apps_flyer_user_id=body.apps_flyer_user_id,
             apps_flyer_platform=body.apps_flyer_platform,
         )

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -46,7 +46,6 @@ class AccountRequest(BaseModel):
     birthdate: datetime.date
     marketing_email_subscription: Optional[bool] = False
     token: str
-    postal_code: Optional[str] = None
     apps_flyer_user_id: Optional[str] = None
     apps_flyer_platform: Optional[str] = None
 

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -750,7 +750,7 @@ def test_digital_offer_without_departement_code_information_sendinblue():
     offer = offers_factories.DigitalOfferFactory()
     stock = offers_factories.StockFactory(offer=offer)
     date_created = datetime(2021, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
-    booking = IndividualBookingFactory(stock=stock, dateCreated=date_created, user__departementCode=None)
+    booking = IndividualBookingFactory(stock=stock, dateCreated=date_created)
 
     email_data = get_booking_confirmation_to_beneficiary_email_data(booking.individualBooking)
     assert email_data.params["BOOKING_DATE"] == "1 juillet 2021"

--- a/api/tests/core/mails/transactional/users/birthday_to_newly_eligible_user_test.py
+++ b/api/tests/core/mails/transactional/users/birthday_to_newly_eligible_user_test.py
@@ -18,9 +18,7 @@ class MailjetSendNewlyEligibleUserEmailTest:
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
     def test_send_anniversary_age_18_email(self):
         # given
-        user = users_factories.UserFactory(
-            dateOfBirth=(datetime.now() - relativedelta(years=18, days=5)), departementCode="93"
-        )
+        user = users_factories.UserFactory(dateOfBirth=(datetime.now() - relativedelta(years=18, days=5)))
 
         # when
         send_birthday_age_18_email_to_newly_eligible_user(user)

--- a/api/tests/core/users/external/external_users_test.py
+++ b/api/tests/core/users/external/external_users_test.py
@@ -61,7 +61,7 @@ def test_update_external_pro_user():
 
 
 def test_get_user_attributes():
-    user = BeneficiaryGrant18Factory(deposit__version=1)
+    user = BeneficiaryGrant18Factory(deposit__version=1, departementCode="75")
     offer = OfferFactory(product__id=list(TRACKED_PRODUCT_IDS.keys())[0])
     b1 = IndividualBookingFactory(individualBooking__user=user, amount=10, stock__offer=offer)
     b2 = IndividualBookingFactory(

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -187,7 +187,7 @@ class ValidateJwtTokenTest:
 class GenerateIdCheckTokenIfEligibleTest:
     @freeze_time("2018-06-01")
     def test_when_elible(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
         token = create_id_check_token(user)
         assert token
 
@@ -1124,7 +1124,6 @@ class BeneficiaryInformationUpdateTest:
             activity=None,
             address=None,
             city=None,
-            departementCode=None,
             firstName=None,
             lastName=None,
             postalCode=None,
@@ -1154,7 +1153,6 @@ class BeneficiaryInformationUpdateTest:
         assert beneficiary.firstName == "Jane"
         assert beneficiary.publicName == "Jane Doe"
         assert beneficiary.phoneNumber == "0612345678"
-        assert beneficiary.departementCode == "67"
         assert beneficiary.postalCode == "67200"
         assert beneficiary.address == "11 Rue du Test"
         assert beneficiary.dateOfBirth == datetime(2000, 5, 1, 0, 0)
@@ -1171,7 +1169,6 @@ class BeneficiaryInformationUpdateTest:
             activity=None,
             address=None,
             city=None,
-            departementCode=None,
             firstName=None,
             lastName=None,
             postalCode=None,

--- a/api/tests/domain/beneficiary/beneficiary_pre_subscription_validator_test.py
+++ b/api/tests/domain/beneficiary/beneficiary_pre_subscription_validator_test.py
@@ -6,7 +6,6 @@ import pytest
 from pcapi.core.subscription.factories import BeneficiaryPreSubscriptionFactory
 import pcapi.core.users.factories as users_factories
 from pcapi.domain.beneficiary_pre_subscription.exceptions import BeneficiaryIsADuplicate
-from pcapi.domain.beneficiary_pre_subscription.exceptions import BeneficiaryIsNotEligible
 from pcapi.domain.beneficiary_pre_subscription.exceptions import CantRegisterBeneficiary
 from pcapi.domain.beneficiary_pre_subscription.validator import validate
 
@@ -149,31 +148,3 @@ def test_doesnt_raise_if_no_exact_duplicate(app):
     except CantRegisterBeneficiary:
         # Then
         assert pytest.fail("Should not raise an exception when email not given")
-
-
-@pytest.mark.parametrize("postal_code", ["98735", "98800", "98800"])
-@pytest.mark.usefixtures("db_session")
-def test_raises_if_not_eligible(postal_code):
-    # Given
-    beneficiary_pre_subcription = BeneficiaryPreSubscriptionFactory(postal_code=postal_code)
-
-    # When
-    with pytest.raises(BeneficiaryIsNotEligible) as error:
-        validate(beneficiary_pre_subcription)
-
-    # Then
-    assert str(error.value) == f"Postal code {postal_code} is not eligible."
-
-
-@pytest.mark.parametrize("postal_code", ["36000", "36034", "97400"])
-@pytest.mark.usefixtures("db_session")
-def test_should_not_raise_if_eligible(postal_code):
-    # Given
-    beneficiary_pre_subcription = BeneficiaryPreSubscriptionFactory(postal_code=postal_code)
-
-    try:
-        # When
-        validate(beneficiary_pre_subcription)
-    except CantRegisterBeneficiary:
-        # Then
-        assert pytest.fail("Should not raise when postal code is eligible")

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -110,7 +110,6 @@ class AccountTest:
             deposit__expirationDate=datetime(2040, 1, 1),
             notificationSubscriptions={"marketing_push": True},
             publicName="jdo",
-            departementCode="93",
             **USER_DATA,
         )
         subscription_factories.SubscriptionMessageFactory(user=user)
@@ -1066,7 +1065,7 @@ class ResendEmailValidationTest:
 @freeze_time("2018-06-01")
 class GetIdCheckTokenTest:
     def test_get_id_check_token_eligible(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
         client.with_token(email=user.email)
 
         response = client.get("/native/v1/id_check_token")
@@ -1074,17 +1073,8 @@ class GetIdCheckTokenTest:
         assert response.status_code == 200
         assert get_id_check_token(response.json["token"])
 
-    def test_get_id_check_token_not_eligible(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2001, 1, 1), departementCode="984")
-        client.with_token(email=user.email)
-
-        response = client.get("/native/v1/id_check_token")
-
-        assert response.status_code == 400
-        assert response.json == {"code": "USER_NOT_ELIGIBLE"}
-
     def test_get_id_check_token_limit_reached(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
 
         expiration_date = datetime.now() + timedelta(hours=2)
         users_factories.IdCheckToken.create_batch(
@@ -1113,7 +1103,7 @@ class UploadIdentityDocumentTest:
         client,
         app,
     ):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
         token = TokenFactory(user=user, type=TokenType.ID_CHECK)
         client.with_token(email=user.email)
         mocked_token_urlsafe.return_value = "a_very_random_secret"
@@ -1138,21 +1128,8 @@ class UploadIdentityDocumentTest:
             {"image_storage_path": "identity_documents/a_very_random_secret.jpg"}
         )
 
-    def test_ineligible_user(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="984")
-        client.with_token(email=user.email)
-        token = TokenFactory(user=user, type=TokenType.ID_CHECK)
-
-        thumb = (self.IMAGES_DIR / "pixel.png").read_bytes()
-        data = {"identityDocumentFile": (BytesIO(thumb), "image.jpg"), "token": token.value}
-
-        response = client.post("/native/v1/identity_document", form=data)
-
-        assert response.status_code == 400
-        assert response.json == {"code": "USER_NOT_ELIGIBLE"}
-
     def test_token_expired(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
         client.with_token(email=user.email)
         token = TokenFactory(user=user, type=TokenType.ID_CHECK, expirationDate=datetime(2000, 1, 1))
 
@@ -1165,7 +1142,7 @@ class UploadIdentityDocumentTest:
         assert response.json == {"code": "EXPIRED_TOKEN", "message": "Token expiré"}
 
     def test_token_used(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
         token = TokenFactory(user=user, type=TokenType.ID_CHECK, isUsed=True)
 
         thumb = (self.IMAGES_DIR / "pixel.png").read_bytes()
@@ -1181,7 +1158,7 @@ class UploadIdentityDocumentTest:
         assert response.json["code"] == "EXPIRED_TOKEN"
 
     def test_no_token_found(self, client, app):
-        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), departementCode="93")
+        user = users_factories.UserFactory(dateOfBirth=datetime(2000, 1, 1))
         token = TokenFactory(user=user, type=TokenType.ID_CHECK, isUsed=True)
 
         thumb = (self.IMAGES_DIR / "pixel.png").read_bytes()
@@ -1202,9 +1179,7 @@ class ShowEligibleCardTest:
     def test_against_different_age(self, age, expected):
         date_of_birth = datetime.now() - relativedelta(years=age, days=5)
         date_of_creation = datetime.now() - relativedelta(years=4)
-        user = users_factories.UserFactory.build(
-            dateOfBirth=date_of_birth, dateCreated=date_of_creation, departementCode="93"
-        )
+        user = users_factories.UserFactory.build(dateOfBirth=date_of_birth, dateCreated=date_of_creation)
         assert account_serializers.UserProfileResponse._show_eligible_card(user) == expected
 
     @pytest.mark.parametrize("beneficiary,expected", [(False, True), (True, False)])
@@ -1215,7 +1190,6 @@ class ShowEligibleCardTest:
         user = users_factories.UserFactory.build(
             dateOfBirth=date_of_birth,
             dateCreated=date_of_creation,
-            departementCode="93",
             roles=roles,
         )
         assert account_serializers.UserProfileResponse._show_eligible_card(user) == expected
@@ -1229,7 +1203,7 @@ class ShowEligibleCardTest:
 
 class SendPhoneValidationCodeTest:
     def test_send_phone_validation_code(self, client, app):
-        user = users_factories.UserFactory(departementCode="93", phoneNumber="+33601020304")
+        user = users_factories.UserFactory(phoneNumber="+33601020304")
         client.with_token(email=user.email)
 
         response = client.post("/native/v1/send_phone_validation_code")
@@ -1269,7 +1243,6 @@ class SendPhoneValidationCodeTest:
     @override_settings(MAX_SMS_SENT_FOR_PHONE_VALIDATION=1)
     def test_send_phone_validation_code_too_many_attempts(self, client, app, age, eligibility_type):
         user = users_factories.UserFactory(
-            departementCode="93",
             phoneNumber="+33601020304",
             dateOfBirth=datetime.now() - relativedelta(years=age, days=5),
         )
@@ -1463,7 +1436,6 @@ class SendPhoneValidationCodeTest:
     @override_settings(BLACKLISTED_SMS_RECIPIENTS={"+33601020304"})
     def test_blocked_phone_number(self, client, app, age, eligibility_type):
         user = users_factories.UserFactory(
-            departementCode="93",
             phoneNumber="+33601020304",
             dateOfBirth=datetime.now() - relativedelta(years=age, days=5),
         )

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -297,7 +297,6 @@ def test_validate_email_when_eligible(client):
     user = users_factories.UserFactory(
         isEmailValidated=False,
         dateOfBirth=datetime(2000, 6, 1),
-        departementCode="93",
     )
     token = users_factories.TokenFactory(userId=user.id, type=TokenType.EMAIL_VALIDATION)
 

--- a/api/tests/routes/shared/get_user_profile_test.py
+++ b/api/tests/routes/shared/get_user_profile_test.py
@@ -1,7 +1,6 @@
 import datetime
 
 from dateutil.relativedelta import relativedelta
-from freezegun import freeze_time
 import pytest
 
 from pcapi.core.categories import subcategories
@@ -20,22 +19,19 @@ from tests.conftest import TestClient
 class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_is_logged_in_and_has_no_deposit(self, app):
-        with freeze_time(datetime.datetime.utcnow() - relativedelta(years=3)):
-            user = users_factories.BeneficiaryGrant18Factory(
-                civility="M.",
-                address=None,
-                city=None,
-                needsToFillCulturalSurvey=False,
-                departementCode="93",
-                email="toto@example.com",
-                firstName="Jean",
-                lastName="Smisse",
-                dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18),
-                phoneNumber="0612345678",
-                postalCode="93020",
-                publicName="Toto",
-                isEmailValidated=True,
-            )
+        user = users_factories.BeneficiaryGrant18Factory(
+            civility="M.",
+            address=None,
+            city=None,
+            needsToFillCulturalSurvey=False,
+            email="toto@example.com",
+            firstName="Jean",
+            lastName="Smisse",
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18),
+            phoneNumber="0612345678",
+            publicName="Toto",
+            isEmailValidated=True,
+        )
 
         # When
         response = TestClient(app.test_client()).with_session_auth(email="toto@example.com").get("/users/current")
@@ -50,7 +46,7 @@ class Returns200Test:
             "civility": "M.",
             "dateCreated": format_into_utc_date(user.dateCreated),
             "dateOfBirth": format_into_utc_date(user.dateOfBirth),
-            "departementCode": "93",
+            "departementCode": None,
             "email": "toto@example.com",
             "externalIds": {},
             "firstName": "Jean",
@@ -68,7 +64,7 @@ class Returns200Test:
             "notificationSubscriptions": {"marketing_email": True, "marketing_push": True},
             "phoneNumber": "0612345678",
             "phoneValidationStatus": None,
-            "postalCode": "93020",
+            "postalCode": None,
             "publicName": "Toto",
             "roles": ["BENEFICIARY"],
         }

--- a/api/tests/routes/shared/signin_test.py
+++ b/api/tests/routes/shared/signin_test.py
@@ -17,7 +17,6 @@ class Returns200Test:
         # given
         user = users_factories.BeneficiaryGrant18Factory(
             civility="M.",
-            departementCode="93",
             city=None,
             address=None,
             needsToFillCulturalSurvey=False,
@@ -45,7 +44,7 @@ class Returns200Test:
             "civility": "M.",
             "dateCreated": format_into_utc_date(user.dateCreated),
             "dateOfBirth": format_into_utc_date(user.dateOfBirth),
-            "departementCode": "93",
+            "departementCode": None,
             "email": "user@example.com",
             "firstName": "Jean",
             "hasPhysicalVenues": False,
@@ -66,7 +65,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_has_no_departement_code(self, app):
         # given
-        user = users_factories.UserFactory(email="USER@example.COM", departementCode=None)
+        user = users_factories.UserFactory(email="USER@example.COM")
         data = {"identifier": user.email, "password": user.clearTextPassword}
 
         # when

--- a/api/tests/scripts/batch_update_users_attributes_test.py
+++ b/api/tests/scripts/batch_update_users_attributes_test.py
@@ -71,7 +71,7 @@ def test_run_sendinblue_only(mock_import_contacts):
 
 @pytest.mark.usefixtures("db_session")
 def test_format_batch_user():
-    user = BeneficiaryGrant18Factory(deposit__version=1)
+    user = BeneficiaryGrant18Factory(deposit__version=1, departementCode="75")
     booking = IndividualBookingFactory(individualBooking__user=user)
 
     res = format_batch_users([user])
@@ -94,7 +94,7 @@ def test_format_batch_user():
 
 @pytest.mark.usefixtures("db_session")
 def test_format_sendinblue_user():
-    user = BeneficiaryGrant18Factory(deposit__version=1)
+    user = BeneficiaryGrant18Factory(deposit__version=1, departementCode="75")
     booking = IndividualBookingFactory(individualBooking__user=user)
 
     res = format_sendinblue_users([user])

--- a/api/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
+++ b/api/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
@@ -17,23 +17,15 @@ class SendMailAfterIdcheckOutageTest:
     def test_get_eligible_users_created_between(self, app):
         ELIGIBLE_CONDTIONS = {
             "dateCreated": datetime.now(),
-            "postalCode": "93000",
             "isBeneficiary": False,
         }
         # 19 yo
         factories.UserFactory(dateOfBirth=datetime(1999, 1, 1), **ELIGIBLE_CONDTIONS)
         user_just_18_in_eligible_area = factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
-        # User just 18 but in an ineligible area
-        factories.UserFactory(
-            dateOfBirth=datetime(2000, 1, 1),
-            dateCreated=datetime.now(),
-            postalCode="98712",
-        )
         # Beneficiary
         factories.BeneficiaryGrant18Factory(
             dateOfBirth=datetime(2000, 1, 1),
             dateCreated=datetime.now(),
-            postalCode="93000",
         )
         # Admin
         factories.AdminFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)

--- a/api/tests/use_cases/create_beneficiary_from_application_test.py
+++ b/api/tests/use_cases/create_beneficiary_from_application_test.py
@@ -346,26 +346,6 @@ def test_cannot_save_beneficiary_if_duplicate(app):
     assert sub_msg.callToActionIcon == subscription_models.CallToActionIcon.EMAIL
 
 
-@patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
-def test_cannot_save_beneficiary_if_department_is_not_eligible(get_application_content, app):
-    # Given
-    postal_code = "984"
-    get_application_content.return_value = JOUVE_CONTENT | {"postalCode": postal_code}
-    applicant = users_factories.UserFactory(
-        firstName=JOUVE_CONTENT["firstName"], lastName=JOUVE_CONTENT["lastName"], email=JOUVE_CONTENT["email"]
-    )
-
-    # When
-    create_beneficiary_from_application.execute(APPLICATION_ID)
-
-    # Then
-    beneficiary_import = BeneficiaryImport.query.one()
-    assert beneficiary_import.currentStatus == ImportStatus.REJECTED
-    assert beneficiary_import.applicationId == APPLICATION_ID
-    assert beneficiary_import.beneficiary == applicant
-    assert beneficiary_import.detail == f"Postal code {postal_code} is not eligible."
-
-
 @patch("pcapi.use_cases.create_beneficiary_from_application.validate")
 @patch("pcapi.connectors.beneficiaries.jouve_backend._get_raw_content")
 def test_calls_send_rejection_mail_with_validation_error(_get_raw_content, stubed_validate, app):

--- a/api/tests/utils/mailing_test.py
+++ b/api/tests/utils/mailing_test.py
@@ -41,21 +41,18 @@ class GetUsersInformationFromStockBookingsTest:
     def test_returns_correct_users_information_from_bookings_stock(self):
         # Given
         user_1 = users_factories.BeneficiaryGrant18Factory.build(
-            departementCode="93",
             email="test@example.com",
             firstName="Jean",
             lastName="Dupont",
             publicName="Test",
         )
         user_2 = users_factories.BeneficiaryGrant18Factory.build(
-            departementCode="93",
             email="mail@example.com",
             firstName="Jaja",
             lastName="Dudu",
             publicName="Test",
         )
         user_3 = users_factories.BeneficiaryGrant18Factory.build(
-            departementCode="93",
             email="mail@example.com",
             firstName="Toto",
             lastName="Titi",
@@ -185,7 +182,7 @@ class FormatBookingHoursForEmailTest:
 class MakeValidationEmailObjectTest:
     def test_should_return_subject_with_correct_departement_code(self):
         # Given
-        user = users_factories.UserFactory.build(departementCode="93")
+        user = users_factories.UserFactory.build()
         offerer = create_offerer(postal_code="95490")
         user_offerer = create_user_offerer(user=user, offerer=offerer)
 


### PR DESCRIPTION
There should be no more postal code validation

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9822


## But de la pull request

Supprimer le code qui s'occupe de la vérification du code postal de l'utilisateur (éligibilité), puisque cela n'a plus de sens aujourd'hui.