### PR TITLE
(PC-13684)[API] Optimize pro attributes unit test

### DIFF
--- a/api/tests/core/users/external/external_pro_test.py
+++ b/api/tests/core/users/external/external_pro_test.py
@@ -21,13 +21,33 @@ from pcapi.models.bank_information import BankInformationStatus
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@pytest.mark.parametrize("attached", ["none", "one", "all"])
-@pytest.mark.parametrize("create_offer,create_booking", [(False, False), (True, False), (True, True)])
-@pytest.mark.parametrize("create_dms_accepted", [True, False])
-@pytest.mark.parametrize("create_dms_draft", [True, False])
-@pytest.mark.parametrize("create_permanent", [True, False])
-@pytest.mark.parametrize("create_virtual", [True, False])
-@pytest.mark.parametrize("enable_subscription", [True, False])
+def _build_params(subs, virt, perman, draft, accep, offer, book, attach):
+    return pytest.param(
+        subs,
+        virt,
+        perman,
+        draft,
+        accep,
+        offer,
+        book,
+        attach,
+        id=f"sub:{subs}, vir:{virt}, per:{perman}, dra:{draft}, " f"acc:{accep}, off:{offer}, boo:{book}, att:{attach}",
+    )
+
+
+@pytest.mark.parametrize(
+    "enable_subscription,create_virtual,create_permanent,create_dms_draft,create_dms_accepted,"
+    "create_offer,create_booking,attached",
+    [
+        #             subs, virt, perman, draft, accep, offer, book, attach
+        _build_params(False, False, False, False, False, False, False, "none"),
+        _build_params(True, False, True, True, False, True, False, "one"),
+        _build_params(False, True, False, False, True, True, False, "all"),
+        _build_params(True, True, True, True, True, True, True, "none"),
+        _build_params(False, True, True, False, True, False, False, "one"),
+        _build_params(True, True, True, True, True, True, True, "all"),
+    ],
+)
 def test_update_external_pro_user_attributes(
     enable_subscription,
     create_virtual,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13684

## But de la pull request

Réduire le temps d'exécution du test unitaire controversé `test_update_external_pro_user_attributes`

## Implémentation

Réduire le nombre de combinaisons.
De 288 combinaisons par l'effet de 7 `parametrize`, j'en ai gardé 6 en un seul `parametrize`.
Cela devrait suffire à couvrir les attributs pro de manière satisfaisante.

## Informations supplémentaires

Temps d'exécution passé de 57 secondes à 2,7 secondes pour le fichier `tests/core/users/external/external_pro_test.py`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
