### PR TITLE
(PC-13500)[ADAGE] tech: add eslint rule requiring to use timezone as an option to format function

### DIFF
--- a/adage-front/eslint-plugin-pass-culture/lib/rules/use-date-fns-tz-format.js
+++ b/adage-front/eslint-plugin-pass-culture/lib/rules/use-date-fns-tz-format.js
@@ -19,6 +19,17 @@ const isImportAll = listOfSpecifiers => {
   return !!foundAllSpecifier
 }
 
+const isTimezoneInFormat = node => {
+  const argumentsList = node.expression?.arguments
+  const optionsArgument = argumentsList?.find(
+    arg => arg.type === 'ObjectExpression'
+  )
+  const foundTimezoneInOptions = optionsArgument?.properties.find(
+    property => property.key.name === 'timeZone'
+  )
+  return !!foundTimezoneInOptions
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -27,9 +38,11 @@ module.exports = {
     },
     messages: {
       useDateFnsTzFormat:
-        'Please use the format function from date-fns-tz library instead of the one from date-fns. Please consider timezone in datetime formatting.',
+        'Please use the format function from date-fns-tz library instead of the one from date-fns. Please consider timezone of venue in datetime formatting.',
       importIndividualFunctions:
         'Please import individual function from date-fns library. If format function is needed, please import it from date-fns-tz and take timezone into account.',
+      useTimezoneOption:
+        'Please use timezone option in format arguments. As offers dates are sent as UTC from the backend, you need to take TZ into account.',
     },
   },
   create: context => ({
@@ -51,6 +64,17 @@ module.exports = {
         context.report({
           node,
           messageId: 'importIndividualFunctions',
+        })
+      }
+    },
+    ExpressionStatement: node => {
+      if (
+        node.expression?.callee?.name === 'format' &&
+        !isTimezoneInFormat(node)
+      ) {
+        context.report({
+          node,
+          messageId: 'useTimezoneOption',
         })
       }
     },

--- a/adage-front/eslint-plugin-pass-culture/tests/lib/rules/use-date-fns-tz.spec.js
+++ b/adage-front/eslint-plugin-pass-culture/tests/lib/rules/use-date-fns-tz.spec.js
@@ -23,6 +23,10 @@ ruleTester.run('use-date-fns-tz', rule, {
       code: "import * as date from 'date-fns-tz'",
       parserOptions,
     },
+    {
+      code: "format(date, dateFormat, { timeZone: 'UTC' })",
+      parserOptions,
+    },
   ],
   invalid: [
     {
@@ -57,6 +61,24 @@ ruleTester.run('use-date-fns-tz', rule, {
       errors: [
         {
           messageId: 'useDateFnsTzFormat',
+        },
+      ],
+      parserOptions,
+    },
+    {
+      code: 'format(date, dateFormat)',
+      errors: [
+        {
+          messageId: 'useTimezoneOption',
+        },
+      ],
+      parserOptions,
+    },
+    {
+      code: 'format(date, dateFormat, { locale: enGB })',
+      errors: [
+        {
+          messageId: 'useTimezoneOption',
         },
       ],
       parserOptions,

--- a/pro/eslint-plugin-pass-culture/lib/rules/use-date-fns-tz-format.js
+++ b/pro/eslint-plugin-pass-culture/lib/rules/use-date-fns-tz-format.js
@@ -19,6 +19,17 @@ const isImportAll = listOfSpecifiers => {
   return !!foundAllSpecifier
 }
 
+const isTimezoneInFormat = node => {
+  const argumentsList = node.expression?.arguments
+  const optionsArgument = argumentsList?.find(
+    arg => arg.type === 'ObjectExpression'
+  )
+  const foundTimezoneInOptions = optionsArgument?.properties.find(
+    property => property.key.name === 'timeZone'
+  )
+  return !!foundTimezoneInOptions
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -27,9 +38,11 @@ module.exports = {
     },
     messages: {
       useDateFnsTzFormat:
-        'Please use the format function from date-fns-tz library instead of the one from date-fns. Please consider timezone in datetime formatting.',
+        'Please use the format function from date-fns-tz library instead of the one from date-fns. Please consider timezone of venue in datetime formatting.',
       importIndividualFunctions:
         'Please import individual function from date-fns library. If format function is needed, please import it from date-fns-tz and take timezone into account.',
+      useTimezoneOption:
+        'Please use timezone option in format arguments. As offers dates are sent as UTC from the backend, you need to take TZ into account.',
     },
   },
   create: context => ({
@@ -51,6 +64,17 @@ module.exports = {
         context.report({
           node,
           messageId: 'importIndividualFunctions',
+        })
+      }
+    },
+    ExpressionStatement: node => {
+      if (
+        node.expression?.callee?.name === 'format' &&
+        !isTimezoneInFormat(node)
+      ) {
+        context.report({
+          node,
+          messageId: 'useTimezoneOption',
         })
       }
     },

--- a/pro/eslint-plugin-pass-culture/tests/lib/rules/use-date-fns-tz.spec.js
+++ b/pro/eslint-plugin-pass-culture/tests/lib/rules/use-date-fns-tz.spec.js
@@ -24,6 +24,10 @@ ruleTester.run('use-date-fns-tz', rule, {
       code: "import * as date from 'date-fns-tz'",
       parserOptions,
     },
+    {
+      code: "format(date, dateFormat, { timeZone: 'UTC' })",
+      parserOptions,
+    },
   ],
   invalid: [
     {
@@ -58,6 +62,24 @@ ruleTester.run('use-date-fns-tz', rule, {
       errors: [
         {
           messageId: 'useDateFnsTzFormat',
+        },
+      ],
+      parserOptions,
+    },
+    {
+      code: 'format(date, dateFormat)',
+      errors: [
+        {
+          messageId: 'useTimezoneOption',
+        },
+      ],
+      parserOptions,
+    },
+    {
+      code: 'format(date, dateFormat, { locale: enGB })',
+      errors: [
+        {
+          messageId: 'useTimezoneOption',
         },
       ],
       parserOptions,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13500

## But de la pull request

Suite à l'implémentation du plugin eslint vérifiant l'utilisation de la fonction format de date-fns-tz (et non celle de date-fns), nous ajoutons ici une règle qui nécessite l'utilisation de la propriété `timeZone` dans les options de l'appel à cette fonction. Le but est toujours le même : éviter qu'un développeur n'oublie l'aspect timezone, fortement impactant sur les fronts du Pass Culture

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
