### PR TITLE
[PC-12830][API][PRO] fix filter per date on offers view for non admin

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -169,8 +169,14 @@ def get_offers_by_filters(
             )
         if venue_id is not None:
             subquery = subquery.filter(Offer.venueId == venue_id)
-        if offerer_id is not None:
+        elif offerer_id is not None:
             subquery = subquery.filter(Venue.managingOffererId == offerer_id)
+        elif not user_is_admin:
+            subquery = (
+                subquery.join(Offerer)
+                .join(UserOfferer)
+                .filter(and_(UserOfferer.userId == user_id, UserOfferer.validationToken.is_(None)))
+            )
         q2 = subquery.subquery()
         query = query.join(q2, q2.c.offerId == Offer.id)
     return query


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12830

## But de la pull request

Corriger le filtre de la page des offres pour un utilisateur non admin.

##  Implémentation

Filtre sur la sous-requête pour un utilisateur pro "classique"

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
