### PR TITLE
(PC-13568)[API] Fix deletion of UserOfferer association in FA

### DIFF
--- a/api/src/pcapi/admin/custom_views/user_offerer_view.py
+++ b/api/src/pcapi/admin/custom_views/user_offerer_view.py
@@ -65,11 +65,13 @@ class UserOffererView(BaseAdminView):
 
     def delete_model(self, user_offerer: UserOfferer) -> bool:
         # user_offerer.user is not available in this call, get email before deletion
+        # joined user is no longer available after delete_model()
         user_offerer_with_join = find_one_or_none_by_id(user_offerer.id)
+        email = user_offerer_with_join.user.email if user_offerer_with_join else None
 
         result = super().delete_model(user_offerer)
 
-        if result and user_offerer_with_join:
-            update_external_pro(user_offerer_with_join.user.email)
+        if result and email:
+            update_external_pro(email)
 
         return result

--- a/api/tests/admin/custom_views/user_offerer_view_test.py
+++ b/api/tests/admin/custom_views/user_offerer_view_test.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+from pcapi.core.offerers.models import Offerer
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.users.factories as users_factories
+from pcapi.core.users.models import User
+from pcapi.models.user_offerer import UserOfferer
+
+from tests.conftest import clean_database
+
+
+class UserOffererViewTest:
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_delete_user_offerer(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        user_offerer = offers_factories.UserOffererFactory()
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            "/pc/back-office/userofferer/delete/",
+            form={"id": f"{user_offerer.id},{user_offerer.userId},{user_offerer.offererId}"},
+        )
+
+        assert response.status_code == 302
+        assert UserOfferer.query.count() == 0
+        assert User.query.count() == 2
+        assert Offerer.query.count() == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13568

## But de la pull request

Corriger le bug : une exception se produit lors de la suppression d'une relation UserOfferer dans Flask-Admin : 
`ERROR:pcapi.routes.error_handlers.generic_error_handlers:Unexpected error on method=POST url=http://localhost:5000/pc/back-office/userofferer/delete/: Parent instance <UserOfferer at 0x7fa614ef6730> is not bound to a Session; lazy load operation of attribute 'user' cannot proceed (Background on this error at: http://sqlalche.me/e/13/bhk3)`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
