### PR TITLE
(PC-12824)[API] fix: create a new fraud_check in case of educonnect multiple calls

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -49,23 +49,14 @@ def on_educonnect_result(
 ) -> models.BeneficiaryFraudCheck:
     eligibility_type = educonnect_content.get_eligibility_type_at_registration()
 
-    fraud_check = models.BeneficiaryFraudCheck.query.filter(
-        models.BeneficiaryFraudCheck.user == user,
-        models.BeneficiaryFraudCheck.type == models.FraudCheckType.EDUCONNECT,
-        models.BeneficiaryFraudCheck.eligibilityType == eligibility_type,
-    ).one_or_none()
+    fraud_check = models.BeneficiaryFraudCheck(
+        user=user,
+        type=models.FraudCheckType.EDUCONNECT,
+        thirdPartyId=str(educonnect_content.educonnect_id),
+        resultContent=educonnect_content.dict(),
+        eligibilityType=eligibility_type,
+    )
 
-    if fraud_check:
-        fraud_check.thirdPartyId = str(educonnect_content.educonnect_id)
-        fraud_check.resultContent = educonnect_content.dict()
-    else:
-        fraud_check = models.BeneficiaryFraudCheck(
-            user=user,
-            type=models.FraudCheckType.EDUCONNECT,
-            thirdPartyId=str(educonnect_content.educonnect_id),
-            resultContent=educonnect_content.dict(),
-            eligibilityType=eligibility_type,
-        )
     on_identity_fraud_check_result(user, fraud_check)
     repository.save(fraud_check)
     return fraud_check

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -235,6 +235,7 @@ class EduconnectFraudTest:
         assert fraud_check.userId == user.id
         assert fraud_check.type == fraud_models.FraudCheckType.EDUCONNECT
         assert fraud_check.eligibilityType == users_models.EligibilityType.UNDERAGE
+        assert fraud_check.status == fraud_models.FraudCheckStatus.OK
         assert fraud_check.source_data().__dict__ == {
             "educonnect_id": "id-1",
             "first_name": "Lucy",
@@ -246,7 +247,7 @@ class EduconnectFraudTest:
             "student_level": "2212",
         }
 
-        # If the user logs in again with another educonnect account, update the fraud check
+        # If the user logs in again with another educonnect account, create another fraud check
         fraud_factories.IneHashWhitelistFactory(ine_hash="0000")
         fraud_api.on_educonnect_result(
             user,
@@ -262,10 +263,14 @@ class EduconnectFraudTest:
             ),
         )
 
-        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
-            user=user,
-            type=fraud_models.FraudCheckType.EDUCONNECT,
-        ).one_or_none()
+        fraud_check = (
+            fraud_models.BeneficiaryFraudCheck.query.filter_by(
+                user=user,
+                type=fraud_models.FraudCheckType.EDUCONNECT,
+            )
+            .filter(fraud_models.BeneficiaryFraudCheck.id != fraud_check.id)
+            .first()
+        )
         assert fraud_check.userId == user.id
         assert fraud_check.type == fraud_models.FraudCheckType.EDUCONNECT
         assert fraud_check.eligibilityType == users_models.EligibilityType.UNDERAGE


### PR DESCRIPTION
Ticket : https://passculture.atlassian.net/browse/PC-12824

Anomalie détectée dans le cadre de [ce ticket](https://passculture.atlassian.net/browse/PC-13447)

[Cette utilisateur](https://backend.passculture.pro/pc/back-office/support_beneficiary/details/?id=2574681&url=%2Fpc%2Fback-office%2Fsupport_beneficiary%2F%3Fsearch%3D1766255) par exemple a un "educonnect KO", car il a dû appeler la route plusieurs fois.

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
