### PR TITLE
(PC-13511)[api] fix: correct wrong emailBlacklisted sent to sendinBlue

### DIFF
--- a/api/src/pcapi/core/users/external/sendinblue.py
+++ b/api/src/pcapi/core/users/external/sendinblue.py
@@ -100,7 +100,7 @@ def update_contact_attributes(
         email=user_email,
         attributes=formatted_attributes,
         contact_list_ids=contact_list_ids,
-        emailBlacklisted=(attributes.marketing_email_subscription is not False),  # attribute may be None
+        emailBlacklisted=(not attributes.marketing_email_subscription),  # attribute may be None
     )
 
     if asynchronous:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13511

## But de la pull request

Depuis quelques jours, des utilisateurs remontent un problème avec l'opt-in et opt-out des notifications SiB:
- certains ont opt-out et reçoivent les emails
- d'autres ont opt-in et ne reçoivent plus les emails

## Implémentation

Une régression  avait été introduite lors de la précédente MEP.
L'attribut emailBlacklisted envoyé à SiB était incorrect.

## Informations supplémentaires

- Ajout d'une assertion dans le test `test_update_external_user` pour éviter une future régression sur ce point

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
