### PR TITLE
(PC-12686)[PRO] fix link to create another offer after submitting one

### DIFF
--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -135,4 +135,5 @@ export type GetStockOfferSuccessPayload = {
   status: Offer['status']
   isBooked: boolean
   venueDepartmentCode: string
+  managingOffererId: string
 }

--- a/pro/src/routes/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
+++ b/pro/src/routes/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
@@ -1,21 +1,17 @@
 import React, { useEffect, useState } from 'react'
-import { useLocation, useParams } from 'react-router'
+import { useParams } from 'react-router'
 
 import useNotification from 'components/hooks/useNotification'
 import Spinner from 'components/layout/Spinner'
-import { queryParamsFromOfferer } from 'components/pages/Offers/utils/queryParamsFromOfferer'
 import { getStockOfferAdapter } from 'core/OfferEducational'
 import { OfferStatus } from 'custom_types/offer'
 import OfferEducationalConfirmationScreen from 'screens/OfferEducationalConfirmation'
 
 const OfferEducationalConfirmation = (): JSX.Element => {
-  const location = useLocation<{ structure?: string; lieu?: string }>()
   const { offerId } = useParams<{ offerId: string }>()
   const [offerStatus, setOfferStatus] = useState<undefined | OfferStatus>()
+  const [offererId, setOffererId] = useState<string>()
   const notify = useNotification()
-
-  const { structure: offererId, lieu: venueId } =
-    queryParamsFromOfferer(location)
 
   useEffect(() => {
     const loadOffer = async () => {
@@ -26,6 +22,7 @@ const OfferEducationalConfirmation = (): JSX.Element => {
       }
 
       setOfferStatus(offerResponse.payload.status)
+      setOffererId(offerResponse.payload.managingOffererId)
     }
 
     loadOffer()
@@ -39,7 +36,6 @@ const OfferEducationalConfirmation = (): JSX.Element => {
     <OfferEducationalConfirmationScreen
       offerStatus={offerStatus}
       offererId={offererId}
-      venueId={venueId}
     />
   )
 }

--- a/pro/src/routes/OfferEducationalCreation/OfferEducationalCreation.tsx
+++ b/pro/src/routes/OfferEducationalCreation/OfferEducationalCreation.tsx
@@ -47,8 +47,7 @@ const OfferEducationalCreation = (): JSX.Element => {
       return notify.error(message)
     }
 
-    const queryString = `?structure=${offer.offererId}&lieu=${offer.venueId}`
-    history.push(`/offre/${payload.offerId}/scolaire/stocks${queryString}`)
+    history.push(`/offre/${payload.offerId}/scolaire/stocks`)
   }
 
   useEffect(() => {

--- a/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.stories.tsx
+++ b/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.stories.tsx
@@ -11,8 +11,6 @@ export default {
   decorators: [withRouterDecorator, withPageTemplate],
 }
 
-const Template = () => (
-  <OfferEducationalConfirmation offererId={null} venueId={null} />
-)
+const Template = () => <OfferEducationalConfirmation offererId={null} />
 
 export const Default = Template.bind({})

--- a/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
+++ b/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
@@ -10,8 +10,7 @@ import { Title } from 'ui-kit'
 import styles from './OfferEducationalConfirmation.module.scss'
 
 interface IOfferEducationalConfirmationProps {
-  offererId: string | null
-  venueId: string | null
+  offererId?: string | null
   offerStatus?: OfferStatus
 }
 
@@ -31,18 +30,8 @@ const pendingOffer = {
 
 const OfferEducationalConfirmation = ({
   offererId,
-  venueId,
   offerStatus,
 }: IOfferEducationalConfirmationProps): JSX.Element => {
-  let queryString = ''
-  if (offererId) {
-    queryString = `?structure=${offererId}`
-  }
-
-  if (venueId) {
-    queryString += `&lieu=${venueId}`
-  }
-
   const { title, description, Icon } =
     offerStatus === OfferStatus.OFFER_STATUS_PENDING
       ? pendingOffer
@@ -70,7 +59,7 @@ const OfferEducationalConfirmation = ({
         </Link>
         <Link
           className={cn('primary-button', styles['confirmation-action'])}
-          to={`/offre/creation${queryString}`}
+          to={`/offre/creation${offererId ? `?structure=${offererId}` : ''}`}
         >
           Créer une nouvelle offre
         </Link>

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.stories.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.stories.tsx
@@ -31,6 +31,7 @@ const Template: Story<{ mode: Mode }> = args => (
       venueDepartmentCode: '974',
       isActive: true,
       isBooked: true,
+      managingOffererId: 'AA',
     }}
     onSubmit={action('onSubmit')}
     setIsOfferActive={() => null}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12686

## But de la pull request

Pouvoir créer une nouvelle offre à la fin du parcours de création d'offre collective. 
Le formulaire a besoin de l'id de la structure comme donnée initiale. Celle-ci vient des query params dans l'url, or on ne les fait pas passer sur la page de confirmation, donc quand on clique sur "créer une nouvelle offre" les query params sont vides.

## Implémentation
- Un peu de cleaning : suppression des query params qu'on n'utilise pas (sur la page stock et création)
- utilisation du managingOffer.id de l'offre créée pour renseigner la structure dans les query params lorsqu'on veut créer une nouvelle offre
