### PR TITLE
(PC-13244)[api]finance: fix InvoiceLine bookings_amount

### DIFF
--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -287,8 +287,9 @@ class InvoiceLine(Model):
     )
 
     @property
-    def get_bookings_amount(self):
-        return self.reimbursed_amount - self.contribution_amount
+    def bookings_amount(self):
+        """returns the (positive) raw amount of the used Bookings priced in this line"""
+        return self.contribution_amount - self.reimbursed_amount
 
     @property
     def contribution_rate(self):

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -215,7 +215,7 @@
     <tr>
         <td class="headRow">Montant remboursé</td>
         <td>{{ line.rate|fr_percentage }}</td>
-        <td>{{ line.get_bookings_amount|fr_currency }} €</td>
+        <td>{{ line.bookings_amount|fr_currency }} €</td>
         <td>{{ line.contribution_rate|fr_percentage }}</td>
         <td>{{ line.contribution_amount|fr_currency }} €</td>
         <td>{{ line.reimbursed_amount|fr_currency }} €</td>

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -233,7 +233,7 @@
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>20 052,00 €</td>
+        <td>20 060,00 €</td>
         <td></td>
         <td>4,00 €</td>
         <td>20 056,00 €</td>
@@ -264,7 +264,7 @@
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>56,00 €</td>
+        <td>60,00 €</td>
         <td></td>
         <td>2,00 €</td>
         <td>58,00 €</td>
@@ -317,7 +317,7 @@
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>38,60 €</td>
+        <td>43,00 €</td>
         <td></td>
         <td>2,20 €</td>
         <td>40,80 €</td>
@@ -326,7 +326,7 @@
     <tr class="bottomTableText">
         <td class="headRow">TOTAL</td>
         <td></td>
-        <td>20 088,60 €</td>
+        <td>20 221,00 €</td>
         <td></td>
         <td>66,20 €</td>
         <td>20 154,80 €</td>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13244

## But de la pull request

Corriger une erreur de calcul des montants de remboursement des `InvoiceLines`

##  Implémentation

- Renommage et correction de la propriété `bookings_amount` de `InvoiceLine`
- Séparation de la création du contexte permettant de _render_ la version HTML de l'`Invoice` afin de le tester unitairement
