### PR TITLE
(PC-9716)[API] Delete is_admin column

### DIFF
--- a/api/src/pcapi/admin/autocomplete.py
+++ b/api/src/pcapi/admin/autocomplete.py
@@ -25,7 +25,7 @@ class Select2Response(pydantic.BaseModel):
 @spectree_serialize(response_model=Select2Response)
 def offerers(query: Select2Query) -> Select2Response:
     """Autocomplete offerers on name or SIREN."""
-    if not (current_user.is_authenticated and current_user.isAdmin):
+    if not (current_user.is_authenticated and current_user.has_admin_role):
         raise Forbidden()
     query = (
         offerers_models.Offerer.query.filter(

--- a/api/src/pcapi/admin/base_configuration.py
+++ b/api/src/pcapi/admin/base_configuration.py
@@ -43,7 +43,7 @@ class BaseAdminMixin:
         return form_class(get_form_data(), obj=obj)
 
     def is_accessible(self) -> bool:
-        authorized = current_user.is_authenticated and current_user.isAdmin
+        authorized = current_user.is_authenticated and current_user.has_admin_role
         if not authorized:
             logger.warning("[ADMIN] Tentative d'accès non autorisé à l'interface d'administration par %s", current_user)
 
@@ -124,7 +124,7 @@ class AdminIndexView(AdminIndexBaseView):
                     publicName=google_user["name"],
                     isEmailValidated=True,
                     isActive=True,
-                    isAdmin=True,
+                    roles=[users_models.UserRole.ADMIN],
                 )
                 # generate a random password as the user won't login to anything else.
                 db_user.setPassword(secrets.token_urlsafe(20))

--- a/api/src/pcapi/admin/custom_views/admin_user_view.py
+++ b/api/src/pcapi/admin/custom_views/admin_user_view.py
@@ -82,12 +82,12 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
     def get_query(self) -> query:
         from pcapi.core.users.models import User
 
-        return User.query.filter(User.isAdmin.is_(True)).from_self()
+        return User.query.filter(User.has_admin_role.is_(True)).from_self()
 
     def get_count_query(self) -> query:
         from pcapi.core.users.models import User
 
-        return self.session.query(func.count(distinct(User.id))).select_from(User).filter(User.isAdmin.is_(True))
+        return self.session.query(func.count(distinct(User.id))).select_from(User).filter(User.has_admin_role.is_(True))
 
     def on_model_change(self, form: Form, model, is_created: bool) -> None:
         model.publicName = f"{model.firstName} {model.lastName}"

--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -159,7 +159,6 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "idPieceNumber",
         "ineHash",
         "isActive",
-        "isAdmin",
         "isEmailValidated",
         "lastConnectionDate",
         "lastName",

--- a/api/src/pcapi/admin/custom_views/partner_user_view.py
+++ b/api/src/pcapi/admin/custom_views/partner_user_view.py
@@ -116,7 +116,7 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
             User.query.outerjoin(UserOfferer)
             .filter(UserOfferer.userId.is_(None))
             .filter(User.is_beneficiary.is_(False))
-            .filter(User.isAdmin.is_(False))
+            .filter(User.has_admin_role.is_(False))
         )
 
     def get_count_query(self) -> query:
@@ -126,5 +126,5 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
             .outerjoin(UserOfferer)
             .filter(UserOfferer.userId.is_(None))
             .filter(User.is_beneficiary.is_(False))
-            .filter(User.isAdmin.is_(False))
+            .filter(User.has_admin_role.is_(False))
         )

--- a/api/src/pcapi/admin/permissions.py
+++ b/api/src/pcapi/admin/permissions.py
@@ -14,7 +14,7 @@ def _get_permission_mapping():
 
 
 def has_permission(user: users_models.User, permission: str):
-    if not user.isAdmin:  # safety belt, do not remove
+    if not user.has_admin_role:  # safety belt, do not remove
         return False
     # Yes, we calculate the mapping on every call. It's fine:
     # - it's fast;

--- a/api/src/pcapi/alembic/run_migrations.py
+++ b/api/src/pcapi/alembic/run_migrations.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 target_metadata = db.metadata
 
-IGNORED_COLUMNS_BY_TABLE = {"booking": ("isUsed", "isCancelled"), "user": ("isBeneficiary",)}
+IGNORED_COLUMNS_BY_TABLE = {"booking": ("isUsed", "isCancelled"), "user": ("isBeneficiary", "isAdmin")}
 IGNORED_TABLES = ("transaction", "activity")
 
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -308,11 +308,11 @@ def can_offerer_create_educational_offer(offerer_id: str) -> bool:
 
 
 def get_educational_offerers(offerer_id: Optional[str], current_user: User) -> list[Offerer]:
-    if current_user.isAdmin and offerer_id is None:
+    if current_user.has_admin_role and offerer_id is None:
         logger.info("Admin user must provide offerer_id as a query parameter")
         raise MissingOffererIdQueryParameter
 
-    if offerer_id and current_user.isAdmin:
+    if offerer_id and current_user.has_admin_role:
         offerers = Offerer.query.filter(
             Offerer.validationToken.is_(None), Offerer.isActive.is_(True), Offerer.id == dehumanize(offerer_id)
         ).all()

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -30,7 +30,7 @@ def get_all_venue_types() -> list[models.VenueType]:
 def get_all_offerers_for_user(user: User, filters: dict) -> list[models.Offerer]:
     query = models.Offerer.query.filter(models.Offerer.isActive.is_(True))
 
