### PR TITLE
(PC-13688)[API] Pro attributes: include venues with bookingEmail in venue_count

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -210,6 +210,6 @@ def venues_have_offers(*venues: models.Venue) -> bool:
     ).scalar()
 
 
-def count_venues(*offerers: models.Offerer) -> bool:
-    """Number of venues managed by all offerers to which the user account with given email is attached"""
-    return models.Venue.query.filter(models.Venue.managingOffererId.in_([offerer.id for offerer in offerers])).count()
+def find_venues_by_offerers(*offerers: models.Offerer) -> list[models.Venue]:
+    """Get all venues managed by any offerer given in arguments"""
+    return models.Venue.query.filter(models.Venue.managingOffererId.in_([offerer.id for offerer in offerers])).all()

--- a/api/src/pcapi/core/users/external/models.py
+++ b/api/src/pcapi/core/users/external/models.py
@@ -44,6 +44,7 @@ class ProAttributes:
     is_user_email: bool  # Email address is set at least for a user account
     is_booking_email: bool  # Email address is set as bookingEmail for at least one venue
     offerer_name: Iterable[str]  # All offerers associated with user account or bookingEmail
+    venue_count: Optional[int] = None  # Total number of venues related to email (by offerer or bookingEmail)
 
     # Attributes set when is_user_email is True:
     user_id: Optional[int] = None
@@ -52,7 +53,6 @@ class ProAttributes:
     marketing_email_subscription: Optional[bool] = None
     user_is_attached: Optional[bool] = None  # User is attached to at least one offerer in which he is not the creator
     user_is_creator: Optional[bool] = None  # User is the creator of at least one offerer
-    venue_count: Optional[int] = None  # Total number of venues attached to structures to which user account is attached
 
     # Attributes set when is_booking_email is True:
     venue_name: Optional[Iterable[str]] = None  # All venues in which contact email is set as bookingEmail

--- a/api/tests/core/users/external/external_pro_test.py
+++ b/api/tests/core/users/external/external_pro_test.py
@@ -172,6 +172,7 @@ def test_update_external_pro_user_attributes(
         if create_virtual
         else {"Juste Libraire", "Plage Culture", "Plage Events"}
     )
+    assert attributes.venue_count == 5 if create_virtual else 4
 
     assert attributes.user_id == pro_user.id
     assert attributes.first_name == pro_user.firstName
@@ -179,7 +180,6 @@ def test_update_external_pro_user_attributes(
     assert attributes.marketing_email_subscription is enable_subscription
     assert attributes.user_is_attached is (attached in ("one", "all"))
     assert attributes.user_is_creator is not (attached == "all")
-    assert attributes.venue_count == 4 if create_virtual else 3
 
     assert (
         attributes.venue_name == {"Cinéma de la plage", "Festival de la mer", "Théâtre de la plage", "Théâtre en ligne"}
@@ -211,6 +211,7 @@ def test_update_external_pro_user_attributes_no_offerer_no_venue():
     assert attributes.is_user_email is True
     assert attributes.is_booking_email is False
     assert attributes.offerer_name == set()
+    assert attributes.venue_count == 0
 
     assert attributes.user_id == user.id
     assert attributes.first_name == user.firstName
@@ -218,7 +219,6 @@ def test_update_external_pro_user_attributes_no_offerer_no_venue():
     assert attributes.marketing_email_subscription is True
     assert attributes.user_is_attached is False
     assert attributes.user_is_creator is False
-    assert attributes.venue_count == 0
 
     assert attributes.venue_name is None
     assert attributes.venue_type is None
@@ -252,6 +252,7 @@ def test_update_external_pro_booking_email_attributes():
     assert attributes.is_user_email is False
     assert attributes.is_booking_email is True
     assert attributes.offerer_name == {offerer.name}
+    assert attributes.venue_count == 1
 
     assert attributes.user_id is None
     assert attributes.first_name is None
@@ -259,7 +260,6 @@ def test_update_external_pro_booking_email_attributes():
     assert attributes.marketing_email_subscription is None
     assert attributes.user_is_attached is None
     assert attributes.user_is_creator is None
-    assert attributes.venue_count is None
 
     assert attributes.venue_name == {venue.name}
     assert attributes.venue_type == {venue.venueTypeCode.name}

--- a/api/tests/core/users/external/external_users_test.py
+++ b/api/tests/core/users/external/external_users_test.py
@@ -75,7 +75,7 @@ def test_update_external_pro_user():
     user = ProFactory()
 
     n_query_get_user = 1
-    n_query_is_pro = 4
+    n_query_is_pro = 3
 
     with assert_num_queries(n_query_get_user + n_query_is_pro):
         update_external_user(user)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13688

## But de la pull request

Changement de spécification sur l’attribut pro `venue_count` envoyé à Sendinblue : ne pas prendre en compte uniquement les lieux rattachés, par leur structure, à l’email de l’utilisateur comme spécifié initialement, mais aussi les lieux qui ont l’adresse email en tant que `bookingEmail`

## Implémentation

Ne compter qu’une seule fois  si le lieu a comme `bookingEmail` l’adresse email d’un utilisateur rattaché à la structure parente du lieu

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
