### PR TITLE
(PC-11888)[API] Catch not found file exception on GCP bucket when trying to delete thumbnail

### DIFF
--- a/api/src/pcapi/core/object_storage/backends/gcp.py
+++ b/api/src/pcapi/core/object_storage/backends/gcp.py
@@ -1,5 +1,6 @@
 import logging
 
+from google.cloud.exceptions import NotFound
 from google.cloud.storage import Client
 from google.cloud.storage.bucket import Bucket
 from google.oauth2.service_account import Credentials
@@ -36,6 +37,8 @@ class GCPBackend(BaseBackend):
             bucket = self.get_gcp_storage_client_bucket()
             gcp_cloud_blob = bucket.blob(storage_path)
             gcp_cloud_blob.delete()
+        except NotFound:
+            logger.info("File not found on deletion on GCP bucket: %s", storage_path)
         except Exception as exc:
             logger.exception("An error has occured while trying to delete file on GCP bucket: %s", exc)
             raise exc


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11888

Catch not found file exception on GCP bucket when trying to delete thumbnail

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
