### PR TITLE
(PC-12928)(PRO) Sanbox : Remove unnecessary call to BankInformationFactory and adapt call to BusinessUnitFactory for venues

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -222,25 +222,25 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
 
     @property
     def bic(self) -> Optional[str]:
-        return self.bankInformation.bic if self.bankInformation else None
+        return self.businessUnit.bankAccount.bic if self.businessUnit and self.businessUnit.bankAccount else None
 
     @property
     def iban(self) -> Optional[str]:
-        return self.bankInformation.iban if self.bankInformation else None
+        return self.businessUnit.bankAccount.iban if self.businessUnit and self.businessUnit.bankAccount else None
 
     @property
     def demarchesSimplifieesApplicationId(self) -> Optional[int]:
-        if not self.bankInformation:
+        if not (self.businessUnit and self.businessUnit.bankAccount):
             return None
 
         can_show_application_id = (
-            self.bankInformation.status == BankInformationStatus.DRAFT
-            or self.bankInformation.status == BankInformationStatus.ACCEPTED
+            self.businessUnit.bankAccount.status == BankInformationStatus.DRAFT
+            or self.businessUnit.bankAccount.status == BankInformationStatus.ACCEPTED
         )
         if not can_show_application_id:
             return None
 
-        return self.bankInformation.applicationId
+        return self.businessUnit.bankAccount.applicationId
 
     @property
     def nOffers(self) -> int:

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -61,11 +61,23 @@ class VenueFactory(BaseFactory):
     mentalDisabilityCompliant = False
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
-    businessUnit = factory.SubFactory(
-        "pcapi.core.finance.factories.BusinessUnitFactory",
-        siret=factory.LazyAttribute(lambda bu: bu.factory_parent.siret),
+    businessUnit = factory.Maybe(
+        factory.LazyAttribute(lambda o: o.isVirtual),
+        None,
+        factory.SubFactory(
+            "pcapi.core.finance.factories.BusinessUnitFactory",
+            siret=factory.LazyAttribute(lambda bu: bu.factory_parent.siret),
+        ),
     )
     contact = factory.RelatedFactory("pcapi.core.offerers.factories.VenueContactFactory", factory_related_name="venue")
+
+    # @factory.post_generation
+    # def businessUnit(self, create, extracted, **kwargs):  # pylint: disable=method-hidden
+    #     import pcapi.core.finance.factories as finance_factories
+
+    #     if "siret" in kwargs and not self.businessUnit:
+    #         self.businessUnit = finance_factories.BusinessUnitFactory(**kwargs)
+    #         self.businessUnitId = self.businessUnit.id
 
 
 class VirtualVenueFactory(VenueFactory):

--- a/api/src/pcapi/sandboxes/scripts/getters/pro_08_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro_08_stocks.py
@@ -12,7 +12,7 @@ def get_existing_pro_validated_user_with_validated_offerer_with_iban_validated_u
         offerer__validationToken=None,
         user__validationToken=None,
     )
-    offers_factories.BankInformationFactory(offerer=user_offerer.offerer)
+
     venue = offers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
     offer = offers_factories.EventOfferFactory(venue=venue, isActive=True)
 
@@ -30,7 +30,6 @@ def get_existing_pro_validated_user_with_validated_offerer_with_iban_validated_u
         offerer__validationToken=None,
         user__validationToken=None,
     )
-    offers_factories.BankInformationFactory(offerer=user_offerer.offerer)
     venue = offers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
     offer = offers_factories.EventOfferFactory(venue=venue, isActive=True)
     stock = offers_factories.EventStockFactory(offer=offer)
@@ -50,7 +49,6 @@ def get_existing_pro_validated_user_with_validated_offerer_with_iban_validated_u
         offerer__validationToken=None,
         user__validationToken=None,
     )
-    offers_factories.BankInformationFactory(offerer=user_offerer.offerer)
     venue = offers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
     venue = offers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
     offer = offers_factories.ThingOfferFactory(venue=venue, isActive=True)

