### PR TITLE
[API] (PC-12885) fix:sandbox: all venues have a type

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -87,6 +87,7 @@ class VirtualVenueTypeFactory(BaseFactory):
 class VenueTypeFactory(BaseFactory):
     class Meta:
         model = VenueType
+        sqlalchemy_get_or_create = ("label",)
 
     label = "Librairie"
 

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -53,6 +53,9 @@ class VenueFactory(BaseFactory):
     siret = factory.LazyAttributeSequence(lambda o, n: f"{o.managingOfferer.siren}{n:05}")
     isVirtual = False
     venueTypeCode = offerers_models.VenueTypeCode.OTHER
+    venueType = factory.SubFactory(
+        "pcapi.core.offerers.factories.VenueTypeFactory", label=factory.SelfAttribute("..venueTypeCode.value")
+    )
     description = factory.Faker("text", max_nb_chars=64)
     audioDisabilityCompliant = False
     mentalDisabilityCompliant = False
@@ -76,6 +79,7 @@ class VirtualVenueFactory(VenueFactory):
     mentalDisabilityCompliant = None
     motorDisabilityCompliant = None
     visualDisabilityCompliant = None
+    venueTypeCode = offerers_models.VenueTypeCode.DIGITAL
 
 
 class ProductFactory(BaseFactory):

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -38,6 +38,7 @@ from pcapi.scripts.venue.venue_label.create_venue_labels import create_venue_lab
 
 
 def save_industrial_sandbox() -> None:
+    venue_types = create_industrial_venue_types()
     (offerers_by_name, pro_users_by_name) = create_industrial_offerers_with_pro_users()
 
     admin_users_by_name = create_industrial_admin_users()
@@ -45,8 +46,6 @@ def save_industrial_sandbox() -> None:
     app_users_by_name = create_industrial_app_users()
 
     users_by_name = dict(dict(admin_users_by_name, **pro_users_by_name), **app_users_by_name)
-
-    venue_types = create_industrial_venue_types()
 
     venues_by_name = create_industrial_venues(offerers_by_name, venue_types)
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_activation_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_activation_offers.py
@@ -1,10 +1,10 @@
 import logging
 
 from pcapi.core.categories import subcategories
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users.models import User
 from pcapi.model_creators.generic_creators import create_booking
 from pcapi.model_creators.generic_creators import create_offerer
-from pcapi.model_creators.generic_creators import create_venue
 from pcapi.model_creators.specific_creators import create_offer_with_thing_product
 from pcapi.model_creators.specific_creators import create_stock_with_thing_offer
 from pcapi.repository import repository
@@ -18,7 +18,7 @@ def create_industrial_activation_offers():
 
     activated_user = User.query.filter_by(has_beneficiary_role=True).first()
     offerer = create_offerer()
-    venue = create_venue(offerer, is_virtual=True, siret=None)
+    venue = offers_factories.VirtualVenueFactory(managingOfferer=offerer)
     offer = create_offer_with_thing_product(venue, thing_subcategory_id=subcategories.ACTIVATION_THING.id)
     stock = create_stock_with_thing_offer(offerer, venue, offer=offer, price=0, quantity=10000)
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
@@ -4,6 +4,7 @@ from pcapi.core.bookings.factories import EducationalBookingFactory
 from pcapi.core.bookings.factories import UsedEducationalBookingFactory
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.educational.factories as educational_factories
+from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.core.offers.factories import EducationalEventStockFactory
 from pcapi.core.offers.factories import MediationFactory
 from pcapi.core.offers.factories import UserOffererFactory
@@ -76,7 +77,11 @@ def create_industrial_educational_bookings() -> None:
     now = datetime.datetime.now(datetime.timezone.utc)
     stocks = []
     venue = VenueFactory(
-        name="Opéra Royal de Versailles", isPermanent=True, siret="95046949400021", managingOfferer__siren="950469494"
+        name="Opéra Royal de Versailles",
+        isPermanent=True,
+        siret="95046949400021",
+        managingOfferer__siren="950469494",
+        venueTypeCode=VenueTypeCode.PERFORMING_ARTS,
     )
     UserOffererFactory(validationToken=None, offerer=venue.managingOfferer)
 
