### PR TITLE
(PC-13431)[PRO][API]: get rid of useless e2e test - there is no token validation in eac workflow

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/getters/pro_10_desk.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro_10_desk.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.sandboxes.scripts.utils.helpers import get_booking_helper
@@ -12,19 +10,6 @@ def get_existing_pro_validated_user_with_validated_offerer_with_validated_user_o
     offer = offers_factories.ThingOfferFactory(venue=venue, isActive=True)
     stock = offers_factories.StockFactory(offer=offer)
     booking = bookings_factories.IndividualBookingFactory(stock=stock)
-
-    return {
-        "booking": get_booking_helper(booking),
-        "user": get_pro_helper(user_offerer.user),
-    }
-
-
-def get_existing_pro_validated_user_with_validated_offerer_with_validated_user_offerer_with_eac_offer_with_stock_with_not_used_booking():
-    user_offerer = offers_factories.UserOffererFactory()
-    booking = bookings_factories.EducationalBookingFactory(
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=5),
-        stock__offer__venue__managingOfferer=user_offerer.offerer,
-    )
 
     return {
         "booking": get_booking_helper(booking),

--- a/pro/testcafe/10_desk.js
+++ b/pro/testcafe/10_desk.js
@@ -29,28 +29,3 @@ test('je peux valider une contremarque', async t => {
     .expect(state.innerText)
     .eql('Contremarque validée !')
 })
-
-test('je peux valider une contremarque lorsque l’offre est éducationnelle et validée par le chef d’établissement', async t => {
-  const { booking, user } = await fetchSandbox(
-    'pro_10_desk',
-    'get_existing_pro_validated_user_with_validated_offerer_with_validated_user_offerer_with_eac_offer_with_stock_with_not_used_booking_validated_by_principal'
-  )
-
-  const pageTitleHeader = Selector('h1')
-  const deskLink = Selector('a').withText('Guichet')
-  const codeInput = Selector('input[type="text"]')
-  const state = Selector('.desk-message')
-  const registerButton = Selector('button').withText('Valider la contremarque')
-
-  await t
-    .useRole(createUserRole(user))
-    .click(deskLink)
-    .expect(pageTitleHeader.innerText)
-    .eql('Guichet')
-    .typeText(codeInput, booking.token)
-    .expect(state.innerText)
-    .eql('Coupon vérifié, cliquez sur "Valider" pour enregistrer')
-    .click(registerButton)
-    .expect(state.innerText)
-    .eql('Contremarque validée !')
-})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13431

## But de la pull request

- Test end-to-end qui n'est plus nécessaire : il n'y a pas de notion de validation de token dans le parcours d'une réservation collective

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
