### PR TITLE
(PC-11786): Remove sort on Amount, fix data sent by API, fix reset filters, improve UI

### DIFF
--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 import pcapi.core.finance.models as finance_models
+import pcapi.core.finance.utils as finance_utils
 import pcapi.serialization.utils as serialization_utils
 
 
@@ -67,7 +68,7 @@ class InvoiceResponseModel(BaseModel):
     def from_orm(cls, invoice: finance_models.Invoice):
         invoice.businessUnitName = invoice.businessUnit.name
         res = super().from_orm(invoice)
-        res.amount /= 100
+        res.amount = -finance_utils.to_euros(res.amount)
         return res
 
 

--- a/api/tests/routes/pro/get_invoices_test.py
+++ b/api/tests/routes/pro/get_invoices_test.py
@@ -16,7 +16,7 @@ def test_get_invoices(client):
     invoice1 = finance_factories.InvoiceFactory(businessUnit=business_unit1, date=dt1)
     business_unit2 = finance_factories.BusinessUnitFactory()
     dt2 = dt1 + datetime.timedelta(days=15)
-    invoice2 = finance_factories.InvoiceFactory(businessUnit=business_unit2, date=dt2, amount=1234)
+    invoice2 = finance_factories.InvoiceFactory(businessUnit=business_unit2, date=dt2, amount=-1234)
     venue1 = offerers_factories.VenueFactory(businessUnit=business_unit1)
     offerer = venue1.managingOfferer
     _venue2 = offerers_factories.VenueFactory(

--- a/pro/src/components/pages/Reimbursements/Reimbursement.scss
+++ b/pro/src/components/pages/Reimbursements/Reimbursement.scss
@@ -58,8 +58,12 @@
   }
 
   .button-group {
-    margin-bottom: rem(32px);
+    margin-bottom: rem(16px);
     position: relative;
+
+    .search-button {
+      padding: 0 rem(32px);
+    }
 
     &-buttons {
       display: flex;

--- a/pro/src/components/pages/Reimbursements/ReimbursementsDetails/DetailsFilters.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsDetails/DetailsFilters.tsx
@@ -1,5 +1,4 @@
-import isEqual from 'lodash.isequal'
-import React, { Dispatch, SetStateAction, useCallback } from 'react'
+import React, { Dispatch, SetStateAction, useCallback, useState } from 'react'
 
 import PeriodSelector from 'components/layout/inputs/PeriodSelector/PeriodSelector'
 import Select from 'components/layout/inputs/Select'
@@ -49,7 +48,10 @@ const DetailsFilters = ({
     periodEnd: selectedPeriodEnd,
   } = filters
 
+  const [areFiltersDefault, setAreFiltersDefault] = useState(true)
+
   function resetFilters() {
+    setAreFiltersDefault(true)
     setFilters(initialFilters)
   }
 
@@ -60,6 +62,7 @@ const DetailsFilters = ({
         ...prevFilters,
         venue: venueId,
       }))
+      setAreFiltersDefault(false)
     },
     [setFilters]
   )
@@ -70,6 +73,7 @@ const DetailsFilters = ({
         ...prevFilters,
         periodStart: startDate,
       }))
+      setAreFiltersDefault(false)
     },
     [setFilters]
   )
@@ -80,6 +84,7 @@ const DetailsFilters = ({
         ...prevFilters,
         periodEnd: endDate,
       }))
+      setAreFiltersDefault(false)
     },
     [setFilters]
   )
@@ -90,7 +95,7 @@ const DetailsFilters = ({
         <h2 className="header-title">{headerTitle}</h2>
         <button
           className="tertiary-button reset-filters"
-          disabled={isEqual(filters, initialFilters)}
+          disabled={areFiltersDefault}
           onClick={resetFilters}
           type="button"
         >

--- a/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/InvoicesFilters.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/InvoicesFilters.tsx
@@ -1,5 +1,4 @@
-import isEqual from 'lodash.isequal'
-import React, { Dispatch, SetStateAction, useCallback } from 'react'
+import React, { Dispatch, SetStateAction, useCallback, useState } from 'react'
 
 import PeriodSelector from 'components/layout/inputs/PeriodSelector/PeriodSelector'
 import Select from 'components/layout/inputs/Select'
@@ -49,7 +48,10 @@ const InvoicesFilters = ({
     periodEnd: selectedPeriodEnd,
   } = filters
 
+  const [areFiltersDefault, setAreFiltersDefault] = useState(true)
+
   function resetFilters() {
+    setAreFiltersDefault(true)
     setFilters(initialFilters)
   }
 
@@ -60,6 +62,7 @@ const InvoicesFilters = ({
         ...prevFilters,
         businessUnit: businessUnitId,
       }))
+      setAreFiltersDefault(false)
     },
     [setFilters]
   )
@@ -70,6 +73,7 @@ const InvoicesFilters = ({
         ...prevFilters,
         periodStart: startDate,
       }))
+      setAreFiltersDefault(false)
     },
     [setFilters]
   )
@@ -80,6 +84,7 @@ const InvoicesFilters = ({
         ...prevFilters,
         periodEnd: endDate,
       }))
