### PR TITLE
(pc-13037) api: Fix exception when support initiates a manual review …

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -390,16 +390,22 @@ def on_user_profiling_check_result(
 
 
 def get_source_data(user: users_models.User) -> pydantic.BaseModel:
-    mapped_class = {models.FraudCheckType.DMS: models.DMSContent, models.FraudCheckType.JOUVE: models.JouveContent}
     fraud_check = (
         models.BeneficiaryFraudCheck.query.filter(
             models.BeneficiaryFraudCheck.userId == user.id,
-            models.BeneficiaryFraudCheck.type.in_([models.FraudCheckType.JOUVE, models.FraudCheckType.DMS]),
+            models.BeneficiaryFraudCheck.type.in_(
+                [
+                    models.FraudCheckType.JOUVE,
+                    models.FraudCheckType.DMS,
+                    models.FraudCheckType.EDUCONNECT,
+                    models.FraudCheckType.UBBLE,
+                ]
+            ),
         )
         .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
         .first()
     )
-    return mapped_class[fraud_check.type](**fraud_check.resultContent)
+    return models.FRAUD_CHECK_MAPPING[fraud_check.type](**fraud_check.resultContent)
 
 
 def create_failed_phone_validation_fraud_check(

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -132,6 +132,58 @@ class BeneficiaryValidationViewTest:
         assert user.idPieceNumber == dms_content.id_piece_number
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
+    def test_validation_view_validate_user_from_educonnect(self, client):
+        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
+        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.EDUCONNECT)
+        admin = users_factories.AdminFactory()
+        client.with_session_auth(admin.email)
+
+        response = client.post(
+            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+        )
+        assert response.status_code == 302
+
+        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
+        assert review.review == fraud_models.FraudReviewStatus.OK
+        assert review.reason == "User is granted"
+        user = users_models.User.query.get(user.id)
+        assert user.has_underage_beneficiary_role
+        assert len(user.deposits) == 1
+
+        educonnect_content = fraud_models.EduconnectContent(**check.resultContent)
+        assert user.firstName == educonnect_content.get_first_name()
+        assert user.lastName == educonnect_content.get_last_name()
+        assert user.idPieceNumber == educonnect_content.get_id_piece_number()
+
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
+    @override_features(IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY=True)
+    def test_validation_view_validate_user_from_ubble(self, client):
+        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
+        admin = users_factories.AdminFactory()
+        client.with_session_auth(admin.email)
+
+        response = client.post(
+            f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
+            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+        )
+        assert response.status_code == 302
+
+        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
+        assert review.review == fraud_models.FraudReviewStatus.OK
+        assert review.reason == "User is granted"
+        user = users_models.User.query.get(user.id)
+        assert user.has_beneficiary_role
+        assert len(user.deposits) == 1
+
+        ubble_content = fraud_models.ubble_fraud_models.UbbleContent(**check.resultContent)
+        assert user.firstName == ubble_content.get_first_name()
+        assert user.lastName == ubble_content.get_last_name()
+        assert user.idPieceNumber == ubble_content.get_id_piece_number()
+
+    @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_wrong_args(self, client):
         user = users_factories.UserFactory()
         admin = users_factories.AdminFactory()


### PR DESCRIPTION
…after educonnect fraud check

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13037

## But de la pull request

Support gets an Internal Server Error when he tries to validate a manual review after Educonnect rejects a user (in this case, because of same name and birth date, guessed as a duplicate) :
`AttributeError("'NoneType' object has no attribute 'type'")`
https://sentry.internal-passculture.app/organizations/sentry/issues/264277/?project=5&referrer=slack

##  Implémentation

##  Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
