### PR TITLE
(PC-12899) Fix DMS eligibilityType definition

### DIFF
--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -81,7 +81,7 @@ DMS_ERROR_MESSSAGE_BIRTH_DATE = """Bonjour,
                         Nous avons bien reçu ton dossier, mais il y a une erreur dans la date de naissance inscrite sur le formulaire en ligne.
 
                         Merci de corriger ton dossier.
-                        Tu trouveras de l'aide dans cet article : <a href="https://aide.passculture.app/fr/articles/5100876-jeunes-ou-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-demarches-simplifiees">https://aide.passculture.app/fr/articles/5100876-jeunes-ou-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-demarches-simplifiees</a>
+                        Tu trouveras de l'aide dans cet article : <a href="https://aide.passculture.app/hc/fr/sections/4411991878545-Inscription-sur-D%C3%A9marches-Simplifi%C3%A9es">https://aide.passculture.app/hc/fr/sections/4411991878545-Inscription-sur-Démarches-Simplifiées</a>
 
                         Bonne journée,
 

--- a/api/src/pcapi/scripts/beneficiary/import_dms_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_dms_users.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import logging
 import re
 
@@ -12,7 +11,6 @@ import pcapi.core.fraud.exceptions as fraud_exceptions
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.subscription.api as subscription_api
 import pcapi.core.subscription.messages as subscription_messages
-import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.domain import user_emails
@@ -253,10 +251,9 @@ def parse_beneficiary_information_graphql(application_detail: dict, procedure_id
         if "Veuillez indiquer votre département" in label:
             information["department"] = re.search("^[0-9]{2,3}|[2BbAa]{2}", value).group(0)
         if label in ("Quelle est votre date de naissance", "Quelle est ta date de naissance ?"):
-            birth_date = date_parser.parse(value, FrenchParserInfo())
-            if users_api.get_eligibility_at_date(birth_date, datetime.now()) is not None:
-                information["birth_date"] = birth_date
-            else:
+            try:
+                information["birth_date"] = date_parser.parse(value, FrenchParserInfo())
+            except Exception:  # pylint: disable=broad-except
                 parsing_errors["birth_date"] = value
 
         if label in (

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -53,7 +53,7 @@ class DmsWebhookApplicationTest:
         form_data = {
             "procedure_id": "48860",
             "dossier_id": "6044787",
-            "state": "en_construction",
+            "state": "accepte",
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
         response = client.post(


### PR DESCRIPTION
The eligibilityType was eroneously considered regarding datetime.now() instead of registration_datetime. Moreover, do not consider as 'ParsingException' when eligibilityType is None. It is a specific case we want to handle separately

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12899


## But de la pull request

(Ajout de fonctionnalités, Problèmes résolus, etc)

##  Implémentation

- (Ajouts de modèles, Changements significatifs)
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
