### PR TITLE
(PC-13162) [API+PRO] Display showcase offer on pro

### DIFF
--- a/api/src/pcapi/domain/pro_offers/offers_recap.py
+++ b/api/src/pcapi/domain/pro_offers/offers_recap.py
@@ -59,6 +59,7 @@ class OfferRecap:
         venue_departement_code: Optional[str],
         stocks: list[dict],
         status: str,
+        is_showcase: bool,
     ):
         self.id = id
         self.has_booking_limit_datetimes_passed = has_booking_limit_datetimes_passed
@@ -90,6 +91,7 @@ class OfferRecap:
             for stock in stocks
         ]
         self.status = status
+        self.is_showcase = is_showcase
 
 
 class OffersRecap:

--- a/api/src/pcapi/infrastructure/repository/pro_offers/offers_recap_domain_converter.py
+++ b/api/src/pcapi/infrastructure/repository/pro_offers/offers_recap_domain_converter.py
@@ -34,6 +34,7 @@ def _offer_recap_to_domain(offer: Offer) -> OfferRecap:
         venue_departement_code=offer.venue.departementCode,
         stocks=stocks,
         status=offer.status.name,
+        is_showcase=offer.extraData.get("isShowcase") if offer.extraData else None,
     )
 
 

--- a/api/src/pcapi/routes/serialization/offers_recap_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_recap_serialize.py
@@ -28,6 +28,7 @@ def _serialize_offer_paginated(offer: OfferRecap) -> dict:
         "venue": _serialize_venue(offer.venue),
         "venueId": humanize(offer.venue.id),
         "status": offer.status,
+        "isShowcase": offer.is_showcase,
     }
 
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -12,6 +12,7 @@ from pcapi.core.bookings.api import compute_cancellation_limit_date
 from pcapi.core.categories.conf import can_create_from_isbn
 from pcapi.core.categories.subcategories import SubcategoryIdEnum
 from pcapi.core.offers import repository as offers_repository
+from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferStatus
 from pcapi.core.offers.models import Stock
 from pcapi.models.feature import FeatureToggle
@@ -327,6 +328,7 @@ class ListOffersOfferResponseModel(BaseModel):
     venue: ListOffersVenueResponseModel
     status: str
     venueId: str
+    isShowcase: Optional[bool]
 
 
 class ListOffersResponseModel(BaseModel):

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -12,7 +12,6 @@ from pcapi.core.bookings.api import compute_cancellation_limit_date
 from pcapi.core.categories.conf import can_create_from_isbn
 from pcapi.core.categories.subcategories import SubcategoryIdEnum
 from pcapi.core.offers import repository as offers_repository
-from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferStatus
 from pcapi.core.offers.models import Stock
 from pcapi.models.feature import FeatureToggle

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -74,6 +74,7 @@ class Returns200Test:
                     "publicName": "My public name",
                 },
                 "venueId": humanize(requested_venue.id),
+                "isShowcase": None,
             }
         ]
 

--- a/api/tests/routes/serialization/offers_recap_serialize_test.py
+++ b/api/tests/routes/serialization/offers_recap_serialize_test.py
@@ -39,6 +39,7 @@ def should_return_serialized_offers_with_relevant_informations():
         venue_departement_code=departement_code,
         stocks=[stock],
         status="ACTIVE",
+        is_showcase=False,
     )
     offers_recap = OffersRecap(offers_recap=[offer])
 

--- a/api/tests/routes/serialization/offers_recap_serialize_test.py
+++ b/api/tests/routes/serialization/offers_recap_serialize_test.py
@@ -80,6 +80,7 @@ def should_return_serialized_offers_with_relevant_informations():
                 "publicName": "Petite librairie",
             },
             "venueId": humanize(venue_id),
+            "isShowcase": False,
         }
     ]
     assert result == expected_serialized_offer

--- a/pro/src/components/pages/Offers/Offers/OfferItem/OfferItem.jsx
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/OfferItem.jsx
@@ -20,7 +20,7 @@ import { formatLocalTimeDateString } from 'utils/timezone'
 import useOfferStockEditionURL from '../../../../hooks/useOfferStockEditionURL'
 
 const OfferItem = ({ disabled, offer, isSelected, selectOffer }) => {
-  const { venue, stocks, id, isEducational } = offer
+  const { venue, stocks, id, isEducational, isShowcase } = offer
 
   const editionOfferLink = useOfferEditionURL(isEducational, id)
   const editionStockLink = useOfferStockEditionURL(isEducational, id)
@@ -55,6 +55,9 @@ const OfferItem = ({ disabled, offer, isSelected, selectOffer }) => {
     offer.status !== OFFER_STATUS_SOLD_OUT
 
   const getDateInformations = () => {
+    if (isShowcase) {
+      return 'Date et prix à définir'
+    }
     return stockSize === 1
       ? formatLocalTimeDateString(
           stocks[0].beginningDatetime,
@@ -180,6 +183,7 @@ OfferItem.propTypes = {
     isEvent: PropTypes.bool,
     productIsbn: PropTypes.string,
     isEducational: PropTypes.bool,
+    isShowcase: PropTypes.bool,
   }).isRequired,
   selectOffer: PropTypes.func.isRequired,
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13162

## But de la pull request

Afficher les offres vitrines avec un label différent pour la date sur la liste des offres de PRO
<img width="862" alt="Capture d’écran 2022-02-10 à 15 31 55" src="https://user-images.githubusercontent.com/35567446/153428821-030a0d94-688d-4506-a8f5-ccc1da093398.png">
