### PR TITLE
(PC-12649)[PRO] homepage: display missing bank information banner only for physical venues

### DIFF
--- a/pro/src/components/pages/Home/Offerers/OffererDetails.jsx
+++ b/pro/src/components/pages/Home/Offerers/OffererDetails.jsx
@@ -66,11 +66,10 @@ const OffererDetails = ({
   const hasMissingBusinessUnits = useMemo(() => {
     if (!isBankInformationWithSiretActive) return false
     if (!selectedOfferer) return false
-    let managedVenues = selectedOfferer.managedVenues
-    if (!selectedOfferer.hasDigitalVenueAtLeastOneOffer) {
-      managedVenues = managedVenues.filter(venue => !venue.isVirtual)
-    }
-    return managedVenues.map(venue => !venue.businessUnitId).some(Boolean)
+    return selectedOfferer.managedVenues
+      .filter(venue => !venue.isVirtual)
+      .map(venue => !venue.businessUnitId)
+      .some(Boolean)
   }, [isBankInformationWithSiretActive, selectedOfferer])
 
   const [isExpanded, setIsExpanded] = useState(

--- a/pro/src/components/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
+++ b/pro/src/components/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
@@ -880,10 +880,9 @@ describe('offererDetailsLegacy', () => {
       ).toBeInTheDocument()
     })
 
-    it('should not display missing business unit banner when virtual venue has no offer has no BU', async () => {
+    it('should not display missing business unit banner when virtual venue has no BU', async () => {
       firstOffererByAlphabeticalOrder = {
         ...firstOffererByAlphabeticalOrder,
-        hasDigitalVenueAtLeastOneOffer: false,
         managedVenues: [
           {
             ...physicalVenue,
@@ -921,34 +920,6 @@ describe('offererDetailsLegacy', () => {
         name: 'Masquer',
       })
 
-      expect(
-        within(offerer).queryByText('Coordonnées bancaires')
-      ).not.toBeInTheDocument()
-    })
-
-    it('should not display missing business unit banner when offerer has only virtual venue with no offer', async () => {
-      firstOffererByAlphabeticalOrder = {
-        ...firstOffererByAlphabeticalOrder,
-        hasDigitalVenueAtLeastOneOffer: false,
-        managedVenues: [
-          {
-            ...virtualVenue,
-            businessUnitId: null,
-          },
-        ],
-      }
-
-      pcapi.getOfferer.mockResolvedValue(firstOffererByAlphabeticalOrder)
-      pcapi.getBusinessUnits.mockResolvedValue([])
-
-      const { waitForElements } = renderHomePage({ store })
-      const { offerer } = await waitForElements()
-
-      expect(
-        within(offerer).getByRole('button', {
-          name: 'Masquer',
-        })
-      ).toBeInTheDocument()
       expect(
         within(offerer).queryByText('Coordonnées bancaires')
       ).not.toBeInTheDocument()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12649


## But de la pull request
- Afficher la bannière cordonnées bancaires manquantes seulement si un ou plusieurs lieux physiques n'ont pas de CB

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
