### PR TITLE
PC-13203 fix: Check for empty strings when updating profile 

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -38,6 +38,7 @@ class ProfileUpdateRequest(BaseModel):
 
     @validator("first_name", "last_name", "address", "city", "postal_code")
     def mandatory_string_fields_cannot_be_empty(cls, v):  # pylint: disable=no-self-argument
+        v = v.strip()
         if not v:
             raise ValueError("This field cannot be empty")
         return v

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -39,12 +39,6 @@ def next_subscription_step(
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_user_required
 def update_profile(user: users_models.User, body: serializers.ProfileUpdateRequest) -> None:
-    # TODO: Corentin: remove this when we send ids in the request body
-    if body.activity_id is not None:
-        activity = users_models.ActivityEnum[body.activity_id.value].value
-    else:
-        activity = body.activity.value
-
     subscription_api.update_user_profile(
         user,
         first_name=body.first_name,
@@ -52,7 +46,7 @@ def update_profile(user: users_models.User, body: serializers.ProfileUpdateReque
         address=body.address,
         city=body.city,
         postal_code=body.postal_code,
-        activity=activity,
+        activity=users_models.ActivityEnum[body.activity_id.value].value,
         school_type=users_models.SchoolTypeEnum[body.school_type_id.value] if body.school_type_id is not None else None,
     )
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -141,7 +141,7 @@ class EduconnectFlowTest:
         )
 
         profile_data = {
-            "activity": "Lycéen",
+            "activityId": "HIGH_SCHOOL_STUDENT",
             "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
             "address": "1 rue des rues",
             "city": "Uneville",
@@ -151,6 +151,8 @@ class EduconnectFlowTest:
         }
 
         response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 204
 
         assert user.city == "Uneville"
         assert subscription_api.has_completed_profile(user)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -519,6 +519,35 @@ class UpdateProfileTest:
         assert response.status_code == 400
 
     @override_features(ENABLE_UBBLE=True)
+    def test_update_profile_empty_field(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            phoneNumber="+33609080706",
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": " ",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+        }
+
+        client.with_token(user.email)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 400
+
+    @override_features(ENABLE_UBBLE=True)
     def test_update_profile_valid_character(self, client):
         user = users_factories.UserFactory(
             address=None,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13203

## But de la pull request

Empêcher un champs contenant uniquement des espaces, si le champs est obligatoire et de type string 

##  Implémentation

- appliquer `string.strip()` avant de checker si elle est vide

##  Informations supplémentaires

- J'en profite pour régler un TODO

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
