### PR TITLE
(PC-12989) (CI) Add condition to execute invalidate-cache job only in…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -897,8 +897,12 @@ jobs:
       - push-to-bucket:
           build_path: ./pro/build/
           bucket_name: ${GCP_PROJECT}-<<parameters.app_environment>>-pro
-      - invalidate-cache:
-          url_map_name: <<parameters.app_environment>>-pro-url-map
+      - when:
+          condition:
+            equal: ["production", <<parameters.app_environment>>]
+          steps:
+            - invalidate-cache:
+                url_map_name: <<parameters.app_environment>>-pro-url-map
       - unless:
           condition:
             equal: ["testing", <<parameters.app_environment>>]
@@ -933,8 +937,12 @@ jobs:
       - push-to-bucket:
           build_path: ./adage-front/build/
           bucket_name: ${GCP_PROJECT}-<<parameters.app_environment>>-adage
-      - invalidate-cache:
-          url_map_name: <<parameters.app_environment>>-adage-url-map
+      - when:
+          condition:
+            equal: ["production", <<parameters.app_environment>>]
+          steps:
+            - invalidate-cache:
+                url_map_name: <<parameters.app_environment>>-pro-url-map
       - unless:
           condition:
             equal: ["testing", <<parameters.app_environment>>]


### PR DESCRIPTION
… production

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12989

## But de la pull request

Permet de lancer la commande d' invalidation de cache seulement en production

## Implémentation

N/A

## Informations supplémentaires

N/A

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
