### PR TITLE
(PC-12794)[PRO]sendinblue email booking expiration

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/booking_expiration_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/booking_expiration_to_pro.py
@@ -1,0 +1,78 @@
+from typing import List
+from typing import Tuple
+
+from pcapi.core import mails
+from pcapi.core.bookings import constants as booking_constants
+from pcapi.core.bookings.models import Booking
+from pcapi.core.categories import subcategories
+from pcapi.core.mails.transactional.sendinblue_template_ids import SendinblueTransactionalEmailData
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offerers.models import Offerer
+from pcapi.domain.postal_code.postal_code import PostalCode
+from pcapi.utils.mailing import build_pc_pro_offer_link
+
+
+def get_bookings_expiration_to_pro_email_data(
+    offerer: Offerer, bookings: list[Booking], withdrawal_period
+) -> SendinblueTransactionalEmailData:
+    return SendinblueTransactionalEmailData(
+        template=TransactionalEmail.BOOKING_EXPIRATION_TO_PRO.value,
+        params={
+            "BOOKINGS": _extract_bookings_information_from_bookings_list(bookings),
+            "DEPARTMENT": PostalCode(offerer.postalCode).get_departement_code(),
+            "WITHDRAWAL_PERIOD": withdrawal_period,
+        },
+    )
+
+
+def _extract_bookings_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
+    bookings_info = []
+    for booking in bookings:
+        bookings_info.append(
+            {
+                "offer_name": booking.stock.offer.name,
+                "venue_name": booking.stock.offer.venue.publicName
+                if booking.stock.offer.venue.publicName
+                else booking.stock.offer.venue.name,
+                "price": str(booking.stock.price) if booking.stock.price > 0 else "gratuit",
+                "user_name": booking.userName,
+                "user_email": booking.email,
+                "pcpro_offer_link": build_pc_pro_offer_link(booking.stock.offer),
+            }
+        )
+    return bookings_info
+
+
+def send_bookings_expiration_to_pro_email(offerer: Offerer, bookings: list[Booking]) -> bool:
+    offerer_booking_email = bookings[0].stock.offer.bookingEmail
+    if not offerer_booking_email:
+        return True
+
+    success = True
+    books_bookings, other_bookings = _filter_books_bookings(bookings)
+    if books_bookings:
+        books_bookings_data = get_bookings_expiration_to_pro_email_data(
+            offerer, books_bookings, booking_constants.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
+        )
+        success &= mails.send(recipients=[offerer_booking_email], data=books_bookings_data)
+
+    if other_bookings:
+        other_bookings_data = get_bookings_expiration_to_pro_email_data(
+            offerer, other_bookings, booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days
+        )
+        success &= mails.send(recipients=[offerer_booking_email], data=other_bookings_data)
+
+    return success
+
+
+def _filter_books_bookings(bookings: list[Booking]) -> Tuple[List[Booking], List[Booking]]:
+    books_bookings = []
+    other_bookings = []
+
+    for booking in bookings:
+        if booking.stock.offer.subcategoryId == subcategories.LIVRE_PAPIER.id:
+            books_bookings.append(booking)
+        else:
+            other_bookings.append(booking)
+
+    return books_bookings, other_bookings

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -110,7 +110,7 @@ class TransactionalEmail(Enum):
     BOOKING_CANCELLATION_CONFIRMATION_BY_PRO = TemplatePro(
         id_prod=0000, id_not_prod=0000, tags=["pro_annulation_rerservation"]
     )
-    BOOKING_EXPIRATION_TO_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=["pro_annulation_reservation_30j"])
+    BOOKING_EXPIRATION_TO_PRO = TemplatePro(id_prod=380, id_not_prod=50, tags=["pro_reservation_expiree_30j"])
     EAC_BOOKING_DAY_TO_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=[""])
     EAC_NEW_BOOKING_TO_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=["pro_nouvelle_reservation_eac"])
     EAC_NEW_PREBOOKING_TO_PRO = TemplatePro(id_prod=0000, id_not_prod=0000, tags=["pro_nouvelle_prereservation_eac"])

--- a/api/src/pcapi/domain/user_emails.py
+++ b/api/src/pcapi/domain/user_emails.py
@@ -3,7 +3,6 @@ import logging
 import typing
 
 from pcapi.core import mails
