### PR TITLE
(PC-13106) Fix venue image delete modal design

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueImageDelete/VenueImageDelete.module.scss
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueImageDelete/VenueImageDelete.module.scss
@@ -26,6 +26,7 @@
 .actions {
   display: flex;
   justify-content: center;
+  margin-top: rem(16px);
 
   .button {
     margin: 0 rem(12px);


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13106

## But de la pull request

Suite à un retour graphique, on agrandit, sur la modale de suppression de visuel de lieu, l'écart entre le contenu et les boutons.

| Retour graphique | Nouvelle implémentation |
| :---: | :---:|
| ![image](https://user-images.githubusercontent.com/26742386/155502945-752d2023-3285-4713-b381-a4db9f5e9f8f.png) | ![image](https://user-images.githubusercontent.com/26742386/155502564-38c3792d-65fe-44b6-8574-4276a850afe0.png) |


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
