### PR TITLE
(PC-13522) add rule on siret in VenueView

### DIFF
--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -1,4 +1,5 @@
 import datetime
+import typing
 
 import pytz
 
@@ -39,6 +40,10 @@ def get_business_units_query(
         venue_subquery = venue_subquery.with_entities(offerers_models.Venue.id).subquery()
         query = query.filter(offerers_models.Venue.id.in_(venue_subquery))
     return query
+
+
+def find_business_unit_by_siret(siret: str) -> typing.Optional[models.BusinessUnit]:
+    return models.BusinessUnit.query.filter_by(siret=siret).one_or_none()
 
 
 def get_invoices_query(

--- a/api/tests/admin/custom_views/venue_view_test.py
+++ b/api/tests/admin/custom_views/venue_view_test.py
@@ -5,10 +5,7 @@ import pytest
 from pcapi.admin.custom_views.venue_view import _get_venue_provider_link
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers import factories as offers_factories
-from pcapi.core.offers.factories import StockFactory
-from pcapi.core.offers.factories import VenueFactory
-from pcapi.core.offers.models import Offer
-from pcapi.core.offers.models import Stock
+from pcapi.core.offers import models as offers_models
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.users.factories import AdminFactory
 
@@ -22,10 +19,12 @@ class VenueViewTest:
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_update_venue_siret(self, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
-        venue = VenueFactory(siret="22222222222222")
+        venue = offers_factories.VenueFactory(siret="22222222222222")
         id_at_provider = "11111"
         old_id_at_providers = f"{id_at_provider}@{venue.siret}"
-        stock = StockFactory(offer__venue=venue, idAtProviders=old_id_at_providers, offer__idAtProvider=id_at_provider)
+        stock = offers_factories.StockFactory(
+            offer__venue=venue, idAtProviders=old_id_at_providers, offer__idAtProvider=id_at_provider
+        )
 
         data = dict(
             name=venue.name,
@@ -45,7 +44,7 @@ class VenueViewTest:
         assert response.status_code == 302
 
         venue_edited = Venue.query.get(venue.id)
-        stock_edited = Stock.query.get(stock.id)
+        stock_edited = offers_models.Stock.query.get(stock.id)
 
         assert venue_edited.siret == "88888888888888"
         assert stock_edited.idAtProviders == "11111@88888888888888"
@@ -56,9 +55,11 @@ class VenueViewTest:
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_venue_other_offer_id_at_provider(self, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
-        venue = VenueFactory(siret="22222222222222")
+        venue = offers_factories.VenueFactory(siret="22222222222222")
         id_at_providers = "id_at_provider_ne_contenant_pas_le_siret"
-        stock = StockFactory(offer__venue=venue, idAtProviders=id_at_providers, offer__idAtProvider=id_at_providers)
+        stock = offers_factories.StockFactory(
+            offer__venue=venue, idAtProviders=id_at_providers, offer__idAtProvider=id_at_providers
+        )
 
         data = dict(
             name=venue.name,
@@ -78,8 +79,8 @@ class VenueViewTest:
         assert response.status_code == 302
 
         venue_edited = Venue.query.get(venue.id)
-        stock = Stock.query.get(stock.id)
-        offer = Offer.query.get(stock.offer.id)
+        stock = offers_models.Stock.query.get(stock.id)
+        offer = offers_models.Offer.query.get(stock.offer.id)
 
         assert venue_edited.siret == "88888888888888"
         assert stock.idAtProviders == "id_at_provider_ne_contenant_pas_le_siret"
@@ -89,7 +90,7 @@ class VenueViewTest:
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_venue_without_siret(self, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
-        venue = VenueFactory(siret=None, comment="comment to allow null siret")
+        venue = offers_factories.VenueFactory(siret=None, comment="comment to allow null siret")
 
         data = dict(
             name=venue.name,
@@ -113,7 +114,7 @@ class VenueViewTest:
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_update_venue_reindex_all(self, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
-        venue = VenueFactory(isPermanent=False)
+        venue = offers_factories.VenueFactory(isPermanent=False)
 
         new_name = venue.name + "(updated)"
         data = dict(
@@ -147,7 +148,7 @@ class VenueViewTest:
         self, mocked_async_index_venue_ids, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app
     ):
         AdminFactory(email="user@example.com")
-        venue = VenueFactory(isPermanent=False)
+        venue = offers_factories.VenueFactory(isPermanent=False)
 
         data = dict(
             name=venue.name,
@@ -186,7 +187,7 @@ class VenueViewTest:
         client,
     ):
         admin = AdminFactory(email="user@example.com")
-        venue = VenueFactory(isPermanent=True)
+        venue = offers_factories.VenueFactory(isPermanent=True)
         tag = offers_factories.CriterionFactory()
         data = {
             "criteria": [tag.id],
@@ -215,7 +216,7 @@ class GetVenueProviderLinkTest:
     @pytest.mark.usefixtures("db_session")
     def test_return_empty_link_when_no_venue_provider(self, app):
         # Given
-        venue = VenueFactory()
+        venue = offers_factories.VenueFactory()
 
         # When
         link = _get_venue_provider_link(None, None, venue, None)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13522

## But de la pull request

Empêcher de pouvoir attribuer à un lieu un SIRET déjà affecté à une BusinessUnit dans le formulaire d'édition de lieu sur FA.

## Implémentation

Modification de `VenueView`

## Informations supplémentaires

Au passage, réorganisation des imports

<img width="529" alt="PC-13522" src="https://user-images.githubusercontent.com/33030007/156151734-b5196f6a-cb32-4f5e-b498-97e7caf3c0a9.png">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
