### PR TITLE
(PC-13592)[API] fix: use DMS application id instead of the dossier id

### DIFF
--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -28,8 +28,8 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
     raw_data = client.get_single_application_details(form.dossier_id)
 
     user_email = raw_data["dossier"]["usager"]["email"]
-    application_id = raw_data["dossier"]["number"]
-    dossier_id = raw_data["dossier"]["id"]
+    application_id = raw_data["dossier"]["number"]  # This is the id we use in our API to identify DMS applications
+    dossier_id = raw_data["dossier"]["id"]  # This is only used to get data from DMS (not used in our API)
 
     log_extra_data = {
         "application_id": application_id,
@@ -74,7 +74,7 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
         dms_api.on_dms_parsing_error(user, application_id, parsing_error, extra_data=log_extra_data)
         return
 
-    dms_subscription_api.handle_dms_state(user, application, form.procedure_id, form.dossier_id, form.state)
+    dms_subscription_api.handle_dms_state(user, application, form.procedure_id, application_id, form.state)
 
 
 @public_api.route("/webhooks/ubble/application_status", methods=["POST"])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13592

## But de la pull request

Fix la mauvaise utilisation des ids de DMS

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
