### PR TITLE
[pc-11751][API][FIX] - Fix sendinblue decimals

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/invoice_available_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/invoice_available_to_pro.py
@@ -11,7 +11,7 @@ def get_invoice_available_to_pro_email_data(invoice) -> Union[dict, SendinblueTr
     return SendinblueTransactionalEmailData(
         template=TransactionalEmail.INVOICE_AVAILABLE_TO_PRO.value,
         params={
-            "MONTANT_REMBOURSEMENT": -finance_utils.to_euros(invoice.amount),
+            "MONTANT_REMBOURSEMENT": str(-finance_utils.to_euros(invoice.amount)),
         },
     )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11751

## But de la pull request

Lorsque des centimes sont en jeux, beaucoup trop de 0 sont ajoutés. Je ne sais pas trop quel comportement a sendinblue lorsqu'il reçoit un `Decimal`, je propose de lui donner une string.

Params envoyés avant : 
`'params': {'MONTANT_REMBOURSEMENT': Decimal('20156.04')}`
Après : 
`'params': {'MONTANT_REMBOURSEMENT': '20156.04'`


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
