### PR TITLE
(PC-12793)[PRO]fix: remove users details in email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
@@ -29,16 +29,8 @@ def get_booking_cancellation_confirmation_by_pro_email_data(
             "EVENT_HOUR": event_hour,
             "QUANTITY": quantity,
             "RESERVATIONS_NUMBER": len(bookings),
-            "USERS": _extract_users_information_from_bookings_list(bookings),
         },
     )
-
-
-def _extract_users_information_from_bookings_list(bookings: list[Booking]) -> list[dict]:
-    users_keys = ("FIRSTNAME", "LASTNAME", "EMAIL", "COUNTERMARK")
-    users_properties = [[booking.firstName, booking.lastName, booking.email, booking.token] for booking in bookings]
-
-    return [dict(zip(users_keys, user_property)) for user_property in users_properties]
 
 
 def send_booking_cancellation_confirmation_by_pro_email(bookings: list[Booking]) -> bool:

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro_test.py
@@ -51,7 +51,6 @@ class BookingCancellationConfirmationByProEmailData:
             "EVENT_HOUR": "12h20",
             "QUANTITY": 2,
             "RESERVATIONS_NUMBER": 1,
-            "USERS": [{"COUNTERMARK": "12345", "EMAIL": "john@example.com", "FIRSTNAME": "John", "LASTNAME": "Doe"}],
         }
 
     def test_should_return_email_data_when_multiple_bookings_and_offer_is_a_thing(self):
@@ -99,10 +98,6 @@ class BookingCancellationConfirmationByProEmailData:
             "EVENT_HOUR": "",
             "QUANTITY": 7,
             "RESERVATIONS_NUMBER": 2,
-            "USERS": [
-                {"COUNTERMARK": "12346", "EMAIL": "john@example.com", "FIRSTNAME": "John", "LASTNAME": "Doe"},
-                {"COUNTERMARK": "12345", "EMAIL": "bond@example.com", "FIRSTNAME": "James", "LASTNAME": "Bond"},
-            ],
         }
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12793

## But de la pull request

fix pour retirer les détails utilisateurs quit peuvent dépasser la limite en données sendinblue de 100ko par email
(si plusieurs centaines d'utilisateurs pour un événement par exemple)

## Implémentation
N/A
## Informations supplémentaires
N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
