### PR TITLE
[API] (PC-12872) feat:venue: increase upload size limit

### DIFF
--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -11,7 +11,7 @@ from pcapi.utils.human_ids import dehumanize
 MAX_LONGITUDE = 180
 MAX_LATITUDE = 90
 
-VENUE_BANNER_MAX_SIZE = 200_000
+VENUE_BANNER_MAX_SIZE = 10_000_000
 
 
 def check_existing_business_unit(business_unit_id: int, offerer: Offerer):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12872


## But de la pull request

Augmenter la taille max d'une image envoyée pour servir d'illustration à un lieu : 200Ko avant contre 10Mo après.
Note : un ticket chargé d'ajouter la compression va arriver rapidement, donc l'idée n'est pas d'enregistrer tel quel des images allant jusqu'à 10Mo.