### PR TITLE
[PC-12628][api][finance] Fix order of reservations in reimbursement list

### DIFF
--- a/api/src/pcapi/repository/reimbursement_queries.py
+++ b/api/src/pcapi/repository/reimbursement_queries.py
@@ -98,7 +98,7 @@ def find_all_offerers_payments(
         .join(Stock)
         .join(Offer)
         .join(Venue)
-        .order_by(finance_models.Cashflow.id.desc())
+        .order_by(Booking.dateUsed.desc(), Booking.id.desc())
         .with_entities(
             User.lastName.label("user_lastName"),
             User.firstName.label("user_firstName"),
@@ -123,10 +123,8 @@ def find_all_offerers_payments(
         )
     )
 
-    results = []
+    results = sent_pricings.all()
     if FeatureToggle.INCLUDE_LEGACY_PAYMENTS_FOR_REIMBURSEMENTS.is_active():
         results.extend(sent_payments.all())
-
-    results.extend(sent_pricings.all())
 
     return results

--- a/api/tests/repository/reimbursement_queries_test.py
+++ b/api/tests/repository/reimbursement_queries_test.py
@@ -376,19 +376,19 @@ class FindAllOffererPaymentsTest:
         }
 
         missing_for_payment = (set(expected_in_both.keys()) | set(specific_for_payment.keys())).symmetric_difference(
-            set(payments[0]._asdict())
+            set(payments[1]._asdict())
         )
         assert missing_for_payment == set()
         for attr, expected in expected_in_both.items():
-            assert getattr(payments[0], attr) == expected
+            assert getattr(payments[1], attr) == expected
         for attr, expected in specific_for_payment.items():
-            assert getattr(payments[0], attr) == expected, f"wrong {attr}"
+            assert getattr(payments[1], attr) == expected, f"wrong {attr}"
 
         missing_for_pricing = (set(expected_in_both.keys()) | set(specific_for_pricing.keys())).symmetric_difference(
-            set(payments[1]._asdict())
+            set(payments[0]._asdict())
         )
         assert missing_for_pricing == set()
         for attr, expected in expected_in_both.items():
-            assert getattr(payments[1], attr) == expected
+            assert getattr(payments[0], attr) == expected
         for attr, expected in specific_for_pricing.items():
-            assert getattr(payments[1], attr) == expected
+            assert getattr(payments[0], attr) == expected

--- a/api/tests/routes/serialization/reimbursement_csv_test.py
+++ b/api/tests/routes/serialization/reimbursement_csv_test.py
@@ -46,7 +46,7 @@ class ReimbursementDetailsTest:
         payments_info = find_all_offerer_payments(payment.booking.offerer.id, reimbursement_period)
 
         # legacy payment data
-        raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
+        raw_csv = ReimbursementDetails(payments_info[1]).as_csv_row()
         assert raw_csv[0] == "2019"
         assert raw_csv[1] == "Juillet : remboursement 1ère quinzaine"
         assert raw_csv[2] == payment.booking.venue.name
@@ -66,7 +66,7 @@ class ReimbursementDetailsTest:
         assert raw_csv[16] == "offre grand public"
 
         # new pricing+cashflow data
-        row = ReimbursementDetails(payments_info[1]).as_csv_row()
+        row = ReimbursementDetails(payments_info[0]).as_csv_row()
         # The first 2 cells are tested in a separate test below.
         assert row[2] == payment.booking.venue.name
         assert row[3] == payment.booking.venue.siret
@@ -110,7 +110,7 @@ class ReimbursementDetailsTest:
         payments_info = find_all_offerer_payments(payment.booking.offerer.id, reimbursement_period)
 
         # legacy payment data
-        raw_csv = ReimbursementDetails(payments_info[0]).as_csv_row()
+        raw_csv = ReimbursementDetails(payments_info[1]).as_csv_row()
         assert raw_csv[0] == "2019"
         assert raw_csv[1] == "Juillet : remboursement 1ère quinzaine"
         assert raw_csv[2] == payment.booking.venue.name
@@ -130,7 +130,7 @@ class ReimbursementDetailsTest:
         assert raw_csv[16] == "offre scolaire"
 
         # new pricing+cashflow data
-        row = ReimbursementDetails(payments_info[1]).as_csv_row()
+        row = ReimbursementDetails(payments_info[0]).as_csv_row()
         # The first 2 cells are tested in a separate test below.
         assert row[2] == payment.booking.venue.name
         assert row[3] == payment.booking.venue.siret
@@ -177,11 +177,11 @@ class ReimbursementDetailsTest:
         payments_info = find_all_offerer_payments(payment.booking.offererId, reimbursement_period)
 
         # legacy payment data
-        row = ReimbursementDetails(payments_info[0]).as_csv_row()
+        row = ReimbursementDetails(payments_info[1]).as_csv_row()
         assert row[13] == ""
 
         # new pricing+cashflow data
-        row = ReimbursementDetails(payments_info[1]).as_csv_row()
+        row = ReimbursementDetails(payments_info[0]).as_csv_row()
         assert row[13] == "12,34 %"
 
     def test_reimbursement_details_date_columns(self):
@@ -262,11 +262,11 @@ def test_generate_reimbursement_details_csv():
         == '"Année";"Virement";"Créditeur";"SIRET créditeur";"Adresse créditeur";"IBAN";"Raison sociale du lieu";"Nom de l\'offre";"Nom utilisateur";"Prénom utilisateur";"Contremarque";"Date de validation de la réservation";"Montant de la réservation";"Barème";"Montant remboursé";"Statut du remboursement";"Type d\'offre"'
     )
     assert (  # legacy payment data
-        rows[1]
+        rows[2]
         == '"2019";"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"CF13QSDFGH456789";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"2021-01-01 12:00:00";"21,00";"100%";"21,00";"Remboursement envoyé";"offre grand public"'
     )
     assert (  # new pricing+cashflow data
-        rows[2]
+        rows[1]
         == '2019;"Juillet : remboursement 1ère quinzaine";"Mon lieu ; un peu ""spécial""";"siret-1234";"1 boulevard Poissonnière";"CF13QSDFGH456789";"Mon lieu ; un peu ""spécial""";"Mon titre ; un peu ""spécial""";"Doux";"Jeanne";"0E2722";"2021-01-01 12:00:00";"21,00";"100 %";"21,00";"Remboursement envoyé";"offre grand public"'
     )
 


### PR DESCRIPTION
New-style data must appear first because it's more recent.

I am not sure what we wanted to sort on by ordering on `Payment.id`. I
suppose that we wanted to order on `Booking.dateUsed`, since payments
are created by iterating over bookings ordered on this attribute.


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12628