-    if not user.isAdmin:
+    if not user.has_admin_role:
         query = query.join(UserOfferer, UserOfferer.offererId == models.Offerer.id).filter(
             UserOfferer.userId == user.id
         )

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -91,7 +91,7 @@ def get_capped_offers_for_filters(
 
 def get_offers_by_ids(user: User, offer_ids: list[int]) -> Query:
     query = Offer.query
-    if not user.isAdmin:
+    if not user.has_admin_role:
         query = query.join(Venue, Offerer, UserOfferer).filter(
             and_(UserOfferer.userId == user.id, UserOfferer.validationToken.is_(None))
         )

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -68,7 +68,7 @@ VALUE_VALIDATION_CONFIG = {
 
 
 def check_user_can_create_activation_event(user: User) -> None:
-    if not user.isAdmin:
+    if not user.has_admin_role:
         error = ForbiddenError()
         error.add_error("type", "Seuls les administrateurs du pass Culture peuvent créer des offres d'activation")
         raise error

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -63,7 +63,6 @@ class UserFactory(BaseFactory):
     lastName = "Neige"
     publicName = "Jean Neige"
     isEmailValidated = True
-    isAdmin = False
     roles = []
     hasSeenProTutorials = True
     subscriptionState = models.SubscriptionState.account_created
@@ -97,7 +96,6 @@ class AdminFactory(BaseFactory):
     lastName = "Columbo"
     publicName = "Frank Columbo"
     isEmailValidated = True
-    isAdmin = True
     roles = [users_models.UserRole.ADMIN]
     hasSeenProTutorials = True
 
@@ -134,7 +132,6 @@ class BeneficiaryGrant18Factory(BaseFactory):
     lastName = "Doux"
     hasCompletedIdCheck = False
     isEmailValidated = True
-    isAdmin = False
     roles = [users_models.UserRole.BENEFICIARY]
     hasSeenProTutorials = True
     subscriptionState = users_models.SubscriptionState.beneficiary_18
@@ -262,7 +259,6 @@ class ProFactory(BaseFactory):
     lastName = "Coty"
     publicName = "René Coty"
     isEmailValidated = True
-    isAdmin = False
     roles = [users_models.UserRole.PRO]
     hasSeenProTutorials = True
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -187,19 +187,6 @@ class User(PcObject, Model, NeedsValidationMixin):
     # use DeactivableMixin. We'll need to add a migration that adds a
     # NOT NULL constraint.
     isActive = sa.Column(sa.Boolean, nullable=True, server_default=expression.true(), default=True)
-    isAdmin = sa.Column(
-        sa.Boolean,
-        sa.CheckConstraint(
-            (
-                f'NOT (({ UserRole.BENEFICIARY }=ANY("roles") OR { UserRole.UNDERAGE_BENEFICIARY }=ANY("roles")) '
-                f'AND { UserRole.ADMIN }=ANY("roles"))'
-            ),
-            name="check_admin_is_not_beneficiary",
-        ),
-        nullable=False,
-        server_default=expression.false(),
-        default=False,
-    )
     isEmailValidated = sa.Column(sa.Boolean, nullable=True, server_default=expression.false())
     lastConnectionDate = sa.Column(sa.DateTime, nullable=True)
     lastName = sa.Column(sa.String(128), nullable=True)

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -84,7 +84,7 @@ def get_newly_eligible_age_18_users(since: date) -> list[User]:
         User.query.outerjoin(UserOfferer)
         .filter(
             User.has_beneficiary_role == False,  # not already beneficiary
-            User.isAdmin == False,  # not an admin
+            User.has_admin_role == False,  # not an admin
             UserOfferer.userId.is_(None),  # not a pro
             User.dateOfBirth > today - relativedelta(years=(constants.ELIGIBILITY_AGE_18 + 1)),  # less than 19yo
             User.dateOfBirth <= today - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # more than or 18yo

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -64,7 +64,7 @@ def get_offerers(query: GetOffererListQueryModel) -> GetOfferersListResponseMode
 
     paginated_offerers = PaginatedOfferersSQLRepository().with_status_and_keywords(
         user_id=current_user.id,
-        user_is_admin=current_user.isAdmin,
+        user_is_admin=current_user.has_admin_role,
         is_filtered_by_offerer_status=is_filtered_by_offerer_status,
         only_validated_offerers=only_validated_offerers,
         keywords=keywords,

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -38,7 +38,7 @@ from pcapi.utils.rest import load_or_404
 def list_offers(query: offers_serialize.ListOffersQueryModel) -> offers_serialize.ListOffersResponseModel:
     paginated_offers = offers_api.list_offers_for_pro_user(
         user_id=current_user.id,
-        user_is_admin=current_user.isAdmin,
+        user_is_admin=current_user.has_admin_role,
         category_id=query.categoryId,
         offerer_id=query.offerer_id,
         venue_id=query.venue_id,
@@ -188,7 +188,7 @@ def patch_all_offers_active_status(
 ) -> offers_serialize.PatchAllOffersActiveStatusResponseModel:
     filters = {
         "user_id": current_user.id,
-        "is_user_admin": current_user.isAdmin,
+        "is_user_admin": current_user.has_admin_role,
         "offerer_id": body.offerer_id,
         "status": body.status,
         "venue_id": body.venue_id,

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -48,7 +48,7 @@ def get_venue(venue_id: str) -> GetVenueResponseModel:
 def get_venues(query: VenueListQueryModel) -> GetVenueListResponseModel:
     venue_list = offerers_repository.get_filtered_venues(
         pro_user_id=current_user.id,
-        user_is_admin=current_user.isAdmin,
+        user_is_admin=current_user.has_admin_role,
         active_offerers_only=query.active_offerers_only,
         offerer_id=query.offerer_id,
         validated_offerer=query.validated,

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -117,6 +117,7 @@ class SharedLoginUserResponseModel(BaseModel):
 
     @classmethod
     def from_orm(cls, user):
+        user.isAdmin = user.has_admin_role
         result = super().from_orm(user)
         return result
 
@@ -156,3 +157,9 @@ class SharedCurrentUserResponseModel(BaseModel):
         json_encoders = {datetime: format_into_utc_date}
         alias_generator = to_camel
         orm_mode = True
+
+    @classmethod
+    def from_orm(cls, user):
+        user.isAdmin = user.has_admin_role
+        result = super().from_orm(user)
+        return result

--- a/api/src/pcapi/scripts/beneficiary/delete_or_suspend_account_from_file.py
+++ b/api/src/pcapi/scripts/beneficiary/delete_or_suspend_account_from_file.py
@@ -44,7 +44,7 @@ def _delete_users_and_favorites(user_ids: set) -> None:
 
 
 def _suspend_users(user_ids: set, admin_email_used: str) -> None:
-    admin = User.query.filter_by(email=admin_email_used, isAdmin=True).one()
+    admin = User.query.filter_by(email=admin_email_used, has_admin_role=True).one()
     for user_id in user_ids:
         user = User.query.get(user_id)
         suspend_account(user, constants.SuspensionReason.UPON_USER_REQUEST, admin)

--- a/api/src/pcapi/scripts/beneficiary/send_mail_after_idcheck_outage.py
+++ b/api/src/pcapi/scripts/beneficiary/send_mail_after_idcheck_outage.py
@@ -23,7 +23,7 @@ def _get_eligible_users_created_between(
     query = User.query.outerjoin(UserOfferer).filter(
         User.dateCreated.between(start_date, end_date),
         User.has_beneficiary_role == False,  # not already beneficiary
-        User.isAdmin == False,  # not an admin
+        User.has_admin_role == False,  # not an admin
         UserOfferer.userId.is_(None),  # not a pro
         User.dateOfBirth > today - relativedelta(years=(constants.ELIGIBILITY_AGE_18 + 1)),  # less than 19yo
         User.dateOfBirth <= today - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # more than or 18yo

--- a/api/src/pcapi/templates/admin/index.html
+++ b/api/src/pcapi/templates/admin/index.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block body %}
-    {% if current_user.is_authenticated and current_user.isAdmin %}
+    {% if current_user.is_authenticated and current_user.has_admin_role %}
         <div class="alert alert-info" role="alert">
             Bonjour <strong>{{ current_user.publicName }}</strong>, bienvenue dans le back office du pass Culture !
         </div>

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -59,7 +59,7 @@
       Soumettre une revue manuelle
     </button>
     {% endif %}
-    {% if current_user.isAdmin %}
+    {% if current_user.has_admin_role %}
     <button name="submit" form="validate_form_button" type="submit" class="btn btn-primary">Valider le n° de
       téléphone</button>
     {# avoid putting the button inside the form to get the buttons aligned on the same grid #}

--- a/api/src/pcapi/validation/models/user.py
+++ b/api/src/pcapi/validation/models/user.py
@@ -24,7 +24,7 @@ def validate(user: User, api_errors: ApiErrors) -> ApiErrors:
         api_errors.check_min_length("publicName", user.publicName, 1)
     if user.email:
         api_errors.check_email("email", user.email)
-    if user.isAdmin and user.is_beneficiary:
+    if user.has_admin_role and user.is_beneficiary:
         api_errors.add_error("is_beneficiary", "Admin ne peut pas être bénéficiaire")
     if user.clearTextPassword:
         api_errors.check_min_length("password", user.clearTextPassword, 8)

--- a/api/tests/admin/base_configuration_test.py
+++ b/api/tests/admin/base_configuration_test.py
@@ -62,7 +62,7 @@ class IsAccessibleTest:
     @patch("flask_login.utils._get_user")
     def test_access_is_forbidden_for_non_admin_users(self, get_user):
         # given
-        get_user.return_value = users_factories.UserFactory.build(isAdmin=False)
+        get_user.return_value = users_factories.UserFactory.build()
 
         # when
         view = DummyAdminView(Booking, fake_db_session)

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -40,7 +40,7 @@ class AdminUserViewTest:
         assert user_created.dateOfBirth is None
         assert user_created.departementCode == "76"
         assert user_created.postalCode == "76001"
-        assert user_created.isAdmin is True
+        assert user_created.has_admin_role is True
         assert not user_created.has_beneficiary_role
         assert user_created.has_admin_role
         assert user_created.hasSeenProTutorials is True

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -260,7 +260,7 @@ class BeneficiaryUserViewTest:
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_beneficiary_user_edition_does_not_send_email(self, mocked_validate_csrf_token, mocked_flask_flash, app):
         users_factories.AdminFactory(email="user@example.com")
-        user_to_edit = users_factories.BeneficiaryGrant18Factory(email="not_yet_edited@email.com", isAdmin=False)
+        user_to_edit = users_factories.BeneficiaryGrant18Factory(email="not_yet_edited@email.com")
 
         data = dict(
             email="edited@email.com",

--- a/api/tests/admin/custom_views/booking_view_test.py
+++ b/api/tests/admin/custom_views/booking_view_test.py
@@ -109,7 +109,7 @@ class BookingViewTest:
         assert booking.status == BookingStatus.CANCELLED
 
     def test_can_not_cancel_refunded_booking(self, app):
-        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        users_factories.AdminFactory(email="admin@example.com")
         booking = bookings_factories.UsedIndividualBookingFactory()
         payments_factories.PaymentFactory(booking=booking)
 
@@ -128,7 +128,7 @@ class BookingViewTest:
         assert not booking.status == BookingStatus.CANCELLED
 
     def test_cant_cancel_cancelled_booking(self, app):
-        users_factories.UserFactory(email="admin@example.com", isAdmin=True)
+        users_factories.AdminFactory(email="admin@example.com")
         booking = bookings_factories.CancelledIndividualBookingFactory()
 
         client = TestClient(app.test_client()).with_session_auth("admin@example.com")

--- a/api/tests/admin/custom_views/partner_user_view_test.py
+++ b/api/tests/admin/custom_views/partner_user_view_test.py
@@ -58,7 +58,6 @@ class PartnerUserViewTest:
         view.on_model_change(Form(), model=user, is_created=False)
 
         # then
-        assert user.isAdmin == False
         assert not user.has_admin_role
 
     def test_a_partner_should_not_need_to_fill_cultural_survey(self, app, db_session):

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -232,7 +232,7 @@ class JouveAccessTest:
     """Specific tests to ensure JOUVE does not access anything else"""
 
     def test_access_index(self, client):
-        user = users_factories.UserFactory(isAdmin=False, roles=[users_models.UserRole.JOUVE])
+        user = users_factories.UserFactory(roles=[users_models.UserRole.JOUVE])
         client.with_session_auth(user.email)
         response = client.get("/pc/back-office/")
         assert response.status_code == 200
@@ -246,7 +246,7 @@ class JouveAccessTest:
         ],
     )
     def test_access_forbidden_views(self, client, url):
-        user = users_factories.UserFactory(isAdmin=False, roles=[users_models.UserRole.JOUVE])
+        user = users_factories.UserFactory(roles=[users_models.UserRole.JOUVE])
         client.with_session_auth(user.email)
         response = client.get(url)
         assert response.status_code == 302
@@ -259,7 +259,7 @@ class ValidatePhoneNumberTest:
         user = users_factories.UserFactory(
             phoneValidationStatus=users_models.PhoneValidationStatusType.BLOCKED_TOO_MANY_CODE_SENDINGS,
         )
-        jouve_admin = users_factories.UserFactory(isAdmin=False, roles=[users_models.UserRole.JOUVE])
+        jouve_admin = users_factories.UserFactory(roles=[users_models.UserRole.JOUVE])
         client.with_session_auth(jouve_admin.email)
 
         response = client.get("/pc/back-office/support_beneficiary/?id={user.id}")

--- a/api/tests/admin/custom_views/venue_provider_view_test.py
+++ b/api/tests/admin/custom_views/venue_provider_view_test.py
@@ -11,6 +11,7 @@ from pcapi.core.offers.factories import StockFactory
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.users.factories import AdminFactory
+from pcapi.core.users.factories import UserFactory
 
 from tests.conftest import clean_database
 
@@ -23,11 +24,10 @@ class VenueProviderViewTest:
         # Then
         assert not view.is_accessible()
 
-    @patch("pcapi.admin.base_configuration.current_user")
-    def test_prevent_access_missing_venue_access(self, current_user, app, db_session):
+    def test_prevent_access_missing_venue_access(self, client, app, db_session):
         # Given
-        current_user.is_authenticated = True
-        current_user.isAdmin = False
+        UserFactory(email="user@example.com")
+        client.with_session_auth("user@example.com")
 
         # When
         view = VenueProviderView(VenueProvider, db_session)

--- a/api/tests/admin/permissions_test.py
+++ b/api/tests/admin/permissions_test.py
@@ -4,12 +4,9 @@ import pcapi.core.users.factories as users_factories
 
 
 class HasPermissionTest:
-    def _make_user(self, email, is_admin=True):
-        return users_factories.UserFactory.build(email=email, isAdmin=is_admin)
-
     @override_settings(PERMISSIONS="")
     def test_empty_permission_list(self):
-        user = self._make_user("jane@example.com")
+        user = users_factories.AdminFactory.build(email="jane@example.com")
         assert not permissions.has_permission(user, "unknown-permission")
 
     @override_settings(
@@ -22,9 +19,9 @@ class HasPermissionTest:
         )
     )
     def test_basics(self):
-        jane = self._make_user("jane@example.com")
-        john = self._make_user("john@example.com")
-        roger = self._make_user("roger@example.com")
+        jane = users_factories.AdminFactory.build(email="jane@example.com")
+        john = users_factories.AdminFactory.build(email="john@example.com")
+        roger = users_factories.AdminFactory.build(email="roger@example.com")
         assert permissions.has_permission(jane, "can-frobulate")
         assert not permissions.has_permission(john, "can-frobulate")
         assert not permissions.has_permission(jane, "can-durlingate")
@@ -35,10 +32,10 @@ class HasPermissionTest:
 
     @override_settings(PERMISSIONS="can-frobulate: *")
     def test_star(self):
-        user = self._make_user("jane@example.com")
+        user = users_factories.AdminFactory.build(email="jane@example.com")
         assert permissions.has_permission(user, "can-frobulate")
 
     @override_settings(PERMISSIONS="can-frobulate: *")
     def test_admin_check(self):
-        user = users_factories.UserFactory.build(isAdmin=False, email="jane@example.com")
+        user = users_factories.UserFactory.build(email="jane@example.com")
         assert not permissions.has_permission(user, "can-frobulate")

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -46,7 +46,7 @@ class GetCappedOffersForFiltersTest:
         # When
         offers = get_capped_offers_for_filters(
             user_id=user_offerer.user.id,
-            user_is_admin=user_offerer.user.isAdmin,
+            user_is_admin=user_offerer.user.has_admin_role,
             offers_limit=requested_max_offers_count,
         )
 
@@ -66,7 +66,7 @@ class GetCappedOffersForFiltersTest:
         repository.save(user_offerer, offer1, offer2)
 
         # When
-        offers = get_capped_offers_for_filters(user_id=user.id, user_is_admin=user.isAdmin, offers_limit=10)
+        offers = get_capped_offers_for_filters(user_id=user.id, user_is_admin=user.has_admin_role, offers_limit=10)
 
         # Then
         assert offers.offers[0].id > offers.offers[1].id
@@ -83,7 +83,7 @@ class GetCappedOffersForFiltersTest:
 
         # when
         offers = get_capped_offers_for_filters(
-            user_id=user_offerer.user.id, user_is_admin=user_offerer.user.isAdmin, offers_limit=10
+            user_id=user_offerer.user.id, user_is_admin=user_offerer.user.has_admin_role, offers_limit=10
         )
 
         # then
@@ -102,7 +102,7 @@ class GetCappedOffersForFiltersTest:
 
         offers = get_capped_offers_for_filters(
             user_id=user_offerer.user.id,
-            user_is_admin=user_offerer.user.isAdmin,
+            user_is_admin=user_offerer.user.has_admin_role,
             offers_limit=10,
             category_id=categories.FILM.id,
         )
@@ -130,7 +130,7 @@ class GetCappedOffersForFiltersTest:
 
         # When
         offers = get_capped_offers_for_filters(
-            user_id=pro_user.id, user_is_admin=pro_user.isAdmin, offers_limit=10, creation_mode="manual"
+            user_id=pro_user.id, user_is_admin=pro_user.has_admin_role, offers_limit=10, creation_mode="manual"
         )
 
         # then
@@ -154,7 +154,7 @@ class GetCappedOffersForFiltersTest:
 
         # When
         offers = get_capped_offers_for_filters(
-            user_id=pro_user.id, user_is_admin=pro_user.isAdmin, offers_limit=10, creation_mode="imported"
+            user_id=pro_user.id, user_is_admin=pro_user.has_admin_role, offers_limit=10, creation_mode="imported"
         )
 
         # then
@@ -172,7 +172,10 @@ class GetCappedOffersForFiltersTest:
 
         # When
         offers = get_capped_offers_for_filters(
-            user_id=pro.id, user_is_admin=pro.isAdmin, offers_limit=10, period_beginning_date="2020-01-01T00:00:00"
+            user_id=pro.id,
+            user_is_admin=pro.has_admin_role,
+            offers_limit=10,
+            period_beginning_date="2020-01-01T00:00:00",
         )
 
         # then
@@ -198,7 +201,7 @@ class GetCappedOffersForFiltersTest:
         # When
         offers = get_capped_offers_for_filters(
             user_id=admin.id,
-            user_is_admin=admin.isAdmin,
+            user_is_admin=admin.has_admin_role,
             offers_limit=10,
             period_beginning_date=period_beginning_date,
             period_ending_date=period_ending_date,
@@ -221,7 +224,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=admin.id,
-                user_is_admin=admin.isAdmin,
+                user_is_admin=admin.has_admin_role,
                 offers_limit=10,
                 venue_id=offer_for_requested_venue.venue.id,
             )
@@ -247,7 +250,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=admin.id,
-                user_is_admin=admin.isAdmin,
+                user_is_admin=admin.has_admin_role,
                 offers_limit=10,
                 venue_id=offer_for_requested_venue.venue.id,
             )
@@ -268,7 +271,7 @@ class GetCappedOffersForFiltersTest:
             # When
             offers = get_capped_offers_for_filters(
                 user_id=admin.id,
-                user_is_admin=admin.isAdmin,
+                user_is_admin=admin.has_admin_role,
                 offers_limit=10,
                 offerer_id=offer_for_requested_offerer.venue.managingOffererId,
             )
@@ -295,7 +298,7 @@ class GetCappedOffersForFiltersTest:
             # When
             offers = get_capped_offers_for_filters(
                 user_id=admin.id,
-                user_is_admin=admin.isAdmin,
+                user_is_admin=admin.has_admin_role,
                 offers_limit=10,
                 offerer_id=offer_for_requested_offerer.venue.managingOffererId,
             )
@@ -317,7 +320,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=pro.id,
-                user_is_admin=pro.isAdmin,
+                user_is_admin=pro.has_admin_role,
                 offers_limit=10,
                 venue_id=offer_for_requested_venue.venue.id,
             )
@@ -343,7 +346,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=pro.id,
-                user_is_admin=pro.isAdmin,
+                user_is_admin=pro.has_admin_role,
                 offers_limit=10,
                 venue_id=offer_for_requested_venue.venue.id,
             )
@@ -364,7 +367,7 @@ class GetCappedOffersForFiltersTest:
             # When
             offers = get_capped_offers_for_filters(
                 user_id=pro.id,
-                user_is_admin=pro.isAdmin,
+                user_is_admin=pro.has_admin_role,
                 offers_limit=10,
                 offerer_id=offer_for_requested_offerer.venue.managingOffererId,
             )
@@ -391,7 +394,7 @@ class GetCappedOffersForFiltersTest:
             # When
             offers = get_capped_offers_for_filters(
                 user_id=pro.id,
-                user_is_admin=pro.isAdmin,
+                user_is_admin=pro.has_admin_role,
                 offers_limit=10,
                 offerer_id=offer_for_requested_offerer.venue.managingOffererId,
             )
@@ -413,7 +416,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=user_offerer.user.id,
-                user_is_admin=user_offerer.user.isAdmin,
+                user_is_admin=user_offerer.user.has_admin_role,
                 offers_limit=10,
                 name_keywords_or_isbn="ocs",
             )
@@ -439,7 +442,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=user_offerer.user.id,
-                user_is_admin=user_offerer.user.isAdmin,
+                user_is_admin=user_offerer.user.has_admin_role,
                 offers_limit=10,
                 name_keywords_or_isbn="seras-tu",
             )
@@ -465,7 +468,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=user_offerer.user.id,
-                user_is_admin=user_offerer.user.isAdmin,
+                user_is_admin=user_offerer.user.has_admin_role,
                 offers_limit=10,
                 name_keywords_or_isbn="mon océan",
             )
@@ -486,7 +489,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=user_offerer.user.id,
-                user_is_admin=user_offerer.user.isAdmin,
+                user_is_admin=user_offerer.user.has_admin_role,
                 offers_limit=10,
                 name_keywords_or_isbn="ocean",
             )
