### PR TITLE
(PC-11264) tweak invoice pdf storage

### DIFF
--- a/api/src/pcapi/connectors/thumb_storage.py
+++ b/api/src/pcapi/connectors/thumb_storage.py
@@ -13,7 +13,7 @@ def create_thumb(
     image_as_bytes = standardize_image(image_as_bytes, crop_params)
 
     object_storage.store_public_object(
-        bucket=settings.BASE_BUCKET_NAME,
+        folder=settings.THUMBS_FOLDER_NAME,
         object_id=model_with_thumb.get_thumb_storage_id(image_index),
         blob=image_as_bytes,
         content_type="image/jpeg",
@@ -25,6 +25,6 @@ def remove_thumb(
     image_index: int,
 ) -> None:
     object_storage.delete_public_object(
-        bucket="thumbs",
+        folder="thumbs",
         object_id=model_with_thumb.get_thumb_storage_id(image_index),
     )

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -825,5 +825,5 @@ def _generate_invoice_html(invoice) -> str:
 def _store_invoice_pdf(invoice_token, invoice_html):
     invoice_pdf = pdf_utils.generate_pdf_from_html(invoice_html)
     store_public_object(
-        bucket="invoices", object_id=f"{invoice_token}.pdf", blob=invoice_pdf, content_type="application/pdf"
+        folder="invoices", object_id=f"{invoice_token}.pdf", blob=invoice_pdf, content_type="application/pdf"
     )

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -723,7 +723,7 @@ def _make_invoice_line(invoice: models.Invoice, group: conf.RuleGroups, pricings
 def generate_and_store_invoice(reference: str, business_unit_id: int, cashflow_ids: list[int]):
     invoice = _generate_invoice(reference, business_unit_id, cashflow_ids)
     invoice_html = _generate_invoice_html(invoice)
-    _store_invoice_pdf(invoice.token, invoice_html)
+    _store_invoice_pdf(invoice, invoice_html)
 
 
 def _generate_invoice(reference: str, business_unit_id: int, cashflow_ids: list[int]):
@@ -822,8 +822,8 @@ def _generate_invoice_html(invoice) -> str:
     return render_template("invoices/invoice.html", **context)
 
 
-def _store_invoice_pdf(invoice_token, invoice_html):
+def _store_invoice_pdf(invoice, invoice_html):
     invoice_pdf = pdf_utils.generate_pdf_from_html(invoice_html)
     store_public_object(
-        folder="invoices", object_id=f"{invoice_token}.pdf", blob=invoice_pdf, content_type="application/pdf"
+        folder="invoices", object_id=invoice.storage_object_id, blob=invoice_pdf, content_type="application/pdf"
     )

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -310,8 +310,15 @@ class Invoice(Model):
     cashflows = sqla_orm.relationship("Cashflow", secondary="invoice_cashflow", back_populates="invoices")
 
     @property
+    def storage_object_id(self):
+        return (
+            f"{self.token}/{self.date.strftime('%d%m%Y')}-{self.reference}-"
+            f"Justificatif-de-remboursement-pass-Culture.pdf"
+        )
+
+    @property
     def url(self):
-        return f"{settings.OBJECT_STORAGE_URL}/invoices/{self.token}.pdf"
+        return f"{settings.OBJECT_STORAGE_URL}/invoices/{self.storage_object_id}"
 
 
 class InvoiceCashflow(Model):

--- a/api/src/pcapi/core/object_storage/__init__.py
+++ b/api/src/pcapi/core/object_storage/__init__.py
@@ -51,13 +51,13 @@ def _get_backends() -> set:
     return backends_set
 
 
-def store_public_object(bucket: str, object_id: str, blob: bytes, content_type: str) -> None:
+def store_public_object(folder: str, object_id: str, blob: bytes, content_type: str) -> None:
     for backend_path in _get_backends():
         backend = import_string(backend_path)
-        backend().store_public_object(bucket, object_id, blob, content_type)
+        backend().store_public_object(folder, object_id, blob, content_type)
 
 
-def delete_public_object(bucket: str, object_id: str) -> None:
+def delete_public_object(folder: str, object_id: str) -> None:
     for backend_path in _get_backends():
         backend = import_string(backend_path)
-        backend().delete_public_object(bucket, object_id)
+        backend().delete_public_object(folder, object_id)

--- a/api/src/pcapi/core/object_storage/backends/base.py
+++ b/api/src/pcapi/core/object_storage/backends/base.py
@@ -1,6 +1,6 @@
 class BaseBackend:
-    def store_public_object(self, bucket: str, object_id: str, blob: bytes, content_type: str) -> None:
+    def store_public_object(self, folder: str, object_id: str, blob: bytes, content_type: str) -> None:
         raise NotImplementedError()
 
-    def delete_public_object(self, bucket: str, object_id: str) -> None:
+    def delete_public_object(self, folder: str, object_id: str) -> None:
         raise NotImplementedError()

--- a/api/src/pcapi/core/object_storage/backends/gcp.py
+++ b/api/src/pcapi/core/object_storage/backends/gcp.py
@@ -20,8 +20,8 @@ class GCPBackend(BaseBackend):
 
         return storage_client.bucket(settings.GCP_BUCKET_NAME)
 
-    def store_public_object(self, bucket: str, object_id: str, blob: bytes, content_type: str) -> None:
-        storage_path = bucket + "/" + object_id
+    def store_public_object(self, folder: str, object_id: str, blob: bytes, content_type: str) -> None:
+        storage_path = folder + "/" + object_id
         try:
             bucket = self.get_gcp_storage_client_bucket()
             gcp_cloud_blob = bucket.blob(storage_path)
@@ -30,8 +30,8 @@ class GCPBackend(BaseBackend):
             logger.exception("An error has occured while trying to upload file on GCP bucket: %s", exc)
             raise exc
 
-    def delete_public_object(self, bucket: str, object_id: str) -> None:
-        storage_path = bucket + "/" + object_id
+    def delete_public_object(self, folder: str, object_id: str) -> None:
+        storage_path = folder + "/" + object_id
         try:
             bucket = self.get_gcp_storage_client_bucket()
             gcp_cloud_blob = bucket.blob(storage_path)

--- a/api/src/pcapi/core/object_storage/backends/local.py
+++ b/api/src/pcapi/core/object_storage/backends/local.py
@@ -21,10 +21,10 @@ class LocalBackend(BaseBackend):
     def local_path(self, bucket: str, object_id: str) -> Path:
         return self.local_dir(bucket, object_id) / PurePath(object_id).name
 
-    def store_public_object(self, bucket: str, object_id: str, blob: bytes, content_type: str) -> None:
+    def store_public_object(self, folder: str, object_id: str, blob: bytes, content_type: str) -> None:
         try:
-            os.makedirs(self.local_dir(bucket, object_id), exist_ok=True)
-            file_local_path = self.local_path(bucket, object_id)
+            os.makedirs(self.local_dir(folder, object_id), exist_ok=True)
+            file_local_path = self.local_path(folder, object_id)
             with open(str(file_local_path) + ".type", "w") as new_type_file:
                 new_type_file.write(content_type)
 
@@ -35,8 +35,8 @@ class LocalBackend(BaseBackend):
             logger.exception("An error has occured while trying to upload file on local file storage: %s", exc)
             raise exc
 
-    def delete_public_object(self, bucket: str, object_id: str) -> None:
-        file_local_path = self.local_path(bucket, object_id)
+    def delete_public_object(self, folder: str, object_id: str) -> None:
+        file_local_path = self.local_path(folder, object_id)
         try:
             os.remove(file_local_path)
             os.remove(str(file_local_path) + ".type")

--- a/api/src/pcapi/core/object_storage/backends/ovh.py
+++ b/api/src/pcapi/core/object_storage/backends/ovh.py
@@ -23,19 +23,19 @@ class OVHBackend(BaseBackend):
             auth_version="3",
         )
 
-    def store_public_object(self, bucket: str, object_id: str, blob: bytes, content_type: str) -> None:
+    def store_public_object(self, folder: str, object_id: str, blob: bytes, content_type: str) -> None:
         container_name = settings.SWIFT_BUCKET_NAME
         try:
-            storage_path = bucket + "/" + object_id
+            storage_path = folder + "/" + object_id
             self.swift_con().put_object(container_name, storage_path, contents=blob, content_type=content_type)
         except Exception as exc:
             logger.exception("An error has occured while trying to upload file on OVH bucket: %s", exc)
             raise exc
 
-    def delete_public_object(self, bucket: str, object_id: str) -> None:
+    def delete_public_object(self, folder: str, object_id: str) -> None:
         container_name = settings.SWIFT_BUCKET_NAME
         try:
-            storage_path = bucket + "/" + object_id
+            storage_path = folder + "/" + object_id
             self.swift_con().delete_object(container_name, storage_path)
         except Exception as exc:
             logger.exception("An error has occured while trying to delete file on OVH bucket: %s", exc)

--- a/api/src/pcapi/core/object_storage/testing.py
+++ b/api/src/pcapi/core/object_storage/testing.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 import shutil
 
 from pcapi import settings
@@ -8,3 +10,8 @@ def reset_bucket() -> None:
         shutil.rmtree(settings.LOCAL_STORAGE_DIR)
     except FileNotFoundError:
         pass
+
+
+def recursive_listdir(directory_path: pathlib.Path) -> list[str]:
+    """This function will return all files in the given directory and its subdirectory"""
+    return [os.path.join(dirpath, f) for dirpath, _dirname, filename in os.walk(directory_path) for f in filename]

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -290,11 +290,11 @@ def validate_offerer(token: str) -> None:
 
 
 def save_venue_banner(user: User, venue: Venue, content: bytes, content_type: str, file_name: str) -> None:
-    bucket_name = settings.BASE_BUCKET_NAME
+    bucket_name = settings.THUMBS_FOLDER_NAME
     object_id = f"venue_{venue.id}_banner"
 
     object_storage.store_public_object(
-        bucket=bucket_name,
+        folder=bucket_name,
         object_id=object_id,
         blob=content,
         content_type=f"image/{content_type.lower()}",

--- a/api/src/pcapi/scripts/delete_unused_mediations_and_assets.py
+++ b/api/src/pcapi/scripts/delete_unused_mediations_and_assets.py
@@ -144,7 +144,7 @@ def delete_assets_tied_to_mediationsqlentities(
         for asset_name in old_mediationsqlentities_asset_names:
             logger.info("deleting asset: %s", asset_name)
             try:
-                backend().delete_public_object(bucket=folder_name, object_id=asset_name)
+                backend().delete_public_object(folder=folder_name, object_id=asset_name)
             except Exception as exc:  # pylint: disable=broad-except
                 logger.exception("An unexpected error was encountered during deletion: %s", exc)
 
@@ -212,7 +212,7 @@ def delete_assets_without_mediation(
         for orphan_assets_name in orphan_assets_names:
             logger.info("deleting asset: %s", orphan_assets_name)
             try:
-                backend().delete_public_object(bucket=folder_name, object_id=orphan_assets_name)
+                backend().delete_public_object(folder=folder_name, object_id=orphan_assets_name)
             except Exception as exc:  # pylint: disable=broad-except
                 logger.exception("An unexpected error was encountered during deletion: %s", exc)
 

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -259,7 +259,7 @@ OBJECT_STORAGE_PROVIDER = os.environ.get("OBJECT_STORAGE_PROVIDER", "")
 LOCAL_STORAGE_DIR = Path(os.path.dirname(os.path.realpath(__file__))) / "static" / "object_store_data"
 
 # THUMBS
-BASE_BUCKET_NAME = os.environ.get("BASE_BUCKET_NAME", "thumbs")
+THUMBS_FOLDER_NAME = os.environ.get("THUMBS_FOLDER_NAME", "thumbs")
 
 # SWIFT
 SWIFT_AUTH_URL = os.environ.get("SWIFT_AUTH_URL", "https://auth.cloud.ovh.net/v3/")

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -56,7 +56,7 @@
 <body>
 
 <h1>Justificatif de remboursement</h1>
-<h2 class="invoice_info">Relevé n°JUSTIFICATIF #4 du 21/12/2021</h2>
+<h2 class="invoice_info">Relevé n°000004 du 21/12/2021</h2>
 
 <p>
 <div><b>Nom :</b> SARL LIBRAIRIE BOOKING</div>

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -246,7 +246,7 @@ class VenueBannerTest:
         with tempfile.TemporaryDirectory() as tmpdirname:
             with override_settings(OBJECT_STORAGE_URL=tmpdirname):
                 settings.OBJECT_STORAGE_URL = tmpdirname
-                mock_local_dir.return_value = pathlib.Path(tmpdirname) / settings.BASE_BUCKET_NAME
+                mock_local_dir.return_value = pathlib.Path(tmpdirname) / settings.THUMBS_FOLDER_NAME
 
                 response = client.post(url, files=file)
                 assert response.status_code == 204


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11624

## But de la pull request

Stocker les PDF avec un nom de fichier plus lisible par un être humain, et les placer chacun dans un dossier basé sur un token de 256 bits.

##  Implémentation

- Ajout d'une propriété `Invoice.storage_object_id`

##  Informations supplémentaires

- [object_storage] Renommage de variables confondant `bucket` et `folder`
- Ajout d'une méthode `recursive_listdir()` permettant de lister des fichiers de manière récursive dans les tests
​