### PR TITLE
[API] (PC-12869) fix:account: rm device id

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-c0aecae92e70 (head)
+f477748a5c40 (head)

--- a/api/src/pcapi/admin/custom_views/user_email_history_view.py
+++ b/api/src/pcapi/admin/custom_views/user_email_history_view.py
@@ -3,7 +3,6 @@ from flask import request
 from flask import url_for
 from flask.helpers import flash
 from flask_admin import expose
-from flask_login import current_user
 from werkzeug import Response
 from werkzeug.exceptions import BadRequestKeyError
 from werkzeug.routing import BuildError
@@ -26,7 +25,6 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
         "newEmail",
         "creationDate",
         "eventType",
-        "deviceId",
     ]
 
     column_labels = dict(
@@ -37,14 +35,12 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
         newDomainEmail="Nouveau nom de domaine d'adresse email",
         creationDate="Date de création",
         eventType="Type d'événement",
-        deviceId="Device ID",
     )
 
     column_searchable_list = [
         "userId",
         "oldEmail",
         "newEmail",
-        "deviceId",
     ]
 
     column_filters = [
@@ -54,7 +50,6 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
         "newEmail",
         "newDomainEmail",
         "eventType",
-        "deviceId",
     ]
 
     @expose("/")
@@ -86,9 +81,7 @@ class UserEmailHistoryView(SuspensionMixin, BaseAdminView):
             )
         else:
             try:
-                users_api.change_user_email(
-                    current_email=entry.oldEmail, new_email=entry.newEmail, admin=True, device_id=current_user.email
-                )
+                users_api.change_user_email(current_email=entry.oldEmail, new_email=entry.newEmail, admin=True)
             except users_exceptions.UserDoesNotExist:
                 flash(f"L'utilisateur avec l'adresse email {entry.oldEmail} n'a pas été trouvé", category="error")
             except users_exceptions.EmailExistsError:

