### PR TITLE
(PC-12871) prefill notification email

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/FormNotifications.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormNotifications/FormNotifications.tsx
@@ -1,5 +1,7 @@
-import React from 'react'
+import { useFormikContext } from 'formik'
+import React, { useEffect } from 'react'
 
+import { IOfferEducationalFormValues } from 'core/OfferEducational'
 import FormLayout from 'new_components/FormLayout'
 import { Checkbox, TextInput } from 'ui-kit'
 
@@ -8,20 +10,33 @@ import {
   NOTIFICATIONS_LABEL,
 } from '../../constants/labels'
 
-const FormNotifications = (): JSX.Element => (
-  <FormLayout.Section title="Notifications">
-    <FormLayout.Row>
-      <Checkbox
-        hideFooter
-        label={NOTIFICATIONS_LABEL}
-        name="notifications"
-        value=""
-      />
-    </FormLayout.Row>
-    <FormLayout.Row>
-      <TextInput label={NOTIFICATIONS_EMAIL_LABEL} name="notificationEmail" />
-    </FormLayout.Row>
-  </FormLayout.Section>
-)
+const FormNotifications = (): JSX.Element => {
+  const { values, setFieldValue } =
+    useFormikContext<IOfferEducationalFormValues>()
+
+  useEffect(() => {
+    if (values.notifications && values.email && !values.notificationEmail) {
+      setFieldValue('notificationEmail', values.email)
+    }
+    // disable eslint because we want to trigger prefill only when checkbox value is updated
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values.notifications, setFieldValue])
+
+  return (
+    <FormLayout.Section title="Notifications">
+      <FormLayout.Row>
+        <Checkbox
+          hideFooter
+          label={NOTIFICATIONS_LABEL}
+          name="notifications"
+          value=""
+        />
+      </FormLayout.Row>
+      <FormLayout.Row>
+        <TextInput label={NOTIFICATIONS_EMAIL_LABEL} name="notificationEmail" />
+      </FormLayout.Row>
+    </FormLayout.Section>
+  )
+}
 
 export default FormNotifications


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12871

## But de la pull request
prefill l'email des notifications si l'AC a coché la case et qu'un email de contact est renseigné 

## Cas de tests
- état initial, l'AC rentre un `email`, coche la case des notifications => `contactEmail` est pré-rempli
- état initial, l'AC coche la case des notifications, rentre un `email` => `contactEmail` est pré-rempli
- état initial, l'AC rentre un `contactEmail`, coche la case des notifications => `contactEmail` ne change pas
- état initial, l'AC rentre un `contactEmail`, rentre un `email`, coche la case des notifications => `contactEmail` ne change pas
- email, contactEmail rempli, case cochée. L'AC supprime le `notificationEmail`, décoche puis recoche la case => `contactEmail` se pré-rempli
- email, contactEmail rempli, case cochée. L'AC modifie le `contactEmail` => pas de nouveau pré-remplissage