### PR TITLE
(PC-13666)[PRO]fix: sendinblue reply_to in template 376 379

### DIFF
--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -30,6 +30,7 @@ class SendinblueBackend(BaseBackend):
                 params=data.params,
                 tags=data.template.tags,
                 sender=asdict(data.template.sender.value),
+                reply_to=asdict(data.reply_to.value) if data.reply_to else None,
                 subject=None,
                 html_content=None,
                 attachment=None,

--- a/api/src/pcapi/core/mails/models/sendinblue_models.py
+++ b/api/src/pcapi/core/mails/models/sendinblue_models.py
@@ -6,15 +6,15 @@ from pcapi import settings
 
 
 @dataclasses.dataclass
-class SenderInfo:
+class EmailInfo:
     email: str
     name: str
 
 
 class SendinblueTransactionalSender(Enum):
-    SUPPORT = SenderInfo(settings.SUPPORT_EMAIL_ADDRESS, "pass Culture")
-    SUPPORT_PRO = SenderInfo(settings.SUPPORT_PRO_EMAIL_ADDRESS, "pass Culture")
-    COMPLIANCE = SenderInfo(settings.COMPLIANCE_EMAIL_ADDRESS, "pass Culture")
+    SUPPORT = EmailInfo(settings.SUPPORT_EMAIL_ADDRESS, "pass Culture")
+    SUPPORT_PRO = EmailInfo(settings.SUPPORT_PRO_EMAIL_ADDRESS, "pass Culture")
+    COMPLIANCE = EmailInfo(settings.COMPLIANCE_EMAIL_ADDRESS, "pass Culture")
 
 
 @dataclasses.dataclass
@@ -53,3 +53,4 @@ class TemplatePro(Template):
 class SendinblueTransactionalEmailData:
     template: Template
     params: dict = dataclasses.field(default_factory=dict)
+    reply_to: Optional[EmailInfo] = None

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
@@ -1,5 +1,6 @@
 from pcapi.core import mails
 from pcapi.core.bookings.models import Booking
+from pcapi.core.mails.models.sendinblue_models import EmailInfo
 from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.utils.mailing import format_booking_date_for_email
@@ -22,6 +23,7 @@ def get_booking_cancellation_by_beneficiary_to_pro_email_data(booking: Booking) 
             "USER_NAME": f"{booking.firstName} {booking.lastName}",
             "USER_EMAIL": booking.email,
         },
+        reply_to=EmailInfo(email=booking.email, name=f"{booking.firstName} {booking.lastName}"),
     )
 
 

--- a/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
@@ -1,5 +1,6 @@
 from pcapi.core import mails
 from pcapi.core.bookings.models import IndividualBooking
+from pcapi.core.mails.models.sendinblue_models import EmailInfo
 from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.models.feature import FeatureToggle
