### PR TITLE
[PC-12688][api] chore: limit version of pygments

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,8 @@
+# temporary
+# FIXME: remove pygments version restriction when no more needed
+pygments<2.11.2  # because pygments 2.11.2 breaks pgcli, see https://github.com/dbcli/pgcli/issues/1303
+# /temporary
+
 alembic==1.4.3
 algoliasearch==2.4.0
 # astroid is required by pylint and version 2.5.7 and 2.5.8 crashes


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12688


## But de la pull request

empècher [pygments de casser pgcli](https://github.com/dbcli/pgcli/issues/1303)

##  Implémentation

limitation de la version de pygments à 2.11.1
​
##  Informations supplémentaires

nope
​
## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [X] Branche : pc-XXX-whatever-describe-the-branch
    - [X] PR : (PC-XXX) Description rapide de l' US
    - [X] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] ~~J'ai écrit les tests nécessaires~~
- [ ] ~~J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
