### PR TITLE
(PC-13479) [API] feat:venue: normalize save_venue_banner

### DIFF
--- a/api/src/pcapi/connectors/thumb_storage.py
+++ b/api/src/pcapi/connectors/thumb_storage.py
@@ -10,8 +10,9 @@ def create_thumb(
     image_as_bytes: bytes,
     image_index: int,
     crop_params: tuple = None,
+    ratio: float = IMAGE_RATIO_PORTRAIT_DEFAULT,
 ) -> None:
-    image_as_bytes = standardize_image(image_as_bytes, ratio=IMAGE_RATIO_PORTRAIT_DEFAULT, crop_params=crop_params)
+    image_as_bytes = standardize_image(image_as_bytes, ratio=ratio, crop_params=crop_params)
 
     object_storage.store_public_object(
         folder=settings.THUMBS_FOLDER_NAME,

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -50,6 +50,7 @@ from pcapi.utils.date import CUSTOM_TIMEZONES
 from pcapi.utils.date import METROPOLE_TIMEZONE
 from pcapi.utils.date import get_department_timezone
 from pcapi.utils.date import get_postal_code_timezone
+from pcapi.utils.human_ids import humanize
 
 
 CONSTRAINT_CHECK_IS_VIRTUAL_XOR_HAS_ADDRESS = """
@@ -276,6 +277,14 @@ class Venue(PcObject, Model, HasThumbMixin, HasAddressMixin, ProvidableMixin, Ne
         if self.businessUnit and self.businessUnit.siret:
             return self.siret == self.businessUnit.siret
         return False
+
+    @property
+    def thumbUrl(self):
+        """
+        Override to discard the thumbCount column: not used by Venues
+        which have at most one banner (thumb).
+        """
+        return "{}/{}/{}".format(self.thumb_base_url, self.thumb_path_component, humanize(self.id))
 
     @hybrid_property
     def timezone(self) -> str:

--- a/api/src/pcapi/models/has_thumb_mixin.py
+++ b/api/src/pcapi/models/has_thumb_mixin.py
@@ -26,8 +26,11 @@ class HasThumbMixin:
         return f"{self.thumb_path_component}/{humanize(self.id)}{suffix}"
 
     @property
+    def thumb_base_url(self):
+        return settings.OBJECT_STORAGE_URL + "/thumbs"
+
+    @property
     def thumbUrl(self):
         if self.thumbCount == 0:
             return None
-        thumb_url = settings.OBJECT_STORAGE_URL + "/thumbs"
-        return "{}/{}/{}".format(thumb_url, self.thumb_path_component, humanize(self.id))
+        return "{}/{}/{}".format(self.thumb_base_url, self.thumb_path_component, humanize(self.id))

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -143,8 +143,7 @@ def upsert_venue_banner(venue_id: str) -> GetVenueResponseModel:
         user=current_user,
         venue=venue,
         content=venue_banner.content,
-        content_type=venue_banner.content_type,
-        file_name=venue_banner.file_name,
+        image_credit=venue_banner.image_credit,
         crop_params=venue_banner.crop_params,
     )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13479

## But de la pull request

1. Normaliser la fonction `save_venue_banner` qui n'appelait pas directement `create_thumb` et qui avait un nommage un peu différent pour ses fichiers : 
    1. appeler `create_thumb` (avec un nouveau paramètre : `ratio`) ;
    2. utiliser la valeur de `thumbUrl` (_property_) pour `bannerUrl` (colonne).

2. Mettre à jour le contenu de bannerMeta : suite à l'ajout de la compression et du redimensionnement, les nom et type du fichier envoyé ne sont plus pertinents donc on les supprime. Et ajout de image_credit qui contient le crédit photo (s'il y en a un).


## Informations supplémentaires

Au passage : ajout du paramètre `ratio` à `create_thumb`.


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires

