### PR TITLE
(PC-12584) Refacto core.fraud files

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -7,7 +7,7 @@ import requests
 from pcapi import settings
 from pcapi.connectors.beneficiaries import exceptions
 from pcapi.core import logging as core_logging
-from pcapi.core.fraud.models import ubble as ubble_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 
 
 logger = logging.getLogger(__name__)
@@ -31,32 +31,32 @@ def build_url(path: str) -> str:
 
 
 INCLUDED_MODELS = {
-    "documents": ubble_models.UbbleIdentificationDocuments,
-    "document-checks": ubble_models.UbbleIdentificationDocumentChecks,
-    "reference-data-checks": ubble_models.UbbleIdentificationReferenceDataChecks,
+    "documents": ubble_fraud_models.UbbleIdentificationDocuments,
+    "document-checks": ubble_fraud_models.UbbleIdentificationDocumentChecks,
+    "reference-data-checks": ubble_fraud_models.UbbleIdentificationReferenceDataChecks,
 }
 
 
 def _get_included_attributes(
-    response: ubble_models.UbbleIdentificationResponse, type_: str
-) -> ubble_models.UbbleIdentificationObject:
+    response: ubble_fraud_models.UbbleIdentificationResponse, type_: str
+) -> ubble_fraud_models.UbbleIdentificationObject:
     filtered = list(filter(lambda included: included["type"] == type_, response["included"]))
     attributes = INCLUDED_MODELS[type_](**filtered[0].get("attributes")) if filtered else None
     return attributes
 
 
-def _get_data_attribute(response: ubble_models.UbbleIdentificationResponse, name: str) -> typing.Any:
+def _get_data_attribute(response: ubble_fraud_models.UbbleIdentificationResponse, name: str) -> typing.Any:
     return response["data"]["attributes"].get(name)
 
 
 def _extract_useful_content_from_response(
-    response: ubble_models.UbbleIdentificationResponse,
-) -> ubble_models.UbbleContent:
-    documents: ubble_models.UbbleIdentificationDocuments = _get_included_attributes(response, "documents")
-    document_checks: ubble_models.UbbleIdentificationDocumentChecks = _get_included_attributes(
+    response: ubble_fraud_models.UbbleIdentificationResponse,
+) -> ubble_fraud_models.UbbleContent:
+    documents: ubble_fraud_models.UbbleIdentificationDocuments = _get_included_attributes(response, "documents")
+    document_checks: ubble_fraud_models.UbbleIdentificationDocumentChecks = _get_included_attributes(
         response, "document-checks"
     )
