### PR TITLE
(PC-13160)[API] Create showase stock

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -75,6 +75,7 @@ from pcapi.repository import transaction
 from pcapi.routes.adage.v1.serialization.prebooking import serialize_educational_booking
 from pcapi.routes.serialization.offers_serialize import CompletedEducationalOfferModel
 from pcapi.routes.serialization.offers_serialize import PostEducationalOfferBodyModel
+from pcapi.routes.serialization.offers_serialize import PostEducationalOfferShadowStockBodyModel
 from pcapi.routes.serialization.offers_serialize import PostOfferBodyModel
 from pcapi.routes.serialization.stock_serialize import EducationalStockCreationBodyModel
 from pcapi.routes.serialization.stock_serialize import StockCreationBodyModel
@@ -1057,3 +1058,48 @@ def cancel_educational_offer_booking(offer: Offer) -> None:
             "Could not notify offerer about deletion of stock",
             extra={"stock": stock.id},
         )
+
+
+def create_educational_shadow_stock_and_set_offer_showcase(
+    stock_data: PostEducationalOfferShadowStockBodyModel, user: User, offer_id: str
+) -> Stock:
+    # When creating a showcase offer we need to create a shadow stock.
+    # We prefill the stock information with false data.
+    # This code will disappear when the new collective offer model is implemented
+    beginning = datetime.datetime(2030, 1, 1)
+    booking_limit_datetime = datetime.datetime(2030, 1, 1)
+    total_price = 1
+    number_of_tickets = 1
+    educational_price_detail = stock_data.educational_price_detail
+
+    offer = Offer.query.filter_by(id=offer_id).options(joinedload(Offer.stocks)).one()
+    if len(offer.activeStocks) > 0:
+        raise educational_exceptions.EducationalStockAlreadyExists()
+
+    if not offer.isEducational:
+        raise educational_exceptions.OfferIsNotEducational(offer_id)
+    validation.check_validation_status(offer)
+
+    stock = Stock(
+        offer=offer,
+        beginningDatetime=beginning,
+        bookingLimitDatetime=booking_limit_datetime,
+        price=total_price,
+        numberOfTickets=number_of_tickets,
+        educationalPriceDetail=educational_price_detail,
+        quantity=1,
+    )
+    repository.save(stock)
+    logger.info("Educational shadow stock has been created", extra={"offer": offer_id})
+
+    extra_data = copy.deepcopy(offer.extraData)
+    extra_data["isShowcase"] = True
+    offer.extraData = extra_data
+    repository.save(offer)
+
+    if offer.validation == OfferValidationStatus.DRAFT:
+        _update_offer_fraud_information(offer, user)
+
+    search.async_index_offer_ids([offer.id])
+
+    return stock

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -127,7 +127,7 @@ class EducationalOfferExtraDataOfferVenueBodyModel(BaseModel):
         extra = "forbid"
 
 
-class EducationalOfferExtraDataBodyModel(BaseModel):
+class PostEducationalOfferExtraDataBodyModel(BaseModel):
     students: list[str]
     offer_venue: EducationalOfferExtraDataOfferVenueBodyModel
     contact_email: str
@@ -150,7 +150,7 @@ class PostEducationalOfferBodyModel(BaseModel):
     mental_disability_compliant: bool = False
     motor_disability_compliant: bool = False
     visual_disability_compliant: bool = False
-    extra_data: EducationalOfferExtraDataBodyModel
+    extra_data: PostEducationalOfferExtraDataBodyModel
 
     @validator("name", pre=True)
     def validate_name(cls, name, values):  # pylint: disable=no-self-argument
@@ -162,7 +162,15 @@ class PostEducationalOfferBodyModel(BaseModel):
         extra = "forbid"
 
 
-class CompletedEducationalOfferModel(PostEducationalOfferBodyModel):
+class EducationalOfferExtraDataBodyModel(PostEducationalOfferExtraDataBodyModel):
+    is_showcase: bool = False
+
+
+class EducationalOfferBodyModel(PostEducationalOfferBodyModel):
+    extra_data: EducationalOfferExtraDataBodyModel
+
+
+class CompletedEducationalOfferModel(EducationalOfferBodyModel):
     is_duo: bool = False
     is_educational: bool = True
     external_ticket_office_url: Optional[str] = None

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -609,3 +609,16 @@ class ImageBodyModel(BaseModel):
 class CategoriesResponseModel(BaseModel):
     categories: list[CategoryResponseModel]
     subcategories: list[SubcategoryResponseModel]
+
+
+class PostEducationalOfferShadowStockBodyModel(BaseModel):
+    educational_price_detail: Optional[str]
+
+    @validator("educational_price_detail")
+    def validate_price_detail(cls, educational_price_detail):  # pylint: disable=no-self-argument
+        if len(educational_price_detail) > 1000:
+            raise ValueError("Le détail du prix ne doit pas excéder 1000 caractères.")
+        return educational_price_detail
+
+    class Config:
+        alias_generator = to_camel

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -210,6 +210,7 @@ class Returns200Test:
             "contactEmail": "toto@toto.com",
             "contactPhone": "0600000000",
             "offerVenue": {"addressType": "other", "otherAddress": "", "venueId": ""},
