### PR TITLE
(PC-13364) Add advices to venue image upload

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,11 @@ Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX
 
 _Ajout de fonctionnalités, Problèmes résolus, etc_
 
-##  Implémentation
+## Implémentation
 
 - _Exemples: Ajouts de modèles, Changements significatifs_
 
-##  Informations supplémentaires
+## Informations supplémentaires
 
 - _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
 - _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_
@@ -16,9 +16,9 @@ _Ajout de fonctionnalités, Problèmes résolus, etc_
 ## Checklist :
 
 - [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
-    - Branche : `pc-XXX-whatever-describe-the-branch`
-    - PR : `(PC-XXX) Description rapide de l' US`
-    - Commit(s) : `[PC-XXX] description rapide du ticket`
+  - Branche : `pc-XXX-whatever-describe-the-branch`
+  - PR : `(PC-XXX) Description rapide de l' US`
+  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
 - [ ] J'ai écrit les tests nécessaires
 - [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
 - [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.module.scss
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.module.scss
@@ -7,4 +7,9 @@
   &-header {
     @include title3;
   }
+  &-hr {
+    background: $grey-medium;
+    height: rem(1px);
+    width: 100%;
+  }
 }

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.module.scss
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.module.scss
@@ -7,9 +7,8 @@
   &-header {
     @include title3;
   }
-  &-hr {
-    background: $grey-medium;
-    height: rem(1px);
+
+  &-horizontal-rule {
     width: 100%;
   }
 }

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.tsx
@@ -47,7 +47,7 @@ export const ImportFromComputer: FunctionComponent<ImportFromComputerProps> = ({
           constraints={constraints}
           failingConstraints={errors}
         />
-        <hr className="tnd-hr" />
+        <hr className={style['import-from-computer-hr']} />
         <Advices hidden={hidden} setHidden={setHidden} />
       </form>
     </section>

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.tsx
@@ -1,5 +1,6 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useState } from 'react'
 
+import Advices from 'new_components/Advices/Advices'
 import { ConstraintCheck } from 'new_components/ConstraintCheck/ConstraintCheck'
 import { Constraint } from 'new_components/ConstraintCheck/imageConstraints'
 import { useCheckAndSetImage } from 'new_components/ConstraintCheck/useCheckAndSetImage'
@@ -22,6 +23,7 @@ export const ImportFromComputer: FunctionComponent<ImportFromComputerProps> = ({
   orientation,
   onSetImage,
 }) => {
+  const [hidden, setHidden] = useState(true)
   const { errors, checkAndSetImage } = useCheckAndSetImage({
     constraints,
     onSetImage,
@@ -45,6 +47,8 @@ export const ImportFromComputer: FunctionComponent<ImportFromComputerProps> = ({
           constraints={constraints}
           failingConstraints={errors}
         />
+        <hr className="tnd-hr" />
+        <Advices hidden={hidden} setHidden={setHidden} />
       </form>
     </section>
   )

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImportFromComputer/ImportFromComputer.tsx
@@ -6,6 +6,7 @@ import { Constraint } from 'new_components/ConstraintCheck/imageConstraints'
 import { useCheckAndSetImage } from 'new_components/ConstraintCheck/useCheckAndSetImage'
 import { ImportFromComputerInput } from 'new_components/ImportFromComputerInput/ImportFromComputerInput'
 import { PreferredOrientation } from 'new_components/PreferredOrientation/PreferredOrientation'
+import { Divider } from 'ui-kit'
 
 import style from './ImportFromComputer.module.scss'
 
@@ -47,7 +48,10 @@ export const ImportFromComputer: FunctionComponent<ImportFromComputerProps> = ({
           constraints={constraints}
           failingConstraints={errors}
         />
-        <hr className={style['import-from-computer-hr']} />
+        <Divider
+          className={style['import-from-computer-horizontal-rule']}
+          size="large"
+        />
         <Advices hidden={hidden} setHidden={setHidden} />
       </form>
     </section>

--- a/pro/src/components/pages/Offers/Offer/Thumbnail/ThumbnailDialog.jsx
+++ b/pro/src/components/pages/Offers/Offer/Thumbnail/ThumbnailDialog.jsx
@@ -7,11 +7,11 @@ import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { IMPORT_TAB_ID } from 'components/pages/Offers/Offer/Thumbnail/_constants'
-import Advices from 'components/pages/Offers/Offer/Thumbnail/Advices/Advices'
 import Credit from 'components/pages/Offers/Offer/Thumbnail/Credit/Credit'
 import ImageEditorWrapper from 'components/pages/Offers/Offer/Thumbnail/ImageEditor/ImageEditorWrapper'
 import ImportFromComputer from 'components/pages/Offers/Offer/Thumbnail/ImportFromComputer/ImportFromComputer'
 import OfferPreview from 'components/pages/Offers/Offer/Thumbnail/Preview/OfferPreview'
+import Advices from 'new_components/Advices/Advices'
 import DialogBox from 'new_components/DialogBox/DialogBox'
 
 const ThumbnailDialog = ({

--- a/pro/src/new_components/Advices/Advices.jsx
+++ b/pro/src/new_components/Advices/Advices.jsx
@@ -1,8 +1,3 @@
-/*
- * @debt complexity "Gaël: file nested too deep in directory structure"
- * @debt directory "Gaël: this file should be migrated within the new directory structure"
- */
-
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useRef } from 'react'
 

--- a/pro/src/new_components/Advices/Advices.tsx
+++ b/pro/src/new_components/Advices/Advices.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as ExternalSite } from 'components/pages/Offers/Offer/Th
 interface Props {
   hidden: boolean
   setHidden: (hidden: boolean) => void
+  children?: never
 }
 
 const Advices: FunctionComponent<Props> = ({ hidden, setHidden }) => {

--- a/pro/src/new_components/Advices/Advices.tsx
+++ b/pro/src/new_components/Advices/Advices.tsx
@@ -1,19 +1,23 @@
-import PropTypes from 'prop-types'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { FunctionComponent, useCallback, useEffect, useRef } from 'react'
 
 import { NBSP } from 'components/pages/Offers/Offer/Thumbnail/_constants'
 import { ReactComponent as ArrowDown } from 'components/pages/Offers/Offer/Thumbnail/assets/arrow-down.svg'
 import { ReactComponent as ArrowUp } from 'components/pages/Offers/Offer/Thumbnail/assets/arrow-up.svg'
 import { ReactComponent as ExternalSite } from 'components/pages/Offers/Offer/Thumbnail/assets/external-site.svg'
 
-const Advices = ({ hidden, setHidden }) => {
+interface Props {
+  hidden: boolean
+  setHidden: (hidden: boolean) => void
+}
+
+const Advices: FunctionComponent<Props> = ({ hidden, setHidden }) => {
   const toggle = useCallback(() => {
     setHidden(!hidden)
   }, [hidden, setHidden])
 
-  const defaultTargetedButton = useRef(null)
+  const defaultTargetedButton = useRef<HTMLButtonElement>(null)
   useEffect(() => {
-    defaultTargetedButton.current.focus()
+    defaultTargetedButton.current?.focus()
   }, [])
 
   return (
@@ -76,11 +80,6 @@ const Advices = ({ hidden, setHidden }) => {
       </div>
     </div>
   )
-}
-
-Advices.propTypes = {
-  hidden: PropTypes.bool.isRequired,
-  setHidden: PropTypes.func.isRequired,
 }
 
 export default Advices

--- a/pro/src/ui-kit/Divider/Divider.module.scss
+++ b/pro/src/ui-kit/Divider/Divider.module.scss
@@ -4,4 +4,8 @@
   &.divider-medium {
     margin: rem(16px) 0 rem(16px) 0;
   }
+
+  &.divider-large {
+    margin: rem(24px) 0 rem(24px) 0;
+  }
 }

--- a/pro/src/ui-kit/Divider/Divider.tsx
+++ b/pro/src/ui-kit/Divider/Divider.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react'
 
 import styles from './Divider.module.scss'
 
-type Size = 'medium'
+type Size = 'medium' | 'large'
 interface IDividerProps {
   size?: Size
   className?: string
@@ -12,6 +12,7 @@ interface IDividerProps {
 const Divider: FC<IDividerProps> = ({ size, className }) => {
   const sizeClassName = {
     medium: styles['divider-medium'],
+    large: styles['divider-large'],
   }[size || 'medium']
 
   return (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13364

## But de la pull request

Ajouter les conseils sur la modale d'upload d'une image pour les lieux

##  Implémentation

- Extraction du composant 'Advices' ;
- Import et utilisation dans la modale d'upload d'image

##  Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
<img width="590" alt="image" src="https://user-images.githubusercontent.com/74320569/153209850-f3961e62-5a0e-49bd-a3c4-b1fa5d6096da.png">
