### PR TITLE
(PC-9892)[API] Set tags on offerers

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-e289b8d9cbe9 (pre) (head)
+ca95cbf376a1 (pre) (head)
 70461af31b6e (post) (effective head)

--- a/api/src/pcapi/admin/custom_views/criteria_view.py
+++ b/api/src/pcapi/admin/custom_views/criteria_view.py
@@ -1,6 +1,7 @@
 from wtforms.fields.core import StringField
 from wtforms.form import Form
 from wtforms.validators import DataRequired
+from wtforms.validators import Length
 from wtforms.validators import Regexp
 
 from pcapi.admin.base_configuration import BaseAdminView
@@ -32,6 +33,7 @@ class CriteriaView(BaseAdminView):
             [
                 DataRequired(),
                 Regexp(CRITERION_NAME_REGEX, message="Le nom ne doit contenir aucun caractère d'espacement"),
+                Length(max=140, message="Le nom d'un tag ne peut excéder 140 caractères"),
             ],
         )
         return form

--- a/api/src/pcapi/admin/custom_views/offerer_tag_view.py
+++ b/api/src/pcapi/admin/custom_views/offerer_tag_view.py
@@ -1,0 +1,33 @@
+from wtforms.fields.core import StringField
+from wtforms.form import Form
+from wtforms.validators import DataRequired
+from wtforms.validators import Length
+from wtforms.validators import Regexp
+
+from pcapi.admin.base_configuration import BaseAdminView
+
+
+TAG_NAME_REGEX = r"^[^\s]+$"
+
+
+class OffererTagView(BaseAdminView):
+    can_create = True
+    can_edit = False  # Nothing to edit
+    can_delete = True
+    column_list = ["id", "name"]
+    column_labels = {"name": "Nom"}
+    column_searchable_list = ["name"]
+    column_filters: list[str] = []
+    form_create_rules = ("name",)
+
+    def get_create_form(self) -> Form:
+        form = self.scaffold_form()
+        form.name = StringField(
+            "Nom",
+            [
+                DataRequired(),
+                Regexp(TAG_NAME_REGEX, message="Le nom ne doit contenir aucun caractère d'espacement"),
+                Length(max=140, message="Le nom ne peut excéder 140 caractères"),
+            ],
+        )
+        return form

--- a/api/src/pcapi/admin/custom_views/offerer_view.py
+++ b/api/src/pcapi/admin/custom_views/offerer_view.py
@@ -1,22 +1,46 @@
 from flask import flash
+from flask_admin.babel import lazy_gettext
+from flask_admin.contrib.sqla import filters as fa_filters
+from flask_admin.contrib.sqla import tools
+from sqlalchemy.orm import Query
 from wtforms import Form
 
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.core.bookings.exceptions import CannotDeleteOffererWithBookingsException
 from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import OffererTag
+from pcapi.core.offerers.models import OffererTagMapping
 from pcapi.core.users.external import update_external_pro
 from pcapi.repository import user_offerer_queries
 from pcapi.scripts.offerer.delete_cascade_offerer_by_id import delete_cascade_offerer_by_id
 
 
+class OffererTagFilter(fa_filters.BaseSQLAFilter):
+    """
+    Filter offerers based on tag (offerer_tag) name.
+    """
+
+    def apply(self, query: Query, value: str, alias: str = None) -> Query:
+        parsed_value = tools.parse_like_term(value)
+        return query.join(OffererTagMapping).join(OffererTag).filter(OffererTag.name.ilike(parsed_value))
+
+    def operation(self):
+        return lazy_gettext("contains")
+
+    def clean(self, value: str) -> str:
+        return value.strip()
+
+
 class OffererView(BaseAdminView):
     can_edit = True
     can_delete = True
-    column_list = ["id", "name", "siren", "city", "postalCode", "address"]
-    column_labels = dict(name="Nom", siren="SIREN", city="Ville", postalCode="Code postal", address="Adresse")
+    column_list = ["id", "name", "siren", "city", "postalCode", "address", "tags"]
+    column_labels = dict(
+        name="Nom", siren="SIREN", city="Ville", postalCode="Code postal", address="Adresse", tags="Tags"
+    )
     column_searchable_list = ["name", "siren"]
-    column_filters = ["postalCode", "city", "id", "name"]
-    form_columns = ["name", "siren", "city", "postalCode", "address"]
+    column_filters = ["postalCode", "city", "id", "name", OffererTagFilter(Offerer.id, "Tag")]
+    form_columns = ["name", "siren", "city", "postalCode", "address", "tags"]
 
     def delete_model(self, offerer: Offerer) -> bool:
         # Get users to update before association info is deleted