-    reference_data_checks: ubble_models.UbbleIdentificationReferenceDataChecks = _get_included_attributes(
+    reference_data_checks: ubble_fraud_models.UbbleIdentificationReferenceDataChecks = _get_included_attributes(
         response, "reference-data-checks"
     )
 
@@ -67,7 +67,7 @@ def _extract_useful_content_from_response(
     status = _get_data_attribute(response, "status")
     registered_at = _get_data_attribute(response, "created-at")
 
-    content = ubble_models.UbbleContent(
+    content = ubble_fraud_models.UbbleContent(
         status=status,
         birth_date=getattr(documents, "birth_date", None),
         first_name=getattr(documents, "first_name", None),
@@ -93,7 +93,7 @@ def start_identification(
     last_name: str,
     webhook_url: str,
     redirect_url: str,
-) -> ubble_models.UbbleContent:
+) -> ubble_fraud_models.UbbleContent:
     session = configure_session()
 
     data = {
@@ -171,7 +171,7 @@ def start_identification(
     return content
 
 
-def get_content(identification_id: str) -> ubble_models.UbbleContent:
+def get_content(identification_id: str) -> ubble_fraud_models.UbbleContent:
     session = configure_session()
     response = session.get(build_url(f"/identifications/{identification_id}/"))
 

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -14,12 +14,11 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.repository import repository
 from pcapi.repository.user_queries import matching
 
-from . import ubble as ubble_api
-from .. import exceptions
-from .. import models
-from .. import repository as fraud_repository
-from ..models import BeneficiaryFraudCheck
-from ..models import ubble as ubble_models
+from . import exceptions
+from . import models
+from . import repository as fraud_repository
+from .ubble import api as ubble_api
+from .ubble import models as ubble_fraud_models
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ USER_PROFILING_FRAUD_CHECK_STATUS_RISK_MAPPING = {
 
 def on_educonnect_result(
     user: users_models.User, educonnect_content: models.EduconnectContent
-) -> BeneficiaryFraudCheck:
+) -> models.BeneficiaryFraudCheck:
     eligibility_type = educonnect_content.get_eligibility_type()
 
     fraud_check = models.BeneficiaryFraudCheck.query.filter(
@@ -580,7 +579,7 @@ def has_user_pending_identity_check(user: users_models.User) -> bool:
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
             models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
             models.BeneficiaryFraudCheck.resultContent["status"]
-            != models.ubble_models.UbbleIdentificationStatus.INITIATED,
+            != models.ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
         ).exists()
     ).scalar()
 
@@ -645,7 +644,7 @@ def is_user_fraudster(user: users_models.User) -> bool:
 def start_fraud_check(
     user: users_models.User,
     application_id: str,
-    source_data: typing.Union[models.DMSContent, ubble_models.UbbleContent],
+    source_data: typing.Union[models.DMSContent, ubble_fraud_models.UbbleContent],
 ) -> models.BeneficiaryFraudCheck:
 
     source_type = models.FRAUD_CONTENT_MAPPING[type(source_data)]
@@ -675,7 +674,7 @@ def start_fraud_check(
 def mark_fraud_check_failed(
     user: users_models.User,
     application_id: str,
-    source_data: typing.Union[models.DMSContent, ubble_models.UbbleContent],
+    source_data: typing.Union[models.DMSContent, ubble_fraud_models.UbbleContent],
     reasons: list[models.FraudItem],
 ) -> None:
     source_type = models.FRAUD_CONTENT_MAPPING[type(source_data)]

--- a/api/src/pcapi/core/fraud/common/models.py
+++ b/api/src/pcapi/core/fraud/common/models.py
@@ -2,8 +2,10 @@ import datetime
 import typing
 
 import pydantic
+import pydantic.datetime_parse
+import pydantic.errors
 
-from pcapi.core.users.models import EligibilityType
+from pcapi.core.users import models as users_models
 
 
 class IdentityCheckContent(pydantic.BaseModel):
@@ -22,7 +24,7 @@ class IdentityCheckContent(pydantic.BaseModel):
     def get_id_piece_number(self) -> typing.Optional[str]:
         raise NotImplementedError()
 
-    def get_eligibility_type(self) -> typing.Optional[EligibilityType]:
+    def get_eligibility_type(self) -> typing.Optional[users_models.EligibilityType]:
         from pcapi.core.users import api as users_api
 
         registration_datetime = self.get_registration_datetime()
@@ -36,7 +38,10 @@ class IdentityCheckContent(pydantic.BaseModel):
 
         # When a user turns 18, his underage credit expires.
         # If he turned 18 between registration and today, we consider the application as coming from a 18 years old user
-        if eligibility_today == EligibilityType.AGE18 and eligibility_at_registration == EligibilityType.UNDERAGE:
-            return EligibilityType.AGE18
+        if (
+            eligibility_today == users_models.EligibilityType.AGE18
+            and eligibility_at_registration == users_models.EligibilityType.UNDERAGE
+        ):
+            return users_models.EligibilityType.AGE18
 
         return eligibility_at_registration

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -10,7 +10,7 @@ import factory.fuzzy
 import pytz
 
 from pcapi.core import testing
-import pcapi.core.fraud.models as fraud_models
+import pcapi.core.fraud.ubble.models as ubble_fraud_models
 from pcapi.core.users import models as users_models
 import pcapi.core.users.factories as users_factories
 
@@ -115,7 +115,7 @@ class DMSContentFactory(factory.Factory):
 
 class UbbleContentFactory(factory.Factory):
     class Meta:
-        model = fraud_models.ubble.UbbleContent
+        model = ubble_fraud_models.UbbleContent
 
     status = None
     birth_date = (date.today() - relativedelta(years=18, months=4)).isoformat()

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -15,8 +15,8 @@ from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 
-from . import ubble as ubble_models
-from .common import IdentityCheckContent
+from .common import models as common_models
+from .ubble import models as ubble_fraud_models
 
 
 class FraudCheckType(enum.Enum):
@@ -87,7 +87,7 @@ def _parse_jouve_datetime(date: typing.Optional[str]) -> typing.Optional[datetim
         return None
 
 
-class EduconnectContent(IdentityCheckContent):
+class EduconnectContent(common_models.IdentityCheckContent):
     birth_date: datetime.date
     educonnect_id: str
     first_name: str
@@ -113,7 +113,7 @@ class EduconnectContent(IdentityCheckContent):
         return None
 
 
-class JouveContent(IdentityCheckContent):
+class JouveContent(common_models.IdentityCheckContent):
     # TODO: analyze jouve results to see where we can remove "optional"
     activity: typing.Optional[str]
     address: typing.Optional[str]
@@ -166,7 +166,7 @@ class JouveContent(IdentityCheckContent):
         return self.bodyPieceNumber
 
 
-class DMSContent(IdentityCheckContent):
+class DMSContent(common_models.IdentityCheckContent):
     last_name: str
     first_name: str
     civility: str
@@ -246,7 +246,7 @@ IdCheckContent = typing.TypeVar(
     DMSContent,
     EduconnectContent,
     JouveContent,
-    ubble_models.UbbleContent,
+    ubble_fraud_models.UbbleContent,
     UserProfilingFraudData,
 )
 
@@ -271,7 +271,7 @@ FRAUD_CHECK_MAPPING = {
     FraudCheckType.JOUVE: JouveContent,
     FraudCheckType.INTERNAL_REVIEW: InternalReviewFraudData,
     FraudCheckType.EDUCONNECT: EduconnectContent,
-    FraudCheckType.UBBLE: ubble_models.UbbleContent,
+    FraudCheckType.UBBLE: ubble_fraud_models.UbbleContent,
 }
 
 FRAUD_CONTENT_MAPPING = {type: cls for cls, type in FRAUD_CHECK_MAPPING.items()}
@@ -345,7 +345,7 @@ class BeneficiaryFraudCheck(PcObject, Model):
         nullable=True,
     )
 
-    def source_data(self) -> typing.Union[IdentityCheckContent, UserProfilingFraudData]:
+    def source_data(self) -> typing.Union[common_models.IdentityCheckContent, UserProfilingFraudData]:
         if self.type not in FRAUD_CHECK_MAPPING:
             raise NotImplementedError(f"Cannot unserialize type {self.type}")
         return FRAUD_CHECK_MAPPING[self.type](**self.resultContent)

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -5,6 +5,7 @@ import typing
 from pcapi import settings
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 from pcapi.core.subscription.ubble.constants import MAX_UBBLE_RETRIES
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
@@ -22,16 +23,16 @@ def on_ubble_result(fraud_check: fraud_models.BeneficiaryFraudCheck) -> None:
 
 
 def _ubble_readable_score(score: typing.Optional[float]) -> str:
-    return fraud_models.ubble.UbbleScore(score).name if score is not None else "AUCUN"
+    return ubble_fraud_models.UbbleScore(score).name if score is not None else "AUCUN"
 
 
-def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_models.FraudItem:
+def _ubble_result_fraud_item(content: ubble_fraud_models.UbbleContent) -> fraud_models.FraudItem:
     status = None
     reason_code = None
     detail = f"Ubble score {_ubble_readable_score(content.score)}: {content.comment}"
 
     # Decision from identification/score
-    if content.score == fraud_models.ubble.UbbleScore.VALID.value:
+    if content.score == ubble_fraud_models.UbbleScore.VALID.value:
         # Decision from age
         age = users_utils.get_age_at_date(content.get_birth_date(), content.get_registration_datetime())
         if age < min(users_constants.ELIGIBILITY_UNDERAGE_RANGE):
@@ -44,21 +45,21 @@ def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_
             detail = f"L'utilisateur a dépassé l'âge maximum ({age} ans)"
         else:
             status = fraud_models.FraudStatus.OK
-    elif content.score == fraud_models.ubble.UbbleScore.INVALID.value:
+    elif content.score == ubble_fraud_models.UbbleScore.INVALID.value:
         # Decision from reference-data-check/score
-        if content.reference_data_check_score == fraud_models.ubble.UbbleScore.INVALID.value:
+        if content.reference_data_check_score == ubble_fraud_models.UbbleScore.INVALID.value:
             status = fraud_models.FraudStatus.SUSPICIOUS
             reason_code = fraud_models.FraudReasonCode.ID_CHECK_DATA_MATCH
             detail += " | Les informations de la pièce d'identité ne correspondent pas"
         else:
             # Decision from documents-check/supported
-            if content.supported == fraud_models.ubble.UbbleScore.INVALID.value:
+            if content.supported == ubble_fraud_models.UbbleScore.INVALID.value:
                 status = fraud_models.FraudStatus.SUSPICIOUS
                 reason_code = fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED
                 detail += " | Le document d'identité n'est pas supporté"
             else:
                 # Decision from documents-check/expiry-date-score
-                if content.expiry_date_score == fraud_models.ubble.UbbleScore.INVALID.value:
+                if content.expiry_date_score == ubble_fraud_models.UbbleScore.INVALID.value:
                     status = fraud_models.FraudStatus.SUSPICIOUS
                     reason_code = fraud_models.FraudReasonCode.ID_CHECK_EXPIRED
                     detail += " | Le document d'identité est expiré"
@@ -70,7 +71,7 @@ def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_
                         f" | document supported {_ubble_readable_score(content.supported)}"
                         f" | expiry-date-score {_ubble_readable_score(content.expiry_date_score)}"
                     )
-    elif content.score == fraud_models.ubble.UbbleScore.UNDECIDABLE.value:
+    elif content.score == ubble_fraud_models.UbbleScore.UNDECIDABLE.value:
         status = fraud_models.FraudStatus.SUSPICIOUS
         reason_code = fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE
         detail += " | Ubble n'a pas réussi à lire le document"
@@ -91,14 +92,14 @@ def _ubble_result_fraud_item(content: fraud_models.ubble.UbbleContent) -> fraud_
 def ubble_fraud_checks(
     user: users_models.User, beneficiary_fraud_check: fraud_models.BeneficiaryFraudCheck
 ) -> list[fraud_models.FraudItem]:
-    content = fraud_models.ubble.UbbleContent(**beneficiary_fraud_check.resultContent)
+    content = ubble_fraud_models.UbbleContent(**beneficiary_fraud_check.resultContent)
 
-    ubble_fraud_item = _ubble_result_fraud_item(content)
-    fraud_items = [ubble_fraud_item]
+    ubble_fraud_models_item = _ubble_result_fraud_item(content)
+    fraud_items = [ubble_fraud_models_item]
 
     id_piece_number = content.get_id_piece_number()
 
-    if ubble_fraud_item.status == fraud_models.FraudStatus.OK or id_piece_number:
+    if ubble_fraud_models_item.status == fraud_models.FraudStatus.OK or id_piece_number:
         fraud_items.append(fraud_api.validate_id_piece_number_format_fraud_item(id_piece_number))
         if id_piece_number:
             fraud_items.append(fraud_api.duplicate_id_piece_number_fraud_item(user, id_piece_number))
@@ -106,7 +107,7 @@ def ubble_fraud_checks(
     return fraud_items
 
 
-def start_ubble_fraud_check(user: users_models.User, ubble_content: fraud_models.ubble.UbbleContent) -> None:
+def start_ubble_fraud_check(user: users_models.User, ubble_content: ubble_fraud_models.UbbleContent) -> None:
     fraud_check = fraud_models.BeneficiaryFraudCheck(
         user=user,
         type=fraud_models.FraudCheckType.UBBLE,
@@ -164,8 +165,8 @@ def is_user_allowed_to_perform_ubble_check(
         for fraud_check in fraud_checks
         if fraud_check.source_data().status
         not in [
-            fraud_models.ubble_models.UbbleIdentificationStatus.INITIATED,
-            fraud_models.ubble_models.UbbleIdentificationStatus.UNINITIATED,
+            ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
+            ubble_fraud_models.UbbleIdentificationStatus.UNINITIATED,
         ]
     ]
 

--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -5,7 +5,7 @@ import typing
 import pydantic
 import pytz
 
-from .common import IdentityCheckContent
+from ..common.models import IdentityCheckContent
 
 
 class UbbleIdentificationStatus(enum.Enum):

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -4,8 +4,10 @@ import typing
 
 from pcapi import settings
 import pcapi.core.fraud.api as fraud_api
+from pcapi.core.fraud.common import models as common_fraud_models
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.fraud.repository as fraud_repository
+from pcapi.core.fraud.ubble import api as ubble_fraud_api
 from pcapi.core.mails.transactional.users import accepted_as_beneficiary
 from pcapi.core.payments import api as payments_api
 from pcapi.core.users import api as users_api
@@ -181,7 +183,7 @@ def needs_to_perform_identity_check(user: users_models.User) -> bool:
     return (
         not user.hasCompletedIdCheck
         and not (
-            not fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
+            not ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
             and FeatureToggle.ENABLE_UBBLE.is_active()
         )
         and not (fraud_api.has_passed_educonnect(user) and user.eligibility == users_models.EligibilityType.UNDERAGE)
@@ -467,7 +469,7 @@ def get_maintenance_page_type(user: users_models.User) -> typing.Optional[models
 
 def on_successful_application(
     user: users_models.User,
-    source_data: fraud_models.IdentityCheckContent,
+    source_data: common_fraud_models.IdentityCheckContent,
     source: BeneficiaryImportSources,
     eligibility_type: users_models.EligibilityType,
     application_id: typing.Optional[int] = None,

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -23,7 +23,9 @@ from pcapi import settings
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.bookings.repository as bookings_repository
 import pcapi.core.fraud.api as fraud_api
+from pcapi.core.fraud.common import models as common_fraud_models
 import pcapi.core.fraud.models as fraud_models
+import pcapi.core.fraud.ubble.models as ubble_fraud_models
 from pcapi.core.mails.transactional import users as user_emails
 from pcapi.core.mails.transactional.users.email_address_change_confirmation import send_email_confirmation_email
 import pcapi.core.payments.api as payment_api
@@ -262,7 +264,7 @@ def validate_phone_number_and_activate_user(user: User, code: str) -> User:
 
 def update_user_information_from_external_source(
     user: User,
-    data: fraud_models.IdentityCheckContent,
+    data: common_fraud_models.IdentityCheckContent,
     commit=False,
 ) -> User:
     if isinstance(data, fraud_models.DMSContent):
@@ -321,7 +323,7 @@ def update_user_information_from_external_source(
         user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0))
         user.ineHash = data.ine_hash
 
-    elif isinstance(data, fraud_models.ubble.UbbleContent):
+    elif isinstance(data, ubble_fraud_models.UbbleContent):
         user.firstName = data.first_name
         user.lastName = data.last_name
         user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0))

--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -3,7 +3,7 @@ import logging
 from pcapi import settings
 from pcapi.connectors import api_demarches_simplifiees
 from pcapi.core import logging as core_logging
-from pcapi.core.fraud import api as fraud_api
+from pcapi.core.fraud.ubble import api as ubble_fraud_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import messages as subscription_messages
 from pcapi.core.subscription.ubble import api as ubble_subscription_api
@@ -129,7 +129,7 @@ def ubble_webhook_update_application_status(
 ) -> ubble_validation.WebhookDummyReponse:
     logger.info("Ubble webhook called", extra={"identification_id": body.identification_id, "status": str(body.status)})
 
-    fraud_check = fraud_api.ubble.get_ubble_fraud_check(body.identification_id)
+    fraud_check = ubble_fraud_api.get_ubble_fraud_check(body.identification_id)
     if not fraud_check:
         raise ValueError(f"no Ubble fraud check found with identification_id {body.identification_id}")
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -11,6 +11,7 @@ from pcapi.connectors import api_recaptcha
 from pcapi.connectors import user_profiling
 from pcapi.connectors.beneficiaries import exceptions as beneficiaries_exceptions
 from pcapi.core.fraud import api as fraud_api
+from pcapi.core.fraud.ubble import api as ubble_fraud_api
 from pcapi.core.logging import get_or_set_correlation_id
 from pcapi.core.subscription.ubble import api as ubble_subscription_api
 from pcapi.core.users import api
@@ -366,7 +367,7 @@ def start_identification_session(
             status_code=400,
         )
 
-    if not fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility):
+    if not ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility):
         raise ApiErrors(
             {"code": "IDCHECK_ALREADY_PROCESSED", "message": "Une identification a déjà été traitée"},
             status_code=400,

--- a/api/src/pcapi/validation/routes/ubble.py
+++ b/api/src/pcapi/validation/routes/ubble.py
@@ -9,7 +9,7 @@ import flask
 import pydantic
 
 from pcapi import settings
-from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 from pcapi.models.api_errors import ForbiddenError
 
 
@@ -23,7 +23,7 @@ class Configuration(pydantic.BaseModel):
 
 class WebhookRequest(pydantic.BaseModel):
     identification_id: str
-    status: fraud_models.ubble.UbbleIdentificationStatus
+    status: ubble_fraud_models.UbbleIdentificationStatus
     configuration: Configuration
 
 

--- a/api/tests/connectors/beneficiaries/ubble_fixtures.py
+++ b/api/tests/connectors/beneficiaries/ubble_fixtures.py
@@ -1,4 +1,4 @@
-from pcapi.core.fraud.models import ubble as ubble_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 
 
 UBBLE_IDENTIFICATION_RESPONSE = {
@@ -6,7 +6,7 @@ UBBLE_IDENTIFICATION_RESPONSE = {
         "type": "identifications",
         "id": "3191295",
         "attributes": {
-            "score": ubble_models.UbbleScore.INVALID.value,
+            "score": ubble_fraud_models.UbbleScore.INVALID.value,
             "anonymized-at": None,
             "comment": None,
             "created-at": "2021-11-18T18:59:59.273402Z",
@@ -50,20 +50,20 @@ UBBLE_IDENTIFICATION_RESPONSE = {
             "type": "document-checks",
             "id": "4997875",
             "attributes": {
-                "data-extracted-score": ubble_models.UbbleScore.INVALID.value,
-                "expiry-date-score": ubble_models.UbbleScore.INVALID.value,
+                "data-extracted-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "expiry-date-score": ubble_fraud_models.UbbleScore.INVALID.value,
                 "issue-date-score": None,
                 "live-video-capture-score": None,
-                "mrz-validity-score": ubble_models.UbbleScore.INVALID.value,
-                "mrz-viz-score": ubble_models.UbbleScore.INVALID.value,
-                "ove-back-score": ubble_models.UbbleScore.INVALID.value,
-                "ove-front-score": ubble_models.UbbleScore.INVALID.value,
-                "ove-score": ubble_models.UbbleScore.INVALID.value,
-                "quality-score": ubble_models.UbbleScore.INVALID.value,
-                "score": ubble_models.UbbleScore.INVALID.value,
-                "supported": ubble_models.UbbleScore.INVALID.value,
-                "visual-back-score": ubble_models.UbbleScore.INVALID.value,
-                "visual-front-score": ubble_models.UbbleScore.INVALID.value,
+                "mrz-validity-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "mrz-viz-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "ove-back-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "ove-front-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "ove-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "quality-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "supported": ubble_fraud_models.UbbleScore.INVALID.value,
+                "visual-back-score": ubble_fraud_models.UbbleScore.INVALID.value,
+                "visual-front-score": ubble_fraud_models.UbbleScore.INVALID.value,
             },
             "relationships": {},
         },

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -6,7 +6,7 @@ import requests.exceptions
 
 from pcapi.connectors.beneficiaries import exceptions
 from pcapi.connectors.beneficiaries import ubble
-from pcapi.core.fraud.models import ubble as ubble_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 
 from tests.core.subscription.test_factories import UbbleIdentificationResponseFactory
 from tests.test_utils import json_default
@@ -25,7 +25,7 @@ class StartIdentificationTest:
                 redirect_url="http://redirect/url",
             )
 
-        assert isinstance(response, ubble_models.UbbleContent)
+        assert isinstance(response, ubble_fraud_models.UbbleContent)
         assert ubble_mock.call_count == 1
 
         attributes = ubble_mock.last_request.json()["data"]["attributes"]

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -9,6 +9,8 @@ import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.exceptions as fraud_exceptions
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
+from pcapi.core.fraud.ubble import api as ubble_fraud_api
+import pcapi.core.fraud.ubble.models as ubble_fraud_models
 from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
@@ -584,7 +586,7 @@ class HasUserPerformedIdentityCheckTest:
         )
 
         assert fraud_api.has_user_performed_identity_check(user)
-        assert fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility) == (
+        assert ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility) == (
             check_type != fraud_models.FraudCheckType.UBBLE
         )
 
@@ -595,7 +597,7 @@ class HasUserPerformedIdentityCheckTest:
         )
 
         assert fraud_api.has_user_performed_identity_check(user)
-        assert fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
+        assert ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
     def test_has_user_performed_identity_check_without_identity_fraud_check(self):
         user = users_factories.UserFactory()
@@ -606,7 +608,7 @@ class HasUserPerformedIdentityCheckTest:
     def test_has_user_performed_identity_check_status_initiated(self):
         user = users_factories.UserFactory()
         ubble_content = fraud_factories.UbbleContentFactory(
-            status=fraud_models.ubble_models.UbbleIdentificationStatus.INITIATED
+            status=ubble_fraud_models.UbbleIdentificationStatus.INITIATED
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
@@ -627,7 +629,7 @@ class HasUserPerformedIdentityCheckTest:
 
         # Suspicous => Retry allowed
         assert fraud_api.has_user_performed_identity_check(user)
-        assert fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
+        assert ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
     def test_has_user_performed_identity_check_ubble_suspicious_x3(self):
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
@@ -642,7 +644,7 @@ class HasUserPerformedIdentityCheckTest:
 
         # Suspicous but all retries already performed
         assert fraud_api.has_user_performed_identity_check(user)
-        assert not fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
+        assert not ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
     def test_has_user_performed_identity_check_ubble_ko(self):
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
@@ -655,7 +657,7 @@ class HasUserPerformedIdentityCheckTest:
 
         # Retry not allowed
         assert fraud_api.has_user_performed_identity_check(user)
-        assert not fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
+        assert not ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/core/fraud/test_factories.py
+++ b/api/tests/core/fraud/test_factories.py
@@ -2,6 +2,7 @@ import pytest
 
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
+import pcapi.core.fraud.ubble.models as ubble_fraud_models
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -14,7 +15,7 @@ class FactoriesTest:
             (fraud_models.FraudCheckType.DMS, fraud_models.DMSContent),
             (fraud_models.FraudCheckType.JOUVE, fraud_models.JouveContent),
             (fraud_models.FraudCheckType.USER_PROFILING, fraud_models.UserProfilingFraudData),
-            (fraud_models.FraudCheckType.UBBLE, fraud_models.ubble.UbbleContent),
+            (fraud_models.FraudCheckType.UBBLE, ubble_fraud_models.UbbleContent),
         ],
     )
     def test_database_serialization(self, check_type, model_class):

--- a/api/tests/core/subscription/test_factories.py
+++ b/api/tests/core/subscription/test_factories.py
@@ -10,7 +10,7 @@ import factory
 import pytz
 
 from pcapi import settings
-from pcapi.core.fraud.models import ubble as ubble_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 
 
 class IdentificationState(Enum):
@@ -24,13 +24,13 @@ class IdentificationState(Enum):
 
 
 STATE_STATUS_MAPPING = {
-    IdentificationState.NEW: ubble_models.UbbleIdentificationStatus.UNINITIATED,
-    IdentificationState.INITIATED: ubble_models.UbbleIdentificationStatus.INITIATED,
-    IdentificationState.ABORTED: ubble_models.UbbleIdentificationStatus.ABORTED,
-    IdentificationState.PROCESSING: ubble_models.UbbleIdentificationStatus.PROCESSING,
-    IdentificationState.VALID: ubble_models.UbbleIdentificationStatus.PROCESSED,
-    IdentificationState.INVALID: ubble_models.UbbleIdentificationStatus.PROCESSED,
-    IdentificationState.UNPROCESSABLE: ubble_models.UbbleIdentificationStatus.PROCESSED,
+    IdentificationState.NEW: ubble_fraud_models.UbbleIdentificationStatus.UNINITIATED,
+    IdentificationState.INITIATED: ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
+    IdentificationState.ABORTED: ubble_fraud_models.UbbleIdentificationStatus.ABORTED,
+    IdentificationState.PROCESSING: ubble_fraud_models.UbbleIdentificationStatus.PROCESSING,
+    IdentificationState.VALID: ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
+    IdentificationState.INVALID: ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
+    IdentificationState.UNPROCESSABLE: ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
 }
 
 
@@ -44,7 +44,7 @@ class IdentificationIncludedType(Enum):
 
 class UbbleIdentificationDataAttributesFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationAttributes
+        model = ubble_fraud_models.UbbleIdentificationAttributes
         rename = {
             "anonymized_at": "anonymized-at",
             "created_at": "created-at",
@@ -89,9 +89,9 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
     @factory.lazy_attribute
     def score(self):
         return {
-            IdentificationState.UNPROCESSABLE: ubble_models.UbbleScore.UNDECIDABLE.value,
-            IdentificationState.INVALID: ubble_models.UbbleScore.INVALID.value,
-            IdentificationState.VALID: ubble_models.UbbleScore.VALID.value,
+            IdentificationState.UNPROCESSABLE: ubble_fraud_models.UbbleScore.UNDECIDABLE.value,
+            IdentificationState.INVALID: ubble_fraud_models.UbbleScore.INVALID.value,
+            IdentificationState.VALID: ubble_fraud_models.UbbleScore.VALID.value,
         }.get(self.identification_state)
 
     @factory.lazy_attribute
@@ -166,7 +166,7 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
 
 class UbbleIdentificationDataFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationData
+        model = ubble_fraud_models.UbbleIdentificationData
 
     class Params:
         identification_state = IdentificationState.NEW
@@ -181,7 +181,7 @@ class UbbleIdentificationDataFactory(factory.Factory):
 
 class UbbleIdentificationIncludedDocumentsAttributesFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationDocuments
+        model = ubble_fraud_models.UbbleIdentificationDocuments
         rename = {
             "birth_date": "birth-date",
             "birth_place": "birth-place",
@@ -221,7 +221,7 @@ class UbbleIdentificationIncludedDocumentsAttributesFactory(factory.Factory):
 
 class UbbleIdentificationIncludedDocumentChecksAttributesFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationDocumentChecks
+        model = ubble_fraud_models.UbbleIdentificationDocumentChecks
         rename = {
             "data_extracted_score": "data-extracted-score",
             "expiry_date_score": "expiry-date-score",
@@ -241,7 +241,7 @@ class UbbleIdentificationIncludedDocumentChecksAttributesFactory(factory.Factory
         identification_state = IdentificationState.VALID
 
     data_extracted_score = None
-    expiry_date_score = ubble_models.UbbleScore.VALID.value
+    expiry_date_score = ubble_fraud_models.UbbleScore.VALID.value
     issue_date_score = None
     live_video_capture_score = None
     mrz_validity_score = None
@@ -250,32 +250,32 @@ class UbbleIdentificationIncludedDocumentChecksAttributesFactory(factory.Factory
     ove_front_score = None
     ove_score = None
     quality_score: None
-    supported = ubble_models.UbbleScore.VALID.value
+    supported = ubble_fraud_models.UbbleScore.VALID.value
     visual_back_score = None
     visual_front_score = None
 
     @factory.lazy_attribute
     def score(self):
         return {
-            IdentificationState.UNPROCESSABLE: ubble_models.UbbleScore.INVALID.value,
-            IdentificationState.INVALID: ubble_models.UbbleScore.INVALID.value,
-            IdentificationState.VALID: ubble_models.UbbleScore.VALID.value,
+            IdentificationState.UNPROCESSABLE: ubble_fraud_models.UbbleScore.INVALID.value,
+            IdentificationState.INVALID: ubble_fraud_models.UbbleScore.INVALID.value,
+            IdentificationState.VALID: ubble_fraud_models.UbbleScore.VALID.value,
         }.get(self.identification_state)
 
 
 class UbbleIdentificationIncludedDocFaceMatchesAttributesFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationDocFaceMatches
+        model = ubble_fraud_models.UbbleIdentificationDocFaceMatches
 
     class Params:
         identification_state = IdentificationState.VALID
 
-    score = ubble_models.UbbleScore.VALID.value
+    score = ubble_fraud_models.UbbleScore.VALID.value
 
 
 class UbbleIdentificationIncludedFaceChecksAttributesFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationFaceChecks
+        model = ubble_fraud_models.UbbleIdentificationFaceChecks
         rename = {
             "active_liveness_score": "active-liveness-score",
             "live_video_capture_score": "live-video-capture-score",
@@ -288,19 +288,19 @@ class UbbleIdentificationIncludedFaceChecksAttributesFactory(factory.Factory):
     active_liveness_score = None
     live_video_capture_score = None
     quality_score = None
-    score = ubble_models.UbbleScore.VALID.value
+    score = ubble_fraud_models.UbbleScore.VALID.value
 
 
 class UbbleIdentificationIncludedReferenceDataChecksAttributesFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationReferenceDataChecks
+        model = ubble_fraud_models.UbbleIdentificationReferenceDataChecks
 
-    score = ubble_models.UbbleScore.VALID.value
+    score = ubble_fraud_models.UbbleScore.VALID.value
 
 
 class UbbleIdentificationIncludedFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationIncluded
+        model = ubble_fraud_models.UbbleIdentificationIncluded
         abstract = True
 
     type = None
@@ -310,7 +310,7 @@ class UbbleIdentificationIncludedFactory(factory.Factory):
 
 class UbbleIdentificationIncludedDocumentsFactory(UbbleIdentificationIncludedFactory):
     class Meta:
-        model = ubble_models.UbbleIdentificationIncludedDocuments
+        model = ubble_fraud_models.UbbleIdentificationIncludedDocuments
 
     type = IdentificationIncludedType.DOCUMENTS.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedDocumentsAttributesFactory)
@@ -318,7 +318,7 @@ class UbbleIdentificationIncludedDocumentsFactory(UbbleIdentificationIncludedFac
 
 class UbbleIdentificationIncludedDocumentChecksFactory(UbbleIdentificationIncludedFactory):
     class Meta:
-        model = ubble_models.UbbleIdentificationIncludedDocumentChecks
+        model = ubble_fraud_models.UbbleIdentificationIncludedDocumentChecks
 
     type = IdentificationIncludedType.DOCUMENT_CHECKS.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedDocumentChecksAttributesFactory)
@@ -326,7 +326,7 @@ class UbbleIdentificationIncludedDocumentChecksFactory(UbbleIdentificationInclud
 
 class UbbleIdentificationIncludedFaceChecksFactory(UbbleIdentificationIncludedFactory):
     class Meta:
-        model = ubble_models.UbbleIdentificationIncludedFaceChecks
+        model = ubble_fraud_models.UbbleIdentificationIncludedFaceChecks
 
     type = IdentificationIncludedType.FACE_CHECKS.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedFaceChecksAttributesFactory)
@@ -334,7 +334,7 @@ class UbbleIdentificationIncludedFaceChecksFactory(UbbleIdentificationIncludedFa
 
 class UbbleIdentificationIncludedReferenceDataChecksFactory(UbbleIdentificationIncludedFactory):
     class Meta:
-        model = ubble_models.UbbleIdentificationIncludedReferenceDataChecks
+        model = ubble_fraud_models.UbbleIdentificationIncludedReferenceDataChecks
 
     type = IdentificationIncludedType.REFERENCE_DATA_CHECKS.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedReferenceDataChecksAttributesFactory)
@@ -342,7 +342,7 @@ class UbbleIdentificationIncludedReferenceDataChecksFactory(UbbleIdentificationI
 
 class UbbleIdentificationIncludedDocFaceMatchesFactory(UbbleIdentificationIncludedFactory):
     class Meta:
-        model = ubble_models.UbbleIdentificationIncludedDocFaceMatches
+        model = ubble_fraud_models.UbbleIdentificationIncludedDocFaceMatches
 
     type = IdentificationIncludedType.DOC_FACE_MATCHES.value
     attributes = factory.SubFactory(UbbleIdentificationIncludedDocFaceMatchesAttributesFactory)
@@ -350,7 +350,7 @@ class UbbleIdentificationIncludedDocFaceMatchesFactory(UbbleIdentificationInclud
 
 class UbbleIdentificationResponseFactory(factory.Factory):
     class Meta:
-        model = ubble_models.UbbleIdentificationResponse
+        model = ubble_fraud_models.UbbleIdentificationResponse
 
     class Params:
         identification_state = IdentificationState.NEW

--- a/api/tests/core/subscription/ubble/test_ubble_workflow.py
+++ b/api/tests/core/subscription/ubble/test_ubble_workflow.py
@@ -5,9 +5,10 @@ from dateutil.relativedelta import relativedelta
 import freezegun
 import pytest
 
-from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.ubble import api as ubble_fraud_api
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 from pcapi.core.subscription import messages as subscription_messages
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription.ubble import api as ubble_subscription_api
@@ -43,32 +44,32 @@ class UbbleWorkflowTest:
         [
             (
                 IdentificationState.INITIATED,
-                fraud_models.ubble.UbbleIdentificationStatus.INITIATED,
+                ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
                 fraud_models.FraudCheckStatus.PENDING,
             ),
             (
                 IdentificationState.PROCESSING,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSING,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSING,
                 fraud_models.FraudCheckStatus.PENDING,
             ),
             (
                 IdentificationState.VALID,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
                 fraud_models.FraudCheckStatus.OK,
             ),
             (
                 IdentificationState.INVALID,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
                 fraud_models.FraudCheckStatus.KO,
             ),
             (
                 IdentificationState.UNPROCESSABLE,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
                 fraud_models.FraudCheckStatus.SUSPICIOUS,
             ),
             (
                 IdentificationState.ABORTED,
-                fraud_models.ubble.UbbleIdentificationStatus.ABORTED,
+                ubble_fraud_models.UbbleIdentificationStatus.ABORTED,
                 fraud_models.FraudCheckStatus.CANCELED,
             ),
         ],
@@ -178,7 +179,7 @@ class UbbleWorkflowTest:
         assert fraud_checks[1].thirdPartyId == ubble_identification
 
         db.session.refresh(user)
-        assert not fraud_api.ubble.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
+        assert not ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
     @freezegun.freeze_time("2020-05-05")
     def test_ubble_workflow_with_eligibility_change_18_19(self, ubble_mocker):

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -20,6 +20,7 @@ from pcapi.core.bookings.factories import IndividualBookingFactory
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.subscription.factories as subscription_factories
 import pcapi.core.subscription.messages as subscription_messages
@@ -1621,9 +1622,9 @@ class IdentificationSessionTest:
     @pytest.mark.parametrize(
         "fraud_check_status,ubble_status",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.PENDING, ubble_fraud_models.UbbleIdentificationStatus.PROCESSING),
+            (fraud_models.FraudCheckStatus.OK, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.KO, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED),
         ],
     )
     def test_request_ubble_second_check_blocked(self, client, ubble_mock, fraud_check_status, ubble_status):
@@ -1676,7 +1677,7 @@ class IdentificationSessionTest:
             type=fraud_models.FraudCheckType.UBBLE,
             status=fraud_models.FraudCheckStatus.CANCELED,
             resultContent=fraud_factories.UbbleContentFactory(
-                status=fraud_models.ubble.UbbleIdentificationStatus.ABORTED
+                status=ubble_fraud_models.UbbleIdentificationStatus.ABORTED
             ),
         )
 
@@ -1727,7 +1728,7 @@ class IdentificationSessionTest:
                 status=fraud_models.FraudCheckStatus.SUSPICIOUS,
                 reasonCodes=[reason],
                 resultContent=fraud_factories.UbbleContentFactory(
-                    status=fraud_models.ubble.UbbleIdentificationStatus.PROCESSED
+                    status=ubble_fraud_models.UbbleIdentificationStatus.PROCESSED
                 ),
             )
 
@@ -1772,7 +1773,7 @@ class IdentificationSessionTest:
             status=fraud_models.FraudCheckStatus.SUSPICIOUS,
             reasonCodes=[reason],
             resultContent=fraud_factories.UbbleContentFactory(
-                status=fraud_models.ubble.UbbleIdentificationStatus.PROCESSED
+                status=ubble_fraud_models.UbbleIdentificationStatus.PROCESSED
             ),
         )
 
@@ -1788,7 +1789,7 @@ class IdentificationSessionTest:
         expected_url = "https://id.ubble.ai/ef055567-3794-4ca5-afad-dce60fe0f227"
 
         ubble_content = fraud_factories.UbbleContentFactory(
-            status=fraud_models.ubble_models.UbbleIdentificationStatus.INITIATED,
+            status=ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
             identification_url=expected_url,
         )
         fraud_factories.BeneficiaryFraudCheckFactory(

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -7,6 +7,7 @@ import pytest
 from pcapi import settings
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
@@ -65,48 +66,48 @@ class NextStepTest:
             (
                 fraud_models.FraudCheckStatus.PENDING,
                 None,
-                fraud_models.ubble.UbbleIdentificationStatus.INITIATED,
+                ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
                 "identity-check",
                 False,
             ),
             (
                 fraud_models.FraudCheckStatus.PENDING,
                 None,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSING,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSING,
                 "honor-statement",
                 True,
             ),
             (
                 fraud_models.FraudCheckStatus.OK,
                 None,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
                 "honor-statement",
                 False,
             ),
             (
                 fraud_models.FraudCheckStatus.KO,
                 fraud_models.FraudReasonCode.AGE_TOO_OLD,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
                 "honor-statement",
                 False,
             ),
             (
                 fraud_models.FraudCheckStatus.CANCELED,
                 None,
-                fraud_models.ubble.UbbleIdentificationStatus.ABORTED,
+                ubble_fraud_models.UbbleIdentificationStatus.ABORTED,
                 "identity-check",
                 False,
             ),
             (
                 fraud_models.FraudCheckStatus.SUSPICIOUS,
                 fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED,
-                fraud_models.ubble.UbbleIdentificationStatus.PROCESSED,
+                ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
                 "identity-check",  # User can retry
                 False,
             ),
-            (None, None, fraud_models.ubble.UbbleIdentificationStatus.INITIATED, "identity-check", False),
-            (None, None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING, "honor-statement", False),
-            (None, None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED, "honor-statement", False),
+            (None, None, ubble_fraud_models.UbbleIdentificationStatus.INITIATED, "identity-check", False),
+            (None, None, ubble_fraud_models.UbbleIdentificationStatus.PROCESSING, "honor-statement", False),
+            (None, None, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED, "honor-statement", False),
         ],
     )
     @override_features(ENABLE_UBBLE=True)
@@ -174,13 +175,13 @@ class NextStepTest:
     @pytest.mark.parametrize(
         "underage_fraud_check_status,underage_ubble_status",
         [
-            (fraud_models.FraudCheckStatus.PENDING, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING),
-            (fraud_models.FraudCheckStatus.OK, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
-            (fraud_models.FraudCheckStatus.KO, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
-            (fraud_models.FraudCheckStatus.SUSPICIOUS, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
-            (fraud_models.FraudCheckStatus.CANCELED, fraud_models.ubble.UbbleIdentificationStatus.ABORTED),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSING),
-            (None, fraud_models.ubble.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.PENDING, ubble_fraud_models.UbbleIdentificationStatus.PROCESSING),
+            (fraud_models.FraudCheckStatus.OK, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.KO, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.SUSPICIOUS, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED),
+            (fraud_models.FraudCheckStatus.CANCELED, ubble_fraud_models.UbbleIdentificationStatus.ABORTED),
+            (None, ubble_fraud_models.UbbleIdentificationStatus.PROCESSING),
+            (None, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED),
         ],
     )
     @override_features(ENABLE_UBBLE=True)
@@ -263,7 +264,7 @@ class NextStepTest:
             type=fraud_models.FraudCheckType.UBBLE,
             status=fraud_models.FraudCheckStatus.PENDING,
             resultContent=fraud_factories.UbbleContentFactory(
-                status=fraud_models.ubble.UbbleIdentificationStatus.PROCESSING
+                status=ubble_fraud_models.UbbleIdentificationStatus.PROCESSING
             ),
             eligibilityType=users_models.EligibilityType.AGE18,
         )
@@ -298,7 +299,7 @@ class NextStepTest:
         # ubble now confirms the status
         ubble_fraud_check.status = fraud_models.FraudCheckStatus.OK
         ubble_fraud_check.resultContent = fraud_factories.UbbleContentFactory(
-            status=fraud_models.ubble.UbbleIdentificationStatus.PROCESSED
+            status=ubble_fraud_models.UbbleIdentificationStatus.PROCESSED
         )
         pcapi_repository.repository.save(ubble_fraud_check)
         response = client.get("/native/v1/subscription/next_step")
@@ -415,7 +416,7 @@ class NextStepTest:
         )
 
         ubble_content = fraud_factories.UbbleContentFactory(
-            status=fraud_models.ubble_models.UbbleIdentificationStatus.INITIATED
+            status=ubble_fraud_models.UbbleIdentificationStatus.INITIATED
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,


### PR DESCRIPTION
Comme discuté en synchro backend, on préfère une organisation : 
- fraud/api.py
- fraud/ubble/api.py

A ce qu'il y avait : 
- fraud/api/ubble.py
- fraud/api/__init__.py

Pour : 
- ne pas avoir de code écrit dans __init__.py
- ça fixe les `fraud_api.ubble.is_user_allowed_to_perform_ubble_check` où le ctrl+click ne fonctionne pas (sur vscode en tout cas)