+            "isShowcase": False,
         }
 
 

--- a/api/tests/routes/pro/post_shadow_stock_for_educational_showcase_offer_test.py
+++ b/api/tests/routes/pro/post_shadow_stock_for_educational_showcase_offer_test.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+
+import pytest
+
+from pcapi.core.offers import factories as offer_factories
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import Stock
+from pcapi.utils.human_ids import dehumanize
+from pcapi.utils.human_ids import humanize
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class Return200Test:
+    def test_create_valid_shadow_stock_for_educational_offer(self, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory(extraData={"isShowcase": False})
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+        print("OFFER ID", offer.id)
+
+        # When
+        stock_payload = {
+            "educationalPriceDetail": "Détail du prix",
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post(f"/offers/educational/{humanize(offer.id)}/shadow-stock", json=stock_payload)
+
+        # Then
+        assert response.status_code == 201
+        response_dict = response.json
+        created_stock = Stock.query.get(dehumanize(response_dict["id"]))
+        updated_offer = Offer.query.get(offer.id)
+        assert offer.id == created_stock.offerId
+        assert created_stock.educationalPriceDetail == "Détail du prix"
+        assert created_stock.beginningDatetime == datetime(2030, 1, 1)
+        assert created_stock.bookingLimitDatetime == datetime(2030, 1, 1)
+        assert created_stock.price == 1
+        assert created_stock.numberOfTickets == 1
+        assert created_stock.educationalPriceDetail == "Détail du prix"
+        assert updated_offer.extraData["isShowcase"] == True
+
+
+class Return400Test:
+    def test_create_educational_shadow_stocks_should_not_be_available_if_user_not_linked_to_offerer(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory(extraData={"isShowcase": False})
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+        )
+
+        # When
+        stock_payload = {
+            "educationalPriceDetail": "Détail du prix",
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post(f"/offers/educational/{humanize(offer.id)}/shadow-stock", json=stock_payload)
+        updated_offer = Offer.query.get(offer.id)
+        # Then
+        assert response.status_code == 403
+        assert response.json == {
+            "global": ["Vous n'avez pas les droits d'accès suffisant pour accéder à cette information."]
+        }
+        assert updated_offer.extraData["isShowcase"] == False
+
+    def should_not_accept_payload_with_price_details_with_more_than_1000_caracters(self, app, client):
+        # Given
+        offer = offer_factories.EducationalEventOfferFactory(extraData={"isShowcase": False})
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        stock_payload = {
+            "educationalPriceDetail": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sodales commodo tellus, at dictum odio vulputate nec. Donec iaculis rutrum nunc. Nam euismod, odio vel iaculis tincidunt, enim ante iaculis purus, ac vehicula ex lacus sit amet nisl. Aliquam et diam tellus. Curabitur in pharetra augue. Nunc scelerisque lectus non diam efficitur, eu porta neque vestibulum. Nullam elementum purus ac ligula viverra tincidunt. Etiam tincidunt metus nec nibh tempor tincidunt. Pellentesque ac ipsum purus. Duis vestibulum mollis nisi a vulputate. Nullam malesuada eros eu convallis rhoncus. Maecenas eleifend ex at posuere maximus. Suspendisse faucibus egestas dolor, sit amet dignissim odio condimentum vitae. Pellentesque ultricies eleifend nisi, quis pellentesque nisi faucibus finibus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse potenti. Aliquam convallis diam nisl, eget ullamcorper odio convallis ac. Ut quis nulla fringilla, commodo tellus ut.",
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post(f"/offers/educational/{humanize(offer.id)}/shadow-stock", json=stock_payload)
+
+        updated_offer = Offer.query.get(offer.id)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"educationalPriceDetail": ["Le détail du prix ne doit pas excéder 1000 caractères."]}
+        assert updated_offer.extraData["isShowcase"] == False
+
+    def should_not_allow_multiple_stocks(self, client):
+        # Given
+        offer = offer_factories.EducationalEventStockFactory(offer__extraData={"isShowcase": False}).offer
+        offer_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        # When
+        stock_payload = {
+            "educationalPriceDetail": "Détail du prix",
+        }
+
+        client.with_session_auth("user@example.com")
+        response = client.post(f"/offers/educational/{humanize(offer.id)}/shadow-stock", json=stock_payload)
+
+        updated_offer = Offer.query.get(offer.id)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json == {"code": "EDUCATIONAL_STOCK_ALREADY_EXISTS"}
+        assert updated_offer.extraData["isShowcase"] == False


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13160

## But de la pull request

Dans le cadre de la création d'offre vitrine, l'AC doit pouvoir créer une offre sans créer de date et de prix
Or, pour que celle-ci puisse remonter et être cohérente avec le reste des données, on doit créer un stock "fantôme" le temps que l'AC décide la date et le prix avec les rédacteurs de projet