### PR TITLE
[PC-11636][API][PRO] missing business unit creation

### DIFF
--- a/api/src/pcapi/scripts/business_unit/create_bu.py
+++ b/api/src/pcapi/scripts/business_unit/create_bu.py
@@ -183,7 +183,7 @@ def create_all_business_units():
                 # * bank_informatin with similar bic/iban than offerer bank_information
                 # * or no bank_informations
                 populate_business_unit(business_units[0], venues)
-            elif len(business_units) > 1:
+            else:
                 # create a business unit without siret
                 # for venue that have no siret and:
                 # * bank_informatin with similar bic/iban than offerer bank_information

--- a/api/src/pcapi/scripts/business_unit/rename_invalid_bu.py
+++ b/api/src/pcapi/scripts/business_unit/rename_invalid_bu.py
@@ -1,0 +1,20 @@
+from collections import defaultdict
+
+from pcapi.core.finance.models import BusinessUnit
+from pcapi.repository import repository
+
+
+def rename_invalid_business_unit():
+    business_unit_list = BusinessUnit.query.filter(BusinessUnit.siret.is_(None)).all()
+    business_units_by_offerer = defaultdict(lambda: [])
+    for business_unit in business_unit_list:
+        if len(business_unit.venues) > 0:
+            offerer_id = business_unit.venues[0].managingOffererId
+            business_units_by_offerer[offerer_id].append(business_unit)
+
+    for offerer_id, offerer_business_unit_list in business_units_by_offerer.items():
+        nb_business_unit = 0
+        for business_unit in offerer_business_unit_list:
+            nb_business_unit += 1
+            business_unit.name = f"Point de remboursement #{nb_business_unit}"
+            repository.save(business_unit)

--- a/api/tests/scripts/business_unit/create_bu_test.py
+++ b/api/tests/scripts/business_unit/create_bu_test.py
@@ -3,6 +3,7 @@ import pytest
 from pcapi.core.finance.models import BusinessUnit
 from pcapi.core.offerers.factories import OffererFactory
 from pcapi.core.offers.factories import BankInformationFactory
+from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.scripts.business_unit.create_bu import create_all_business_units
 
@@ -212,3 +213,26 @@ def test_business_unit_without_siret_name():
     business_unit = BusinessUnit.query.order_by("name").all()
     assert business_unit[0].name == "Point de remboursement #1"
     assert business_unit[1].name == "Point de remboursement #2"
+
+
+@pytest.mark.usefixtures("db_session")
+def test_create_single_bu_without_siret_on_offerer_cb():
+    expected_results = {
+        "bu_with_siret": 0,
+        "bu_without_siret": 0,
+    }
+
+    offerer = OffererFactory()
+    BankInformationFactory(offerer=offerer)
+    venue = VenueFactory(
+        managingOfferer=offerer,
+        businessUnit=None,
+        siret=None,
+        isVirtual=True,
+    )
+    OfferFactory(venue=venue)
+
+    create_all_business_units()
+    business_units = BusinessUnit.query.all()
+
+    assert len(business_units) == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11636

Il y à un gros trou de BusinessUnit non créer en production : 

```sql
SELECT
    count(DISTINCT(venue.id))
FROM venue
    JOIN offerer ON (offerer.id = venue."managingOffererId")
    JOIN bank_information ON (bank_information."offererId" = offerer.id)
WHERE venue."businessUnitId" IS NULL
    AND venue.siret IS NULL
    AND offerer."isActive"
    AND bank_information.status = 'ACCEPTED'
;
-[ RECORD 1 ]
count | 4484
```
Parmis ces 4400 lieu, 680 ont des offres dont 540 ont des offre actives.

Une fois mergé il nous faut rééxécuter en production :

```
create_bu()  # creation de bu manquante
purge_virtual_venue_business_units()  # suppression des liens et business unit inutiles 
rename_invalid_business_unit() # normalisation des nom des business unit invalides.
```