### PR TITLE
(PC 9019) : add constraint to offer idAtProvider

### DIFF
--- a/api/src/pcapi/alembic/versions/20220121T105010_1c78fd29dcf6_remove_offer_idatproviders_checks.py
+++ b/api/src/pcapi/alembic/versions/20220121T105010_1c78fd29dcf6_remove_offer_idatproviders_checks.py
@@ -9,17 +9,19 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
+def upgrade() -> None:
     op.drop_constraint("offer_idAtProviders_key", "offer", type_="unique")
     op.drop_constraint("check_providable_with_provider_has_idatproviders", "offer", type_="check")
-    op.create_check_constraint(
-        "check_providable_with_provider_has_idatprovider",
-        "offer",
-        '"lastProviderId" IS NULL OR "idAtProvider" IS NOT NULL',
+    op.execute(
+        """
+        ALTER TABLE "offer" ADD CONSTRAINT check_providable_with_provider_has_idatprovider CHECK (
+            'lastProviderId' IS NULL OR 'idAtProvider' IS NOT NULL
+        ) NOT VALID;
+        """
     )
 
 
-def downgrade():
+def downgrade() -> None:
     op.create_unique_constraint("offer_idAtProviders_key", "offer", ["idAtProviders"])
     op.create_check_constraint(
         "check_providable_with_provider_has_idatproviders",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9019

## But de la pull request

Ajout d'une contrainte sur offer et idAtProvider.

##  Implémentation

- Migration pour ajouter la contrainte.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] ~J'ai écrit les tests nécessaires~
- [X] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] ~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~
- [ ] ~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~
