### PR TITLE
(PC-13203) accept typographic apostrophe in names and adresses

### DIFF
--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -128,7 +128,7 @@ def string_to_boolean_field(field_name: str) -> classmethod:
 
 def is_latin(s: str) -> bool:
     for char in s:
-        if char in (" ", "-", "'", ".", ","):
+        if char in (" ", "-", ".", ",", "'", "’"):
             continue
         if not "LATIN" in unicodedata.name(char):
             return False

--- a/api/tests/serialization/utils_test.py
+++ b/api/tests/serialization/utils_test.py
@@ -13,6 +13,7 @@ class UtilsUnitTest:
             ("Verona", True),
             ("Charles-Apollon", True),
             ("John O'Wick", True),
+            ("John O’Wick", True),
             ("Martin king, Jr.", True),
             ("მარიამ", False),
             ("aé", True),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13203

## But de la pull request

Accepter les apostrophes typographiques, qui peuvent provenir d'un clavier de téléphone mobile

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