@@ -513,7 +516,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=user_offerer.user.id,
-                user_is_admin=user_offerer.user.isAdmin,
+                user_is_admin=user_offerer.user.has_admin_role,
                 offers_limit=10,
                 name_keywords_or_isbn="1234567891234",
             )
@@ -737,7 +740,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="ACTIVE"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="ACTIVE"
             )
 
             # then
@@ -771,7 +774,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="INACTIVE"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="INACTIVE"
             )
 
             # then
@@ -805,7 +808,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=10, status="SOLD_OUT"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=10, status="SOLD_OUT"
             )
 
             # then
@@ -838,7 +841,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=10, status="SOLD_OUT"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=10, status="SOLD_OUT"
             )
 
             # then
@@ -853,7 +856,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="SOLD_OUT"
             )
 
             # then
@@ -867,7 +870,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="SOLD_OUT"
             )
 
             # then
@@ -881,7 +884,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="SOLD_OUT"
             )
 
             # then
@@ -895,7 +898,7 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.isAdmin, offers_limit=5, status="EXPIRED"
+                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="EXPIRED"
             )
 
             # then
@@ -982,7 +985,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=self.pro.id,
-                user_is_admin=self.pro.isAdmin,
+                user_is_admin=self.pro.has_admin_role,
                 offers_limit=5,
                 status="SOLD_OUT",
                 venue_id=self.other_venue.id,
