### PR TITLE
(PC-13512)[API] feat: order stocks sync by oldest sync date

### DIFF
--- a/api/src/pcapi/local_providers/provider_api/provider_api_stocks.py
+++ b/api/src/pcapi/local_providers/provider_api/provider_api_stocks.py
@@ -23,6 +23,7 @@ def synchronize_stocks() -> None:
         .filter(provider_alias.apiUrl.isnot(None))
         .filter(provider_alias.isActive.is_(True))
         .filter(VenueProvider.isActive.is_(True))
+        .order_by(VenueProvider.lastSyncDate.asc().nullsfirst())
         .all()
     )
 

--- a/api/tests/local_providers/provider_api_stocks_test.py
+++ b/api/tests/local_providers/provider_api_stocks_test.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import call
 from unittest.mock import patch
 
@@ -13,15 +14,17 @@ class ProviderApiStocksTest:
     @pytest.mark.usefixtures("db_session")
     def test_synchronize_venue_providers(self, mocked_synchronize_venue_provider, app):
         # Given
+        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+        two_days_ago = datetime.datetime.now() - datetime.timedelta(days=2)
         api_provider_1 = offerers_factories.APIProviderFactory()
         api_provider_2 = offerers_factories.APIProviderFactory()
         specific_provider = offerers_factories.AllocineProviderFactory()
         inactive_provider = offerers_factories.APIProviderFactory(isActive=False)
 
         correct_venue_providers = [
-            VenueProviderFactory(isActive=True, provider=api_provider_1),
-            VenueProviderFactory(isActive=True, provider=api_provider_1),
-            VenueProviderFactory(isActive=True, provider=api_provider_2),
+            VenueProviderFactory(isActive=True, provider=api_provider_2, lastSyncDate=yesterday),
+            VenueProviderFactory(isActive=True, provider=api_provider_1, lastSyncDate=two_days_ago),
+            VenueProviderFactory(isActive=True, provider=api_provider_1, lastSyncDate=None),
         ]
 
         VenueProviderFactory(isActive=True, provider=specific_provider)
@@ -33,4 +36,4 @@ class ProviderApiStocksTest:
 
         # Then
         assert mocked_synchronize_venue_provider.call_count == len(correct_venue_providers)
-        mocked_synchronize_venue_provider.assert_has_calls(call(v) for v in correct_venue_providers)
+        mocked_synchronize_venue_provider.assert_has_calls(call(v) for v in reversed(correct_venue_providers))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13512

## But de la pull request

Order the stock synchronization by:
- starting with venue without no prior synchronization
- venues with the longest missed synchronization

This will makes sure that whenever the stock synchronization is
stopped for whatever reason (deploy, OOM killer...) it will
restart with those that have NOT been treated first.

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
