### PR TITLE
(PC-13608) [API] fix:venue: check right access before rm banner

### DIFF
--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -155,6 +155,8 @@ def upsert_venue_banner(venue_id: str) -> GetVenueResponseModel:
 @spectree_serialize(on_success_status=204)
 def delete_venue_banner(venue_id: str) -> None:
     venue = load_or_404(Venue, venue_id)
+    check_user_has_access_to_offerer(current_user, venue.managingOffererId)
+
     offerers_api.delete_venue_banner(venue)
 
 

--- a/api/tests/routes/pro/delete_venue_banner_test.py
+++ b/api/tests/routes/pro/delete_venue_banner_test.py
@@ -42,3 +42,15 @@ class VenueBannerTest:
 
         response = client.delete("/venues/AZERTYUIOP1234567890/banner")
         assert response.status_code == 404
+
+    @patch("pcapi.core.offerers.api.delete_venue_banner")
+    def test_no_access_rights(self, mock_delete_venue_banner, client):
+        user = offers_factories.UserOffererFactory()
+        venue = offers_factories.VenueFactory()  # user has no rights to do anything with this venue
+
+        client = client.with_session_auth(email=user.user.email)
+
+        response = client.delete(f"/venues/{humanize(venue.id)}/banner")
+        assert response.status_code == 403
+
+        mock_delete_venue_banner.assert_not_called()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13608

## But de la pull request

FIX : ajout de l'appel à `check_user_has_access_to_offerer` avant la suppression de l'image d'un lieu.
Sans ça, n'importe quel utilisateur authentifié peut supprimer l'image de n'importe quel lieu.