### PR TITLE
(PC-13721) add firstName and lastName to the fields necessary for profile completion

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -93,7 +93,8 @@ def _send_beneficiary_activation_email(user: users_models.User, has_activated_ac
 
 
 def has_completed_profile(user: users_models.User) -> bool:
-    return user.city is not None and user.activity is not None
+    mandatory_fields = [user.city, user.activity, user.firstName, user.lastName]
+    return all(elem is not None for elem in mandatory_fields)
 
 
 def is_eligibility_activable(

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -136,7 +136,11 @@ class NextSubscriptionStepTest:
 
     @override_features(ENABLE_EDUCONNECT_AUTHENTICATION=True)
     def test_next_subscription_step_underage_honor_statement(self):
-        user = users_factories.UserFactory(dateOfBirth=self.fifteen_years_ago, city="Zanzibar", activity="Collégien")
+        user = users_factories.UserFactory(
+            dateOfBirth=self.fifteen_years_ago,
+            city="Zanzibar",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
+        )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=fraud_models.FraudCheckType.EDUCONNECT,
@@ -148,7 +152,11 @@ class NextSubscriptionStepTest:
 
     @override_features(ENABLE_EDUCONNECT_AUTHENTICATION=True)
     def test_next_subscription_step_underage_finished(self):
-        user = users_factories.UserFactory(dateOfBirth=self.fifteen_years_ago, city="Zanzibar", activity="Collégien")
+        user = users_factories.UserFactory(
+            dateOfBirth=self.fifteen_years_ago,
+            city="Zanzibar",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
+        )
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.HONOR_STATEMENT,
             resultContent=None,
@@ -205,7 +213,7 @@ class NextSubscriptionStepTest:
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             city="Zanzibar",
-            activity="Collégien",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -225,7 +233,7 @@ class NextSubscriptionStepTest:
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             city="Zanzibar",
-            activity="Collégien",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -245,7 +253,7 @@ class NextSubscriptionStepTest:
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             address="3 rue du quai",
-            activity="Collégien",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
         )
         content = fraud_factories.UserProfilingFraudDataFactory(risk_rating="trusted")
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -372,6 +380,22 @@ class NextSubscriptionStepTest:
         user = users_factories.UserFactory(dateOfBirth=dateOfBirth, schoolType=user_school_type)
         with override_features(**feature_flags):
             assert subscription_api.get_allowed_identity_check_methods(user) == expected_result
+
+    def test_has_completed_profile_names_mandatory(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=self.eighteen_years_ago,
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            address="3 rue du quai",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
+        )
+        assert subscription_api.has_completed_profile(user)
+
+        user = users_factories.UserFactory(
+            dateOfBirth=self.eighteen_years_ago,
+            firstName=None,
+            lastName=None,
+        )
+        assert not subscription_api.has_completed_profile(user)
 
     @pytest.mark.parametrize(
         "feature_flags,user_age,expected_result",

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -74,7 +74,7 @@ class NextStepTest:
         user = users_factories.UserFactory(
             dateOfBirth=datetime.datetime.combine(datetime.date.today(), datetime.time(0, 0))
             - relativedelta(years=15, months=5),
-            activity="Collégien",
+            activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
         )
 
         client.with_token(user.email)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13721

## But de la pull request

- Tant qu'on a pas le nom + prénom de l'utilisateur, la prochaine étape d'activation doit être la complétion du profil

## Implémentation

- Rendre ces deux champs obligatoirement non vides pour valider la complétion du profile dans le calcul des prochaines steps

## Informations supplémentaires

- Fix un bug qui permettait de démarrer un dossier Ubble, sans nom + prénom. Ubble remonte alors les dossiers comme suspicieux car il n'a pas de noms pour comparer à celui de la pièce d'ID

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
