### PR TITLE
[API] (PC-12853) feat:search: administrative venues

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -215,7 +215,7 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
 
     @property
     def is_eligible_for_search(self) -> bool:
-        return self.isPermanent and self.managingOfferer.isActive
+        return self.isPermanent and self.managingOfferer.isActive and self.venueTypeCode != VenueTypeCode.ADMINISTRATIVE
 
     def store_departement_code(self) -> None:
         self.departementCode = PostalCode(self.postalCode).get_departement_code()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12853


## But de la pull request

Un lieu ne peut être indexé que s'il respecte ces trois conditions : 

1. il est permanent ;
2. sa structure est active ;
3. son type ne fait pas partie de la liste des types interdits (uniquement [lieux administratifs](https://github.com/pass-culture/pass-culture-main/pull/1030) pour l'instant).

Les deux premières sont celles déjà appliquées, cette PR ajoute la dernière.
​
##  Informations supplémentaires

Si la liste des types de lieux interdits grandit, on pourra déplacer tout ça dans une propriété / une constante / autre... mais pour l'instant, autant aller au plus simple.