### PR TITLE
(BSR) Measure CI execution time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,12 @@ parameters:
   adage-front_cache_key:
     type: string
     default: 'node_modules-14.18-{{ checksum "adage-front/yarn.lock" }}'
+  run_measurement_workflow:
+    type: boolean
+    default: false
+  measure_workflow_id:
+    type: string
+    default: ''
 
 ###################
 #  EXECUTORS
@@ -1004,6 +1010,36 @@ jobs:
           command: gcloud container clusters get-credentials --region ${GCP_REGION} ${GKE_CLUSTER_NAME}
       - run: kubectl get deploy -n <<parameters.helm_environment>> -o name | xargs  -L 1 kubectl rollout restart -n <<parameters.helm_environment>>
 
+  measure_workflow_execution_time:
+    docker:
+      - image: cimg/python:3.9.7
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - checkout
+      - run:
+          name: Measure circle CI workflow execution time from workflow_id
+          command: |
+            pip install -U datetime tzlocal
+            python3 scripts/measure_workflow_execution_time.py $CIRCLE_CI_TOKEN $METRICS_ENDPOINT << pipeline.parameters.measure_workflow_id >>
+
+  trigger_measure_workflow_execution_time:
+    docker:
+      - image: cimg/base:2021.04
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - run:
+          name: Trigger measure workflow execution time
+          command: >
+            curl --request POST \
+              --url https://circleci.com/api/v2/project/github/pass-culture/pass-culture-main/pipeline \
+              --header "Circle-Token: $CIRCLE_CI_TOKEN" \
+              --header 'content-type: application/json' \
+              --data "{\"parameters\":{\"run_measurement_workflow\":true, \"measure_workflow_id\":\"$CIRCLE_WORKFLOW_ID\"}}"
+
 ###################
 #  WORKFLOWS
 ###################
@@ -1153,6 +1189,26 @@ workflows:
            - GCP
            - GCP_EHP
          app_environment: testing
+      - trigger_measure_workflow_execution_time:
+         filters:
+           branches:
+             ignore:
+               - production
+               - staging
+               - integration
+               - master
+         requires:
+           - type-checking-pro
+           - quality-pro
+           - type-checking-adage-front
+           - quality-adage-front
+           - quality-api
+           - tests-api
+           - tests-adage-front
+           - tests-pro-unit-tests
+           - tests-pro-e2e-tests
+         context:
+           - CI_MEASURE
   gcp-ehp:
     jobs:
       - build-and-push-image:
@@ -1250,3 +1306,9 @@ workflows:
           context:
             - GCP
             - GCP_PROD
+  measure_execution_time:
+    when: << pipeline.parameters.run_measurement_workflow >>
+    jobs:
+      - measure_workflow_execution_time:
+          context:
+            - CI_MEASURE

--- a/scripts/measure_workflow_execution_time.py
+++ b/scripts/measure_workflow_execution_time.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+import http.client
+import json
+import sys
+
+import tzlocal
+
+
+def measure_workflow_execution_time(
+    circle_ci_token,
+    metrics_endpoint,
+    workflow_id,
+):
+    conn = http.client.HTTPSConnection("circleci.com")
+    auth = f"Basic {circle_ci_token}"
+    circle_ci_headers = {"authorization": auth}
+    conn.request("GET", f"/api/v2/workflow/{workflow_id}", headers=circle_ci_headers)
+
+    res = conn.getresponse()
+    data = res.read()
+
+    created_at = datetime.strptime(json.loads(data.decode("utf-8"))["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+    worfklow_execution_time = datetime.utcnow() - created_at
+    conn = http.client.HTTPSConnection(metrics_endpoint)
+    headers = {"Content-Type": "text/plain"}
+
+    conn.request(
+        "POST",
+        "/push-metric",
+        json.dumps(
+            {
+                "value": int(worfklow_execution_time.total_seconds()),
+                "creationDate": datetime.now(tzlocal.get_localzone()).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "project": 988,
+                "metricType": "0442e902-b72c-45b7-8482-d2afe7842bf7",
+            }
+        ),
+        headers,
+    )
+
+
+if __name__ == "__main__":
+    measure_workflow_execution_time(sys.argv[1], sys.argv[2], sys.argv[3])


### PR DESCRIPTION
## But de la pull request

L'objectif de cette PR est de pouvoir lever une alerte lorsque ce temps de CI est trop élevé pour investiguer et corriger le problème.
Cela permet aussi de suivre son évolution au fil du temps et donc de mesurer l'impact des actions prises pour optimiser ce temps de CI.

Les mesures vont dans un outil hors du pass et ce job n'envoie que le temps d'exécution des workflows (données non sensibles donc) et permettent aux gens qui travaillent sur l'optimisation des CIs de regrouper les différents projets et apprentissages pour mieux aider ces projets.