### PR TITLE
Pc 13078 use jsonb fields

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ffafc4d7210f (post) (head)
-932e613984b3 (pre) (head)
+e9ddaad94160 (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220214T111936_e9ddaad94156_set_jsonb_fields_as_used_ones.py
+++ b/api/src/pcapi/alembic/versions/20220214T111936_e9ddaad94156_set_jsonb_fields_as_used_ones.py
@@ -1,0 +1,43 @@
+"""set JSONB fields as used ones
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "e9ddaad94156"
+down_revision = "932e613984b3"
+branch_labels = None
+depends_on = None
+
+
+# Those fields can be altered because:
+# - it belongs to the `offer_validation_config` table that contain very few records
+# - a test on staging shows that it is very quick for the table `email`
+fields_to_be_renamed = [
+    ("email", "content"),
+    ("offer_validation_config", "specs"),
+]
+
+
+def rename(table: str, field: str) -> None:
+    op.execute(f'ALTER TABLE {table} RENAME COLUMN "{field}" TO "{field}Old";')
+    op.execute(f'ALTER TABLE {table} ALTER COLUMN "{field}Old" DROP NOT NULL;')
+    op.execute(f'ALTER TABLE {table} RENAME COLUMN "{field}New" TO "{field}";')
+    op.execute(f'ALTER TABLE {table} ALTER COLUMN "{field}" SET NOT NULL;')
+
+
+def unrename(table: str, field: str) -> None:
+    op.execute(f'ALTER TABLE {table} ALTER COLUMN "{field}" DROP NOT NULL;')
+    op.execute(f'ALTER TABLE {table} RENAME COLUMN "{field}" TO "{field}New";')
+    op.execute(f'ALTER TABLE {table} ALTER COLUMN "{field}Old" SET NOT NULL;')
+    op.execute(f'ALTER TABLE {table} RENAME COLUMN "{field}Old" TO "{field}";')
+
+
+def upgrade():
+    for table, field in fields_to_be_renamed:
+        rename(table, field)
+
+
+def downgrade():
+    for table, field in fields_to_be_renamed:
+        unrename(table, field)

--- a/api/src/pcapi/alembic/versions/20220214T145737_e9ddaad94157_create_new_index_product-jsondata-isbn.py
+++ b/api/src/pcapi/alembic/versions/20220214T145737_e9ddaad94157_create_new_index_product-jsondata-isbn.py
@@ -1,0 +1,23 @@
+"""create new index on product.jsonData.isbn
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "e9ddaad94157"
+down_revision = "e9ddaad94156"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS product_isbn_idx ON product (("jsonData" ->> 'isbn'))
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS product_isbn_idx;")

--- a/api/src/pcapi/alembic/versions/20220214T145738_e9ddaad94158_create_new_index_offer-jsondata-isbn.py
+++ b/api/src/pcapi/alembic/versions/20220214T145738_e9ddaad94158_create_new_index_offer-jsondata-isbn.py
@@ -1,0 +1,23 @@
+"""create new index on offer.jsonData.isbn
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "e9ddaad94158"
+down_revision = "e9ddaad94157"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS offer_isbn_idx ON offer (("jsonData" ->> 'isbn'))
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS offer_isbn_idx;")

--- a/api/src/pcapi/alembic/versions/20220214T145739_e9ddaad94159_drop_obsolete_index_offer-extradata-isbn.py
+++ b/api/src/pcapi/alembic/versions/20220214T145739_e9ddaad94159_drop_obsolete_index_offer-extradata-isbn.py
@@ -1,0 +1,23 @@
+"""drop obsolete index on offer.extraData.isbn
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "e9ddaad94159"
+down_revision = "e9ddaad94158"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP INDEX IF EXISTS offer_expr_idx;")
+
+
+def downgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS offer_expr_idx ON offer (("extraData" ->> 'isbn'))
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20220214T145740_e9ddaad94160_drop_obsolete_index_product-extradata-isbn.py
+++ b/api/src/pcapi/alembic/versions/20220214T145740_e9ddaad94160_drop_obsolete_index_product-extradata-isbn.py
@@ -1,0 +1,23 @@
+"""drop obsolete index on product.extraData.isbn
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "e9ddaad94160"
+down_revision = "e9ddaad94159"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP INDEX IF EXISTS product_expr_idx;")
+
+
+def downgrade():
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS product_expr_idx ON product (("extraData" ->> 'isbn'))
+        """
+    )

--- a/api/src/pcapi/core/mails/models/models.py
+++ b/api/src/pcapi/core/mails/models/models.py
@@ -25,8 +25,8 @@ class EmailStatus(enum.Enum):
 
 
 class Email(PcObject, Model):
-    _content = Column("content", JSON, nullable=False)
-    _contentNew = Column("contentNew", JSONB)  # TODO (ASK, JSONB): set this none nullable when JSONB migration is done
+    _content = Column("content", JSONB, nullable=False)
+    _contentOld = Column("contentOld", JSON)  # TODO (ASK, JSONB): remove this field when JSONB migration is done
     status = Column(Enum(EmailStatus), nullable=False, index=True)
 
     datetime = Column(DateTime, nullable=False, default=datetime.utcnow)
