### PR TITLE
(PC-11552)[API]payment script: clean text format for accounting 

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -532,13 +532,20 @@ def _generate_business_units_file() -> pathlib.Path:
     )
     row_formatter = lambda row: (
         human_ids.humanize(row.venue_id),
-        row.business_unit_siret,
-        row.business_unit_name,
-        row.venue_name,
-        row.iban,
-        row.bic,
+        _clean_for_accounting(row.business_unit_siret),
+        _clean_for_accounting(row.business_unit_name),
+        _clean_for_accounting(row.venue_name),
+        _clean_for_accounting(row.iban),
+        _clean_for_accounting(row.bic),
     )
     return _write_csv("business_units", header, rows=query, row_formatter=row_formatter)
+
+
+def _clean_for_accounting(value: str) -> str:
+    # 2022-01-13 remove potential trailing space, new line and doublequote for BU, venue and offer name
+    if not isinstance(value, str):
+        return value
+    return value.strip().replace('"', "")
 
 
 def _generate_payments_file(batch_id: int) -> pathlib.Path:
@@ -628,12 +635,12 @@ def _payment_details_row_formatter(sql_row):
     reimbursement_rate = (reimbursed_amount / booking_total_amount).quantize(decimal.Decimal("0.01"))
     return (
         human_ids.humanize(sql_row.business_unit_venue_id),
-        sql_row.business_unit_siret,
-        sql_row.business_unit_venue_name,
+        _clean_for_accounting(sql_row.business_unit_siret),
+        _clean_for_accounting(sql_row.business_unit_venue_name),
         human_ids.humanize(sql_row.offer_venue_id),
-        sql_row.offer_venue_name,
+        _clean_for_accounting(sql_row.offer_venue_name),
         sql_row.offer_id,
-        sql_row.offer_name,
+        _clean_for_accounting(sql_row.offer_name),
         sql_row.offer_subcategory_id,
         booking_total_amount,
         booking_type,


### PR DESCRIPTION
…nerated csv

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11552

## But de la pull request

Retirer potentiel saut de ligne dans les champs texte de csv généré pour la finance
A voir dans un second temps contrôle des caractères dans les champs selon la norme ISO 20022 (XML SEPA)
qui normalement autorise tous les caractères UTF-8. Cependant, les banques françaises se limitent au jeu de caractères latins, composé de :
a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 0 1 2 3 4 5 6 7 8 9 / - ? : ( ) . , ? + Espace.

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
