### PR TITLE
[MAIN] BSR: launch adage quality tests on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,11 +459,31 @@ jobs:
       - checkout
       - skip_unchanged:
           paths: adage-front
+      - unless:
+          condition:
+            equal: ["master", << pipeline.git.branch >>]
+          steps:
+            - restore_cache:
+                name: Restore Yarn Package Cache
+                key: << pipeline.parameters.adage-front_cache_key >>
+      - run:
+          name: Install dependencies
+          working_directory: adage-front
+          command: |
+            yarn install
+      - unless:
+          condition:
+            equal: ["master", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                name: Save Yarn Package Cache
+                key: << pipeline.parameters.adage-front_cache_key >>
+                paths:
+                  - ~/.cache/yarn
       - run:
           name: Run Unit Test Adage-front
+          working_directory: adage-front
           command: |
-            cd adage-front
-            yarn install
             yarn test:unit
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ parameters:
   pro_cache_key:
     type: string
     default: 'yarn-packages-{{ checksum "pro/yarn.lock" }}'
+  adage-front_cache_key:
+    type: string
+    default: 'yarn-packages-{{ checksum "adage-front/yarn.lock" }}'
 
 ###################
 #  EXECUTORS
@@ -400,6 +403,47 @@ jobs:
           working_directory: api
       - store_test_results:
           path: api/test-results
+      - when:
+          condition:
+            equal: ["master", << pipeline.git.branch >>]
+          steps:
+            - notify-slack:
+                channel: shérif
+  
+  quality-adage-front:
+    docker:
+      - image: cimg/node:14.17
+    working_directory: ~/pass-culture
+    steps:
+      - checkout
+      - skip_unchanged:
+          paths: adage-front
+      - unless:
+          condition:
+            equal: ["master", << pipeline.git.branch >>]
+          steps:
+            - restore_cache:
+                name: Restore Yarn Package Cache
+                key: << pipeline.parameters.adage-front_cache_key >>
+      - run:
+          name: Install dependencies
+          working_directory: adage-front
+          command: |
+            yarn install
+      - unless:
+          condition:
+            equal: ["master", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                name: Save Yarn Package Cache
+                key: << pipeline.parameters.adage-front_cache_key >>
+                paths:
+                  - ~/.cache/yarn
+      - run:
+          name: Running linter
+          working_directory: adage-front
+          command: |
+            yarn lint:js
       - when:
           condition:
             equal: ["master", << pipeline.git.branch >>]
@@ -850,6 +894,14 @@ workflows:
                 - staging
                 - integration
           context: Slack
+      - quality-adage-front:
+          filters:
+            branches:
+              ignore:
+                - production
+                - staging
+                - integration
+          context: Slack
       - quality-api:
           filters:
             branches:
@@ -976,6 +1028,7 @@ workflows:
               only:
                 - master
           requires:
+            - quality-adage-front
             - tests-adage-front
             - restart-pcapi
           context:

--- a/adage-front/src/app/components/OffersSearch/OfferFilters/OfferFilters.spec.tsx
+++ b/adage-front/src/app/components/OffersSearch/OfferFilters/OfferFilters.spec.tsx
@@ -1,9 +1,8 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import selectEvent from 'react-select-event'
 
-import * as pcapi from 'repository/pcapi/pcapi'
-import { Role, VenueFilterType } from 'utils/types'
+import { VenueFilterType } from 'utils/types'
 
 import { OfferFilters } from './OfferFilters'
 
@@ -11,7 +10,6 @@ jest.mock('repository/pcapi/pcapi', () => ({
   authenticate: jest.fn(),
   getVenueBySiret: jest.fn(),
 }))
-const mockedPcapi = pcapi as jest.Mocked<typeof pcapi>
 
 describe('offerFilters', () => {
   describe('filter tags', () => {

--- a/adage-front/src/app/types/facets.ts
+++ b/adage-front/src/app/types/facets.ts
@@ -1,1 +1,1 @@
-export type Facets = (string|string[])[]
+export type Facets = (string | string[])[]


### PR DESCRIPTION
## But de la pull request

Suite au passage monorepo, les tests de qualité adage-front ne se lançaient plus en ci

##  Implémentation

- Remontée de la conf circle-ci de adage-front/.circleci au niveau du fichier de config du main
​
##  Informations supplémentaires

- Exemples : nettoyage de code, utilisation de factories, Boy Scout Rule
- Explications sur l'utilisation d'outils peu communs (Exemple psql window function, metaclasses, yield from)
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
