### PR TITLE
[pc-12806][api] Allows to update idPieceNumber in flask

### DIFF
--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from flask.helpers import flash
+from flask_admin.contrib.sqla import tools
 from flask_admin.contrib.sqla.filters import BaseSQLAFilter
 from markupsafe import Markup
 from sqlalchemy import and_
@@ -187,6 +188,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         has_active_deposit="Dépôt valable ?",
         has_beneficiary_role="Bénéficiaire 18 ans ?",
         has_underage_beneficiary_role="Bénéficiaire 15-17 ?",
+        idPieceNumber="N° de pièce d'identité",
         isActive="Est activé",
         isEmailValidated="Email validé ?",
         lastName="Nom",
@@ -233,6 +235,9 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         )
         if self.check_super_admins():
             fields += ("firstName", "lastName", "comment")
+        if settings.IS_TESTING:
+            fields += ("idPieceNumber",)
+
         return fields
 
     form_args = dict(
@@ -278,6 +283,9 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
                 "error",
             )
         super().after_model_change(form, model, is_created)
+
+    def get_one(self, model_id: str) -> query:
+        return User.query.get(tools.iterdecode(model_id))
 
     def get_query(self) -> query:
         return (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12806


## But de la pull request

Permettre la mise à jour de la pièce d'identité en testing uniquement pour simplifier les tests ubble
et pouvoir retester avec la meme ID

##  Implémentation

Autoriser la modification uniquement en testing

##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)