### PR TITLE
[pc-12582][api] Remove use of BeneficiaryFraudResult

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view.py
+++ b/api/src/pcapi/admin/custom_views/support_view.py
@@ -33,27 +33,6 @@ from pcapi.models.feature import FeatureToggle
 logger = logging.getLogger(__name__)
 
 
-def beneficiary_fraud_results_formatter(view, context, model, name) -> Markup:
-    css_classes = {
-        fraud_models.FraudStatus.OK: "badge-success",
-        fraud_models.FraudStatus.KO: "badge-danger",
-        fraud_models.FraudStatus.SUSPICIOUS: "badge-warning",
-        fraud_models.FraudStatus.SUBSCRIPTION_ON_HOLD: "badge-warning",
-    }
-    if not model.beneficiaryFraudResults:
-        return Markup("""<span class="badge badge-secondary">Inconnu</span>""")
-
-    statuses = Markup("<div>")
-    for (index, fraud_result) in enumerate(model.beneficiaryFraudResults):
-        statuses += Markup("""<span class="badge {css_class}" style="{extra_style}">{value}</span>""").format(
-            css_class=css_classes[fraud_result.status],
-            extra_style="margin-left: 8px" if index > 0 else "",
-            value=fraud_result.status.value,
-        )
-    statuses += Markup("</div>")
-    return statuses
-
-
 def beneficiary_fraud_review_formatter(view, context, model, name) -> Markup:
     result_mapping_class = {
         fraud_models.FraudReviewStatus.OK: "badge-success",
@@ -117,7 +96,6 @@ class BeneficiaryView(base_configuration.BaseAdminView):
         "firstName",
         "lastName",
         "email",
-        "beneficiaryFraudResults",
         "beneficiaryFraudChecks",
         "beneficiaryFraudReview",
         "dateCreated",
@@ -125,7 +103,6 @@ class BeneficiaryView(base_configuration.BaseAdminView):
     column_labels = {
         "firstName": "Prénom",
         "lastName": "Nom",
-        "beneficiaryFraudResults": "Statut(s)",
         "beneficiaryFraudChecks": "Vérifications anti fraudes",
         "beneficiaryFraudReview": "Evaluation Manuelle",
         "dateCreated": "Date de creation de compte",
@@ -135,7 +112,6 @@ class BeneficiaryView(base_configuration.BaseAdminView):
     column_filters = [
         "email",
         "dateCreated",
-        "beneficiaryFraudResults.status",
         "beneficiaryFraudChecks.type",
         "beneficiaryFraudReview",
     ]
@@ -162,7 +138,6 @@ class BeneficiaryView(base_configuration.BaseAdminView):
         formatters.update(
             {
                 "beneficiaryFraudChecks": beneficiary_fraud_checks_formatter,
-                "beneficiaryFraudResults": beneficiary_fraud_results_formatter,
                 "beneficiaryFraudReview": beneficiary_fraud_review_formatter,
             }
         )
@@ -182,7 +157,6 @@ class BeneficiaryView(base_configuration.BaseAdminView):
         view_filter = self.get_view_filter()
         query = users_models.User.query.filter(view_filter).options(
             sqlalchemy.orm.joinedload(users_models.User.beneficiaryFraudChecks),
-            sqlalchemy.orm.joinedload(users_models.User.beneficiaryFraudResults),
             sqlalchemy.orm.joinedload(users_models.User.beneficiaryFraudReview),
         )
         return query

--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -5,15 +5,6 @@ from pcapi.core.users import models as users_models
 from . import models
 
 
-def get_current_beneficiary_fraud_result(
-    user: users_models.User, eligibilityType: users_models.EligibilityType
-) -> Optional[models.BeneficiaryFraudResult]:
-    return models.BeneficiaryFraudResult.query.filter(
-        models.BeneficiaryFraudResult.userId == user.id,
-        models.BeneficiaryFraudResult.eligibilityType == eligibilityType,
-    ).one_or_none()
-
-
 def get_last_user_profiling_fraud_check(user: users_models.User) -> Optional[models.BeneficiaryFraudCheck]:
     # User profiling is not performed for UNDERAGE credit, no need to filter on eligibilityType here
     return (

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -186,41 +186,6 @@
   </div>
   {% endif %}
 </div>
-<div class="section">
-  <h3>Résultat de l'algorithme</h3>
-  {% for result in model.beneficiaryFraudResults|reverse %}
-  <table class="table">
-    <tr>
-      <th scope="row">Éligibilité</th>
-      <td>{{ result.eligibilityType|eligibility_format }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Etat</th>
-      <td>{{ result.status.value }}</td>
-    </tr>
-    <tr>
-      <th scope="row">Date de création</th>
-      <td>{{ result.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</dd>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Dernière mise à jour</th>
-      <td>{% if result.dateUpdated %}{{ result.dateUpdated.strftime('le
-        %d/%m/%Y à %H:%M:%S') }}{% else %}Inconnue{% endif %}</dd>
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">Explication</th>
-      <td>{{ result.reason }}</dd>
-      </td>
-    </tr>
-  </table>
-  {% else %}
-  <div class="card card-body">
-    Aucun résultat de fraude
-  </div>
-  {% endfor %}
-</div>
 
 <div class="section">
   <h3>Historique des changements d'adresse email</h3>

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -190,9 +190,6 @@ class EduconnectFlowTest:
             == "https://webapp-v2.example.com/educonnect/validation?firstName=Max&lastName=SENS&dateOfBirth=2006-08-18&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
-        assert len(user.beneficiaryFraudResults) == 1
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
-
         beneficiary_import = BeneficiaryImport.query.filter_by(beneficiaryId=user.id).one_or_none()
         assert beneficiary_import is not None
         assert beneficiary_import.currentStatus == ImportStatus.CREATED

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -962,11 +962,6 @@ class SendPhoneValidationCodeTest:
         assert content["message"] == expected_reason
         assert content["phone_number"] == "+33601020304"
 
-        # check that a fraud result has also been created
-        assert len(user.beneficiaryFraudResults) == 1
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
-        assert user.beneficiaryFraudResults[0].reason == expected_reason
-
     def test_send_phone_validation_code_already_beneficiary(self, client, app):
         user = users_factories.BeneficiaryGrant18Factory(
             isEmailValidated=True, phoneNumber="+33601020304", roles=[UserRole.BENEFICIARY]
@@ -1246,11 +1241,6 @@ class ValidatePhoneNumberTest:
         assert content["message"] == expected_reason
         assert content["phone_number"] == "+33607080900"
 
-        # check that a fraud result has also been created
-        assert len(user.beneficiaryFraudResults) == 1
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.SUSPICIOUS
-        assert user.beneficiaryFraudResults[0].reason == expected_reason
-
     def test_wrong_code(self, client, app):
         user = users_factories.UserFactory(
             phoneNumber="+33607080900",
@@ -1493,10 +1483,7 @@ class ProfilingFraudScoreTest:
         response = client.post("/native/v1/user_profiling", json={"sessionId": session_id, "agentType": "agent_mobile"})
 
         assert response.status_code == 204
-        assert (
-            fraud_models.BeneficiaryFraudResult.query.filter(fraud_models.BeneficiaryFraudResult.user == user).count()
-            == 1
-        )
+
         assert len(user.subscriptionMessages) == 1
         sub_message = user.subscriptionMessages[0]
         assert sub_message.userMessage == "Ton inscription n'a pas pu aboutir."

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -143,9 +143,7 @@ class EduconnectTest:
             "school_uai": "school_uai",
             "student_level": "2212",
         }
-        assert len(user.beneficiaryFraudResults) == 1
         assert has_passed_educonnect(user)
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
         beneficiary_import = BeneficiaryImport.query.filter_by(beneficiaryId=user.id).one_or_none()
         assert beneficiary_import.currentStatus == ImportStatus.CREATED
         assert user.firstName == "Max"
@@ -355,7 +353,7 @@ class EduconnectTest:
 
         assert response.status_code == 302
         assert response.location.startswith("https://webapp-v2.example.com/educonnect/validation")
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.OK
+        assert user.is_beneficiary
 
     @override_features(ENABLE_INE_WHITELIST_FILTER=False)
     @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_educonnect_user")
@@ -372,7 +370,7 @@ class EduconnectTest:
             "https://webapp-v2.example.com/educonnect/erreur?code=UserAgeNotValid&logoutUrl=https%3A%2F%2Feduconnect.education.gouv.fr%2FLogout"
         )
 
-        assert user.beneficiaryFraudResults[0].status == fraud_models.FraudStatus.KO
+        assert not user.is_beneficiary
 
         response = client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
         assert response.status_code == 302


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12582


## But de la pull request

Supprimer l'ensemble de l'utilisation des BeneficiaryFraudResults qui ne sont désormais plus utiles
##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)