### PR TITLE
[PC-13231][api][offers] Allow to change stock price if offer custom rule is not valid anymore

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -11,6 +11,7 @@ from PIL import Image
 from pcapi import settings
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
+import pcapi.core.finance.repository as finance_repository
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
 from pcapi.core.users.models import User
@@ -121,7 +122,11 @@ def check_stock_price(price: float, offer: Offer) -> None:
             "Le prix d’une offre ne peut excéder 300 euros.",
         )
         raise api_errors
-    if offer.custom_reimbursement_rules:
+    if finance_repository.has_active_or_future_custom_reimbursement_rule(offer):
+        # We obviously look for active rules, but also future ones: if
+        # a reimbursement rule has been negotiated that will enter in
+        # effect tomorrow, we don't want to let the offerer change its
+        # price today.
         error = (
             "Vous ne pouvez pas modifier le prix ou créer un stock pour cette offre, "
             "car elle bénéficie d'un montant de remboursement spécifique."

--- a/api/tests/core/finance/test_repository.py
+++ b/api/tests/core/finance/test_repository.py
@@ -7,6 +7,7 @@ from pcapi.core.finance import factories
 from pcapi.core.finance import models
 from pcapi.core.finance import repository
 import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
 from pcapi.models.bank_information import BankInformationStatus
@@ -193,3 +194,26 @@ def test_has_reimbursement():
     db.session.add(pricing)
     db.session.commit()
     assert repository.has_reimbursement(booking)
+
+
+class HasActiveOrFutureCustomRemibursementRuleTest:
+    def test_active_rule(self):
+        now = datetime.datetime.utcnow()
+        timespan = (now - datetime.timedelta(days=1), now + datetime.timedelta(days=1))
+        rule = payments_factories.CustomReimbursementRuleFactory(timespan=timespan)
+        offer = rule.offer
+        assert repository.has_active_or_future_custom_reimbursement_rule(offer)
+
+    def test_future_rule(self):
+        now = datetime.datetime.utcnow()
+        timespan = (now + datetime.timedelta(days=1), None)
+        rule = payments_factories.CustomReimbursementRuleFactory(timespan=timespan)
+        offer = rule.offer
+        assert repository.has_active_or_future_custom_reimbursement_rule(offer)
+
+    def test_past_rule(self):
+        now = datetime.datetime.utcnow()
+        timespan = (now - datetime.timedelta(days=2), now - datetime.timedelta(days=1))
+        rule = payments_factories.CustomReimbursementRuleFactory(timespan=timespan)
+        offer = rule.offer
+        assert not repository.has_active_or_future_custom_reimbursement_rule(offer)


### PR DESCRIPTION
When creating a stock or editing the price of an existing stock, we
used to check if the offer had a custom reimbursement rule. If so, we
would reject the request.

Now we allow the creation or edition if the reimbursement rule is in
the past (i.e. if it's not active anymore). If the rule is active or
will be active, we still refuse to create or modify a stock.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13231