### PR TITLE
(PC-12723)[PRO] Redirect to individual/collective depending on offer.isEducational

### DIFF
--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
@@ -853,44 +853,6 @@ describe('offerDetails - Edition', () => {
       expect(screen.getByLabelText('Aucune')).toBeDisabled()
     })
 
-    it('should disable all offer options input when offer is educational', async () => {
-      // Given
-      const editedOffer = {
-        id: 'ABC12',
-        nonHumanizedId: 111,
-        subcategoryId: 'ID',
-        name: 'My edited offer',
-        description: 'Offer description',
-        venue: editedOfferVenue,
-        venueId: editedOfferVenue.id,
-        withdrawalDetails: 'Offer withdrawal details',
-        bookingEmail: 'booking@example.net',
-        status: 'ACTIVE',
-        isEducational: true,
-      }
-      pcapi.loadOffer.mockResolvedValue(editedOffer)
-      const eventCategoryResponse = {
-        ...categories,
-        subcategories: [
-          {
-            ...categories.subcategories[0],
-            isEvent: true,
-          },
-        ],
-      }
-      pcapi.loadCategories.mockResolvedValue(eventCategoryResponse)
-
-      // When
-      await renderOffers(props, store)
-
-      // Then
-      const isDuoOption = await getOfferInputForField('isDuo')
-      expect(isDuoOption).toBeDisabled()
-      const isEducationalOption = await getOfferInputForField('isEducational')
-      expect(isEducationalOption).toBeDisabled()
-      expect(screen.getByLabelText('Aucune')).toBeDisabled()
-    })
-
     it("should display venue's publicName instead of name if exists", async () => {
       // Given
       editedOfferVenue.publicName = 'Le publicName du lieu'

--- a/pro/src/components/pages/Offers/Offer/OfferLayout.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferLayout.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useState } from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Route, Switch, useHistory } from 'react-router-dom'
 
 import Titles from 'components/layout/Titles/Titles'
 import ConfirmationContainer from 'components/pages/Offers/Offer/Confirmation/ConfirmationContainer'
