### PR TITLE
(PC-11624) use reference_scheme for invoice.reference

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-6940a75b4417 (head)
+c0aecae92e70 (head)

--- a/api/src/pcapi/alembic/versions/20220119T134451_c0aecae92e70_upsert_invoice_reference_into_reference_scheme.py
+++ b/api/src/pcapi/alembic/versions/20220119T134451_c0aecae92e70_upsert_invoice_reference_into_reference_scheme.py
@@ -1,0 +1,29 @@
+"""Upsert invoice.reference into reference_scheme
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "c0aecae92e70"
+down_revision = "6940a75b4417"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        INSERT INTO reference_scheme ("name", "prefix", "year", "nextNumber", "numberPadding")
+        VALUES
+         ('invoice.reference', 'F', 2022, 1, 7),
+         ('invoice.reference', 'F', 2023, 1, 7),
+         ('invoice.reference', 'F', 2024, 1, 7),
+         ('invoice.reference', 'F', 2025, 1, 7),
+         ('invoice.reference', 'F', 2026, 1, 7)
+         ON CONFLICT DO NOTHING;
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -56,7 +56,7 @@
 <body>
 
 <h1>Justificatif de remboursement</h1>
-<h2 class="invoice_info">Relevé n°000004 du 21/12/2021</h2>
+<h2 class="invoice_info">Relevé n°F220000001 du 21/12/2021</h2>
 
 <p>
 <div><b>Nom :</b> SARL LIBRAIRIE BOOKING</div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11624


## But de la pull request

Utiliser des références uniques consécutives pour les Invoices.

##  Implémentation

- Migration d’ajout de données initiales dans la table reference_scheme (pour 5 ans)
- Utilisation d’un ReferenceScheme pour invoice.reference
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
