### PR TITLE
(PC-11806)[API] No whitespace allowed in tag name when creating a new tag

### DIFF
--- a/api/src/pcapi/admin/custom_views/criteria_view.py
+++ b/api/src/pcapi/admin/custom_views/criteria_view.py
@@ -1,8 +1,12 @@
 from wtforms.fields.core import StringField
 from wtforms.form import Form
 from wtforms.validators import DataRequired
+from wtforms.validators import Regexp
 
 from pcapi.admin.base_configuration import BaseAdminView
+
+
+CRITERION_NAME_REGEX = r"^[^\s]+$"
 
 
 class CriteriaView(BaseAdminView):
@@ -23,5 +27,11 @@ class CriteriaView(BaseAdminView):
 
     def get_create_form(self) -> Form:
         form = self.scaffold_form()
-        form.name = StringField("Nom", [DataRequired()])
+        form.name = StringField(
+            "Nom",
+            [
+                DataRequired(),
+                Regexp(CRITERION_NAME_REGEX, message="Le nom ne doit contenir aucun caractère d'espacement"),
+            ],
+        )
         return form

--- a/api/tests/admin/custom_views/criteria_view_test.py
+++ b/api/tests/admin/custom_views/criteria_view_test.py
@@ -1,12 +1,53 @@
 from unittest.mock import patch
 
+import pytest
+
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
+from pcapi.models.criterion import Criterion
 
 from tests.conftest import clean_database
 
 
 class CriteriaViewTest:
+    @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!"])
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_create_criterion(self, mocked_validate_csrf_token, client, name):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            "/pc/back-office/criterion/new/",
+            form={"name": name, "description": "My description", "startDateTime": None, "endDateTime": None},
+        )
+
+        assert response.status_code == 302
+        assert Criterion.query.count() == 1
+        criterion = Criterion.query.first()
+        assert criterion.name == name
+        assert criterion.description == "My description"
+
+    @pytest.mark.parametrize(
+        "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
+    )
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_create_criterion_with_whitespace(self, mocked_validate_csrf_token, client, name):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            "/pc/back-office/criterion/new/",
+            form={"name": name, "description": "My description", "startDateTime": None, "endDateTime": None},
+        )
+
+        assert response.status_code == 200
+        assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
+        assert Criterion.query.count() == 0
+
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_criterion(self, mocked_validate_csrf_token, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11806

## But de la pull request

Les noms des nouveaux tags ne doivent pas contenir de caractères d'espacement

## Implémentation

Ajout d'un validateur sur une expression régulière

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
