### PR TITLE
Pc 13142/call adage route when booking cancelled by offerer

### DIFF
--- a/api/src/pcapi/core/educational/adage_backends/__init__.py
+++ b/api/src/pcapi/core/educational/adage_backends/__init__.py
@@ -22,3 +22,9 @@ def get_adage_offerer(siren: str) -> list[AdageVenue]:
     backend = import_string(settings.ADAGE_BACKEND)
     result = backend().get_adage_offerer(siren=siren)
     return result
+
+
+def notify_booking_cancellation_by_offerer(data: EducationalBookingResponse) -> AdageApiResult:
+    backend = import_string(settings.ADAGE_BACKEND)
+    result = backend().notify_booking_cancellation_by_offerer(data=data)
+    return result

--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -63,3 +63,20 @@ class AdageHttpClient(AdageClient):
             raise AdageException("Error getting Adage API", api_response.status_code, api_response.text)
 
         return parse_obj_as(list[AdageVenue], api_response.json())
+
+    def notify_booking_cancellation_by_offerer(self, data: EducationalBookingResponse) -> AdageApiResult:
+        api_url = f"{self.base_url}/v1/prereservation-annule"
+        api_response = requests.post(
+            api_url,
+            headers={self.header_key: self.api_key, "Content-Type": "application/json"},
+            data=data.json(),
+        )
+
+        if api_response.status_code != 201:
+            raise AdageException(
+                "Error posting booking cancellation by offerer notification to Adage API.",
+                api_response.status_code,
+                api_response.text,
+            )
+
+        return AdageApiResult(sent_data=data.dict(), response=dict(api_response.json()), success=True)

--- a/api/src/pcapi/core/educational/adage_backends/base.py
+++ b/api/src/pcapi/core/educational/adage_backends/base.py
@@ -17,3 +17,6 @@ class AdageClient:
 
     def get_adage_offerer(self, siren: str) -> list[AdageVenue]:
         raise NotImplementedError()
+
+    def notify_booking_cancellation_by_offerer(self, data: EducationalBookingResponse) -> AdageApiResult:
+        raise NotImplementedError()

--- a/api/src/pcapi/core/educational/adage_backends/logger.py
+++ b/api/src/pcapi/core/educational/adage_backends/logger.py
@@ -27,3 +27,9 @@ class AdageLoggerClient(AdageClient):
             return [AdageVenue.parse_obj({"siret": "95046949400021"})]
 
         raise CulturalPartnerNotFoundException("Requested siren is not a known cultural partner for Adage")
+
+    def notify_booking_cancellation_by_offerer(self, data: EducationalBookingResponse) -> AdageApiResult:
+        logger.info(
+            "Adage has been notified at %s, with payload: %s", f"{self.base_url}/v1/prereservation-annule", data
+        )
+        return AdageApiResult(sent_data=data.dict(), response={"status_code": 201}, success=True)

--- a/api/src/pcapi/core/educational/adage_backends/testing.py
+++ b/api/src/pcapi/core/educational/adage_backends/testing.py
@@ -17,3 +17,7 @@ class AdageSpyClient(AdageClient):
 
     def get_adage_offerer(self, siren: str) -> list[AdageVenue]:
         raise Exception("Do not use the spy for this method, mock the get request instead")
