### PR TITLE
(PC-13280)[api]finance: fix assertion error in _make_invoice_line()

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -789,7 +789,7 @@ def find_reimbursement_rule(rule_reference: [str, int]) -> payments_models.Reimb
     return payments_models.CustomReimbursementRule.query.get(rule_reference)
 
 
-def _make_invoice_line(invoice: models.Invoice, group: conf.RuleGroups, pricings: list):
+def _make_invoice_line(group: conf.RuleGroups, pricings: list, line_rate: decimal.Decimal = None):
     reimbursed_amount = 0
     flat_lines = list(itertools.chain.from_iterable(pricing.lines for pricing in pricings))
     # positive
@@ -805,8 +805,10 @@ def _make_invoice_line(invoice: models.Invoice, group: conf.RuleGroups, pricings
     )
 
     reimbursed_amount += offerer_revenue + contribution_amount + passculture_commission
-
-    rate = decimal.Decimal(reimbursed_amount / offerer_revenue).quantize(decimal.Decimal("0.0001"))
+    # A rate is calculated for this line if we are using a CustomRule with an amount instead of a rate
+    rate = line_rate or (decimal.Decimal(reimbursed_amount) / decimal.Decimal(offerer_revenue)).quantize(
+        decimal.Decimal("0.0001")
+    )
     invoice_line = models.InvoiceLine(
         label="Montant remboursé",
         group=group.value,
@@ -884,13 +886,13 @@ def _generate_invoice(business_unit_id: int, cashflow_ids: list[int]):
         for pricing, rate in pricings_and_rates:
             rates[rate].append(pricing)
         for rate, pricings in rates.items():
-            invoice_line, reimbursed_amount = _make_invoice_line(invoice, rule_group, pricings)
-            assert invoice_line.rate == rate
+            invoice_line, reimbursed_amount = _make_invoice_line(rule_group, pricings, rate)
             invoice_lines.append(invoice_line)
             total_reimbursed_amount += reimbursed_amount
 
     for custom_rule, pricings in pricings_by_custom_rule.items():
-        invoice_line, reimbursed_amount = _make_invoice_line(invoice, custom_rule.group, pricings)
+        # An InvoiceLine rate will be calculated for a CustomRule with a set reimbursed amount
+        invoice_line, reimbursed_amount = _make_invoice_line(custom_rule.group, pricings, custom_rule.rate)
         invoice_lines.append(invoice_line)
         total_reimbursed_amount += reimbursed_amount
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -57,7 +57,7 @@ def create_specific_invoice():
     stocks = [
         offers_factories.StockFactory(offer=thing_offer1, price=30),
         offers_factories.StockFactory(offer=book_offer1, price=20),
-        offers_factories.StockFactory(offer=thing_offer2, price=80),
+        offers_factories.StockFactory(offer=thing_offer2, price=81.3),
         offers_factories.StockFactory(offer=book_offer2, price=40),
         offers_factories.StockFactory(offer=digital_offer1, price=27),
         offers_factories.StockFactory(offer=digital_offer2, price=31),

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -764,7 +764,7 @@ def invoice_test_data():
         offers_factories.StockFactory(offer=thing_offer1, price=30),
         offers_factories.StockFactory(offer=book_offer1, price=20),
         offers_factories.StockFactory(offer=thing_offer2, price=19_950),
-        offers_factories.StockFactory(offer=thing_offer2, price=80),
+        offers_factories.StockFactory(offer=thing_offer2, price=81.3),
         offers_factories.StockFactory(offer=book_offer2, price=40),
         offers_factories.StockFactory(offer=digital_offer1, price=27),
         offers_factories.StockFactory(offer=digital_offer2, price=31),
@@ -958,7 +958,7 @@ class GenerateInvoiceTest:
         assert len(invoice.cashflows) == 2
         assert invoice.reference == "F220000001"
         assert invoice.businessUnit == business_unit
-        assert invoice.amount == -20_154.8 * 100
+        assert invoice.amount == -20_156_04
         # général 100%, général 95%, livre 100%, livre 95%, pas remboursé, custom 1, custom 2
         assert len(invoice.lines) == 7
 
@@ -974,8 +974,8 @@ class GenerateInvoiceTest:
 
         line1 = invoice_lines[1]
         assert line1.group == {"label": "Barème général", "position": 1}
-        assert line1.contributionAmount == 4 * 100
-        assert line1.reimbursedAmount == -76 * 100
+        assert line1.contributionAmount == 406
+        assert line1.reimbursedAmount == -7724
         assert line1.rate == Decimal("0.9500")
         assert line1.label == "Montant remboursé"
 
@@ -1009,8 +1009,8 @@ class GenerateInvoiceTest:
 
         line6 = invoice_lines[6]
         assert line6.group == {"label": "Barème dérogatoire", "position": 4}
-        assert line6.contributionAmount == 1.2 * 100
-        assert line6.reimbursedAmount == -18.8 * 100
+        assert line6.contributionAmount == 120
+        assert line6.reimbursedAmount == -1880
         assert line6.rate == Decimal("0.9400")
         assert line6.label == "Montant remboursé"
 
@@ -1053,9 +1053,9 @@ class PrepareInvoiceContextTest:
         invoice = api._generate_invoice(business_unit_id=business_unit.id, cashflow_ids=cashflow_ids)
         context = api._prepare_invoice_context(invoice)
         general, books, not_reimbursed, custom = tuple(g for g in context["groups"])
-        assert general.used_bookings_subtotal == 2006000
-        assert general.contribution_subtotal == 400
-        assert general.reimbursed_amount_subtotal == -2005600
+        assert general.used_bookings_subtotal == 2006130
+        assert general.contribution_subtotal == 406
+        assert general.reimbursed_amount_subtotal == -2005724
 
         assert books.used_bookings_subtotal == 6000
         assert books.contribution_subtotal == 200
@@ -1070,9 +1070,9 @@ class PrepareInvoiceContextTest:
         assert custom.reimbursed_amount_subtotal == -4080
 
         assert context["invoice"] == invoice
-        assert context["total_used_bookings_amount"] == 2022100
-        assert context["total_contribution_amount"] == 6620
-        assert context["total_reimbursed_amount"] == -2015480
+        assert context["total_used_bookings_amount"] == 2022230
+        assert context["total_contribution_amount"] == 6626
+        assert context["total_reimbursed_amount"] == -2015604
 
 
 class GenerateInvoiceHtmlTest:

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -224,19 +224,19 @@
     <tr>
         <td class="headRow">Montant remboursé</td>
         <td>95 %</td>
-        <td>80,00 €</td>
+        <td>81,30 €</td>
         <td>5 %</td>
-        <td>4,00 €</td>
-        <td>76,00 €</td>
+        <td>4,06 €</td>
+        <td>77,24 €</td>
     </tr>
 
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>20 060,00 €</td>
+        <td>20 061,30 €</td>
         <td></td>
-        <td>4,00 €</td>
-        <td>20 056,00 €</td>
+        <td>4,06 €</td>
+        <td>20 057,24 €</td>
     </tr>
 
     <tr class="coloredSection">
@@ -326,10 +326,10 @@
     <tr class="bottomTableText">
         <td class="headRow">TOTAL</td>
         <td></td>
-        <td>20 221,00 €</td>
+        <td>20 222,30 €</td>
         <td></td>
-        <td>66,20 €</td>
-        <td>20 154,80 €</td>
+        <td>66,26 €</td>
+        <td>20 156,04 €</td>
     </tr>
     </tbody>
 </table>
@@ -366,13 +366,13 @@
         <td>Virement FR2710010000000000000000064</td>
         <td class="cashflow_id">2</td>
         <td class="cashflow_creation_date">21/12/2021</td>
-        <td>154,80 €</td>
+        <td>156,04 €</td>
         <td> SARL LIBRAIRIE BOOKING</td>
     </tr>
 
     <tr class="coloredSection bottomTableText">
         <td class="headRow" colspan="3">TOTAL RÈGLEMENT PASS CULTURE</td>
-        <td>20 154,80 €</td>
+        <td>20 156,04 €</td>
     </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13280

## But de la pull request

Corriger une erreur lors de la génération des justificatifs de remboursement, causée par une assertion sur `InvoiceLine.rate`


##  Implémentation

Supprimer l'assertion, et utiliser le `rate` de la règle de remboursement, ou un `rate` calculé seulement dans le cas d'une règle de remboursement personnalisée qui définit un `amount`.


##  Informations supplémentaires

- Modification des données de test permettant de détecter ce bug.
- Utiliser des `int` dans les assertions de tests, au lieu de `float` multiplié par 100, certes plus lisibles mais pouvant causer des erreurs d'approximation, par exemple:
```
In [1]: 4.06 * 100
Out[1]: 405.99999999999994
```
- Modification de `create_specific_invoice()` dans la sandbox

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
