### PR TITLE
(PC-13370) [API] wording:admin: fix criterion menu name

### DIFF
--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -88,7 +88,9 @@ def install_views(admin: Admin, session: Session) -> None:
             endpoint="offer_for_venue",
         )
     )
-    admin.add_view(CriteriaView(Criterion, session, name="Tags des offres", category=Category.OFFRES_STRUCTURES_LIEUX))
+    admin.add_view(
+        CriteriaView(Criterion, session, name="Tags des offres et des lieux", category=Category.OFFRES_STRUCTURES_LIEUX)
+    )
     admin.add_view(
         OffererView(offerers_models.Offerer, session, name="Structures", category=Category.OFFRES_STRUCTURES_LIEUX)
     )


### PR DESCRIPTION
Tags (criterion) now works for offers and venues.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13370

## But de la pull request

Renommer le titre du menu des tags sur FA : les tags peuvent maintenant être utilisés pour des offres et des lieux.