@@ -1012,7 +1015,7 @@ class GetCappedOffersForFiltersTest:
             # when
             offers = get_capped_offers_for_filters(
                 user_id=self.pro.id,
-                user_is_admin=self.pro.isAdmin,
+                user_is_admin=self.pro.has_admin_role,
                 offers_limit=5,
                 status="ACTIVE",
                 period_beginning_date=utc_datetime_to_department_timezone(in_six_days_beginning, "75").isoformat(),

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -207,7 +207,7 @@ class SuspendAccountTest:
 
         assert user.suspensionReason == str(reason)
         assert not user.isActive
-        assert not user.isAdmin
+        assert not user.has_admin_role
         assert not user.has_admin_role
         assert not UserSession.query.filter_by(userId=user.id).first()
         assert actor.isActive
@@ -583,7 +583,7 @@ class CreateProUserTest:
         pro_user = create_pro_user(pro_user_creation_body)
 
         assert pro_user.email == "prouser@example.com"
-        assert not pro_user.isAdmin
+        assert not pro_user.has_admin_role
         assert not pro_user.needsToFillCulturalSurvey
         assert not pro_user.has_pro_role
         assert not pro_user.has_admin_role
@@ -599,7 +599,7 @@ class CreateProUserTest:
         pro_user = create_pro_user(pro_user_creation_body)
 
         assert pro_user.email == "prouser@example.com"
-        assert not pro_user.isAdmin
+        assert not pro_user.has_admin_role
         assert not pro_user.needsToFillCulturalSurvey
         assert not pro_user.has_pro_role
         assert not pro_user.has_admin_role
@@ -646,7 +646,7 @@ class BeneficiaryInformationUpdateTest:
         assert beneficiary.address == "11 Rue du Test"
         assert beneficiary.dateOfBirth == datetime(2000, 5, 1, 0, 0)
         assert not beneficiary.has_beneficiary_role
-        assert not beneficiary.isAdmin
+        assert not beneficiary.has_admin_role
         assert beneficiary.password is not None
         assert beneficiary.activity == "Lycéen"
         assert beneficiary.civility == "Mme"

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -55,13 +55,6 @@ class UserTest:
             assert user_models.User.query.filter(user_models.User.has_beneficiary_role.is_(False)).all() == []
             assert user_models.User.query.filter(user_models.User.has_beneficiary_role.is_(True)).all() == [user]
 
-        def test_has_admin_role_with_legacy_property(self):
-            user = users_factories.UserFactory(isAdmin=True, roles=[])
-
-            assert user.has_admin_role
-            assert user_models.User.query.filter(user_models.User.has_admin_role.is_(False)).all() == []
-            assert user_models.User.query.filter(user_models.User.has_admin_role.is_(True)).all() == [user]
-
         def test_has_beneficiary_role_with_legacy_property(self):
             user = users_factories.UserFactory(roles=[user_models.UserRole.BENEFICIARY])
 
@@ -89,7 +82,6 @@ class UserTest:
             user.add_admin_role()
 
             assert user.has_admin_role
-            assert user.isAdmin
 
         def test_add_admin_role_only_once(self):
             user = users_factories.UserFactory.build()
@@ -150,33 +142,12 @@ class UserTest:
                 assert user.has_beneficiary_role
                 assert not user.has_admin_role
 
-        def test_cannot_add_beneficiary_role_to_an_admin_with_legacy_property(self):
-            user = users_factories.UserFactory.build(isAdmin=True, roles=[])
-
-            with pytest.raises(InvalidUserRoleException):
-                user.add_beneficiary_role()
-
-                assert not user.has_beneficiary_role
-                assert user.has_admin_role
-                assert user.isAdmin
-
-        def test_cannot_add_admin_role_to_a_beneficiary_with_legacy_property(self):
-            user = users_factories.UserFactory.build(roles=[user_models.UserRole.BENEFICIARY])
-
-            with pytest.raises(InvalidUserRoleException):
-                user.add_admin_role()
-
-                assert user.has_beneficiary_role
-                assert not user.has_admin_role
-                assert not user.isAdmin
-
         def test_remove_admin_role(self):
             user = users_factories.AdminFactory.build()
 
             user.remove_admin_role()
 
             assert not user.has_admin_role
-            assert not user.isAdmin
 
         def test_remove_admin_role_when_user_is_not_admin(self):
             user = users_factories.BeneficiaryGrant18Factory.build()
@@ -185,7 +156,6 @@ class UserTest:
 
             assert user.has_beneficiary_role
             assert not user.has_admin_role
-            assert not user.isAdmin
 
         def test_remove_beneficiary_role(self):
             user = users_factories.BeneficiaryGrant18Factory.build()

--- a/api/tests/core/users/test_users_sql_entity.py
+++ b/api/tests/core/users/test_users_sql_entity.py
@@ -25,9 +25,7 @@ from pcapi.repository import repository
 @pytest.mark.usefixtures("db_session")
 def test_cannot_create_admin_that_can_book(app):
     # Given
-    user = users_factories.UserFactory.build(
-        roles=[user_models.UserRole.BENEFICIARY, user_models.UserRole.ADMIN], isAdmin=True
-    )
+    user = users_factories.UserFactory.build(roles=[user_models.UserRole.BENEFICIARY, user_models.UserRole.ADMIN])
 
     # When
     with pytest.raises(ApiErrors):

--- a/api/tests/infrastructure/repository/pro_offerers/paginated_offerer_sql_repository_test.py
+++ b/api/tests/infrastructure/repository/pro_offerers/paginated_offerer_sql_repository_test.py
@@ -24,7 +24,7 @@ class PaginatedOffererSQLRepositoryTest:
         # When
         paginated_offerers = PaginatedOfferersSQLRepository().with_status_and_keywords(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             is_filtered_by_offerer_status=False,
             only_validated_offerers=None,
             pagination_limit=10,
@@ -53,7 +53,7 @@ class PaginatedOffererSQLRepositoryTest:
         # When
         paginated_offerers = PaginatedOfferersSQLRepository().with_status_and_keywords(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             is_filtered_by_offerer_status=False,
             only_validated_offerers=None,
             pagination_limit=10,
@@ -81,7 +81,7 @@ class PaginatedOffererSQLRepositoryTest:
         # When
         paginated_offerers = PaginatedOfferersSQLRepository().with_status_and_keywords(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             is_filtered_by_offerer_status=False,
             only_validated_offerers=None,
             pagination_limit=10,
@@ -107,7 +107,7 @@ class PaginatedOffererSQLRepositoryTest:
         # When
         paginated_offerers = PaginatedOfferersSQLRepository().with_status_and_keywords(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             is_filtered_by_offerer_status=False,
             only_validated_offerers=None,
             pagination_limit=10,
@@ -133,7 +133,7 @@ class PaginatedOffererSQLRepositoryTest:
         # When
         paginated_offerers = PaginatedOfferersSQLRepository().with_status_and_keywords(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             is_filtered_by_offerer_status=True,
             only_validated_offerers=True,
             pagination_limit=10,

--- a/api/tests/models/offerer_test.py
+++ b/api/tests/models/offerer_test.py
@@ -164,7 +164,7 @@ class AppendUserHasAccessAttributeTest:
         offerer = create_offerer()
 
         # When
-        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.isAdmin)
+        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.has_admin_role)
 
         # Then
         assert hasattr(offerer, "userHasAccess")
@@ -175,7 +175,7 @@ class AppendUserHasAccessAttributeTest:
         offerer = create_offerer()
 
         # When
-        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.isAdmin)
+        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.has_admin_role)
 
         # Then
         assert offerer.userHasAccess is False
@@ -189,7 +189,7 @@ class AppendUserHasAccessAttributeTest:
         repository.save(user_offerer)
 
         # When
-        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.isAdmin)
+        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.has_admin_role)
 
         # Then
         assert offerer.userHasAccess is True
