### PR TITLE
(PC-12211) type extra data when creating and updating educational offer

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import enum
 from typing import Any
 from typing import Optional
 from typing import Union
@@ -121,6 +122,33 @@ class PostOfferBodyModel(BaseModel):
         extra = "forbid"
 
 
+class OfferAddressType(enum.Enum):
+    OFFERER_VENUE = "offererVenue"
+    SCHOOL = "school"
+    OTHER = "other"
+
+
+class EducationalOfferExtraDataOfferVenueBodyModel(BaseModel):
+    addressType: OfferAddressType
+    otherAddress: str
+    venueId: str
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
+
+
+class EducationalOfferExtraDataBodyModel(BaseModel):
+    students: list[str]
+    offer_venue: EducationalOfferExtraDataOfferVenueBodyModel
+    contact_email: str
+    contact_phone: str
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
+
+
 class PostEducationalOfferBodyModel(BaseModel):
     offerer_id: str
     venue_id: str
@@ -133,7 +161,7 @@ class PostEducationalOfferBodyModel(BaseModel):
     mental_disability_compliant: bool = False
     motor_disability_compliant: bool = False
     visual_disability_compliant: bool = False
-    extra_data: Any
+    extra_data: EducationalOfferExtraDataBodyModel
 
     @validator("name", pre=True)
     def validate_name(cls, name, values):  # pylint: disable=no-self-argument
@@ -185,11 +213,22 @@ class PatchOfferBodyModel(BaseModel):
         extra = "forbid"
 
 
+class EducationalOfferPartialExtraDataBodyModel(BaseModel):
+    students: Optional[list[str]]
+    offerVenue: Optional[EducationalOfferExtraDataOfferVenueBodyModel]
+    contactEmail: Optional[str]
+    contactPhone: Optional[str]
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"
+
+
 class PatchEducationalOfferBodyModel(BaseModel):
     bookingEmail: Optional[str]
     description: Optional[str]
     name: Optional[str]
-    extraData: Any
+    extraData: Optional[EducationalOfferPartialExtraDataBodyModel]
     durationMinutes: Optional[int]
     audioDisabilityCompliant: Optional[bool]
     mentalDisabilityCompliant: Optional[bool]

--- a/api/tests/routes/pro/patch_educational_offer_test.py
+++ b/api/tests/routes/pro/patch_educational_offer_test.py
@@ -158,6 +158,27 @@ class Returns400Test:
         # Then
         assert response.status_code == 400
 
+    def test_patch_offer_with_wrong_extra_data(self, app, client):
+        # Given
+        offer = offers_factories.OfferFactory(
+            mentalDisabilityCompliant=False,
+            extraData={"contactEmail": "johndoe@yopmail.com", "contactPhone": "0600000000"},
+            isEducational=True,
+        )
+        offers_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        data = {"extraData": {"wrongKey": 1}}
+        response = client.with_session_auth("user@example.com").patch(
+            f"/offers/educational/{humanize(offer.id)}", json=data
+        )
+
+        # Then
+        assert response.status_code == 400
+
 
 class Returns403Test:
     def when_user_is_not_attached_to_offerer(self, app, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12211

## But de la pull request

Lors de la création d'offre EAC, il y a des champs obligatoire du formulaire qui sont envoyés et stockés dans un objet `extraData` en base de donnée. Or cet `extraData` est typé comme `Any` donc on n'a pas de moyen de valider si tous les champs obligatoires sont bien présents ou non.

Cette PR a pour but de typer `extraData` pour s'assurer que l'objet soit complet et valide 

##  Implémentation

- Ajout de classes pour typer `extraData` au moment du `post` et du `patch`
- Ajout de tests
​