### PR TITLE
(PC-13282) Reduce plus icon size in image upload button

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageUploadButton/ImageUploadButton.module.scss
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageUploadButton/ImageUploadButton.module.scss
@@ -26,7 +26,8 @@
   }
 
   &-icon {
-    height: 42px;
+    height: 32px;
+    width: 32px;
   }
 
   &-label {

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageUploadButton/ImageUploadButton.module.scss
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageUploadButton/ImageUploadButton.module.scss
@@ -26,8 +26,8 @@
   }
 
   &-icon {
-    height: 32px;
-    width: 32px;
+    height: rem(32px);
+    width: rem(32px);
   }
 
   &-label {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13282

## But de la pull request

Réduire la taille de l'icône + dans le bouton d'upload d'une image pour les lieux et offres.
Largeur et hauteur imposées : 32px.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`

- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
Précédemment : 
<img width="280" alt="image" src="https://user-images.githubusercontent.com/74320569/154461308-0db3204e-acd2-4f5d-997e-e65137e97075.png">

Modification : 
<img width="281" alt="image" src="https://user-images.githubusercontent.com/74320569/154460828-efd87fb4-027e-4fd1-b96f-9754af3164fb.png">

