### PR TITLE
[bsr][api][offers] Optimize `compute_offer_validation_score()`

### DIFF
--- a/api/src/pcapi/core/offers/offer_validation.py
+++ b/api/src/pcapi/core/offers/offer_validation.py
@@ -64,4 +64,6 @@ def compute_offer_validation_score(validation_items: list[OfferValidationRuleIte
     score = 1.0
     for validation_item in validation_items:
         score *= validation_item.resolve()
+        if score == 0:
+            break
     return score


### PR DESCRIPTION
If the score is zero, it won't increase anymore. No need to check
other validation rules.