### PR TITLE
(PC-12583) Add subscription steps visualisation in admin

### DIFF
--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -240,3 +240,5 @@ def install_admin_autocomplete_views():
 
 def install_admin_template_filters(app: Flask) -> None:
     app.jinja_env.filters["yesno"] = templating.yesno
+    app.jinja_env.filters["subscription_status_format"] = templating.subscription_status_format
+    app.jinja_env.filters["eligibility_format"] = templating.eligibility_format

--- a/api/src/pcapi/admin/templating.py
+++ b/api/src/pcapi/admin/templating.py
@@ -2,9 +2,45 @@ import typing
 
 from markupsafe import Markup
 
+from pcapi.core.subscription import models as subscription_models
+from pcapi.core.users import models as users_models
+
 
 def yesno(value: typing.Any) -> str:
     return Markup("""<span class="badge badge-{css_class}">{text}</span>""").format(
         css_class="success" if value else "danger",
         text="Oui" if value else "Non",
+    )
+
+
+SUBSCRIPTION_STATUS_FORMATS = {
+    subscription_models.SubscriptionItemStatus.KO: {"css_class": "danger", "text": "KO"},
+    subscription_models.SubscriptionItemStatus.NOT_APPLICABLE: {"css_class": "void", "text": "N/A"},
+    subscription_models.SubscriptionItemStatus.NOT_ENABLED: {"css_class": "void", "text": "Désactivé"},
+    subscription_models.SubscriptionItemStatus.OK: {"css_class": "success", "text": "OK"},
+    subscription_models.SubscriptionItemStatus.PENDING: {"css_class": "warning", "text": "PENDING"},
+    subscription_models.SubscriptionItemStatus.SUSPICIOUS: {"css_class": "warning", "text": "SUSPICIOUS"},
+    subscription_models.SubscriptionItemStatus.TODO: {"css_class": "info", "text": "TODO"},
+    subscription_models.SubscriptionItemStatus.VOID: {"css_class": "void", "text": "vide"},
+}
+
+
+def subscription_status_format(subscription_status: subscription_models.SubscriptionItemStatus) -> str:
+    return Markup("""<span class="badge badge-{css_class}">{text}</span>""").format(
+        css_class=SUBSCRIPTION_STATUS_FORMATS[subscription_status]["css_class"],
+        text=SUBSCRIPTION_STATUS_FORMATS[subscription_status]["text"],
+    )
+
+
+def eligibility_format(eligibility_type: users_models.EligibilityType) -> str:
+    if eligibility_type == users_models.EligibilityType.UNDERAGE:
+        text = "pass 15-17"
+    elif eligibility_type == users_models.EligibilityType.AGE18:
+        text = "pass 18"
+    else:
+        text = "vide"
+
+    return Markup("""<span class="badge badge-{css_class}">{text}</span>""").format(
+        css_class="info" if eligibility_type else "void",
+        text=text,
     )

--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -24,3 +24,13 @@ def get_last_user_profiling_fraud_check(user: users_models.User) -> Optional[mod
         .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
         .first()
     )
+
+
+def get_identity_fraud_checks(
+    user: users_models.User, eligibilityType: users_models.EligibilityType
+) -> list[models.BeneficiaryFraudCheck]:
+    return models.BeneficiaryFraudCheck.query.filter(
+        models.BeneficiaryFraudCheck.user == user,
+        models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
+        models.BeneficiaryFraudCheck.eligibilityType == eligibilityType,
+    ).all()

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -28,6 +28,23 @@ class SubscriptionStep(enum.Enum):
     HONOR_STATEMENT = "honor-statement"
 
 
+class SubscriptionItemStatus(enum.Enum):
+    KO = "ko"
+    NOT_APPLICABLE = "not-applicable"
+    NOT_ENABLED = "not-enabled"
+    OK = "ok"
+    PENDING = "pending"
+    SUSPICIOUS = "suspicious"
+    TODO = "todo"
+    VOID = "void"
+
+
+@dataclasses.dataclass
+class SubscriptionItem:
+    type: SubscriptionStep
+    status: SubscriptionItemStatus
+
+
 class IdentityCheckMethod(enum.Enum):
     EDUCONNECT = "educonnect"
     JOUVE = "jouve"

