### PR TITLE
(PC-13077)[API] fix: Update is_latin function

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -36,7 +36,13 @@ class ProfileUpdateRequest(BaseModel):
     class Config:
         alias_generator = to_camel
 
-    @validator("first_name", "last_name", "address", "city")
+    @validator("first_name", "last_name", "address", "city", "postal_code")
+    def mandatory_string_fields_cannot_be_empty(cls, v):  # pylint: disable=no-self-argument
+        if not v:
+            raise ValueError("This field cannot be empty")
+        return v
+
+    @validator("first_name", "last_name", "city")
     def string_must_contain_latin_characters(cls, v):  # pylint: disable=no-self-argument
         if not is_latin(v):
             raise ValueError("Les champs textuels doivent contenir des caractères latins")

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -5,6 +5,7 @@ from pydantic import validator
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import profile_options
 from pcapi.core.users import models as users_models
+from pcapi.serialization.utils import has_latin_or_numeric_chars
 from pcapi.serialization.utils import is_latin
 from pcapi.serialization.utils import to_camel
 
@@ -39,6 +40,13 @@ class ProfileUpdateRequest(BaseModel):
     def string_must_contain_latin_characters(cls, v):  # pylint: disable=no-self-argument
         if not is_latin(v):
             raise ValueError("Les champs textuels doivent contenir des caractères latins")
+        return v
+
+    @validator("address")
+    def address_must_be_valid(cls, v):  # pylint: disable=no-self-argument
+        if not has_latin_or_numeric_chars(v):
+            raise ValueError("L'adresse doit contenir des caractères alphanumériques")
+
         return v
 
 

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -133,3 +133,12 @@ def is_latin(s: str) -> bool:
         if not "LATIN" in unicodedata.name(char):
             return False
     return True
+
+
+def has_latin_or_numeric_chars(address: str) -> bool:
+    for char in address:
+        if char == " ":
+            continue
+        if not is_latin(char) and not char.isnumeric():
+            return False
+    return True

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -126,5 +126,10 @@ def string_to_boolean_field(field_name: str) -> classmethod:
     return validator(field_name, pre=True, allow_reuse=True)(string_to_boolean)
 
 
-def is_latin(s: str):
-    return all("LATIN" in unicodedata.name(char) for char in s if char.isalpha())
+def is_latin(s: str) -> bool:
+    for char in s:
+        if char in (" ", "-", "'", ".", ","):
+            continue
+        if not "LATIN" in unicodedata.name(char):
+            return False
+    return True

--- a/api/tests/serialization/utils_test.py
+++ b/api/tests/serialization/utils_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pcapi.serialization.utils import is_latin
+
+
+class UtilsUnitTest:
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            ("", True),
+            ("a", True),
+            ("Verona", True),
+            ("Charles-Apollon", True),
+            ("John O'Wick", True),
+            ("Martin king, Jr.", True),
+            ("მარიამ", False),
+            ("aé", True),
+            ("&", False),
+            ("a&", False),
+            ("1", False),
+        ],
+    )
+    def test_is_latin(self, test_input, expected):
+        assert is_latin(test_input) == expected

--- a/api/tests/serialization/utils_test.py
+++ b/api/tests/serialization/utils_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pcapi.serialization.utils import has_latin_or_numeric_chars
 from pcapi.serialization.utils import is_latin
 
 
@@ -22,3 +23,17 @@ class UtilsUnitTest:
     )
     def test_is_latin(self, test_input, expected):
         assert is_latin(test_input) == expected
+
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            ("a", True),
+            ("მარიამ", False),
+            ("1 allée des séqoïas", True),
+            ("&", False),
+            ("25 & 26 rue Duhesme", False),
+            ("1", True),
+        ],
+    )
+    def test_is_address_valid(self, test_input, expected):
+        assert has_latin_or_numeric_chars(test_input) == expected


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13077

## But de la pull request

Corriger la détection de caractères latin

Avant
```bash
In [6]: is_latin("a")                                                                                 
Out[6]: True

In [7]: is_latin("&")                                                                                 
Out[7]: True
```

Après
```bash
In [2]: is_latin("&")                                                                                 
Out[2]: False

In [3]: is_latin("a")                                                                                 
Out[3]: True

In [4]: is_latin("1")                                                                                 
Out[4]: False
```

Aussi s'assurer que les champs ne sont pas vides


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
