### PR TITLE
(PC-11853)[API] fix: Timeout on filtered EAC offer

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-90c1a1eeeee0 (pre) (head)
+7f2d9876eb6e (pre) (head)
 70461af31b6e (post) (head)

--- a/api/src/pcapi/alembic/versions/20220223T094200_7f2d9876eb6e_index_educationel_offer.py
+++ b/api/src/pcapi/alembic/versions/20220223T094200_7f2d9876eb6e_index_educationel_offer.py
@@ -1,0 +1,40 @@
+"""index_educationel_offer
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# revision identifiers, used by Alembic.
+revision = "7f2d9876eb6e"
+down_revision = "90c1a1eeeee0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+		SET SESSION statement_timeout = '300s'
+		"""
+    )
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_offer_isEducational" ON offer ("isEducational")
+        """
+    )
+    op.execute(
+        f"""
+           SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+           """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+		DROP INDEX CONCURRENTLY IF EXISTS "ix_offer_isEducational"
+		"""
+    )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11853

## But de la pull request

résoudre l'utilisation de filtre des 'offre EAC' qui tombe en timeout

## Implémentation

### Stratégie technique envisagée:
Actuellement un index est en prod suite à une manipulation manuelle mais ce n’est pas pérenne

Créer une migration pour être d'équerre avec l'état actuel de la base de données de production:
- :warning: CREATE INDEX CONCURRENTLY IF NOT EXISTS avec le nom ‘ix_offer_isEducational’ sur le champ ‘isEducational’ de Offer
- Bien penser à désactiver le statement timeout temporairement pour cette commande puisque cette requête non bloquante va prendre un certain temps (comme dans `alembic/versions/20210527_77d29ab6c382_add_index_for_last_validation_date.py`)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)