@@ -85,7 +90,10 @@ def create_industrial_educational_bookings() -> None:
         validationToken=None, user__email="pc.test.payments.eac@example.com"
     )
     venue_reimbursements = VenueFactory(
-        name="Théâtre des potirons", isPermanent=True, managingOfferer=user_offerer_reimbursements.offerer
+        name="Théâtre des potirons",
+        isPermanent=True,
+        managingOfferer=user_offerer_reimbursements.offerer,
+        venueTypeCode=VenueTypeCode.PERFORMING_ARTS,
     )
 
     for stock_data in FAKE_STOCK_DATA:

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerers_with_pro_users.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerers_with_pro_users.py
@@ -1,11 +1,12 @@
 import logging
 
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.repository import check_if_siren_already_exists
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.model_creators.generic_creators import create_bank_information
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user_offerer
-from pcapi.model_creators.generic_creators import create_venue
 from pcapi.repository import repository
 from pcapi.sandboxes.scripts.mocks.educational_siren_mocks import MOCK_ADAGE_ELIGIBLE_SIREN
 from pcapi.sandboxes.scripts.mocks.offerer_mocks import MOCK_NAMES
@@ -176,15 +177,16 @@ def create_industrial_offerers_with_pro_users():
 
         if create_educational_offerer:
             offerer.siren = MOCK_ADAGE_ELIGIBLE_SIREN
-            create_venue(
-                offerer,
+            offers_factories.VenueFactory(
+                managingOfferer=offerer,
                 address=offerer.address,
-                booking_email="fake@email.com",
+                bookingEmail="fake@email.com",
                 city=offerer.city,
                 comment="Salle de cinéma",
                 name=offerer.name + " - Salle 1",
-                postal_code=offerer.postalCode,
+                postalCode=offerer.postalCode,
                 siret="88145723811111",
+                venueTypeCode=offerers_models.VenueTypeCode.MOVIE,
             )
 
         # create every OFFERERS_WITH_IBAN_REMOVE_MODULO an offerer with no iban

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
@@ -8,6 +8,7 @@ from pcapi.core.offerers.factories import AllocineVenueProviderPriceRuleFactory
 from pcapi.core.offerers.factories import VenueProviderFactory
 from pcapi.core.offerers.models import VENUE_TYPE_CODE_MAPPING
 from pcapi.core.offerers.models import VenueType
+from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.core.offers.factories import BankInformationFactory
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.offers.factories import VirtualVenueFactory
@@ -73,7 +74,7 @@ def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType
             # the venue_type table has been finally replaced by the
             # VenueTypeCode enum
             venue_type = random.choice(venue_types)
-            venue_type_code = label_to_code.get(venue_type.label, "OTHER")
+            venue_type_code = VenueTypeCode[label_to_code.get(venue_type.label, "OTHER")]
 
             venue = VenueFactory(
                 managingOfferer=offerer,

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -7,6 +7,7 @@ import pytest
 
 from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
 from pcapi.core.search.backends.algolia import AlgoliaBackend
 from pcapi.model_creators.generic_creators import create_criterion
 from pcapi.model_creators.generic_creators import create_offerer
@@ -518,7 +519,7 @@ class BuildObjectTest:
 @pytest.mark.usefixtures("db_session")
 def test_serialize_venue():
     venue = offerers_factories.VenueFactory(
-        venueTypeCode="VISUAL_ARTS",
+        venueTypeCode=offerers_models.VenueTypeCode.VISUAL_ARTS,
         audioDisabilityCompliant=True,
         contact__email="venue@example.com",
         contact__website="http://venue.example.com",

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -234,7 +234,7 @@ class Returns200Test:
                 "siret": "12345678912345",
                 "thumbCount": 0,
                 "venueLabelId": None,
-                "venueTypeId": None,
+                "venueTypeId": humanize(venue.venueTypeId),
                 "visualDisabilityCompliant": False,
             },
             "venueId": humanize(venue.id),

--- a/api/tests/routes/webapp/get_booking_by_id_test.py
+++ b/api/tests/routes/webapp/get_booking_by_id_test.py
@@ -155,7 +155,7 @@ class Returns200Test:
                         "siret": offer.venue.siret,
                         "thumbCount": 0,
                         "venueLabelId": None,
-                        "venueTypeId": None,
+                        "venueTypeId": humanize(offer.venue.venueTypeId),
                         "visualDisabilityCompliant": False,
                         "venueTypeCode": offer.venue.venueTypeCode.value,
                         "withdrawalDetails": None,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12885


## But de la pull request

Faire en sorte que les lieux créés par la _sandbox industrial_ ont tous un type (`venueTypeId` et `venueTypeCode` - en attendant que la transition vers `venueTypeCode` soit terminée).
 
Le problème est que d'un côté la colonne `venueTypeId` peut être nulle, de l'autre on s'attend à ce qu'un lieu ait toujours un type. Résultat, avec la _sandbox_, deux tiers des lieux créés n'avaient pas de type, ce qui n'est pas idéal pour réaliser des tests en **testing**.