### PR TITLE
[API] PC 13531 immediate indexing when tagging

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 ffafc4d7210f (post) (head)
-e9ddaad94160 (pre) (head)
+ddedcf7e2c67 (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220221T195851_ddedcf7e2c67_add_ondelete_constraints_to_criterion_tables.py
+++ b/api/src/pcapi/alembic/versions/20220221T195851_ddedcf7e2c67_add_ondelete_constraints_to_criterion_tables.py
@@ -1,0 +1,42 @@
+"""add ondelete constraints to criterion tables
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "ddedcf7e2c67"
+down_revision = "e9ddaad94160"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("SET SESSION statement_timeout = '300s'")
+
+    # Re-create foreign keys for offer_criterion
+    op.drop_constraint("offer_criterion_criterionId_fkey", "offer_criterion", type_="foreignkey")
+    op.drop_constraint("offer_criterion_offerId_fkey", "offer_criterion", type_="foreignkey")
+
+    op.create_foreign_key(None, "offer_criterion", "criterion", ["criterionId"], ["id"], ondelete="CASCADE")
+    op.create_foreign_key(None, "offer_criterion", "offer", ["offerId"], ["id"], ondelete="CASCADE")
+
+    # Re-create foreign keys for venue_criterion
+    op.drop_constraint("venue_criterion_criterionId_fkey", "venue_criterion", type_="foreignkey")
+    op.drop_constraint("venue_criterion_venueId_fkey", "venue_criterion", type_="foreignkey")
+
+    op.create_foreign_key(None, "venue_criterion", "venue", ["venueId"], ["id"], ondelete="CASCADE")
+    op.create_foreign_key(None, "venue_criterion", "criterion", ["criterionId"], ["id"], ondelete="CASCADE")
+
+
+def downgrade():
+    op.drop_constraint(None, "venue_criterion", type_="foreignkey")
+    op.drop_constraint(None, "venue_criterion", type_="foreignkey")
+
+    op.create_foreign_key("venue_criterion_venueId_fkey", "venue_criterion", "venue", ["venueId"], ["id"])
+    op.create_foreign_key("venue_criterion_criterionId_fkey", "venue_criterion", "criterion", ["criterionId"], ["id"])
+
+    op.drop_constraint(None, "offer_criterion", type_="foreignkey")
+    op.drop_constraint(None, "offer_criterion", type_="foreignkey")
+
+    op.create_foreign_key("offer_criterion_offerId_fkey", "offer_criterion", "offer", ["offerId"], ["id"])
+    op.create_foreign_key("offer_criterion_criterionId_fkey", "offer_criterion", "criterion", ["criterionId"], ["id"])

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -50,7 +50,7 @@ from .exceptions import ValidationTokenNotFoundError
 logger = logging.getLogger(__name__)
 
 UNCHANGED = object()
-VENUE_ALGOLIA_INDEXED_FIELDS = ["name", "publicName", "postalCode", "city", "latitude", "longitude"]
+VENUE_ALGOLIA_INDEXED_FIELDS = ["name", "publicName", "postalCode", "city", "latitude", "longitude", "criteria"]
 API_KEY_SEPARATOR = "_"
 
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -364,11 +364,11 @@ class VenueContact(PcObject, Model):
 
 
 class VenueCriterion(PcObject, Model):
-    venueId = Column(BigInteger, ForeignKey("venue.id"), index=True, nullable=False)
+    venueId = Column(BigInteger, ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=False)
 
     venue = relationship("Venue", foreign_keys=[venueId])
 
-    criterionId = Column(BigInteger, ForeignKey("criterion.id"), nullable=False, index=True)
+    criterionId = Column(BigInteger, ForeignKey("criterion.id", ondelete="CASCADE"), nullable=False, index=True)
 
     criterion = relationship("Criterion", foreign_keys=[criterionId])
 

--- a/api/src/pcapi/models/offer_criterion.py
+++ b/api/src/pcapi/models/offer_criterion.py
@@ -8,10 +8,10 @@ from pcapi.models.pc_object import PcObject
 
 
 class OfferCriterion(PcObject, Model):
-    offerId = Column(BigInteger, ForeignKey("offer.id"), index=True, nullable=False)
+    offerId = Column(BigInteger, ForeignKey("offer.id", ondelete="CASCADE"), index=True, nullable=False)
 
     offer = relationship("Offer", foreign_keys=[offerId])
 
-    criterionId = Column(BigInteger, ForeignKey("criterion.id"), nullable=False)
+    criterionId = Column(BigInteger, ForeignKey("criterion.id", ondelete="CASCADE"), nullable=False)
 
     criterion = relationship("Criterion", foreign_keys=[criterionId])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13531 

## But de la pull request

FA : Indexer immédiatement un lieu ou une offre lorsque la modification pour sur les tags.

Ceci permettra de faire remonter (quasi)immédiatement les tags sur l'index de recherche, dont se servent différents outils externes. Pour l'instant, on est obligé d'attendre que le prochain _job_ d'indexation se lance, ce qui rend le travail avec des outils externes pénibles et compliqués.

## Informations supplémentaires

Au passage : ajout de contraintes `ondelete=CASCADE` aux tables `offer_criterion` et `venue_criterion`. 