### PR TITLE
(PC-13191)[PRO] remove redux-saga-data from SignupFormContainer

### DIFF
--- a/pro/src/components/pages/Signup/SignupForm/SignupFormContainer.js
+++ b/pro/src/components/pages/Signup/SignupForm/SignupFormContainer.js
@@ -3,8 +3,8 @@ import { removeWhitespaces } from 'react-final-form-utils'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { compose } from 'redux'
-import { requestData } from 'redux-saga-data'
 
+import * as pcapi from 'repository/pcapi/pcapi'
 import { removeErrors } from 'store/reducers/errors'
 import { showNotification } from 'store/reducers/notificationReducer'
 import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
@@ -23,20 +23,14 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
     dispatch(removeErrors(STATE_ERROR_NAME))
 
     const { firstName, siren } = payload
-    dispatch(
-      requestData({
-        apiPath: '/users/signup/pro',
-        method: 'POST',
-        body: {
-          ...payload,
-          siren: removeWhitespaces(siren),
-          publicName: firstName,
-        },
-        name: STATE_ERROR_NAME,
-        handleFail: onHandleFail,
-        handleSuccess: onHandleSuccess,
+    pcapi
+      .signup({
+        ...payload,
+        siren: removeWhitespaces(siren),
+        publicName: firstName,
       })
-    )
+      .then(() => onHandleSuccess())
+      .catch(() => onHandleFail())
   },
 
   redirectToConfirmation: () => {

--- a/pro/src/components/pages/Signup/SignupForm/__specs__/SignupFormContainer.spec.js
+++ b/pro/src/components/pages/Signup/SignupForm/__specs__/SignupFormContainer.spec.js
@@ -1,6 +1,11 @@
+import * as pcapi from 'repository/pcapi/pcapi'
 import { showNotification } from 'store/reducers/notificationReducer'
 
 import { mapDispatchToProps } from '../SignupFormContainer'
+
+jest.mock('repository/pcapi/pcapi', () => ({
+  signup: jest.fn().mockResolvedValue({}),
+}))
 
 describe('src | components | pages | Signup | SignupFormContainer', () => {
   describe('mapDispatchToProps', () => {
@@ -57,17 +62,7 @@ describe('src | components | pages | Signup | SignupFormContainer', () => {
         functions.createNewProUser(payload, onHandleFail, onHandleSuccess)
 
         // then
-        expect(dispatch).toHaveBeenCalledWith({
-          config: {
-            apiPath: '/users/signup/pro',
-            body: expectedFetchPayload,
-            handleFail: onHandleFail,
-            handleSuccess: onHandleSuccess,
-            method: 'POST',
-            name: 'user',
-          },
-          type: 'REQUEST_DATA_POST_/USERS/SIGNUP/PRO',
-        })
+        expect(pcapi.signup).toHaveBeenCalledWith(expectedFetchPayload)
       })
 
       it('should insert publicName value equal to firstName', () => {
@@ -82,20 +77,10 @@ describe('src | components | pages | Signup | SignupFormContainer', () => {
         functions.createNewProUser(payload, jest.fn(), jest.fn())
 
         // then
-        expect(dispatch).toHaveBeenCalledWith({
-          config: {
-            apiPath: '/users/signup/pro',
-            body: {
-              lastName: 'Lastname',
-              firstName: 'Firstname',
-              publicName: 'Firstname',
-            },
-            handleFail: expect.any(Function),
-            handleSuccess: expect.any(Function),
-            method: 'POST',
-            name: 'user',
-          },
-          type: 'REQUEST_DATA_POST_/USERS/SIGNUP/PRO',
+        expect(pcapi.signup).toHaveBeenCalledWith({
+          lastName: 'Lastname',
+          firstName: 'Firstname',
+          publicName: 'Firstname',
         })
       })
 
@@ -110,18 +95,8 @@ describe('src | components | pages | Signup | SignupFormContainer', () => {
         functions.createNewProUser(payload, jest.fn(), jest.fn())
 
         // then
-        expect(dispatch).toHaveBeenCalledWith({
-          config: {
-            apiPath: '/users/signup/pro',
-            body: {
-              siren: '123456789',
-            },
-            handleFail: expect.any(Function),
-            handleSuccess: expect.any(Function),
-            method: 'POST',
-            name: 'user',
-          },
-          type: 'REQUEST_DATA_POST_/USERS/SIGNUP/PRO',
+        expect(pcapi.signup).toHaveBeenCalledWith({
+          siren: '123456789',
         })
       })
     })

--- a/pro/src/repository/pcapi/pcapi.js
+++ b/pro/src/repository/pcapi/pcapi.js
@@ -326,6 +326,8 @@ export const postThumbnail = (
 
 export const signin = user => client.post('/users/signin', user)
 
+export const signup = user => client.post('/users/signup/pro', user)
+
 export const signout = () => client.get('/users/signout')
 
 export const updateUserInformations = body => {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13191

## But de la pull request

Retirer redux saga data de SignupFormContainer


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
