### PR TITLE
(BSR) Remove isCancelled column from booking model

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -110,8 +110,6 @@ class Booking(PcObject, Model):
 
     amount = Column(Numeric(10, 2), nullable=False)
 
-    isCancelled = Column(Boolean, nullable=False, server_default=expression.false(), default=False)
-
     cancellationDate = Column(DateTime, nullable=True)
 
     isUsed = Column(Boolean, nullable=False, default=False, server_default=expression.false())


### PR DESCRIPTION
The isCancelled column usage has been removed in a proper JIRA ticket but we were waiting for the MOB to help column removal.
Here is the PR associated to the cleaning of isCancelled