### PR TITLE
(PC-12636)[api][bookings] use firstName and lastName

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -295,9 +295,9 @@ class Booking(PcObject, Model):
         return None
 
     @property
-    def publicName(self) -> Optional[str]:
+    def userName(self) -> Optional[str]:
         if self.individualBooking is not None:
-            return self.individualBooking.user.publicName
+            return f"{self.individualBooking.user.firstName} {self.individualBooking.user.lastName}"
 
         if self.educationalBooking is not None:
             return f"{self.educationalBooking.educationalRedactor.firstName} {self.educationalBooking.educationalRedactor.lastName}"

--- a/api/src/pcapi/emails/offerer_expired_bookings.py
+++ b/api/src/pcapi/emails/offerer_expired_bookings.py
@@ -28,7 +28,7 @@ def _extract_bookings_information_from_bookings_list(bookings: list[Booking]) ->
                 "offer_name": offer.name,
                 "venue_name": offer.venue.publicName if offer.venue.publicName else offer.venue.name,
                 "price": str(stock.price) if stock.price > 0 else "gratuit",
-                "user_name": booking.publicName,
+                "user_name": booking.userName,
                 "user_email": booking.email,
                 "pcpro_offer_link": build_pc_pro_offer_link(offer),
             }

--- a/api/src/pcapi/routes/pro/bookings.py
+++ b/api/src/pcapi/routes/pro/bookings.py
@@ -280,7 +280,7 @@ def _create_response_to_get_booking_by_token(booking: Booking) -> dict:
         "email": booking.email,
         "isUsed": booking.isUsed,
         "offerName": offer_name,
-        "userName": booking.publicName,
+        "userName": booking.userName,
         "venueDepartementCode": venue_departement_code,
     }
 

--- a/api/src/pcapi/routes/serialization/bookings_serialize.py
+++ b/api/src/pcapi/routes/serialization/bookings_serialize.py
@@ -76,7 +76,7 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
         price=booking.amount,
         quantity=booking.quantity,
         theater=extra_data.get("theater", ""),
