### PR TITLE
[PC-12524](API) Add Pre and Post Deployment Branches for migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,13 +402,15 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            if [ ! -z "$(alembic branches)" ]; then echo "Multiple alembic heads found"; exit 1; fi
+            LINE_COUNT=$(wc -l \<<< "$(alembic heads)")
+            if [${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
           working_directory: api
       - run:
           name: Check database and model are aligned
           command: |
             RUN_ENV=tests venv/bin/flask install_postgres_extensions
-            RUN_ENV=tests venv/bin/alembic upgrade head
+            RUN_ENV=tests venv/bin/alembic upgrade pre@head
+            RUN_ENV=tests venv/bin/alembic upgrade post@head
             RUN_ENV=tests venv/bin/flask install_data
             RUN_ENV=tests venv/bin/python tests/alembic/check_db_schema.py
           working_directory: api

--- a/api/README.md
+++ b/api/README.md
@@ -135,7 +135,8 @@ Si la base de données n'a pas été initialisée, vous devez suivre les étapes
   ```shell
   source venv/bin/activate
   flask install_postgres_extensions
-  alembic upgrade head
+  alembic upgrade pre@head
+  alembic upgrade post@head
   ```
 
 Vous pouvez maintenant lancer l'application Flask

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,2 @@
-2a111d4feac2 (head)
+ffafc4d7210f (post) (head)
+d3da2eac435d (pre) (head)

--- a/api/src/pcapi/alembic/CONTRIBUTING.md
+++ b/api/src/pcapi/alembic/CONTRIBUTING.md
@@ -4,35 +4,58 @@
 
 Pour effectuer une migration du schéma de la base de données, il est recommandé d'effectuer les étapes suivantes :
 
-1. Modifier le modèle applicatif dans les fichiers python
+### 1. Modifier le modèle applicatif dans les fichiers python
 
-2. Générer la migration de manière automatique
+### 2. Générer la migration de manière automatique
 
-```
-pc alembic  revision --autogenerate -m nom_de_la_migration
-```
+⚠️ Attention à ne pas avoir de contrainte `NOT NULL` au moment du lancement de la commande : 
 
-Si [alembic ne détecte pas automatiquement les différences entre le modèle et la db](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect), générer un fichier vide : `pc alembic revision -m nom_de_la_migration`.
-
-3. Lire le fichier de migration généré et enlever les commentaires "please adjust"
-
-4. Jouer la migration :
-
-```
-pc alembic upgrade head`
+```bash
+pc alembic  revision --autogenerate --head pre@head -m nom_de_la_migration
 ```
 
-5. Tester la fonction de downgrade
+Pour générer automatiquement les migrations après l'ajout de contrainte `NOT NULL`
+
+```bash
+pc alembic  revision --autogenerate --head post@head -m nom_de_la_migration
+```
+
+Si [alembic ne détecte pas automatiquement les différences entre le modèle et la db](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#what-does-autogenerate-detect-and-what-does-it-not-detect), générer un fichier vide : 
+
+#### 2.1 Sans contrainte `NOT NULL` : 
+```bash
+pc alembic revision -m nom_de_la_migration --head pre@head.
+```
+#### 2.2 AVEC contrainte `NOT NULL` :
+```bash
+pc alembic revision -m nom_de_la_migration --head post@head.
+```
+
+### 3. Lire le fichier de migration généré et enlever les commentaires "please adjust"
+
+### 4. Jouer la migration :
+
+#### 4.1. Dans le cas d'une modification qui n'est pas une contrainte `NOT NULL` ou d'un remplissage de données : 
+
+```bash
+pc alembic upgrade pre@head
+```
+#### 4.1. Si on veut ajouter une contrainte `NOT NULL` ou remplir une nouvelle colonne :
+```bash
+pc alembic upgrade post@head
+```
+
+### 5. Tester la fonction de downgrade
 
 ```bash
 pc alembic downgrade -1
 ```
 
-Autres commandes utiles :
+## Autres commandes utiles :
 
 - Afficher le sql généré entre 2 migrations sans la jouer : `pc alembic upgrade e7b46b06f6dd:head --sql`
 
-## Do
+### Do
 
 Il est possible d'effectuer une migration soit par des commandes SQL :
 
@@ -46,7 +69,7 @@ soit par les fonctions fournies par la bibliothèque alembic:
 op.add_column('venue_provider', sa.Column('syncWorkerId', sa.VARCHAR(24), nullable=True))
 ```
 
-## Don't
+### Don't
 
 Lorsque vous souhaitez modifier la structure de plusieurs tables en même temps,
 il ne faut pas utiliser la même transaction pour l'ensemble.

--- a/api/src/pcapi/alembic/versions/20220207T154955_d3da2eac435d_fork_pre_deploy.py
+++ b/api/src/pcapi/alembic/versions/20220207T154955_d3da2eac435d_fork_pre_deploy.py
@@ -1,0 +1,16 @@
+"""fork pre-deploy
+"""
+
+# revision identifiers, used by Alembic.
+revision = "d3da2eac435d"
+down_revision = "2a111d4feac2"
+branch_labels = ("pre",)
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/alembic/versions/20220207T155219_ffafc4d7210f_fork_post_deploy.py
+++ b/api/src/pcapi/alembic/versions/20220207T155219_ffafc4d7210f_fork_post_deploy.py
@@ -1,0 +1,17 @@
+"""fork post-deploy
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = "ffafc4d7210f"
+down_revision = "2a111d4feac2"
+branch_labels = ("post",)
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/api/start-api-when-database-is-ready.sh
+++ b/api/start-api-when-database-is-ready.sh
@@ -21,7 +21,8 @@ echo >&2 -e "\n\033[0;32mPostgres is up - Install app\n"
 flask install_postgres_extensions
 
 echo >&2 -e "\n\033[0;32mPostgres is up - Running migration\n"
-alembic upgrade head
+alembic upgrade pre@head
+alembic upgrade post@head
 
 echo >&2 -e "\n\033[0;32mMigrations have run - Installing feature flags\n"
 flask install_data

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -42,7 +42,7 @@ from tests.serialization.serialization_decorator_test import test_blueprint
 def run_migrations():
     alembic_cfg = Config("alembic.ini")
     alembic_cfg.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
-    command.upgrade(alembic_cfg, "head")
+    command.upgrade(alembic_cfg, "heads")
 
 
 def pytest_configure(config):

--- a/pc
+++ b/pc
@@ -379,6 +379,7 @@ elif [[ "$CMD" == "tag" ]]; then
     git commit -m "🚀 $TAG_VERSION" -n
     git tag -a "$TAG_VERSION" -m "🚀 $TAG_VERSION"
     git push origin "$TAG_VERSION"
+    alembic revision -m "post tag $TAG_VERSION" --head=pre@head --depends-on=post@head
 
     echo "New version tagged : $TAG_NAME"
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Besoin
(Le besoin avait déjà été repéré lors de l'audit réalisé en septembre-octobre 2020, cf. [Stratégie de migrations](https://www.notion.so/Strat-gie-de-migration-1a137f4eb18a4b589079eb1d6740e939). La présente page reprend et complète le document écrit à l'époque.)

Actuellement, les migrations sont jouées exclusivement en début de déploiement, *avant* le déploiement du code. Pour ajouter une colonne pour laquelle on souhaite une contrainte NOT NULL, il faut donc faire 2 déploiements :

Le premier déploiement ajoute la colonne sans la contrainte.

Le second déploiement ajoute la contrainte.

Il est donc nécessaire de faire le suivi de ces ajouts de colonne sur 2 déploiements à suivre. Il est probable que l’ajout de contrainte NOT NULL est souvent oublié à cause de cette complication.

Nous suggérons de mettre en place un système de migrations en plusieurs phases :

application des migrations “pré-déploiement” (en l’occurrence ajout des colonnes sans contrainte NOT NULL) ;

déploiement du code ;

application des migrations “post-déploiement” (en l’occurrence remplissage des colonnes ajoutées, si nécessaire, et ajout des contraintes NOT NULL).

En bonus, on peut même prévoir un 3ème type de migration : les migrations "irréversibles" car destructives : suppression d'une colonne ou suppression d'une table. Une migration "irréversible" embarquée dans la version 10 du backend ne serait jouée que lors du déploiement de la version 11.

Un peu d’outillage est nécessaire pour mettre en place ce système, mais il facilite grandement le travail de développement.

Etapes d'implémentation
Trouver un moyen de marquer les migrations comme "pré", "post" ou "irréversible".

Trouver une commande (ou écrire un utilitaire) permettant de lancer les migrations par type : soit les "pré", soit les "post", soit les irréversibles.

Adapter le déroulement global du déploiement pour :
    1. Appliquer les migrations irréversibles de la version N-1.
    2. Appliquer les migrations pré-déploiement de la version N.
    3. Déployer le code de la version N.
    4. Appliquer les migrations post-déploiement de la version N.

 

Cf Chantier tech  https://www.notion.so/passcultureapp/S-paration-des-migrations-en-pr-et-post-d-ploiement-5a6760f405d643e78f3799c7803a98c0

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)