### PR TITLE
Fix storybook style for image preview

### DIFF
--- a/pro/src/new_components/ImagePreview/stories/HomeScreenShell.module.scss
+++ b/pro/src/new_components/ImagePreview/stories/HomeScreenShell.module.scss
@@ -1,22 +1,19 @@
 .home-screen-shell {
-  left: rem(26px);
   position: absolute;
-  top: rem(34px);
   height: 515px;
 }
 
 .preview-on-home-screen {
   background-color: $white;
   border-radius: rem(5px);
-  left: rem(42px);
+  left: rem(17px);
   position: absolute;
-  top: rem(186px);
+  top: rem(152px);
   height: 228px;
 }
 
 .offer-screen-shell {
-  left: rem(26px);
-  top: rem(270px);
+  top: rem(236px);
   position: absolute;
   height: 280px;
 }
@@ -24,9 +21,9 @@
 .blurred-preview-on-offer-screen {
   background-color: $white;
   filter: blur(2px);
-  left: rem(27px);
+  left: rem(1px);
   position: absolute;
-  top: rem(35px);
+  top: rem(1px);
   height: 435px;
   width: 290px;
 }
@@ -34,8 +31,8 @@
 .preview-on-offer-screen {
   background-color: $white;
   border-radius: rem(5px);
-  left: rem(91px);
+  left: rem(65px);
   position: absolute;
-  top: rem(97px);
-  height: 247px;
+  top: rem(71px);
+  height: 240px;
 }


### PR DESCRIPTION
## But de la pull request

Correction de style du ImagePreview.stories pour corriger l'apparence dans storybook

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
Précédemment : 
<img width="984" alt="image" src="https://user-images.githubusercontent.com/74320569/154318135-9ddfb767-a00a-4550-8f0e-b8e034e42442.png">

Correction : 
<img width="948" alt="image" src="https://user-images.githubusercontent.com/74320569/154317910-34acc3b3-8e00-49ed-bd73-60e158f87773.png">
