### PR TITLE
[PC-12947][API] indisponibilité de l'API entreprise

### DIFF
--- a/api/src/pcapi/connectors/api_entreprises.py
+++ b/api/src/pcapi/connectors/api_entreprises.py
@@ -16,9 +16,13 @@ class ApiEntrepriseException(Exception):
 
 
 def get_by_offerer(offerer: "Offerer") -> dict:
-    response = requests.get(
-        f"https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/{offerer.siren}", verify=False
-    )
+    try:
+        response = requests.get(
+            f"https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/{offerer.siren}", verify=False
+        )
+    except (requests.ConnectionError, requests.HTTPError, requests.Timeout) as exc:
+        logger.exception("Failed to get data from entreprise.data.gouv.fr", extra={"offerer": offerer.id})
+        raise ApiEntrepriseException("Error getting API entreprise DATA for SIREN : {}".format(offerer.siren)) from exc
 
     if response.status_code != 200:
         raise ApiEntrepriseException("Error getting API entreprise DATA for SIREN : {}".format(offerer.siren))

--- a/api/src/pcapi/connectors/api_entreprises.py
+++ b/api/src/pcapi/connectors/api_entreprises.py
@@ -17,9 +17,7 @@ class ApiEntrepriseException(Exception):
 
 def get_by_offerer(offerer: "Offerer") -> dict:
     try:
-        response = requests.get(
-            f"https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/{offerer.siren}", verify=False
-        )
+        response = requests.get(f"https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/{offerer.siren}")
     except (requests.ConnectionError, requests.HTTPError, requests.Timeout) as exc:
         logger.exception("Failed to get data from entreprise.data.gouv.fr", extra={"offerer": offerer.id})
         raise ApiEntrepriseException("Error getting API entreprise DATA for SIREN : {}".format(offerer.siren)) from exc

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -95,6 +95,7 @@ class FeatureToggle(enum.Enum):
     INCLUDE_LEGACY_PAYMENTS_FOR_REIMBURSEMENTS = (
         "Inclure les anciens modèles de données pour le téléchargement des remboursements "
     )
+    ENABLE_PRO_ACCOUNT_CREATION = "Permettre l'inscription des comptes professionels"
 
     def is_active(self) -> bool:
         if flask.has_request_context():

--- a/api/tests/connectors/api_entreprises_test.py
+++ b/api/tests/connectors/api_entreprises_test.py
@@ -51,9 +51,7 @@ class GetByOffererTest:
         get_by_offerer(offerer)
 
         # Then
-        requests_get.assert_called_once_with(
-            "https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/732075312", verify=False
-        )
+        requests_get.assert_called_once_with("https://entreprise.data.gouv.fr/api/sirene/v3/unites_legales/732075312")
 
     @patch("pcapi.connectors.api_entreprises.requests.get")
     def test_returns_unite_legale_informations_with_etablissement_siege(self, requests_get):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12947

## But de la pull request

- Make it possible to turn off the professionals account creation

##  Implémentation

- Ajout du feature flag `ENABLE_PRO_ACCOUNT_CREATION`

## Chemin de code utilisant l'API

- `get_by_offerer`
  - `make_validation_email_object`
    - `maybe_send_offerer_validation_email`
      - `_send_to_pc_admin_offerer_to_validate_email`
        - `_send_to_pc_admin_offerer_to_validate_email`
          - `create_offerer`
            - `create_offerer` (route)
      - `validate_user` (route)
  - `get_offerer_legal_category` (catches `ApiEntrepriseException`)
    - `Offerer.legal_category`
      - `ValidationView.edit` (admin)

- `get_by_siret`
  - `check_siret_is_still_active`
    - `SaveVenueBankInformations.get_referent_venue` (procédure DMS bic/iban)

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
