### PR TITLE
[PC-12485](CI) Service Account authentification from stdin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ executors:
 ###################
 
 commands:
+
   notify-slack:
     description: Send notification to Slack
     parameters:
@@ -117,14 +118,14 @@ commands:
                 exit 0;
             fi
             circleci step halt;
+
   authenticate_gcp:
     description: Authenticate to a GCP project
     parameters:
       gcp-key-name:
         type: env_var_name
     steps:
-      - run: echo ${<< parameters.gcp-key-name >>} > ${HOME}/gcp-key.json
-      - run: gcloud auth activate-service-account --key-file ${HOME}/gcp-key.json
+      - run: echo ${<< parameters.gcp-key-name >>} | gcloud auth activate-service-account --key-file=-
       - run: gcloud --quiet config set project ${GCP_PROJECT}
 
   export_app_version:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12485

## But de la pull request

Permet de s’authentifier depuis la sortie stdin et non avec un fichier

##  Implémentation

N/A

##  Informations supplémentaires

N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
