### PR TITLE
(PC-13369)[PRO] fix: remove separator when offer has a date

### DIFF
--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -117,7 +117,7 @@ const OfferEducationalStock = ({
               )}
               {!displayElementsForShowcaseOption && (
                 <>
-                  {!displayElementsForShowcaseOption && (
+                  {shouldDisplayShowcaseScreen && (
                     <div className={styles['separator']} />
                   )}
                   <Banner


### PR DESCRIPTION
Retour de validation : le séparateur en dessous de "date et prix" ne doit pas apparaître quand l'offre a une date et un prix

<img width="850" alt="Capture d’écran 2022-02-17 à 15 08 26" src="https://user-images.githubusercontent.com/35567446/154498556-bcfad191-913b-4902-8bff-654a16cd9e05.png">
