### PR TITLE
(PC-13274) Update dms fraudCheck content on reception

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -84,11 +84,13 @@ def on_dms_fraud_result(
             thirdPartyId=str(dms_content.application_id),
             resultContent=dms_content.dict(),
             eligibilityType=eligibility_type,
+            status=models.FraudCheckStatus.PENDING,
         )
-
-    if fraud_check.eligibilityType != eligibility_type:
-        logger.info("User changed his eligibility in DMS application", extra={"user_id": user.id})
-        fraud_check.eligibilityType = eligibility_type
+    else:
+        fraud_check.resultContent = dms_content.dict()
+        if fraud_check.eligibilityType != eligibility_type:
+            logger.info("User changed his eligibility in DMS application", extra={"user_id": user.id})
+            fraud_check.eligibilityType = eligibility_type
     on_identity_fraud_check_result(user, fraud_check)
     repository.save(fraud_check)
 


### PR DESCRIPTION
En ré-important l’utilisateur du ticket PC-13274, je me suis rendu compte d’un bug : quand le dossier dms est accepté, on ne met pas à jour le contenu du FraudCheck DMS. Celui-ci est créé lorsque le dossier DMS est passé en mode Draft ; mais il peut avoir changé entre temps.