### PR TITLE
[pc-12975][api] Add started state to DMS fraud check

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -75,7 +75,7 @@ def on_dms_fraud_result(
 ) -> models.BeneficiaryFraudCheck:
 
     eligibility_type = dms_content.get_eligibility_type()
-    fraud_check = dms_api.get_dms_fraud_check(user, str(dms_content.application_id))
+    fraud_check = dms_api.get_fraud_check(user, str(dms_content.application_id))
     if not fraud_check:
         logger.warning("DMS fraud check from user %d not previously created", user.id)
         fraud_check = models.BeneficiaryFraudCheck(

--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-import pcapi.core.fraud.exceptions as fraud_exceptions
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.models as users_models
 import pcapi.repository as pcapi_repository
@@ -10,7 +9,7 @@ import pcapi.repository as pcapi_repository
 logger = logging.getLogger(__name__)
 
 
-def get_dms_fraud_check(
+def get_fraud_check(
     user: users_models.User,
     application_id: str,
 ) -> Optional[fraud_models.BeneficiaryFraudCheck]:
@@ -26,24 +25,18 @@ def get_dms_fraud_check(
     )
 
 
-def start_dms_fraud_check(
+def create_fraud_check(
     user: users_models.User,
     source_data: fraud_models.DMSContent,
 ) -> fraud_models.BeneficiaryFraudCheck:
     application_id = str(source_data.application_id)
-    fraud_check = get_dms_fraud_check(user, application_id)
-    if not fraud_check:
-        fraud_check = fraud_models.BeneficiaryFraudCheck(
-            user=user,
-            type=fraud_models.FraudCheckType.DMS,
-            thirdPartyId=application_id,
-            resultContent=source_data.dict(),
-            status=fraud_models.FraudCheckStatus.PENDING,
-            eligibilityType=source_data.get_eligibility_type(),
-        )
-        pcapi_repository.repository.save(fraud_check)
-
-    if fraud_check.status != fraud_models.FraudCheckStatus.PENDING:
-        raise fraud_exceptions.ApplicationValidationAlreadyStarted()
-
+    fraud_check = fraud_models.BeneficiaryFraudCheck(
+        user=user,
+        type=fraud_models.FraudCheckType.DMS,
+        thirdPartyId=application_id,
+        resultContent=source_data.dict(),
+        status=fraud_models.FraudCheckStatus.STARTED,
+        eligibilityType=source_data.get_eligibility_type(),
+    )
+    pcapi_repository.repository.save(fraud_check)
     return fraud_check

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -1,7 +1,6 @@
 import logging
 
 from pcapi.connectors.dms import api as api_dms
-import pcapi.core.fraud.api as fraud_api
 from pcapi.core.fraud.dms import api as fraud_dms_api
 import pcapi.core.fraud.models as fraud_models
 from pcapi.core.subscription import messages as subscription_messages
@@ -12,20 +11,6 @@ import pcapi.repository as pcapi_repository
 logger = logging.getLogger(__name__)
 
 
-def start_dms_workflow(user: users_models.User, content: fraud_models.DMSContent) -> fraud_models.BeneficiaryFraudCheck:
-    user.submit_user_identity()
-    pcapi_repository.repository.save(user)
-    fraud_check = fraud_dms_api.start_dms_fraud_check(user, content)
-    return fraud_check
-
-
-def stop_dms_workflow(
-    user: users_models.User, thirdparty_id: str, content: fraud_models.DMSContent
-) -> fraud_models.BeneficiaryFraudCheck:
-    fraud_check = fraud_api.mark_fraud_check_failed(user, thirdparty_id, content, reasons=[])
-    return fraud_check
-
-
 def handle_dms_state(
     user: users_models.User,
     application: fraud_models.DMSContent,
@@ -34,41 +19,34 @@ def handle_dms_state(
     state: api_dms.GraphQLApplicationStates,
 ) -> None:
 
-    if state == api_dms.GraphQLApplicationStates.accepted:
+    logs_extra = {
+        "application_id": application_id,
+        "procedure_id": procedure_id,
+        "user_email": user.email,
+    }
 
-        logger.info(
-            "DMS Application accepted.",
-            extra={
-                "application_id": application_id,
-                "procedure_id": procedure_id,
-                "user_email": user.email,
-            },
-        )
-    elif state in (
-        api_dms.GraphQLApplicationStates.draft,
-        api_dms.GraphQLApplicationStates.on_going,
-    ):
+    current_fraud_check = fraud_dms_api.get_fraud_check(user, application_id)
+    if current_fraud_check is None:
+        # create a fraud_check whatever the status is because we may have missed a webhook event
+        current_fraud_check = fraud_dms_api.create_fraud_check(user, application)
+        user.submit_user_identity()
+
+    if state == api_dms.GraphQLApplicationStates.draft:
         subscription_messages.on_dms_application_received(user)
-        start_dms_workflow(user, application)
+        logger.info("DMS Application started.", extra=logs_extra)
 
-        logger.info(
-            "DMS Application created.",
-            extra={
-                "application_id": application_id,
-                "procedure_id": procedure_id,
-                "user_email": user.email,
-            },
-        )
+    elif state == api_dms.GraphQLApplicationStates.on_going:
+        subscription_messages.on_dms_application_received(user)
+        current_fraud_check.status = fraud_models.FraudCheckStatus.PENDING
+        logger.info("DMS Application created.", extra=logs_extra)
+
+    elif state == api_dms.GraphQLApplicationStates.accepted:
+        logger.info("DMS Application accepted. User will be validated in the cron job.", extra=logs_extra)
 
     elif state == api_dms.GraphQLApplicationStates.refused:
+        current_fraud_check.status = fraud_models.FraudCheckStatus.KO
         subscription_messages.on_dms_application_refused(user)
-        stop_dms_workflow(user, application_id, application)
 
-        logger.info(
-            "DMS Application refused.",
-            extra={
-                "application_id": application_id,
-                "procedure_id": procedure_id,
-                "user_email": user.email,
-            },
-        )
+        logger.info("DMS Application refused.", extra=logs_extra)
+
+    pcapi_repository.repository.save(current_fraud_check)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -6,7 +6,6 @@ import freezegun
 import pytest
 
 import pcapi.core.fraud.api as fraud_api
-import pcapi.core.fraud.dms.api as fraud_dms_api
 import pcapi.core.fraud.exceptions as fraud_exceptions
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
@@ -214,20 +213,6 @@ class CommonFraudCheckTest:
 
 @pytest.mark.usefixtures("db_session")
 class DMSFraudCheckTest:
-    def test_dms_fraud_check_already_started(self):
-        application_id = "123123"
-        user = users_factories.UserFactory()
-        dms_content = fraud_factories.DMSContentFactory(application_id=application_id)
-        fraud_dms_api.start_dms_fraud_check(user, dms_content)
-        fraud_api.on_dms_fraud_result(user, dms_content)
-
-        fraud_checks = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).all()
-        assert len(fraud_checks) == 1
-        fraud_check = fraud_checks[0]
-
-        assert fraud_check.type == fraud_models.FraudCheckType.DMS
-        assert fraud_check.status == fraud_models.FraudCheckStatus.OK
-
     def test_dms_fraud_check(self):
         user = users_factories.UserFactory()
         content = fraud_factories.DMSContentFactory()

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -13,7 +13,6 @@ from pcapi.core.fraud import models as fraud_models
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import models as subscription_models
-from pcapi.core.subscription.dms import api as dms_subscription_api
 from pcapi.core.testing import override_features
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import factories as users_factories
@@ -724,20 +723,6 @@ class OnSuccessfulDMSApplicationTest:
         # TODO: requires 19yo fixes : PC-12560
         assert applicant.has_beneficiary_role is False
         assert subscription_api.get_next_subscription_step(applicant) == None
-
-
-@pytest.mark.usefixtures("db_session")
-class DMSSubscriptionTest:
-    def test_dms_subscription(self):
-        user = users_factories.UserFactory(subscriptionState=users_models.SubscriptionState.phone_validated)
-        content = fraud_factories.DMSContentFactory()
-        fraud_check = dms_subscription_api.start_dms_workflow(user, content=content)
-
-        assert user.subscriptionState == users_models.SubscriptionState.identity_check_pending
-        assert fraud_check.user == user
-        assert fraud_check.status == fraud_models.FraudCheckStatus.PENDING
-        assert fraud_check.type == fraud_models.FraudCheckType.DMS
-        assert fraud_check.eligibilityType == users_models.EligibilityType.AGE18
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12975

## But de la pull request

Ajouter l'état "started" sur les dossiers dms pour améliorer l'infos et simplifier les regles de reprises ou re tentatives.

##  Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)