### PR TITLE
(PC-13477)[API] subscription: make activity mandatory for profile completion

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -93,8 +93,7 @@ def _send_beneficiary_activation_email(user: users_models.User, has_activated_ac
 
 
 def has_completed_profile(user: users_models.User) -> bool:
-    # TODO(add a check on user.activity once the field is mandatory in subscription/profile_completion route)
-    return user.city is not None
+    return user.city is not None and user.activity is not None
 
 
 def is_eligibility_activable(

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -6,7 +6,6 @@ from pcapi.core.fraud.utils import has_latin_or_numeric_chars
 from pcapi.core.fraud.utils import is_latin
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import profile_options
-from pcapi.core.users import models as users_models
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -23,9 +23,8 @@ class NextSubscriptionStepResponse(BaseModel):
 
 
 class ProfileUpdateRequest(BaseModel):
-    activity_id: Optional[profile_options.ACTIVITY_ID_ENUM]
-    activity: Optional[users_models.ActivityEnum]  # TODO: CorentinN: remove this field when frontend sends activity_id
-    address: Optional[str]
+    activity_id: profile_options.ACTIVITY_ID_ENUM
+    address: str
     city: str
     first_name: str
     last_name: str

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -57,6 +57,7 @@ class EduconnectFlowTest:
         assert response.status_code == 204
 
         assert user.city == "Uneville"
+        assert user.activity == "Lycéen"
         assert subscription_api.has_completed_profile(user)
 
         # Get educonnect login form with saml protocol
@@ -135,7 +136,7 @@ class NextSubscriptionStepTest:
 
     @override_features(ENABLE_EDUCONNECT_AUTHENTICATION=True)
     def test_next_subscription_step_underage_honor_statement(self):
-        user = users_factories.UserFactory(dateOfBirth=self.fifteen_years_ago, city="Zanzibar")
+        user = users_factories.UserFactory(dateOfBirth=self.fifteen_years_ago, city="Zanzibar", activity="Collégien")
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=fraud_models.FraudCheckType.EDUCONNECT,
@@ -147,7 +148,7 @@ class NextSubscriptionStepTest:
 
     @override_features(ENABLE_EDUCONNECT_AUTHENTICATION=True)
     def test_next_subscription_step_underage_finished(self):
-        user = users_factories.UserFactory(dateOfBirth=self.fifteen_years_ago, city="Zanzibar")
+        user = users_factories.UserFactory(dateOfBirth=self.fifteen_years_ago, city="Zanzibar", activity="Collégien")
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.HONOR_STATEMENT,
             resultContent=None,
@@ -204,6 +205,7 @@ class NextSubscriptionStepTest:
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             city="Zanzibar",
+            activity="Collégien",
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -223,6 +225,7 @@ class NextSubscriptionStepTest:
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             city="Zanzibar",
+            activity="Collégien",
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -242,6 +245,7 @@ class NextSubscriptionStepTest:
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             address="3 rue du quai",
+            activity="Collégien",
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -678,10 +682,18 @@ class CommonSubscritpionTest:
 class HasPassedAllChecksToBecomeBeneficiaryTest:
     AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
 
-    def eligible_user(self, validate_phone: bool, city: typing.Optional[str] = "Quito"):
+    def eligible_user(
+        self,
+        validate_phone: bool,
+        city: typing.Optional[str] = "Quito",
+        activity: typing.Optional[users_models.ActivityEnum] = "Étudiant",
+    ):
         phone_validation_status = users_models.PhoneValidationStatusType.VALIDATED if validate_phone else None
         return users_factories.UserFactory(
-            dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE, phoneValidationStatus=phone_validation_status, city=city
+            dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE,
+            phoneValidationStatus=phone_validation_status,
+            city=city,
+            activity=activity,
         )
 
     def test_no_missing_step(self):

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -522,6 +522,7 @@ class UbbleWebhookTest:
         user = users_factories.UserFactory(
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             dateOfBirth=datetime.datetime.now() - relativedelta.relativedelta(years=18),
+            activity="Lycéen",
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -877,6 +878,7 @@ class UbbleWebhookTest:
             email=email,
             dateOfBirth=subscription_birth_date,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            activity="Lycéen",
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1160,6 +1160,7 @@ class ValidatePhoneNumberTest:
         user = users_factories.UserFactory(
             phoneNumber="+33607080900",
             subscriptionState=users_models.SubscriptionState.email_validated,
+            activity="Lycéen",
         )
 
         fraud_factories.BeneficiaryFraudCheckFactory(

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1281,15 +1281,8 @@ def test_public_api(client, app):
                 },
                 "ProfileUpdateRequest": {
                     "properties": {
-                        "activity": {
-                            "anyOf": [{"$ref": "#/components/schemas/ActivityEnum"}],
-                            "nullable": True,
-                        },
-                        "activityId": {
-                            "anyOf": [{"$ref": "#/components/schemas/ActivityIdEnum"}],
-                            "nullable": True,
-                        },
-                        "address": {"nullable": True, "title": "Address", "type": "string"},
+                        "activityId": {"$ref": "#/components/schemas/ActivityIdEnum"},
+                        "address": {"title": "Address", "type": "string"},
                         "city": {"title": "City", "type": "string"},
                         "firstName": {"title": "Firstname", "type": "string"},
                         "lastName": {"title": "Lastname", "type": "string"},
@@ -1299,24 +1292,9 @@ def test_public_api(client, app):
                             "nullable": True,
                         },
                     },
-                    "required": ["city", "firstName", "lastName", "postalCode"],
+                    "required": ["activityId", "address", "city", "firstName", "lastName", "postalCode"],
                     "title": "ProfileUpdateRequest",
                     "type": "object",
-                },
-                "ActivityEnum": {
-                    "description": "An enumeration.",
-                    "enum": [
-                        "Coll\u00e9gien",
-                        "Lyc\u00e9en",
-                        "\u00c9tudiant",
-                        "Employ\u00e9",
-                        "Apprenti",
-                        "Alternant",
-                        "Volontaire",
-                        "Inactif",
-                        "Ch\u00f4meur",
-                    ],
-                    "title": "ActivityEnum",
                 },
                 "ActivityIdEnum": {
                     "description": "An enumeration.",

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -32,7 +32,7 @@ class EduconnectTest:
     default_underage_user_age = 15
 
     def connect_to_educonnect(self, client, app):
-        user = users_factories.UserFactory(email=self.email)
+        user = users_factories.UserFactory(email=self.email, activity="Collégien")
         access_token = create_access_token(identity=self.email)
         client.auth_header = {"Authorization": f"Bearer {access_token}"}
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13477

## But de la pull request

- Rendre obligatoire les champs activityId et adresse de la route de mise à jour du profile. On enlève le champs `activity` (il ne devrait pas y avoir de breaking change car l'application native n'envoie plus ce champs depuis une version antérieure à la version dont on a forcé la màj (v1.166.0) fin décembre.
- L'étape profile est maintenant complétée si l'utilisateur a une ville ET une activité renseignées.


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
