### PR TITLE
(PC-12308) update user data after id check

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -437,12 +437,14 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
 
     # Cancel the old fraud check
     fraud_check.status = fraud_models.FraudCheckStatus.CANCELED
-    if fraud_check.reason is None or fraud_check.reason == "":
-        fraud_check.reason = "Eligibility type changed by the identity provider"
-    else:
-        fraud_check.reason += (
-            f"{fraud_api.FRAUD_RESULT_REASON_SEPARATOR} Eligibility type changed by the identity provider"
-        )
+
+    reason_message = "Eligibility type changed by the identity provider"
+    fraud_check.reason = (
+        f"{fraud_check.reason} {fraud_api.FRAUD_RESULT_REASON_SEPARATOR} {reason_message}"
+        if fraud_check.reason
+        else reason_message
+    )
+
     if fraud_check.reasonCodes is None:
         fraud_check.reasonCodes = []
     fraud_check.reasonCodes.append(fraud_models.FraudReasonCode.ELIGIBILITY_CHANGED)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -453,3 +453,17 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
     pcapi_repository.repository.save(new_fraud_check, fraud_check)
 
     return new_fraud_check
+
+
+def update_user_birth_date(user: users_models.User, birth_date: typing.Optional[datetime.date]) -> None:
+    """Updates the user birth date based on data received from the identity provider.
+
+    Args:
+        user (users_models.User): The user to update.
+        birth_date (typing.Optional[datetime.date]): The birth date to set.
+    """
+    if user.is_beneficiary:
+        return
+    if user.dateOfBirth != birth_date and birth_date is not None:
+        user.dateOfBirth = birth_date
+        pcapi_repository.repository.save(user)

--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -56,6 +56,7 @@ def handle_educonnect_authentication(
             raise exceptions.EduconnectSubscriptionException()
     else:
         _add_error_subscription_messages(user, fraud_check.reasonCodes, educonnect_user)
+        subscription_api.update_user_birth_date(user, fraud_check.source_data().get_birth_date())
         logger.warning(
             "Fraud suspicion after educonnect authentication with codes: %s",
             (", ").join([code.value for code in fraud_check.reasonCodes]),

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -54,6 +54,7 @@ def update_ubble_workflow(
             if fraud_check.status != fraud_models.FraudCheckStatus.OK:
                 subscription_api.handle_validation_errors(user=user, reason_codes=fraud_check.reasonCodes)
                 subscription_messages.on_ubble_journey_cannot_continue(user)
+                subscription_api.update_user_birth_date(user, fraud_check.source_data().get_birth_date())
                 return
 
             try:

--- a/api/src/pcapi/scripts/beneficiary/import_dms_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_dms_users.py
@@ -166,7 +166,7 @@ def process_application(
 ) -> None:
 
     try:
-        information = parsing_function(application_details, procedure_id)
+        information: fraud_models.IdCheckContent = parsing_function(application_details, procedure_id)
     except DMSParsingError as exc:
         process_parsing_error(exc, procedure_id, application_id)
         return
@@ -198,6 +198,7 @@ def process_application(
     else:
         if fraud_result.status != fraud_models.FraudStatus.OK:
             handle_validation_errors(user, fraud_result, information, procedure_id)
+            subscription_api.update_user_birth_date(user, information.get_birth_date())
             return
 
         try:

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -745,7 +745,9 @@ class CommonSubscritpionTest:
             != fraud_check
         )
 
-        user_fraud_checks = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).all()
+        user_fraud_checks = sorted(
+            fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).all(), key=lambda x: x.id
+        )
         assert len(user_fraud_checks) == 2
         assert user_fraud_checks[0].eligibilityType == users_models.EligibilityType.UNDERAGE
         assert user_fraud_checks[0].reason == "Eligibility type changed by the identity provider"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12308


## But de la pull request

Enregistrer les données fournies par l'ID provider dès réception. 
Side effect (aussi une feature): l'utilisateur sera redirigé vers le bon parcours 

Exemple: s'il a déclaré avoir 17 ans in app, mais que le provider trouve 18 ans, on lui demandera les infos manquantes (i.e. num de téléphone) pour finaliser son inscription

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
