### PR TITLE
(PC-13610) [API] feat:venue: add nonHumanizedId to pro response

### DIFF
--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -131,6 +131,7 @@ class GetVenueResponseModel(base.BaseVenueResponse):
     dateCreated: datetime
     isValidated: bool
     managingOffererId: str
+    nonHumanizedId: int
 
     bannerMeta: Optional[BannerMetaModel]
     bic: Optional[str]
@@ -168,6 +169,7 @@ class GetVenueResponseModel(base.BaseVenueResponse):
         # pydantic expects an enum key in order to build it, and therefore
         # does not work when passing directly an enum instance.
         venue.venueTypeCode = venue.venueTypeCode.name if venue.venueTypeCode else None
+        venue.nonHumanizedId = venue.id
         return super().from_orm(venue)
 
 

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -95,6 +95,7 @@ class Returns200Test:
             "withdrawalDetails": None,
             "bannerUrl": venue.bannerUrl,
             "bannerMeta": banner_meta_out,
+            "nonHumanizedId": venue.id,
         }
 
         # when


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13610

## But de la pull request

Ajout du vrai id d'un lieu à la réponse renvoyée au client front, côté PRO.
Ceci permettra de construire l'URL vers l'app native (PRO utilise des ids "humanisés" alors que l'app native utilise les vrais ids).