--- a/api/src/pcapi/alembic/versions/20220119T145431_f477748a5c40_rm_deviceid.py
+++ b/api/src/pcapi/alembic/versions/20220119T145431_f477748a5c40_rm_deviceid.py
@@ -1,0 +1,19 @@
+"""rm deviceId
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f477748a5c40"
+down_revision = "c0aecae92e70"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("user_email_history", "deviceId")
+
+
+def downgrade():
+    op.add_column("user_email_history", sa.Column("deviceId", sa.VARCHAR(), autoincrement=False, nullable=True))

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -452,7 +452,6 @@ def bulk_unsuspend_account(user_ids: list[int], actor: User) -> None:
 def change_user_email(
     current_email: str,
     new_email: str,
-    device_id: typing.Optional[str] = None,
     admin: bool = False,
 ) -> None:
     current_user = find_user_by_email(current_email)
@@ -460,9 +459,7 @@ def change_user_email(
     if not current_user:
         raise exceptions.UserDoesNotExist()
 
-    email_history = UserEmailHistory.build_validation(
-        user=current_user, new_email=new_email, device_id=device_id, admin=admin
-    )
+    email_history = UserEmailHistory.build_validation(user=current_user, new_email=new_email, admin=admin)
 
     try:
         current_user.email = new_email

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -20,7 +20,7 @@ from .send import send_user_emails_for_email_change
 logger = logging.getLogger(__name__)
 
 
-def request_email_update(user: User, email: str, password: str, device_id: typing.Optional[str] = None) -> None:
+def request_email_update(user: User, email: str, password: str) -> None:
     check_email_update_attempts(user)
 
     expiration_date = generate_token_expiration_date()
@@ -29,11 +29,7 @@ def request_email_update(user: User, email: str, password: str, device_id: typin
     check_email_address_does_not_exist(email)
     check_user_password(user, password)
 
-    email_history = UserEmailHistory.build_update_request(
-        user=user,
-        new_email=email,
-        device_id=device_id,
-    )
+    email_history = UserEmailHistory.build_update_request(user=user, new_email=email)
     repository.save(email_history)
 
     send_user_emails_for_email_change(user, email, expiration_date)

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -389,7 +389,6 @@ class UserEmailHistoryFactory(BaseFactory):
     oldDomainEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[1])
     newUserEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[0])
     newDomainEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[1] + ".update")
-    deviceId = "deviceId"
 
 
 class EmailUpdateEntryFactory(UserEmailHistoryFactory):

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -572,14 +572,11 @@ class UserEmailHistory(PcObject, Model):
 
     eventType = sa.Column(sa.Enum(EmailHistoryEventTypeEnum), nullable=False)
 
-    deviceId = sa.Column(sa.String, nullable=True)
-
     @classmethod
     def _build(
         cls,
         user: User,
         new_email: str,
-        device_id: Optional[str],
         event_type: EmailHistoryEventTypeEnum,
     ) -> "UserEmailHistory":
         old_user_email, old_domain_email = split_email(user.email)
@@ -590,19 +587,18 @@ class UserEmailHistory(PcObject, Model):
             oldDomainEmail=old_domain_email,
             newUserEmail=new_user_email,
             newDomainEmail=new_domain_email,
-            deviceId=device_id,
             eventType=event_type,
         )
 
     @classmethod
-    def build_update_request(cls, user: User, new_email: str, device_id: Optional[str]) -> "UserEmailHistory":
-        return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.UPDATE_REQUEST)
+    def build_update_request(cls, user: User, new_email: str) -> "UserEmailHistory":
+        return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.UPDATE_REQUEST)
 
     @classmethod
-    def build_validation(cls, user: User, new_email: str, device_id: Optional[str], admin: bool) -> "UserEmailHistory":
+    def build_validation(cls, user: User, new_email: str, admin: bool) -> "UserEmailHistory":
         if admin:
-            return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.ADMIN_VALIDATION)
-        return cls._build(user, new_email, device_id, event_type=EmailHistoryEventTypeEnum.VALIDATION)
+            return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.ADMIN_VALIDATION)
+        return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.VALIDATION)
 
     @hybrid_property
     def oldEmail(self) -> str:

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -79,12 +79,7 @@ def reset_recredit_amount_to_show(user: User) -> None:
 @authenticated_user_required
 def update_user_email(user: User, body: serializers.UserProfileEmailUpdate) -> None:
     try:
-        email_api.request_email_update(
-            user,
-            body.email,
-            body.password,
-            device_id=request.headers.get("device-id"),
-        )
+        email_api.request_email_update(user, body.email, body.password)
     except exceptions.EmailUpdateTokenExists:
         raise ApiErrors(
             {"code": "TOKEN_EXISTS", "message": "Une demande de modification d'adresse e-mail est déjà en cours"},
@@ -116,11 +111,7 @@ def update_user_email(user: User, body: serializers.UserProfileEmailUpdate) -> N
 def validate_user_email(body: beneficiaries_serialization.ChangeBeneficiaryEmailBody) -> None:
     try:
         payload = beneficiaries_serialization.ChangeEmailTokenContent.from_token(body.token)
-        api.change_user_email(
-            current_email=payload.current_email,
-            new_email=payload.new_email,
-            device_id=request.headers.get("device-id"),
-        )
+        api.change_user_email(current_email=payload.current_email, new_email=payload.new_email)
     except pydantic.ValidationError:
         raise ApiErrors(
             {"code": "INVALID_EMAIL", "message": "Adresse email invalide"},

--- a/api/src/pcapi/routes/webapp/beneficiaries.py
+++ b/api/src/pcapi/routes/webapp/beneficiaries.py
@@ -87,7 +87,6 @@ def change_beneficiary_email(body: ChangeBeneficiaryEmailBody) -> None:
         users_api.change_user_email(
             current_email=payload.current_email,
             new_email=payload.new_email,
-            device_id=request.headers.get("device-id"),
         )
     except pydantic.ValidationError:
         # Do nothing to avoid a breaking change

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -229,7 +229,6 @@
         <td>{{ email_history.newEmail }}</td>
         <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
         <td>{{ email_history.eventType.value }}</td>
-        <td>{{ email_history.deviceId }}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12869


## But de la pull request

Supprimer la colonne `deviceId` de la table `user_email_history` : l'information est récupérée de la requête http, l'information peut trop facilement être modifiée et n'est donc pas fiable, il n'y a donc aucune raison de la conserver.