@@ -203,7 +203,7 @@ class AppendUserHasAccessAttributeTest:
         repository.save(user_offerer)
 
         # When
-        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.isAdmin)
+        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.has_admin_role)
 
         # Then
         assert offerer.userHasAccess is False
@@ -218,7 +218,7 @@ class AppendUserHasAccessAttributeTest:
         repository.save(user_offerer)
 
         # When
-        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.isAdmin)
+        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.has_admin_role)
 
         # Then
         assert offerer.userHasAccess is False
@@ -233,7 +233,7 @@ class AppendUserHasAccessAttributeTest:
         repository.save(user_offerer)
 
         # When
-        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.isAdmin)
+        offerer.append_user_has_access_attribute(user_id=current_user.id, is_admin=current_user.has_admin_role)
 
         # Then
         assert offerer.userHasAccess is True

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -120,7 +120,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=None,
             venue_id=venue.id,
             category_id=None,
@@ -145,7 +145,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=None,
             venue_id=None,
             category_id=None,
@@ -175,7 +175,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=offerer.id,
             venue_id=None,
             category_id=None,
@@ -200,7 +200,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=None,
             venue_id=None,
             category_id=None,
@@ -229,7 +229,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=None,
             venue_id=None,
             category_id=None,
@@ -258,7 +258,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=None,
             venue_id=None,
             category_id=None,
