### PR TITLE
[bsr][api][finance] Use `has_reimbursement()` instead of `Booking.payments`

### DIFF
--- a/api/src/pcapi/admin/custom_views/booking_view.py
+++ b/api/src/pcapi/admin/custom_views/booking_view.py
@@ -13,6 +13,7 @@ from pcapi.admin.base_configuration import BaseCustomAdminView
 from pcapi.core.bookings import models as booking_models
 import pcapi.core.bookings.api as bookings_api
 from pcapi.core.educational.models import EducationalBooking
+import pcapi.core.finance.repository as finance_repository
 from pcapi.core.offers.models import Stock
 from pcapi.domain.client_exceptions import ClientError
 from pcapi.models.api_errors import ApiErrors
@@ -72,7 +73,7 @@ class BookingView(BaseCustomAdminView):
                     and booking.status != booking_models.BookingStatus.CANCELLED
                 ):
                     flash("Vous ne pouvez pas annuler une réservation associée à une offre collective")
-                elif not booking.payments:
+                elif not finance_repository.has_reimbursement(booking):
                     cancel_form = CancelForm(booking_id=booking.id)
         elif "id" in request.args:
             booking = (

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -22,6 +22,7 @@ from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalBookingStatus
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.models as finance_models
+import pcapi.core.finance.repository as finance_repository
 from pcapi.core.mails.transactional.bookings.booking_confirmation_to_beneficiary import (
     send_individual_booking_confirmation_email_to_beneficiary,
 )
@@ -311,7 +312,7 @@ def mark_as_cancelled(booking: Booking) -> None:
     if booking.status == BookingStatus.CANCELLED:
         raise exceptions.BookingAlreadyCancelled("la réservation a déjà été annulée")
 
-    if booking.payments:
+    if finance_repository.has_reimbursement(booking):
         raise exceptions.BookingAlreadyRefunded("la réservation a déjà été remboursée")
 
     _cancel_booking(booking, BookingCancellationReasons.BENEFICIARY)

--- a/api/src/pcapi/scripts/stock/soft_delete_stock.py
+++ b/api/src/pcapi/scripts/stock/soft_delete_stock.py
@@ -1,6 +1,7 @@
 import pcapi.core.bookings.api as bookings_api
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
+import pcapi.core.finance.repository as finance_repository
 from pcapi.core.offers.models import Stock
 from pcapi.repository import repository
 
@@ -34,7 +35,7 @@ def _check_bookings(bookings):
         if booking.isUsed:
             print("KO: f{booking} is used")
             stock_can_be_deleted = False
-        if booking.payments:
+        if finance_repository.has_reimbursement(booking):
             print("KO: f{booking} has payments")
             stock_can_be_deleted = False
     return stock_can_be_deleted


### PR DESCRIPTION
There were a few places where we used `Booking.payments` which is not
the right way anymore to check whether a booking has been reimbursed.