### PR TITLE
(pc-10170)(API)(FA) Add Info and Actions on VenueProviders and Provid…

### DIFF
--- a/api/src/pcapi/admin/custom_views/provider_view.py
+++ b/api/src/pcapi/admin/custom_views/provider_view.py
@@ -1,0 +1,21 @@
+from pcapi.admin.base_configuration import BaseAdminView
+
+
+class ProviderView(BaseAdminView):
+    can_edit = True
+    can_create = True
+    can_delete = False
+
+    column_list = ["name", "apiUrl", "enabledForPro", "isActive"]
+
+    column_labels = {
+        "name": "Nom",
+        "apiUrl": "URL Api",
+        "enabledForPro": "Activé pour les pros",
+        "isActive": "Actif ?",
+    }
+
+    column_default_sort = ("id", True)
+    column_searchable_list = ["name", "apiUrl"]
+    column_filters = ["enabledForPro", "isActive"]
+    form_columns = ["name", "apiUrl", "enabledForPro", "isActive"]

--- a/api/src/pcapi/admin/custom_views/venue_provider_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_provider_view.py
@@ -35,7 +35,7 @@ def _get_venue_name_and_id(venue: Venue) -> str:
 
 class VenueProviderView(BaseAdminView):
     can_edit = True
-    can_create = False
+    can_create = True
     can_delete = False
 
     column_list = [
@@ -47,6 +47,7 @@ class VenueProviderView(BaseAdminView):
         "isDuo",
         "quantity",
         "provider.isActive",
+        "lastSyncDate",
         "venue_link",
     ]
     column_labels = {
@@ -60,6 +61,7 @@ class VenueProviderView(BaseAdminView):
         "isDuo": "En duo ? (Allocine seulement)",
         "quantity": "Quantité (Allocine seulement)",
         "provider.isActive": "Provider activé",
+        "lastSyncDate": "Date de dernière synchronisation",
         "venue_link": "Lien",
     }
 

--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -21,6 +21,7 @@ from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOpera
 from pcapi.admin.custom_views.offerer_view import OffererView
 from pcapi.admin.custom_views.partner_user_view import PartnerUserView
 from pcapi.admin.custom_views.pro_user_view import ProUserView
+from pcapi.admin.custom_views.provider_view import ProviderView
 from pcapi.admin.custom_views.support_view import view
 from pcapi.admin.custom_views.suspend_fraudulent_users_by_email_providers import (
     SuspendFraudulentUsersByEmailProvidersView,
@@ -34,6 +35,7 @@ import pcapi.core.offers.models as offers_models
 from pcapi.core.offers.models import OfferValidationConfig
 from pcapi.core.payments.models import CustomReimbursementRule
 from pcapi.core.providers.models import AllocinePivot
+from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users.models import User
@@ -149,6 +151,15 @@ def install_views(admin: Admin, session: Session) -> None:
     )
     admin.add_view(
         AllocinePivotView(AllocinePivot, session, name="Pivot Allocine", category=Category.OFFRES_STRUCTURES_LIEUX)
+    )
+    admin.add_view(
+        ProviderView(
+            Provider,
+            session,
+            name="Fournisseurs d'import",
+            endpoint="/providers",
+            category=Category.CUSTOM_OPERATIONS,
+        )
     )
     admin.add_view(
         ManyOffersOperationsView(


### PR DESCRIPTION
…ers in FlaskAdmin

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10170

## But de la pull request

Description
Contexte :
On parle des VenueProviders et des Provider
D'information et d'action à rajouter sur FlaskAdmin

Modifications : 

sur la liste des VenueProviders (https://backend.passculture.beta.gouv.fr/pc/back-office/venue_providers/) ajouter la date de dernière synchronisation (lastSyncDate)

sur la page de création de VenueProvider (https://backend.passculture.beta.gouv.fr/pc/back-office/venue_providers/new/), dans la dropdown des Provider, ne pas enlever les Provider qui ont enabledForPro à False

création d'une page "Fournisseurs d'import" = liste des Providers, avec nom, class, apiUrl, isEnableForPro, isActive

page d'édition d'un Provider = modication du isActive et EnableForPro


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira 
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
 
![Capture d’écran 2022-01-24 à 16 47 50](https://user-images.githubusercontent.com/9610732/150816091-442c4b4b-b153-4f4c-b2e2-0e403d2dfa04.png)
![Capture d’écran 2022-01-24 à 16 48 12](https://user-images.githubusercontent.com/9610732/150816098-3db3ab4f-5489-4f44-b3e4-386d5b4805b3.png)
![Capture d’écran 2022-01-24 à 16 48 23](https://user-images.githubusercontent.com/9610732/150816103-2b59ffc0-594c-47b7-8ffc-26b19d96d66e.png)
![Capture d’écran 2022-01-24 à 16 48 30](https://user-images.githubusercontent.com/9610732/150816104-f96f6d0a-3f26-4835-a826-4bbca1fbbd6c.png)

