### PR TITLE
(PC-12768) Add retry on batch ConnectTimeout requests

### DIFF
--- a/api/src/pcapi/notifications/push/__init__.py
+++ b/api/src/pcapi/notifications/push/__init__.py
@@ -1,14 +1,16 @@
 from pcapi import settings
+from pcapi.notifications.push import models as push_models
 from pcapi.notifications.push.backends.batch import BatchAPI
-from pcapi.notifications.push.backends.batch import BatchBackend
 from pcapi.notifications.push.backends.batch import UserUpdateData
 from pcapi.notifications.push.transactional_notifications import TransactionalNotificationData
 from pcapi.utils.module_loading import import_string
 
 
-def update_user_attributes(batch_api: BatchAPI, user_id: int, attribute_values: dict) -> None:
+def update_user_attributes(
+    batch_api: BatchAPI, user_id: int, attribute_values: dict
+) -> push_models.UpdateAttributeRequestResult:
     backend = import_string(settings.PUSH_NOTIFICATION_BACKEND)
-    backend().update_user_attributes(batch_api, user_id, attribute_values)
+    return backend().update_user_attributes(batch_api, user_id, attribute_values)
 
 
 def update_users_attributes(users_data: list[UserUpdateData]) -> None:

--- a/api/src/pcapi/notifications/push/backends/logger.py
+++ b/api/src/pcapi/notifications/push/backends/logger.py
@@ -1,5 +1,6 @@
 import logging
 
+from pcapi.notifications.push import models as push_models
 from pcapi.notifications.push.backends.batch import BatchAPI
 from pcapi.notifications.push.backends.batch import UserUpdateData
 from pcapi.notifications.push.transactional_notifications import TransactionalNotificationData
@@ -9,13 +10,16 @@ logger = logging.getLogger(__name__)
 
 
 class LoggerBackend:
-    def update_user_attributes(self, batch_api: BatchAPI, user_id: int, attribute_values: dict) -> None:
+    def update_user_attributes(
+        self, batch_api: BatchAPI, user_id: int, attribute_values: dict
+    ) -> push_models.UpdateAttributeRequestResult:
         logger.info(
             "A request to update user attributes would be sent for user with id=%d with new attributes=%s to api=%s",
             user_id,
             attribute_values,
             batch_api.name,
         )
+        return push_models.UpdateAttributeRequestResult(should_retry=False)
 
     def update_users_attributes(self, users_data: list[UserUpdateData]) -> None:
         logger.info(

--- a/api/src/pcapi/notifications/push/backends/testing.py
+++ b/api/src/pcapi/notifications/push/backends/testing.py
@@ -1,3 +1,4 @@
+from pcapi.notifications.push import models as push_models
 from pcapi.notifications.push import testing
 from pcapi.notifications.push.backends.batch import BatchAPI
 from pcapi.notifications.push.backends.batch import UserUpdateData
@@ -6,9 +7,12 @@ from pcapi.notifications.push.transactional_notifications import TransactionalNo
 
 
 class TestingBackend(LoggerBackend):
-    def update_user_attributes(self, batch_api: BatchAPI, user_id: int, attribute_values: dict) -> None:
+    def update_user_attributes(
+        self, batch_api: BatchAPI, user_id: int, attribute_values: dict
+    ) -> push_models.UpdateAttributeRequestResult:
         super().update_user_attributes(batch_api, user_id, attribute_values)
         testing.requests.append({"user_id": user_id, "attribute_values": attribute_values, "batch_api": batch_api.name})
+        return push_models.UpdateAttributeRequestResult(should_retry=False)
 
     def update_users_attributes(self, users_data: list[UserUpdateData]) -> None:
         super().update_users_attributes(users_data)

--- a/api/src/pcapi/notifications/push/models.py
+++ b/api/src/pcapi/notifications/push/models.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class UpdateAttributeRequestResult:
+    should_retry: bool

--- a/api/src/pcapi/tasks/batch_tasks.py
+++ b/api/src/pcapi/tasks/batch_tasks.py
@@ -5,6 +5,7 @@ import logging
 from pydantic import BaseModel
 
 from pcapi import settings
+from pcapi.models.api_errors import ApiErrors
 from pcapi.notifications.push import delete_user_attributes
 from pcapi.notifications.push import update_user_attributes
 from pcapi.notifications.push.backends.batch import BatchAPI
@@ -25,12 +26,16 @@ class DeleteBatchUserAttributesRequest(BaseModel):
 
 @task(settings.GCP_BATCH_CUSTOM_DATA_ANDROID_QUEUE_NAME, "/batch/android/update_user_attributes")
 def update_user_attributes_android_task(payload: UpdateBatchAttributesRequest) -> None:
-    update_user_attributes(BatchAPI.ANDROID, payload.user_id, payload.attributes)
+    result = update_user_attributes(BatchAPI.ANDROID, payload.user_id, payload.attributes)
+    if result.should_retry:
+        raise ApiErrors()
 
 
 @task(settings.GCP_BATCH_CUSTOM_DATA_IOS_QUEUE_NAME, "/batch/ios/update_user_attributes")
 def update_user_attributes_ios_task(payload: UpdateBatchAttributesRequest) -> None:
-    update_user_attributes(BatchAPI.IOS, payload.user_id, payload.attributes)
+    result = update_user_attributes(BatchAPI.IOS, payload.user_id, payload.attributes)
+    if result.should_retry:
+        raise ApiErrors()
 
 
 @task(settings.GCP_BATCH_CUSTOM_DATA_QUEUE_NAME, "/batch/delete_user_attributes")

--- a/api/tests/tasks/batch_tasks_test.py
+++ b/api/tests/tasks/batch_tasks_test.py
@@ -41,3 +41,15 @@ def test_batch_task_android(request_mock, client):
 
     assert url == ("https://api.example.com/1.0/fake_android_api_key/data/users/123",)
     assert call_args["json"] == {"overwrite": False, "values": {"TEXTE_À": True}}
+
+
+@override_settings(PUSH_NOTIFICATION_BACKEND="pcapi.notifications.push.backends.batch.BatchBackend")
+@patch("pcapi.notifications.push.backends.batch.requests.post", side_effect=Exception())
+def test_batch_task_retry(request_mock, client):
+    response = client.post(
+        f"{settings.API_URL}/cloud-tasks/batch/android/update_user_attributes",
+        json={"user_id": 123, "attributes": {"TEXTE_À": True}},
+        headers={AUTHORIZATION_HEADER_KEY: AUTHORIZATION_HEADER_VALUE},
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
Raising an error with status code = 400 in cloud task endpoint will trigger a retry by cloud task. The ConnectTimeout errors that we currently had were not retried because the exception was caught.

Erreur sentry liée https://sentry.internal-passculture.app/organizations/sentry/issues/10763/?environment=production&project=5&query=is%3Aunresolved
