### PR TITLE
(PC-13055) set booking token to None if offer is educational

### DIFF
--- a/api/src/pcapi/domain/booking_recap/booking_recap.py
+++ b/api/src/pcapi/domain/booking_recap/booking_recap.py
@@ -85,7 +85,12 @@ class BookingRecap:
         return object.__new__(cls)
 
     def _get_booking_token(self) -> Optional[str]:
-        if not self.event_beginning_datetime and not self.booking_is_used and not self.booking_is_cancelled:
+        if (
+            not self.event_beginning_datetime
+            and not self.booking_is_used
+            and not self.booking_is_cancelled
+            or self.booking_is_educational
+        ):
             return None
         return self._booking_token
 

--- a/api/tests/routes/pro/get_all_bookings_test.py
+++ b/api/tests/routes/pro/get_all_bookings_test.py
@@ -118,6 +118,7 @@ class Returns200Test:
             "lastname": "Moustaki",
             "phonenumber": None,
         }
+        assert response.json["bookings_recap"][0]["booking_token"] is None
 
     def when_user_is_linked_to_a_valid_offerer(self, app):
         booking = bookings_factories.UsedIndividualBookingFactory(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13055

## But de la pull request

Ne plus voir de contremarque dans les réservations lorsqu'il s'agit d'une offre collective
