### PR TITLE
(PC-13065)[api]bookings: edit eac booking label in csv

### DIFF
--- a/api/src/pcapi/core/offers/serialize.py
+++ b/api/src/pcapi/core/offers/serialize.py
@@ -1,2 +1,2 @@
 def serialize_offer_type_educational_or_individual(offer_is_educational: bool) -> str:
-    return "offre scolaire" if offer_is_educational else "offre grand public"
+    return "offre collective" if offer_is_educational else "offre grand public"

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -2673,9 +2673,9 @@ class GetCsvReportTest:
 
         # Then
         expected_type = {
-            booking_1.stock.offer.name: "offre scolaire",
+            booking_1.stock.offer.name: "offre collective",
             booking_2.stock.offer.name: "offre grand public",
-            booking_3.stock.offer.name: "offre scolaire",
+            booking_3.stock.offer.name: "offre collective",
             booking_4.stock.offer.name: "offre grand public",
         }
 

--- a/api/tests/routes/serialization/reimbursement_csv_test.py
+++ b/api/tests/routes/serialization/reimbursement_csv_test.py
@@ -127,7 +127,7 @@ class ReimbursementDetailsTest:
         assert raw_csv[13] == f"{int(payment.reimbursementRate * 100)}%"
         assert raw_csv[14] == "21,00"
         assert raw_csv[15] == "Remboursement envoyé"
-        assert raw_csv[16] == "offre scolaire"
+        assert raw_csv[16] == "offre collective"
 
         # new pricing+cashflow data
         row = ReimbursementDetails(payments_info[0]).as_csv_row()
@@ -146,7 +146,7 @@ class ReimbursementDetailsTest:
         assert row[13] == f"{int(payment.reimbursementRate * 100)} %"
         assert row[14] == "21,00"
         assert row[15] == "Remboursement envoyé"
-        assert row[16] == "offre scolaire"
+        assert row[16] == "offre collective"
 
     def test_reimbursement_details_with_custom_rule_as_csv(self):
         # given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13065

## But de la pull request

Replacement de l'appellation` offre scolaire` par `offre collective` dans le CSV des réservations.
<img width="1703" alt="pc-13065" src="https://user-images.githubusercontent.com/33030007/151385557-1668f936-438a-45d3-87e7-39861b452858.png">

