### PR TITLE
[bsr][api] Tweak IPython configuration

### DIFF
--- a/api/.flaskenv
+++ b/api/.flaskenv
@@ -1,1 +1,2 @@
 FLASK_APP=pcapi.flask_app:app
+IPYTHONDIR=.ipython

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -72,6 +72,8 @@ target/
 
 # IPython Notebook
 .ipynb_checkpoints
+.ipython
+!.ipython/profile_default/ipython_config.py
 
 # pyenv
 .python-version

--- a/api/.ipython/profile_default/ipython_config.py
+++ b/api/.ipython/profile_default/ipython_config.py
@@ -1,0 +1,30 @@
+import pygments.token
+
+from pcapi import settings
+
+
+def get_prompt_color():
+    # Colors come from https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/windowsterminal/Ubuntu.json
+    if settings.ENV in "production":
+        return "#cc0000"  # red
+    if settings.ENV == "staging":
+        return "#ad7fa8"  # purple
+    if settings.ENV == "testing":
+        return "#06989a"  # cyan
+    return None  # do not customize locally
+
+
+prompt_color = get_prompt_color()
+
+
+c = get_config()
+
+c.TerminalInteractiveShell.autoformatter = None
+if prompt_color:
+    c.TerminalInteractiveShell.highlighting_style_overrides = {
+        pygments.token.Token.Prompt: f"{prompt_color} bold",
+        pygments.token.Token.PromptNum: f"{prompt_color} bold",
+        pygments.token.Token.OutPrompt: f"{prompt_color} bold",
+        pygments.token.Token.OutPromptNum: f"{prompt_color} bold",
+    }
+c.TerminalInteractiveShell.term_title = False

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import time
 import typing
 
@@ -171,33 +170,3 @@ app.url_map.strict_slashes = False
 
 with app.app_context():
     app.redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)
-
-
-@app.shell_context_processor
-def get_shell_extra_context():
-    # We abuse `shell_context_processor` to call custom code when
-    # `flask shell` is run.
-    _set_python_prompt()
-    return {}
-
-
-def _non_printable(seq):
-    return f"\001{seq}\002"
-
-
-def _set_python_prompt():
-    env = settings.ENV
-    if env in "production":
-        color = "\x1b[1;49;31m"  # red
-    elif env == "staging":
-        color = "\x1b[1;49;35m"  # purple
-    elif env == "testing":
-        color = "\x1b[1;49;36m"  # cyan
-    else:
-        color = None
-
-    if color:
-        color = _non_printable(color)
-        reset = _non_printable("\x1b[0m")
-
-        sys.ps1 = f"{color}{env} >>> {reset}"


### PR DESCRIPTION
1. Do not change the title of the terminal. "IPython: src/app" is not
   particularly helpful (especially for those of us who customize
   their terminal title with the environment they are on).

2. Do not reformat code with Black. It fails with an error on staging
   and production.

3. Tweak color of the prompt as we used to do with the default Python
   prompt.