### PR TITLE
(PC-13189)[PRO] remove redux-saga-data from OffererCreationContainer

### DIFF
--- a/pro/src/components/pages/Offerers/OffererCreation/OffererCreationContainer.js
+++ b/pro/src/components/pages/Offerers/OffererCreation/OffererCreationContainer.js
@@ -1,8 +1,6 @@
-import { removeWhitespaces } from 'react-final-form-utils'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { compose } from 'redux'
-import { requestData } from 'redux-saga-data'
 
 import { isFeatureActive } from 'store/features/selectors'
 import { showNotification } from 'store/reducers/notificationReducer'
@@ -18,18 +16,6 @@ export function mapStateToProps(state) {
 }
 
 export const mapDispatchToProps = dispatch => ({
-  createNewOfferer: (payload, onHandleFail, onHandleSuccess) => {
-    const { siren } = payload
-    dispatch(
-      requestData({
-        apiPath: `/offerers`,
-        method: 'POST',
-        body: { ...payload, siren: removeWhitespaces(siren) },
-        handleFail: onHandleFail,
-        handleSuccess: onHandleSuccess,
-      })
-    )
-  },
   showNotification: (message, type) => {
     dispatch(
       showNotification({

--- a/pro/src/components/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.jsx
+++ b/pro/src/components/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.jsx
@@ -11,7 +11,6 @@ describe('src | components | OffererCreation', () => {
 
   beforeEach(() => {
     props = {
-      createNewOfferer: jest.fn(),
       isEntrepriseApiDisabled: false,
       showNotification: jest.fn(),
       redirectAfterSubmit: jest.fn(),

--- a/pro/src/components/pages/Offerers/OffererCreation/__specs__/OffererCreationContainer.spec.js
+++ b/pro/src/components/pages/Offerers/OffererCreation/__specs__/OffererCreationContainer.spec.js
@@ -33,7 +33,6 @@ describe('src | components | pages | Offerer | OfferCreation | OffererCreationCo
 
       // then
       expect(functions).toStrictEqual({
-        createNewOfferer: expect.any(Function),
         showNotification: expect.any(Function),
       })
     })
@@ -66,42 +65,6 @@ describe('src | components | pages | Offerer | OfferCreation | OffererCreationCo
             type: 'success',
           },
           type: 'SHOW_NOTIFICATION',
-        })
-      })
-    })
-
-    describe('createNewOfferer', () => {
-      it('should dispatch', () => {
-        // Given
-        const ownProps = {
-          currentUser: {
-            id: 'TY56er',
-          },
-          match: {
-            params: {
-              offererId: 'AGH',
-            },
-          },
-        }
-        const { createNewOfferer } = mapDispatchToProps(dispatch, ownProps)
-        const payload = {
-          key: 'value',
-          siren: '123 456 789',
-        }
-
-        // When
-        createNewOfferer(payload)
-
-        expect(dispatch).toHaveBeenCalledWith({
-          config: {
-            apiPath: '/offerers',
-            method: 'POST',
-            body: {
-              key: 'value',
-              siren: '123456789',
-            },
-          },
-          type: 'REQUEST_DATA_POST_/OFFERERS',
         })
       })
     })

--- a/pro/src/repository/pcapi/pcapi.js
+++ b/pro/src/repository/pcapi/pcapi.js
@@ -182,6 +182,8 @@ export const getEducationalOfferers = offererId => {
   return client.get(`/offerers/educational${queryParams}`)
 }
 
+export const createOfferer = offerer => client.post(`/offerers`, offerer)
+
 //
 // venues
 //


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13189

## But de la pull request

Retirer redux-saga-data de OffererCreationContainer

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
