### PR TITLE
(PC-12735) Add github workflow to ping slack on every db scheme change

### DIFF
--- a/.github/workflows/ping_data_team.yml
+++ b/.github/workflows/ping_data_team.yml
@@ -1,0 +1,22 @@
+name: Ping data team on slack
+# This action pings slack for every new PR that adds, changes or removes a db migration.
+# The ping is done on every push.
+
+on:
+  pull_request:
+    paths:
+      - 'api/src/pcapi/alembic/versions/**'
+
+jobs:
+  send-message:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Ping slack
+        shell: bash
+        env:
+          SLACK_WEBHOOK_DB_CHANGE: ${{ secrets.SLACK_WEBHOOK_DB_CHANGE }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nouvelle PR avec une migration db -> ${{ github.event.pull_request.html_url }}"}'  "$SLACK_WEBHOOK_DB_CHANGE"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12735


## But de la pull request

Ceci est un POC qui sera challengé par l'équipe data s'il fonctionne.

Le but est de pinger slack pour chaque nouvelle pr sur l'api qui modifier la db : ajout, modification ou suppression d'une migration.

##  Implémentation

Avec github action
​
##  Informations supplémentaires

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
