### PR TITLE
(PC-9976)[API] Add Offer Subcategory verification before send

### DIFF
--- a/api/src/pcapi/domain/admin_emails.py
+++ b/api/src/pcapi/domain/admin_emails.py
@@ -51,7 +51,7 @@ def send_payments_report_emails(
 
 
 def _check_offer_subcategory_before_send(offer: Offer) -> bool:
-    return offer.subcategoryId in (
+    return offer.subcategoryId not in (
         subcategories.ABO_JEU_VIDEO.id,
         subcategories.ABO_LIVRE_NUMERIQUE.id,
         subcategories.ACHAT_INSTRUMENT.id,

--- a/api/tests/domain/admin_emails_test.py
+++ b/api/tests/domain/admin_emails_test.py
@@ -145,7 +145,7 @@ class SendOfferNotificationToAdministrationTest:
 
     def test_send_approval_notification_failure(self):
         author = users_factories.UserFactory(email="author@email.com")
-        offer = OfferFactory(name="Test Visit", author=author, subcategoryId=subcategories.VISITE_GUIDEE.id)
+        offer = OfferFactory(name="Test Film", author=author, subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
 
         # When
         send_offer_validation_notification_to_administration(OfferValidationStatus.APPROVED, offer)
@@ -154,14 +154,14 @@ class SendOfferNotificationToAdministrationTest:
 
     def test_send_approval_notification_success(self):
         author = users_factories.UserFactory(email="author@email.com")
-        offer = OfferFactory(name="Test Film", author=author, subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
+        offer = OfferFactory(name="Test Visit", author=author, subcategoryId=subcategories.VISITE_GUIDEE.id)
 
         # When
         send_offer_validation_notification_to_administration(OfferValidationStatus.APPROVED, offer)
 
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["To"] == "administration@example.com"
-        assert mails_testing.outbox[0].sent_data["Subject"] == "[Création d’offre - 75] Test Film"
+        assert mails_testing.outbox[0].sent_data["Subject"] == "[Création d’offre - 75] Test Visit"
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9976

## But de la pull request

Aujourd’hui, les biz reçoivent tous les mails de création d’offres des acteurs : création de DVD, de CD, de vinyles… Ils souhaiteraient ne plus recevoir les mails liés aux CD, DVD, livres et vinyles.

## Implémentation

Après discussion avec Caroline Nerot, il a été proposé de ne pas envoyer le mail “Création d’offre” (cf. [code ici](https://github.com/pass-culture/pass-culture-main/blob/2c0a4eb2c62211ef1e6508189015254fd995103a/api/src/pcapi/utils/mailing.py#L202-L222)) lorsque l’offre appartient aux 16 sous-catégories suivantes : 

* ABO_JEU_VIDEO

* ABO_LIVRE_NUMERIQUE

* ACHAT_INSTRUMENT

* AUTRE_SUPPORT_NUMERIQUE 

* BON_ACHAT_INSTRUMENT

* LIVRE_AUDIO_PHYSIQUE 

* LIVRE_NUMERIQUE

* LIVRE_PAPIER

* LOCATION_INSTRUMENT

* MATERIEL_ART_CREATIF

* PARTITION

* SUPPORT_PHYSIQUE_FILM

* SUPPORT_PHYSIQUE_MUSIQUE

* TELECHARGEMENT_LIVRE_AUDIO

* TELECHARGEMENT_MUSIQUE

* VOD

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)