### PR TITLE
[PC-12887][api][finance] Fix compression of `payments_details.csv` CSV file

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -514,7 +514,12 @@ def _write_csv(
                 writer.writerows(row_formatter(row) for row in rows_)
     if compress:
         compressed_path = pathlib.Path(str(path) + ".zip")
-        with zipfile.ZipFile(compressed_path, "w") as zfile:
+        with zipfile.ZipFile(
+            compressed_path,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+        ) as zfile:
             zfile.write(path, arcname=path.name)
         path = compressed_path
     return path


### PR DESCRIPTION
The default value for `compression` is `ZIP_STORED`: "The numeric
constant for an uncompressed archive member". The 60Mb CSV file was
thus compressed into a 60Mb ZIP file. In fact, the ZIP file was
slightly larger. That was not quite what was intended.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12887