-        userName=booking.publicName,
+        userName=booking.userName,
         venueAddress=booking.venue.address,
         venueDepartmentCode=booking.venue.departementCode,
         venueName=booking.venue.name,

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -99,7 +99,7 @@ def make_validation_email_object(
 def make_offerer_driven_cancellation_email_for_offerer(booking: Booking) -> dict:
     stock_name = booking.stock.offer.name
     venue = booking.venue
-    user_name = booking.publicName
+    user_name = booking.userName
     user_email = booking.email
     email_subject = "Confirmation de votre annulation de réservation pour {}, proposé par {}".format(
         stock_name, venue.name

--- a/api/tests/emails/offer_cancellation_test.py
+++ b/api/tests/emails/offer_cancellation_test.py
@@ -39,7 +39,7 @@ class MakeOffererDrivenCancellationEmailForOffererTest:
         html_recap = str(email_html.find("p", {"id": "recap"}))
         html_no_recal = str(email_html.find("p", {"id": "no-recap"}))
         assert "Vous venez d'annuler" in html_action
-        assert booking.publicName in html_action
+        assert booking.userName in html_action
         assert booking.email in html_action
         assert f"pour {stock.offer.name}" in html_recap
         assert f"proposé par {venue.name}" in html_recap
@@ -100,7 +100,7 @@ class MakeOffererDrivenCancellationEmailForOffererTest:
         html_recap = email_html.find("p", {"id": "recap"}).text
         html_recap_table = email_html.find("table", {"id": "recap-table"}).text
         assert "Vous venez d'annuler" in html_action
-        assert booking.publicName in html_action
+        assert booking.userName in html_action
         assert booking.email in html_action
         assert f"pour {stock.offer.product.name}" in html_recap
         assert f"proposé par {venue.name}" in html_recap
@@ -149,7 +149,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationWithMailjetTemplateTest:
                 "date": "09-Oct-2019",
                 "heure": "12h20",
                 "quantite": booking.quantity,
-                "user_name": booking.publicName,
+                "user_name": booking.userName,
                 "user_email": booking.email,
                 "is_active": 1,
                 "nombre_resa": 0,
@@ -187,7 +187,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationWithMailjetTemplateTest:
                 "date": "09-Oct-2019",
                 "heure": "12h20",
                 "quantite": booking1.quantity,
-                "user_name": booking1.publicName,
+                "user_name": booking1.userName,
                 "user_email": booking1.email,
                 "is_active": 1,
                 "nombre_resa": 1,
@@ -232,7 +232,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationWithMailjetTemplateTest:
                 "date": "",
                 "heure": "",
                 "quantite": booking1.quantity,
-                "user_name": booking1.publicName,
+                "user_name": booking1.userName,
                 "user_email": booking1.email,
                 "is_active": 0,
                 "nombre_resa": 1,
@@ -277,7 +277,7 @@ class MakeOffererBookingRecapEmailAfterUserCancellationWithMailjetTemplateTest:
                 "date": "",
                 "heure": "",
                 "quantite": booking1.quantity,
-                "user_name": booking1.publicName,
+                "user_name": booking1.userName,
                 "user_email": booking1.email,
                 "is_active": 0,
                 "nombre_resa": 1,

--- a/api/tests/emails/offerer_expired_bookings_test.py
+++ b/api/tests/emails/offerer_expired_bookings_test.py
@@ -24,7 +24,8 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_a
     long_ago = now - timedelta(days=31)
     dvd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
     expired_today_dvd_booking = CancelledIndividualBookingFactory(
-        individualBooking__user__publicName="Dory",
+        individualBooking__user__firstName="Dory",
+        individualBooking__user__lastName="Who",
         individualBooking__user__email="dory@example.com",
         stock__offer__product=dvd,
         stock__offer__name="Memento",
@@ -36,7 +37,8 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_a
 
     cd = ProductFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id)
     expired_today_cd_booking = CancelledIndividualBookingFactory(
-        individualBooking__user__publicName="Dorian",
+        individualBooking__user__firstName="Dorian",
+        individualBooking__user__lastName="Gray",
         individualBooking__user__email="dorian@example.com",
         stock__offer__product=cd,
         stock__offer__name="Random Access Memories",
@@ -59,7 +61,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_a
                     "offer_name": "Memento",
                     "venue_name": "Mnémosyne",
                     "price": "10.00",
-                    "user_name": "Dory",
+                    "user_name": "Dory Who",
                     "user_email": "dory@example.com",
                     "pcpro_offer_link": "http://pc_pro.com/offer_link",
                 },
@@ -67,7 +69,7 @@ def test_should_send_email_to_offerer_when_expired_bookings_cancelled_with_new_a
                     "offer_name": "Random Access Memories",
                     "venue_name": "Virgin Megastore",
                     "price": "10.00",
-                    "user_name": "Dorian",
+                    "user_name": "Dorian Gray",
                     "user_email": "dorian@example.com",
                     "pcpro_offer_link": "http://pc_pro.com/offer_link",
                 },

--- a/api/tests/routes/pro/get_booking_by_token_test.py
+++ b/api/tests/routes/pro/get_booking_by_token_test.py
@@ -39,7 +39,7 @@ class Returns200Test:
             "email": booking.email,
             "isUsed": False,
             "offerName": booking.stock.offer.name,
-            "userName": booking.publicName,
+            "userName": booking.userName,
             "venueDepartementCode": booking.stock.offer.venue.departementCode,
         }
 
@@ -64,7 +64,7 @@ class Returns200Test:
             "email": booking.email,
             "isUsed": False,
             "offerName": booking.stock.offer.product.name,
-            "userName": booking.publicName,
+            "userName": booking.userName,
             "venueDepartementCode": booking.stock.offer.venue.departementCode,
         }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12636


## But de la pull request

Utiliser prénom + nom dans l'affichage de l'utilisateur dans le guichet et les emails.

##  Implémentation

- modification du nom de la propriété `publicName` en `userName`
- édition de son résultat​
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)

**Bénéficiaire:**
<img width="670" alt="user" src="https://user-images.githubusercontent.com/33030007/148933792-16beb23d-177b-4ede-be6c-1be8757bfa77.png">
**Guichet existant:**
<img width="772" alt="avant changement" src="https://user-images.githubusercontent.com/33030007/148933803-4dfb28c6-823b-4801-a591-f6b7afe6260a.png">
**Guichet avec correctif:**
<img width="768" alt="après changement" src="https://user-images.githubusercontent.com/33030007/148933836-c5df86b1-ddd2-4b54-9a6b-a2e93fbf98b2.png">


