### PR TITLE
[PC-12573][script] feature(payments): allow partial batch to be marked as sent

### DIFF
--- a/api/src/pcapi/scripts/payment/mark_payments_as_sent.py
+++ b/api/src/pcapi/scripts/payment/mark_payments_as_sent.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.functions import func
 
 from pcapi.core.bookings.api import mark_bookings_as_reimbursed_from_payment_ids
@@ -28,6 +29,16 @@ def get_payments_ids_under_review(min_id: int, batch_size: int, transaction_labe
     return [payment_id for payment_id, in payments_ids_query.all()]
 
 
+def mark_payments_batch_as_sent(payments_ids: list[int], now: datetime.datetime) -> None:
+    payment_statuses_to_add: list[PaymentStatus] = []
+    for payment_id in payments_ids:
+        payment_statuses_to_add.append(PaymentStatus(paymentId=payment_id, status=TransactionStatus.SENT, date=now))
+
+    db.session.bulk_save_objects(payment_statuses_to_add)
+    mark_bookings_as_reimbursed_from_payment_ids(payments_ids, now)
+    db.session.commit()
+
+
 def mark_payments_as_sent(transaction_label: str, batch_size: int = 1000) -> None:
     modified_sum = 0
     min_id = db.session.query(func.min(Payment.id)).filter(Payment.transactionLabel == transaction_label).scalar()
@@ -43,14 +54,51 @@ def mark_payments_as_sent(transaction_label: str, batch_size: int = 1000) -> Non
         if len(payments_ids) == 0:
             continue
 
-        payment_statuses_to_add: list[PaymentStatus] = []
-        for payment_id in payments_ids:
-            payment_statuses_to_add.append(PaymentStatus(paymentId=payment_id, status=TransactionStatus.SENT, date=now))
-
-        db.session.bulk_save_objects(payment_statuses_to_add)
-        mark_bookings_as_reimbursed_from_payment_ids(payments_ids, now)
-        db.session.commit()
-
+        mark_payments_batch_as_sent(payments_ids, now)
         modified_sum += len(payments_ids)
 
     logger.info("%d payments have been marked as sent for transaction %s", modified_sum, transaction_label)
+
+
+def mark_payments_as_sent_from_file(ids_file: str, transaction_label: str, batch_size: int = 1000) -> None:
+    """
+    Allows to mark as SENT payments whose ids are read from a text file.
+    The transaction label is used only to check the payments' ones.
+    The file must be a text file with one id per line.
+
+    ---usage---
+
+    Copy the text file on the pod before running the function with `kubectl ps`:
+        kubens staging  # choose the correct namespace
+        kubectl get pods  # eventually list the pods to retrieve the wanted one (console)
+        kubectl cp /local/path/to/reimbursement_ids.txt <the console pod name>:/usr/src
+
+    Open a python interpreter on the pod:
+        pc -e staging python
+
+    Run the function:
+        from pcapi.scripts.payment.mark_payments_as_sent import mark_payments_as_sent_from_file
+        mark_payments_as_sent_from_file('/usr/src/reimbursement_ids.txt', '<the related transaction label>')
+
+    """
+    with open(ids_file, "r") as fp:
+        ids = [int(_id.strip()) for _id in fp if _id]
+    batches = [ids[index : index + batch_size] for index in range(0, len(ids), batch_size)]
+
+    now = datetime.datetime.utcnow()
+    for batch_nr, batch in enumerate(batches):
+        errors = []
+        print(f"processing batch#{batch_nr}", end=": ")
+        payments = Payment.query.filter(Payment.id.in_(batch)).options(joinedload(Payment.statuses))
+        for payment in payments:
+            if payment.transactionLabel != transaction_label:
+                errors.append(f"payment#{payment.id}: wrong transaction label '{payment.transactionLabel}'")
+            if payment.currentStatus.status != TransactionStatus.UNDER_REVIEW:
+                errors.append(f"payment#{payment.id}: wrong transaction status '{payment.currentStatus.status}'")
+
+        if errors:
+            print(f"{len(errors)} errors")
+            print("\n".join(errors))
+        else:
+            mark_payments_batch_as_sent(batch, now)
+            print(f"{len(batch)} payments marked as sent")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12573


## But de la pull request

permettre de passer au status SENT seulement une partie des remboursements à partir d'un fichier texte de payment id

##  Implémentation

nouvelle fonction qui prend en entrée un fichier texte d'id de remboursements
​
##  Informations supplémentaires

nope
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
