### PR TITLE
[PC-12612][PRO] - Skip this test until not flaky anymore

### DIFF
--- a/pro/testcafe/06_offers.js
+++ b/pro/testcafe/06_offers.js
@@ -229,7 +229,6 @@ test("Je suis empêché de quitter la création d'offre sans confirmation", asyn
     .click(venueOption.withText(venue.name))
     .click(noDisabilityCompliantCheckbox)
     .click(navBrandLogoItem)
-    .wait(200) // RouteLeavingGuard take time to block navigation.
     .expect(exitOfferCreationMessage.exists)
     .ok()
     .click(exitOfferCreationDialogCancelButton)
@@ -237,7 +236,6 @@ test("Je suis empêché de quitter la création d'offre sans confirmation", asyn
     .expect(getPathname())
     .match(/\/offre\/([A-Z0-9]+)\/individuel\/stocks$/)
     .click(navBrandLogoItem())
-    .wait(200) // RouteLeavingGuard take time to block navigation.
     .expect(exitOfferCreationMessage.exists)
     .ok()
     .click(exitOfferCreationDialogCancelButton)
@@ -265,7 +263,6 @@ test("Je peux quitter la création d'offre avec confirmation", async t => {
     .click(venueOption.withText(venue.name))
     .click(noDisabilityCompliantCheckbox)
     .click(navBrandLogoItem)
-    .wait(200) // RouteLeavingGuard take time to block navigation.
     .expect(exitOfferCreationMessage.exists)
     .ok()
     .click(exitOfferCreationDialogConfirmButton)
@@ -311,9 +308,7 @@ test("Je suis redirigé sur la page de choix du type d'offre si je clique sur re
     .click(subcategoryOption.withText('Support physique (DVD, Blu-ray...)'))
     .typeText(nameInput, 'Rencontre avec Franck Lepage')
 
-  // RouteLeavingGuard take time to block navigation.
   await goBack()
-  await t.wait(200)
 
   await t
     .expect(exitOfferCreationMessage.exists)
@@ -345,9 +340,7 @@ test.skip("Je suis redirigé sur la liste des offres si je clique sur retour à 
     .expect(getPathname())
     .match(/\/offre\/([A-Z0-9]+)\/individuel\/stocks$/)
 
-  // RouteLeavingGuard take time to block navigation.
   await goBack()
-  await t.wait(200)
 
   await t
     .expect(exitOfferCreationMessage.exists)
@@ -390,9 +383,7 @@ test("Je suis redirigé sur la liste des offres si je clique sur retour à parti
     .expect(getPathname())
     .match(/\/offre\/([A-Z0-9]+)\/individuel\/confirmation$/)
 
-  // RouteLeavingGuard take time to block navigation.
   await goBack()
-  await t.wait(200)
 
   await t.expect(getPathname()).eql('/offres')
 })
@@ -435,9 +426,6 @@ test.skip('Je suis redirigé sur la liste des offres si je clique sur retour à 
     .match(/\/offre\/creation\/individuel$/)
 
   await goBack()
-
-  // RouteLeavingGuard take time to block navigation.
-  await t.wait(200)
 
   await t
     .expect(exitOfferCreationMessage.exists)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12612

Ce test est flaky, on arrive pas trop à savoir pourquoi. Pour enlever du bruit et libérer de la charge mentale on skip ce test. 

Sur les 15/20 dernieres erreurs vu sur test-pro-e2e-tests, 
- [Je suis redirigé sur la liste des offres si je clique sur retour à partir de la page des stock au moment de la création d'offre](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/9629/workflows/21d7da37-de4b-42d8-b56e-58690c2f383f/jobs/67914)
- [Je suis redirigé sur la liste des offres si je clique sur retour à partir de la page de création quand je viens de la confirmation](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/9621/workflows/286b4fbb-b34f-4832-a321-6e3497481c04/jobs/67903)
- 1 autre erreur [je peux valider une contremarque lorsque l’offre est éducationnelle et validée par le chef d’établissement](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/9613/workflows/15b75b2d-2181-4237-b0a3-dd56d3c796aa/jobs/67755) Que je ne considère pas flaky mais à fix pour le moment?