### PR TITLE
[pc-13109][api] restart workflow for STARTED fraud_check

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -515,15 +515,6 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
     ).scalar()
 
 
-def get_pending_identity_check(user: users_models.User) -> typing.Optional[models.BeneficiaryFraudCheck]:
-    return models.BeneficiaryFraudCheck.query.filter(
-        models.BeneficiaryFraudCheck.user == user,
-        models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.PENDING,
-        models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
-        models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
-    ).one_or_none()
-
-
 def has_passed_educonnect(user: users_models.User) -> bool:
     return db.session.query(
         models.BeneficiaryFraudCheck.query.filter(

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -188,3 +188,19 @@ def is_user_allowed_to_perform_ubble_check(
         return False
 
     return True
+
+
+def get_pending_identity_check(user: users_models.User) -> typing.Optional[fraud_models.BeneficiaryFraudCheck]:
+    started_fraud_check = (
+        fraud_models.BeneficiaryFraudCheck.query.filter(
+            fraud_models.BeneficiaryFraudCheck.user == user,
+            fraud_models.BeneficiaryFraudCheck.status.in_(
+                [fraud_models.FraudCheckStatus.STARTED, fraud_models.FraudCheckStatus.PENDING]
+            ),
+            fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE,
+            fraud_models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
+        )
+        .order_by(fraud_models.BeneficiaryFraudCheck.id.desc())
+        .first()
+    )
+    return started_fraud_check

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -337,7 +337,7 @@ def start_identification_session(
             status_code=400,
         )
 
-    fraud_check = fraud_api.get_pending_identity_check(user)
+    fraud_check = ubble_fraud_api.get_pending_identity_check(user)
     if fraud_check:
         if ubble_subscription_api.is_ubble_workflow_restartable(fraud_check):
             return serializers.IdentificationSessionResponse(

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1751,7 +1751,7 @@ class IdentificationSessionTest:
         assert response.status_code == 400
         assert len(user.beneficiaryFraudChecks) == 2
 
-    def test_allow_rerun_identification(self, client, ubble_mock):
+    def test_allow_rerun_identification_from_pending(self, client, ubble_mock):
         user = users_factories.UserFactory(dateOfBirth=datetime.now() - relativedelta(years=18, days=5))
         client.with_token(user.email)
 
@@ -1764,6 +1764,32 @@ class IdentificationSessionTest:
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             status=fraud_models.FraudCheckStatus.PENDING,
+            user=user,
+            resultContent=ubble_content,
+        )
+        response = client.post("/native/v1/ubble_identification", json={"redirectUrl": "http://example.com/deeplink"})
+
+        assert response.status_code == 200
+        assert len(user.beneficiaryFraudChecks) == 1
+        assert ubble_mock.call_count == 0
+
+        check = user.beneficiaryFraudChecks[0]
+        assert check.type == fraud_models.FraudCheckType.UBBLE
+        assert response.json["identificationUrl"] == expected_url
+
+    def test_allow_rerun_identification_from_started(self, client, ubble_mock):
+        user = users_factories.UserFactory(dateOfBirth=datetime.now() - relativedelta(years=18, days=5))
+        client.with_token(user.email)
+
+        expected_url = "https://id.ubble.ai/ef055567-3794-4ca5-afad-dce60fe0f227"
+
+        ubble_content = fraud_factories.UbbleContentFactory(
+            status=ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
+            identification_url=expected_url,
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            type=fraud_models.FraudCheckType.UBBLE,
+            status=fraud_models.FraudCheckStatus.STARTED,
             user=user,
             resultContent=ubble_content,
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13109

Réutiliser un fraud_check ubble lorsque l'utilisateur reprend une session qu'il a précédemment quittée

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)