### PR TITLE
(PC-13312) Fix dms webhook types

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -587,13 +587,13 @@ def start_fraud_check(
 
 def update_or_create_fraud_check_failed(
     user: users_models.User,
-    application_id: str,
+    thirdPartyId: str,
     source_data: typing.Union[models.DMSContent, ubble_fraud_models.UbbleContent],
     reasons: list[models.FraudReasonCode],
 ) -> models.BeneficiaryFraudCheck:
     fraud_check = models.BeneficiaryFraudCheck.query.filter(
         models.BeneficiaryFraudCheck.user == user,
-        models.BeneficiaryFraudCheck.thirdPartyId == application_id,
+        models.BeneficiaryFraudCheck.thirdPartyId == thirdPartyId,
         ~models.BeneficiaryFraudCheck.status.in_([models.FraudCheckStatus.OK, models.FraudCheckStatus.KO]),
     ).one_or_none()
 
@@ -601,7 +601,7 @@ def update_or_create_fraud_check_failed(
         fraud_check = models.BeneficiaryFraudCheck(
             user=user,
             type=models.FRAUD_CONTENT_MAPPING[type(source_data)],
-            thirdPartyId=application_id,
+            thirdPartyId=thirdPartyId,
             resultContent=source_data.dict(),
             status=models.FraudCheckStatus.KO,
             eligibilityType=source_data.get_eligibility_type(),

--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -11,14 +11,14 @@ logger = logging.getLogger(__name__)
 
 def get_fraud_check(
     user: users_models.User,
-    application_id: str,
+    application_id: int,
 ) -> Optional[fraud_models.BeneficiaryFraudCheck]:
     # replace with one_or_one once the data are cleaned up
     return (
         fraud_models.BeneficiaryFraudCheck.query.filter(
             fraud_models.BeneficiaryFraudCheck.user == user,
             fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.DMS,
-            fraud_models.BeneficiaryFraudCheck.thirdPartyId == application_id,
+            fraud_models.BeneficiaryFraudCheck.thirdPartyId == str(application_id),
         )
         .order_by(fraud_models.BeneficiaryFraudCheck.id.desc())
         .first()

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -25,16 +25,12 @@ logger = logging.getLogger(__name__)
 def handle_dms_state(
     user: users_models.User,
     application: fraud_models.DMSContent,
-    procedure_id: str,
-    application_id: str,
+    procedure_id: int,
+    application_id: int,
     state: dms_connector_api.GraphQLApplicationStates,
 ) -> None:
 
-    logs_extra = {
-        "application_id": application_id,
-        "procedure_id": procedure_id,
-        "user_email": user.email,
-    }
+    logs_extra = {"application_id": application_id, "procedure_id": procedure_id, "user_email": user.email}
 
     current_fraud_check = fraud_dms_api.get_fraud_check(user, application_id)
     if current_fraud_check is None:
@@ -56,7 +52,10 @@ def handle_dms_state(
 
     elif state == dms_connector_api.GraphQLApplicationStates.refused:
         fraud_api.update_or_create_fraud_check_failed(
-            user, application_id, current_fraud_check.source_data(), [fraud_models.FraudReasonCode.REFUSED_BY_OPERATOR]
+            user,
+            str(application_id),
+            current_fraud_check.source_data(),
+            [fraud_models.FraudReasonCode.REFUSED_BY_OPERATOR],
         )
         subscription_messages.on_dms_application_refused(user)
 

--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -106,8 +106,8 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
     if import_status:
         subscription_api.attach_beneficiary_import_details(
             user,
-            int(form.dossier_id),
-            int(form.procedure_id),
+            form.dossier_id,
+            form.procedure_id,
             BeneficiaryImportSources.demarches_simplifiees,
             eligibility_type=application.get_eligibility_type(),
             details="Webhook status update",

--- a/api/src/pcapi/validation/routes/dms.py
+++ b/api/src/pcapi/validation/routes/dms.py
@@ -23,8 +23,8 @@ def coerce_for_enum(enum):
 
 
 class DMSWebhookRequest(pydantic.BaseModel):
-    procedure_id: str
-    dossier_id: str
+    procedure_id: int
+    dossier_id: int
     state: api_dms.GraphQLApplicationStates
     updated_at: datetime.datetime
 

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -51,8 +51,8 @@ class DmsWebhookApplicationTest:
         user = users_factories.UserFactory()
         execute_query.return_value = make_single_application(12, state="closed", email=user.email)
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": "accepte",
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -78,8 +78,8 @@ class DmsWebhookApplicationTest:
         user = users_factories.UserFactory(hasCompletedIdCheck=False)
         execute_query.return_value = make_single_application(12, state="closed", email=user.email)
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": dms_status.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -111,8 +111,8 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = make_single_application(12, state="closed", email=user.email)
 
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.draft.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -140,8 +140,8 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = make_single_application(12, state="closed", email=user.email)
 
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.on_going.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -171,8 +171,8 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = make_single_application(12, state="closed", email=user.email)
 
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.refused.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -199,8 +199,8 @@ class DmsWebhookApplicationTest:
     def test_dms_double_parsing_error(self, send_user_message, execute_query, client):
         user = users_factories.UserFactory()
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.draft.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -236,8 +236,8 @@ class DmsWebhookApplicationTest:
             12, state=api_dms.GraphQLApplicationStates.draft.value, email="user@example.com"
         )
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.draft.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -263,8 +263,8 @@ class DmsWebhookApplicationTest:
             id_piece_number="error_identity_piece_number",
         )
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.draft.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -293,8 +293,8 @@ class DmsWebhookApplicationTest:
             12, state=api_dms.GraphQLApplicationStates.draft.value, email=user.email, postal_code="error_postal_code"
         )
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.draft.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -328,8 +328,8 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = return_value
 
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": api_dms.GraphQLApplicationStates.draft.value,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }
@@ -369,8 +369,8 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = make_single_application(12, state=graphql_app_state, email=user.email)
 
         form_data = {
-            "procedure_id": "48860",
-            "dossier_id": "6044787",
+            "procedure_id": 48860,
+            "dossier_id": 6044787,
             "state": graphql_app_state,
             "updated_at": "2021-09-30 17:55:58 +0200",
         }


### PR DESCRIPTION
There were graphql exceptions because int was expected instead of str

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13312.

Bug créé par le ticket [PC-12335: App Native - DMS : Mettre à jour le fraudcheck (pending, cancelled) en fonction du retour DMS (webhook)TERMINE](https://passculture.atlassian.net/browse/PC-12335) à cause de [cette ligne](https://github.com/pass-culture/pass-culture-main/commit/93d18156da6baf185079b50ff4d8e66e3d76dba5#diff-d6ed29320fad01ec92a80616b0a0f100dc313811ad49d07d58cbe660fe00c159R26)

Erreur sentry : https://sentry.internal-passculture.app/organizations/sentry/issues/256627/events/latest : l’api graphql râle parce qu’on utilise un str plutôt qu’un int

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

##  Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
