### PR TITLE
(PC-12977)[ADAGE]: refine query when typing Enter key on search bar

### DIFF
--- a/adage-front/src/app/components/OffersSearch/OffersSearchBarAndFilters/OffersSearchBarAndFilters.tsx
+++ b/adage-front/src/app/components/OffersSearch/OffersSearchBarAndFilters/OffersSearchBarAndFilters.tsx
@@ -30,7 +30,7 @@ export const SearchAndFiltersComponent = ({
 
   return (
     <>
-      <SearchBox query={query} setQuery={setQuery} />
+      <SearchBox query={query} refine={refine} setQuery={setQuery} />
       <OfferFilters
         className="search-filters"
         handleSearchButtonClick={handleSearchButtonClick}

--- a/adage-front/src/app/components/OffersSearch/SearchBox.tsx
+++ b/adage-front/src/app/components/OffersSearch/SearchBox.tsx
@@ -1,17 +1,25 @@
 import './SearchBox.scss'
 import React, { useCallback } from 'react'
+import type { SearchBoxProvided } from 'react-instantsearch-core'
 
 import { ReactComponent as MagnifyingGlassIcon } from 'assets/magnifying-glass.svg'
+
 export const SearchBoxComponent = ({
   query,
   setQuery,
+  refine,
 }: {
   query: string
   setQuery: (query: string) => void
+  refine: SearchBoxProvided['refine']
 }): React.ReactElement => {
-  const onSubmit = useCallback(event => {
-    event.preventDefault()
-  }, [])
+  const onSubmit = useCallback(
+    event => {
+      event.preventDefault()
+      refine(query)
+    },
+    [query, refine]
+  )
 
   return (
     <form className="search-wrapper" onSubmit={onSubmit}>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12977

## But de la pull request

Lorsque l'utilisateur entre une chaîne de caractères de recherche dans la barre de recherche adage, il doit pouvoir lancer la recherche en tapant sur la touche "Entrée"

##  Implémentation

Ajouter un appel à `refine(query)` dans la fonction `onSubmit` du formulaire

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
