### PR TITLE
[PC-12916][API] fix email for expired bookings

### DIFF
--- a/api/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -17,6 +17,7 @@ from pcapi.core.mails.transactional.bookings.booking_expired_to_beneficiary impo
 )
 from pcapi.core.mails.transactional.sendinblue_template_ids import SendinblueTransactionalEmailData
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.users.models import User
 from pcapi.domain.user_emails import send_expired_individual_bookings_recap_email_to_offerer
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
@@ -146,9 +147,10 @@ def notify_users_of_expired_individual_bookings(expired_on: datetime.date = None
     expired_on = expired_on or datetime.date.today()
 
     logger.info("[notify_users_of_expired_bookings] Start")
-    users = bookings_repository.find_users_with_expired_individual_bookings(expired_on)
+    user_ids = bookings_repository.find_user_ids_with_expired_individual_bookings(expired_on)
     notified_users_str = []
-    for user in users:
+    for user_id in user_ids:
+        user = User.query.get(user_id)
         send_expired_bookings_to_beneficiary_email(
             user,
             [


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12916

## But de la pull request

Since we send an email  for expired bookings, an entry in the
mail table is added and commited for each user.
However the commit for the first user breaks the cursor used for
looping over users.
This work around the issue by getting the list of user's ids and
then fetch the user one by one. Might not be the most efficient
but saves memory.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
