### PR TITLE
[API] (PC-10791) use venueTypeCode only

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -12,12 +12,12 @@ from pcapi.connectors.api_adage import CulturalPartnerNotFoundException
 from pcapi.core import object_storage
 from pcapi.core import search
 import pcapi.core.finance.models as finance_models
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.exceptions import MissingOffererIdQueryParameter
 from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offerers.models import VenueContact
-from pcapi.core.offerers.models import VenueType
 from pcapi.core.offerers.repository import find_offerer_by_siren
 from pcapi.core.offerers.repository import find_offerer_by_validation_token
 from pcapi.core.offerers.repository import find_siren_by_offerer_id
@@ -55,13 +55,9 @@ def create_digital_venue(offerer: Offerer) -> Venue:
     digital_venue = Venue()
     digital_venue.isVirtual = True
     digital_venue.name = "Offre numérique"
-    digital_venue.venueTypeId = _get_digital_venue_type_id()
+    digital_venue.venueTypeCode = offerers_models.VenueTypeCode.DIGITAL
     digital_venue.managingOfferer = offerer
     return digital_venue
-
-
-def _get_digital_venue_type_id() -> int:
-    return VenueType.query.filter_by(label="Offre numérique").one().id
 
 
 def update_venue(
@@ -90,9 +86,6 @@ def update_venue(
             )
 
     venue.populate_from_dict(modifications)
-
-    # TODO: Remove this step when a new stable venue type system is setup
-    venue.fill_venue_type_code_from_label()
 
     repository.save(venue)
     search.async_index_venue_ids([venue.id])
@@ -149,9 +142,6 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
 
     if venue_data.contact:
         upsert_venue_contact(venue, venue_data.contact)
-
-    # TODO: Remove this step when a new stable venue type system is setup
-    venue.fill_venue_type_code_from_label()
 
     repository.save(venue)
 

--- a/api/src/pcapi/model_creators/generic_creators.py
+++ b/api/src/pcapi/model_creators/generic_creators.py
@@ -3,6 +3,7 @@ from hashlib import sha256
 from typing import Optional
 
 from pcapi.core.bookings.models import Booking
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Mediation
@@ -264,7 +265,7 @@ def create_venue(
     siret: Optional[str] = "12345678912345",
     thumb_count: int = 0,
     validation_token: Optional[str] = None,
-    venue_type_id: int = None,
+    venue_type_code: Optional[offerers_models.VenueTypeCode] = None,
     date_created: Optional[datetime] = datetime.now(),
 ) -> Venue:
     venue = Venue()
@@ -282,7 +283,7 @@ def create_venue(
     venue.thumbCount = thumb_count
     venue.validationToken = validation_token
     venue.siret = siret
-    venue.venueTypeId = venue_type_id
+    venue.venueTypeCode = venue_type_code
 
     if not is_virtual:
         venue.address = address

--- a/api/src/pcapi/routes/pro/venue_types.py
+++ b/api/src/pcapi/routes/pro/venue_types.py
@@ -1,6 +1,6 @@
 from flask_login import login_required
 
-from pcapi.core.offerers import repository as offerers_repository
+from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization.venue_types_serialize import VenueTypeListResponseModel
 from pcapi.routes.serialization.venue_types_serialize import VenueTypeResponseModel
@@ -11,8 +11,8 @@ from pcapi.serialization.decorator import spectree_serialize
 @login_required
 @spectree_serialize(response_model=VenueTypeListResponseModel)
 def get_venue_types() -> VenueTypeListResponseModel:
-    venue_type_list = [
-        VenueTypeResponseModel.from_orm(venue_type) for venue_type in offerers_repository.get_all_venue_types()
+    venue_types = [
+        VenueTypeResponseModel(id=code_id, label=label)
+        for code_id, label in offerers_models.VENUE_TYPE_CODE_MAPPING.items()
     ]
-
-    return VenueTypeListResponseModel(__root__=venue_type_list)
+    return VenueTypeListResponseModel(__root__=venue_types)

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -36,6 +36,9 @@ def get_venue(venue_id: str) -> GetVenueResponseModel:
     venue = load_or_404(Venue, venue_id)
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
 
+    # pydantic expects an enum key in order to build it, and therefore
+    # does not work when passing directly an enum instance.
+    venue.venueTypeCode = venue.venueTypeCode.name if venue.venueTypeCode else None
     return GetVenueResponseModel.from_orm(venue)
 
 
@@ -126,6 +129,9 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
     if body.bookingEmail and body.isEmailAppliedOnAllOffers:
         update_all_venue_offers_email_job.delay(venue, body.bookingEmail)
 
+    # pydantic expects an enum key in order to build it, and therefore
+    # does not work when passing directly an enum instance.
+    venue.venueTypeCode = venue.venueTypeCode.name if venue.venueTypeCode else None
     return GetVenueResponseModel.from_orm(venue)
 
 

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -29,7 +29,6 @@ class GetOffererVenueResponseModel(BaseModel):
     postalCode: Optional[str]
     publicName: Optional[str]
     venueLabelId: Optional[str]
-    venueTypeId: Optional[str]
     withdrawalDetails: Optional[str]
     audioDisabilityCompliant: Optional[bool]
     mentalDisabilityCompliant: Optional[bool]
@@ -38,7 +37,6 @@ class GetOffererVenueResponseModel(BaseModel):
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
     _humanize_venue_label_id = humanize_field("venueLabelId")
-    _humanize_venue_type_id = humanize_field("venueTypeId")
 
     class Config:
         orm_mode = True

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -479,7 +479,6 @@ class GetOfferVenueResponseModel(BaseModel):
     siret: Optional[str]
     thumbCount: int
     venueLabelId: Optional[str]
-    venueTypeId: Optional[str]
     audioDisabilityCompliant: Optional[bool]
     mentalDisabilityCompliant: Optional[bool]
     motorDisabilityCompliant: Optional[bool]
@@ -489,7 +488,6 @@ class GetOfferVenueResponseModel(BaseModel):
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
     _humanize_last_provider_id = humanize_field("lastProviderId")
     _humanize_venue_label_id = humanize_field("venueLabelId")
-    _humanize_venue_type_id = humanize_field("venueTypeId")
 
     class Config:
         orm_mode = True

--- a/api/src/pcapi/routes/serialization/venue_types_serialize.py
+++ b/api/src/pcapi/routes/serialization/venue_types_serialize.py
@@ -1,16 +1,9 @@
 from pydantic import BaseModel
 
-from pcapi.serialization.utils import humanize_field
-
 
 class VenueTypeResponseModel(BaseModel):
     id: str
     label: str
-
-    _humanize_id = humanize_field("id")
-
-    class Config:
-        orm_mode = True
 
 
 class VenueTypeListResponseModel(BaseModel):

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from pydantic import root_validator
 from pydantic import validator
 
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.validation import VENUE_BANNER_MAX_SIZE
 from pcapi.routes.serialization.finance_serialize import BusinessUnitResponseModel
 from pcapi.serialization.utils import dehumanize_field
@@ -70,7 +71,7 @@ class PostVenueBodyModel(BaseModel):
     postalCode: str
     siret: Optional[str]
     venueLabelId: Optional[str]
-    venueTypeId: str
+    venueTypeCode: str
     withdrawalDetails: Optional[str]
     description: Optional[VenueDescription]  # type: ignore
     audioDisabilityCompliant: Optional[bool]
@@ -176,7 +177,7 @@ class GetVenueResponseModel(BaseModel):
     publicName: Optional[str]
     siret: Optional[str]
     venueLabelId: Optional[str]
-    venueTypeId: Optional[str]
+    venueTypeCode: Optional[offerers_models.VenueTypeCode]
     withdrawalDetails: Optional[str]
     description: Optional[VenueDescription]  # type: ignore
     audioDisabilityCompliant: Optional[bool]
@@ -190,7 +191,6 @@ class GetVenueResponseModel(BaseModel):
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
     _humanize_venue_label_id = humanize_field("venueLabelId")
-    _humanize_venue_type_id = humanize_field("venueTypeId")
 
     class Config:
         orm_mode = True
@@ -208,7 +208,7 @@ class EditVenueBodyModel(BaseModel):
     city: Optional[str]
     publicName: Optional[str]
     comment: Optional[str]
-    venueTypeId: Optional[int]
+    venueTypeCode: Optional[str]
     venueLabelId: Optional[int]
     withdrawalDetails: Optional[str]
     isAccessibilityAppliedOnAllOffers: Optional[bool]
@@ -223,7 +223,6 @@ class EditVenueBodyModel(BaseModel):
     businessUnitId: Optional[int]
 
     _dehumanize_venue_label_id = dehumanize_field("venueLabelId")
-    _dehumanize_venue_type_id = dehumanize_field("venueTypeId")
 
 
 class VenueListItemResponseModel(BaseModel):

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -234,7 +234,6 @@ class Returns200Test:
                 "siret": "12345678912345",
                 "thumbCount": 0,
                 "venueLabelId": None,
-                "venueTypeId": humanize(venue.venueTypeId),
                 "visualDisabilityCompliant": False,
             },
             "venueId": humanize(venue.id),

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -87,7 +87,6 @@ class Returns200Test:
                     "postalCode": offererVenue.postalCode,
                     "publicName": offererVenue.publicName,
                     "venueLabelId": humanize(offererVenue.venueLabelId),
-                    "venueTypeId": humanize(offererVenue.venueTypeId),
                     "visualDisabilityCompliant": False,
                     "withdrawalDetails": offererVenue.withdrawalDetails,
                 }

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -10,7 +10,7 @@ from tests.conftest import TestClient
 
 class Returns200Test:
     @pytest.mark.usefixtures("db_session")
-    def when_user_has_rights_on_managing_offerer(self, app):
+    def when_user_has_rights_on_managing_offerer(self, client):
         # given
         user_offerer = offers_factories.UserOffererFactory(user__email="user.pro@test.com")
         venue = offers_factories.VenueFactory(name="L'encre et la plume", managingOfferer=user_offerer.offerer)
@@ -77,13 +77,13 @@ class Returns200Test:
             "publicName": venue.publicName,
             "siret": venue.siret,
             "venueLabelId": humanize(venue.venueLabelId),
-            "venueTypeId": humanize(venue.venueTypeId),
+            "venueTypeCode": venue.venueTypeCode.name if venue.venueTypeCode else None,
             "visualDisabilityCompliant": venue.visualDisabilityCompliant,
             "withdrawalDetails": None,
         }
 
         # when
