### PR TITLE
(PC-12935)(PRO) Open DMS link in new tab when offerer does not have a business unit

### DIFF
--- a/pro/src/components/pages/Home/Offerers/MissingBusinessUnits.jsx
+++ b/pro/src/components/pages/Home/Offerers/MissingBusinessUnits.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import Icon from 'components/layout/Icon'
-import InternalBanner from 'components/layout/InternalBanner'
+import { Banner } from 'ui-kit'
 import { DEMARCHES_SIMPLIFIEES_BUSINESS_UNIT_RIB_UPLOAD_PROCEDURE_URL } from 'utils/config'
 
 const MissingBusinessUnits = ({ hasTitle }) => {
@@ -24,16 +24,15 @@ const MissingBusinessUnits = ({ hasTitle }) => {
       )}
 
       <div className="h-card-content">
-        <InternalBanner
+        <Banner
           href={DEMARCHES_SIMPLIFIEES_BUSINESS_UNIT_RIB_UPLOAD_PROCEDURE_URL}
           icon="ico-outer-pen"
           linkTitle="Renseigner des coordonnées bancaires"
-          targetLink="_self"
         >
           Certains de vos lieux ne sont pas rattachés à des coordonnées
           bancaires. Pour percevoir les remboursements liés aux offres de ces
           lieux, veuillez renseigner des coordonnées bancaires.
-        </InternalBanner>
+        </Banner>
       </div>
     </>
   )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12935


## But de la pull request

Lorsque l'on clique sur le lien "Renseigner des coordonnées bancaires" le site DMS s'ouvre dans un nouvel onglet
​
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [x] Branche : pc-XXX-whatever-describe-the-branch
    - [x] PR : (PC-XXX) Description rapide de l' US
    - [x] Commit(s) : [PC-XXX] description rapide du ticket
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
