### PR TITLE
(PC-13540)[PRO] feat: modify stock deletion pop in wording message

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
@@ -43,7 +43,9 @@ const DeleteStockDialog = ({
       <h1 id={DIALOG_LABEL_ID}>Voulez-vous supprimer ce stock ?</h1>
       <p>
         {'Ce stock ne sera plus disponible à la réservation et '}
-        <strong>entraînera l’annulation des réservations en cours !</strong>
+        <strong>
+          entraînera l’annulation des réservations en cours et validées !
+        </strong>
       </p>
       <p>
         L’ensemble des utilisateurs concernés sera automatiquement averti par

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -1576,12 +1576,12 @@ describe('stocks page', () => {
             expect(
               queryByTextTrimHtml(
                 screen,
-                'Ce stock ne sera plus disponible à la réservation et entraînera l’annulation des réservations en cours !'
+                'Ce stock ne sera plus disponible à la réservation et entraînera l’annulation des réservations en cours et validées !'
               )
             ).toBeInTheDocument()
             expect(
               screen.getByText(
-                'entraînera l’annulation des réservations en cours !',
+                'entraînera l’annulation des réservations en cours et validées !',
                 {
                   selector: 'strong',
                 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13540

## But de la pull request

Modifier le wording de la pop-in de suppression de stocks : 

_Ce stock ne sera plus disponible à la réservation et entraînera l’annulation des réservations en cours !_ → **Ce stock ne sera plus disponible à la réservation et entraînera l’annulation des réservations en cours et validées !**

## Screenshots

![DeleteStockMesssage](https://user-images.githubusercontent.com/71768799/154969836-415502ab-dc5e-43c1-8655-acf5b549ffff.PNG)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
