### PR TITLE
(PC-13307)[api] handle invalid name format dms

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import logging
 from os import path
+import random
+import string
 from typing import Optional
 
 from flask import current_app as app
@@ -149,9 +151,9 @@ def _get_mocked_user_for_performance_tests(user_id: str) -> models.EduconnectUse
         birth_date=user.dateOfBirth.date(),
         connection_datetime=datetime.now(),
         educonnect_id=f"educonnect-id_perf-test_{user.id}",
-        first_name=f"firstname_perf-test_{user.id}",
+        first_name="".join(random.choice(string.ascii_letters) for _ in range(10)),
         ine_hash=f"inehash_perf-test_{user.id}",
-        last_name=f"lastname_perf-test_{user.id}",
+        last_name="".join(random.choice(string.ascii_letters) for _ in range(10)),
         saml_request_id=mocked_saml_request_id,
     )
 

--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -13,7 +13,6 @@ from pcapi import settings
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.subscription import exceptions as subscription_exceptions
-from pcapi.serialization.utils import is_latin
 from pcapi.utils import requests
 from pcapi.utils.date import FrenchParserInfo
 
@@ -118,11 +117,6 @@ class DMSGraphQLClient:
         return self.execute_query(query, variables=variables)
 
 
-def is_subscription_name_valid(name: str) -> bool:
-    stripped_name = name.strip()
-    return bool(is_latin(name) and stripped_name)
-
-
 def parse_beneficiary_information_graphql(application_detail: dict, procedure_id: int) -> fraud_models.DMSContent:
     email = application_detail["usager"]["email"]
 
@@ -139,10 +133,10 @@ def parse_beneficiary_information_graphql(application_detail: dict, procedure_id
     }
     parsing_errors = {}
 
-    if not is_subscription_name_valid(information["first_name"]):
+    if not fraud_api.is_subscription_name_valid(information["first_name"]):
         parsing_errors["first_name"] = information["first_name"]
 
-    if not is_subscription_name_valid(information["last_name"]):
+    if not fraud_api.is_subscription_name_valid(information["last_name"]):
         parsing_errors["last_name"] = information["last_name"]
 
     for field in application_detail["champs"]:

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -16,6 +16,7 @@ from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository import repository
 from pcapi.repository.user_queries import matching
+from pcapi.serialization.utils import is_latin
 
 from . import models
 from .common import models as common_models