@@ -40,6 +41,10 @@ def get_new_booking_to_pro_email_data(
         is_booking_autovalidated = False
 
     data = SendinblueTransactionalEmailData(
+        reply_to=EmailInfo(
+            email=individual_booking.user.email,
+            name=f"{individual_booking.user.firstName} {individual_booking.user.lastName}",
+        ),
         template=TransactionalEmail.NEW_BOOKING_TO_PRO.value,
         params={
             "OFFER_NAME": offer.name,

--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
     to = [{"email": email} for email in payload.recipients]
     sender = payload.sender
+    reply_to = payload.reply_to or sender
 
     extra = {
         "template_id": payload.template_id,
@@ -21,7 +22,7 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
         "recipients": payload.recipients,
     }
 
-    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(to=to, sender=sender, reply_to=sender)
+    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(to=to, sender=sender, reply_to=reply_to)
 
     # Can send email with: to, sender, template_id, tags, params
 

--- a/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
+++ b/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
@@ -19,6 +19,7 @@ class SendTransactionalEmailRequest(BaseModel):
     subject: Optional[str] = None
     html_content: Optional[str] = None
     attachment: Optional[dict] = None
+    reply_to: Optional[dict] = None
 
 
 class UpdateProAttributesRequest(BaseModel):

--- a/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
@@ -334,6 +334,9 @@ class SendNewBookingEmailToProTest:
     @pytest.mark.usefixtures("db_session")
     def test_send_to_offerer(self):
         booking = bookings_factories.IndividualBookingFactory(
+            individualBooking__user__email="user@example.com",
+            individualBooking__user__firstName="Tom",
+            individualBooking__user__lastName="P",
             stock__offer__bookingEmail="booking.email@example.com",
         )
 
@@ -342,3 +345,7 @@ class SendNewBookingEmailToProTest:
         assert len(mails_testing.outbox) == 1  # test number of emails sent
         assert mails_testing.outbox[0].sent_data["To"] == "booking.email@example.com"
         assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.NEW_BOOKING_TO_PRO.value)
+        assert mails_testing.outbox[0].sent_data["reply_to"] == {
+            "email": "user@example.com",
+            "name": "Tom P",
+        }

--- a/api/tests/core/mails/transactional/test_send_transactional_email.py
+++ b/api/tests/core/mails/transactional/test_send_transactional_email.py
@@ -41,6 +41,34 @@ class TransactionalEmailWithTemplateTest:
         assert mock_send_transac_email.call_args[0][0].template_id == TransactionalEmail.EMAIL_CONFIRMATION.value.id
         assert mock_send_transac_email.call_args[0][0].to == [{"email": "avery.kelly@woobmail.com"}]
         assert mock_send_transac_email.call_args[0][0].tags is None
+        assert mock_send_transac_email.call_args[0][0].reply_to == {
+            "email": "support@example.com",
+            "name": "pass Culture",
+        }
+
+    @patch(
+        "pcapi.core.mails.transactional.send_transactional_email.sib_api_v3_sdk.api.TransactionalEmailsApi.send_transac_email"
+    )
+    def test_send_transactional_email_with_reply_to_success(self, mock_send_transac_email):
+        payload = SendTransactionalEmailRequest(
+            sender={"email": "support@example.com", "name": "pass Culture"},
+            recipients=["avery.kelly@woobmail.com"],
+            template_id=TransactionalEmail.EMAIL_CONFIRMATION.value.id,
+            params={"name": "Avery"},
+            reply_to={"email": "reply@example.com", "name": "reply"},
+        )
+        send_transactional_email(payload)
+
+        mock_send_transac_email.assert_called_once()
+        assert mock_send_transac_email.call_args[0][0].sender == {
+            "email": "support@example.com",
+            "name": "pass Culture",
+        }
+        assert mock_send_transac_email.call_args[0][0].params == {"name": "Avery"}
+        assert mock_send_transac_email.call_args[0][0].template_id == TransactionalEmail.EMAIL_CONFIRMATION.value.id
+        assert mock_send_transac_email.call_args[0][0].to == [{"email": "avery.kelly@woobmail.com"}]
+        assert mock_send_transac_email.call_args[0][0].tags is None
+        assert mock_send_transac_email.call_args[0][0].reply_to == {"email": "reply@example.com", "name": "reply"}
 
     @patch(
         "pcapi.core.mails.transactional.send_transactional_email.sib_api_v3_sdk.api.TransactionalEmailsApi.send_transac_email"
@@ -104,6 +132,10 @@ class TransactionalEmailWithoutTemplateTest:
         assert mock_send_transac_email.call_args[0][0].html_content == "Bonjour"
         assert mock_send_transac_email.call_args[0][0].to == [{"email": "avery.kelly@woobmail.com"}]
         assert mock_send_transac_email.call_args[0][0].tags is None
+        assert mock_send_transac_email.call_args[0][0].reply_to == {
+            "email": "support@example.com",
+            "name": "pass Culture",
+        }
 
     @patch(
         "pcapi.core.mails.transactional.send_transactional_email.sib_api_v3_sdk.api.TransactionalEmailsApi.send_transac_email"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13666

## But de la pull request
Ajout de la possibilité de définir le mail de réponse (le reply_to) lors de la définition d'un template de mail
2 mails concernés mis à jour pour empêcher une sur-sollicitation du support

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
