### PR TITLE
(PC-13305)[API] feat: add ministry field in educational deposit table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ffafc4d7210f (post) (head)
-d3da2eac435d (pre) (head)
+932e613984b3 (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220221T104132_932e613984b3_add_ministry_enum_field_to_educational_deposit.py
+++ b/api/src/pcapi/alembic/versions/20220221T104132_932e613984b3_add_ministry_enum_field_to_educational_deposit.py
@@ -1,0 +1,26 @@
+"""add_ministry_enum_field_to_educational_deposit
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "932e613984b3"
+down_revision = "d3da2eac435d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE TYPE ministry AS ENUM ('EDUCATION_NATIONALE', 'MER', 'AGRICULTURE', 'ARMEES')")
+    op.add_column(
+        "educational_deposit",
+        sa.Column(
+            "ministry", sa.Enum("EDUCATION_NATIONALE", "MER", "AGRICULTURE", "ARMEES", name="ministry"), nullable=True
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("educational_deposit", "ministry")
+    op.execute("DROP TYPE ministry")

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -26,6 +26,13 @@ class EducationalBookingStatus(enum.Enum):
     REFUSED = "REFUSED"
 
 
+class Ministry(enum.Enum):
+    EDUCATION_NATIONALE = "MENjs"
+    MER = "MMe"
+    AGRICULTURE = "MAg"
+    ARMEES = "MAr"
+
+
 class EducationalInstitution(PcObject, Model):
     __tablename__ = "educational_institution"
 
@@ -70,6 +77,11 @@ class EducationalDeposit(PcObject, Model):
     dateCreated: datetime = Column(DateTime, nullable=False, default=datetime.utcnow, server_default=func.now())
 
     isFinal: bool = Column(Boolean, nullable=False, default=True)
+
+    ministry = Column(
+        Enum(Ministry),
+        nullable=True,
+    )
 
     def get_amount(self) -> Decimal:
         return round(self.amount * Decimal(self.TEMPORARY_FUND_AVAILABLE_RATIO), 2) if not self.isFinal else self.amount


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13305

## But de la pull request

Préparer le backend pour recevoir les budgets des nouveaux ministères

## Implémentation

- Créer une nouvelle colonne `ministry` dans la table `EducationalDeposit` (enum)
- Ecrire un script pour rattraper les données existantes

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