--- a/api/src/pcapi/scripts/business_unit/create_bu.py
+++ b/api/src/pcapi/scripts/business_unit/create_bu.py
@@ -67,6 +67,7 @@ def create_business_unit(venue, bank_information, business_unit_name=None):
     bank_information = BankInformation(
         bic=bank_information.bic,
         iban=bank_information.iban,
+        applicationId=bank_information.applicationId,
         status=BankInformationStatus.ACCEPTED,
     )
     business_unit = BusinessUnit(

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -456,6 +456,7 @@ class GenerateCashflowsTest:
 def test_generate_payment_files():
     # The contents of generated files is unit-tested in other test
     # functions below.
+    offers_factories.VenueFactory()
     factories.PricingFactory(status=models.PricingStatus.VALIDATED)
     cutoff = datetime.datetime.utcnow()
     batch_id = api.generate_cashflows(cutoff)

--- a/api/tests/models/venue_sql_entity_test.py
+++ b/api/tests/models/venue_sql_entity_test.py
@@ -8,6 +8,7 @@ from pcapi.model_creators.specific_creators import create_offer_with_thing_produ
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.bank_information import BankInformationStatus
 from pcapi.repository import repository
+from pcapi.scripts.business_unit.create_bu import create_business_unit
 
 
 @pytest.mark.usefixtures("db_session")
@@ -322,8 +323,8 @@ class VenueBankInformationTest:
         # Given
         offerer = create_offerer(siren="123456789")
         venue = create_venue(offerer, siret="12345678912345")
-        bank_information = create_bank_information(bic="BDFEFR2LCCB", venue=venue)
-        repository.save(bank_information)
+        businessUnit = create_business_unit(venue, create_bank_information(bic="BDFEFR2LCCB"))
+        repository.save(businessUnit)
 
         # When
         bic = venue.bic
@@ -349,8 +350,8 @@ class VenueBankInformationTest:
         # Given
         offerer = create_offerer(siren="123456789")
         venue = create_venue(offerer, siret="12345678912345")
-        bank_information = create_bank_information(iban="FR7630007000111234567890144", venue=venue)
-        repository.save(bank_information)
+        businessUnit = create_business_unit(venue, create_bank_information(iban="FR7630007000111234567890144"))
+        repository.save(businessUnit)
 
         # When
         iban = venue.iban
@@ -376,10 +377,10 @@ class VenueBankInformationTest:
         # Given
         offerer = create_offerer(siren="123456789")
         venue = create_venue(offerer, siret="12345678912345")
-        bank_information = create_bank_information(
-            application_id=12345, venue=venue, status=BankInformationStatus.DRAFT, iban=None, bic=None
+        businessUnit = create_business_unit(
+            venue, create_bank_information(application_id=12345, status=BankInformationStatus.DRAFT)
         )
-        repository.save(bank_information)
+        repository.save(businessUnit)
 
         # When
         field = venue.demarchesSimplifieesApplicationId

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -14,12 +14,11 @@ class Returns200Test:
         # given
         user_offerer = offers_factories.UserOffererFactory(user__email="user.pro@test.com")
         venue = offers_factories.VenueFactory(name="L'encre et la plume", managingOfferer=user_offerer.offerer)
-        bank_information = offers_factories.BankInformationFactory(venue=venue)
 
         expected_serialized_venue = {
             "address": venue.address,
             "audioDisabilityCompliant": venue.audioDisabilityCompliant,
-            "bic": bank_information.bic,
+            "bic": venue.businessUnit.bankAccount.bic,
             "bookingEmail": venue.bookingEmail,
             "businessUnit": {
                 "bic": venue.businessUnit.bankAccount.bic,
@@ -43,7 +42,7 @@ class Returns200Test:
             "departementCode": venue.departementCode,
             "description": venue.description,
             "fieldsUpdated": venue.fieldsUpdated,
-            "iban": bank_information.iban,
+            "iban": venue.businessUnit.bankAccount.iban,
             "id": humanize(venue.id),
             "idAtProviders": venue.idAtProviders,
             "isBusinessUnitMainVenue": True,

--- a/api/tests/scripts/payment/batch_steps_test.py
+++ b/api/tests/scripts/payment/batch_steps_test.py
@@ -5,6 +5,7 @@ from lxml.etree import DocumentInvalid
 import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.finance.factories as finance_factories
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
@@ -242,9 +243,14 @@ class SetNotProcessablePaymentsWithBankInformationToRetryTest:
     ):
         # Given
         offerer = offers_factories.OffererFactory(name="first offerer")
-        stock = offers_factories.ThingStockFactory(offer__venue__managingOfferer=offerer)
+        bu = finance_factories.BusinessUnitFactory(
+            bankAccount__iban="FR7611808009101234567890147",
+            bankAccount__bic="CCBPFRPPVER",
+            bankAccount__offererId=offerer.id,
+        )
+        stock = offers_factories.ThingStockFactory(offer__venue__managingOfferer=offerer, offer__venue__businessUnit=bu)
         booking = bookings_factories.UsedBookingFactory(stock=stock)
-        offers_factories.BankInformationFactory(offerer=offerer, iban="FR7611808009101234567890147", bic="CCBPFRPPVER")
+
         not_processable_payment = payments_factories.PaymentFactory(
             amount=10,
             booking=booking,
@@ -314,9 +320,13 @@ class SetNotProcessablePaymentsWithBankInformationToRetryTest:
     ):
         # Given
         offerer = offers_factories.OffererFactory(name="first offerer")
-        stock = offers_factories.ThingStockFactory(offer__venue__managingOfferer=offerer)
+        bu = finance_factories.BusinessUnitFactory(
+            bankAccount__iban="FR7611808009101234567890147",
+            bankAccount__bic="CCBPFRPPVER",
+            bankAccount__offererId=offerer.id,
+        )
+        stock = offers_factories.ThingStockFactory(offer__venue__managingOfferer=offerer, offer__venue__businessUnit=bu)
         booking = bookings_factories.UsedBookingFactory(stock=stock)
-        offers_factories.BankInformationFactory(offerer=offerer, iban="FR7611808009101234567890147", bic="CCBPFRPPVER")
         not_processable_payment = payments_factories.PaymentFactory(booking=booking, amount=10, iban=None, bic=None)
         payments_factories.PaymentStatusFactory(
             payment=not_processable_payment, status=TransactionStatus.NOT_PROCESSABLE

--- a/api/tests/scripts/payment/generate_new_payments_test.py
+++ b/api/tests/scripts/payment/generate_new_payments_test.py
@@ -5,6 +5,7 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
+import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.testing import assert_num_queries
@@ -36,7 +37,7 @@ class GenerateNewPaymentsTest:
 
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
         offerer = offers_factories.OffererFactory()
-        offer = offers_factories.ThingOfferFactory(venue__managingOfferer=offerer)
+        offer = offers_factories.ThingOfferFactory(venue__managingOfferer=offerer, venue__businessUnit=None)
         paying_stock = offers_factories.ThingStockFactory(offer=offer)
         free_stock = offers_factories.ThingStockFactory(offer=offer, price=0)
         bookings_factories.UsedBookingFactory(user=beneficiary, stock=paying_stock, dateUsed=before_cutoff)
@@ -75,9 +76,13 @@ class GenerateNewPaymentsTest:
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="user@example.com")
         offerer1 = offers_factories.OffererFactory(siren="123456789")
         offerer2 = offers_factories.OffererFactory(siren="987654321")
-        offers_factories.BankInformationFactory(bic="BDFEFR2LCCB", iban="FR7630006000011234567890189", offerer=offerer1)
-        venue1 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="12345678912345")
-        venue2 = offers_factories.VenueFactory(managingOfferer=offerer2, siret="98765432154321")
+        bu = finance_factories.BusinessUnitFactory(
+            bankAccount__bic="BDFEFR2LCCB",
+            bankAccount__iban="FR7630006000011234567890189",
+            bankAccount__offererId=offerer1.id,
+        )
+        venue1 = offers_factories.VenueFactory(managingOfferer=offerer1, siret="12345678912345", businessUnit=bu)
+        venue2 = offers_factories.VenueFactory(managingOfferer=offerer2, siret="98765432154321", businessUnit=None)
         offer1 = offers_factories.ThingOfferFactory(venue=venue1)
         offer2 = offers_factories.ThingOfferFactory(venue=venue2)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12928


## But de la pull request

Modifier la sandbox pour créer des business unit associé aux lieus non virtuel.
Supprimer les appels obsolètes à BankInformationFactory
​
## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - [ ] Branche : pc-XXX-whatever-describe-the-branch
    - [ ] PR : (PC-XXX) Description rapide de l' US
    - [ ] Commit(s) : [PC-XXX] description rapide du ticket
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté un / des screenshots pour d'éventuels changements graphiques (ex: Admin)
