### PR TITLE
(PC-12608)[API]sendinblue adding booking web link to transac email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -12,6 +12,7 @@ from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
 from pcapi.utils.human_ids import humanize
+from pcapi.utils.urls import booking_app_link
 
 
 def send_individual_booking_confirmation_email_to_beneficiary(individual_booking: IndividualBooking) -> bool:
@@ -110,6 +111,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
                 "has_offer_url": int(offer.isDigital),
                 "digital_offer_url": individual_booking.booking.completedUrl or "",
                 "offer_withdrawal_details": offer.withdrawalDetails or "",
+                "booking_link": booking_app_link(individual_booking.booking),
             },
         }
 
@@ -145,5 +147,6 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "HAS_OFFER_URL": offer.isDigital,
             "DIGITAL_OFFER_URL": individual_booking.booking.completedUrl or None,
             "OFFER_WITHDRAWAL_DETAILS": offer.withdrawalDetails or None,
+            "BOOKING_LINK": booking_app_link(individual_booking.booking),
         },
     )

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary.py
@@ -9,6 +9,7 @@ from pcapi.core.mails.transactional.sendinblue_template_ids import Transactional
 from pcapi.models.feature import FeatureToggle
 from pcapi.utils.mailing import format_booking_hours_for_email
 from pcapi.utils.mailing import get_event_datetime
+from pcapi.utils.urls import booking_app_link
 
 
 def send_batch_booking_postponement_email_to_users(bookings: list[Booking]) -> list[bool]:
@@ -43,9 +44,10 @@ def get_booking_postponed_by_pro_to_beneficiary_email_data(
             "Vars": {
                 "offer_name": offer.name,
                 "user_first_name": booking.firstName,
-                "venue_name": offer.venue.publicName if offer.venue.publicName else offer.venue.name,
+                "venue_name": offer.venue.publicName or offer.venue.name,
                 "event_date": event_date if event_date else "",
                 "event_hour": event_hour if event_hour else "",
+                "booking_link": booking_app_link(booking),
             },
         }
 
@@ -54,8 +56,9 @@ def get_booking_postponed_by_pro_to_beneficiary_email_data(
         params={
             "OFFER_NAME": offer.name,
             "FIRSTNAME": booking.firstName,
-            "VENUE_NAME": offer.venue.publicName if offer.venue.publicName else offer.venue.name,
+            "VENUE_NAME": offer.venue.publicName or offer.venue.name,
             "EVENT_DATE": event_date if event_date else "",
             "EVENT_HOUR": event_hour if event_hour else "",
+            "BOOKING_LINK": booking_app_link(booking),
         },
     )

--- a/api/src/pcapi/utils/urls.py
+++ b/api/src/pcapi/utils/urls.py
@@ -2,6 +2,7 @@ from typing import Optional
 from urllib.parse import urlencode
 
 from pcapi import settings
+from pcapi.core.bookings.models import Booking
 
 
 def generate_firebase_dynamic_link(path: str, params: Optional[dict]) -> str:
@@ -11,3 +12,7 @@ def generate_firebase_dynamic_link(path: str, params: Optional[dict]) -> str:
 
     firebase_dynamic_query_string = urlencode({"link": universal_link_url})
     return f"{settings.FIREBASE_DYNAMIC_LINKS_URL}/?{firebase_dynamic_query_string}"
+
+
+def booking_app_link(booking: Booking) -> str:
+    return f"{settings.WEBAPP_V2_URL}/reservations/{booking.id}/details"

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -112,6 +112,7 @@ def get_expected_base_mailjet_email_data(booking, mediation, **overrides):
             "digital_offer_url": "",
             "offer_withdrawal_details": "",
             "expiration_delay": "",
+            "booking_link": f"https://webapp-v2.example.com/reservations/{booking.id}/details",
         },
     }
     email_data["Vars"].update(overrides)
@@ -467,6 +468,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "DIGITAL_OFFER_URL": None,
             "OFFER_WITHDRAWAL_DETAILS": None,
             "EXPIRATION_DELAY": None,
+            "BOOKING_LINK": f"https://webapp-v2.example.com/reservations/{booking.id}/details",
         },
     )
     email_data.params.update(overrides)
@@ -530,6 +532,7 @@ def test_should_return_thing_specific_data_for_email_when_offer_is_a_thing_sendi
         OFFER_NAME="Super bien culturel",
         CAN_EXPIRE=True,
         EXPIRATION_DELAY=30,
+        BOOKING_LINK=f"https://webapp-v2.example.com/reservations/{booking.id}/details",
     )
     assert email_data == expected
 

--- a/api/tests/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary_test.py
@@ -33,6 +33,7 @@ class GetBookingPostponedByProToBeneficiaryTest:
                 "venue_name": booking.venue.name,
                 "event_date": "mardi 20 août 2019",
                 "event_hour": "14h",
+                "booking_link": f"https://webapp-v2.example.com/reservations/{booking.id}/details",
             },
         }
 
@@ -52,4 +53,5 @@ class GetBookingPostponedByProToBeneficiaryTest:
             "VENUE_NAME": booking.venue.name,
             "EVENT_DATE": "mardi 20 août 2019",
             "EVENT_HOUR": "14h",
+            "BOOKING_LINK": f"https://webapp-v2.example.com/reservations/{booking.id}/details",
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12608

## But de la pull request
Ajouter un lien web vers la réservation concernée dans l'email
/!\ le modèle des emails doit encore être modifié -> ajout de params.BOOKING_LINK dans un bouton de l'email
Voir détails sur Jira

##  Implémentation

Ajout fichier api/src/pcapi/core/bookings/utils.py

##  Informations supplémentaires
N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
