### PR TITLE
(PC-13243)[API]fix: sendinblue booking expiration to beneficiary email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_expiration_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_expiration_to_beneficiary.py
@@ -56,13 +56,13 @@ def send_expired_bookings_to_beneficiary_email(beneficiary: User, bookings: list
 
     if books_bookings:
         books_bookings_data = get_expired_bookings_to_beneficiary_data(
-            beneficiary, bookings, booking_constants.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
+            beneficiary, books_bookings, booking_constants.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
         )
         success &= mails.send(recipients=[beneficiary.email], data=books_bookings_data)
 
     if other_bookings:
         other_bookings_data = get_expired_bookings_to_beneficiary_data(
-            beneficiary, bookings, booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days
+            beneficiary, other_bookings, booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days
         )
         success &= mails.send(recipients=[beneficiary.email], data=other_bookings_data)
 

--- a/api/tests/core/mails/transactional/bookings/booking_expiration_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_expiration_to_pro_test.py
@@ -49,8 +49,10 @@ class SendExpiredBookingsRecapEmailToOffererTest:
         )
         assert mails_testing.outbox[0].sent_data["params"]["WITHDRAWAL_PERIOD"] == 10
         assert mails_testing.outbox[0].sent_data["params"]["BOOKINGS"][0]["offer_name"] == "Les misérables"
+        assert len(mails_testing.outbox[0].sent_data["params"]["BOOKINGS"]) == 1
         assert (
             mails_testing.outbox[1].sent_data["template"] == TransactionalEmail.BOOKING_EXPIRATION_TO_PRO.value.__dict__
         )
         assert mails_testing.outbox[1].sent_data["params"]["WITHDRAWAL_PERIOD"] == 30
         assert mails_testing.outbox[1].sent_data["params"]["BOOKINGS"][0]["offer_name"] == "Intouchables"
+        assert len(mails_testing.outbox[1].sent_data["params"]["BOOKINGS"]) == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13243

## But de la pull request

Fix du contenu généré pour l'email EXPIRED_BOOKING_TO_BENEFICIARY

##  Implémentation
N/A

##  Informations supplémentaires
N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
