### PR TITLE
(PC-13232)[API PRO]: set eac bookings to none in booking csv

### DIFF
--- a/api/src/pcapi/domain/booking_recap/booking_recap.py
+++ b/api/src/pcapi/domain/booking_recap/booking_recap.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from pcapi.core.bookings import models as bookings_models
+from pcapi.domain.booking_recap import utils
 from pcapi.domain.booking_recap.booking_recap_history import BookingRecapCancelledHistory
 from pcapi.domain.booking_recap.booking_recap_history import BookingRecapConfirmedHistory
 from pcapi.domain.booking_recap.booking_recap_history import BookingRecapHistory
@@ -85,14 +86,9 @@ class BookingRecap:
         return object.__new__(cls)
 
     def _get_booking_token(self) -> Optional[str]:
-        if (
-            not self.event_beginning_datetime
-            and not self.booking_is_used
-            and not self.booking_is_cancelled
-            or self.booking_is_educational
-        ):
-            return None
-        return self._booking_token
+        return utils.get_booking_token(
+            self._booking_token, self.booking_raw_status, self.booking_is_educational, self.event_beginning_datetime
+        )
 
     def _set_booking_token(self, booking_token: str) -> None:
         self._booking_token = booking_token

--- a/api/src/pcapi/domain/booking_recap/utils.py
+++ b/api/src/pcapi/domain/booking_recap/utils.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import Optional
+
+from pcapi.core.bookings.models import BookingStatus
+
+
+def get_booking_token(
+    booking_token: str,
+    booking_status: BookingStatus,
+    booking_is_educational: bool,
+    event_beginning_datetime: Optional[datetime],
+) -> Optional[str]:
+    if (
+        not event_beginning_datetime
+        and booking_status
+        not in [
+            BookingStatus.REIMBURSED,
+            BookingStatus.CANCELLED,
+            BookingStatus.USED,
+        ]
+        or booking_is_educational
+    ):
+        return None
+    return booking_token

--- a/api/tests/domain/booking_recap_test.py
+++ b/api/tests/domain/booking_recap_test.py
@@ -175,9 +175,7 @@ class BookingRecapTest:
 
         def test_should_return_token_when_offer_is_thing_and_booking_is_used_and_not_cancelled(self):
             # Given
-            booking_recap = create_domain_booking_recap(
-                booking_token="ABCDE", booking_is_used=True, booking_is_cancelled=False
-            )
+            booking_recap = create_domain_booking_recap(booking_token="ABCDE", booking_status=BookingStatus.USED)
 
             # When
             booking_recap_token = booking_recap.booking_token
@@ -187,21 +185,7 @@ class BookingRecapTest:
 
         def test_should_return_token_when_offer_is_thing_and_booking_is_not_used_and_is_cancelled(self):
             # Given
-            booking_recap = create_domain_booking_recap(
-                booking_token="ABCDE", booking_is_used=False, booking_is_cancelled=True
-            )
-
-            # When
-            booking_recap_token = booking_recap.booking_token
-
-            # Then
-            assert booking_recap_token == "ABCDE"
-
-        def test_should_return_token_when_offer_is_thing_and_booking_is_used_and_cancelled(self):
-            # Given
-            booking_recap = create_domain_booking_recap(
-                booking_token="ABCDE", booking_is_used=True, booking_is_cancelled=True
-            )
+            booking_recap = create_domain_booking_recap(booking_token="ABCDE", booking_status=BookingStatus.CANCELLED)
 
             # When
             booking_recap_token = booking_recap.booking_token


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13232

## But de la pull request

- Il a récemment été décidé, et implémenté, le fait de ne pas remonter de contremarque pour les réservations correspondant à des offres collectives, dans la liste des réservations côté pro.
- Cependant, les contremarques remontaient dans le csv listant les réservations
- Le but de cette PR est double:
    1. Ne pas remonter la contremarque d'une réservation collective dans le csv des réservations
    2. Harmoniser la fonction _get_booking_token pour que cette dernière soit utilisée à la fois par la page des réservations et le csv 

##  Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
