### PR TITLE
(PC-8955) api: User suspension history

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-e6b4ede78bb3 (head)
+4e4384ac4c8f (head)

--- a/api/src/pcapi/admin/custom_views/admin_user_view.py
+++ b/api/src/pcapi/admin/custom_views/admin_user_view.py
@@ -55,10 +55,11 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
         has_underage_beneficiary_role="Bénéficiaire 15-17 ?",
         isEmailValidated="Email validé ?",
         publicName="Nom d'utilisateur",
+        suspension_history="Historique de suspension",
     )
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
     column_filters = ["email", "isEmailValidated"]
-    column_details_list = ["comment"]
+    column_details_list = ["suspension_history", "comment"]
 
     @property
     def form_columns(self):

--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -172,6 +172,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "roles",
         "subscriptionState",
         "suspensionReason",
+        "suspension_history",
     ]
 
     column_labels = dict(
@@ -195,6 +196,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         physical_remaining="Crédit physique restant",
         postalCode="Code postal",
         publicName="Nom d'utilisateur",
+        suspension_history="Historique de suspension",
         total_remaining="Crédit global restant",
         total_initial="Crédit initial",
     )
@@ -290,6 +292,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
             User.query.filter(User.has_pro_role.is_(False))
             .filter(User.is_beneficiary.is_(True))
             .options(joinedload(User.deposits))
+            .options(joinedload(User.suspension_history))
         )
 
     def get_count_query(self) -> query:

--- a/api/src/pcapi/admin/custom_views/partner_user_view.py
+++ b/api/src/pcapi/admin/custom_views/partner_user_view.py
@@ -63,11 +63,12 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
         phoneNumber="Numéro de téléphone",
         postalCode="Code postal",
         isEmailValidated="Email validé ?",
+        suspension_history="Historique de suspension",
     )
 
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
     column_filters = ["isEmailValidated"]
-    column_details_list = ["comment"]
+    column_details_list = ["suspension_history", "comment"]
 
     @property
     def form_columns(self):

--- a/api/src/pcapi/admin/custom_views/pro_user_view.py
+++ b/api/src/pcapi/admin/custom_views/pro_user_view.py
@@ -94,10 +94,11 @@ class ProUserView(SuspensionMixin, BaseAdminView):
         validationToken="Jeton de validation d'adresse email",
         has_beneficiary_role="Bénéficiaire 18 ans ?",
         has_underage_beneficiary_role="Bénéficiaire 15-17 ?",
+        suspension_history="Historique de suspension",
     )
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
     column_filters = ["postalCode", "has_beneficiary_role", "has_underage_beneficiary_role", "isEmailValidated"]
-    column_details_list = ["comment"]
+    column_details_list = ["suspension_history", "comment"]
 
     form_create_rules = (
         rules.Header("Utilisateur créé :"),

--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -254,3 +254,5 @@ def install_admin_template_filters(app: Flask) -> None:
     app.jinja_env.filters["subscription_status_format"] = templating.subscription_status_format
     app.jinja_env.filters["fraud_check_status_format"] = templating.fraud_check_status_format
     app.jinja_env.filters["eligibility_format"] = templating.eligibility_format
+    app.jinja_env.filters["suspension_event_format"] = templating.suspension_event_format
+    app.jinja_env.filters["suspension_reason_format"] = templating.suspension_reason_format

--- a/api/src/pcapi/admin/templating.py
+++ b/api/src/pcapi/admin/templating.py
@@ -6,6 +6,7 @@ from markupsafe import Markup
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import models as users_models
+import pcapi.core.users.constants as users_constants
 
 
 logger = logging.getLogger(__name__)
@@ -74,3 +75,12 @@ def eligibility_format(eligibility_type: users_models.EligibilityType) -> str:
         css_class="info" if eligibility_type else "void",
         text=text,
     )
+
+
+def suspension_event_format(event_type: users_constants.SuspensionEventType) -> str:
+    return Markup("<span>{text}</span>").format(text=dict(users_constants.SUSPENSION_EVENT_TYPE_CHOICES)[event_type])
+
+
+def suspension_reason_format(suspension_reason: typing.Optional[users_constants.SuspensionReason]) -> str:
+    text = dict(users_constants.SUSPENSION_REASON_CHOICES)[suspension_reason] if suspension_reason else ""
+    return Markup("<span>{text}</span>").format(text=text)

