### PR TITLE
[bsr][api][tests] Keep ReferenceScheme in the test database

### DIFF
--- a/api/src/pcapi/core/reference/factories.py
+++ b/api/src/pcapi/core/reference/factories.py
@@ -6,7 +6,19 @@ from . import models
 class ReferenceSchemeFactory(BaseFactory):
     class Meta:
         model = models.ReferenceScheme
+        sqlalchemy_get_or_create = ["name", "year"]
 
     name = "invoice.reference"
-    prefix = "F"
     year = 2022
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        # We need to set the prefix ourselves, because it's not part
+        # of the "key" of `sqlalchemy_get_or_create, and there are two
+        # UNIQUE contraints on both `(name, year)` and `(prefix, year)`.
+        if "prefix" not in kwargs:
+            if kwargs["name"] == "invoice.reference":
+                kwargs["prefix"] = "F"
+            else:
+                kwargs["prefix"] = kwargs["name"][0]
+        return super()._create(model_class, *args, **kwargs)

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -36,7 +36,6 @@ from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
-from pcapi.core.reference.models import ReferenceScheme
 from pcapi.core.users.models import Favorite
 from pcapi.core.users.models import Token
 from pcapi.core.users.models import User
@@ -73,7 +72,6 @@ def clean_all_database(*args, **kwargs):
     CashflowLog.query.delete()
     Cashflow.query.delete()
     CashflowBatch.query.delete()
-    ReferenceScheme.query.delete()
     PricingLine.query.delete()
     PricingLog.query.delete()
     Pricing.query.delete()

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -21,7 +21,6 @@ from pcapi.core.object_storage.testing import recursive_listdir
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
-import pcapi.core.reference.factories as reference_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import clean_temporary_files
 from pcapi.core.testing import override_settings
@@ -748,7 +747,6 @@ class GenerateInvoiceTest:
     )
 
     def test_reference_scheme_increments(self):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         venue = offers_factories.VenueFactory(siret="85331845900023")
         business_unit = venue.businessUnit
         invoice = api._generate_invoice(business_unit_id=business_unit.id, cashflow_ids=[1, 2])
@@ -758,7 +756,6 @@ class GenerateInvoiceTest:
         assert second_invoice.reference == "F220000002"
 
     def test_one_regular_rule_one_rate(self):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         venue = offers_factories.VenueFactory(siret="85331845900023")
         business_unit = venue.businessUnit
         offer = offers_factories.ThingOfferFactory(venue=venue)
@@ -789,7 +786,6 @@ class GenerateInvoiceTest:
         assert line.label == "Montant remboursé"
 
     def test_two_regular_rules_two_rates(self):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         venue = offers_factories.VenueFactory(siret="85331845900023")
         business_unit = venue.businessUnit
         offer = offers_factories.ThingOfferFactory(venue=venue)
@@ -831,7 +827,6 @@ class GenerateInvoiceTest:
         assert line_rate_0_95.label == "Montant remboursé"
 
     def test_one_custom_rule(self):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         venue = offers_factories.VenueFactory(siret="85331845900023")
         business_unit = venue.businessUnit
         offer = offers_factories.ThingOfferFactory(venue=venue)
@@ -864,7 +859,6 @@ class GenerateInvoiceTest:
         assert line.label == "Montant remboursé"
 
     def test_many_rules_and_rates_two_cashflows(self, invoice_data):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         business_unit, stocks = invoice_data
         bookings = []
         for stock in stocks:
@@ -950,7 +944,6 @@ class GenerateInvoiceHtmlTest:
     TEST_FILES_PATH = pathlib.Path(tests.__path__[0]) / "files"
 
     def test_basics(self, invoice_data):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         business_unit, stocks = invoice_data
         bookings = []
         for stock in stocks:
@@ -999,7 +992,6 @@ class StoreInvoicePdfTest:
     @override_settings(OBJECT_STORAGE_URL=BASE_THUMBS_DIR)
     def test_basics(self, clear_tests_invoices_bucket, invoice_data):
         existing_number_of_files = len(recursive_listdir(self.INVOICES_DIR))
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         business_unit, stocks = invoice_data
         bookings = []
         for stock in stocks:
@@ -1033,7 +1025,6 @@ class GenerateAndStoreInvoiceTest:
 
     @override_settings(OBJECT_STORAGE_URL=BASE_THUMBS_DIR)
     def test_basics(self, clear_tests_invoices_bucket, invoice_data):
-        reference_factories.ReferenceSchemeFactory(name="invoice.reference", prefix="F", year=2022)
         business_unit, stocks = invoice_data
         bookings = []
         for stock in stocks:

--- a/api/tests/core/finance/test_integration.py
+++ b/api/tests/core/finance/test_integration.py
@@ -6,7 +6,6 @@ import pcapi.core.bookings.api as bookings_api
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.finance import api
 from pcapi.core.finance import models
-import pcapi.core.reference.factories as reference_factories
 from pcapi.models import db
 
 
@@ -27,7 +26,6 @@ def test_integration():
     db.session.refresh(pricing)
     assert pricing.status == models.PricingStatus.PROCESSED
 
-    reference_factories.ReferenceSchemeFactory()
     api._generate_invoice(pricing.businessUnitId, [cashflow.id])
     db.session.refresh(pricing)
     assert pricing.status == models.PricingStatus.INVOICED


### PR DESCRIPTION
There is a migration that creates multiple ReferenceScheme. We can use
that as data fixtures for tests, to avoid having to create a
ReferenceScheme each time a test generates invoices. For this to work,
we must not clean the table in `clean_database`, adapt the factory to
reuse existing instances, and be a bit more careful in tests that do
need to use `ReferenceSchemeFactory`.