### PR TITLE
(PC-12812) fix(venueEdition): remove magic z-indexes from the map

### DIFF
--- a/pro/src/styles/components/pages/Venue/fields/LocationFields/_LocationViewer.scss
+++ b/pro/src/styles/components/pages/Venue/fields/LocationFields/_LocationViewer.scss
@@ -49,5 +49,18 @@
     margin-top: 1rem;
     overflow: hidden;
     width: 100%;
+
+    /* the default z-indexes are set to:
+     * -  400 for leaflet-pane
+     * -  800 for leaflet-control
+     * - 1000 for leaflet-top and leaflet-bottom
+     * which are random values, interfering with modals
+     */
+    .leaflet-pane,
+    .leaflet-top,
+    .leaflet-bottom,
+    .leaflet-control {
+      z-index: 0;
+    }
   }
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12812

## But de la pull request

Résolution d'un bug visuel sur la page d'édition de lieu : la carte passait au-dessus de la modale.

![image](https://user-images.githubusercontent.com/26742386/151823149-6193026a-fc00-4a0f-bc1f-fa808ce44307.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
