### PR TITLE
(PC-12748) font-style normal in placeholder if value is selected

### DIFF
--- a/adage-front/src/app/App.tsx
+++ b/adage-front/src/app/App.tsx
@@ -4,6 +4,7 @@ import { QueryCache, QueryClient, QueryClientProvider } from 'react-query'
 
 import '@fontsource/barlow'
 import '@fontsource/barlow/600.css'
+import '@fontsource/barlow/300.css'
 import { UnauthenticatedError } from 'app/components/UnauthenticatedError/UnauthenticatedError'
 import * as pcapi from 'repository/pcapi/pcapi'
 import { Role, VenueFilterType } from 'utils/types'

--- a/adage-front/src/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss
+++ b/adage-front/src/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss
@@ -20,6 +20,7 @@
       .multi-select-autocomplete__value-container
         .multi-select-autocomplete__placeholder {
         font-style: normal;
+        font-weight: normal;
       }
     }
 
@@ -29,6 +30,7 @@
       .multi-select-autocomplete__placeholder {
         font-style: italic;
         color: $black;
+        font-weight: 300;
       }
     }
 

--- a/adage-front/src/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss
+++ b/adage-front/src/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss
@@ -16,6 +16,13 @@
       box-shadow: none;
     }
 
+    &.multi-select-autocomplete-input--has-selected-value {
+      .multi-select-autocomplete__value-container
+        .multi-select-autocomplete__placeholder {
+        font-style: normal;
+      }
+    }
+
     .multi-select-autocomplete__value-container {
       padding: 0;
 


### PR DESCRIPTION
Retour du ticket PC-12748

Le texte du placeholder du multiselect ne doit plus être en italique une fois qu'une valeur est sélectionnée

<img width="517" alt="Capture d’écran 2022-01-20 à 17 07 57" src="https://user-images.githubusercontent.com/35567446/150376534-4ecdec17-8575-4ec9-a7ca-1cec8dad171b.png">
