### PR TITLE
(PC-12735) Ping slack seulement au merge

### DIFF
--- a/.github/workflows/ping_data_team.yml
+++ b/.github/workflows/ping_data_team.yml
@@ -4,13 +4,15 @@ name: Ping data team on slack
 
 on:
   pull_request:
+    types: [closed]
     paths:
       - 'api/src/pcapi/alembic/versions/**'
+      - 'api/src/pcapi/alembic/run_migrations.py'
 
 jobs:
   send-message:
     runs-on: ubuntu-latest
-
+    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v2
 
@@ -19,4 +21,4 @@ jobs:
         env:
           SLACK_WEBHOOK_DB_CHANGE: ${{ secrets.SLACK_WEBHOOK_DB_CHANGE }}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nouvelle PR avec une migration db -> ${{ github.event.pull_request.html_url }}"}'  "$SLACK_WEBHOOK_DB_CHANGE"
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nouvelle PR avec une migration db ou une colonne en cours de suppression -> ${{ github.event.pull_request.html_url }}"}'  "$SLACK_WEBHOOK_DB_CHANGE"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12735

## But de la pull request

Le channel slack #db-changes reçoit une notification pour chaque PR avec une migration.

Le but de la PR est que cette notif ne parte qu'au merge.

Et qu'elle parte aussi s'il y a une colonne qui est marqué comme supprimée sans avoir été enlevée de la db.

##  Implémentation

Modification de la CI

- filtre sur pull_request.merged : ça aurait pu être au push sur merge autrement mais on aurait pas eu le lien de la PR facilement
- déclenchement avec le fichier run_migrations.py également

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
