### PR TITLE
(PC-12681)[PRO] fix: wording on confirmation page for showcase offers

### DIFF
--- a/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
+++ b/pro/src/screens/OfferEducationalConfirmation/OfferEducationalConfirmation.tsx
@@ -30,7 +30,7 @@ const pendingOffer = {
 }
 
 const showcaseOffer = {
-  title: 'Offre en cours de validation !',
+  title: 'Offre créée avec succès !',
   description:
     'Votre offre est désormais disponible sur ADAGE (L’Application Dédiée À la Généralisation de l’Éducation artistique et culturelle) et visible par les enseignants et chefs d’établissement de l’Éducation nationale. Vous aurez la possibilité de revenir éditer votre offre et compléter les éléments de date(s) et prix.',
   Icon: ValidateIcon,


### PR DESCRIPTION
<img width="900" alt="Capture d’écran 2022-02-17 à 15 17 14" src="https://user-images.githubusercontent.com/35567446/154500193-7b51e28d-bbf0-4627-9b7f-17edbb6f95be.png">
