### PR TITLE
[pc-12644][api] Instanciation unique de la machine à état d'inscription

### DIFF
--- a/api/src/pcapi/core/subscription/transitions.py
+++ b/api/src/pcapi/core/subscription/transitions.py
@@ -1,3 +1,6 @@
+import flask
+import transitions
+
 from pcapi.core.users import models as users_models
 
 
@@ -36,3 +39,12 @@ TRANSITIONS = [
     ],
     ["admin_rejection", "*", users_models.SubscriptionState.rejected_by_admin],
 ]
+
+
+def install_machine():
+    flask.g.subscription_machine = transitions.Machine(
+        states=users_models.SubscriptionState,
+        transitions=TRANSITIONS,
+        model_attribute="subscriptionState",
+        ignore_invalid_triggers=True,
+    )

--- a/api/src/pcapi/models/pc_object.py
+++ b/api/src/pcapi/models/pc_object.py
@@ -53,9 +53,6 @@ class PcObject:
             object_id = f"{self.id}/{humanize(self.id)}"
         return "<%s #%s>" % (self.__class__.__name__, object_id)
 
-    def __hash__(self):
-        return hash(self.id)
-
     def dump(self):
         pprint(vars(self))
 

--- a/api/src/pcapi/models/pc_object.py
+++ b/api/src/pcapi/models/pc_object.py
@@ -53,13 +53,6 @@ class PcObject:
             object_id = f"{self.id}/{humanize(self.id)}"
         return "<%s #%s>" % (self.__class__.__name__, object_id)
 
-    def __eq__(self, other):
-        # pylint: disable=unidiomatic-typecheck
-        return other and type(self) == type(other) and self.id == other.id
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __hash__(self):
         return hash(self.id)
 

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -259,20 +259,6 @@ class SynchronizeStocksTest:
         )
 
         # Then
-        assert new_offers == [
-            Offer(
-                bookingEmail="booking_email",
-                description="product_desc",
-                extraData="extra",
-                idAtProviders="offer_ref_2",
-                lastProviderId=provider.id,
-                name="product_name",
-                productId=456,
-                venueId=venue.id,
-                subcategoryId=subcategories.LIVRE_PAPIER.id,
-                withdrawalDetails=venue.withdrawalDetails,
-            ),
-        ]
         new_offer = new_offers[0]
         assert new_offer.bookingEmail == "booking_email"
         assert new_offer.description == "product_desc"

--- a/api/tests/models/pc_object_test.py
+++ b/api/tests/models/pc_object_test.py
@@ -44,13 +44,6 @@ time_interval.end = datetime(2018, 2, 2, 5, 15, 25, 222000)
 now = datetime.utcnow()
 
 
-def test_equality():
-    assert Offer(id=1) == Offer(id=1)
-    assert Offer(id=1) != Offer(id=2)
-    assert Offer(id=1) != User(id=1)
-    assert Offer(id=1) != 1
-
-
 class SerializeTest:
     def test_on_datetime_list_returns_string_with_date_in_ISO_8601_list(self):
         # Given

--- a/api/tests/scripts/payment/add_custom_offer_reimbursement_rule_test.py
+++ b/api/tests/scripts/payment/add_custom_offer_reimbursement_rule_test.py
@@ -32,7 +32,7 @@ def test_basics(app):
     # fmt: on
     assert "Created new rule" in result.output
     rule = payments_models.CustomReimbursementRule.query.one()
-    assert rule.offer == offer
+    assert rule.offer.id == offer.id
     assert rule.amount == decimal.Decimal("12.34")
 
 
@@ -73,5 +73,5 @@ def test_force_with_warnings(app):
     # fmt: on
     assert "Created new rule" in result.output
     rule = payments_models.CustomReimbursementRule.query.one()
-    assert rule.offer == offer
+    assert rule.offer.id == offer.id
     assert rule.amount == decimal.Decimal("12.34")


### PR DESCRIPTION
Lien vers le ticket Jira : [12644](https://passculture.atlassian.net/browse/PC-12644)

Depuis l'ajout de la machine a état sur le modèle utilisateur pour simplifier le parcours d'inscription,
la consommation de la ram a pu augmenter : une machine a état est instancié pour chaque `User`

Le design de la lib transitions permet de n'instancier qu'une seule fois la machine a état et d'ajouter le modele lors du chargement de la donnée depuis la base, et de le supprimer lorsqu'on n'utilise plus le modele User

Problème : la surcharge des méthodes __eq__ et __ne__ empêchent la bonne utilisation de ces deux fonctions d'ajout et de suppression : la machine a état vérifie qu'une instance du modèle n'a pas déjà été ajoutée:

`if mod not in self.models:`

de notre côté, un modele est considéré égal si il a le même ID, ce qui nous empêche d'avoir X instance d'un modèle qui a le même ID a être ajouté a la machine a état.

De ce fait, je propose de supprimer la surcharge d' __eq__ et __ne__

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
