### PR TITLE
[PC-10224][api][providers] Add to rawProviderQuantity the number of *used* bookings only

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
+07a30dcf25c5 (pre) (head)
 ffafc4d7210f (post) (head)
-d3da2eac435d (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220218T162405_f8e8c5e39eb7_check_stock_function.py
+++ b/api/src/pcapi/alembic/versions/20220218T162405_f8e8c5e39eb7_check_stock_function.py
@@ -1,0 +1,89 @@
+"""Update `check_stock` SQL function."""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f8e8c5e39eb7"
+down_revision = "d3da2eac435d"
+branch_labels = None
+depends_on = None
+
+
+OLD_DDL = """
+    CREATE OR REPLACE FUNCTION check_stock()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      IF
+       NOT NEW.quantity IS NULL
+       AND
+        (
+         (
+          SELECT SUM(booking.quantity)
+          FROM booking
+          WHERE "stockId"=NEW.id
+          AND NOT booking.status = 'CANCELLED'
+         ) > NEW.quantity
+        )
+      THEN
+       RAISE EXCEPTION 'quantity_too_low'
+       USING HINT = 'stock.quantity cannot be lower than number of bookings';
+      END IF;
+
+      IF NEW."bookingLimitDatetime" IS NOT NULL AND
+        NEW."beginningDatetime" IS NOT NULL AND
+         NEW."bookingLimitDatetime" > NEW."beginningDatetime" THEN
+
+      RAISE EXCEPTION 'bookingLimitDatetime_too_late'
+      USING HINT = 'bookingLimitDatetime after beginningDatetime';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+"""
+
+NEW_DDL = """
+    CREATE OR REPLACE FUNCTION check_stock()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      IF
+       NOT NEW.quantity IS NULL
+       -- We allow synchronized stocks to have a negative remaining quantity
+       -- because items that have been booked through us could be sold
+       -- by the library at the same time. In that case, we want to allow
+       -- the update of `Stock.quantity` to reflect the reality.
+       AND NEW."lastProviderId" IS NULL
+       AND
+        (
+         (
+          SELECT SUM(booking.quantity)
+          FROM booking
+          WHERE "stockId"=NEW.id
+          AND NOT booking.status = 'CANCELLED'
+         ) > NEW.quantity
+        )
+      THEN
+       RAISE EXCEPTION 'quantity_too_low'
+       USING HINT = 'stock.quantity cannot be lower than number of bookings';
+      END IF;
+
+      IF NEW."bookingLimitDatetime" IS NOT NULL AND
+        NEW."beginningDatetime" IS NOT NULL AND
+         NEW."bookingLimitDatetime" > NEW."beginningDatetime" THEN
+
+      RAISE EXCEPTION 'bookingLimitDatetime_too_late'
+      USING HINT = 'bookingLimitDatetime after beginningDatetime';
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade():
+    op.execute(NEW_DDL)
+
+
+def downgrade():
+    op.execute(OLD_DDL)

--- a/api/src/pcapi/alembic/versions/20220218T170226_07a30dcf25c5_check_booking_function.py
+++ b/api/src/pcapi/alembic/versions/20220218T170226_07a30dcf25c5_check_booking_function.py
@@ -1,0 +1,123 @@
+"""Update check_booking SQL function."""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "07a30dcf25c5"
+down_revision = "f8e8c5e39eb7"
+branch_labels = None
+depends_on = None
+
+
+OLD_DDL = """
+    CREATE OR REPLACE FUNCTION check_booking()
+    RETURNS TRIGGER AS $$
+    DECLARE
+        lastStockUpdate date := (SELECT "dateModified" FROM stock WHERE id=NEW."stockId");
+        deposit_id bigint := (SELECT individual_booking."depositId" FROM booking LEFT JOIN individual_booking ON individual_booking.id = booking."individualBookingId" WHERE booking.id=NEW.id);
+    BEGIN
+    IF EXISTS (SELECT "quantity" FROM stock WHERE id=NEW."stockId" AND "quantity" IS NOT NULL)
+        AND (
+            (SELECT "quantity" FROM stock WHERE id=NEW."stockId")
+            <
+            (SELECT SUM(quantity) FROM booking WHERE "stockId"=NEW."stockId" AND status != 'CANCELLED')
+            )
+        THEN RAISE EXCEPTION 'tooManyBookings'
+                    USING HINT = 'Number of bookings cannot exceed "stock.quantity"';
+    END IF;
+
+    IF (
+        (NEW."educationalBookingId" IS NULL AND OLD."educationalBookingId" IS NULL)
+        AND (NEW."individualBookingId" IS NOT NULL OR OLD."individualBookingId" IS NOT NULL)
+        AND (
+        -- If this is a new booking, we probably want to check the wallet.
+        OLD IS NULL
+        -- If we're updating an existing booking...
+        OR (
+            -- Check the wallet if we are changing the quantity or the amount
+            -- The backend should never do that, but let's be defensive.
+            (NEW."quantity" != OLD."quantity" OR NEW."amount" != OLD."amount")
+            -- If amount and quantity are unchanged, we want to check the wallet
+            -- only if we are UNcancelling a booking. (Users with no credits left
+            -- should be able to cancel their booking. Also, their booking can
+            -- be marked as used or not used.)
+            OR (NEW.status != OLD.status AND OLD.status = 'CANCELLED' AND NEW.status != 'CANCELLED')
+        )
+        )
+        AND (
+            -- Allow to book free offers even with no credit left (or expired deposits)
+            (deposit_id IS NULL AND NEW."amount" != 0)
+            OR (deposit_id IS NOT NULL AND get_deposit_balance(deposit_id, false) < 0)
+        )
+    )
+    THEN RAISE EXCEPTION 'insufficientFunds'
+                USING HINT = 'The user does not have enough credit to book';
+    END IF;
+
+    RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+"""
+
+NEW_DDL = """
+    CREATE OR REPLACE FUNCTION check_booking()
+    RETURNS TRIGGER AS $$
+    DECLARE
+        lastStockUpdate date := (SELECT "dateModified" FROM stock WHERE id=NEW."stockId");
+        deposit_id bigint := (SELECT individual_booking."depositId" FROM booking LEFT JOIN individual_booking ON individual_booking.id = booking."individualBookingId" WHERE booking.id=NEW.id);
+    BEGIN
+
+    -- We allow synchronized stocks to have a negative remaining quantity
+    -- because items that have been booked through us could be sold
+    -- by the library at the same time. In that case, we want to allow
+    -- changing the status of the booking.
+    IF EXISTS (SELECT "quantity" FROM stock WHERE id=NEW."stockId" AND "quantity" IS NOT NULL AND "lastProviderId" IS NULL)
+        AND (
+            (SELECT "quantity" FROM stock WHERE id=NEW."stockId")
+            <
+            (SELECT SUM(quantity) FROM booking WHERE "stockId"=NEW."stockId" AND status != 'CANCELLED')
+            )
+        THEN RAISE EXCEPTION 'tooManyBookings'
+                    USING HINT = 'Number of bookings cannot exceed "stock.quantity"';
+    END IF;
+
+    IF (
+        (NEW."educationalBookingId" IS NULL AND OLD."educationalBookingId" IS NULL)
+        AND (NEW."individualBookingId" IS NOT NULL OR OLD."individualBookingId" IS NOT NULL)
+        AND (
+        -- If this is a new booking, we probably want to check the wallet.
+        OLD IS NULL
+        -- If we're updating an existing booking...
+        OR (
+            -- Check the wallet if we are changing the quantity or the amount
+            -- The backend should never do that, but let's be defensive.
+            (NEW."quantity" != OLD."quantity" OR NEW."amount" != OLD."amount")
+            -- If amount and quantity are unchanged, we want to check the wallet
+            -- only if we are UNcancelling a booking. (Users with no credits left
+            -- should be able to cancel their booking. Also, their booking can
+            -- be marked as used or not used.)
+            OR (NEW.status != OLD.status AND OLD.status = 'CANCELLED' AND NEW.status != 'CANCELLED')
+        )
+        )
+        AND (
+            -- Allow to book free offers even with no credit left (or expired deposits)
+            (deposit_id IS NULL AND NEW."amount" != 0)
+            OR (deposit_id IS NOT NULL AND get_deposit_balance(deposit_id, false) < 0)
+        )
+    )
+    THEN RAISE EXCEPTION 'insufficientFunds'
+                USING HINT = 'The user does not have enough credit to book';
+    END IF;
+
+    RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade():
+    op.execute(NEW_DDL)
+
+
+def downgrade():
+    op.execute(OLD_DDL)

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -252,7 +252,7 @@ def get_offers_map_by_venue_reference(id_at_provider_list: list[str], venue_id: 
 def get_stocks_by_id_at_providers(id_at_providers: list[str]) -> dict:
     stocks = (
         Stock.query.filter(Stock.idAtProviders.in_(id_at_providers))
-        .outerjoin(Booking, and_(Stock.id == Booking.stockId, Booking.status != BookingStatus.CANCELLED))
+        .outerjoin(Booking, and_(Stock.id == Booking.stockId, Booking.is_used_or_reimbursed.is_(True)))
         .group_by(Stock.id)
         .with_entities(
             Stock.id,
@@ -266,7 +266,7 @@ def get_stocks_by_id_at_providers(id_at_providers: list[str]) -> dict:
     return {
         id_at_providers: {
             "id": id,
-            "booking_quantity": booking_quantity,
+            "retrieved_bookings_quantity": booking_quantity,
             "quantity": quantity,
             "price": price,
         }

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -291,7 +291,7 @@ def _get_stocks_to_upsert(
             update_stock_mapping.append(
                 {
                     "id": stock["id"],
-                    "quantity": stock_detail.available_quantity + stock["booking_quantity"],
+                    "quantity": stock_detail.available_quantity + stock["retrieved_bookings_quantity"],
                     "rawProviderQuantity": stock_detail.available_quantity,
                     "price": book_price,
                     "lastProviderId": provider_id,
@@ -377,7 +377,7 @@ def _should_reindex_offer(new_quantity: int, new_price: float, existing_stock: d
         # Existing stock could be None (i.e. infinite) if the offerer manually overrides
         # the quantity of this synchronized stock.
         existing_stock["quantity"] is not None
-        and existing_stock["quantity"] <= existing_stock["booking_quantity"]
+        and existing_stock["quantity"] <= existing_stock["retrieved_bookings_quantity"]
     )
     is_new_quantity_stock_empty = new_quantity == 0
 

--- a/api/tests/core/providers/test_integration.py
+++ b/api/tests/core/providers/test_integration.py
@@ -1,0 +1,91 @@
+import pytest
+
+import pcapi.core.bookings.api as bookings_api
+import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.bookings.models as bookings_models
+from pcapi.core.categories import subcategories
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.providers import api
+from pcapi.core.providers import models
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_negative_remaining_quantity_then_cancel_booking():
+    # We have a pending booking...
+    provider = offerers_factories.APIProviderFactory()
+    stock = offers_factories.StockFactory(
+        rawProviderQuantity=1,
+        quantity=1,
+        lastProvider=provider,
+        idAtProviders="reference@siret",
+        offer__idAtProvider="reference",
+        offer__product__idAtProviders="reference",
+        offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
+        offer__venue__siret="siret",
+    )
+    booking = bookings_factories.IndividualBookingFactory(stock=stock)
+
+    # ... but the library informs us that, actually, they sold the
+    # last item.
+    details = [
+        models.StockDetail(
+            products_provider_reference="reference",
+            offers_provider_reference="reference",
+            venue_reference=f"reference@{booking.venue.id}",
+            stocks_provider_reference=f"reference@{booking.venue.siret}",
+            available_quantity=0,
+            price=10,
+        ),
+    ]
+    api.synchronize_stocks(details, booking.venue, provider.id)
+    assert stock.rawProviderQuantity == 0
+    assert stock.quantity == 0
+    assert stock.dnBookedQuantity == 1
+
+    # The beneficiary or the library should be able to cancel the
+    # booking.
+    bookings_api.cancel_booking_by_offerer(booking)
+    assert booking.status == bookings_models.BookingStatus.CANCELLED
+
+
+def test_negative_remaining_quantity_then_validate_booking():
+    # We have a pending booking...
+    provider = offerers_factories.APIProviderFactory()
+    stock = offers_factories.StockFactory(
+        rawProviderQuantity=1,
+        quantity=1,
+        lastProvider=provider,
+        idAtProviders="reference@siret",
+        offer__idAtProvider="reference",
+        offer__product__idAtProviders="reference",
+        offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
+        offer__venue__siret="siret",
+    )
+    booking = bookings_factories.BookingFactory(stock=stock)
+
+    # ... but the library informs us that, actually, they sold the
+    # last copy of the book.
+    details = [
+        models.StockDetail(
+            products_provider_reference="reference",
+            offers_provider_reference="reference",
+            venue_reference=f"reference@{booking.venue.id}",
+            stocks_provider_reference=f"reference@{booking.venue.siret}",
+            available_quantity=0,
+            price=10,
+        ),
+    ]
+    api.synchronize_stocks(details, booking.venue, provider.id)
+    assert stock.rawProviderQuantity == 0
+    assert stock.quantity == 0
+    assert stock.dnBookedQuantity == 1
+
+    # ... but in turns out that, in fact, the library had an extra,
+    # unaccounted copy hidden somewhere. The beneficiary has been able
+    # to retrieve their booking and we should be able to mark it as
+    # used.
+    bookings_api.mark_as_used(booking)
+    assert booking.status == bookings_models.BookingStatus.USED

--- a/api/tests/local_providers/provider_manager_test.py
+++ b/api/tests/local_providers/provider_manager_test.py
@@ -82,7 +82,7 @@ class SynchronizeVenueProviderTest:
             offer__idAtProvider=existing_product.idAtProviders,
             idAtProviders=stock_id_at_providers,
         )
-        bookings_factories.BookingFactory(stock=existing_stock)
+        bookings_factories.UsedBookingFactory(stock=existing_stock)
 
         product_to_synchronized = offers_factories.ProductFactory(
             idAtProviders="1234",
@@ -105,7 +105,7 @@ class SynchronizeVenueProviderTest:
 
         # Check that previously synchronized stock have been updated.
         assert existing_stock.offer.lastProviderId == provider.id
-        assert existing_stock.quantity == 12 + existing_stock.dnBookedQuantity
+        assert existing_stock.quantity == 12 + 1
 
         # Check that offers and stocks have been created.
         created_offer = Offer.query.filter_by(product=product_to_synchronized).one()

--- a/api/tests/local_providers/synchronize_provider_api_test.py
+++ b/api/tests/local_providers/synchronize_provider_api_test.py
@@ -5,7 +5,7 @@ from freezegun.api import freeze_time
 import pytest
 import requests_mock
 
-from pcapi.core.bookings.factories import BookingFactory
+import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offerers.models import Venue
@@ -103,8 +103,8 @@ class ProviderAPICronTest:
         create_product(ISBNs[8], isSynchronizationCompatible=False, product_price="7.08")
 
         stock_with_booking = create_stock(ISBNs[5], siret, venue, quantity=20, product_price="18.01")
-        BookingFactory(stock=stock_with_booking)
-        BookingFactory(stock=stock_with_booking, quantity=2)
+        bookings_factories.BookingFactory(stock=stock_with_booking)
+        bookings_factories.UsedBookingFactory(stock=stock_with_booking, quantity=2)
 
         # When
         with requests_mock.Mocker() as request_mock:
@@ -143,9 +143,9 @@ class ProviderAPICronTest:
         second_created_offer = Offer.query.filter_by(idAtProvider=ISBNs[4]).one()
         assert second_created_offer.stocks[0].quantity == 17
 
-        # Test existing bookings are added to quantity
-        assert stock_with_booking.quantity == 17 + 1 + 2
+        # Test only used bookings are added to quantity
         assert stock_with_booking.rawProviderQuantity == 17
+        assert stock_with_booking.quantity == 17 + 2
 
         # Test fill stock attributes
         assert created_stock.price == Decimal("30")

--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
@@ -169,8 +169,10 @@ const StockItem = ({
   }, [changeActivationCodesExpirationDatetime])
 
   const totalQuantityValue = totalQuantity !== null ? totalQuantity : ''
-  const computedRemainingQuantity =
+  const computedRemainingQuantity = Math.max(
+    0,
     totalQuantityValue - initialStock.bookingsQuantity
+  )
   const remainingQuantityValue =
     totalQuantityValue !== '' ? computedRemainingQuantity : 'Illimité'
   const isEventStockEditable =


### PR DESCRIPTION
Le calcul de la quantité totale d’un stock est incorrect pour les stocks synchronisés et permet la sur-réservation : la possibilité d’effectuer une réservation alors qu’il n’y a plus de stock suffisant en boutique.

Pour une explication complète, cf. le ticket [PC-10224](https://passculture.atlassian.net/browse/PC-10224).