+
+    def notify_booking_cancellation_by_offerer(self, data: EducationalBookingResponse) -> AdageApiResult:
+        testing.adage_requests.append({"url": f"{self.base_url}/v1/prereservation-annule", "sent_data": data})
+        return AdageApiResult(sent_data=data.dict(), response={"status_code": 201}, success=True)

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
@@ -28,7 +28,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
 
     if not FeatureToggle.ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS.is_active():
         return {
-            "MJ-TemplateID": 1116690 if booking.individualBooking is not None else 3192295,
+            "MJ-TemplateID": 1116690,
             "MJ-TemplateLanguage": True,
             "Vars": {
                 "event_date": event_date if event_date else "",
@@ -47,9 +47,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
         }
 
     return SendinblueTransactionalEmailData(
-        template=TransactionalEmail.BOOKING_CANCELLATION_BY_PRO_TO_BENEFICIARY.value
-        if booking.individualBooking is not None
-        else TransactionalEmail.BOOKING_CANCELLATION_BY_PRO_TO_TEACHER.value,
+        template=TransactionalEmail.BOOKING_CANCELLATION_BY_PRO_TO_BENEFICIARY.value,
         params={
             "EVENT_DATE": event_date,
             "EVENT_HOUR": event_hour,

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -48,7 +48,6 @@ class TransactionalEmail(Enum):
     BOOKING_CANCELLATION_BY_PRO_TO_BENEFICIARY = Template(
         id_prod=225, id_not_prod=37, tags=["jeunes_offre_annulee_pros"]
     )
-    BOOKING_CANCELLATION_BY_PRO_TO_TEACHER = Template(id_prod=475, id_not_prod=44, tags=["profs_annulation_offreur"])
     BOOKING_CONFIRMATION_BY_BENEFICIARY = Template(id_prod=219, id_not_prod=29, tags=["jeunes_reservation_confirmee"])
     BOOKING_POSTPONED_BY_PRO_TO_BENEFICIARY = Template(id_prod=224, id_not_prod=36, tags=["jeunes_offre_reportee_pro"])
     BOOKING_SOON_TO_BE_EXPIRED_TO_BENEFICIARY = Template(

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
@@ -55,41 +55,6 @@ class MailjetRetrieveDataToWarnUserAfterProBookingCancellationTest:
         }
 
     @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
-    def test_should_return_redactor_first_name_when_booking_is_educational(self):
-        # Given
-        stock = offers_factories.EventStockFactory(
-            beginningDatetime=datetime(2019, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
-        )
-        booking = bookings_factories.EducationalBookingFactory(
-            stock=stock,
-            educationalBooking__educationalRedactor__firstName="Georgio",
-            educationalBooking__educationalRedactor__lastName="Di georgio",
-        )
-
-        # When
-        mailjet_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
-
-        # Then
-        assert mailjet_data == {
-            "MJ-TemplateID": 3192295,
-            "MJ-TemplateLanguage": True,
-            "Vars": {
-                "event_date": "samedi 20 juillet 2019",
-                "event_hour": "14h",
-                "is_event": 1,
-                "is_free_offer": 0,
-                "is_online": 0,
-                "is_thing": 0,
-                "offer_name": booking.stock.offer.name,
-                "offer_price": "10.00",
-                "offerer_name": booking.offerer.name,
-                "user_first_name": "Georgio",
-                "user_last_name": "Di georgio",
-                "venue_name": booking.venue.name,
-            },
-        }
-
-    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=False)
     def test_should_return_thing_data_when_booking_is_on_a_thing(self):
         # Given
         stock = offers_factories.ThingStockFactory()
@@ -294,38 +259,6 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "OFFERER_NAME": booking.offerer.name,
             "USER_FIRST_NAME": "Georges",
             "USER_LAST_NAME": "Moustiquos",
-            "VENUE_NAME": booking.venue.name,
-        }
-
-    @override_features(ENABLE_SENDINBLUE_TRANSACTIONAL_EMAILS=True)
-    def test_should_return_redactor_first_name_when_booking_is_educational(self):
-        # Given
-        stock = offers_factories.EventStockFactory(
-            beginningDatetime=datetime(2019, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
-        )
-        booking = bookings_factories.EducationalBookingFactory(
-            stock=stock,
-            educationalBooking__educationalRedactor__firstName="Georgio",
-            educationalBooking__educationalRedactor__lastName="Di georgio",
-        )
-
-        # When
-        email_data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
-
-        # Then
-        assert email_data.template == Template(id_prod=475, id_not_prod=44, tags=["profs_annulation_offreur"])
-        assert email_data.params == {
-            "EVENT_DATE": "samedi 20 juillet 2019",
-            "EVENT_HOUR": "14h",
-            "IS_EVENT": True,
-            "IS_FREE_OFFER": False,
-            "IS_ONLINE": False,
-            "IS_THING": False,
-            "OFFER_NAME": booking.stock.offer.name,
-            "OFFER_PRICE": 10.00,
-            "OFFERER_NAME": booking.offerer.name,
-            "USER_FIRST_NAME": "Georgio",
-            "USER_LAST_NAME": "Di georgio",
             "VENUE_NAME": booking.venue.name,
         }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13142

## But de la pull request

Notifier adage lorsqu'un acteur culturel annule une réservation collective.

##  Implémentation

- Ajout d'une méthode dans les adapter adage_backends pour les différents environnements
- Appel de cette méthode dans offers/api.py/cancel_educational_offer_booking

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
