### PR TITLE
(PC-12014) script to manage old offerers without siren

### DIFF
--- a/api/src/pcapi/scripts/offerer/manage_offerer_without_siren.py
+++ b/api/src/pcapi/scripts/offerer/manage_offerer_without_siren.py
@@ -1,0 +1,61 @@
+import logging
+from typing import Iterable
+
+from sqlalchemy import and_
+from sqlalchemy.orm.exc import NoResultFound
+
+from pcapi.core.bookings.exceptions import CannotDeleteVenueWithBookingsException
+from pcapi.core.bookings.models import Booking
+from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import Venue
+from pcapi.models import db
+from pcapi.scripts.offerer.delete_cascade_venue_by_id import delete_cascade_venue_by_id
+
+
+logger = logging.getLogger(__name__)
+
+
+def manage_offerer_without_siren(offerer_ids: Iterable[int]) -> None:
+    soft_deleted_offerer = []
+    offerers_with_booking_not_reimbursed = []
+    not_existing_offerers = []
+    for offerer_id in offerer_ids:
+        should_offerer_be_soft_deleted = True
+        try:
+            offerer = Offerer.query.filter(Offerer.id == offerer_id).one()
+        except NoResultFound:
+            not_existing_offerers.append(offerer_id)
+        venues = Venue.query.filter(Venue.managingOffererId == offerer.id).all()
+        for venue in venues:
+            venue_has_not_reimbursed_bookings = db.session.query(
+                Booking.query.filter(
+                    Booking.venueId == venue.id,
+                    and_(Booking.status != BookingStatus.REIMBURSED, Booking.status != BookingStatus.CANCELLED),
+                ).exists()
+            ).scalar()
+            if venue_has_not_reimbursed_bookings:
+                should_offerer_be_soft_deleted = False
+            else:
+                try:
+                    delete_cascade_venue_by_id(venue.id)
+                except CannotDeleteVenueWithBookingsException:
+                    logging.info(
+                        "Cannot delete venue with booking",
+                        extra={
+                            "OffererId": offerer_id,
+                            "VenueId": venue.id,
+                        },
+                    )
+        if should_offerer_be_soft_deleted:
+            soft_deleted_offerer.append(offerer_id)
+            offerer.isActive = False
+        else:
+            offerers_with_booking_not_reimbursed.append(offerer_id)
+    db.session.commit()
+    recap_data = {
+        "soft_deleted_offerer": soft_deleted_offerer,
+        "offerers_with_booking_not_reimbursed": offerers_with_booking_not_reimbursed,
+        "not_existing_offerers": not_existing_offerers,
+    }
+    logging.info("Manage offerers without siren", extra=recap_data)

--- a/api/src/pcapi/scripts/pro/migrate_offers_to_venue.py
+++ b/api/src/pcapi/scripts/pro/migrate_offers_to_venue.py
@@ -1,0 +1,34 @@
+import logging
+
+from pcapi.core.bookings.models import Booking
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.models import Offer
+from pcapi.models import db
+from pcapi.scripts.offerer.delete_cascade_venue_by_id import delete_cascade_venue_by_id
+
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_offers_to_venue(source_venue_id: int, target_venue_id: int, delete_source_venue: bool = False) -> None:
+    source_venue = Venue.query.filter(Venue.id == source_venue_id).one()
+    target_venue = Venue.query.filter(Venue.id == target_venue_id).one()
+
+    source_bookings = Booking.query.filter(Booking.venueId == source_venue.id).all()
+    for booking in source_bookings:
+        booking.venueId = target_venue.id
+        booking.offererId = target_venue.managingOfferer.id
+
+    source_offers = Offer.query.filter(Offer.venueId == source_venue.id).all()
+    for offer in source_offers:
+        offer.venueId = target_venue.id
+    db.session.commit()
+
+    if delete_source_venue:
+        delete_cascade_venue_by_id(source_venue.id)
+
+    recap_data = {
+        "source_venue": source_venue_id,
+        "target_venue": target_venue_id,
+    }
+    logging.info("Migrate offers to venue", extra=recap_data)

--- a/api/tests/scripts/offerer/manage_offerer_without_siren_test.py
+++ b/api/tests/scripts/offerer/manage_offerer_without_siren_test.py
@@ -48,7 +48,7 @@ def test_manage_offerer_without_siren():
     # Then
     assert offerer_without_venue.isActive == False
     assert offerer_without_offer.isActive == False
-    # # one venue was deleted
+    # one venue was deleted
     assert Venue.query.count() == 2
     assert offerer_with_all_bookings_reimbursed.isActive == False
     assert offerer_with_booking_not_reimbursed.isActive == True