@@ -38,4 +38,4 @@ class Email(PcObject, Model):
     @content.setter
     def content(self, value):
         self._content = value
-        self._contentNew = value
+        self._contentOld = value

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -340,9 +340,8 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin):
     #  can be used by PostgreSQL when filtering on the `venueId` column only.
     sa.Index("venueId_idAtProvider_index", venueId, idAtProvider, unique=True)
 
-    # TODO (ASK, JSONB): remove this index and uncomment "offer_isbn_idx" one when JSONB migration is done
-    sa.Index("offer_expr_idx", ExtraDataMixin._extraData["isbn"].astext)
-    # sa.Index("offer_isbn_idx", ExtraDataMixin._jsonData["isbn"].astext)
+    # TODO (ASK, JSONB): change _jsonData for extraData when JSONB migration is done
+    sa.Index("offer_isbn_idx", ExtraDataMixin._jsonData["isbn"].astext)
 
     @sa.ext.declarative.declared_attr
     def lastProviderId(cls):  # pylint: disable=no-self-argument
@@ -587,10 +586,10 @@ class OfferValidationConfig(PcObject, Model):
 
     user = sa.orm.relationship("User", foreign_keys=[userId], backref="offer_validation_configs")
 
-    _specs = sa.Column("specs", sa.dialects.postgresql.JSON, nullable=False)
+    _specs = sa.Column("specs", sa.dialects.postgresql.JSONB, nullable=False)
     _specsNew = sa.Column(
-        "specsNew", sa.dialects.postgresql.JSONB
-    )  # TODO (ASK, JSONB): set this non nullable when JSONB migration is done
+        "specsOld", sa.dialects.postgresql.JSON
+    )  # TODO (ASK, JSONB): remove this field when JSONB migration is done
 
     @sa.ext.hybrid.hybrid_property
     def specs(self):
@@ -599,7 +598,7 @@ class OfferValidationConfig(PcObject, Model):
     @specs.setter
     def specs(self, value):
         self._specs = value
-        self._specsNew = value
+        self._specsOld = value
 
 
 @dataclass

--- a/api/src/pcapi/models/extra_data_mixin.py
+++ b/api/src/pcapi/models/extra_data_mixin.py
@@ -11,7 +11,7 @@ class ExtraDataMixin:
 
     @hybrid_property
     def extraData(self):
-        return self._extraData
+        return self._jsonData
 
     @extraData.setter
     def extraData(self, value):

--- a/api/src/pcapi/models/product.py
+++ b/api/src/pcapi/models/product.py
@@ -63,9 +63,8 @@ class Product(PcObject, Model, ExtraDataMixin, HasThumbMixin, ProvidableMixin):
 
     thumb_path_component = "products"
 
-    # TODO (ASK, JSONB): remove this index and uncomment "product_isbn_idx" one when JSONB migration is done
-    Index("product_expr_idx", ExtraDataMixin._extraData["isbn"].astext)
-    # Index("product_isbn_idx", ExtraDataMixin._jsonData["isbn"].astext)
+    # TODO (ASK, JSONB): change _jsonData for extraData when JSONB migration is done
+    Index("product_isbn_idx", ExtraDataMixin._jsonData["isbn"].astext)
 
     @property
     def subcategory(self) -> subcategories.Subcategory:

--- a/api/src/pcapi/validation/models/generic.py
+++ b/api/src/pcapi/validation/models/generic.py
@@ -17,7 +17,7 @@ def validate_generic(model: Model) -> ApiErrors:
         # TODO (ASK, JSONB): dirty patch to allow extraData, specs and content properties
         #  to work properly during the JSONB migration
         #  remove it when JSONB migration is done
-        if key in ("jsonData", "specsNew", "contentNew"):
+        if key in ("jsonData", "specsOld", "contentOld"):
             continue
 
         column = columns[key]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13078

## But de la pull request

Utiliser les champs JSONB récemment créer plutôt que leurs équivalents JSON

## Implémentation

- rename `email.content` to `email.contentOld` and `email.contentNew` to `email.content`
- rename `offer_validation_config.specs` to `offer_validation_config.specsOld` and `offer_validation_config.specsNew` to `offer_validation_config.specs`
- read from `jsonData` instead of `extraData` for `ExtraDataMixin`
- remove indexes `product_expr_idx` and `offer_expr_idx`
- create new index `product_isbn_idx` on `product.jsonData`
- create new index `offer_isbn_idx` on `offer.jsonData`

## Informations supplémentaires

apparemment le renommage de champs, même sur des grosses tables, est très rapide (testé sur une table avec 43M+ enregistrement sur staging -> moins d'une seconde).
la migration avec les renommage de fichier ne devrait donc pas poser de problème de performance

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] ~~J'ai écrit les tests nécessaires~~
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
