### PR TITLE
[PC-11791] - Fix svg size + margin

### DIFF
--- a/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableBody/ReimbursementsTableBody.module.scss
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableBody/ReimbursementsTableBody.module.scss
@@ -15,5 +15,11 @@ tbody.reimbursement-body {
   .invoice {
     text-align: right;
     width: rem(220px);
+
+    svg {
+        height: unset;
+        width: unset;
+        margin-right: rem(8px);
+    }
   }
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11791

## But de la pull request

Réduire la taille de l'icone téléchargement + ajout d'une marge à droite de l'icone pour compense. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
