### PR TITLE
(PC-6876) fix:cron: update decorator order

### DIFF
--- a/api/src/pcapi/scheduled_tasks/clock.py
+++ b/api/src/pcapi/scheduled_tasks/clock.py
@@ -234,8 +234,8 @@ def pc_users_one_year_with_pass_automation() -> None:
     users_one_year_with_pass_automation()
 
 
-@log_cron_with_transaction
 @cron_context
+@log_cron_with_transaction
 def pc_notify_users_bookings_not_retrieved() -> None:
     """
     Find soon expiring bookings that will expire in exactly N days and


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-6876

## But de la pull request

Avant : on log un message alors que le contexte de l’application n’est pas encore disponible (à cause de l'ordre des décorateurs appliqués à `pc_notify_users_bookings_not_retrieved`)
Après : les décorateurs sont appliqués dans le bon ordre

Bug remonté et expliqué par @xordoquy , merci 🙏 
