### PR TITLE
(PC-12932)[api] use STARTED ubble status for pending initiated uninitiated users

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -498,8 +498,6 @@ def has_user_pending_identity_check(user: users_models.User) -> bool:
             models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.PENDING,
             models.BeneficiaryFraudCheck.type.in_(models.IDENTITY_CHECK_TYPES),
             models.BeneficiaryFraudCheck.eligibilityType == user.eligibility,
-            models.BeneficiaryFraudCheck.resultContent["status"]
-            != models.ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
         ).exists()
     ).scalar()
 

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -180,7 +180,7 @@ def is_user_allowed_to_perform_ubble_check(
     return True
 
 
-def get_started_identity_check(user: users_models.User) -> typing.Optional[fraud_models.BeneficiaryFraudCheck]:
+def get_restartable_identity_checks(user: users_models.User) -> typing.Optional[fraud_models.BeneficiaryFraudCheck]:
     started_fraud_check = (
         fraud_models.BeneficiaryFraudCheck.query.filter(
             fraud_models.BeneficiaryFraudCheck.user == user,

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -101,16 +101,6 @@ def start_ubble_workflow(user: users_models.User, redirect_url: str) -> str:
     return content.identification_url
 
 
-def is_ubble_workflow_restartable(fraud_check: fraud_models.BeneficiaryFraudCheck) -> bool:
-    if fraud_check.type != fraud_models.FraudCheckType.UBBLE:
-        return False
-
-    ubble_content: ubble_fraud_models.UbbleContent = fraud_check.source_data()
-    if ubble_content.status == ubble_fraud_models.UbbleIdentificationStatus.INITIATED:
-        return True
-    return False
-
-
 def handle_validation_errors(
     user: users_models.User,
     reason_codes: typing.Optional[list[fraud_models.FraudReasonCode]],

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -337,7 +337,7 @@ def start_identification_session(
             status_code=400,
         )
 
-    fraud_check = ubble_fraud_api.get_started_identity_check(user)
+    fraud_check = ubble_fraud_api.get_restartable_identity_checks(user)
     if fraud_check:
         return serializers.IdentificationSessionResponse(identificationUrl=fraud_check.source_data().identification_url)
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -337,16 +337,9 @@ def start_identification_session(
             status_code=400,
         )
 
-    fraud_check = ubble_fraud_api.get_pending_identity_check(user)
+    fraud_check = ubble_fraud_api.get_started_identity_check(user)
     if fraud_check:
-        if ubble_subscription_api.is_ubble_workflow_restartable(fraud_check):
-            return serializers.IdentificationSessionResponse(
-                identificationUrl=fraud_check.source_data().identification_url
-            )
-        raise ApiErrors(
-            {"code": "IDCHECK_ALREADY_PROCESSED", "message": "Une identification a déjà été traitée"},
-            status_code=400,
-        )
+        return serializers.IdentificationSessionResponse(identificationUrl=fraud_check.source_data().identification_url)
 
     try:
         identification_url = ubble_subscription_api.start_ubble_workflow(user, body.redirectUrl)

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1751,32 +1751,6 @@ class IdentificationSessionTest:
         assert response.status_code == 400
         assert len(user.beneficiaryFraudChecks) == 2
 
-    def test_allow_rerun_identification_from_pending(self, client, ubble_mock):
-        user = users_factories.UserFactory(dateOfBirth=datetime.now() - relativedelta(years=18, days=5))
-        client.with_token(user.email)
-
-        expected_url = "https://id.ubble.ai/ef055567-3794-4ca5-afad-dce60fe0f227"
-
-        ubble_content = fraud_factories.UbbleContentFactory(
-            status=ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
-            identification_url=expected_url,
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            type=fraud_models.FraudCheckType.UBBLE,
-            status=fraud_models.FraudCheckStatus.PENDING,
-            user=user,
-            resultContent=ubble_content,
-        )
-        response = client.post("/native/v1/ubble_identification", json={"redirectUrl": "http://example.com/deeplink"})
-
-        assert response.status_code == 200
-        assert len(user.beneficiaryFraudChecks) == 1
-        assert ubble_mock.call_count == 0
-
-        check = user.beneficiaryFraudChecks[0]
-        assert check.type == fraud_models.FraudCheckType.UBBLE
-        assert response.json["identificationUrl"] == expected_url
-
     def test_allow_rerun_identification_from_started(self, client, ubble_mock):
         user = users_factories.UserFactory(dateOfBirth=datetime.now() - relativedelta(years=18, days=5))
         client.with_token(user.email)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -64,7 +64,7 @@ class NextStepTest:
         "fraud_check_status,reason_code,ubble_status,next_step,pending_idcheck",
         [
             (
-                fraud_models.FraudCheckStatus.PENDING,
+                fraud_models.FraudCheckStatus.STARTED,
                 None,
                 ubble_fraud_models.UbbleIdentificationStatus.INITIATED,
                 "identity-check",
@@ -105,9 +105,6 @@ class NextStepTest:
                 "identity-check",  # User can retry
                 False,
             ),
-            (None, None, ubble_fraud_models.UbbleIdentificationStatus.INITIATED, "identity-check", False),
-            (None, None, ubble_fraud_models.UbbleIdentificationStatus.PROCESSING, "honor-statement", False),
-            (None, None, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED, "honor-statement", False),
         ],
     )
     @override_features(ENABLE_UBBLE=True)
@@ -422,7 +419,7 @@ class NextStepTest:
             type=fraud_models.FraudCheckType.UBBLE,
             user=user,
             resultContent=ubble_content,
-            status=fraud_models.FraudCheckStatus.PENDING,
+            status=fraud_models.FraudCheckStatus.STARTED,
         )
         client.with_token(user.email)
         response = client.get("/native/v1/subscription/next_step")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12932

## But de la pull request

Utilisation généralisée du statut `STARTED` ubble dans le processus de vérification.

##  Implémentation

Rattrapage des utilisateurs à la fois PENDING et INITIATED/UNINITIATED pour les passer en ubble status `STARTED`. Rattrapage effectué le 7 février en prod.

Suppression des vérifications sur le statut Initiated/uninitiated du fraud_check

##  Informations supplémentaires

- Le script passé en prod pour passer tous les PENDING INITIATED/UNINITIATED à STARTED est publié en commentaire du ticket JIRA. Il n'est pas commité pour ne pas alourdir la codebase.


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