@@ -289,6 +290,11 @@ def _check_user_eligibility(
     return models.FraudItem(
         status=models.FraudStatus.OK, detail="L'utilisateur est éligible à un nouveau statut bénéficiaire"
     )
+
+
+def is_subscription_name_valid(name: str) -> bool:
+    stripped_name = name.strip()
+    return bool(is_latin(name) and stripped_name)
 
 
 def _check_user_email_is_validated(user: users_models.User) -> models.FraudItem:

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -6,6 +6,7 @@ import typing
 import pydantic
 import sqlalchemy
 
+from pcapi.core.fraud.utils import is_latin
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import constants
@@ -16,7 +17,6 @@ from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository import repository
 from pcapi.repository.user_queries import matching
-from pcapi.serialization.utils import is_latin
 
 from . import models
 from .common import models as common_models
@@ -299,7 +299,7 @@ def is_subscription_name_valid(name: typing.Optional[str]) -> bool:
     if not name:
         return False
     stripped_name = name.strip()
-    return bool(is_latin(name) and stripped_name)
+    return is_latin(stripped_name)
 
 
 def _check_user_names_valid(first_name: typing.Optional[str], last_name: typing.Optional[str]):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -300,6 +300,7 @@ class FraudReasonCode(enum.Enum):
     ID_CHECK_UNPROCESSABLE = "id_check_unprocessable"
     INE_NOT_WHITELISTED = "ine_not_whitelisted"
     INVALID_ID_PIECE_NUMBER = "invalid_id_piece_number"
+    NAME_INCORRECT = "name_incorrect"
     NOT_ELIGIBLE = "not_eligible"
     PHONE_NOT_VALIDATED = "phone_not_validated"
     REFUSED_BY_OPERATOR = "refused_by_operator"

--- a/api/src/pcapi/core/fraud/utils.py
+++ b/api/src/pcapi/core/fraud/utils.py
@@ -1,0 +1,25 @@
+import unicodedata
+
+
+def is_latin(s: str) -> bool:
+    if s == "":
+        return False
+    for char in s:
+        if char in (" ", "-", ".", ",", "'", "’"):
+            continue
+        try:
+            if not "LATIN" in unicodedata.name(char):
+                return False
+        # if unicodedata.name does not recognize char, it raises a ValueError
+        except ValueError:
+            return False
+    return True
+
+
+def has_latin_or_numeric_chars(address: str) -> bool:
+    for char in address:
+        if char == " ":
+            continue
+        if not is_latin(char) and not char.isnumeric():
+            return False
+    return True

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -148,6 +148,12 @@ def notify_parsing_exception(parsing_error: subscription_exceptions.DMSParsingEr
             settings.DMS_INSTRUCTOR_ID,
             subscription_messages.DMS_ERROR_MESSAGE_ERROR_ID_PIECE,
         )
+    elif "first_name" in parsing_error or "last_name" in parsing_error:
+        client.send_user_message(
+            application_techid,
+            settings.DMS_INSTRUCTOR_ID,
+            subscription_messages.DMS_NAME_INVALID_ERROR_MESSAGE,
+        )
 
 
 def process_parsing_exception(

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -87,6 +87,21 @@ DMS_ERROR_MESSSAGE_BIRTH_DATE = """Bonjour,
 
                         L'équipe du pass Culture"""
 
+DMS_NAME_INVALID_ERROR_MESSAGE = """Bonjour,
+
+                            Nous avons bien reçu ton dossier !
+                            Cependant, ton dossier ne peut pas être traité pour la raison suivante :
+                            Les champs "Nom" et / ou "Prénom" ont été renseignés au mauvais format.
+
+                            Pour que ton dossier soit traité, tu dois les modifier en faisant bien attention à remplir correctement toutes les informations. Pour avoir plus d'informations sur les étapes de ton inscription sur Démarches Simplifiées, nous t'invitons à consulter les articles suivants :
+
+                            Jeune de 18 ans : <a href="https://aide.passculture.app/hc/fr/articles/4411991957521--Jeunes-Comment-remplir-le-formulaire-sur-D%C3%A9marches-Simplifi%C3%A9es-">https://aide.passculture.app/hc/fr/articles/4411991957521--Jeunes-Comment-remplir-le-formulaire-sur-Démarches-Simplifiées</a>
+                            Jeune de 15 à 17 ans : <a href="https://aide.passculture.app/hc/fr/articles/4404373671324--Jeunes-15-17-ans-Comment-remplir-le-formulaire-sur-D%C3%A9marches-Simplifi%C3%A9es-">https://aide.passculture.app/hc/fr/articles/4404373671324--Jeunes-15-17-ans-Comment-remplir-le-formulaire-sur-Démarches-Simplifiées-</a>
+
+                            Nous te souhaitons une belle journée,
+
+                            L'équipe du pass Culture"""
+
 
 def on_review_pending(user: users_models.User) -> None:
     message = models.SubscriptionMessage(
@@ -291,6 +306,8 @@ def _generate_form_field_error(error_text_singular: str, error_text_plural: str,
         "id_piece_number": "ta pièce d'identité",
         "postal_code": "ton code postal",
         "birth_date": "ta date de naissance",
+        "first_name": "ton prénom",
+        "last_name": "ton nom",
     }
 
     user_message = error_text_singular.format(

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -322,8 +322,8 @@ def _generate_form_field_error(error_text_singular: str, error_text_plural: str,
 
 def on_dms_application_parsing_errors_but_updatables_values(user: users_models.User, error_fields: list[str]) -> None:
     user_message = _generate_form_field_error(
-        "Il semblerait que le champ ‘{formatted_error_fields}’ soit erroné. Tu peux te rendre sur le site Démarche-simplifiées pour le rectifier.",
-        "Il semblerait que les champs ‘{formatted_error_fields}’ soient erronés. Tu peux te rendre sur le site Démarche-simplifiées pour les rectifier.",
+        "Il semblerait que le champ ‘{formatted_error_fields}’ soit erroné. Tu peux te rendre sur le site Démarches-simplifiées pour le rectifier.",
+        "Il semblerait que les champs ‘{formatted_error_fields}’ soient erronés. Tu peux te rendre sur le site Démarches-simplifiées pour les rectifier.",
         error_fields,
     )
     message = models.SubscriptionMessage(

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -2,12 +2,12 @@ from typing import Optional
 
 from pydantic import validator
 
+from pcapi.core.fraud.utils import has_latin_or_numeric_chars
+from pcapi.core.fraud.utils import is_latin
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import profile_options
 from pcapi.core.users import models as users_models
 from pcapi.routes.serialization import BaseModel
-from pcapi.serialization.utils import has_latin_or_numeric_chars
-from pcapi.serialization.utils import is_latin
 from pcapi.serialization.utils import to_camel
 
 

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -2,7 +2,6 @@ import re
 from typing import Any
 from typing import Optional
 from typing import Union
-import unicodedata
 
 from flask import Request
 from flask import Response
@@ -125,27 +124,3 @@ def validate_phone_number_format(field_name: str) -> classmethod:
 
 def string_to_boolean_field(field_name: str) -> classmethod:
     return validator(field_name, pre=True, allow_reuse=True)(string_to_boolean)
-
-
-def is_latin(s: str) -> bool:
-    if s == "":
-        return False
-    for char in s:
-        if char in (" ", "-", ".", ",", "'", "’"):
-            continue
-        try:
-            if not "LATIN" in unicodedata.name(char):
-                return False
-        # if unicodedata.name does not recognize char, it raises a ValueError
-        except ValueError:
-            return False
-    return True
-
-
-def has_latin_or_numeric_chars(address: str) -> bool:
-    for char in address:
-        if char == " ":
-            continue
-        if not is_latin(char) and not char.isnumeric():
-            return False
-    return True

--- a/api/tests/core/fraud/utils_test.py
+++ b/api/tests/core/fraud/utils_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from pcapi.serialization.utils import has_latin_or_numeric_chars
-from pcapi.serialization.utils import is_latin
+from pcapi.core.fraud.utils import has_latin_or_numeric_chars
+from pcapi.core.fraud.utils import is_latin
 
 
 class UtilsUnitTest:

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -225,7 +225,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Il semblerait que les champs ‘ta pièce d'identité, ton code postal’ soient erronés. Tu peux te rendre sur le site Démarche-simplifiées pour les rectifier."
+            == "Il semblerait que les champs ‘ta pièce d'identité, ton code postal’ soient erronés. Tu peux te rendre sur le site Démarches-simplifiées pour les rectifier."
         )
 
         fraud_check = user.beneficiaryFraudChecks[0]
@@ -290,7 +290,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Il semblerait que le champ ‘ta pièce d'identité’ soit erroné. Tu peux te rendre sur le site Démarche-simplifiées pour le rectifier."
+            == "Il semblerait que le champ ‘ta pièce d'identité’ soit erroné. Tu peux te rendre sur le site Démarches-simplifiées pour le rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -320,7 +320,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Il semblerait que le champ ‘ton prénom’ soit erroné. Tu peux te rendre sur le site Démarche-simplifiées pour le rectifier."
+            == "Il semblerait que le champ ‘ton prénom’ soit erroné. Tu peux te rendre sur le site Démarches-simplifiées pour le rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -354,7 +354,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Il semblerait que les champs ‘ton prénom, ton nom’ soient erronés. Tu peux te rendre sur le site Démarche-simplifiées pour les rectifier."
+            == "Il semblerait que les champs ‘ton prénom, ton nom’ soient erronés. Tu peux te rendre sur le site Démarches-simplifiées pour les rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -384,7 +384,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Il semblerait que le champ ‘ton code postal’ soit erroné. Tu peux te rendre sur le site Démarche-simplifiées pour le rectifier."
+            == "Il semblerait que le champ ‘ton code postal’ soit erroné. Tu peux te rendre sur le site Démarches-simplifiées pour le rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -419,7 +419,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Il semblerait que le champ ‘ta date de naissance’ soit erroné. Tu peux te rendre sur le site Démarche-simplifiées pour le rectifier."
+            == "Il semblerait que le champ ‘ta date de naissance’ soit erroné. Tu peux te rendre sur le site Démarches-simplifiées pour le rectifier."
         )
 
         fraud_check = user.beneficiaryFraudChecks[0]

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -222,7 +222,7 @@ APPLICATION_DETAIL_STANDARD_RESPONSE = {
     }
 }
 
-
+# TODO yorickeando: code mort
 def make_new_beneficiary_application_details(
     application_id: int,
     state: str,
@@ -280,6 +280,8 @@ def make_graphql_application(
     full_graphql_response: bool = False,
     has_next_page: bool = False,
     construction_datetime: str = "2020-05-13T09:09:46+02:00",
+    first_name: str = "John",
+    last_name: str = "Doe",
 ) -> dict:
     data = {
         "id": "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
@@ -374,7 +376,7 @@ def make_graphql_application(
         ],
         "annotations": [],
         "usager": {"email": email},
-        "demandeur": {"civilite": civility, "nom": "Doe", "prenom": "John", "dateDeNaissance": None},
+        "demandeur": {"civilite": civility, "nom": last_name, "prenom": first_name, "dateDeNaissance": None},
     }
     if full_graphql_response:
         enveloppe = {

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import random
 import string
@@ -221,50 +220,6 @@ APPLICATION_DETAIL_STANDARD_RESPONSE = {
         ],
     }
 }
-
-# TODO yorickeando: code mort
-def make_new_beneficiary_application_details(
-    application_id: int,
-    state: str,
-    postal_code: int = 67200,
-    department_code: str = "67 - Bas-Rhin",
-    civility: str = "Mme",
-    activity: str = "Étudiant",
-    id_piece_number: Optional[str] = None,
-    email: Optional[str] = None,
-    birth_date: Optional[datetime.date] = None,
-) -> dict:
-    application = copy.deepcopy(APPLICATION_DETAIL_STANDARD_RESPONSE)
-    application["dossier"]["id"] = application_id
-    application["dossier"]["state"] = state
-    application["dossier"]["individual"]["civilite"] = civility
-    if email:
-        application["dossier"]["email"] = email
-    for field in application["dossier"]["champs"]:
-        if field["type_de_champ"]["libelle"] == "Veuillez indiquer votre département de résidence":
-            field["value"] = department_code
-        if field["type_de_champ"]["libelle"] == "Quel est le code postal de votre commune de résidence ?":
-            field["value"] = postal_code
-        if field["type_de_champ"]["libelle"] == "Veuillez indiquer votre statut":
-            field["value"] = activity
-        if birth_date:
-            if field["type_de_champ"]["libelle"] == "Quelle est votre date de naissance":
-                field["value"] = birth_date.strftime("%Y-%m-%d")
-
-    if id_piece_number:
-        application["dossier"]["champs"].append(
-            {
-                "value": id_piece_number,
-                "type_de_champ": {
-                    "id": 123123,
-                    "libelle": "Quel est le numéro de la pièce que vous venez de saisir ?",
-                    "type_champ": "unknown",
-                    "order_place": 123,
-                    "description": "WIP",
-                },
-            }
-        )
-    return application
 
 
 def make_graphql_application(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13307

## But de la pull request

Notre API refuse les utilisateurs dont les nom/prénom ne sont pas en caractères latins. DMS ne fait pas ce filtre. Cette PR fait deux choses : 
- Lors des dépôts de dossier DMS, on veut alerter l'utilisateur qu'il a mal renseigné ses informations et lui donner la chance de modifier sur DMS.
- Lors de l'import des dossiers validés par DMS, on invalide les dossiers mal renseignés et on remonte un subscription message pour l'utilisateur.

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
