### PR TITLE
(PC-13653)[PRO] fix: fix wording for non event offers on stock deletion

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
@@ -7,6 +7,7 @@ import * as pcapi from 'repository/pcapi/pcapi'
 import { ReactComponent as DeletionIcon } from './assets/deletion.svg'
 
 const DeleteStockDialog = ({
+  isEvent,
   notifyDeletionError,
   notifyDeletionSuccess,
   onDelete,
@@ -44,7 +45,8 @@ const DeleteStockDialog = ({
       <p>
         {'Ce stock ne sera plus disponible à la réservation et '}
         <strong>
-          entraînera l’annulation des réservations en cours et validées !
+          entraînera l’annulation des réservations en cours
+          {isEvent && ' et validées'} !
         </strong>
       </p>
       <p>
@@ -73,6 +75,7 @@ const DeleteStockDialog = ({
 }
 
 DeleteStockDialog.propTypes = {
+  isEvent: PropTypes.bool.isRequired,
   notifyDeletionError: PropTypes.func.isRequired,
   notifyDeletionSuccess: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,

--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
@@ -343,6 +343,7 @@ const StockItem = ({
         )}
         {isDeleting && (
           <DeleteStockDialogContainer
+            isEvent={isEvent}
             onDelete={onDelete}
             setIsDeleting={setIsDeleting}
             stockId={initialStock.id}

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -2151,6 +2151,30 @@ describe('stocks page', () => {
           expect(informationMessage).toHaveAttribute('aria-disabled', 'true')
         })
       })
+
+      it('should warn that pending booking will be canceled on thing offer stock deletion', async () => {
+        // Given
+        await renderOffers(props, store)
+
+        // When
+        userEvent.click(screen.getByTitle('Supprimer le stock'))
+
+        // Then
+        expect(
+          queryByTextTrimHtml(
+            screen,
+            'Ce stock ne sera plus disponible à la réservation et entraînera l’annulation des réservations en cours !'
+          )
+        ).toBeInTheDocument()
+        expect(
+          screen.getByText(
+            'entraînera l’annulation des réservations en cours !',
+            {
+              selector: 'strong',
+            }
+          )
+        ).toBeInTheDocument()
+      })
     })
   })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13653

## But de la pull request

Lors de la suppression d'un stock non event, ne pas affichées le wording "validées"

## Screenshots

![PopInMessage](https://user-images.githubusercontent.com/71768799/155513902-2263eab0-2faa-4b9e-8e82-5cbbd92f7b03.PNG)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
