### PR TITLE
(BSR) Add ubble "expired" status

### DIFF
--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -9,11 +9,11 @@ from ..common.models import IdentityCheckContent
 
 
 class UbbleIdentificationStatus(enum.Enum):
-    UNINITIATED = "uninitiated"
-    INITIATED = "initiated"
-    PROCESSING = "processing"
-    PROCESSED = "processed"
-    ABORTED = "aborted"
+    UNINITIATED = "uninitiated"  # Identification has only been created (user has not started the verification flow)
+    INITIATED = "initiated"  # User has started the verification flow
+    PROCESSING = "processing"  # User has ended the verification flow, identification-url is not usable anymore
+    PROCESSED = "processed"  # Identification is completely processed by Ubble
+    ABORTED = "aborted"  # User has left the identification, the identification-url is no longer usable (this status is in beta test)
 
 
 class UbbleScore(enum.Enum):

--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -14,6 +14,7 @@ class UbbleIdentificationStatus(enum.Enum):
     PROCESSING = "processing"  # User has ended the verification flow, identification-url is not usable anymore
     PROCESSED = "processed"  # Identification is completely processed by Ubble
     ABORTED = "aborted"  # User has left the identification, the identification-url is no longer usable (this status is in beta test)
+    EXPIRED = "expired"  # The identification-url has expired and is no longer usable (only uninitiated and initiated identifications can become expired)
 
 
 class UbbleScore(enum.Enum):

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -70,7 +70,10 @@ def update_ubble_workflow(
                     fraud_check.thirdPartyId,
                 )
 
-    elif status == ubble_fraud_models.UbbleIdentificationStatus.ABORTED:
+    elif status in (
+        ubble_fraud_models.UbbleIdentificationStatus.ABORTED,
+        ubble_fraud_models.UbbleIdentificationStatus.EXPIRED,
+    ):
         fraud_check.status = fraud_models.FraudCheckStatus.CANCELED
         pcapi_repository.repository.save(fraud_check)
 


### PR DESCRIPTION
CF doc https://ubbleai.github.io/developer-documentation/#lifecycle

Quand on reçoit ce statut on doit considérer le dossier comme annulé, pour permettre à l'utilisateur d'en recommencer un.