### PR TITLE
[bsr][api] Suppression de IPython pour "flask shell"

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,6 @@ Flask-Cors==3.0.10
 Flask-JWT-Extended==4.3.1
 Flask-Limiter==1.4
 Flask-Login==0.5.0
-flask-shell-ipython
 Flask-SQLAlchemy==2.4.4
 freezegun==0.3.12
 google-auth==1.23.0


### PR DESCRIPTION
This reverts commit b2353d5d0bfe204fdd6d345b33d713914139ca92.

We added IPython mostly for the auto-completion, when we were using
Flask 1. Now we have migrated to Flask 2 that provides that feature.
We thus do not really need IPython.

---

Autre possibilité, conserver (mais personnaliser IPython) : #1144