### PR TITLE
(PC-12566) api: Fix exception when processing Ubble response: aware-offfset datetime

### DIFF
--- a/api/src/pcapi/core/fraud/api/ubble.py
+++ b/api/src/pcapi/core/fraud/api/ubble.py
@@ -22,7 +22,7 @@ def on_ubble_result(fraud_check: fraud_models.BeneficiaryFraudCheck) -> None:
 
 
 def _ubble_readable_score(score: typing.Optional[float]) -> str:
-    return fraud_models.ubble.UbbleScore(score).name if score else "AUCUN"
+    return fraud_models.ubble.UbbleScore(score).name if score is not None else "AUCUN"
 
 
 def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_models.FraudItem:
@@ -33,7 +33,7 @@ def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_
     # Decision from identification/score
     if content.score == fraud_models.ubble.UbbleScore.VALID.value:
         # Decision from age
-        age = users_utils.get_age_at_date(content.birth_date, content.registration_datetime)
+        age = users_utils.get_age_at_date(content.get_birth_date(), content.get_registration_datetime())
         if age < min(users_constants.ELIGIBILITY_UNDERAGE_RANGE):
             status = fraud_models.FraudStatus.KO
             reason_code = fraud_models.FraudReasonCode.AGE_TOO_YOUNG

--- a/api/tests/core/subscription/test_factories.py
+++ b/api/tests/core/subscription/test_factories.py
@@ -7,6 +7,7 @@ import uuid
 
 from dateutil.relativedelta import relativedelta
 import factory
+import pytz
 
 from pcapi import settings
 from pcapi.core.fraud.models import ubble as ubble_models
@@ -64,7 +65,7 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
         identification_state = IdentificationState.NEW
 
     anonymized_at = None
-    created_at = factory.LazyFunction(lambda: datetime.datetime.now())  # pylint: disable=unnecessary-lambda
+    created_at = factory.LazyFunction(lambda: datetime.datetime.now(tz=pytz.utc))  # pylint: disable=unnecessary-lambda
     identification_id = factory.LazyFunction(lambda: str(uuid.uuid4()))
     identification_url = factory.LazyAttribute(
         lambda o: f"{settings.UBBLE_API_URL}/identifications/{o.identification_id}"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12566


## But de la pull request

Test avec l'app sur testing : Exception lorsque Ubble OK mais ma date de naissance n'est pas celle déclarée.
Ça reste en PENDING du fait de cette exception, à cause des dates offset-naive vs offset-aware.
https://sentry.internal-passculture.app/organizations/sentry/issues/247478/?project=5

##  Implémentation

​
##  Informations supplémentaires


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
