### PR TITLE
(PC-13058): get bookings pro filter by status date

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
+90c1a1eeeee0 (pre) (head)
 ffafc4d7210f (post) (head)
-ddedcf7e2c67 (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220222T083056_90c1a1eeeee0_add_index_on_booking_reimbursementdate.py
+++ b/api/src/pcapi/alembic/versions/20220222T083056_90c1a1eeeee0_add_index_on_booking_reimbursementdate.py
@@ -1,0 +1,40 @@
+"""add_index_on_booking_reimbursementDate
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from pcapi import settings
+
+
+revision = "90c1a1eeeee0"
+down_revision = "ddedcf7e2c67"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        SET SESSION statement_timeout = '300s'
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_booking_reimbursementDate" ON booking ("reimbursementDate")
+        """
+    )
+    op.execute(
+        f"""
+            SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+            """
+    )
+
+
+def downgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "ix_booking_reimbursementDate"
+        """
+    )

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -50,6 +50,12 @@ class BookingStatus(enum.Enum):
     REIMBURSED = "REIMBURSED"
 
 
+class BookingStatusFilter(enum.Enum):
+    BOOKED = "booked"
+    VALIDATED = "validated"
+    REIMBURSED = "reimbursed"
+
+
 class IndividualBooking(PcObject, Model):
     __tablename__ = "individual_booking"
 

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -445,12 +445,18 @@ def get_bookings_from_deposit(deposit_id: int) -> list[Booking]:
 def get_csv_report(
     user: User,
     booking_period: tuple[date, date],
+    status_filter: BookingStatusFilter = BookingStatusFilter.BOOKED,
     event_date: Optional[datetime] = None,
     venue_id: Optional[int] = None,
     offer_type: Optional[OfferType] = None,
 ) -> str:
     bookings_query = _get_filtered_booking_report(
-        pro_user=user, period=booking_period, event_date=event_date, venue_id=venue_id, offer_type=offer_type
+        pro_user=user,
+        period=booking_period,
+        status_filter=status_filter,
+        event_date=event_date,
+        venue_id=venue_id,
+        offer_type=offer_type,
     )
     bookings_query = _duplicate_booking_when_quantity_is_two(bookings_query)
     return _serialize_csv_report(bookings_query)
@@ -530,6 +536,7 @@ def _get_filtered_bookings_count(
 def _get_filtered_booking_report(
     pro_user: User,
     period: tuple[date, date],
+    status_filter: BookingStatusFilter,
     event_date: Optional[datetime] = None,
     venue_id: Optional[int] = None,
     offer_type: Optional[OfferType] = None,
@@ -538,6 +545,7 @@ def _get_filtered_booking_report(
         _get_filtered_bookings_query(
             pro_user,
             period,
+            status_filter,
             event_date,
             venue_id,
             offer_type,

--- a/api/src/pcapi/routes/pro/bookings.py
+++ b/api/src/pcapi/routes/pro/bookings.py
@@ -88,6 +88,7 @@ def get_bookings_pro(query: ListBookingsQueryModel) -> ListBookingsResponseModel
     page = query.page
     venue_id = query.venue_id
     event_date = query.event_date
+    booking_status = query.booking_status_filter
     booking_period = (query.booking_period_beginning_date, query.booking_period_ending_date)
     offer_type = query.offer_type
 
@@ -98,6 +99,7 @@ def get_bookings_pro(query: ListBookingsQueryModel) -> ListBookingsResponseModel
     bookings_recap_paginated = booking_repository.find_by_pro_user(
         user=current_user._get_current_object(),  # for tests to succeed, because current_user is actually a LocalProxy
         booking_period=booking_period,
+        status_filter=booking_status,
         event_date=event_date,
         venue_id=venue_id,
         offer_type=offer_type,

--- a/api/src/pcapi/routes/pro/bookings.py
+++ b/api/src/pcapi/routes/pro/bookings.py
@@ -129,11 +129,13 @@ def get_bookings_csv(query: ListBookingsQueryModel) -> bytes:
     venue_id = query.venue_id
     event_date = query.event_date
     booking_period = (query.booking_period_beginning_date, query.booking_period_ending_date)
+    booking_status = query.booking_status_filter
     offer_type = query.offer_type
 
     bookings = booking_repository.get_csv_report(
         user=current_user._get_current_object(),  # for tests to succeed, because current_user is actually a LocalProxy
         booking_period=booking_period,
+        status_filter=booking_status,
         event_date=event_date,
         venue_id=venue_id,
         offer_type=offer_type,

--- a/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
+++ b/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Any
 from typing import Optional
 
+from pcapi.core.bookings.models import BookingStatusFilter
 from pcapi.domain.booking_recap.booking_recap import BookingRecap
 from pcapi.domain.booking_recap.booking_recap import BookingRecapStatus
 from pcapi.domain.booking_recap.booking_recap_history import BookingRecapCancelledHistory
@@ -116,6 +117,7 @@ class ListBookingsQueryModel(BaseModel):
     page: int = 1
     venue_id: Optional[int]
     event_date: Optional[datetime]
+    booking_status_filter: BookingStatusFilter
     booking_period_beginning_date: date
     booking_period_ending_date: date
     offer_type: Optional[OfferType]

--- a/api/tests/routes/pro/get_all_bookings_test.py
+++ b/api/tests/routes/pro/get_all_bookings_test.py
@@ -33,7 +33,7 @@ class GetAllBookingsTest:
         response = (
             TestClient(app.test_client())
             .with_session_auth(pro.email)
-            .get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&page=3")
+            .get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&page=3")
         )
 
         assert response.status_code == 200
@@ -50,7 +50,9 @@ class GetAllBookingsTest:
     @patch("pcapi.core.bookings.repository.find_by_pro_user")
     def test_call_repository_with_page_1(self, find_by_pro_user, app):
         pro = users_factories.ProFactory()
-        TestClient(app.test_client()).with_session_auth(pro.email).get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
+        TestClient(app.test_client()).with_session_auth(pro.email).get(
+            f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked"
+        )
         find_by_pro_user.assert_called_once_with(
             user=pro,
             booking_period=BOOKING_PERIOD,
@@ -69,7 +71,7 @@ class GetAllBookingsTest:
 
         # When
         TestClient(app.test_client()).with_session_auth(pro.email).get(
-            f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&venueId={humanize(venue.id)}"
+            f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&venueId={humanize(venue.id)}"
         )
 
         # Then
@@ -94,7 +96,7 @@ class Returns200Test:
         )
 
         client = TestClient(app.test_client()).with_session_auth(admin.email)
-        response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
+        response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
 
         assert response.status_code == 200
         assert len(response.json["bookings_recap"]) == 1
@@ -111,7 +113,7 @@ class Returns200Test:
         )
 
         client = TestClient(app.test_client()).with_session_auth(admin.email)
-        response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
+        response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
 
         assert response.status_code == 200
         assert response.json["bookings_recap"][0]["stock"]["offer_is_educational"] is True
@@ -138,7 +140,7 @@ class Returns200Test:
 
         client = TestClient(app.test_client()).with_session_auth(pro_user.email)
         with assert_num_queries(testing.AUTHENTICATION_QUERIES + 2):
-            response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
+            response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
 
         expected_bookings_recap = [
             {
@@ -196,7 +198,9 @@ class Returns200Test:
 
         client = TestClient(app.test_client()).with_session_auth(pro_user.email)
         with assert_num_queries(testing.AUTHENTICATION_QUERIES + 2):
-            response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&eventDate={requested_date_iso_format}")
+            response = client.get(
+                f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&eventDate={requested_date_iso_format}"
+            )
 
         assert response.status_code == 200
         assert len(response.json["bookings_recap"]) == 1
@@ -217,7 +221,7 @@ class Returns200Test:
         client = TestClient(app.test_client()).with_session_auth(pro_user.email)
         with assert_num_queries(testing.AUTHENTICATION_QUERIES + 2):
             response = client.get(
-                "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s"
+                "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s&bookingStatusFilter=booked"
                 % (booking_period_beginning_date_iso, booking_period_ending_date_iso)
             )
 
@@ -239,7 +243,9 @@ class Returns200Test:
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
-        response = client.with_session_auth(pro_user.email).get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
+        response = client.with_session_auth(pro_user.email).get(
+            f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked"
+        )
 
         expected_bookings_recap_status_history = [
             {
@@ -260,7 +266,9 @@ class Returns200Test:
         pro_user = users_factories.ProFactory(email="pro@example.com")
         offers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
-        response = client.with_session_auth(pro_user.email).get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
+        response = client.with_session_auth(pro_user.email).get(
+            f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked"
+        )
 
         expected_bookings_recap = [
             {

--- a/api/tests/routes/pro/get_all_bookings_test.py
+++ b/api/tests/routes/pro/get_all_bookings_test.py
@@ -40,6 +40,7 @@ class GetAllBookingsTest:
         find_by_pro_user.assert_called_once_with(
             user=pro,
             booking_period=BOOKING_PERIOD,
+            status_filter=bookings_models.BookingStatusFilter.BOOKED,
             event_date=None,
             venue_id=None,
             offer_type=None,
@@ -56,6 +57,7 @@ class GetAllBookingsTest:
         find_by_pro_user.assert_called_once_with(
             user=pro,
             booking_period=BOOKING_PERIOD,
+            status_filter=bookings_models.BookingStatusFilter.BOOKED,
             event_date=None,
             venue_id=None,
             offer_type=None,
@@ -78,6 +80,7 @@ class GetAllBookingsTest:
         find_by_pro_user.assert_called_once_with(
             user=pro,
             booking_period=BOOKING_PERIOD,
+            status_filter=bookings_models.BookingStatusFilter.BOOKED,
             event_date=None,
             venue_id=venue.id,
             offer_type=None,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13058

## But de la pull request
Ajout d'un filtre de Période de réservation / validation / remboursement sur la page de réservations.

## Implémentation

- Ajout du paramètre `BookingStatusFilter` dans `ListBookingsQueryModel`.
- Filtrer les réservations sur (`dateCreated`, `dateUsed`, `reimbursementDate`) selon le paramètre `booking_status_filter` (`BOOKED`, `VALIDATED`, `REIMBURSED`).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
