### PR TITLE
PC-9976 check offer subcategory before notify

### DIFF
--- a/api/src/pcapi/domain/admin_emails.py
+++ b/api/src/pcapi/domain/admin_emails.py
@@ -1,5 +1,6 @@
 from pcapi import settings
 from pcapi.core import mails
+from pcapi.core.categories import subcategories
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferValidationStatus
@@ -49,6 +50,27 @@ def send_payments_report_emails(
     return mails.send(recipients=recipients, data=email)
 
 
+def _check_offer_subcategory_before_send(offer: Offer) -> bool:
+    return offer.subcategoryId in (
+        subcategories.ABO_JEU_VIDEO.id,
+        subcategories.ABO_LIVRE_NUMERIQUE.id,
+        subcategories.ACHAT_INSTRUMENT.id,
+        subcategories.AUTRE_SUPPORT_NUMERIQUE.id,
+        subcategories.BON_ACHAT_INSTRUMENT.id,
+        subcategories.LIVRE_AUDIO_PHYSIQUE.id,
+        subcategories.LIVRE_NUMERIQUE.id,
+        subcategories.LIVRE_PAPIER.id,
+        subcategories.LOCATION_INSTRUMENT.id,
+        subcategories.MATERIEL_ART_CREATIF.id,
+        subcategories.PARTITION.id,
+        subcategories.SUPPORT_PHYSIQUE_FILM.id,
+        subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id,
+        subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
+        subcategories.TELECHARGEMENT_MUSIQUE.id,
+        subcategories.VOD.id,
+    )
+
+
 def send_offer_creation_notification_to_administration(offer: Offer) -> bool:
     email = make_offer_creation_notification_email(offer)
     return mails.send(recipients=[settings.ADMINISTRATION_EMAIL_ADDRESS], data=email)
@@ -63,7 +85,8 @@ def send_offer_validation_notification_to_administration(
     validation_status: OfferValidationStatus, offer: Offer
 ) -> bool:
     if validation_status is OfferValidationStatus.APPROVED:
-        return send_offer_creation_notification_to_administration(offer)
+        if _check_offer_subcategory_before_send(offer) == True:
+            return send_offer_creation_notification_to_administration(offer)
     if validation_status is OfferValidationStatus.REJECTED:
         return send_offer_rejection_notification_to_administration(offer)
     return True

--- a/api/tests/domain/admin_emails_test.py
+++ b/api/tests/domain/admin_emails_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.categories import subcategories
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.factories import OffererFactory
@@ -142,17 +143,25 @@ class SendOfferNotificationToAdministrationTest:
         assert mails_testing.outbox[0].sent_data["To"] == "administration@example.com"
         assert mails_testing.outbox[0].sent_data["Subject"] == "[Création d’offre : refus - 75] Test Book"
 
-    def test_send_approval_notification(self, app):
+    def test_send_approval_notification_failure(self):
         author = users_factories.UserFactory(email="author@email.com")
-        offer = OfferFactory(name="Test Book", author=author)
+        offer = OfferFactory(name="Test Visit", author=author, subcategoryId=subcategories.VISITE_GUIDEE.id)
 
         # When
         send_offer_validation_notification_to_administration(OfferValidationStatus.APPROVED, offer)
 
-        # Then
+        assert len(mails_testing.outbox) == 0
+
+    def test_send_approval_notification_success(self):
+        author = users_factories.UserFactory(email="author@email.com")
+        offer = OfferFactory(name="Test Film", author=author, subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
+
+        # When
+        send_offer_validation_notification_to_administration(OfferValidationStatus.APPROVED, offer)
+
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["To"] == "administration@example.com"
-        assert mails_testing.outbox[0].sent_data["Subject"] == "[Création d’offre - 75] Test Book"
+        assert mails_testing.outbox[0].sent_data["Subject"] == "[Création d’offre - 75] Test Film"
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9976

## But de la pull request

Aujourd’hui, les biz reçoivent tous les mails de création d’offres des acteurs : création de DVD, de CD, de vinyles… Ils souhaiteraient ne plus recevoir les mails liés aux CD, DVD, livres et vinyles.

## Implémentation

Après discussion avec Caroline Nerot, il a été proposé de ne pas envoyer le mail “Création d’offre” (cf. [code ici](https://github.com/pass-culture/pass-culture-main/blob/2c0a4eb2c62211ef1e6508189015254fd995103a/api/src/pcapi/utils/mailing.py#L202-L222)) lorsque l’offre appartient aux 16 sous-catégories suivantes : 

* ABO_JEU_VIDEO

* ABO_LIVRE_NUMERIQUE

* ACHAT_INSTRUMENT

* AUTRE_SUPPORT_NUMERIQUE 

* BON_ACHAT_INSTRUMENT

* LIVRE_AUDIO_PHYSIQUE 

* LIVRE_NUMERIQUE

* LIVRE_PAPIER

* LOCATION_INSTRUMENT

* MATERIEL_ART_CREATIF

* PARTITION

* SUPPORT_PHYSIQUE_FILM

* SUPPORT_PHYSIQUE_MUSIQUE

* TELECHARGEMENT_LIVRE_AUDIO

* TELECHARGEMENT_MUSIQUE

* VOD

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)