### PR TITLE
[PC-13313] Interne - Bizdev - Indiquer “EAC” dans les mails de notification de création d’offre

### DIFF
--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -129,6 +129,7 @@ class OfferFactory(BaseFactory):
     mentalDisabilityCompliant = False
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
+    isEducational = False
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/templates/mails/offer_creation_notification_email.html
+++ b/api/src/pcapi/templates/mails/offer_creation_notification_email.html
@@ -15,6 +15,9 @@
     <p id="offer_is_duo">
         Offre duo : {{ offer.isDuo }}
     </p>
+    <p id="offer_is_educational">
+        Offre EAC : {{ offer.isEducational }}
+    </p>
     <p id="venue_details">
         Lien vers le lieu : {{ pro_venue_link }}
         <br >

--- a/api/src/pcapi/templates/mails/offer_creation_refusal_notification_email.html
+++ b/api/src/pcapi/templates/mails/offer_creation_refusal_notification_email.html
@@ -15,6 +15,9 @@
     <p id="offer_is_duo">
         Offre duo : {{ offer.isDuo }}
     </p>
+    <p id="offer_is_educational">
+        Offre EAC : {{ offer.isEducational }}
+    </p>
     <p id="venue_details">
         Lien vers le lieu : {{ pro_venue_link }}
         <br >

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -208,10 +208,11 @@ def make_offer_creation_notification_email(offer: Offer) -> dict:
         pro_venue_link=pro_venue_link,
     )
     location_information = offer.venue.departementCode or "numérique"
+    is_educational_offer_label = "EAC " if offer.isEducational else ""
     return {
         "Html-part": html,
         "FromName": "pass Culture",
-        "Subject": f"[Création d’offre - {location_information}] {offer.name}",
+        "Subject": f"[Création d’offre {is_educational_offer_label}- {location_information}] {offer.name}",
     }
 
 
@@ -229,10 +230,12 @@ def make_offer_rejection_notification_email(offer: Offer) -> dict:
         pro_venue_link=pro_venue_link,
     )
     location_information = offer.venue.departementCode or "numérique"
+    is_educational_offer_label = "EAC " if offer.isEducational else ""
+
     return {
         "Html-part": html,
         "FromName": "pass Culture",
-        "Subject": f"[Création d’offre : refus - {location_information}] {offer.name}",
+        "Subject": f"[Création d’offre {is_educational_offer_label}: refus - {location_information}] {offer.name}",
     }
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13313

## But de la pull request

En tant que CT
J'aimerais voir indiqué “EAC” dans l’objet et le corps du mail des création d’offre
Afin de traiter ces offres plus rapidement 

## Implémentation

Règles de gestion

Ajouter une variable dans l’objet du mail “[Création d’offre - XX EAC] Nom de l’offre”

Ajouter dans le corps du mail : 
Offre EAC = True 


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)