### PR TITLE
(PC-FIX) fix:alembic: version conflict detection

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-6bb141d40d77 (head)
+eb6c7fc2d56f (head)


### PR DESCRIPTION
## But de la pull request

Le fichier alembic_version_conflict_detection.txt n'avait pas été mis à jour lors de [ce commit](https://github.com/pass-culture/pass-culture-main/commit/4a37de7b51a6e5306073d974ec33affa16d43e57).