### PR TITLE
[PC-13236][API] clear SQLA. session between DMS archive action

### DIFF
--- a/api/src/pcapi/scripts/beneficiary/archive_dms_applications.py
+++ b/api/src/pcapi/scripts/beneficiary/archive_dms_applications.py
@@ -3,6 +3,7 @@ import logging
 from pcapi import settings
 from pcapi.connectors.dms import api as api_dms
 from pcapi.core.users import models as users_models
+from pcapi.models import db
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
 from pcapi.models.beneficiary_import_status import ImportStatus
@@ -38,6 +39,8 @@ def archive_applications(procedure_id: int, dry_run: bool = True) -> None:
                 bi.beneficiaryId,
             )
             archived_applications += 1
+        # remove object from SQLAlchemy session's cache and release read locks
+        db.session.rollback()
     logger.info(
         "script ran : total applications : %d to archive applications : %d", total_applications, archived_applications
     )

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -151,10 +151,10 @@ class RunTest:
         beneficiary_import = BeneficiaryImport.query.filter(
             BeneficiaryImport.id != initial_beneficiary_import_id
         ).first()
-        details = [status.detail for status in beneficiary_import.statuses]
+        details = {status.detail for status in beneficiary_import.statuses}
         assert beneficiary_import.currentStatus == ImportStatus.REJECTED
         assert beneficiary_import.applicationId == 123
-        assert details == ["Compte existant avec cet email", "Voir les details dans la page support"]
+        assert details == {"Compte existant avec cet email", "Voir les details dans la page support"}
         assert beneficiary_import.beneficiary == user
         on_sucessful_application.assert_not_called()
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13236

## But de la pull request

Corriger un plantage des process DMS  à cause d'une trop grande consommation mémoire.

##  Implémentation

The fact that we have a lot of application to process and that
we query but don't commit when performing an archive means the
objects in SQLAlchemy session cache stack up to the point it
fills the memory and crashes the process.
Adding a rollback forces SQLAlchemy to clear its cache and
free memory.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
