### PR TITLE
PC-13592 save fraud check on dms errors

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -354,6 +354,8 @@ class BeneficiaryFraudCheck(PcObject, Model):
     def source_data(self) -> typing.Union[common_models.IdentityCheckContent, UserProfilingFraudData]:
         if self.type not in FRAUD_CHECK_MAPPING:
             raise NotImplementedError(f"Cannot unserialize type {self.type}")
+        if self.resultContent is None:
+            raise ValueError("No source data associated with this fraud check")
         return FRAUD_CHECK_MAPPING[self.type](**self.resultContent)
 
     def get_detailed_source(self) -> str:

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -39,11 +39,7 @@ def handle_dms_state(
 
     logs_extra = {"application_id": application_id, "procedure_id": procedure_id, "user_email": user.email}
 
-    current_fraud_check = fraud_dms_api.get_fraud_check(user, application_id)
-    if current_fraud_check is None:
-        # create a fraud_check whatever the status is because we may have missed a webhook event
-        current_fraud_check = fraud_dms_api.create_fraud_check(user, result_content)
-        user.submit_user_identity()
+    current_fraud_check = fraud_dms_api.get_or_create_fraud_check(user, application_id, result_content)
 
     if state == dms_connector_api.GraphQLApplicationStates.draft:
         subscription_messages.on_dms_application_received(user)

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -42,7 +42,12 @@ def handle_dms_state(
     current_fraud_check = fraud_dms_api.get_or_create_fraud_check(user, application_id, result_content)
 
     if state == dms_connector_api.GraphQLApplicationStates.draft:
-        subscription_messages.on_dms_application_received(user)
+        eligibility_type = current_fraud_check.eligibilityType
+        if eligibility_type is None:
+            fraud_dms_api.on_dms_eligibility_error(user, current_fraud_check, extra_data=logs_extra)
+        else:
+            subscription_messages.on_dms_application_received(user)
+        current_fraud_check.status = fraud_models.FraudCheckStatus.STARTED
         logger.info("DMS Application started.", extra=logs_extra)
 
     elif state == dms_connector_api.GraphQLApplicationStates.on_going:

--- a/api/tests/core/fraud/dms/test_api.py
+++ b/api/tests/core/fraud/dms/test_api.py
@@ -1,0 +1,36 @@
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.dms.api import get_or_create_fraud_check
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
+
+
+@pytest.mark.usefixtures("db_session")
+class DmsApiTest:
+    def test_get_or_create_fraud_check_creates(self):
+        user = users_factories.UserFactory()
+        application_id = 1
+        result_content = None
+
+        fraud_check = get_or_create_fraud_check(user, application_id, result_content)
+
+        user_fraud_checks = user.beneficiaryFraudChecks
+        assert len(user_fraud_checks) == 1
+        assert user_fraud_checks[0] == fraud_check
+        assert user_fraud_checks[0].thirdPartyId == str(application_id)
+        assert user_fraud_checks[0].resultContent == None
+
+    def test_get_or_create_fraud_check_gets(self):
+        user = users_factories.UserFactory()
+        fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS, thirdPartyId=1)
+        application_id = 1
+
+        fraud_check = get_or_create_fraud_check(user, application_id)
+
+        user_fraud_checks = user.beneficiaryFraudChecks
+        assert len(user_fraud_checks) == 1
+        assert user_fraud_checks[0] == fraud_check
+        assert user_fraud_checks[0].thirdPartyId == str(application_id)
+        assert user_fraud_checks[0].eligibilityType == users_models.EligibilityType.AGE18

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -222,6 +222,14 @@ class DmsWebhookApplicationTest:
             == "Il semblerait que les champs ‘ta pièce d'identité, ton code postal’ soient erronés. Tu peux te rendre sur le site Démarche-simplifiées pour les rectifier."
         )
 
+        fraud_check = user.beneficiaryFraudChecks[0]
+        assert fraud_check.type == fraud_models.FraudCheckType.DMS
+        assert fraud_check.status == fraud_models.FraudCheckStatus.STARTED
+        assert (
+            fraud_check.reason
+            == "Erreur lors de la récupération de l'application DMS: les champs ['id_piece_number', 'postal_code'] sont erronés"
+        )
+
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
     @patch.object(api_dms.DMSGraphQLClient, "send_user_message")
     def test_dms_request_with_unexisting_user(self, send_user_message, execute_query, client):
@@ -343,6 +351,11 @@ class DmsWebhookApplicationTest:
             user.subscriptionMessages[0].userMessage
             == "Il semblerait que le champ ‘ta date de naissance’ soit erroné. Tu peux te rendre sur le site Démarche-simplifiées pour le rectifier."
         )
+
+        fraud_check = user.beneficiaryFraudChecks[0]
+        assert fraud_check.type == fraud_models.FraudCheckType.DMS
+        assert fraud_check.status == fraud_models.FraudCheckStatus.STARTED
+        assert fraud_check.reason == "La date de naissance de l'utilisateur ne correspond pas à un âge autorisé"
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
     def test_dms_application_on_going(self, execute_query, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13592

## But de la pull request

- Créer un fraud check en cas d'erreur de parsing ou d'éligibilité, pour tracer rapidement où en est le dossier, et pourquoi

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
