### PR TITLE
[PC-13442][api][mail] Use new URL for Mailjet HTTP API

### DIFF
--- a/api/src/pcapi/core/mails/backends/mailjet.py
+++ b/api/src/pcapi/core/mails/backends/mailjet.py
@@ -33,7 +33,15 @@ class MailjetBackend(BaseBackend):
     def __init__(self):
         super().__init__()
         auth = (settings.MAILJET_API_KEY, settings.MAILJET_API_SECRET)
-        self.mailjet_client = mailjet_rest.Client(auth=auth, version="v3")
+        self.mailjet_client = mailjet_rest.Client(
+            auth=auth,
+            version="v3",
+            # The mailjet_rest package used `api.eu.mailjet.com` until
+            # version 1.3.3, but the SSL certificate expires on
+            # 2022-02-20, leading us to think that we should use
+            # another domain instead.
+            api_url="https://api.mailjet.com/",
+        )
 
     def _send(self, recipients: Iterable[str], data: dict) -> MailResult:
         data["To"] = ", ".join(recipients)

--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -88,5 +88,4 @@ class Session(_SessionMixin, requests.Session):
         unsafe_adapter = HTTPAdapter(max_retries=unsafe_retry_strategy)
         self.mount("https://www.demarches-simplifiees.fr", safe_adapter)
         self.mount("https://api.mailjet.com", unsafe_adapter)
-        self.mount("https://api.eu.mailjet.com", unsafe_adapter)
         self.mount("https://api.batch.com", unsafe_adapter)

--- a/api/tests/core/mails/tests.py
+++ b/api/tests/core/mails/tests.py
@@ -47,7 +47,7 @@ class SendTest:
         expected = copy.deepcopy(self.expected_sent_data)
         expected["MJ-TemplateErrorReporting"] = "dev@example.com"
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            posted = mock.post("https://api.mailjet.com/v3/send")
             successful = mails.send(recipients=self.recipients, data=self.data)
             assert posted.last_request.json() == expected
         assert successful
@@ -74,7 +74,7 @@ class MailjetBackendTest:
     def test_send_mail(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            posted = mock.post("https://api.mailjet.com/v3/send")
             result = backend.send_mail(recipients=self.recipients, data=self.data)
 
         assert posted.last_request.json() == self.expected_sent_data
@@ -83,7 +83,7 @@ class MailjetBackendTest:
     def test_send_mail_with_error_response(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send", status_code=400)
+            posted = mock.post("https://api.mailjet.com/v3/send", status_code=400)
             result = backend.send_mail(recipients=self.recipients, data=self.data)
 
         assert posted.last_request.json() == self.expected_sent_data
@@ -92,7 +92,7 @@ class MailjetBackendTest:
     def test_send_mail_with_timeout(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
-            mock.post("https://api.eu.mailjet.com/v3/send", exc=requests.exceptions.ConnectTimeout)
+            mock.post("https://api.mailjet.com/v3/send", exc=requests.exceptions.ConnectTimeout)
             result = backend.send_mail(recipients=self.recipients, data=self.data)
         assert not result.successful
 
@@ -100,7 +100,7 @@ class MailjetBackendTest:
     def test_use_our_requests_wrapper_that_logs(self, mocked_logger):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            posted = mock.post("https://api.mailjet.com/v3/send")
             backend.send_mail(recipients=self.recipients, data=self.data)
 
         assert posted.last_request.json() == self.expected_sent_data
@@ -123,7 +123,7 @@ class ToDevMailjetBackendTest:
     def test_send_mail_overrides_recipients(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            posted = mock.post("https://api.mailjet.com/v3/send")
             result = backend.send_mail(recipients=self.recipients, data=self.data)
 
         expected = copy.deepcopy(self.expected_sent_data)
@@ -135,7 +135,7 @@ class ToDevMailjetBackendTest:
     def test_send_mail_if_any_recipient_is_whitelisted(self):
         backend = self._get_backend()
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            posted = mock.post("https://api.mailjet.com/v3/send")
             result = backend.send_mail(recipients=self.recipients, data=self.data)
 
         assert posted.last_request.json() == self.expected_sent_data
@@ -147,7 +147,7 @@ class ToDevMailjetBackendTest:
         data["Html-part"] = "<div>some HTML...<div>"
 
         with requests_mock.Mocker() as mock:
-            posted = mock.post("https://api.eu.mailjet.com/v3/send")
+            posted = mock.post("https://api.mailjet.com/v3/send")
             result = backend.send_mail(recipients=self.recipients, data=data)
 
         expected = copy.deepcopy(self.expected_sent_data)


### PR DESCRIPTION
We use version 1.3.3 of the `mailjet_rest` package. It sends requests
to `api.eu.mailjet.com`, whose SSL certificate expires on 2022-02-20.

We could move to version 1.3.4, which uses `api.mailjet.com`, but the
changelog is not up-to-date and I am not too confident about the
contents of the changes. So let's just tweak the URL when creating the
HTTP client. Since we're going away from Mailjet, it looks like it's
the simple solution.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13442