@@ -283,7 +283,7 @@ class Returns200Test:
         assert response.status_code == 200
         mocked_list_offers.assert_called_once_with(
             user_id=pro.id,
-            user_is_admin=pro.isAdmin,
+            user_is_admin=pro.has_admin_role,
             offerer_id=None,
             venue_id=None,
             category_id="LIVRE",

--- a/api/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/api/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -181,7 +181,7 @@ class Returns410Test:
     @pytest.mark.usefixtures("db_session")
     def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, client):
         # Given
-        admin = users_factories.UserFactory(isAdmin=True)
+        admin = users_factories.AdminFactory()
         booking = bookings_factories.CancelledBookingFactory()
         url = f"/v2/bookings/keep/token/{booking.token}"
 

--- a/api/tests/routes/pro/patch_user_test.py
+++ b/api/tests/routes/pro/patch_user_test.py
@@ -48,7 +48,7 @@ def test_reject_beneficiary(app):
 def test_forbid_some_attributes(app):
     pro = users_factories.ProFactory()
     # It's tedious to test all attributes. We focus on the most sensitive ones.
-    forbidden_attributes = {"isAdmin": True, "dateCreated": "2018-08-01 12:00:00", "roles": ["BENEFICIARY"]}
+    forbidden_attributes = {"dateCreated": "2018-08-01 12:00:00", "roles": ["BENEFICIARY"]}
 
     client = TestClient(app.test_client()).with_session_auth(email=pro.email)
 

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -45,7 +45,7 @@ class Returns204Test:
         assert user.departementCode == "92"
         assert user.email == "toto_pro@example.com"
         assert user.firstName == "Toto"
