### PR TITLE
(PC-13536) [API] fix:venue: bannerUrl -> banner_url (Algolia)

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -319,7 +319,7 @@ class AlgoliaBackend(base.SearchBackend):
             "instagram": social_medias.get("instagram"),
             "snapchat": social_medias.get("snapchat"),
             "tags": [criterion.name for criterion in venue.criteria],
-            "bannerUrl": venue.bannerUrl,
+            "banner_url": venue.bannerUrl,
             "_geoloc": position(venue),
         }
 

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -552,6 +552,6 @@ def test_serialize_venue():
         "snapchat": None,
         "twitter": "https://twitter.com/my.venue",
         "tags": [],
-        "bannerUrl": venue.bannerUrl,
+        "banner_url": venue.bannerUrl,
         "_geoloc": {"lng": float(venue.longitude), "lat": float(venue.latitude)},
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13536

## But de la pull request

Renommer le champ `bannerUrl` de l'index Algolia (les autres sont en _snake_case_).