### PR TITLE
(Pc 13330) (CI) configure chart version per environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,9 @@ commands:
       version_file:
         type: string
     steps:
-      - run: echo "export CHART_VERSION=$(cat << parameters.version_file >> | tr -d '[:space:]')" >> $BASH_ENV
+      - run:
+          name: Export Chart Version
+          command: echo "export CHART_VERSION=$(cat <<parameters.version_file>> | grep "chartVersion" | awk -F':' '{print $2}' | tr -d '[:space:]')" >> $BASH_ENV
 
   deploy-helm-chart:
     description: Deploy Crons and worker via helm to Kubernetes Cluster
@@ -769,7 +771,7 @@ jobs:
       - authenticate_gcp:
           gcp-key-name: GCP_METIER_KEY
       - export_chart_version:
-          version_file: ~/pass-culture-deployment/helm/db-ops/chart_version.txt
+          version_file: ~/pass-culture-deployment/helm/db-ops/values.${DBOPS_ENV}.yaml
       - run:
           name: Get GKE cluster credentials
           command: gcloud container clusters get-credentials --region ${GCP_REGION} ${GKE_CLUSTER_NAME}
@@ -813,7 +815,7 @@ jobs:
           gcp-key-name: GCP_METIER_KEY
       - export_app_version
       - export_chart_version:
-          version_file: ~/pass-culture-deployment/helm/pcapi/chart_version.txt
+          version_file: ~/pass-culture-deployment/helm/pcapi/values.<<parameters.helm_environment>>.yaml
       - run:
           name: Get GKE cluster credentials
           command: gcloud container clusters get-credentials --region ${GCP_REGION} ${GKE_CLUSTER_NAME}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13330

## But de la pull request

Changer dans le job de ci `export_chart_version` le fichier contenant la version du chart pcpai

##  Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
