### PR TITLE
(PC-13475) api: User suspension history: add foreign keys

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,1 @@
-71c6af16b135 (head)
+2a111d4feac2 (head)

--- a/api/src/pcapi/alembic/versions/20220215T141341_2a111d4feac2_create_user_suspension_foreign_keys.py
+++ b/api/src/pcapi/alembic/versions/20220215T141341_2a111d4feac2_create_user_suspension_foreign_keys.py
@@ -1,0 +1,24 @@
+"""Create User Suspension foreign keys
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "2a111d4feac2"
+down_revision = "0d942b3261b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_foreign_key(
+        "user_suspension_actorUserId_fkey", "user_suspension", "user", ["actorUserId"], ["id"], ondelete="SET NULL"
+    )
+    op.create_foreign_key(
+        "user_suspension_userId_fkey", "user_suspension", "user", ["userId"], ["id"], ondelete="CASCADE"
+    )
+
+
+def downgrade():
+    op.drop_constraint("user_suspension_userId_fkey", "user_suspension", type_="foreignkey")
+    op.drop_constraint("user_suspension_actorUserId_fkey", "user_suspension", type_="foreignkey")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13475

## But de la pull request

Dans le ticket [PC-8955](https://passculture.atlassian.net/browse/PC-8955), une table `user_suspension` a été créée en base de données, et référence l’utilisateur (`userId`) et la personne à l’origine de la suspension ou réactivation (`actorUserId`).

Dans la création de la table, les clés étrangères (_foreign keys_) vers la table user sont manquantes, alors qu’elles sont définies dans le modèle.

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
