### PR TITLE
[pc-12883][api] Enforce userprofiling check on DMS application before being beneficiary

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -538,10 +538,7 @@ def has_passed_all_checks_to_become_beneficiary(user: users_models.User) -> bool
         return False
 
     subscription_item = get_user_profiling_subscription_item(user, fraud_check.eligibilityType)
-    if (
-        subscription_item.type == models.SubscriptionStep.USER_PROFILING
-        and subscription_item.status == models.SubscriptionItemStatus.TODO
-    ):
+    if subscription_item.status in (models.SubscriptionItemStatus.TODO, models.SubscriptionItemStatus.KO):
         return False
 
     if not fraud_api.has_performed_honor_statement(user, fraud_check.eligibilityType):

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -537,6 +537,13 @@ def has_passed_all_checks_to_become_beneficiary(user: users_models.User) -> bool
     ):
         return False
 
+    subscription_item = get_user_profiling_subscription_item(user, fraud_check.eligibilityType)
+    if (
+        subscription_item.type == models.SubscriptionStep.USER_PROFILING
+        and subscription_item.status == models.SubscriptionItemStatus.TODO
+    ):
+        return False
+
     if not fraud_api.has_performed_honor_statement(user, fraud_check.eligibilityType):
         if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
             logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -186,27 +186,6 @@ def initialize_account(
     return user
 
 
-def has_passed_all_checks_to_become_beneficiary(user: User) -> bool:
-    fraud_check = get_activable_identity_fraud_check(user)
-    if not fraud_check:
-        return False
-
-    if (
-        not user.is_phone_validated
-        and fraud_check.eligibilityType != EligibilityType.UNDERAGE
-        and FeatureToggle.FORCE_PHONE_VALIDATION.is_active()
-    ):
-        return False
-
-    if not fraud_api.has_performed_honor_statement(user, fraud_check.eligibilityType):
-        if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
-            logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})
-        else:
-            return False
-
-    return True
-
-
 def validate_phone_number_and_activate_user(user: User, code: str) -> User:
     validate_phone_number(user, code)
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -721,12 +721,9 @@ class OnSuccessfulDMSApplicationTest:
                 source_id=123456,
             )
 
-        # TODO: why ?
+        # TODO: requires 19yo fixes : PC-12560
         assert applicant.has_beneficiary_role is False
-        assert (
-            subscription_api.get_next_subscription_step(applicant)
-            == subscription_models.SubscriptionStep.PHONE_VALIDATION
-        )
+        assert subscription_api.get_next_subscription_step(applicant) == None
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -39,7 +39,6 @@ from pcapi.core.users.models import Credit
 from pcapi.core.users.models import DomainsCredit
 from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import EmailHistoryEventTypeEnum
-from pcapi.core.users.models import PhoneValidationStatusType
 from pcapi.core.users.models import Token
 from pcapi.core.users.models import TokenType
 from pcapi.core.users.models import User

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -366,7 +366,13 @@ class UbbleWebhookTest:
         return f"ts={timestamp},v1={token}"
 
     def _init_test(self, current_identification_state, notified_identification_state):
-        user = users_factories.UserFactory()
+        user = users_factories.UserFactory(phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED)
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.USER_PROFILING,
+            status=fraud_models.FraudCheckStatus.OK,
+            eligibilityType=users_models.EligibilityType.AGE18,
+        )
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             resultContent=fraud_factories.UbbleContentFactory(
@@ -688,7 +694,17 @@ class UbbleWebhookTest:
         document_birth_date = datetime.datetime.combine(
             datetime.date.today(), datetime.time(0, 0)
         ) - relativedelta.relativedelta(years=28)
-        user = users_factories.UserFactory(email=email, dateOfBirth=subscription_birth_date)
+        user = users_factories.UserFactory(
+            email=email,
+            dateOfBirth=subscription_birth_date,
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.USER_PROFILING,
+            status=fraud_models.FraudCheckStatus.OK,
+            eligibilityType=users_models.EligibilityType.AGE18,
+        )
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             resultContent=fraud_factories.UbbleContentFactory(

--- a/api/tests/routes/webapp/phone_validation_test.py
+++ b/api/tests/routes/webapp/phone_validation_test.py
@@ -45,7 +45,7 @@ def test_send_phone_validation(app):
 
 
 @pytest.mark.usefixtures("db_session")
-def test_send_phone_validation_and_become_beneficiary(app):
+def test_send_phone_validation_and_become_beneficiary(app, client):
     """
     Test that a user with an OK Identity FraudCheck becomes a beneficiary once its phone
     number is validated.
@@ -58,13 +58,18 @@ def test_send_phone_validation_and_become_beneficiary(app):
         hasCompletedIdCheck=True,
     )
     fraud_factories.BeneficiaryFraudCheckFactory(
+        user=user,
+        type=fraud_models.FraudCheckType.USER_PROFILING,
+        status=fraud_models.FraudCheckStatus.OK,
+    )
+    fraud_factories.BeneficiaryFraudCheckFactory(
         user=user, type=fraud_models.FraudCheckType.UBBLE, status=fraud_models.FraudCheckStatus.OK
     )
     fraud_factories.BeneficiaryFraudCheckFactory(
         user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
     )
 
-    client = TestClient(app.test_client()).with_session_auth(email=user.email)
+    client.with_session_auth(email=user.email)
 
     response = client.post("/send_phone_validation_code")
 

--- a/api/tests/scripts/force_19_yo_dms_import_test.py
+++ b/api/tests/scripts/force_19_yo_dms_import_test.py
@@ -5,7 +5,9 @@ import pytest
 
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
 from pcapi.scripts.force_19yo_dms_import import force_19yo_dms_import
 
 
@@ -15,7 +17,14 @@ class User19YearOldActivationTest:
         user = users_factories.UserFactory(
             dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
             dateCreated=datetime.datetime.now() - relativedelta(months=5),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.USER_PROFILING,
+            status=fraud_models.FraudCheckStatus.OK,
+        )
+
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=fraud_models.FraudCheckType.DMS,
@@ -32,6 +41,33 @@ class User19YearOldActivationTest:
 
         assert user.has_beneficiary_role
         assert user.has_active_deposit
+
+    def test_user_required_to_validate_user_profiling(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.USER_PROFILING,
+            status=fraud_models.FraudCheckStatus.OK,
+        )
+
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.DMS,
+            status=fraud_models.FraudCheckStatus.KO,
+            reasonCodes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+        fraud_factories.BeneficiaryFraudResultFactory(
+            user=user,
+            status=fraud_models.FraudStatus.KO,
+            reason_codes=[fraud_models.FraudReasonCode.NOT_ELIGIBLE],
+        )
+
+        force_19yo_dms_import(dry_run=False)
+        # TODO : a 19yo user which has applied at 18 year old might be able to activate his account
+        assert subscription_api.get_next_subscription_step(user) == None
 
     def test_user_should_not_be_activated_dry_run(self):
         user = users_factories.UserFactory(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12883


## But de la pull request

verifier la validation de l'userprofiling avant de passer un utilisateur beneficiaire

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)