### PR TITLE
(PC-12913)[PRO]fix:sendinblue sender for email reset password

### DIFF
--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -12,7 +12,12 @@ logger = logging.getLogger(__name__)
 
 def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
     to = [{"email": email} for email in payload.recipients]
-    sender = {"email": settings.SUPPORT_EMAIL_ADDRESS, "name": "pass Culture"}
+    #  FIXME(2022-01-20, tgabin): use an env variable
+    sender = (
+        {"email": settings.SUPPORT_EMAIL_ADDRESS, "name": "pass Culture"}
+        if payload.template_id != 364
+        else {"email": "support-pro@passculture.app", "name": "pass Culture [PRO]"}
+    )
     template_id = payload.template_id
     tags = payload.tags
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12913


## But de la pull request

HF pour corriger l'adresse d'envoi du mail de reinitilisation mdp en production
support-pro@passculture.app (au lieu de support@passculture.app)

##  Implémentation

- fix temporaire pour cas particilier (1 seul mail concerné pour le moment)
​
##  Informations supplémentaires

N/A
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
