### PR TITLE
(PC-12647) remove error toaster on backend error

### DIFF
--- a/pro/src/routes/OfferEducationalCreation/adapters/getIsOffererEligibleToEducationalOfferAdapter.ts
+++ b/pro/src/routes/OfferEducationalCreation/adapters/getIsOffererEligibleToEducationalOfferAdapter.ts
@@ -9,7 +9,7 @@ const FAILING_RESPONSE: AdapterFailure<{
 }> = {
   isOk: false,
   message:
-    "Une erreur est survenue lors de la vérification de votre éligibilité à la création d'offre collective",
+    'Une erreur technique est survenue lors de la vérification de votre éligibilité.',
   payload: {
     isOffererEligibleToEducationalOffer: false,
   },
@@ -28,7 +28,7 @@ const getIsOffererEligibleToEducationalOfferAdapter: GetIsOffererEligibleToEduca
         },
       }
     } catch (error) {
-      if (hasStatusCode(error) && error.status === 403) {
+      if (hasStatusCode(error) && error.status === 404) {
         return {
           isOk: true,
           message: null,

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -67,11 +67,14 @@ const OfferEducationalForm = ({
             selectedOfferer.id
           )
 
+        if (isOk) {
+          setIsEligible(payload.isOffererEligibleToEducationalOffer)
+        }
+
         if (!isOk) {
           notify.error(message)
         }
 
-        setIsEligible(payload.isOffererEligibleToEducationalOffer)
         setIsLoading(false)
       }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12647

## But de la pull request

Retirer le toaster d'erreur en cas de non éligibilité de l'acteur culturel, car celui-ci porte à confusion --> l'utilisateur a l'impression que le problème vient de pass culture ou d'adage dans tous les cas

##  Implémentation

- Affichage du toaster uniquement si il y a une erreur du back autre qu'une 404 (qui indique que l'AC n'est pas éligible car non référencé auprès d'adage)
- Suppression du block jaune indiquant que l'utilisateur doit faire une référencement dans le cas de l'affichage du toaster
​