-from pcapi.core.bookings import constants as booking_constants
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import IndividualBooking
@@ -23,7 +22,6 @@ from pcapi.emails.beneficiary_offer_cancellation import (
     retrieve_offerer_booking_recap_email_data_after_user_cancellation,
 )
 from pcapi.emails.beneficiary_pre_subscription_rejected import make_dms_wrong_values_data
-from pcapi.emails.beneficiary_soon_to_be_expired_bookings import filter_books_bookings
 from pcapi.emails.new_offerer_validated_withdrawal_terms import (
     retrieve_data_for_new_offerer_validated_withdrawal_terms_email,
 )
@@ -31,7 +29,6 @@ from pcapi.emails.offerer_booking_recap import retrieve_data_for_offerer_booking
 from pcapi.emails.offerer_bookings_recap_after_deleting_stock import (
     retrieve_offerer_bookings_recap_email_data_after_offerer_cancellation,
 )
-from pcapi.emails.offerer_expired_bookings import build_expired_bookings_recap_email_data_for_offerer
 from pcapi.utils.mailing import make_admin_user_validation_email
 from pcapi.utils.mailing import make_offerer_driven_cancellation_email_for_offerer
 from pcapi.utils.mailing import make_pro_user_validation_email
@@ -85,28 +82,6 @@ def send_booking_cancellation_emails_to_user_and_offerer(
     if reason == BookingCancellationReasons.FRAUD:
         return send_user_driven_cancellation_email_to_offerer(booking)
     return True
-
-
-def send_expired_individual_bookings_recap_email_to_offerer(offerer: Offerer, bookings: list[Booking]) -> bool:
-    offerer_booking_email = bookings[0].stock.offer.bookingEmail
-    if not offerer_booking_email:
-        return True
-
-    success = True
-    books_bookings, other_bookings = filter_books_bookings(bookings)
-    if books_bookings:
-        books_bookings_data = build_expired_bookings_recap_email_data_for_offerer(
-            offerer, books_bookings, booking_constants.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
-        )
-        success &= mails.send(recipients=[offerer_booking_email], data=books_bookings_data)
-
-    if other_bookings:
-        other_bookings_data = build_expired_bookings_recap_email_data_for_offerer(
-            offerer, other_bookings, booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days
-        )
-        success &= mails.send(recipients=[offerer_booking_email], data=other_bookings_data)
-
-    return success
 
 
 def send_pro_user_validation_email(user: User) -> bool:

--- a/api/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -15,10 +15,10 @@ import pcapi.core.bookings.repository as bookings_repository
 from pcapi.core.mails.transactional.bookings.booking_expired_to_beneficiary import (
     send_expired_bookings_to_beneficiary_email,
 )
+from pcapi.core.mails.transactional.pro.booking_expiration_to_pro import send_bookings_expiration_to_pro_email
 from pcapi.core.mails.transactional.sendinblue_template_ids import SendinblueTransactionalEmailData
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.users.models import User
-from pcapi.domain.user_emails import send_expired_individual_bookings_recap_email_to_offerer
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 
@@ -185,7 +185,7 @@ def notify_offerers_of_expired_individual_bookings(expired_on: datetime.date = N
     notified_offerers = []
 
     for offerer, individual_bookings in expired_individual_bookings_grouped_by_offerer.items():
-        send_expired_individual_bookings_recap_email_to_offerer(
+        send_bookings_expiration_to_pro_email(
             offerer,
             [individual_booking.booking for individual_booking in individual_bookings],
         )

--- a/api/tests/core/mails/transactional/pro/booking_expiration_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/booking_expiration_to_pro_test.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+import pytest
+
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.categories import subcategories
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.mails.transactional.pro.booking_expiration_to_pro import send_bookings_expiration_to_pro_email
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offers.factories import OffererFactory
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class SendExpiredBookingsRecapEmailToOffererTest:
+    def test_should_send_email_to_offerer_when_expired_bookings_cancelled(self, app):
+        offerer = OffererFactory()
+        expired_today_dvd_booking = bookings_factories.IndividualBookingFactory(
+            stock__offer__bookingEmail="offerer.booking@example.com"
+        )
+        expired_today_cd_booking = bookings_factories.IndividualBookingFactory(
+            stock__offer__bookingEmail="offerer.booking@example.com"
+        )
+
+        send_bookings_expiration_to_pro_email(offerer, [expired_today_cd_booking, expired_today_dvd_booking])
+        assert len(mails_testing.outbox) == 1
+        assert (
+            mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.BOOKING_EXPIRATION_TO_PRO.value.__dict__
+        )
+        assert mails_testing.outbox[0].sent_data["params"]
+
+    def test_should_send_two_emails_to_offerer_when_expired_books_bookings_and_other_bookings_cancelled(self):
+        offerer = OffererFactory()
+        expired_today_dvd_booking = bookings_factories.IndividualBookingFactory(
+            stock__offer__name="Intouchables",
+            stock__offer__bookingEmail="offerer.booking@example.com",
+            stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+        )
+        expired_today_book_booking = bookings_factories.IndividualBookingFactory(
+            stock__offer__name="Les misérables",
+            stock__offer__bookingEmail="offerer.booking@example.com",
+            stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
+        )
+
+        send_bookings_expiration_to_pro_email(offerer, [expired_today_dvd_booking, expired_today_book_booking])
+
+        assert len(mails_testing.outbox) == 2
+        assert (
+            mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.BOOKING_EXPIRATION_TO_PRO.value.__dict__
+        )
+        assert mails_testing.outbox[0].sent_data["params"]["WITHDRAWAL_PERIOD"] == 10
+        assert mails_testing.outbox[0].sent_data["params"]["BOOKINGS"][0]["offer_name"] == "Les misérables"
+        assert (
+            mails_testing.outbox[1].sent_data["template"] == TransactionalEmail.BOOKING_EXPIRATION_TO_PRO.value.__dict__
+        )
+        assert mails_testing.outbox[1].sent_data["params"]["WITHDRAWAL_PERIOD"] == 30
+        assert mails_testing.outbox[1].sent_data["params"]["BOOKINGS"][0]["offer_name"] == "Intouchables"

--- a/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
@@ -127,6 +127,7 @@ class SendinblueSendOfferValidationTest:
 
         # Then
         assert len(mails_testing.outbox) == 1  # test number of emails sent
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.OFFER_APPROVAL_TO_PRO.value.__dict__
         assert mails_testing.outbox[0].sent_data["To"] == "jules.verne@example.com"
         assert mails_testing.outbox[0].sent_data["params"] == {
             "OFFER_NAME": offer.name,
@@ -163,6 +164,7 @@ class SendinblueSendOfferValidationTest:
 
         # Then
         assert len(mails_testing.outbox) == 1  # test number of emails sent
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.OFFER_REJECTION_TO_PRO.value.__dict__
         assert mails_testing.outbox[0].sent_data["To"] == "jules.verne@example.com"
         assert mails_testing.outbox[0].sent_data["params"] == {
             "OFFER_NAME": offer.name,

--- a/api/tests/scripts/booking/handle_expired_bookings_test.py
+++ b/api/tests/scripts/booking/handle_expired_bookings_test.py
@@ -335,7 +335,7 @@ class NotifyUsersOfExpiredBookingsTest:
 
 
 class NotifyOfferersOfExpiredBookingsTest:
-    @mock.patch("pcapi.scripts.booking.handle_expired_bookings.send_expired_individual_bookings_recap_email_to_offerer")
+    @mock.patch("pcapi.scripts.booking.handle_expired_bookings.send_bookings_expiration_to_pro_email")
     def test_should_notify_of_todays_expired_individual_bookings(self, mocked_send_email_recap, app) -> None:
         now = datetime.utcnow()
         yesterday = now - timedelta(days=1)
@@ -373,7 +373,7 @@ class NotifyOfferersOfExpiredBookingsTest:
             [expired_today_cd_booking.individualBooking.booking],
         )
 
-    @mock.patch("pcapi.scripts.booking.handle_expired_bookings.send_expired_individual_bookings_recap_email_to_offerer")
+    @mock.patch("pcapi.scripts.booking.handle_expired_bookings.send_bookings_expiration_to_pro_email")
     def test_should_not_notify_of_todays_expired_educational_bookings(self, mocked_send_email_recap, app) -> None:
         # Given
         now = datetime.utcnow()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12794

## But de la pull request

migration mailjet vers sendinblue - email de notification aux acteurs culturels quand des réservations expirent au bout de 30 jours (10 jours pour les livres) car les bénéficiaires n'ont pas utilisé leur contremarque

##  Implémentation
déplacement pcapi/emails vers pcapi/core/mails/transactional/pro

##  Informations supplémentaires
suppression des valeurs mailjet (pas nécessaire de les conserver) car le feature flag ne peut pas être retiré ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
