### PR TITLE
[bsr][api][users] Fix properties of User required by flask-login

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -254,9 +254,6 @@ class User(PcObject, Model, NeedsValidationMixin):
     def checkPassword(self, passwordToCheck):
         return crypto.check_password(passwordToCheck, self.password)
 
-    def get_id(self):
-        return str(self.id)
-
     def get_notification_subscriptions(self) -> NotificationSubscriptions:
         return NotificationSubscriptions(**self.notificationSubscriptions or {})
 
@@ -278,14 +275,20 @@ class User(PcObject, Model, NeedsValidationMixin):
         subscriptions = self.get_notification_subscriptions()
         return subscriptions.marketing_push
 
-    def is_authenticated(self) -> bool:
+    @property
+    def is_authenticated(self) -> bool:  # required by flask-login
         return True
 
-    def is_active(self) -> bool:
-        return True
+    @property
+    def is_active(self) -> bool:  # required by flask-login
+        return self.isActive
 
-    def is_anonymous(self) -> bool:
+    @property
+    def is_anonymous(self) -> bool:  # required by flask-login
         return False
+
+    def get_id(self):  # required by flask-login
+        return str(self.id)
 
     def is_super_admin(self) -> bool:
         if settings.IS_PROD:

--- a/api/tests/validation/routes/users_authentifications_test.py
+++ b/api/tests/validation/routes/users_authentifications_test.py
@@ -1,3 +1,4 @@
+from flask_login.mixins import AnonymousUserMixin
 import pytest
 
 from pcapi.core.users.models import User
@@ -7,44 +8,19 @@ from pcapi.validation.routes.users_authentifications import check_user_is_logged
 
 class CheckUserIsLoggedInOrEmailIsProvidedTest:
     def test_raises_an_error_when_no_email_nor_user_logged(self):
-        # Given
-        user = User()
-        user.is_authenticated = False
-        email = None
-
-        # When
+        anonymous = AnonymousUserMixin()
         with pytest.raises(ApiErrors) as excinfo:
-            check_user_is_logged_in_or_email_is_provided(user, email)
-
-        # Then
+            check_user_is_logged_in_or_email_is_provided(anonymous, email=None)
         assert excinfo.value.errors["email"] == [
             "Vous devez préciser l'email de l'utilisateur quand vous n'êtes pas connecté(e)"
         ]
 
     def test_does_not_raise_error_when_email_is_provided(self):
-        # Given
-        user = User()
-        user.is_authenticated = False
-        email = "fake@example.com"
-
-        # When
-        try:
-            check_user_is_logged_in_or_email_is_provided(user, email)
-
-        # Then
-        except ApiErrors:
-            assert False
+        anonymous = AnonymousUserMixin()
+        # The following call should not raise.
+        check_user_is_logged_in_or_email_is_provided(anonymous, email="fake@example.com")
 
     def test_does_not_raise_error_when_user_is_authenticated(self):
-        # Given
         user = User()
-        user.is_authenticated = True
-        email = "fake@example.com"
-
-        # When
-        try:
-            check_user_is_logged_in_or_email_is_provided(user, email)
-
-        # Then
-        except ApiErrors:
-            assert False
+        # The following call should not raise.
+        check_user_is_logged_in_or_email_is_provided(user, email="fake@example.com")


### PR DESCRIPTION
Multiple fixes:

1. flask-login requires `is_authenticated`, `is_anonymous` and
   `is_active` to be properties, not methods.

2. `is_active` is used by `flask_login.utils.login_user()`. Our code
   should not pass inactive users to this function, but if it wrongly
   did, we should rely on `User.is_active` to return the right thing.