### PR TITLE
(PC-12392)[API] Add STARTED status to fraud check

### DIFF
--- a/api/src/pcapi/admin/templating.py
+++ b/api/src/pcapi/admin/templating.py
@@ -33,6 +33,7 @@ FRAUD_CHECK_STATUS_FORMATS = {
     fraud_models.FraudCheckStatus.KO: "danger",
     fraud_models.FraudCheckStatus.OK: "success",
     fraud_models.FraudCheckStatus.PENDING: "warning",
+    fraud_models.FraudCheckStatus.STARTED: "warning",
     fraud_models.FraudCheckStatus.SUSPICIOUS: "warning",
     fraud_models.FraudCheckStatus.CANCELED: "warning",
 }

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -515,6 +515,7 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.user == user,
             models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.CANCELED),
+            models.BeneficiaryFraudCheck.status.is_distinct_from(models.FraudCheckStatus.STARTED),
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
         ).exists()
     ).scalar()

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -307,6 +307,7 @@ class FraudReasonCode(enum.Enum):
 class FraudCheckStatus(enum.Enum):
     KO = "ko"
     OK = "ok"
+    STARTED = "started"
     SUSPICIOUS = "suspiscious"
     PENDING = "pending"
     CANCELED = "canceled"

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -113,7 +113,7 @@ def start_ubble_fraud_check(user: users_models.User, ubble_content: ubble_fraud_
         type=fraud_models.FraudCheckType.UBBLE,
         thirdPartyId=str(ubble_content.identification_id),
         resultContent=ubble_content,
-        status=fraud_models.FraudCheckStatus.PENDING,
+        status=fraud_models.FraudCheckStatus.STARTED,
         eligibilityType=user.eligibility,
     )
     db.session.add(fraud_check)
@@ -156,6 +156,7 @@ def is_user_allowed_to_perform_ubble_check(
     fraud_checks = fraud_models.BeneficiaryFraudCheck.query.filter(
         fraud_models.BeneficiaryFraudCheck.user == user,
         fraud_models.BeneficiaryFraudCheck.status.is_distinct_from(fraud_models.FraudCheckStatus.CANCELED),
+        fraud_models.BeneficiaryFraudCheck.status.is_distinct_from(fraud_models.FraudCheckStatus.STARTED),
         fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE,
         fraud_models.BeneficiaryFraudCheck.eligibilityType == eligibility_type,
     ).all()

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -35,8 +35,9 @@ def update_ubble_workflow(
 
     if status == ubble_fraud_models.UbbleIdentificationStatus.PROCESSING:
         user.hasCompletedIdCheck = True
-        pcapi_repository.repository.save(user)
         subscription_messages.on_review_pending(user)
+        fraud_check.status = fraud_models.FraudCheckStatus.PENDING
+        pcapi_repository.repository.save(user, fraud_check)
 
     elif status == ubble_fraud_models.UbbleIdentificationStatus.PROCESSED:
         try:

--- a/api/tests/core/subscription/ubble/test_ubble_workflow.py
+++ b/api/tests/core/subscription/ubble/test_ubble_workflow.py
@@ -34,7 +34,7 @@ class UbbleWorkflowTest:
         assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId is not None
         assert fraud_check.resultContent is not None
-        assert fraud_check.status == fraud_models.FraudCheckStatus.PENDING
+        assert fraud_check.status == fraud_models.FraudCheckStatus.STARTED
 
         ubble_request = ubble_mock.last_request.json()
         assert ubble_request["data"]["attributes"]["webhook"] == "http://localhost/webhooks/ubble/application_status"

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -368,6 +368,7 @@ class UbbleWebhookTest:
                 status=test_factories.STATE_STATUS_MAPPING[current_identification_state].value,
             ),
             user=user,
+            status=fraud_models.FraudCheckStatus.STARTED,
         )
         request_data = self._get_request_body(
             fraud_check, test_factories.STATE_STATUS_MAPPING[notified_identification_state]
@@ -430,7 +431,7 @@ class UbbleWebhookTest:
         assert response.status_code == 403
         assert response.json == {"signature": ["Invalid signature"]}
 
-    def test_fraud_check_intiated(self, client, ubble_mocker):
+    def test_fraud_check_initiated(self, client, ubble_mocker):
         current_identification_state = test_factories.IdentificationState.NEW
         notified_identification_state = test_factories.IdentificationState.INITIATED
         _, request_data, ubble_identification_response = self._init_test(
@@ -444,7 +445,7 @@ class UbbleWebhookTest:
         )
         assert fraud_check.reason is None
         assert fraud_check.reasonCodes is None
-        assert fraud_check.status is fraud_models.FraudCheckStatus.PENDING
+        assert fraud_check.status is fraud_models.FraudCheckStatus.STARTED
         assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.thirdPartyId == ubble_identification_response.data.attributes.identification_id
         content = ubble_fraud_models.UbbleContent(**fraud_check.resultContent)

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1567,6 +1567,7 @@ class IdentificationSessionTest:
 
         check = user.beneficiaryFraudChecks[0]
         assert check.type == fraud_models.FraudCheckType.UBBLE
+        assert check.status == fraud_models.FraudCheckStatus.STARTED
         assert response.json["identificationUrl"] == "https://id.ubble.ai/29d9eca4-dce6-49ed-b1b5-8bb0179493a8"
 
     @pytest.mark.parametrize("age", [14, 19, 20])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12392

## But de la pull request

Ajouter un statut `STARTED` au FraudCheck pour le dissocier du statut `PENDING` qui correspond à un dossier en cours d'analyse.

##  Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