--- a/api/src/pcapi/static/css/support_beneficiary_details.css
+++ b/api/src/pcapi/static/css/support_beneficiary_details.css
@@ -1,0 +1,12 @@
+.section {
+  margin-top: 16px;
+}
+.row-section {
+  display: flex;
+}
+.row-element:not(:first-child) {
+  margin-left: 64px;
+}
+.subscription-info .additional-subscription-info {
+  margin-top: 32px;
+}

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -1,4 +1,9 @@
 {% extends 'admin/model/details.html' %}
+{% block head_css %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/support_beneficiary_details.css') }}">
+{% endblock %}
+
 {% import 'admin/lib.html' as lib with context %}
 
 {% block details_search %}{% endblock %}
@@ -82,7 +87,7 @@
     </div>
   </div>
 </div>
-<div class="row">
+<div class="section">
   <div class="col">
     {% if has_performed_identity_check and not model.beneficiaryFraudReview and (current_user.has_jouve_role or
     current_user.is_super_admin()) %}
@@ -105,8 +110,8 @@
     {% endif %}
   </div>
 </div>
-<div class="row">
-  <div class="col">
+<div class="section row-section">
+  <div class="row-element">
     <h3>Utilisateur</h3>
     <table class="table">
       <tr>
@@ -134,51 +139,16 @@
         <td>{% if model.dateOfBirth %}{{ model.dateOfBirth.strftime('%d/%m/%Y') }}{% else %}Inconnue{% endif %}</td>
       </tr>
       <tr>
-        <th scope="row">Code départemental</th>
-        <td>{{ model.departementCode|default('Inconnu') }}</td>
-      </tr>
-      <tr>
         <th scope="row">N° de la pièce d'identité</th>
         <td>{{ model.idPieceNumber }}</td>
       </tr>
       <tr>
         <th scope="row">Commentaire</th>
-        <td>{{ model.comment }}</td>
-      </tr>
-      <tr>
-    </table>
-    </dl>
-  </div>
-  <div class="col">
-    <h3>Parcours de validation</h3>
-    <table class="table">
-      <tr>
-        <th scope="row">Etat du parcours d'inscription</th>
-        <td>{% if model.subscriptionState %} {{ model.subscriptionState.value }} {% else %}Inconnu{% endif %}</td>
-      </tr>
-      <tr>
-        <th scope="row">Email validé</th>
-        <td>{{ model.isEmailValidated|yesno }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Téléphone validé</th>
-        <td>{{ model.phoneValidationStatus.value|yesno }}</td>
+        <td>{% if model.comment %} {{ model.comment }} {% endif %}</td>
       </tr>
       <tr>
         <th scope="row">Compte actif</th>
         <td>{{ model.isActive|yesno }}</td>
-      </tr>
-      <tr>
-        <th scope="row">IDCheck déposé</th>
-        <td>{{ model.hasCompletedIdCheck|yesno }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Bénéficiaire</th>
-        <td>{{ model.has_beneficiary_role|yesno }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Bénéficiaire 15-17</th>
-        <td>{{ model.has_underage_beneficiary_role|yesno }}</td>
       </tr>
       {% if model.suspensionReason %}
       <tr>
@@ -186,45 +156,56 @@
         <td>{{ model.suspensionReason }}</td>
       </tr>
       {% endif %}
+      <tr>
+        <th scope="row">Bénéficiaire 15-17</th>
+        <td>{{ model.has_underage_beneficiary_role|yesno }}</td>
+      </tr>
+      <tr>
+        <th scope="row">Bénéficiaire 18</th>
+        <td>{{ model.has_beneficiary_role|yesno }}</td>
+      </tr>
+      <tr>
     </table>
+    </dl>
   </div>
-  <div class="col">
-    <h3>Résultat de l'algorithme</h3>
-    {% for result in model.beneficiaryFraudResults|reverse %}
-    <table class="table">
+  <div class="row-element subscription-info">
+    <h3>Parcours d'inscription</h3>
+    <div class="table subscription-info">
+      <table class="table">
       <tr>
-        <th scope="row">Souscription</th>
-        <td>{{ "pass 15-17" if result.eligibilityType and result.eligibilityType.value == "underage" else "pass 18 ans" if result.eligibilityType and result.eligibilityType.value == "age-18" else "inconnu" }}</td>
+          <th/>
+          <th scope="col" style="text-align: center;">pass 15-17</th>
+          <th scope="col" style="text-align: center;">pass 18</th>
       </tr>
-      <tr>
-        <th scope="row">Etat</th>
-        <td>{{ result.status.value }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Date de création</th>
-        <td>{{ result.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</dd>
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">Dernière mise à jour</th>
-        <td>{% if result.dateUpdated %}{{ result.dateUpdated.strftime('le
-          %d/%m/%Y à %H:%M:%S') }}{% else %}Inconnue{% endif %}</dd>
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">Explication</th>
-        <td>{{ result.reason }}</dd>
-        </td>
-      </tr>
-    </table>
-    {% else %}
-    <div class="card card-body">
-      Aucun résultat de fraude
+      {% for item in subscription_items %}
+        <tr>
+          <th scope="row">{{item.UNDERAGE.type.name}}</th>
+          <td style="text-align: center;">{{ item.UNDERAGE.status|subscription_status_format }}</td>
+          <td style="text-align: center;">{{ item.AGE18.status|subscription_status_format }}</td>
+        </tr>
+      {% endfor %}
+      </table>
     </div>
-    {% endfor %}
+    <div class="table additional-subscription-info">
+      <h4>Autres</h4>
+      <table >
+        <tr>
+          <th scope="row">Éligibilité</th>
+          <td>{{ model.eligibility|eligibility_format }}</td>
+        </tr>
+        <tr>
+          <th scope="row">État</th>
+          <td>{% if model.subscriptionState %} {{ model.subscriptionState.value }} {% else %}Inconnu{% endif %}</td>
+        </tr>
+        <tr>
+          <th scope="row">Prochaine étape sur l'app</th>
+          <td>{% if next_subscription_step %} {{ next_subscription_step.name }} {% else %}Aucune{% endif %}</td>
+        </tr>
+      </table>
+    </div>
   </div>
   {% if model.beneficiaryFraudReview %}
-  <div class="col">
+  <div class="row-element">
     <h3>Revue manuelle</h3>
     <table class="table">
       <tr>
@@ -250,162 +231,198 @@
   </div>
   {% endif %}
 </div>
-
-<h3>Historique des changements d'adresse email</h3>
-<div class="row">
-  <div class="col-lg-12">
-    {% if model.email_history|length == 0 %}
-    <p class="card card-body">
-        Pas de changement d'adresse email pour le moment
-    </p>
-    {% else %}
-    <a href="{{ url_for('/user_email_history.index_view', flt1_0=model.id ) }}">Vue détaillée</a>
-    <table class="table table-striped table-hover">
-      <thead>
-        <tr>
-          {% if current_user.is_super_admin() %}
-            <th scope="col">Validation</th>
-          {% endif %}
-          <th scope="col">Ancienne adresse email</th>
-          <th scope="col">Nouvelle adresse email</th>
-          <th scope="col">Date</th>
-          <th scope="col">Type d'événement</th>
-          <th scope="col">Device ID</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for email_history in model.email_history %}
-        <tr>
-          {% if current_user.is_super_admin() %}
-              <td>
-                {% if email_history.eventType.value == enum_update_request_value %}
-                    <form
-                        action={{ url_for("/user_email_history.validate_user_email", entry_id=email_history.id, next="support_beneficiary.details_view", id=model.id) }}
-                        method="POST">
-                        <button
-                            class="btn btn-secondary"
-                            onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
-                            title="Approve">
-                            Valider
-                        </button>
-                    </form>
-                {% endif %}
-              </td>
-          {% endif %}
-          <td>{{ email_history.oldEmail }}</td>
-          <td>{{ email_history.newEmail }}</td>
-          <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
-          <td>{{ email_history.eventType.value }}</td>
-          <td>{{ email_history.deviceId }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    {% endif %}
-  </div>
-</div>
-
-<h3>Beneficiary Imports</h3>
-<div class="row">
-  {% for import in model.beneficiaryImports %}
-  <div class="col-lg-4">
-
-    <table class="table">
-      <tr>
-        <th scope="row">Auteur</th>
-        <td>{{ import.author|default("Aucun") }}</td>
-      </tr>
-
-      <tr>
-        <th scope="row">Application ID</th>
-        <td>{{ import.applicationId }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Source ID</th>
-        <td>{{ import.sourceId }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Source</th>
-        <td>{{ import.source }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Etat</th>
-        <td>{{ import.currentStatus.value }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Historique</th>
-        <td>
-          <ul>
-            {% for status in import.statuses %}
-            <li>{{ status.status.value }} - {{ status.detail }} - {% if status.date %}le {{ status.date.strftime('le
-              %d/%m/%Y à %H:%M:%S') }} {% endif %}
-            </li>
-            {% endfor %}
-          </ul>
-        </td>
-      </tr>
-    </table>
-  </div>
+<div class="section">
+  <h3>Résultat de l'algorithme</h3>
+  {% for result in model.beneficiaryFraudResults|reverse %}
+  <table class="table">
+    <tr>
+      <th scope="row">Éligibilité</th>
+      <td>{{ result.eligibilityType|eligibility_format }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Etat</th>
+      <td>{{ result.status.value }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Date de création</th>
+      <td>{{ result.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</dd>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Dernière mise à jour</th>
+      <td>{% if result.dateUpdated %}{{ result.dateUpdated.strftime('le
+        %d/%m/%Y à %H:%M:%S') }}{% else %}Inconnue{% endif %}</dd>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">Explication</th>
+      <td>{{ result.reason }}</dd>
+      </td>
+    </tr>
+  </table>
   {% else %}
   <div class="card card-body">
-    Aucun résultat d'import de bénéficiaire
+    Aucun résultat de fraude
   </div>
   {% endfor %}
 </div>
 
-
-<h3>Vérification des données utilisateurs</h3>
-<div class="row">
-  {% for check in model.beneficiaryFraudChecks %}
-  <div class="col-lg-4">
-    <table class="table">
+<div class="section">
+  <h3>Historique des changements d'adresse email</h3>
+  {% if model.email_history|length == 0 %}
+  <p class="card card-body">
+      Pas de changement d'adresse email pour le moment
+  </p>
+  {% else %}
+  <a href="{{ url_for('/user_email_history.index_view', flt1_0=model.id ) }}">Vue détaillée</a>
+  <table class="table table-striped table-hover">
+    <thead>
       <tr>
-        <th scope="row">Souscription</th>
-        <td>{{ "pass 15-17" if check.eligibilityType.value == "underage" else "pass 18 ans" if check.eligibilityType.value == "age-18" else "inconnu" }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Type</th>
-        <td>{{ check.type.value }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Etat</th>
-        {% if check.status %}
-        <td>{{ check.status.value }}</td>
-        {% else %}
-        <td>Inconnu</td>
+        {% if current_user.is_super_admin() %}
+          <th scope="col">Validation</th>
         {% endif %}
+        <th scope="col">Ancienne adresse email</th>
+        <th scope="col">Nouvelle adresse email</th>
+        <th scope="col">Date</th>
+        <th scope="col">Type d'événement</th>
+        <th scope="col">Device ID</th>
       </tr>
+    </thead>
+    <tbody>
+      {% for email_history in model.email_history %}
       <tr>
-        <th scope="row">Date de création</th>
-        <td>{{ check.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+        {% if current_user.is_super_admin() %}
+            <td>
+              {% if email_history.eventType.value == enum_update_request_value %}
+                  <form
+                      action={{ url_for("/user_email_history.validate_user_email", entry_id=email_history.id, next="support_beneficiary.details_view", id=model.id) }}
+                      method="POST">
+                      <button
+                          class="btn btn-secondary"
+                          onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
+                          title="Approve">
+                          Valider
+                      </button>
+                  </form>
+              {% endif %}
+            </td>
+        {% endif %}
+        <td>{{ email_history.oldEmail }}</td>
+        <td>{{ email_history.newEmail }}</td>
+        <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+        <td>{{ email_history.eventType.value }}</td>
+        <td>{{ email_history.deviceId }}</td>
       </tr>
-      <tr>
-        <th scope="row">Identifiant technique</th>
-        <td>{{ check.thirdPartyId }}</td>
-      </tr>
-      <tr>
-        <th>Codes d'erreurs</th>
-        <td>
-          <ul>
-            {% for code in check.reasonCodes|default([], true) %}
-            <li>{{code.value}}</li>
-            {% else %}
-            Aucune erreur
-            {% endfor %}
-          </ul>
-        </td>
-      </tr>
-
-    </table>
-    <h4>Détails techniques</h4>
-    <div class="row">
-      <pre class="pre-scrollable"><code>{{ check.resultContent|pprint }}</code></pre>
-    </div>
-  </div>
-  {% else %}
-  <div class="card card-body">
-    Aucune vérification externe (Jouve, DMS)
-  </div>
-  {% endfor %}
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
 </div>
-{% endblock %}
+
+<div class="section">
+  <h3>Beneficiary Imports</h3>
+  <div class="row">
+    {% for import in model.beneficiaryImports %}
+    <div class="col-lg-4">
+
+      <table class="table">
+        <tr>
+          <th scope="row">Auteur</th>
+          <td>{{ import.author|default("Aucun") }}</td>
+        </tr>
+
+        <tr>
+          <th scope="row">Application ID</th>
+          <td>{{ import.applicationId }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Source ID</th>
+          <td>{{ import.sourceId }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Source</th>
+          <td>{{ import.source }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Etat</th>
+          <td>{{ import.currentStatus.value }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Historique</th>
+          <td>
+            <ul>
+              {% for status in import.statuses %}
+              <li>{{ status.status.value }} - {{ status.detail }} - {% if status.date %}le {{ status.date.strftime('le
+                %d/%m/%Y à %H:%M:%S') }} {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          </td>
+        </tr>
+      </table>
+    </div>
+    {% else %}
+    <div class="card card-body">
+      Aucun résultat d'import de bénéficiaire
+    </div>
+    {% endfor %}
+  </div>
+</div>
+
+<div class="section">
+  <h3>Vérification des données utilisateurs</h3>
+  <div class="row">
+    {% for check in model.beneficiaryFraudChecks %}
+    <div class="col-lg-4">
+      <table class="table">
+        <tr>
+          <th scope="row">Éligibilité</th>
+          <td>{{ check.eligibilityType|eligibility_format }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Type</th>
+          <td>{{ check.type.value }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Etat</th>
+          {% if check.status %}
+          <td>{{ check.status.value }}</td>
+          {% else %}
+          <td>Inconnu</td>
+          {% endif %}
+        </tr>
+        <tr>
+          <th scope="row">Date de création</th>
+          <td>{{ check.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Identifiant technique</th>
+          <td>{{ check.thirdPartyId }}</td>
+        </tr>
+        <tr>
+          <th>Codes d'erreurs</th>
+          <td>
+            <ul>
+              {% for code in check.reasonCodes|default([], true) %}
+              <li>{{code.value}}</li>
+              {% else %}
+              Aucune erreur
+              {% endfor %}
+            </ul>
+          </td>
+        </tr>
+
+      </table>
+      <h4>Détails techniques</h4>
+      <div class="row">
+        <pre class="pre-scrollable"><code>{{ check.resultContent|pprint }}</code></pre>
+      </div>
+    </div>
+    {% else %}
+    <div class="card card-body">
+      Aucune vérification externe (Jouve, DMS)
+    </div>
+    {% endfor %}
+  </div>
+  {% endblock %}
+</div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12583
![image](https://user-images.githubusercontent.com/22373097/148996798-521dbe4b-91c0-4cfa-8b7b-c12aa761d81a.png)

##  Implémentation

- Ajout de fonction dans subsxcription_api pour récupérer des "SubscriptionItems"
- TODO : il faudra utiliser ces fonctions pour calculer le next SubscriptionStep
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
