### PR TITLE
(PC-13609) algolia: remove visa from algolia distinct field

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -256,7 +256,7 @@ class AlgoliaBackend(base.SearchBackend):
 
         # Field used by Algolia (not the frontend) to deduplicate results
         # https://www.algolia.com/doc/api-reference/api-parameters/distinct/
-        distinct = extra_data.get("isbn") or extra_data.get("visa") or str(offer.id)
+        distinct = extra_data.get("isbn") or str(offer.id)
 
         object_to_index = {
             "distinct": distinct,

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -165,22 +165,6 @@ class BuildObjectTest:
         assert result["offer"]["artist"] == "MEFA"
 
     @pytest.mark.usefixtures("db_session")
-    def test_distinct_should_return_visa_when_exists(self, app):
-        # Given
-        offerer = create_offerer()
-        venue = create_venue(offerer=offerer)
-        offer = create_offer_with_thing_product(venue=venue)
-        offer.extraData = {"visa": "123456"}
-        stock = create_stock(offer=offer)
-        repository.save(stock)
-
-        # When
-        result = AlgoliaBackend.serialize_offer(offer)
-
-        # Then
-        assert result["distinct"] == offer.extraData["visa"]
-
-    @pytest.mark.usefixtures("db_session")
     def test_distinct_should_return_isbn_when_exists(self, app):
         # Given
         offerer = create_offerer()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13609

## But de la pull request

Supprimer la déduplication des offres qui ont le même visa d'exploitation.
Contexte: aujourd'hui beaucoup d'acteurs se plaignent de ne pas voir apparaître à la fois les films en VO et en VF dans leurs résultats de recherche.

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
