### PR TITLE
(PC-13192)[PRO] remove redux-saga-data from SignupValidation

### DIFF
--- a/pro/src/repository/pcapi/pcapi.js
+++ b/pro/src/repository/pcapi/pcapi.js
@@ -331,6 +331,8 @@ export const getUserInformations = () => {
   return client.get('/users/current')
 }
 
+export const validateUser = token => client.patch(`/validate/user/${token}`)
+
 //
 // password
 //


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13192

## But de la pull request

retirer redux saga-data de SignupValidation


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
