### PR TITLE
Pc 13482/refacto date format adage

### DIFF
--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -58,6 +58,7 @@ export const Offer = ({
           canPrebookOffers={canPrebookOffers}
           className="offer-prebooking-button"
           stock={offer.stocks[0]}
+          venue={offer.venue}
         />
         <div className="offer-header">
           <h2 className="offer-header-title">{offer.name}</h2>

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as EuroIcon } from 'assets/euro.svg'
 import { ReactComponent as LocationIcon } from 'assets/location.svg'
 import { ReactComponent as SubcategoryIcon } from 'assets/subcategory.svg'
 import { ReactComponent as UserIcon } from 'assets/user.svg'
-import { getLocalDepartmentDatetimeFromPostalCode } from 'utils/date'
+import { formatDatetimeToPostalCodeTimezone } from 'utils/date'
 import { ADRESS_TYPE, OfferType } from 'utils/types'
 import './OfferSummary.scss'
 
@@ -61,7 +61,7 @@ const OfferSummary = ({ offer }: { offer: OfferType }): JSX.Element => {
         {beginningDatetime && (
           <li className="offer-summary-item">
             <DateIcon className="offer-summary-item-icon" />
-            {getLocalDepartmentDatetimeFromPostalCode(
+            {formatDatetimeToPostalCodeTimezone(
               beginningDatetime,
               venue.postalCode,
               'dd/MM/yyyy à HH:mm'

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferSummary/OfferSummary.tsx
@@ -6,37 +6,9 @@ import { ReactComponent as EuroIcon } from 'assets/euro.svg'
 import { ReactComponent as LocationIcon } from 'assets/location.svg'
 import { ReactComponent as SubcategoryIcon } from 'assets/subcategory.svg'
 import { ReactComponent as UserIcon } from 'assets/user.svg'
-import { toISOStringWithoutMilliseconds } from 'utils/date'
-import { formatLocalTimeDateString } from 'utils/timezone'
+import { getLocalDepartmentDatetimeFromPostalCode } from 'utils/date'
 import { ADRESS_TYPE, OfferType } from 'utils/types'
-
 import './OfferSummary.scss'
-
-const extractDepartmentCode = (venuePostalCode: string): string => {
-  const departmentNumberBase: number = parseInt(venuePostalCode.slice(0, 2))
-  if (departmentNumberBase > 95) {
-    return venuePostalCode.slice(0, 3)
-  } else {
-    return venuePostalCode.slice(0, 2)
-  }
-}
-
-const getLocalBeginningDatetime = (
-  beginningDatetime: Date,
-  venuePostalCode: string
-): string => {
-  const departmentCode = extractDepartmentCode(venuePostalCode)
-  const stockBeginningDate = new Date(beginningDatetime)
-  const stockBeginningDateISOString =
-    toISOStringWithoutMilliseconds(stockBeginningDate)
-  const stockLocalBeginningDate = formatLocalTimeDateString(
-    stockBeginningDateISOString,
-    departmentCode,
-    'dd/MM/yyyy à HH:mm'
-  )
-
-  return stockLocalBeginningDate
-}
 
 const OfferSummary = ({ offer }: { offer: OfferType }): JSX.Element => {
   const { subcategoryLabel, stocks, venue, extraData } = offer
@@ -89,7 +61,11 @@ const OfferSummary = ({ offer }: { offer: OfferType }): JSX.Element => {
         {beginningDatetime && (
           <li className="offer-summary-item">
             <DateIcon className="offer-summary-item-icon" />
-            {getLocalBeginningDatetime(beginningDatetime, venue.postalCode)}
+            {getLocalDepartmentDatetimeFromPostalCode(
+              beginningDatetime,
+              venue.postalCode,
+              'dd/MM/yyyy à HH:mm'
+            )}
           </li>
         )}
         <li className="offer-summary-item">

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -8,7 +8,7 @@ import {
 import { Button } from 'app/ui-kit'
 import { ReactComponent as HourGlassIcon } from 'assets/hourglass.svg'
 import { preBookStock } from 'repository/pcapi/pcapi'
-import { getLocalDepartmentDatetimeFromPostalCode } from 'utils/date'
+import { formatDatetimeToPostalCodeTimezone } from 'utils/date'
 import { StockType, VenueType } from 'utils/types'
 
 import './PrebookingButton.scss'
@@ -79,7 +79,7 @@ const PrebookingButton = ({
               {stock.bookingLimitDatetime && (
                 <span className="prebooking-button-booking-limit">
                   avant le :{' '}
-                  {getLocalDepartmentDatetimeFromPostalCode(
+                  {formatDatetimeToPostalCodeTimezone(
                     stock.bookingLimitDatetime,
                     venue.postalCode,
                     'dd/MM/yyyy'

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/PrebookingButton/PrebookingButton.tsx
@@ -1,4 +1,3 @@
-import { format } from 'date-fns-tz'
 import React, { useCallback, useState } from 'react'
 
 import {
@@ -9,9 +8,11 @@ import {
 import { Button } from 'app/ui-kit'
 import { ReactComponent as HourGlassIcon } from 'assets/hourglass.svg'
 import { preBookStock } from 'repository/pcapi/pcapi'
-import { StockType } from 'utils/types'
+import { getLocalDepartmentDatetimeFromPostalCode } from 'utils/date'
+import { StockType, VenueType } from 'utils/types'
 
 import './PrebookingButton.scss'
+
 import PrebookingModal from './PrebookingModal'
 import { getErrorMessage } from './utils'
 
@@ -19,10 +20,12 @@ const PrebookingButton = ({
   className,
   stock,
   canPrebookOffers,
+  venue,
 }: {
   className?: string
   stock: StockType
   canPrebookOffers: boolean
+  venue: VenueType
 }): JSX.Element => {
   const [hasPrebookedOffer, setHasPrebookedOffer] = useState(false)
   const [notification, setNotification] = useState<Notification | null>(null)
@@ -76,7 +79,11 @@ const PrebookingButton = ({
               {stock.bookingLimitDatetime && (
                 <span className="prebooking-button-booking-limit">
                   avant le :{' '}
-                  {format(new Date(stock.bookingLimitDatetime), 'dd/MM/yyyy')}
+                  {getLocalDepartmentDatetimeFromPostalCode(
+                    stock.bookingLimitDatetime,
+                    venue.postalCode,
+                    'dd/MM/yyyy'
+                  )}
                 </span>
               )}
             </>

--- a/adage-front/src/utils/date.ts
+++ b/adage-front/src/utils/date.ts
@@ -1,5 +1,7 @@
 import { format } from 'date-fns-tz'
 
+import { formatLocalTimeDateString } from './timezone'
+
 export const FORMAT_ISO = "yyyy-MM-dd'T'HH:mm:ssX"
 export const FORMAT_ISO_DATE_ONLY = 'yyyy-MM-dd'
 export const FORMAT_DD_MM_YYYY_HH_mm = 'dd/MM/yyyy HH:mm'
@@ -25,4 +27,30 @@ export const toDateStrippedOfTimezone = (dateIsoString: string): Date => {
 
 export const toISOStringWithoutMilliseconds = (date: Date): string => {
   return date.toISOString().replace(/\.\d{3}/, '')
+}
+
+const extractDepartmentCode = (venuePostalCode: string): string => {
+  const departmentNumberBase: number = parseInt(venuePostalCode.slice(0, 2))
+  if (departmentNumberBase > 95) {
+    return venuePostalCode.slice(0, 3)
+  } else {
+    return venuePostalCode.slice(0, 2)
+  }
+}
+
+export const getLocalDepartmentDatetimeFromPostalCode = (
+  datetime: Date,
+  venuePostalCode: string,
+  dateFormat: string
+): string => {
+  const departmentCode = extractDepartmentCode(venuePostalCode)
+  const dateUTC = new Date(datetime)
+  const dateUTCISOString = toISOStringWithoutMilliseconds(dateUTC)
+  const localDate = formatLocalTimeDateString(
+    dateUTCISOString,
+    departmentCode,
+    dateFormat
+  )
+
+  return localDate
 }

--- a/adage-front/src/utils/date.ts
+++ b/adage-front/src/utils/date.ts
@@ -38,7 +38,7 @@ const extractDepartmentCode = (venuePostalCode: string): string => {
   }
 }
 
-export const getLocalDepartmentDatetimeFromPostalCode = (
+export const formatDatetimeToPostalCodeTimezone = (
   datetime: Date,
   venuePostalCode: string,
   dateFormat: string


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13492

## But de la pull request

Suite à l'implémentation du plugin date-fns-tz, un format de date incorrect a été repéré pour l'affichage de la date limite de réservation côté adage. C'est en effet la date utc qui était utilisé.

## Implémentation

Extraction de la fonction qui convertit une date utc en string dans le format souhaité et à la timezone du code postal, dans le module date.ts
Utilisation de cette fonction dans PreBooking.tsx

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
