### PR TITLE
(PC-13077)[API] subscription: check firstname and lastname validity

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -1,8 +1,11 @@
 from typing import Optional
 
+from pydantic import validator
+
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import profile_options
 from pcapi.core.users import models as users_models
+from pcapi.serialization.utils import is_latin
 from pcapi.serialization.utils import to_camel
 
 from . import BaseModel
@@ -31,6 +34,12 @@ class ProfileUpdateRequest(BaseModel):
 
     class Config:
         alias_generator = to_camel
+
+    @validator("first_name", "last_name", "address", "city")
+    def string_must_contain_latin_characters(cls, v):  # pylint: disable=no-self-argument
+        if not is_latin(v):
+            raise ValueError("Les champs textuels doivent contenir des caractères latins")
+        return v
 
 
 class SchoolTypeResponseModel(BaseModel):

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -2,6 +2,7 @@ import re
 from typing import Any
 from typing import Optional
 from typing import Union
+import unicodedata
 
 from flask import Request
 from flask import Response
@@ -123,3 +124,7 @@ def validate_phone_number_format(field_name: str) -> classmethod:
 
 def string_to_boolean_field(field_name: str) -> classmethod:
     return validator(field_name, pre=True, allow_reuse=True)(string_to_boolean)
+
+
+def is_latin(s: str):
+    return all("LATIN" in unicodedata.name(char) for char in s if char.isalpha())

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -489,6 +489,64 @@ class UpdateProfileTest:
         assert not notification["attribute_values"]["u.is_beneficiary"]
         assert notification["attribute_values"]["u.postal_code"] == "77000"
 
+    @override_features(ENABLE_UBBLE=True)
+    def test_update_profile_invalid_character(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            phoneNumber="+33609080706",
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": "ჯონ",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+        }
+
+        client.with_token(user.email)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 400
+
+    @override_features(ENABLE_UBBLE=True)
+    def test_update_profile_valid_character(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            phoneNumber="+33609080706",
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": "John",
+            "lastName": "àâçéèêîôœùûÀÂÇÉÈÊÎÔŒÙÛ-' ",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+        }
+
+        client.with_token(user.email)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 204
+
 
 class ProfileOptionsTypeTest:
     def test_get_profile_options(self, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13077

## But de la pull request

Vérifier que les nom et prénom renseignés dans la route /subscription/profile sont bien dans un alphabet latin.

##  Implémentation

- utilisation de la lib alphabet-detector

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
