### PR TITLE
(PC-12592)[API] fix: create orphan dms application in the webhook

### DIFF
--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -241,7 +241,7 @@ class DmsWebhookApplicationTest:
     def test_dms_request_with_unexisting_user(self, send_user_message, execute_query, client):
 
         execute_query.return_value = make_single_application(
-            12, state=api_dms.GraphQLApplicationStates.draft.value, email="user@example.com"
+            6044787, state=api_dms.GraphQLApplicationStates.draft.value, email="user@example.com"
         )
         form_data = {
             "procedure_id": 48860,
@@ -259,6 +259,11 @@ class DmsWebhookApplicationTest:
         assert execute_query.call_count == 1
         assert send_user_message.call_count == 1
         assert send_user_message.call_args[0][2] == subscription_messages.DMS_ERROR_MESSAGE_USER_NOT_FOUND
+
+        orphan_dms_application = fraud_models.OrphanDmsApplication.query.filter(
+            fraud_models.OrphanDmsApplication.email == "user@example.com"
+        ).first()
+        assert orphan_dms_application.application_id == 6044787
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
     @patch.object(api_dms.DMSGraphQLClient, "send_user_message")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12592

## But de la pull request

Enregistrer un dossier comme orphelin si on ne trouve pas l'utilisateur associé dans le webhook
Permet l'adoption à l'inscription après, sans avoir à attendre le cron

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
