### PR TITLE
POC: Use private DMS annotation to warn for potential errors

### DIFF
--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -109,3 +109,27 @@ class DMSGraphQLClient:
         query = self.build_query("pro/get_banking_info_v2")
         variables = {"dossierNumber": dossier_id}
         return self.execute_query(query, variables=variables)
+
+    def update_checkbox_annotation(self, dossier_id: str, instructeur_id: str, annotation_id: str, value: bool) -> Any:
+        query = self.build_query("update_checkbox_annotation")
+        variables = {
+            "input": {
+                "dossierId": dossier_id,
+                "instructeurId": instructeur_id,
+                "annotationId": annotation_id,
+                "value": value,
+            }
+        }
+        return self.execute_query(query, variables=variables)
+
+    def update_text_annotation(self, dossier_id: str, instructeur_id: str, annotation_id: str, value: str) -> Any:
+        query = self.build_query("update_text_annotation")
+        variables = {
+            "input": {
+                "dossierId": dossier_id,
+                "instructeurId": instructeur_id,
+                "annotationId": annotation_id,
+                "value": value,
+            }
+        }
+        return self.execute_query(query, variables=variables)

--- a/api/src/pcapi/validation_dms.py
+++ b/api/src/pcapi/validation_dms.py
@@ -1,0 +1,25 @@
+from pcapi.connectors.dms import api as api_dms
+
+
+client = api_dms.DMSGraphQLClient()
+
+data = client.get_single_application_details(7555183)
+
+for annotation in data["dossier"]["annotations"]:
+    if annotation["label"] == "Données validées par l' API":
+        response = client.update_checkbox_annotation(
+            dossier_id=data["dossier"]["id"],
+            instructeur_id="SW5zdHJ1Y3RldXItNTY5OTQ=",
+            annotation_id=annotation["id"],
+            value=True,
+        )
+    if annotation["label"] == "Champs en erreur":
+        response = client.update_text_annotation(
+            dossier_id=data["dossier"]["id"],
+            instructeur_id="SW5zdHJ1Y3RldXItNTY5OTQ=",
+            annotation_id=annotation["id"],
+            value="""Erreur dans les champs :
+            - xxx
+            - yyy
+            """,
+        )


### PR DESCRIPTION
Preuve de conception pour utiliser les annotations DMS pour vérifier l'intégrité des données envoyées par un jeune 