### PR TITLE
[api] Fix python gql installation with version 3.0.0

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -31,7 +31,7 @@ google-auth==1.23.0
 google-cloud-storage==1.35.0
 google-cloud-tasks==2.3.0
 # once moving to gql 3.0 we might want to limit dependances with installing gql[requests]
-gql
+gql[requests]
 gunicorn==20.0.4
 ipaddress
 isort==5.6.4


### PR DESCRIPTION
## But de la pull request

Corriger l'installation de GraphQL depuis la mise a jour vers la version 3.0.0
Il faut désormais utiliser le suffixe d'installation "requests" afin d'installer les dependances correctement

les tests utilisent des mocks, j'ai donc fait une requete a la main pour vérifier qu'on peut toujours se connecter à DMS.