### PR TITLE
(PC-13122)(PRO): Reset invoices page state on filters reset

### DIFF
--- a/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/InvoicesFilters.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/InvoicesFilters.tsx
@@ -26,6 +26,7 @@ interface IReimbursementsSectionHeaderProps {
   hasNoInvoicesYet: boolean
   headerTitle: string
   initialFilters: filtersType
+  loadInvoices: (shouldReset: boolean) => void
   selectLabel: string
   selectName: string
   selectableOptions: selectableOptionsType
@@ -42,6 +43,7 @@ const InvoicesFilters = ({
   hasNoInvoicesYet,
   headerTitle,
   initialFilters,
+  loadInvoices,
   selectLabel,
   selectName,
   selectableOptions,
@@ -57,6 +59,7 @@ const InvoicesFilters = ({
   function resetFilters() {
     setAreFiltersDefault(true)
     setFilters(initialFilters)
+    loadInvoices(true)
   }
 
   const setBusinessUnitFilter = useCallback(

--- a/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/InvoicesNoResult.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsInvoices/InvoicesNoResult.tsx
@@ -11,6 +11,7 @@ type filtersType = {
 interface IInvoicesNoResultsProps {
   areFiltersDefault: boolean
   initialFilters: filtersType
+  loadInvoices: (shouldReset: boolean) => void
   setAreFiltersDefault: Dispatch<SetStateAction<boolean>>
   setFilters: Dispatch<SetStateAction<filtersType>>
 }
@@ -18,12 +19,14 @@ interface IInvoicesNoResultsProps {
 const InvoicesNoResult = ({
   areFiltersDefault,
   initialFilters,
+  loadInvoices,
   setAreFiltersDefault,
   setFilters,
 }: IInvoicesNoResultsProps): JSX.Element => {
   function resetFilters() {
     setAreFiltersDefault(true)
     setFilters(initialFilters)
+    loadInvoices(true)
   }
 
   return (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13122

## But de la pull request

Remettre à l'état initial la page justificatifs de remboursement lors du clic sur Réinitialiser les filtres