--- a/api/tests/scripts/offerer/manage_offerer_without_siren_test.py
+++ b/api/tests/scripts/offerer/manage_offerer_without_siren_test.py
@@ -1,0 +1,54 @@
+import pytest
+
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.factories import OffererFactory
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.scripts.offerer.manage_offerer_without_siren import manage_offerer_without_siren
+
+
+@pytest.mark.usefixtures("db_session")
+def test_manage_offerer_without_siren():
+    # Given
+    offerer_without_venue = OffererFactory(siren=None)
+
+    offerer_without_offer = OffererFactory(siren=None)
+    VenueFactory(managingOfferer=offerer_without_offer)
+
+    offerer_with_all_bookings_reimbursed = OffererFactory(siren=None)
+    venue_with_all_bookings_reimbursed = VenueFactory(managingOfferer=offerer_with_all_bookings_reimbursed)
+    BookingFactory(
+        stock__offer__venue=venue_with_all_bookings_reimbursed,
+        offerer=offerer_with_all_bookings_reimbursed,
+        status=BookingStatus.REIMBURSED,
+    )
+    BookingFactory(
+        stock__offer__venue=venue_with_all_bookings_reimbursed,
+        offerer=offerer_with_all_bookings_reimbursed,
+        status=BookingStatus.CANCELLED,
+    )
+
+    offerer_with_booking_not_reimbursed = OffererFactory(siren=None)
+    venue_with_booking_not_reimbursed = VenueFactory(managingOfferer=offerer_with_booking_not_reimbursed)
+    BookingFactory(
+        stock__offer__venue=venue_with_booking_not_reimbursed,
+        status=BookingStatus.USED,
+    )
+
+    # When
+    ids = [
+        offerer_without_venue.id,
+        offerer_without_offer.id,
+        offerer_with_all_bookings_reimbursed.id,
+        offerer_with_booking_not_reimbursed.id,
+    ]
+    manage_offerer_without_siren(ids)
+
+    # Then
+    assert offerer_without_venue.isActive == False
+    assert offerer_without_offer.isActive == False
+    # # one venue was deleted
+    assert Venue.query.count() == 2
+    assert offerer_with_all_bookings_reimbursed.isActive == False
+    assert offerer_with_booking_not_reimbursed.isActive == True

--- a/api/tests/scripts/pro/migrate_offers_to_venue_test.py
+++ b/api/tests/scripts/pro/migrate_offers_to_venue_test.py
@@ -1,0 +1,50 @@
+import pytest
+
+from pcapi.core.bookings.factories import BookingFactory
+from pcapi.core.bookings.models import Booking
+from pcapi.core.offerers.models import Venue
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.core.offers.models import Offer
+from pcapi.models import db
+from pcapi.scripts.pro.migrate_offers_to_venue import migrate_offers_to_venue
+
+
+@pytest.mark.usefixtures("db_session")
+def test_migrate_offers_to_venue():
+    # Given
+    source_venue = VenueFactory()
+    BookingFactory(venueId=source_venue.id, offererId=source_venue.managingOfferer.id, stock__offer__venue=source_venue)
+    BookingFactory(venueId=source_venue.id, offererId=source_venue.managingOfferer.id, stock__offer__venue=source_venue)
+    target_venue = VenueFactory()
+    BookingFactory(venueId=target_venue.id, offererId=target_venue.managingOfferer.id, stock__offer__venue=target_venue)
+
+    # When
+    migrate_offers_to_venue(source_venue_id=source_venue.id, target_venue_id=target_venue.id)
+
+    # Then
+    # don't loose anything
+    assert Offer.query.count() == 3
+    assert Booking.query.count() == 3
+    assert Venue.query.count() == 2
+    # Offers and bookings have been migrated
+    assert Offer.query.filter(Offer.venueId == target_venue.id).count() == 3
+    assert Booking.query.filter(Booking.venueId == target_venue.id).count() == 3
+    assert Booking.query.filter(Booking.offererId == target_venue.managingOfferer.id).count() == 3
+    # There is anything left in source venue
+    assert Offer.query.filter(Offer.venueId == source_venue.id).count() == 0
+    assert Booking.query.filter(Booking.venueId == source_venue.id).count() == 0
+    assert Booking.query.filter(Booking.offererId == source_venue.managingOfferer.id).count() == 0
+
+
+@pytest.mark.usefixtures("db_session")
+def test_migrate_offers_to_venue_delete_source_venue():
+    # Given
+    source_venue = VenueFactory()
+    target_venue = VenueFactory()
+
+    # When
+    migrate_offers_to_venue(source_venue_id=source_venue.id, target_venue_id=target_venue.id, delete_source_venue=True)
+
+    # Then
+    assert Venue.query.count() == 1
+    assert db.session.query(Venue.query.filter(Venue.id == target_venue.id).exists()).scalar()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12014

## But de la pull request

Créer un script pour nettoyer des offerers : 
- les offerers sans lieu sont soft delete
- les offerers sans offres sont soft delete
- les offerers avec réservations toutes remboursées ou annulées sont soft delete
- les offerers avec réservations non remboursées ou non annulées ne sont pas soft delete 
- les venues pouvant être supprimée le sont

Créer un autre script pour migrer des offres et leur bookings d'une venue vers une autre

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
