### PR TITLE
[API] PC 12874 compress venue banner

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -36,6 +36,8 @@ from pcapi.routes.serialization.offerers_serialize import CreateOffererQueryMode
 from pcapi.routes.serialization.venues_serialize import PostVenueBodyModel
 from pcapi.utils import crypto
 from pcapi.utils.human_ids import dehumanize
+from pcapi.utils.image_conversion import CropParams
+from pcapi.utils.image_conversion import standardize_image
 
 from . import validation
 from .exceptions import ApiKeyCountMaxReached
@@ -296,10 +298,18 @@ def validate_offerer(token: str) -> None:
         )
 
 
-def save_venue_banner(user: User, venue: Venue, content: bytes, content_type: str, file_name: str) -> None:
+def save_venue_banner(
+    user: User,
+    venue: Venue,
+    content: bytes,
+    content_type: str,
+    file_name: str,
+    crop_params: Optional[CropParams] = None,
+) -> None:
     bucket_name = settings.THUMBS_FOLDER_NAME
     object_id = f"venue_{venue.id}_banner"
 
+    content = standardize_image(content, crop_params)
     object_storage.store_public_object(
         folder=bucket_name,
         object_id=object_id,

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -36,9 +36,6 @@ def get_venue(venue_id: str) -> GetVenueResponseModel:
     venue = load_or_404(Venue, venue_id)
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
 
-    # pydantic expects an enum key in order to build it, and therefore
-    # does not work when passing directly an enum instance.
-    venue.venueTypeCode = venue.venueTypeCode.name if venue.venueTypeCode else None
     return GetVenueResponseModel.from_orm(venue)
 
 
@@ -129,9 +126,6 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
     if body.bookingEmail and body.isEmailAppliedOnAllOffers:
         update_all_venue_offers_email_job.delay(venue, body.bookingEmail)
 
-    # pydantic expects an enum key in order to build it, and therefore
-    # does not work when passing directly an enum instance.
-    venue.venueTypeCode = venue.venueTypeCode.name if venue.venueTypeCode else None
     return GetVenueResponseModel.from_orm(venue)
 
 

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -131,8 +131,8 @@ def edit_venue(venue_id: str, body: EditVenueBodyModel) -> GetVenueResponseModel
 
 @private_api.route("/venues/<venue_id>/banner", methods=["POST"])
 @login_required
-@spectree_serialize(on_success_status=204)
-def upsert_venue_banner(venue_id: str) -> None:
+@spectree_serialize(response_model=GetVenueResponseModel, on_success_status=201)
+def upsert_venue_banner(venue_id: str) -> GetVenueResponseModel:
     venue = load_or_404(Venue, venue_id)
 
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
@@ -147,6 +147,8 @@ def upsert_venue_banner(venue_id: str) -> None:
         file_name=venue_banner.file_name,
         crop_params=venue_banner.crop_params,
     )
+
+    return GetVenueResponseModel.from_orm(venue)
 
 
 @private_api.route("/venues/<humanized_venue_id>/stats", methods=["GET"])

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -151,6 +151,7 @@ def upsert_venue_banner(venue_id: str) -> None:
         content=venue_banner.content,
         content_type=venue_banner.content_type,
         file_name=venue_banner.file_name,
+        crop_params=venue_banner.crop_params,
     )
 
 

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -198,6 +198,13 @@ class GetVenueResponseModel(BaseModel):
         orm_mode = True
         json_encoders = {datetime: format_into_utc_date}
 
+    @classmethod
+    def from_orm(cls, venue: offerers_models.Venue) -> "GetVenueResponseModel":
+        # pydantic expects an enum key in order to build it, and therefore
+        # does not work when passing directly an enum instance.
+        venue.venueTypeCode = venue.venueTypeCode.name if venue.venueTypeCode else None
+        return super().from_orm(venue)
+
 
 class EditVenueBodyModel(BaseModel):
     name: Optional[str]

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -11,6 +11,7 @@ import pydantic
 from pydantic import BaseModel
 from pydantic import root_validator
 from pydantic import validator
+from typing_extensions import TypedDict
 
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.validation import VENUE_BANNER_MAX_SIZE
@@ -151,6 +152,11 @@ class GetVenueManagingOffererResponseModel(BaseModel):
         json_encoders = {datetime: format_into_utc_date}
 
 
+class BannerMetaModel(TypedDict):
+    file_name: str
+    content_type: str
+
+
 class GetVenueResponseModel(BaseModel):
     address: Optional[str]
     bic: Optional[str]
@@ -189,6 +195,8 @@ class GetVenueResponseModel(BaseModel):
     contact: Optional[VenueContactModel]
     businessUnitId: Optional[int]
     businessUnit: Optional[BusinessUnitResponseModel]
+    bannerUrl: Optional[str]
+    bannerMeta: Optional[BannerMetaModel]
 
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")

--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -1,3 +1,11 @@
+"""
+Handle some basic image processing.
+Those functions are basically wrapper around one or more functions
+from the PIL library:
+
+    https://pillow.readthedocs.io/
+"""
+from dataclasses import dataclass
 import io
 
 import PIL
@@ -11,7 +19,40 @@ DO_NOT_CROP = (0, 0, 1)
 IMAGE_RATIO_V2 = 6 / 9
 
 
