### PR TITLE
(PC-11552)[API]payment script: remove trailing newline in generate csv

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -532,13 +532,20 @@ def _generate_business_units_file() -> pathlib.Path:
     )
     row_formatter = lambda row: (
         human_ids.humanize(row.venue_id),
-        row.business_unit_siret,
-        row.business_unit_name,
-        row.venue_name,
+        _clean_trailing_newline(row.business_unit_siret),
+        _clean_trailing_newline(row.business_unit_name),
+        _clean_trailing_newline(row.venue_name),
         row.iban,
         row.bic,
     )
     return _write_csv("business_units", header, rows=query, row_formatter=row_formatter)
+
+
+def _clean_trailing_newline(row: str) -> str:
+    """remove trailing new line if string --> intended for BU, venue and offerer name"""
+    if isinstance(row, str):
+        return row.rstrip("\n")
+    return row
 
 
 def _generate_payments_file(batch_id: int) -> pathlib.Path:
@@ -628,10 +635,10 @@ def _payment_details_row_formatter(sql_row):
     reimbursement_rate = (reimbursed_amount / booking_total_amount).quantize(decimal.Decimal("0.01"))
     return (
         human_ids.humanize(sql_row.business_unit_venue_id),
-        sql_row.business_unit_siret,
-        sql_row.business_unit_venue_name,
+        _clean_trailing_newline(sql_row.business_unit_siret),
+        _clean_trailing_newline(sql_row.business_unit_venue_name),
         human_ids.humanize(sql_row.offer_venue_id),
-        sql_row.offer_venue_name,
+        _clean_trailing_newline(sql_row.offer_venue_name),
         sql_row.offer_id,
         sql_row.offer_name,
         sql_row.offer_subcategory_id,

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -45,6 +45,18 @@ def create_booking_with_undeletable_dependent(date_used=None):
     return booking
 
 
+class CleanStringTest:
+    def test_remove_new_line_if_string(self):
+        name = "saut de ligne\n"
+        result = api._clean_trailing_newline(name)
+        assert result == "saut de ligne"
+
+    def test_return_value_sent_if_not_string(self):
+        number = 1
+        result = api._clean_trailing_newline(number)
+        assert result == 1
+
+
 class PriceBookingTest:
     def test_basics(self):
         booking = bookings_factories.UsedBookingFactory(
@@ -412,10 +424,10 @@ def test_generate_payment_files():
 @clean_temporary_files
 def test_generate_business_units_file():
     venue1 = offers_factories.VenueFactory(
-        name="Venue 1 only name",
+        name="Venue 1 only name\n",
         publicName=None,
         siret="siret 1",
-        businessUnit__name="Business unit 1",
+        businessUnit__name="Business unit 1\n",
         businessUnit__bankAccount__bic="bic 1",
         businessUnit__bankAccount__iban="iban 1",
     )
@@ -424,8 +436,8 @@ def test_generate_business_units_file():
     venue2 = offers_factories.VenueFactory(
         name="dummy, we should use publicName instead",
         siret="siret 2",
-        publicName="Venue 2 public name",
-        businessUnit__name="Business unit 2",
+        publicName="Venue 2 public name\n",
+        businessUnit__name="Business unit 2\n",
         businessUnit__bankAccount__bic="bic 2",
         businessUnit__bankAccount__iban="iban 2",
     )
@@ -461,7 +473,7 @@ def test_generate_payments_file():
     # This pricing belong to a business unit whose venue is the same
     # as the venue of the offer.
     venue1 = offers_factories.VenueFactory(
-        name="Le Petit Rintintin",
+        name="Le Petit Rintintin\n",
         siret="11111111122222",
     )
     pricing1 = factories.PricingFactory(
@@ -485,11 +497,11 @@ def test_generate_payments_file():
     # NOT the venue of the offers.
     business_unit_venue2 = offers_factories.VenueFactory(
         siret="22222222233333",
-        name="BU du Gigantesque Cubitus",
+        name="BU du Gigantesque Cubitus\n",
     )
     business_unit2 = business_unit_venue2.businessUnit
     offer_venue2 = offers_factories.VenueFactory(
-        name="Le Gigantesque Cubitus",
+        name="Le Gigantesque Cubitus\n",
         siret="99999999999999",
         businessUnit=business_unit2,
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11552


## But de la pull request

Retirer potentiel saut de ligne dans les champs texte de csv généré pour la finance
A voir dans un second temps contrôle des caractères dans les champs selon la norme ISO 20022 (XML SEPA)
qui normalement autorise tous les caractères UTF-8. Cependant, les banques françaises se limitent au jeu de caractères latins, composé de :
a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9 / - ? : ( ) . , ? + Espace.


##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
