### PR TITLE
(PC-12648) UI Fixes : ApplicationBanner and Venue invalid bu banner

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/ApplicationBanner.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/ApplicationBanner.jsx
@@ -11,9 +11,11 @@ import { Banner } from 'ui-kit'
 export const ApplicationBanner = ({ applicationId }) => (
   <Banner
     href={`https://www.demarches-simplifiees.fr/dossiers/${applicationId}`}
-    linkTitle="Accéder au dossier"
+    linkTitle="Voir le dossier en cours"
+    type="notification-info"
   >
-    Votre dossier est en cours pour ce lieu
+    Les coordonnées bancaires de votre lieu sont en cours de validation par
+    notre service financier.
   </Banner>
 )
 

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/ApplicationBanner.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/ApplicationBanner.spec.jsx
@@ -20,9 +20,11 @@ describe('when offerer has no bank informations', () => {
 
     // then
     expect(wrapper.find('Banner').props()).toStrictEqual({
-      children: 'Votre dossier est en cours pour ce lieu',
-      linkTitle: 'Accéder au dossier',
+      children:
+        'Les coordonnées bancaires de votre lieu sont en cours de validation par notre service financier.',
+      linkTitle: 'Voir le dossier en cours',
       href: 'https://www.demarches-simplifiees.fr/dossiers/12',
+      type: 'notification-info',
     })
   })
 })

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
@@ -157,7 +157,7 @@ describe('src | Venue | BankInformation', () => {
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
-        const seeDataLink = screen.getByText('Accéder au dossier')
+        const seeDataLink = screen.getByText('Voir le dossier en cours')
         expect(seeDataLink).toBeInTheDocument()
         expect(seeDataLink).toHaveAttribute('href', expectedUrl)
       })
@@ -186,7 +186,7 @@ describe('src | Venue | BankInformation', () => {
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
-        const seeDataLink = screen.getByText('Accéder au dossier')
+        const seeDataLink = screen.getByText('Voir le dossier en cours')
         expect(seeDataLink).toBeInTheDocument()
         expect(seeDataLink).toHaveAttribute('href', expectedUrl)
 
@@ -211,7 +211,7 @@ describe('src | Venue | BankInformation', () => {
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
-        const seeDataLink = screen.getByText('Accéder au dossier')
+        const seeDataLink = screen.getByText('Voir le dossier en cours')
         expect(seeDataLink).toBeInTheDocument()
         expect(seeDataLink).toHaveAttribute('href', expectedUrl)
 
@@ -241,7 +241,7 @@ describe('src | Venue | BankInformation', () => {
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
-        const seeDataLink = screen.getByText('Accéder au dossier')
+        const seeDataLink = screen.getByText('Voir le dossier en cours')
         expect(seeDataLink).toBeInTheDocument()
         expect(seeDataLink).toHaveAttribute('href', expectedUrl)
 

--- a/pro/src/styles/components/pages/Venue/_Venue.scss
+++ b/pro/src/styles/components/pages/Venue/_Venue.scss
@@ -66,7 +66,9 @@
   }
 
   .banner-invalid-bu img {
-    width: rem(18px);
+    width: rem(16px);
+    vertical-align: bottom;
+    margin-right: rem(8px);
   }
 }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12648


## But de la pull request

- Modifier le wording et le style du bandeau dossier en cours (coordonnées bancaires)
- Modifier la taille et l'espacement du picto dans le bandeau BU invalide dans les détails d'un lieu.

## Screenshots

Bandeau dossier en cours : 

![12648-CBLieu](https://user-images.githubusercontent.com/71768799/150334052-5ce80283-fde9-4110-8669-54ab84afbe52.PNG)

Bandeau BU invalide : 

![AlignementBot](https://user-images.githubusercontent.com/71768799/150334193-b2d07f48-9c36-4eeb-bebe-f07d7136e21c.PNG)

​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)