-def standardize_image(image: bytes, crop_params: tuple = None) -> bytes:
+CropParam = confloat(ge=0.0, le=1.0)
+CropParams = tuple[CropParam, CropParam, CropParam]  # type: ignore
+
+
+@dataclass
+class Coordinates:
+    x: float
+    y: float
+
+
+def standardize_image(image: bytes, crop_params: Optional[CropParams] = None) -> bytes:
+    """
+    Standardization steps are:
+        * transpose image
+        * convert to RGB mode
+        * crop image (if specified), see below
+        * convert to jpeg using predefined values
+
+    The cropping sets a new top left corner position, the crop_params
+    are used to compute its new coordinates. The bottom right corner's
+    coordinates will be computed using the top left's ones using some
+    predifined ratio and max height (see constants below).
+
+    crop_params is a three-float tuple. All values must be between 0.0
+    and 1.0.
+
+    The first value will be used to set the top left corner's abscissa
+    (X): width * <first_value> = new X value. The second value will be
+    used to set the ordinate (Y). The third to set the height.
+
+    Check PIL's documentation regarding the coordinate system to have a
+    better understanding of how the cropping works:
+        https://pillow.readthedocs.io/en/stable/handbook/concepts.html#coordinate-system
+    """
     crop_params = crop_params or DO_NOT_CROP
     raw_image = PIL.Image.open(io.BytesIO(image))
 
@@ -24,8 +65,8 @@ def standardize_image(image: bytes, crop_params: tuple = None) -> bytes:
         transposed_image = background
     transposed_image = transposed_image.convert("RGB")
 
-    x_position, y_position, crop_size = crop_params
-    cropped_image = _crop_image(x_position, y_position, crop_size, transposed_image)
+    x_crop_percent, y_crop_percent, height_crop_percent = crop_params
+    cropped_image = _crop_image(x_crop_percent, y_crop_percent, height_crop_percent, transposed_image)
     resized_image = _resize_image(cropped_image)
     standard_image = _convert_to_jpeg(resized_image)
     return standard_image
@@ -35,20 +76,32 @@ def _transpose_image(raw_image):
     return ImageOps.exif_transpose(raw_image)
 
 
-def _crop_image(crop_origin_x: int, crop_origin_y: int, crop_rect_height: int, image: Image) -> Image:
-    if (crop_origin_x, crop_origin_y, crop_rect_height) == DO_NOT_CROP:
+def _crop_image(
+    x_crop_percent: CropParam, y_crop_percent: CropParam, height_crop_percent: CropParam, image: Image
+) -> Image:
+    """
+    x_crop_percent and y_crop_percent will be used to compute new top left
+    corner coordinates.
+
+    height_crop_percent will be used to compute the bottom right corner's
+    Y value, since X is computed using a predefined ratio.
+    """
+    if (x_crop_percent, y_crop_percent, height_crop_percent) == DO_NOT_CROP:
         return image
 
     width = image.size[0]
     height = image.size[1]
-    updated_x_position = width * crop_origin_x
-    updated_y_position = height * crop_origin_y
-    updated_height = height * crop_rect_height
-    updated_width_from_ratio = updated_height * IMAGE_RATIO_V2
-    bottom_right_corner_x = min(updated_x_position + updated_width_from_ratio, width)
-    bottom_right_corner_y = min(updated_y_position + updated_height, height)
 
-    cropped_img = image.crop((updated_x_position, updated_y_position, bottom_right_corner_x, bottom_right_corner_y))
+    top_left_corner = Coordinates(x=width * x_crop_percent, y=height * y_crop_percent)
+
+    updated_height = height * height_crop_percent
+    updated_width_from_ratio = updated_height * IMAGE_RATIO_V2
+
+    bottom_right_corner = Coordinates(
+        x=min(top_left_corner.x + updated_width_from_ratio, width), y=min(top_left_corner.y + updated_height, height)
+    )
+
+    cropped_img = image.crop((top_left_corner.x, top_left_corner.y, bottom_right_corner.x, bottom_right_corner.y))
 
     return cropped_img
 

--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -7,10 +7,12 @@ from the PIL library:
 """
 from dataclasses import dataclass
 import io
+from typing import Optional
 
 import PIL
 from PIL import Image
 from PIL import ImageOps
+from pydantic import confloat
 
 
 MAX_THUMB_WIDTH = 750

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -81,6 +81,8 @@ class Returns200Test:
             "venueTypeCode": venue.venueTypeCode.name if venue.venueTypeCode else None,
             "visualDisabilityCompliant": venue.visualDisabilityCompliant,
             "withdrawalDetails": None,
+            "bannerUrl": None,
+            "bannerMeta": None,
         }
 
         # when


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12874 

## But de la pull request

Ajout de la compression et du recadrage lors de l'enregistrement d'une image pour un lieu.

##  Informations supplémentaires

Au passage : 

* ajout d'une méthode `from_orm` à `GetVenueResponseModel` qui a besoin de modifier le champ `venueTypeCode` puisque ce dernier doit être une clé qui permet de reconstruire l'`enum` et non un `enum` directement (sinon pydantic ne parvient pas à sérialiser) ;
* la route d'api qui permet de sauvegarder l'image d'un lieu renvoie maintenant le lieu en question (avant la route ne renvoyait rien), ceci permet de récupérer l'URL de l'image sauvegardée.