### PR TITLE
(PC-12792)[API]sendinblue pro offer approval email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/offer_validation_to_pro.py
@@ -10,17 +10,27 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.utils.mailing import build_pc_pro_offer_link
 
 
-def retrieve_data_for_offer_approval_email(offer: Offer) -> dict:
-    return {
-        "MJ-TemplateID": 2613721,
-        "MJ-TemplateLanguage": True,
-        "FromEmail": settings.COMPLIANCE_EMAIL_ADDRESS,
-        "Vars": {
-            "offer_name": offer.name,
-            "venue_name": offer.venue.publicName or offer.venue.name,
-            "pc_pro_offer_link": build_pc_pro_offer_link(offer),
+def retrieve_data_for_offer_approval_email(offer: Offer) -> Union[dict, SendinblueTransactionalEmailData]:
+    if not FeatureToggle.ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS.is_active():
+        return {
+            "MJ-TemplateID": 2613721,
+            "MJ-TemplateLanguage": True,
+            "FromEmail": settings.COMPLIANCE_EMAIL_ADDRESS,
+            "Vars": {
+                "offer_name": offer.name,
+                "venue_name": offer.venue.publicName or offer.venue.name,
+                "pc_pro_offer_link": build_pc_pro_offer_link(offer),
+            },
+        }
+
+    return SendinblueTransactionalEmailData(
+        template=TransactionalEmail.OFFER_APPROVAL_TO_PRO.value,
+        params={
+            "OFFER_NAME": offer.name,
+            "VENUE_NAME": offer.venue.publicName or offer.venue.name,
+            "PC_PRO_OFFER_LINK": build_pc_pro_offer_link(offer),
         },
-    }
+    )
 
 
 def retrieve_data_for_offer_rejection_email(offer: Offer) -> Union[dict, SendinblueTransactionalEmailData]:

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -120,8 +120,8 @@ class TransactionalEmail(Enum):
     FIRST_OFFER_CREATED_BY_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=[""])
     FRAUD_PREVENTION_TO_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=[""])
     NEW_BOOKING_TO_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=["pro_nouvelle_reservation"])
-    OFFER_MANUAL_VALIDATION_TO_PRO = TemplatePro(
-        id_prod=0000, id_not_prod=0000, tags=["pro_validation_offre"], sender=SendinblueTransactionalSender.COMPLIANCE
+    OFFER_APPROVAL_TO_PRO = TemplatePro(
+        id_prod=349, id_not_prod=49, tags=["pro_validation_offre"], sender=SendinblueTransactionalSender.COMPLIANCE
     )
     OFFER_REJECTION_TO_PRO = TemplatePro(
         id_prod=375, id_not_prod=48, tags=["pro_offre_refusee"], sender=SendinblueTransactionalSender.COMPLIANCE


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12792

## But de la pull request
migration mailjet vers sendinblue
lorsqu'une offre est approuvé, l'acteur culturel reçoit un email de validation.

##  Implémentation
N/A
​
##  Informations supplémentaires
N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
