### PR TITLE
(PC-13452)[API] Remove column suspensionReason from user table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 90c1a1eeeee0 (pre) (head)
-ffafc4d7210f (post) (head)
+70461af31b6e (post) (head)

--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -170,7 +170,6 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "recreditAmountToShow",
         "roles",
         "subscriptionState",
-        "suspensionReason",
         "suspension_history",
     ]
 

--- a/api/src/pcapi/alembic/versions/20220221T154105_70461af31b6e_drop_suspensionreason_from_user.py
+++ b/api/src/pcapi/alembic/versions/20220221T154105_70461af31b6e_drop_suspensionreason_from_user.py
@@ -1,0 +1,19 @@
+"""Drop suspensionReason from User
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "70461af31b6e"
+down_revision = "ffafc4d7210f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("user", "suspensionReason")
+
+
+def downgrade():
+    op.add_column("user", sa.Column("suspensionReason", sa.TEXT(), autoincrement=False, nullable=True))

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -358,7 +358,6 @@ def suspend_account(user: User, reason: constants.SuspensionReason, actor: User)
 
 def unsuspend_account(user: User, actor: User) -> None:
     user.isActive = True
-    user.suspensionReason = ""  # TODO(prouzet) Remove when suspensionReason data in prod is migrated to user_suspension
     user_suspension = models.UserSuspension(
         user=user,
         eventType=models.SuspensionEventType.UNSUSPENDED,
@@ -378,8 +377,7 @@ def unsuspend_account(user: User, actor: User) -> None:
 
 def bulk_unsuspend_account(user_ids: list[int], actor: User) -> None:
     User.query.filter(User.id.in_(user_ids)).update(
-        # TODO(prouzet) Remove suspensionReason param when suspensionReason data in prod is migrated to user_suspension
-        values={"isActive": True, "suspensionReason": ""},
+        values={"isActive": True},
         synchronize_session=False,
     )
     for user_id in user_ids:

--- a/api/src/pcapi/utils/includes.py
+++ b/api/src/pcapi/utils/includes.py
@@ -5,7 +5,6 @@ USER_INCLUDES = [
     "-hasSeenTutorials",
     "-isActive",
     "-password",
-    "-suspensionReason",
     "-validationToken",
     "hasPhysicalVenues",
 ]

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -300,7 +300,6 @@ class UnsuspendAccountTest:
 
         users_api.unsuspend_account(user, suspension.actorUser)
 
-        assert not user.suspensionReason
         assert not user.suspension_reason
         assert not user.suspension_date
         assert user.isActive


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13452

## But de la pull request

Suppression de la colonne `suspensionReason` de la table user, remplacée dans `PC-8955` par une table `user_suspension`.

## Implémentation

## Informations supplémentaires

Migration PC-13451 exécutée le 21/02/2022 sur staging, OK.
Cette PR ne sera _mergée_ sur master qu'après PC-13451 sur la production.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
