### PR TITLE
[bsr][api][requirements] Bump notion-client

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -40,7 +40,7 @@ lxml
 mailjet-rest==1.3.3
 MarkupSafe==2.0.1
 mypy==0.812
-notion-client==0.4.0
+notion-client==0.9.0
 pgcli==2.2.0
 phonenumberslite==8.12.23
 Pillow>=8.1.1


### PR DESCRIPTION
This new version does not have any upper limit on the version of
`httpx`, which lets us use httpx 0.18.0 (at least), which fixes a
warning (about an ignored exception) that is displayed when running
`flask shell` (or anything that imports "dns.query"):

    $ python -c "import dns.query"
    Exception ignored in: <function Client.__del__ at 0x7fce48ffc1f0>
    Traceback (most recent call last):
      File ".../site-packages/httpx/_client.py", line 1134, in __del__
        self.close()
      File ".../site-packages/httpx/_client.py", line 1106, in close
        self._transport.close()
    AttributeError: 'Client' object has no attribute '_transport'

See encode/httpx@b43af721cd7804214396b5511e4f for the fix in httpx.