### PR TITLE
[PC-13667][api][admin] Do no show score on offer validation list view

### DIFF
--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -472,7 +472,6 @@ class OfferValidationViewTest:
         n_queries = testing.AUTHENTICATION_QUERIES
         n_queries += 1  # count
         n_queries += 1  # select offers
-        n_queries += 1  # select latest offer validation configuration
         with testing.assert_num_queries(n_queries):
             response = client.get("/pc/back-office/validation/")
 


### PR DESCRIPTION
Computing the score for each offer may make additional SQL queries if
we did not join the right table(s) beforehand. We were already bitten
by this in last December (see 981fc3f5c). The page is slow again
because of a new validation rule that selects all offers of the venue
of the offer we want the score of. Doing that for each of the 100
offers that are shown in the list view is not a good idea...

It appears that showing the score in the list view is not strictly
necessary. We can remove it. It's still shown in the validation page
for a single offer, and that's enough.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13667