### PR TITLE
(PC-13536) [API] fix:venue: add total=False to TypedDict

### DIFF
--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -122,7 +122,7 @@ class GetVenueManagingOffererResponseModel(BaseModel):
         json_encoders = {datetime: format_into_utc_date}
 
 
-class BannerMetaModel(TypedDict):
+class BannerMetaModel(TypedDict, total=False):
     image_credit: Optional[str]
 
 

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -9,11 +9,23 @@ from tests.conftest import TestClient
 
 
 class Returns200Test:
+    # if bannerMeta is not None, the response should only serialize some
+    # fields, others should be ignored.
+    @pytest.mark.parametrize(
+        "banner_meta_in,banner_meta_out",
+        [
+            ({"image_credit": "someone"}, {"image_credit": "someone"}),
+            ({"random": "content", "should": "be_ignored"}, {}),
+            (None, None),
+        ],
+    )
     @pytest.mark.usefixtures("db_session")
-    def when_user_has_rights_on_managing_offerer(self, client):
+    def when_user_has_rights_on_managing_offerer(self, client, banner_meta_in, banner_meta_out):
         # given
         user_offerer = offers_factories.UserOffererFactory(user__email="user.pro@test.com")
-        venue = offers_factories.VenueFactory(name="L'encre et la plume", managingOfferer=user_offerer.offerer)
+        venue = offers_factories.VenueFactory(
+            name="L'encre et la plume", managingOfferer=user_offerer.offerer, bannerMeta=banner_meta_in
+        )
         bank_information = offers_factories.BankInformationFactory(venue=venue)
 
         expected_serialized_venue = {
@@ -82,7 +94,7 @@ class Returns200Test:
             "visualDisabilityCompliant": venue.visualDisabilityCompliant,
             "withdrawalDetails": None,
             "bannerUrl": venue.bannerUrl,
-            "bannerMeta": venue.bannerMeta,
+            "bannerMeta": banner_meta_out,
         }
 
         # when


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13536

## But de la pull request

Bug : sans l'option `total=False`, le modèle `pydantic` s'attend à ce que les données correspondent exactement. Ce qui signifie que si `venue.bannerMeta` n'est pas nul et contient autre chose que `{"image_credit": "quelque_chose"}`, `pydantic` génère une erreur.

Fix : ajout de l'option [`total=False`](https://pydantic-docs.helpmanual.io/usage/types/#typeddict), qui permet de simplement dire quels champs sérialiser.

+ mise à jour d'un test pour contrôler ce comportement.
