### PR TITLE
(PC 9019) fix KeyError in offers synchronisation

### DIFF
--- a/api/src/pcapi/alembic/run_migrations.py
+++ b/api/src/pcapi/alembic/run_migrations.py
@@ -13,7 +13,11 @@ logger = logging.getLogger(__name__)
 
 target_metadata = db.metadata
 
-IGNORED_COLUMNS_BY_TABLE = {"booking": ("isUsed", "isCancelled"), "user": ("isBeneficiary", "isAdmin")}
+IGNORED_COLUMNS_BY_TABLE = {
+    "booking": ("isUsed", "isCancelled"),
+    "user": ("isBeneficiary", "isAdmin"),
+    "offer": ("idAtProviders",),
+}
 IGNORED_TABLES = ("transaction", "activity")
 
 

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -122,7 +122,7 @@ def _build_stock_details_from_body(raw_stocks: List[UpdateVenueStockBodyModel], 
     for stock in raw_stocks:
         stock_details[stock.ref] = {
             "products_provider_reference": stock.ref,
-            "offers_provider_reference": f"{stock.ref}@{str(venue_id)}",
+            "offers_provider_reference": f"{stock.ref}",
             "stocks_provider_reference": f"{stock.ref}@{str(venue_id)}",
             "available_quantity": stock.available,
             "price": stock.price,

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -257,6 +257,7 @@ class SynchronizeStocksTest:
         )
 
         # Then
+        assert len(new_offers) == 1
         new_offer = new_offers[0]
         assert new_offer.bookingEmail == "booking_email"
         assert new_offer.description == "product_desc"

--- a/api/tests/routes/pro/post_venue_stocks_test.py
+++ b/api/tests/routes/pro/post_venue_stocks_test.py
@@ -21,7 +21,7 @@ def test_accepts_request(app):
     offer_to_update = offers_factories.OfferFactory(
         product__idAtProviders="123456789",
         product__subcategoryId="LIVRE_PAPIER",
-        idAtProviders=f"123456789@{venue.id}",
+        idAtProviders="123456789",
         venue=venue,
     )
     ApiKeyFactory(offerer=offerer)
@@ -56,7 +56,7 @@ def test_accepts_request_with_price(price, expected_price, app):
     offer_to_update = offers_factories.OfferFactory(
         product__idAtProviders="123456789",
         product__subcategoryId="LIVRE_PAPIER",
-        idAtProviders=f"123456789@{venue.id}",
+        idAtProviders="123456789",
         product__extraData={"prix_livre": expected_price},
         venue=venue,
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9019

## But de la pull request

Correction de l'erreur `KeyError` dans la synchronisation des offers dans le endpoint de l'API pro.

##  Implémentation

- correction de l'erreur
- adaptation des tests associés

##  Informations supplémentaires

- ajout d'un migration ignore pour la colonne idAtProviders de offer (elle ne sera plus prise en compte dans la génération automatique de migration d'alembic

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
- [X] J'ai écrit les tests nécessaires
- [X] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