-        auth_request = TestClient(app.test_client()).with_session_auth(email=user_offerer.user.email)
+        auth_request = client.with_session_auth(email=user_offerer.user.email)
         response = auth_request.get("/venues/%s" % humanize(venue.id))
 
         # then

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -24,7 +24,6 @@ def populate_missing_data_from_venue(venue_data: dict, venue: offerers_models.Ve
         "postalCode": venue.postalCode,
         "publicName": venue.publicName,
         "siret": venue.siret,
-        "venueTypeId": humanize(venue.venueTypeId),
         "venueLabelId": humanize(venue.venueLabelId),
         "withdrawalDetails": venue.withdrawalDetails,
         "isEmailAppliedOnAllOffers": False,
@@ -41,7 +40,6 @@ class Returns200Test:
         user_offerer = offers_factories.UserOffererFactory()
         venue = offers_factories.VenueFactory(name="old name", managingOfferer=user_offerer.offerer)
 
-        venue_type = offerers_factories.VenueTypeFactory(label="Musée")
         venue_label = offerers_factories.VenueLabelFactory(label="CAC - Centre d'art contemporain d'intérêt national")
 
         auth_request = TestClient(app.test_client()).with_session_auth(email=user_offerer.user.email)
@@ -51,7 +49,7 @@ class Returns200Test:
         venue_data = populate_missing_data_from_venue(
             {
                 "name": "Ma librairie",
-                "venueTypeId": humanize(venue_type.id),
+                "venueTypeCode": "BOOKSTORE",
                 "venueLabelId": humanize(venue_label.id),
             },
             venue,
@@ -63,7 +61,7 @@ class Returns200Test:
         assert response.status_code == 200
         venue = Venue.query.get(venue_id)
         assert venue.name == "Ma librairie"
-        assert venue.venueTypeId == venue_type.id
+        assert venue.venueTypeCode == "BOOKSTORE"
         json = response.json
         assert json["isValidated"] is True
         assert "validationToken" not in json

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -11,7 +11,6 @@ from pcapi.core.offers.factories import UserOffererFactory
 from pcapi.core.users.factories import AdminFactory
 from pcapi.core.users.factories import ProFactory
 from pcapi.models.user_offerer import UserOfferer
-from pcapi.utils.human_ids import humanize
 
 from tests.conftest import TestClient
 
@@ -32,7 +31,8 @@ class Returns201Test:
         )
 
         pro = ProFactory()
-        digital_venue_type = VirtualVenueTypeFactory()
+        VirtualVenueTypeFactory()
+
         body = {
             "name": "Test Offerer",
             "siren": "418166096",
@@ -50,7 +50,6 @@ class Returns201Test:
         assert response.json["name"] == "Test Offerer"
         virtual_venues = list(filter(lambda v: v["isVirtual"], response.json["managedVenues"]))
         assert len(virtual_venues) == 1
-        assert virtual_venues[0]["venueTypeId"] == humanize(digital_venue_type.id)
 
     @patch("pcapi.connectors.api_entreprises.requests.get")
     @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -27,7 +27,6 @@ def create_valid_venue_data(user=None):
     if user:
         user_offerer_data["user"] = user
     user_offerer = offers_factories.UserOffererFactory(**user_offerer_data)
-    venue_type = offerers_factories.VenueTypeFactory(label="Musée")
     venue_label = offerers_factories.VenueLabelFactory(label="CAC - Centre d'art contemporain d'intérêt national")
 
     return {
@@ -41,7 +40,7 @@ def create_valid_venue_data(user=None):
         "latitude": 48.82387,
         "longitude": 2.35284,
         "publicName": "Ma venue publique",
-        "venueTypeId": humanize(venue_type.id),
+        "venueTypeCode": "BOOKSTORE",
         "venueLabelId": humanize(venue_label.id),
         "description": "Some description",
         "audioDisabilityCompliant": True,
@@ -53,10 +52,10 @@ def create_valid_venue_data(user=None):
 
 
 @pytest.mark.usefixtures("db_session")
-def test_should_register_new_venue(app):
+def test_should_register_new_venue(client):
     # given
     user = ProFactory()
-    auth_request = TestClient(app.test_client()).with_session_auth(email=user.email)
+    auth_request = client.with_session_auth(email=user.email)
     venue_data = create_valid_venue_data(user)
 
     # when
@@ -71,7 +70,7 @@ def test_should_register_new_venue(app):
     assert venue.name == venue_data["name"]
     assert venue.publicName == venue_data["publicName"]
     assert venue.siret == venue_data["siret"]
-    assert venue.venueTypeId == dehumanize(venue_data["venueTypeId"])
+    assert venue.venueTypeCode.name == "BOOKSTORE"
     assert venue.venueLabelId == dehumanize(venue_data["venueLabelId"])
     assert venue.description == venue_data["description"]
     assert venue.audioDisabilityCompliant == venue_data["audioDisabilityCompliant"]

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcapi.core.offerers.factories import VirtualVenueTypeFactory
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import UserOffererFactory
@@ -31,7 +31,6 @@ class Returns204Test:
     def when_user_data_is_valid(self, app):
         # Given
         data = BASE_DATA_PRO.copy()
-        venue_type = VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -59,7 +58,7 @@ class Returns204Test:
         assert offerer.validationToken is not None
         assert len(offerer.managedVenues) == 1
         assert offerer.managedVenues[0].isVirtual
-        assert offerer.managedVenues[0].venueTypeId == venue_type.id
+        assert offerer.managedVenues[0].venueTypeCode == offerers_models.VenueTypeCode.DIGITAL
         user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
         assert user_offerer is not None
         assert user_offerer.validationToken is None
@@ -68,7 +67,6 @@ class Returns204Test:
         # Given
         data_pro = BASE_DATA_PRO.copy()
         data_pro["contactOk"] = "true"
-        venue_type = VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data_pro)
@@ -84,14 +82,13 @@ class Returns204Test:
         assert offerer.validationToken is not None
         assert len(offerer.managedVenues) == 1
         assert offerer.managedVenues[0].isVirtual
-        assert offerer.managedVenues[0].venueTypeId == venue_type.id
+        assert offerer.managedVenues[0].venueTypeCode == offerers_models.VenueTypeCode.DIGITAL
         user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
         assert user_offerer is not None
         assert user_offerer.validationToken is None
 
     def when_successful_and_existing_offerer_creates_editor_user_offerer_and_does_not_log_in(self, app):
         # Given
-        VirtualVenueTypeFactory()
         offerer = OffererFactory(siren="349974931", validationToken="not_validated")
         pro = ProFactory(email="bobby@test.com", publicName="bobby")
         UserOffererFactory(user=pro, offerer=offerer)
@@ -166,7 +163,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         data["email"] = "toto"
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -179,7 +175,6 @@ class Returns400Test:
     def when_email_is_already_used(self, app):
         # Given
         data = BASE_DATA_PRO.copy()
-        VirtualVenueTypeFactory()
         TestClient(app.test_client()).post("/users/signup/pro", json=data)
 
         # When
@@ -194,7 +189,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         del data["publicName"]
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -208,7 +202,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         data["publicName"] = "x" * 300
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -254,7 +247,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         del data["name"]
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -268,7 +260,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         del data["city"]
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -282,7 +273,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         del data["postalCode"]
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -296,7 +286,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         data["postalCode"] = "111"
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)
@@ -323,7 +312,6 @@ class Returns400Test:
             "isAdmin": True,
             "contactOk": "true",
         }
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=user_json)
@@ -337,7 +325,6 @@ class Returns400Test:
         # Given
         data = BASE_DATA_PRO.copy()
         data["phoneNumber"] = "abc 123"