--- a/api/src/pcapi/alembic/versions/20220211T120000_4e4384ac4c8f_create_user_suspension_table.py
+++ b/api/src/pcapi/alembic/versions/20220211T120000_4e4384ac4c8f_create_user_suspension_table.py
@@ -1,0 +1,30 @@
+"""Create User Suspension Table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4e4384ac4c8f"
+down_revision = "e6b4ede78bb3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "user_suspension",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("userId", sa.BigInteger(), nullable=False),
+        sa.Column("eventType", sa.String(), nullable=False),
+        sa.Column("eventDate", sa.DateTime(), server_default=sa.text("now()"), nullable=True),
+        sa.Column("actorUserId", sa.BigInteger(), nullable=True),
+        sa.Column("reasonCode", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_user_suspension_userId"), "user_suspension", ["userId"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_user_suspension_userId"), table_name="user_suspension")
+    op.drop_table("user_suspension")

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -82,6 +82,20 @@ SUSPENSION_REASON_CHOICES = (
 
 assert set(_t[0] for _t in SUSPENSION_REASON_CHOICES) == set(SuspensionReason)
 
+
+class SuspensionEventType(Enum):
+    SUSPENDED = "SUSPENDED"
+    UNSUSPENDED = "UNSUSPENDED"
+
+
+SUSPENSION_EVENT_TYPE_CHOICES = (
+    (SuspensionEventType.SUSPENDED, "Suspendu"),
+    (SuspensionEventType.UNSUSPENDED, "Réactivé"),
+)
+
+assert set(_t[0] for _t in SUSPENSION_EVENT_TYPE_CHOICES) == set(SuspensionEventType)
+
+
 PHONE_PREFIX_BY_DEPARTEMENT_CODE = {
     "971": "590",  # Guadeloupe
     "972": "596",  # Martinique

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -395,3 +395,14 @@ class EmailValidationEntryFactory(UserEmailHistoryFactory):
 
 class EmailAdminValidationEntryFactory(UserEmailHistoryFactory):
     eventType = users_models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION.value
+
+
+class UserSuspensionFactory(BaseFactory):
+    class Meta:
+        model = users_models.UserSuspension
+
+    user = factory.SubFactory(UserFactory, isActive=False)
+    actorUser = factory.SubFactory(AdminFactory)
+    eventType = users_models.SuspensionEventType.SUSPENDED
+    eventDate = factory.LazyFunction(lambda: datetime.utcnow() - relativedelta(days=1))
+    reasonCode = users_constants.SuspensionReason.FRAUD_SUSPICION

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -113,10 +113,10 @@
         <th scope="row">Compte actif</th>
         <td>{{ model.isActive|yesno }}</td>
       </tr>
-      {% if model.suspensionReason %}
+      {% if model.suspension_reason %}
       <tr>
         <th scope="row">L'utilisateur est suspendu</th>
-        <td>{{ model.suspensionReason }}</td>
+        <td>{{ model.suspension_reason|suspension_reason_format }}</td>
       </tr>
       {% endif %}
       <tr>
@@ -169,7 +169,7 @@
     <table class="table">
       <tr>
         <th scope="row">Auteur</th>
-        <td>{{ model.beneficiaryFraudReview.author.firstName }}{{ model.beneficiaryFraudReview.author.lastName }}</td>
+        <td>{{ model.beneficiaryFraudReview.author.firstName }} {{ model.beneficiaryFraudReview.author.lastName }}</td>
       </tr>
 
       <tr>
@@ -190,6 +190,44 @@
   </div>
   {% endif %}
 </div>
+
+{% if model.suspension_history|length > 0 %}
+<div class="section">
+  <h3>Historique des suspensions de compte</h3>
+  <table class="table table-striped table-hover">
+    <thead>
+      <tr>
+        <th scope="col">Événement</th>
+        <th scope="col">Date</th>
+        <th scope="col">Auteur</th>
+        <th scope="col">Explication</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for suspension_event in model.suspension_history %}
+      <tr>
+        <td>{{ suspension_event.eventType|suspension_event_format }}</td>
+        <td>
+          {% if suspension_event.eventDate %}
+            {{ suspension_event.eventDate.strftime('le %d/%m/%Y à %H:%M:%S') }}
+          {% else %}
+            -
+          {% endif %}
+        </td>
+        <td>
+          {% if suspension_event.actorUser %}
+            {{ suspension_event.actorUser.firstName }} {{ suspension_event.actorUser.lastName }}
+          {% else %}
+            -
+          {% endif %}
+        </td>
+        <td>{{ suspension_event.reasonCode|suspension_reason_format }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
 
 <div class="section">
   <h3>Historique des changements d'adresse email</h3>

--- a/api/tests/core/users/test_factories.py
+++ b/api/tests/core/users/test_factories.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class UsersFactoriesTest:
+    def test_user_suspension_factory(self):
+        suspension = users_factories.UserSuspensionFactory()
+
+        assert not suspension.user.isActive
+        assert suspension.user.suspension_reason
+        assert suspension.user.suspension_date
+        assert suspension.actorUser.has_admin_role


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-8955

## But de la pull request

Permettre au support et à la fraude d'avoir des informations supplémentaires sur la suspension d'un compte utilisateur : la date, la personne qui a initié la suspension ou la réactivation, l'historique

##  Implémentation

Ajout d'une nouvelle table `user_suspension` dans la base de données (on ajoute des lignes, on n'en supprime ou modifie jamaisà)

##  Informations supplémentaires

Captures d'écran du backoffice dans le ticket Jira.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
    - Branche : `pc-XXX-whatever-describe-the-branch`
    - PR : `(PC-XXX) Description rapide de l' US`
    - Commit(s) : `[PC-XXX] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
