### PR TITLE
(PC-12629)[API+ADAGE] add offerer name next to venue name in adage

### DIFF
--- a/adage-front/src/app/components/OffersSearch/Offers/Offer.tsx
+++ b/adage-front/src/app/components/OffersSearch/Offers/Offer.tsx
@@ -4,17 +4,34 @@ import React, { useState } from 'react'
 
 import { ReactComponent as ChevronIcon } from 'assets/chevron.svg'
 import { ReactComponent as Logo } from 'assets/logo-without-text.svg'
-import { OfferType } from 'utils/types'
+import { OfferType, VenueType } from 'utils/types'
 
 import OfferDetails from './OfferDetails/OfferDetails'
 import OfferSummary from './OfferSummary/OfferSummary'
 import PrebookingButton from './PrebookingButton/PrebookingButton'
+
 const formatToReadableString = (input: string | null): string | null => {
   if (input == null) {
     return input
   }
   const lowerCasedInput = input.toLowerCase()
   return lowerCasedInput.charAt(0).toUpperCase() + lowerCasedInput.slice(1)
+}
+
+const getOfferVenueAndOffererName = (offerVenue: VenueType): string => {
+  const venueName =
+    offerVenue.publicName || formatToReadableString(offerVenue.name)
+  const offererName = offerVenue.managingOfferer.name
+
+  if (venueName?.toLowerCase() === offererName.toLowerCase()) {
+    return venueName
+  }
+
+  if (!venueName) {
+    return offererName
+  }
+
+  return `${venueName} - ${offererName}`
 }
 
 export const Offer = ({
@@ -40,7 +57,7 @@ export const Offer = ({
         <div className="offer-header">
           <h2 className="offer-header-title">{offer.name}</h2>
           <p className="offer-venue-name">
-            {offer.venue.publicName || formatToReadableString(offer.venue.name)}
+            {getOfferVenueAndOffererName(offer.venue)}
           </p>
         </div>
         <OfferSummary offer={offer} />

--- a/adage-front/src/utils/types.ts
+++ b/adage-front/src/utils/types.ts
@@ -8,6 +8,9 @@ export interface VenueType {
   name: string
   postalCode: string
   publicName?: string
+  managingOfferer: {
+    name: string
+  }
 }
 
 export enum ADRESS_TYPE {

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -16,6 +16,13 @@ from pcapi.utils.date import format_into_utc_date
 logger = logging.getLogger(__name__)
 
 
+class OfferManagingOffererResponse(BaseModel):
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
 class OfferStockResponse(BaseModel):
     id: int
     beginningDatetime: Optional[datetime]
@@ -47,6 +54,7 @@ class OfferVenueResponse(BaseModel):
     postalCode: Optional[str]
     publicName: Optional[str]
     coordinates: Coordinates
+    managingOfferer: OfferManagingOffererResponse
 
     class Config:
         orm_mode = True

--- a/api/tests/routes/adage_iframe/get_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_offer_test.py
@@ -90,6 +90,7 @@ class Returns200Test:
                 "name": offer.venue.name,
                 "postalCode": "75000",
                 "publicName": offer.venue.publicName,
+                "managingOfferer": {"name": offer.venue.managingOfferer.name},
             },
             "audioDisabilityCompliant": False,
             "mentalDisabilityCompliant": False,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12629

## But de la pull request

Ajouter le nom de la structure à côté du nom du lieu, sous le titre de l'offre sur adage

<img width="1166" alt="Capture d’écran 2022-01-10 à 16 17 38" src="https://user-images.githubusercontent.com/35567446/148792912-4abe51fe-aac0-440d-b1d6-bec9751ac0a0.png">