-        VirtualVenueTypeFactory()
 
         # When
         response = TestClient(app.test_client()).post("/users/signup/pro", json=data)

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreationContainer.spec.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreationContainer.spec.js
@@ -244,7 +244,7 @@ describe('src | components | pages | VenueContainer | mapDispatchToProps', () =>
             comment: 'Commentaire',
             description: 'description',
             address: '3 Place Saint-Michel',
-            venueTypeId: null,
+            venueTypeCode: null,
             venueLabelId: null,
           },
           handleFail: handleFail,

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
@@ -137,7 +137,7 @@ const VenueEdition = ({
       latitude: formLatitude,
       longitude: formLongitude,
       siret: formSiret,
-      venueTypeId,
+      venueTypeCode,
       venueLabelId,
     } = values
 
@@ -169,7 +169,7 @@ const VenueEdition = ({
             venueIsVirtual={initialIsVirtual}
             venueLabelId={venueLabelId}
             venueLabels={venueLabels}
-            venueTypeId={venueTypeId}
+            venueTypeCode={venueTypeCode}
             venueTypes={venueTypes}
           />
           {!initialIsVirtual && (

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/__specs__/VenueEdition.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/__specs__/VenueEdition.spec.jsx
@@ -99,7 +99,7 @@ describe('test page : VenueEdition', () => {
         postalCode: '75000',
         publicName: 'Maison de la Brique',
         siret: '22222222311111',
-        venueTypeId: 'DE',
+        venueTypeCode: 'DE',
         businessUnit: { id: 20 },
         contact: {
           email: '',

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/__specs__/VenueEditionContainer.spec.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/__specs__/VenueEditionContainer.spec.js
@@ -261,7 +261,7 @@ describe('src | components | pages | VenueContainer | mapDispatchToProps', () =>
             comment: 'Commentaire',
             description: '',
             address: '3 Place Saint-Michel',
-            venueTypeId: null,
+            venueTypeCode: null,
             venueLabelId: null,
           },
           handleFail: handleFail,
@@ -312,7 +312,7 @@ describe('src | components | pages | VenueContainer | mapDispatchToProps', () =>
           publicName: '',
           postalCode: '75008',
           siret: '25687265176',
-          venueTypeId: 'BA',
+          venueTypeCode: 'BA',
           venueLabelId: 'DA',
         }
 
@@ -345,7 +345,7 @@ describe('src | components | pages | VenueContainer | mapDispatchToProps', () =>
           postalCode: '75008',
           publicName: '',
           siret: '25687265176',
-          venueTypeId: 'BA',
+          venueTypeCode: 'BA',
           venueLabelId: 'DA',
         })
       })
@@ -389,7 +389,7 @@ describe('src | components | pages | VenueContainer | mapDispatchToProps', () =>
           publicName: '',
           postalCode: '75008',
           siret: '25687265176',
-          venueTypeId: 'BA',
+          venueTypeCode: 'BA',
         }
 
         const handleFail = jest.fn()
@@ -416,7 +416,7 @@ describe('src | components | pages | VenueContainer | mapDispatchToProps', () =>
           publicName: '',
           postalCode: '75008',
           siret: '25687265176',
-          venueTypeId: 'BA',
+          venueTypeCode: 'BA',
           venueLabelId: null,
         })
       })

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/IdentifierFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/IdentifierFields.jsx
@@ -112,7 +112,7 @@ class IdentifierFields extends PureComponent {
       venueLabels,
       venueLabelId,
       venueTypes,
-      venueTypeId,
+      venueTypeCode,
     } = this.props
 
     const venueTypesWithoutVirtualOffer = venueTypes.filter(
@@ -123,7 +123,7 @@ class IdentifierFields extends PureComponent {
       ? 'SIRET du lieu qui accueille vos offres (si applicable) : '
       : 'SIRET : '
 
-    const venueTypeLabel = getLabelFromList(venueTypes, venueTypeId)
+    const venueTypeLabel = getLabelFromList(venueTypes, venueTypeCode)
     const venueLabelText = getLabelFromList(venueLabels, venueLabelId)
 
     return (
@@ -217,7 +217,7 @@ class IdentifierFields extends PureComponent {
                     <Field
                       component="select"
                       id="venue-type"
-                      name="venueTypeId"
+                      name="venueTypeCode"
                       required
                       validate={this.venueTypeValidate}
                     >
@@ -304,7 +304,7 @@ IdentifierFields.defaultProps = {
   readOnly: true,
   venueIsVirtual: false,
   venueLabelId: null,
-  venueTypeId: null,
+  venueTypeCode: null,
 }
 
 IdentifierFields.propTypes = {
@@ -317,7 +317,7 @@ IdentifierFields.propTypes = {
   venueIsVirtual: PropTypes.bool,
   venueLabelId: PropTypes.string,
   venueLabels: PropTypes.arrayOf(PropTypes.instanceOf(VenueLabel)).isRequired,
-  venueTypeId: PropTypes.string,
+  venueTypeCode: PropTypes.string,
   venueTypes: PropTypes.arrayOf(PropTypes.instanceOf(VenueType)).isRequired,
 }
 

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/__specs__/IdentifierFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/__specs__/IdentifierFields.spec.jsx
@@ -31,7 +31,7 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       isModifiedEntity: true,
       readOnly: true,
       venueTypes: [],
-      venueTypeId: null,
+      venueTypeCode: null,
       venueLabels: [],
       venueLabelId: null,
     }
@@ -423,7 +423,7 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
           it('should not exist', () => {
             // Given
             props.readOnly = true
-            props.venueTypeId = null
+            props.venueTypeCode = null
             props.venueTypes = [
               new VenueType({ id: 'A1', label: "Centre d'art et d'essais" }),
             ]
@@ -443,7 +443,7 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
           it('should display the label', () => {
             // Given
             props.readOnly = true
-            props.venueTypeId = 'A1'
+            props.venueTypeCode = 'A1'
             props.venueTypes = [
               new VenueType({ id: 'A1', label: "Centre d'art et d'essais" }),
             ]

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/utils/getLabelFromList.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/utils/getLabelFromList.js
@@ -2,9 +2,9 @@
  * @debt complexity "Gaël: file nested too deep in directory structure"
  */
 
-const getLabelFromList = (venueTypes, venueTypeId) => {
+const getLabelFromList = (venueTypes, venueTypeCode) => {
   const venueType = venueTypes.find(venueType => {
-    return venueType.id === venueTypeId
+    return venueType.id === venueTypeCode
   })
   return venueType ? venueType.label : '-'
 }

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/__specs__/formatPatch.spec.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/__specs__/formatPatch.spec.js
@@ -51,7 +51,7 @@ describe('formatPatch', () => {
         publicName: 'Cinéma de la fin des fins',
         postalCode: '93600',
         siret: '22222222911111',
-        venueTypeId: null,
+        venueTypeCode: null,
         venueLabelId: null,
       }
       // then
@@ -104,15 +104,15 @@ describe('formatPatch', () => {
         publicName: 'Cinéma de la fin publique',
         postalCode: '93600',
         siret: '22222222911111',
-        venueTypeId: null,
+        venueTypeCode: null,
         venueLabelId: null,
       })
     })
 
-    it('should preserve venueTypeId and venueLabelId when empty', () => {
+    it('should preserve venueTypeCode and venueLabelId when empty', () => {
       // given
       const patch = {
-        venueTypeId: '',
+        venueTypeCode: '',
         venueLabelId: '',
       }
 
@@ -121,7 +121,7 @@ describe('formatPatch', () => {
 
       // then
       expect(result).toStrictEqual({
-        venueTypeId: '',
+        venueTypeCode: '',
         venueLabelId: '',
         description: '',
       })

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
@@ -19,7 +19,7 @@ const creation_authorized_input_field = [
   'publicName',
   'siret',
   'venueLabelId',
-  'venueTypeId',
+  'venueTypeCode',
   'withdrawalDetails',
   'audioDisabilityCompliant',
   'mentalDisabilityCompliant',
@@ -45,7 +45,7 @@ const edition_authorized_input_field = [
   'publicName',
   'siret',
   'venueLabelId',
-  'venueTypeId',
+  'venueTypeCode',
   'withdrawalDetails',
   'audioDisabilityCompliant',
   'mentalDisabilityCompliant',
@@ -81,7 +81,7 @@ export const formatVenuePayload = (payload, isCreatedEntity) => {
 
     if (payload[inputName] !== undefined) {
       requestPayload[inputName] = payload[inputName]
-    } else if (inputName === 'venueTypeId' || inputName === 'venueLabelId') {
+    } else if (inputName === 'venueTypeCode' || inputName === 'venueLabelId') {
       requestPayload[inputName] = null
     }
   })

--- a/pro/src/core/OfferEducational/adapters/getOfferersAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getOfferersAdapter.ts
@@ -63,7 +63,6 @@ type IAPIOfferer = {
     thumbCount: number
     venueLabelId: string | null
     venueTypeCode: string
-    venueTypeId: string
     visualDisabilityCompliant: boolean
     withdrawalDetails: null
   }[]

--- a/pro/src/routes/BusinessUnitList/BusinessUnitList.tsx
+++ b/pro/src/routes/BusinessUnitList/BusinessUnitList.tsx
@@ -33,7 +33,7 @@ interface IAPIVenue {
   postalCode: string | null
   publicName: string
   venueLabelId: string | null
-  venueTypeId: string | null
+  venueTypeCode: string | null
   withdrawalDetails: string | null
   audioDisabilityCompliant: boolean
   mentalDisabilityCompliant: boolean


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10791


## But de la pull request

Supprimer l'utilisation de `venueTypeId` côté pro.

**Contexte**
Cette colonne (avec la table `venue_type`) vise à être remplacée par `venueTypeCode`. Le but est d'avoir un code stable qui permet de faire un mapping (label / icône / etc.) - le mapping est réalisé côté app native pour l'instant.

L'app native utilise directement `venue.venueTypeCode` et pour l'instant on mettait à jour les deux colonnes (`venue.venueTypeId` et `venue.venueTypeCode`) en attendant de terminer la transition.

Il reste un test à corriger côté webapp mais c'est un peu plus compliqué que prévu, et vu qu'on veut supprimer la webapp... pas la peine de creuser, non ?