+      setAreFiltersDefault(false)
     },
     [setFilters]
   )
@@ -90,7 +95,7 @@ const InvoicesFilters = ({
         <h2 className="header-title">{headerTitle}</h2>
         <button
           className="tertiary-button reset-filters"
-          disabled={isEqual(filters, initialFilters)}
+          disabled={areFiltersDefault}
           onClick={resetFilters}
           type="button"
         >

--- a/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/ReimbursementsInvoices.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/ReimbursementsInvoices.tsx
@@ -43,7 +43,7 @@ const ReimbursementsInvoices = ({
     {
       title: 'Montant remboursé',
       sortBy: 'amount',
-      selfDirection: 'default',
+      selfDirection: 'None',
     },
   ]
 
@@ -118,7 +118,7 @@ const ReimbursementsInvoices = ({
         setFilters={setFilters}
       >
         <button
-          className="primary-button"
+          className="primary-button search-button"
           disabled={shouldDisableButton}
           onClick={() => loadInvoices()}
           type="button"

--- a/pro/src/components/pages/Reimbursements/ReimbursementsTable/ReimbursementsTable.module.scss
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsTable/ReimbursementsTable.module.scss
@@ -31,8 +31,9 @@ table.reimbursement-table {
     }
 
     th:nth-child(4) {
-      justify-content: flex-end;
+      cursor: default;
       margin-left: rem(20px);
+      text-align: right;
     }
   }
 

--- a/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableBody/ReimbursementsTableBody.module.scss
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableBody/ReimbursementsTableBody.module.scss
@@ -8,7 +8,7 @@ tbody.reimbursement-body {
   }
 
   .amount {
-    padding-left: rem(40px);
+    padding: 0;
     text-align: right;
   }
 }

--- a/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableHead/ReimbursementsTableHead.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableHead/ReimbursementsTableHead.tsx
@@ -18,10 +18,16 @@ const ReimbursementsTableHead = ({
   sortBy,
 }: IReimbursementsTableHead): JSX.Element => {
   const changeDirection = (columnOption: ColumnOptionType) => {
+    if (columnOption.selfDirection === 'None') {
+      return
+    }
+
     const otherColumnOption = columns.filter(title => title !== columnOption)
 
     otherColumnOption.forEach(columnOption => {
-      columnOption.selfDirection = 'default'
+      if (columnOption.selfDirection !== 'None') {
+        columnOption.selfDirection = 'default'
+      }
     })
 
     if (columnOption.selfDirection === 'default') {
@@ -33,6 +39,15 @@ const ReimbursementsTableHead = ({
     }
   }
 
+  const sortAndChangeColumnDirection = (columnOption: ColumnOptionType) => {
+    if (columnOption.selfDirection === 'None') {
+      return
+    } else {
+      sortBy(columnOption.sortBy)
+      changeDirection(columnOption)
+    }
+  }
+
   return (
     <thead>
       <tr>
@@ -40,31 +55,40 @@ const ReimbursementsTableHead = ({
           <th
             key={column.title}
             onClick={() => {
-              sortBy(column.sortBy)
-              changeDirection(column)
+              sortAndChangeColumnDirection(column)
             }}
           >
             {column.title}
-            {column.selfDirection === 'default' && (
-              <Icon alt="" png="" role="button" svg="ico-unfold" tabIndex={0} />
-            )}
-            {column.selfDirection === 'desc' && (
-              <Icon
-                alt=""
-                png=""
-                role="button"
-                svg="ico-arrow-up-r"
-                tabIndex={0}
-              />
-            )}
-            {column.selfDirection === 'asc' && (
-              <Icon
-                alt=""
-                png=""
-                role="button"
-                svg="ico-arrow-down-r"
-                tabIndex={0}
-              />
+            {column.selfDirection !== 'None' && (
+              <>
+                {column.selfDirection === 'default' && (
+                  <Icon
+                    alt=""
+                    png=""
+                    role="button"
+                    svg="ico-unfold"
+                    tabIndex={0}
+                  />
+                )}
+                {column.selfDirection === 'desc' && (
+                  <Icon
+                    alt=""
+                    png=""
+                    role="button"
+                    svg="ico-arrow-up-r"
+                    tabIndex={0}
+                  />
+                )}
+                {column.selfDirection === 'asc' && (
+                  <Icon
+                    alt=""
+                    png=""
+                    role="button"
+                    svg="ico-arrow-down-r"
+                    tabIndex={0}
+                  />
+                )}
+              </>
             )}
           </th>
         ))}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11786
Prend aussi en compte les retours pour les tickets 11787 & 11788

## But de la pull request

- L'API renvoie le montant en valeur absolue
- La colonne montant n'est plus triable
- Le bouton réinitialiser les filtres est disabled quand aucun filtre n'est sélectionné
- Petits retours UI tailles / espacements / ...

##  Implémentation

- Définir une valeur `selfDirection` à `'None'` pour la colonne `amount` (n'ayant pas réussi à rendre la valeur optionnelle avec TS) et changer la logique dépendamment de cette valeur côté Table
