### PR TITLE
(PC-13563) cleanup OFFER_VALIDATION_MOCK_COMPUTATION feature flag

### DIFF
--- a/api/src/pcapi/alembic/versions/20210322_bd142e43ea07_add_feature_flag_offer_validation_.py
+++ b/api/src/pcapi/alembic/versions/20210322_bd142e43ea07_add_feature_flag_offer_validation_.py
@@ -1,14 +1,11 @@
-"""add_feature_flag_offer_validation_computation
+"""This migration used to add the `OFFER_VALIDATION_MOCK_COMPUTATION`
+ feature flag, but it is no longer needed.
 
 Revision ID: bd142e43ea07
 Revises: 069e6621725a
 Create Date: 2021-03-22 12:07:13.888217
 
 """
-from alembic import op
-from sqlalchemy import text
-
-from pcapi.models.feature import FeatureToggle
 
 
 # revision identifiers, used by Alembic.
@@ -19,14 +16,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    feature = FeatureToggle.OFFER_VALIDATION_MOCK_COMPUTATION
-    op.execute(
-        text("""INSERT INTO feature (name, description, "isActive") VALUES (:name, :value, true)""").bindparams(
-            name=feature.name, value=feature.value
-        )
-    )
+    pass
 
 
 def downgrade() -> None:
-    feature = FeatureToggle.OFFER_VALIDATION_MOCK_COMPUTATION
-    op.execute(text("""DELETE FROM feature WHERE name = :name""").bindparams(name=feature.name))
+    pass

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -99,11 +99,6 @@ logger = logging.getLogger(__name__)
 
 OFFERS_RECAP_LIMIT = 501
 UNCHANGED = object()
-VALIDATION_KEYWORDS_MAPPING = {
-    "APPROVED": OfferValidationStatus.APPROVED,
-    "PENDING": OfferValidationStatus.PENDING,
-    "REJECTED": OfferValidationStatus.REJECTED,
-}
 
 
 def list_offers_for_pro_user(
@@ -861,12 +856,6 @@ def deactivate_inappropriate_products(isbn: str) -> bool:
 
 
 def set_offer_status_based_on_fraud_criteria(offer: Offer) -> OfferValidationStatus:
-    # TODO (rchaffal) to delete after implementation is completed
-    if not settings.IS_PROD and FeatureToggle.OFFER_VALIDATION_MOCK_COMPUTATION.is_active():
-        for keyword, validation_status in VALIDATION_KEYWORDS_MAPPING.items():
-            if keyword in offer.name:
-                return validation_status
-
     current_config = offers_repository.get_current_offer_validation_config()
     if not current_config:
         return OfferValidationStatus.APPROVED

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -304,7 +304,10 @@ def check_validation_config_parameters(config_as_dict: dict, valid_keys: list) -
     for key, value in config_as_dict.items():
         if key not in valid_keys:
             raise KeyError(f"Wrong key: {key}")
-
+        if key == "condition" and value["operator"] == "contains" and not isinstance(value["comparated"], list):
+            raise TypeError(
+                f"The `comparated` argument `{value['comparated']}` for the `contains` operator is not a list"
+            )
         if isinstance(value, list) and key in KEY_VALIDATION_CONFIG:
             for item in value:
                 check_validation_config_parameters(item, KEY_VALIDATION_CONFIG[key])

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -70,7 +70,6 @@ class FeatureToggle(enum.Enum):
     )
     ID_CHECK_ADDRESS_AUTOCOMPLETION = "Autocomplétion de l'adresse lors du parcours IDCheck"
     IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY = "Vérifier que l'utilisateur a bien rempli l'étape de confirmation sur l'honneur avant d'activer son compte bénéficiaire"  # TODO (vionnex) remove after v164 is forced on native app
-    OFFER_VALIDATION_MOCK_COMPUTATION = "Active le calcul automatique de validation d'offre depuis le nom de l'offre"
     PRICE_BOOKINGS = "Active la valorisation des réservations"
     PRO_ENABLE_UPLOAD_VENUE_IMAGE = "Active la fonctionnalité d'upload des images des lieux permanents"
     QR_CODE = "Permettre la validation dune contremarque via QR code"

--- a/api/src/pcapi/utils/custom_logic.py
+++ b/api/src/pcapi/utils/custom_logic.py
@@ -36,8 +36,11 @@ def less_or_equal(a: object, b: object, *args) -> bool:
 
 
 def contains(a, b) -> bool:
+    """Checks if the list b contains the element a"""
     if not a:
         return False
+    if not isinstance(b, list):
+        raise TypeError(f"{b} is not a list")
     return (
         any(sanitize_str(element) in sanitize_str(a) for element in b)
         if "__contains__" in dir(b)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1925,7 +1925,8 @@ class ComputeOfferValidationTest:
                  attribute: "name"
                  condition:
                     operator: "contains"
-                    comparated: "suspicious"
+                    comparated: 
+                      - "suspicious"
         """
         api.import_offer_validation_config(example_yaml)
         assert api.set_offer_status_based_on_fraud_criteria(offer) == offer_models.OfferValidationStatus.PENDING
@@ -2046,6 +2047,25 @@ class ImportOfferValidationConfigTest:
         assert "namme" in str(error.value)
 
     @override_features(OFFER_VALIDATION_MOCK_COMPUTATION=False)
+    def test_raise_if_contains_comparated_not_a_list(self):
+        config_yaml = """
+            minimum_score: 0.6
+            rules:
+                - name: "nom de l'offre"
+                  factor: 0
+                  conditions:
+                    - model: "Offer"
+                      attribute: "name"
+                      condition:
+                        operator: "contains"
+                        comparated: "danger"
+            """
+
+        with pytest.raises(TypeError) as exc:
+            api.import_offer_validation_config(config_yaml)
+
+        assert str(exc.value) == "The `comparated` argument `danger` for the `contains` operator is not a list"
+
     def test_is_saved(self):
         config_yaml = """
         minimum_score: 0.6

--- a/api/tests/utils/custom_logic_test.py
+++ b/api/tests/utils/custom_logic_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pcapi.utils.custom_logic import OPERATIONS
 
 
@@ -139,6 +141,15 @@ def test_contains_return_false():
     b = ["hello", "world"]
     result = OPERATIONS["contains"](a, b)
     assert not result
+
+
+def test_raise_if_contains_comparated_is_not_a_list():
+    a = "An innocent offer"
+    b = "regret"
+
+    with pytest.raises(TypeError) as exc:
+        OPERATIONS["contains"](a, b)
+        assert str(exc.value) == "regret is not a list"
 
 
 def test_contains_exact_return_true():


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13563

## But de la pull request

Supprimer le FF OFFER_VALIDATION_MOCK_COMPUTATION, autrefois nécessaire au développement des fonctionnalités de validation d'offre.

## Implémentation

- modification de la migration d'ajout
- suppression des occurrences dans le code

## Informations supplémentaires

- Au passage, ajout d'une vérification que l'argument `comparated` de l'opérateur `contains` est bien une liste, et pas simplement une `str` afin d'éviter les faux positifs.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
