### PR TITLE
(PC-12986)(API) Mark educonnect uai and level fields as optional

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -121,8 +121,8 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
             logout_url=logout_url,
             user_type=user_type,
             saml_request_id=saml_request_id,
-            school_uai=educonnect_identity.get(_get_field_oid("72"))[0],
-            student_level=educonnect_identity.get(_get_field_oid("73"))[0],
+            school_uai=educonnect_identity.get(_get_field_oid("72"), [None])[0],
+            student_level=educonnect_identity.get(_get_field_oid("73"), [None])[0],
         )
 
     except Exception:

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -11,6 +11,7 @@ from saml2.validate import ResponseLifetimeExceed
 
 from pcapi import settings
 from pcapi.core.users import constants
+from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 
 from . import exceptions
@@ -143,16 +144,12 @@ def _get_mocked_user_for_performance_tests(user_id: str) -> models.EduconnectUse
     key = build_saml_request_id_key(mocked_saml_request_id)
     app.redis_client.set(name=key, value=user.id, ex=constants.EDUCONNECT_SAML_REQUEST_ID_TTL)
 
-    return models.EduconnectUser(
+    return users_factories.EduconnectUserFactory(
         birth_date=user.dateOfBirth.date(),
         connection_datetime=datetime.now(),
         educonnect_id=f"educonnect-id_perf-test_{user.id}",
         first_name=f"firstname_perf-test_{user.id}",
         ine_hash=f"inehash_perf-test_{user.id}",
         last_name=f"lastname_perf-test_{user.id}",
-        logout_url="example.com/logout",
-        user_type="eleve1d",
         saml_request_id=mocked_saml_request_id,
-        school="mocked_uai",
-        student_level="2212",
     )

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/exceptions.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/exceptions.py
@@ -10,7 +10,13 @@ class ResponseTooOld(EduconnectAuthenticationException):
 
 
 class ParsingError(EduconnectAuthenticationException):
-    pass
+    parsed_dict: dict
+    logout_url: Optional[str]
+
+    def __init__(self, parsed_dict: dict, logout_url: str, *args: object) -> None:
+        super().__init__(*args)
+        self.parsed_dict = parsed_dict
+        self.logout_url = logout_url
 
 
 class UserTypeNotStudent(EduconnectAuthenticationException):

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/models.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/models.py
@@ -14,5 +14,5 @@ class EduconnectUser:
     logout_url: str
     user_type: Optional[str]
     saml_request_id: str
-    school_uai: str
-    student_level: str
+    school_uai: Optional[str]
+    student_level: Optional[str]

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -88,6 +88,7 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
         "Received educonnect authentication response",
         extra={
             "user_email": user.email,
+            "user_id": user.id,
             "date_of_birth": educonnect_user.birth_date.isoformat(),
             "educonnect_connection_date": educonnect_user.connection_datetime.isoformat(),
             "educonnect_id": educonnect_user.educonnect_id,

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -65,8 +65,12 @@ def on_educonnect_authentication_response() -> Response:  # pylint: disable=too-
         error_query_param = {"code": "UserTypeNotStudent", "logoutUrl": exc.logout_url}
         return redirect(ERROR_PAGE_URL + urlencode(error_query_param), code=302)
 
+    except educonnect_exceptions.ParsingError as exc:
+        logger.exception("KeyError after educonnect exception", extra={"parsed_data": exc.parsed_dict})
+        return redirect(ERROR_PAGE_URL + urlencode({"logout_url": exc.logout_url}), code=302)
+
     except Exception as exc:  # pylint: disable=broad-except
-        logger.exception("Error after educonnect authentication: %s", exc)
+        logger.exception("Error after educonnect authentication")
         return redirect(ERROR_PAGE_URL, code=302)
 
     user_id = _user_id_from_saml_request_id(educonnect_user.saml_request_id)

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -127,6 +127,7 @@ class EduconnectTest:
             "school_uai": "school_uai",
             "student_level": "2212",
             "user_email": self.email,
+            "user_id": user.id,
         }
 
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12986

## But de la pull request

Code plus robuste qui n'échoue pas si un champ manque dans le `educonnect_identity`.
Ainsi, on peut avoir plus d'information sur le vecteur identité reçu dans des cas d'erreur comme celui-ci : https://sentry.internal-passculture.app/organizations/sentry/issues/253669/?environment=production. 

La PR permet de grouper l'erreur ci-dessus et [cette erreur](https://sentry.internal-passculture.app/organizations/sentry/issues/253668/?environment=production).

Cette PR gère aussi le cas d'un élève dont le "Niveau" n'est pas défini (erreur mentionnée [ci-dessus](https://github.com/pass-culture/pass-culture-main/pull/1133)). Comme on n'utilise pas ce champ, on fait en sorte que ça marche pour cette pauvre Lola.