### PR TITLE
(PC-13474)[API] feat: add check on profile completion

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -471,6 +471,10 @@ def has_passed_all_checks_to_become_beneficiary(user: users_models.User) -> bool
     if subscription_item.status in (models.SubscriptionItemStatus.TODO, models.SubscriptionItemStatus.KO):
         return False
 
+    profile_completion = get_profile_completion_subscription_item(user, fraud_check.eligibilityType)
+    if profile_completion.status != models.SubscriptionItemStatus.OK:
+        return False
+
     if not fraud_api.has_performed_honor_statement(user, fraud_check.eligibilityType):
         if not FeatureToggle.IS_HONOR_STATEMENT_MANDATORY_TO_ACTIVATE_BENEFICIARY.is_active():
             logger.warning("The honor statement has not been performed or recorded", extra={"user_id": user.id})

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -758,8 +758,10 @@ class HasPassedAllChecksToBecomeBeneficiaryTest:
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.OK
         )
-        result = subscription_api.has_passed_all_checks_to_become_beneficiary(user)
-        assert not result
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK
+        )
+        assert not subscription_api.has_passed_all_checks_to_become_beneficiary(user)
 
     def test_missing_profile_after_dms_application(self):
         user = self.eligible_user(validate_phone=True, city=None)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13474

## But de la pull request

Petite faille détectée par notre chère PO : après DMS on peut activer un utilisateur même s'il n'a pas rempli l'étape du profil.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
