### PR TITLE
(PC-13515) CI: Fix build-and-push-image-db-ops job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -781,8 +781,8 @@ jobs:
           name: Build & push db-ops image
           command: |
             source ${BASH_ENV}
-            docker build ./infra/docker-images/db-ops \
-              -f ./infra/docker-images/db-ops/Dockerfile \
+            docker build ~/pass-culture-db-operations \
+              -f ~/pass-culture-db-operations/Dockerfile \
               --build-arg BASE_PCAPI_TAG=${APP_VERSION} \
               -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_TOOLS_REGISTRY_NAME}/db-ops:${APP_VERSION} \
               -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_TOOLS_REGISTRY_NAME}/db-ops:latest


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13515

## But de la pull request

Fix le chemin où sera build l'image db-ops

## Implémentation

N/A

## Informations supplémentaires

N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
