### PR TITLE
(PC-12583) Fix UserProfiling status display in admin

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -236,7 +236,16 @@ def get_user_profiling_subscription_item(
     else:
         user_profiling = fraud_repository.get_last_user_profiling_fraud_check(user)
         if user_profiling:
-            status = user_profiling.status
+            if user_profiling.status == fraud_models.FraudCheckStatus.OK:
+                status = models.SubscriptionItemStatus.OK
+            elif user_profiling.status == fraud_models.FraudCheckStatus.KO:
+                status = models.SubscriptionItemStatus.KO
+            elif user_profiling.status == fraud_models.FraudCheckStatus.SUSPICIOUS:
+                status = models.SubscriptionItemStatus.SUSPICIOUS
+            else:
+                logger.exception("Unexpected UserProfiling status %s", user_profiling.status)
+                status = models.SubscriptionItemStatus.KO
+
         elif _is_eligibility_activable(user, eligibility):
             status = models.SubscriptionItemStatus.TODO
         else:


### PR DESCRIPTION
We were returning a fraud_models.FraudCheckStatus instead of a subscription_models.SubscriptionItemStatus

Error https://sentry.internal-passculture.app/organizations/sentry/issues/246592/?environment=testing&project=5&query=is%3Aunresolved


## But de la pull request

(Ajout de fonctionnalités, Problèmes résolus, etc)

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
