### PR TITLE
(PC-11271)[PRO] Venue edition: display venue provider even when all providers are disabled for pro

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
@@ -40,7 +40,7 @@ const VenueProvidersManager = ({ venue }) => {
     setVenueProviders(newVenueProviders)
   }
 
-  if (!isLoading && !providers.length) {
+  if (!isLoading && !providers.length && !venueProviders.length) {
     return null
   }
 

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
@@ -69,6 +69,29 @@ describe('src | VenueProvidersManager', () => {
     expect(pcapi.loadVenueProviders).toHaveBeenCalledTimes(1)
   })
 
+  describe('when all providers are disabled for pro', () => {
+    it('should display provider section if venue already have one', async () => {
+      // Given
+      venueProviders = [
+        {
+          id: 'AD',
+          nOffers: 1,
+          provider: { id: 'providerId', name: 'TiteLive' },
+          venueId: props.venue.id,
+          lastSyncDate: '2018-01-01T10:00:00',
+        },
+      ]
+      pcapi.loadProviders.mockResolvedValue([])
+      pcapi.loadVenueProviders.mockResolvedValue(venueProviders)
+
+      // When
+      await renderVenueProvidersManager(props)
+
+      // Then
+      expect(screen.queryByText('Importer des offres')).not.toBeInTheDocument()
+    })
+  })
+
   describe('when venue has providers synchronized', () => {
     it('should display the list of synchronized providers', async () => {
       // given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11271

## But de la pull request
Afficher la section 'providers' sur la page lieu s'il y a au moins un provider enabledForPro ou au moins un provider déjà activé pour le lieu

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
