### PR TITLE
(PC-11970)[API] fix error on showType

### DIFF
--- a/api/src/pcapi/domain/show_types.py
+++ b/api/src/pcapi/domain/show_types.py
@@ -121,6 +121,18 @@ show_types = [
             {"code": 1504, "label": "Spectacle aquatique"},
         ],
     },
+    {
+        "code": 1510,
+        "label": "Opéra",
+        "children": [
+            {"code": 1511, "label": "Opéra série"},
+            {"code": 1512, "label": "Grand opéra"},
+            {"code": 1513, "label": "Opéra bouffe"},
+            {"code": 1514, "label": "Opéra comique"},
+            {"code": 1515, "label": "Opéra-ballet"},
+            {"code": 1516, "label": "Singspiel"},
+        ],
+    },
 ]
 
 SHOW_TYPES_DICT = {show_type["code"]: show_type["label"] for show_type in show_types}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11970


## But de la pull request

Résoudre une erreur sentry sur les showType

##  Implémentation

le fichier showType avait été modifié sur pro mais pas sur l'api, j'ai donc repercuté les changements
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