-        assert user.isAdmin is False
+        assert not user.has_admin_role
         assert user.lastName == "Pro"
         assert user.phoneNumber == "0102030405"
         assert user.postalCode == "92000"

--- a/api/tests/scripts/beneficiary/import_users_test.py
+++ b/api/tests/scripts/beneficiary/import_users_test.py
@@ -45,6 +45,5 @@ class ReadFileTest:
         assert len(jean.deposits) == 1
 
         admin = User.query.filter_by(email="admin@example.com").one()
-        assert admin.isAdmin
         assert admin.has_admin_role
         assert not admin.has_beneficiary_role

--- a/api/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
+++ b/api/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
@@ -25,7 +25,7 @@ class SendMailAfterIdcheckOutageTest:
             dateCreated=datetime.now(),
         )
         # Admin
-        factories.AdminFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
+        factories.AdminFactory(dateOfBirth=datetime(2000, 1, 1), dateCreated=datetime.now())
         # Pro
         pro_user = factories.ProFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
         offers_factories.UserOffererFactory(user=pro_user)

--- a/api/tests/validation/models/user_test.py
+++ b/api/tests/validation/models/user_test.py
@@ -125,9 +125,8 @@ class EmailTest:
 class AdminTest:
     def test_should_return_error_message_when_admin_user_is_beneficiary(self, app):
         # Given
-        user = users_factories.UserFactory(
-            isAdmin=True,
-            roles=[user_models.UserRole.BENEFICIARY],
+        user = users_factories.UserFactory.build(
+            roles=[user_models.UserRole.BENEFICIARY, user_models.UserRole.ADMIN],
         )
         api_errors = ApiErrors()
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9716

## But de la pull request

Retirer l'usage à la colonne is_admin 

##  Implémentation

- Usage de user.has_admin_role au lieu de user.isAdmin
