### PR TITLE
(PC-13589)[PRO]fix: sendinblue email without template pydantic error

### DIFF
--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -30,6 +30,9 @@ class SendinblueBackend(BaseBackend):
                 params=data.params,
                 tags=data.template.tags,
                 sender=asdict(data.template.sender.value),
+                subject=None,
+                html_content=None,
+                attachment=None,
             )
             if data.template.use_priority_queue:
                 send_transactional_email_primary_task.delay(payload)
@@ -43,6 +46,9 @@ class SendinblueBackend(BaseBackend):
                 subject=data.subject,
                 html_content=data.html_content,
                 attachment=data.attachment,
+                template_id=None,
+                params=None,
+                tags=None,
             )
             send_transactional_email_secondary_task.delay(payload)
 

--- a/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
+++ b/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
@@ -12,12 +12,12 @@ class UpdateSendinblueContactRequest(BaseModel):
 
 class SendTransactionalEmailRequest(BaseModel):
     recipients: list[str]
-    params: dict
-    template_id: int
-    tags: Optional[list[str]]
+    params: Optional[dict] = None
+    template_id: Optional[int] = None
+    tags: Optional[list[str]] = None
     sender: dict
-    subject: str = None
-    html_content: str = None
+    subject: Optional[str] = None
+    html_content: Optional[str] = None
     attachment: Optional[dict] = None
 
 

--- a/api/tests/core/mails/transactional/pro/reset_password_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/reset_password_to_pro_test.py
@@ -58,5 +58,10 @@ class SendinblueProResetPasswordEmailDataTest:
         assert mails_testing.outbox[0].sent_data["To"] == "pro@example.com"
 
         assert reset_password_link in mails_testing.outbox[0].sent_data["html_content"]
-        assert "subject" in mails_testing.outbox[0].sent_data
-        assert "html_content" in mails_testing.outbox[0].sent_data
+        assert mails_testing.outbox[0].sent_data["subject"] == "Création d'un compte pro"
+        assert (
+            mails_testing.outbox[0].sent_data["html_content"]
+            == "<html><head></head><body><div><div>Bonjour,</div><div>Vous venez de créer le compte de René Coty."
+            "</div><div>Le lien de création de mot de passe est <a href='http://exemple.com/reset/?ABCDEFG'>"
+            "http://exemple.com/reset/?ABCDEFG</a></div>"
+        )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13589

## But de la pull request

Problème résolu: les emails sans template_id ne sont pas envoyés. Problème avec la dataclass SendinblueTransactionalEmailData où il manquait des champs optionnels

## Implémentation
N/A

## Informations supplémentaires
N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
