### PR TITLE
(PC-8764)[API] TiteLive Stocks API upgraded to v3

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,1 +1,0 @@
-2a111d4feac2 (head)

--- a/api/src/pcapi/alembic/versions/20220216T151426_3909d91d79da_titelivestocks_api_v3.py
+++ b/api/src/pcapi/alembic/versions/20220216T151426_3909d91d79da_titelivestocks_api_v3.py
@@ -1,0 +1,31 @@
+"""Upgrade TiteLive Stocks from API v2 to API v3
+"""
+from alembic import op
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision = "3909d91d79da"
+down_revision = "2a111d4feac2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    statement = text(
+        "UPDATE provider "
+        'SET "apiUrl" = \'https://api-stock.epagine.fr/v3/stocks\', "pricesInCents" = false '
+        'WHERE "apiUrl" = :apiUrl'
+    )
+    statement = statement.bindparams(apiUrl="https://stockv2.epagine.fr/stocks")
+    op.execute(statement)
+
+
+def downgrade():
+    statement = text(
+        "UPDATE provider "
+        'SET "apiUrl" = \'https://stockv2.epagine.fr/stocks\', "pricesInCents" = true '
+        'WHERE "apiUrl" = :apiUrl'
+    )
+    statement = statement.bindparams(apiUrl="https://api-stock.epagine.fr/v3/stocks")
+    op.execute(statement)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-8764

## But de la pull request

Basculer vers la v3 de Titelive `https://api-stock.epagine.fr/v3/`

## Implémentation

L'URL de l'API est écrite dans la base de données.
Une migration permet de mettre à jour l'API, de la même manière que `priceInCents` avait été mis à `true` dans la migration `e63d336e9da8`.

## Informations supplémentaires

Synchronisation testée sur staging sur des lieux (librairies) utilisant ce provider.
J'obtiens les mêmes prix dans la base de données avec l'ancienne (v2) et la nouvelle (v3) API.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
