### PR TITLE
(BSR) [api][Dockerfile] add missing library during image build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /usr/local/bin
 
 RUN apt-get update \
-	&& apt-get -y install gcc libpq-dev libffi-dev xmlsec1 libxmlsec1-openssl libpango-1.0-0 libpangoft2-1.0-0 \
+	&& apt-get -y install gcc libpq-dev libffi-dev xmlsec1 libxmlsec1-openssl libpango-1.0-0 libpangoft2-1.0-0 libharfbuzz0b \
 	&& apt-get clean
 
 COPY ./requirements.txt ./


### PR DESCRIPTION
## But de la pull request

Correction de l'erreur au lancement de la sandbox dans les jobs tests-pro-e2e

##  Implémentation

- Installation de `libharfbuzz0b` lors de la création de l'image Docker `pc-flask`
​
##  Informations supplémentaires

- Documentation d'installation de weasyprint sur Ubuntu >20.4: https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#ubuntu-20-04
​