@@ -25,7 +49,7 @@ class OffererView(BaseAdminView):
         try:
             delete_cascade_offerer_by_id(offerer.id)
         except CannotDeleteOffererWithBookingsException:
-            flash("Impossible d'effacer une structure juridique pour lequel il existe des reservations.", "error")
+            flash("Impossible d'effacer une structure juridique pour laquelle il existe des réservations.", "error")
             return False
 
         for user_offerer in users_offerer:

--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -18,6 +18,7 @@ from pcapi.admin.custom_views.criteria_view import CriteriaView
 from pcapi.admin.custom_views.custom_reimbursement_rule_view import CustomReimbursementRuleView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
+from pcapi.admin.custom_views.offerer_tag_view import OffererTagView
 from pcapi.admin.custom_views.offerer_view import OffererView
 from pcapi.admin.custom_views.partner_user_view import PartnerUserView
 from pcapi.admin.custom_views.pro_user_view import ProUserView
@@ -90,6 +91,11 @@ def install_views(admin: Admin, session: Session) -> None:
     )
     admin.add_view(
         CriteriaView(Criterion, session, name="Tags des offres et des lieux", category=Category.OFFRES_STRUCTURES_LIEUX)
+    )
+    admin.add_view(
+        OffererTagView(
+            offerers_models.OffererTag, session, name="Tags des structures", category=Category.OFFRES_STRUCTURES_LIEUX
+        )
     )
     admin.add_view(
         OffererView(offerers_models.Offerer, session, name="Structures", category=Category.OFFRES_STRUCTURES_LIEUX)

--- a/api/src/pcapi/alembic/versions/20220224T135029_ca95cbf376a1_create_offerer_tag_table.py
+++ b/api/src/pcapi/alembic/versions/20220224T135029_ca95cbf376a1_create_offerer_tag_table.py
@@ -1,0 +1,40 @@
+"""Create offerer_tag table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ca95cbf376a1"
+down_revision = "e289b8d9cbe9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "offerer_tag",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=140), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_table(
+        "offerer_tag_mapping",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("offererId", sa.BigInteger(), nullable=False),
+        sa.Column("tagId", sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["offererId"], ["offerer.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tagId"], ["offerer_tag.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("offererId", "tagId", name="unique_offerer_tag"),
+    )
+    op.create_index(op.f("ix_offerer_tag_mapping_offererId"), "offerer_tag_mapping", ["offererId"], unique=False)
+    op.create_index(op.f("ix_offerer_tag_mapping_tagId"), "offerer_tag_mapping", ["tagId"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_offerer_tag_mapping_tagId"), table_name="offerer_tag_mapping")
+    op.drop_index(op.f("ix_offerer_tag_mapping_offererId"), table_name="offerer_tag_mapping")
+    op.drop_table("offerer_tag_mapping")
+    op.drop_table("offerer_tag")

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -275,7 +275,7 @@ class CriterionFactory(BaseFactory):
     class Meta:
         model = Criterion
 
-    name = factory.Sequence("Criterion {}".format)
+    name = factory.Sequence("Criterion_{}".format)
 
 
 class OfferCriterionFactory(BaseFactory):
@@ -312,3 +312,18 @@ class OfferValidationConfigFactory(BaseFactory):
 
     user = factory.SubFactory(users_factories.UserFactory)
     specs = factory.LazyAttribute(lambda config: {"minimum_score": 0.1, "rules": []})
+
+
+class OffererTagFactory(BaseFactory):
+    class Meta:
+        model = offerers_models.OffererTag
+
+    name = factory.Sequence("OffererTag_{}".format)
+
+
+class OffererTagMappingFactory(BaseFactory):
+    class Meta:
+        model = offerers_models.OffererTagMapping
+
+    offerer = factory.SubFactory(OffererFactory)
+    tag = factory.SubFactory(OffererTagFactory)

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -23,6 +23,7 @@ from pcapi.core.fraud.models import BeneficiaryFraudReview
 from pcapi.core.mails.models.models import Email
 from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import Offerer
+from pcapi.core.offerers.models import OffererTag
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offerers.models import VenueLabel
 from pcapi.core.offerers.models import VenueType
@@ -101,6 +102,7 @@ def clean_all_database(*args, **kwargs):
     UserOfferer.query.delete()
     ApiKey.query.delete()
     Offerer.query.delete()
+    OffererTag.query.delete()
     Recredit.query.delete()
     Deposit.query.delete()
     BeneficiaryImportStatus.query.delete()

--- a/api/tests/admin/custom_views/criteria_view_test.py
+++ b/api/tests/admin/custom_views/criteria_view_test.py
@@ -10,7 +10,7 @@ from tests.conftest import clean_database
 
 
 class CriteriaViewTest:
-    @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!"])
+    @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_criterion(self, mocked_validate_csrf_token, client, name):
@@ -46,6 +46,22 @@ class CriteriaViewTest:
 
         assert response.status_code == 200
         assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
+        assert Criterion.query.count() == 0
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_create_criterion_too_long(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            "/pc/back-office/criterion/new/",
+            form={"name": "x" * 141, "description": "My description", "startDateTime": None, "endDateTime": None},
+        )
+
+        assert response.status_code == 200
+        assert "Le nom d&#39;un tag ne peut excéder 140 caractères" in response.data.decode("utf8")
         assert Criterion.query.count() == 0
 
     @clean_database

--- a/api/tests/admin/custom_views/offerer_tag_view_test.py
+++ b/api/tests/admin/custom_views/offerer_tag_view_test.py
@@ -1,0 +1,70 @@
+from unittest.mock import patch
+
+import pytest
+
+from pcapi.core.offerers.models import OffererTag
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import clean_database
+
+
+class OffererTagViewTest:
+    @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_create_tag(self, mocked_validate_csrf_token, client, name):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name})
+
+        assert response.status_code == 302
+        assert OffererTag.query.count() == 1
+        assert OffererTag.query.first().name == name
+
+    @pytest.mark.parametrize(
+        "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
+    )
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_create_tag_with_whitespace(self, mocked_validate_csrf_token, client, name):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name})
+
+        assert response.status_code == 200
+        assert "Le nom ne doit contenir aucun caractère d&#39;espacement" in response.data.decode("utf8")
+        assert OffererTag.query.count() == 0
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_create_tag_too_long(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": "x" * 141})
+
+        assert response.status_code == 200
+        assert "Le nom ne peut excéder 140 caractères" in response.data.decode("utf8")
+        assert OffererTag.query.count() == 0
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_delete_tag(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        offerer = offers_factories.OffererFactory()
+        tag = offers_factories.OffererTagFactory(name="test_delete_tag")
+        offers_factories.OffererTagMappingFactory(offerer=offerer, tag=tag)
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post("/pc/back-office/offerertag/delete/", form={"id": tag.id})
+
+        assert response.status_code == 302
+        assert len(offerer.tags) == 0

--- a/api/tests/admin/custom_views/offerer_view_test.py
+++ b/api/tests/admin/custom_views/offerer_view_test.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.users.factories as users_factories
+from pcapi.models import db
+
+from tests.conftest import clean_database
+
+
+class OffererViewTest:
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_edit_offerer_add_tags(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        offerer = offers_factories.OffererFactory()
+        tag1 = offers_factories.OffererTagFactory(name="test_tag_1")
+        tag2 = offers_factories.OffererTagFactory(name="test_tag_2")
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            f"/pc/back-office/offerer/edit/?id={offerer.id}",
+            form={
+                "name": "Updated offerer",
+                "siren": offerer.siren,
+                "city": offerer.city,
+                "postalCode": offerer.postalCode,
+                "address": offerer.address,
+                "tags": [tag1.id, tag2.id],  # Add both tags
+            },
+        )
+
+        assert response.status_code == 302
+        db.session.refresh(offerer)
+        assert offerer.name == "Updated offerer"
+        assert {tag.name for tag in offerer.tags} == {tag1.name, tag2.name}
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_edit_offerer_remove_tags(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        offerer = offers_factories.OffererFactory()
+        offers_factories.OffererTagMappingFactory(offerer=offerer)
+        offers_factories.OffererTagMappingFactory(offerer=offerer)
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            f"/pc/back-office/offerer/edit/?id={offerer.id}",
+            form={
+                "name": "Updated offerer",
+                "siren": offerer.siren,
+                "city": offerer.city,
+                "postalCode": offerer.postalCode,
+                "address": offerer.address,
+                "tags": [],  # Remove both tags
+            },
+        )
+
+        assert response.status_code == 302
+        db.session.refresh(offerer)
+        assert offerer.name == "Updated offerer"
+        assert len(offerer.tags) == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9892

## But de la pull request

Pouvoir définir des tags sur des structures, à des fins de filtrage dans le backoffice et de suivi dans metabase.

## Implémentation

Règles de gestion dans le ticket https://passculture.atlassian.net/browse/PC-9892

## Informations supplémentaires

J'ai en même temps ajouté la vérification de la longueur des tags des offres et lieux ; on avait une exception en saisissant plus de 140 caractères.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
