### PR TITLE
(PC-12894)[API - ADAGE] : disable search button while fetching offers

### DIFF
--- a/adage-front/src/app/components/OffersSearch/OffersSearch.tsx
+++ b/adage-front/src/app/components/OffersSearch/OffersSearch.tsx
@@ -113,7 +113,11 @@ export const OffersSearch = ({
           venueFilter={venueFilter}
         />
         <div className="search-results">
-          <Offers setIsLoading={setIsLoading} userRole={userRole} />
+          <Offers
+            isLoading={isLoading}
+            setIsLoading={setIsLoading}
+            userRole={userRole}
+          />
         </div>
         <Pagination />
       </InstantSearch>

--- a/adage-front/src/app/ui-kit/SearchButton/SearchButton.scss
+++ b/adage-front/src/app/ui-kit/SearchButton/SearchButton.scss
@@ -20,8 +20,8 @@
   }
 
   &:disabled {
-    background-color: $primary-disabled;
-    border: rem(3px) solid $primary-disabled;
+    outline: none;
+    background-color: $primary-dark;
     cursor: not-allowed;
   }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12894

## But de la pull request

Rendre le bouton "Lancer la recherche" disable le temps que les offres soient récupérées côté api

##  Implémentation

utilisation de la lib react-query et notamment du hook `useIsFetching`

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements 



