### PR TITLE
(PC-13332)[API] feat: add ENABLE_NATIVE_CULTURAL_SURVEY feature flag

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -48,6 +48,9 @@ class FeatureToggle(enum.Enum):
         "Active le champ isbn obligatoire lors de la création d'offre de type LIVRE_EDITION"
     )
     ENABLE_NATIVE_APP_RECAPTCHA = "Active le reCaptacha sur l'API native"
+    ENABLE_NATIVE_CULTURAL_SURVEY = (
+        "Active le Questionnaire des pratiques initiales natif (non TypeForm) sur l'app native et décli web"
+    )
     ENABLE_NATIVE_ID_CHECK_VERSION = "Utilise la version d'ID-Check intégrée à l'application native"
     ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING = (
         "Active le mode debug Firebase pour l'Id Check intégrée à l'application native"
@@ -123,6 +126,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.ENABLE_EDUCONNECT_AUTHENTICATION,
     FeatureToggle.ENABLE_ID_CHECK_RETENTION,
     FeatureToggle.ENABLE_ISBN_REQUIRED_IN_LIVRE_EDITION_OFFER_CREATION,
+    FeatureToggle.ENABLE_NATIVE_CULTURAL_SURVEY,
     FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,
     FeatureToggle.ENABLE_NEW_BOOKING_FILTERS,
     FeatureToggle.ENABLE_NEW_VENUE_PAGES,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13332

## But de la pull request

Ajout du Feature flag qui permettra d'activer le questionnaire des pratiques initiales sur l'app native.

## Implémentation

Ajout au fichier `feature.py` et désactivation par défaut.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
