### PR TITLE
(PC-13269)[API] Cancel booking with status=USED from Flask Admin

### DIFF
--- a/api/src/pcapi/admin/custom_views/booking_view.py
+++ b/api/src/pcapi/admin/custom_views/booking_view.py
@@ -19,6 +19,12 @@ from pcapi.domain.client_exceptions import ClientError
 from pcapi.models.api_errors import ApiErrors
 
 
+def _get_exception_message(exc: Exception) -> str:
+    if isinstance(exc, (ClientError, ApiErrors)):
+        return list(exc.errors.values())[0][0]
+    return str(exc)
+
+
 class SearchForm(SecureForm):
     token = StringField(
         "Code de contremarque",
@@ -106,11 +112,7 @@ class BookingView(BaseCustomAdminView):
         try:
             bookings_api.mark_as_used_with_uncancelling(booking)
         except Exception as exc:  # pylint: disable=broad-except
-            if isinstance(exc, (ClientError, ApiErrors)):
-                err = list(exc.errors.values())[0][0]
-            else:
-                err = str(exc)
-            flash(f"L'opération a échoué : {err}", "error")
+            flash(f"L'opération a échoué : {_get_exception_message(exc)}", "error")
         else:
             flash("La réservation a été dés-annulée et marquée comme utilisée.", "info")
         return redirect(booking_url)
@@ -127,7 +129,7 @@ class BookingView(BaseCustomAdminView):
         try:
             bookings_api.mark_as_cancelled(booking)
         except Exception as exc:  # pylint: disable=broad-except
-            flash(f"L'opération a échoué : {str(exc)}", "error")
+            flash(f"L'opération a échoué : {_get_exception_message(exc)}", "error")
         else:
             flash("La réservation a été marquée comme annulée", "info")
         return redirect(booking_url)

--- a/api/src/pcapi/templates/admin/booking.html
+++ b/api/src/pcapi/templates/admin/booking.html
@@ -18,6 +18,7 @@
 <div><b>Rédacteur:</b> {{ booking.email }} ({{ booking.educationalBooking.educationalRedactor.id }})</div>
 {% endif %}
 <div><b>Offre :</b> {{ booking.stock.offer.name }}</div>
+<div><b>État :</b> {{ booking.status.value }}</div>
 <div><b>Date d'annulation :</b>
   {% if booking.status.value == 'CANCELLED' %}
     {{ booking.cancellationDate.strftime('%d/%m/%Y %H:%M') }}
@@ -46,7 +47,8 @@
 </p>
 <form action={{ url_for(".cancel", booking_id=booking.id) }} method="POST">
     {{ forms.display_form(cancel_form) }}
-    <input class="btn btn-danger" type="submit" value="Marquer comme annulée">
+    <input class="btn btn-danger" type="submit" value="Marquer comme annulée"{% if booking.status.value == 'USED' %}
+        onclick="return confirm('Êtes-vous sûr de vouloir annuler une réservation validée ?')" {% endif %}>
 </form>
 {% endif %}
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13269

## But de la pull request

Permettre au support d'annuler une contremarque dans l'état USED (mais pas encore remboursée).

## Implémentation

Utilisation du paramètre `cancel_even_if_used` ajouté récemment par https://passculture.atlassian.net/browse/PC-13321

## Informations supplémentaires

C'était peut-être un bug, puisque le bouton était affiché dans l'état USED, mais en cliquant sur le bouton rouge le message _flash_ indiquait une réussite de l'annulation, alors que rien n'avait changé dans la base de données.
J'ai donc corrigé la propagation des exceptions pour obtenir le message d'erreur dans Flask-Admin lorsqu'une erreur se produit.
J'ai également ajouté l'état de la réservation dans l'écran `booking_view`, ça ne coûte pas cher et c'est plus clair.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
