### PR TITLE
[PC-12830][API][PRO] fix filter per date on offers view

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -167,6 +167,10 @@ def get_offers_by_filters(
                 )
                 <= period_ending_date
             )
+        if venue_id is not None:
+            subquery = subquery.filter(Offer.venueId == venue_id)
+        if offerer_id is not None:
+            subquery = subquery.filter(Venue.managingOffererId == offerer_id)
         q2 = subquery.subquery()
         query = query.join(q2, q2.c.offerId == Offer.id)
     return query


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12830


## But de la pull request

When rewriting the offer view's query the filter on date was moved
to a subquery to apply the DISTINCT ON offerId.
It seesm that the subquery was a bit too broad and missing filters
on venue/offerer takes way too long.
I guess that - at some point - this will be again an issue but
that should buy us time before.

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
