### PR TITLE
(PC-12607)[api] feat(bookings csv) : add offer type column to bookings csv - educational vs. individual

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -540,6 +540,7 @@ def _get_filtered_booking_report(
             Venue.departementCode.label("venueDepartmentCode"),
             Offerer.postalCode.label("offererPostalCode"),
             Offer.name.label("offerName"),
+            Offer.isEducational.label("offerIsEducational"),
             Stock.beginningDatetime.label("stockBeginningDatetime"),
             Stock.offerId,
             Offer.extraData["isbn"].label("isbn"),
@@ -884,6 +885,7 @@ def _serialize_csv_report(query: Query) -> str:
             "Prix de la réservation",
             "Statut de la contremarque",
             "Date et heure de remboursement",
+            "Type d'offre",
         )
     )
     for booking in query.yield_per(1000):
@@ -902,6 +904,7 @@ def _serialize_csv_report(query: Query) -> str:
                 booking.amount,
                 _get_booking_status(booking.status, booking.isConfirmed),
                 _serialize_date_with_timezone(booking.reimbursedAt, booking),
+                "offre scolaire" if booking.offerIsEducational else "offre grand public",
             )
         )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12607


## But de la pull request

Ajout d'une colonne "Type d'offre" dans le csv des réservations, afin de pouvoir distinguer entre offres scolaires et grand public

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