@@ -25,12 +25,15 @@ const mapPathToStep = {
 }
 
 const OfferLayout = ({ location, match }) => {
+  const history = useHistory()
+
   const [offer, setOffer] = useState(null)
   const [isCreatingOffer, setIsCreatingOffer] = useState(true)
 
   const loadOffer = useCallback(
     async (offerId, creationMode = false) => {
       const existingOffer = await pcapi.loadOffer(offerId)
+
       setOffer(existingOffer)
       setIsCreatingOffer(
         creationMode || existingOffer.status === OFFER_STATUS_DRAFT
@@ -38,6 +41,9 @@ const OfferLayout = ({ location, match }) => {
     },
     [setOffer]
   )
+
+  const stepName = location.pathname.match(/[a-z]+$/)
+  const activeStep = stepName ? mapPathToStep[stepName[0]] : null
 
   const reloadOffer = useCallback(
     async (creationMode = false) =>
@@ -51,9 +57,6 @@ const OfferLayout = ({ location, match }) => {
     }
     match.params.offerId && loadOfferFromQueryParam()
   }, [loadOffer, match.params.offerId])
-
-  const stepName = location.pathname.match(/[a-z]+$/)
-  const activeStep = stepName ? mapPathToStep[stepName[0]] : null
 
   let pageTitle = 'Nouvelle offre'
 
@@ -69,6 +72,14 @@ const OfferLayout = ({ location, match }) => {
     !isCreatingOffer && !location.pathname.includes('/confirmation') ? (
       <OfferHeader offer={offer} reloadOffer={reloadOffer} />
     ) : null
+
+  if (offer?.isEducational) {
+    history.push(
+      `/offre/${match.params.offerId}/scolaire/${
+        activeStep === 'stocks' ? 'stocks/edition' : 'edition'
+      }`
+    )
+  }
 
   return (
     <div className="offer-page">

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -1425,36 +1425,6 @@ describe('stocks page', () => {
               ).not.toBeInTheDocument()
             })
 
-            it('should not display price error when the price is above 300 euros and offer is educational', async () => {
-              // Given
-              const educationalOffer = {
-                ...eventOffer,
-                isEducational: true,
-              }
-              pcapi.loadOffer.mockResolvedValue(educationalOffer)
-              await renderOffers(props, store)
-              fireEvent.change(screen.getByLabelText('Prix'), {
-                target: { value: '301' },
-              })
-
-              // When
-              fireEvent.click(screen.getByText('Enregistrer'))
-
-              // Then
-              expect(
-                queryByTextTrimHtml(
-                  screen,
-                  'Le prix d’une offre ne peut excéder 300 euros. Pour plus d’infos, merci de consulter nos Conditions Générales d’Utilisation'
-                )
-              ).not.toBeInTheDocument()
-
-              expect(
-                screen.queryByText(
-                  'Une ou plusieurs erreurs sont présentes dans le formulaire.'
-                )
-              ).not.toBeInTheDocument()
-            })
-
             it('should be able to edit stock when remaining quantity is unlimited and there is existing bookings', async () => {
               // Given
               const eventStock = {
@@ -2064,36 +2034,6 @@ describe('stocks page', () => {
             ).toBeInTheDocument()
           })
 
-          it('should not display price error when the price is above 300 euros and offer is educational', async () => {
-            // Given
-            const educationalOffer = {
-              ...thingOffer,
-              isEducational: true,
-            }
-            pcapi.loadOffer.mockResolvedValue(educationalOffer)
-            await renderOffers(props, store)
-            fireEvent.change(screen.getByLabelText('Prix'), {
-              target: { value: '301' },
-            })
-
-            // When
-            fireEvent.click(screen.getByText('Enregistrer'))
-
-            // Then
-            expect(
-              queryByTextTrimHtml(
-                screen,
-                'Le prix d’une offre ne peut excéder 300 euros. Pour plus d’infos, merci de consulter nos Conditions Générales d’Utilisation'
-              )
-            ).not.toBeInTheDocument()
-
-            expect(
-              screen.queryByText(
-                'Une ou plusieurs erreurs sont présentes dans le formulaire.'
-              )
-            ).not.toBeInTheDocument()
-          })
-
           it('should display error message on api error', async () => {
             // Given
             pcapi.bulkCreateOrEditStock.mockRejectedValueOnce({
@@ -2570,46 +2510,6 @@ describe('stocks page', () => {
         ).not.toBeInTheDocument()
       })
 
-      it('should not display price error when the price is above 300 euros and offer is educational', async () => {
-        // Given
-        const educationalOffer = {
-          ...noStockOffer,
-          isEvent: true,
-          isEducational: true,
-        }
-        pcapi.loadOffer.mockResolvedValue(educationalOffer)
-        await renderOffers(props, store)
-        fireEvent.click(screen.getByText('Ajouter une date'))
-
-        fireEvent.click(screen.getByLabelText('Date de l’événement'))
-        fireEvent.click(screen.getByText('24'))
-
-        fireEvent.click(screen.getByLabelText('Heure de l’événement'))
-        fireEvent.click(screen.getByText('20:00'))
-
-        // When
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '301' },
-        })
-        await act(async () => {
-          fireEvent.click(screen.getByText('Enregistrer'))
-        })
-
-        // Then
-        expect(
-          queryByTextTrimHtml(
-            screen,
-            'Le prix d’une offre ne peut excéder 300 euros. Pour plus d’infos, merci de consulter nos Conditions Générales d’Utilisation'
-          )
-        ).not.toBeInTheDocument()
-
-        expect(
-          screen.queryByText(
-            'Une ou plusieurs erreurs sont présentes dans le formulaire.'
-          )
-        ).not.toBeInTheDocument()
-      })
-
       it('should display error message on api error', async () => {
         // Given
         pcapi.bulkCreateOrEditStock.mockRejectedValueOnce({
@@ -2912,37 +2812,6 @@ describe('stocks page', () => {
             'Le prix d’une offre ne peut excéder 300 euros. Pour plus d’infos, merci de consulter nos Conditions Générales d’Utilisation'
           )
         ).toBeInTheDocument()
-      })
-
-      it('should not display price error when the price is above 300 euros and offer is educational', async () => {
-        // Given
-        const educationalOffer = {
-          ...noStockOffer,
-          isEducational: true,
-        }
-        pcapi.loadOffer.mockResolvedValue(educationalOffer)
-        await renderOffers(props, store)
-        fireEvent.click(screen.getByText('Ajouter un stock'))
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '301' },
-        })
-
-        // When
-        fireEvent.click(screen.getByText('Enregistrer'))
-
-        // Then
-        expect(
-          queryByTextTrimHtml(
-            screen,
-            'Le prix d’une offre ne peut excéder 300 euros. Pour plus d’infos, merci de consulter nos Conditions Générales d’Utilisation'
-          )
-        ).not.toBeInTheDocument()
-
-        expect(
-          screen.queryByText(
-            'Une ou plusieurs erreurs sont présentes dans le formulaire.'
-          )
-        ).not.toBeInTheDocument()
       })
 
       it('should display error message on api error', async () => {

--- a/pro/src/core/OfferEducational/adapters/getStockOfferAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getStockOfferAdapter.ts
@@ -33,6 +33,7 @@ export const getStockOfferAdapter: GetOfferAdapter = async offerId => {
         status: offer.status,
         venueDepartmentCode: offer.venue.departementCode,
         isBooked,
+        isEducational: offer.isEducational,
       },
     }
   } catch (error) {

--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -136,4 +136,5 @@ export type GetStockOfferSuccessPayload = {
   isBooked: boolean
   venueDepartmentCode: string
   managingOffererId: string
+  isEducational: boolean
 }

--- a/pro/src/custom_types/offer.ts
+++ b/pro/src/custom_types/offer.ts
@@ -36,6 +36,7 @@ export type Offer = {
   }
   stocks: Stock[]
   isActive: boolean
+  isEducational: boolean
   audioDisabilityCompliant: boolean
   mentalDisabilityCompliant: boolean
   motorDisabilityCompliant: boolean

--- a/pro/src/routes/OfferEducationalEdition/OfferEducationalEdition.tsx
+++ b/pro/src/routes/OfferEducationalEdition/OfferEducationalEdition.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { useParams } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 
 import { withTracking } from 'components/hocs'
 import useNotification from 'components/hooks/useNotification'
@@ -35,6 +35,7 @@ const OfferEducationalEdition = ({
   tracking: { trackEvent: (props: { action: string; name: string }) => void }
 }): JSX.Element => {
   const { offerId } = useParams<{ offerId: string }>()
+  const history = useHistory()
 
   const [isReady, setIsReady] = useState<boolean>(false)
   const [screenProps, setScreenProps] = useState<AsyncScreenProps | null>(null)
@@ -152,9 +153,14 @@ const OfferEducationalEdition = ({
 
   useEffect(() => {
     if (!isReady) {
-      getOfferAdapter(offerId).then(offerResponse => loadData(offerResponse))
+      getOfferAdapter(offerId).then(offerResponse => {
+        if (offerResponse.isOk && !offerResponse.payload.isEducational) {
+          return history.push(`/offres/${offerId}/edition`)
+        }
+        loadData(offerResponse)
+      })
     }
-  }, [isReady, offerId, loadData])
+  }, [isReady, offerId, loadData, history])
 
   return (
     <OfferEducationalLayout

--- a/pro/src/routes/OfferEducationalStockEdition/OfferEducationalStockEdition.tsx
+++ b/pro/src/routes/OfferEducationalStockEdition/OfferEducationalStockEdition.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 
 import useNotification from 'components/hooks/useNotification'
 import Spinner from 'components/layout/Spinner'
@@ -22,6 +22,8 @@ import { StockResponse } from './types'
 import { extractInitialStockValues } from './utils/extractInitialStockValues'
 
 const OfferEducationalStockEdition = (): JSX.Element => {
+  const history = useHistory()
+
   const [initialValues, setInitialValues] =
     useState<OfferEducationalStockFormValues>(DEFAULT_EAC_STOCK_FORM_VALUES)
   const [offer, setOffer] = useState<GetStockOfferSuccessPayload | null>(null)
@@ -94,6 +96,11 @@ const OfferEducationalStockEdition = (): JSX.Element => {
         if (!offerResponse.isOk) {
           return notify.error(offerResponse.message)
         }
+
+        if (!offerResponse.payload.isEducational) {
+          return history.push(`/offres/${offerId}/stocks`)
+        }
+
         if (!stockResponse.isOk) {
           return notify.error(stockResponse.message)
         }
@@ -108,7 +115,7 @@ const OfferEducationalStockEdition = (): JSX.Element => {
       }
       loadStockAndOffer()
     }
-  }, [offerId, isReady, notify])
+  }, [offerId, isReady, notify, history])
 
   return (
     <OfferEducationalLayout

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.stories.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.stories.tsx
@@ -32,6 +32,7 @@ const Template: Story<{ mode: Mode }> = args => (
       isActive: true,
       isBooked: true,
       managingOffererId: 'AA',
+      isEducational: true,
     }}
     onSubmit={action('onSubmit')}
     setIsOfferActive={() => null}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12723

## But de la pull request

- Un AC pouvait modifier l'url dans sa barre de navigation pour changer l'id de l'offre/stock qu'il était en train de modifier
  - si l'url était l'url d'édition d'une offre individuelle et que l'id modifié était celui d'une offre collective alors l'AC avait accès à un formulaire différent de celui de la création d'offre, et donc avait la possibilité d'ajouter des champs à son offre
  - idem dans l'autre sens
- Dans cette PR on interdit l'accès aux urls de l'individuel si l'offre est collective et vice versa
