### PR TITLE
Pc 13545/duplicate collective offer creation in new models

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -55,7 +55,7 @@ class CollectiveOfferTemplateFactory(BaseFactory):
     class Meta:
         model = models.CollectiveOfferTemplate
 
-    subcategoryId = factory.Iterator(COLLECTIVE_SUBCATEGORIES, getter=lambda s: s.id)
+    subcategoryId = factory.Iterator(COLLECTIVE_SUBCATEGORIES)
     name = factory.Sequence("CollectiveOffer {}".format)
     description = factory.Sequence("A passionate description of collectiveoffer {}".format)
     venue = factory.SubFactory(VenueFactory)

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -22,7 +22,7 @@ class CollectiveOfferFactory(BaseFactory):
     class Meta:
         model = models.CollectiveOffer
 
-    subcategoryId = factory.Iterator(COLLECTIVE_SUBCATEGORIES, getter=lambda s: s.id)
+    subcategoryId = factory.Iterator(COLLECTIVE_SUBCATEGORIES)
     name = factory.Sequence("CollectiveOffer {}".format)
     description = factory.Sequence("A passionate description of collectiveoffer {}".format)
     venue = factory.SubFactory(VenueFactory)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -17,6 +17,7 @@ from sqlalchemy.sql.sqltypes import Numeric
 
 from pcapi.core.bookings import exceptions as booking_exceptions
 from pcapi.core.educational import exceptions
+from pcapi.core.offers.models import Offer
 from pcapi.models import Model
 from pcapi.models.offer_mixin import AccessibilityMixin
 from pcapi.models.offer_mixin import OfferValidationStatus
@@ -143,6 +144,36 @@ class CollectiveOffer(PcObject, ValidationMixin, AccessibilityMixin, StatusMixin
             sa.exists()
             .where(CollectiveStock.offerId == cls.id)
             .where(CollectiveStock.hasBookingLimitDatetimePassed.is_(True))
+        )
+
+    @classmethod
+    def create_from_offer(cls, offer: Offer):
+        list_of_common_attributes = [
+            "isActive",
+            "venue",
+            "name",
+            "description",
+            "durationMinutes",
+            "dateCreated",
+            "subcategoryId",
+            "dateUpdated",
+            "bookingEmail",
+            "lastValidationDate",
+            "validation",
+            "audioDisabilityCompliant",
+            "mentalDisabilityCompliant",
+            "motorDisabilityCompliant",
+            "visualDisabilityCompliant",
+        ]
+        offer_mapping = {x: getattr(offer, x) for x in list_of_common_attributes}
+        students = [StudentLevels(x).name for x in offer.extraData.get("students")]
+        return cls(
+            **offer_mapping,
+            offerId=offer.id,
+            contactEmail=offer.extraData.get("contactEmail"),
+            contactPhone=offer.extraData.get("contactPhone"),
+            offerVenue=offer.extraData.get("offerVenue"),
+            students=students,
         )
 
 

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -228,6 +228,67 @@ class CollectiveOfferTemplate(PcObject, ValidationMixin, AccessibilityMixin, Sta
             and self.venue.managingOfferer.isValidated
         )
 
+    @classmethod
+    def create_from_collective_offer(cls, collective_offer: CollectiveOffer, price_detail: str = None):
+        list_of_common_attributes = [
+            "isActive",
+            "venue",
+            "name",
+            "description",
+            "durationMinutes",
+            "dateCreated",
+            "subcategoryId",
+            "dateUpdated",
+            "bookingEmail",
+            "lastValidationDate",
+            "validation",
+            "audioDisabilityCompliant",
+            "mentalDisabilityCompliant",
+            "motorDisabilityCompliant",
+            "visualDisabilityCompliant",
+            "contactEmail",
+            "contactPhone",
+            "offerVenue",
+            "students",
+        ]
+        collective_offer_mapping = {x: getattr(collective_offer, x) for x in list_of_common_attributes}
+        return cls(
+            **collective_offer_mapping,
+            offerId=collective_offer.offerId,
+            priceDetail=price_detail,
+        )
+
+    @classmethod
+    def create_from_offer(cls, offer: Offer, price_detail: str = None):
+        list_of_common_attributes = [
+            "isActive",
+            "venue",
+            "name",
+            "description",
+            "durationMinutes",
+            "dateCreated",
+            "subcategoryId",
+            "dateUpdated",
+            "bookingEmail",
+            "lastValidationDate",
+            "validation",
+            "audioDisabilityCompliant",
+            "mentalDisabilityCompliant",
+            "motorDisabilityCompliant",
+            "visualDisabilityCompliant",
+        ]
+        offer_mapping = {x: getattr(offer, x) for x in list_of_common_attributes}
+        students = [StudentLevels(x).name for x in offer.extraData.get("students")]
+        return cls(
+            **offer_mapping,
+            offerId=offer.id,
+            contactEmail=offer.extraData.get("contactEmail"),
+            contactPhone=offer.extraData.get("contactPhone"),
+            offerVenue=offer.extraData.get("offerVenue"),
+            students=students,
+            priceDetail=price_detail,
+        )
+
 
 class CollectiveStock(PcObject, Model):  # type: ignore[valid-type]
     __tablename__ = "collective_stock"

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from datetime import datetime
 from decimal import Decimal
@@ -174,6 +176,35 @@ class CollectiveOffer(PcObject, ValidationMixin, AccessibilityMixin, StatusMixin
             contactPhone=offer.extraData.get("contactPhone"),
             offerVenue=offer.extraData.get("offerVenue"),
             students=students,
+        )
+
+    @classmethod
+    def create_from_collective_offer_template(cls, collective_offer_template: CollectiveOfferTemplate):
+        list_of_common_attributes = [
+            "isActive",
+            "venue",
+            "name",
+            "description",
+            "durationMinutes",
+            "dateCreated",
+            "subcategoryId",
+            "dateUpdated",
+            "bookingEmail",
+            "lastValidationDate",
+            "validation",
+            "audioDisabilityCompliant",
+            "mentalDisabilityCompliant",
+            "motorDisabilityCompliant",
+            "visualDisabilityCompliant",
+            "contactEmail",
+            "contactPhone",
+            "offerVenue",
+            "students",
+        ]
+        offer_mapping = {x: getattr(collective_offer_template, x) for x in list_of_common_attributes}
+        return cls(
+            **offer_mapping,
+            offerId=collective_offer_template.offerId,
         )
 
 

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -168,7 +168,7 @@ class CollectiveOffer(PcObject, ValidationMixin, AccessibilityMixin, StatusMixin
             "visualDisabilityCompliant",
         ]
         offer_mapping = {x: getattr(offer, x) for x in list_of_common_attributes}
-        students = [StudentLevels(x).name for x in offer.extraData.get("students")]
+        students = [StudentLevels(x).name for x in offer.extraData.get("students", [])]
         return cls(
             **offer_mapping,
             offerId=offer.id,
@@ -309,7 +309,7 @@ class CollectiveOfferTemplate(PcObject, ValidationMixin, AccessibilityMixin, Sta
             "visualDisabilityCompliant",
         ]
         offer_mapping = {x: getattr(offer, x) for x in list_of_common_attributes}
-        students = [StudentLevels(x).name for x in offer.extraData.get("students")]
+        students = [StudentLevels(x).name for x in offer.extraData.get("students", [])]
         return cls(
             **offer_mapping,
             offerId=offer.id,

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -44,14 +44,6 @@ class SubcategoryNotEligibleForEducationalOffer(ClientError):
         )
 
 
-class OfferCannotBeDuoAndEducational(ClientError):
-    def __init__(self):
-        super().__init__(
-            "offer",
-            "Une offre ne peut être à la fois 'duo' et 'éducationnelle'.",
-        )
-
-
 class UnknownOfferSubCategory(ClientError):
     def __init__(self):
         super().__init__(
@@ -115,4 +107,8 @@ class EducationalOfferHasMultipleStocks(Exception):
 
 
 class NoBookingToCancel(Exception):
+    pass
+
+
+class CollectiveOfferNotFound(Exception):
     pass

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -325,11 +325,6 @@ def check_offer_is_eligible_for_educational(subcategory_id: str, is_educational:
             raise exceptions.SubcategoryNotEligibleForEducationalOffer()
 
 
-def check_offer_not_duo_and_educational(is_duo: bool, is_educational: bool):
-    if is_duo and is_educational:
-        raise exceptions.OfferCannotBeDuoAndEducational()
-
-
 def check_offer_subcategory_is_valid(offer_subcategory_id):
     if offer_subcategory_id not in ALL_SUBCATEGORIES_DICT:
         raise exceptions.UnknownOfferSubCategory()

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -79,16 +79,6 @@ def post_offer(body: offers_serialize.PostOfferBodyModel) -> offers_serialize.Of
     try:
         offer = offers_api.create_offer(offer_data=body, user=current_user)
 
-    except exceptions.OfferCannotBeDuoAndEducational as error:
-        logger.info(
-            "Could not create offer: offer cannot be both 'duo' and 'educational'",
-            extra={"offer_name": body.name, "venue_id": body.venue_id},
-        )
-        raise ApiErrors(
-            error.errors,
-            status_code=400,
-        )
-
     except exceptions.UnknownOfferSubCategory as error:
         logger.info(
             "Could not create offer: selected subcategory is unknown.",
@@ -332,6 +322,11 @@ def create_shadow_stock_for_educational_showcase_offer(
         raise ApiErrors(
             {"code": "EDUCATIONAL_STOCK_ALREADY_EXISTS"},
             status_code=400,
+        )
+    except exceptions.CollectiveOfferNotFound:
+        raise ApiErrors(
+            {"code": "COLLECTIVE_OFFER_NOT_FOUND"},
+            status_code=404,
         )
 
     return StockIdResponseModel.from_orm(stock)

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -327,7 +327,7 @@ def create_shadow_stock_for_educational_showcase_offer(
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
-        stock = offers_api.create_educational_shadow_stock_and_set_offer_showcase(body, current_user, offer_id)
+        stock = offers_api.create_collective_shadow_offer(body, current_user, offer_id)
     except educational_exceptions.EducationalStockAlreadyExists:
         raise ApiErrors(
             {"code": "EDUCATIONAL_STOCK_ALREADY_EXISTS"},

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -166,7 +166,9 @@ def transform_shadow_stock_into_educational_stock(
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
-        stock = offers_api.transform_shadow_stock_and_create_collective_offer(dehumanize(stock_id), body, current_user)
+        stock = offers_api.transform_shadow_stock_into_educational_stock_and_create_collective_offer(
+            dehumanize(stock_id), body, current_user
+        )
     except educational_exceptions.OfferIsNotShowcase:
         raise ApiErrors({"code": "OFFER_IS_NOT_SHOWCASE"}, status_code=400)
     return stock_serialize.StockEditionResponseModel.from_orm(stock)

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -166,7 +166,7 @@ def transform_shadow_stock_into_educational_stock(
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
-        stock = offers_api.transform_shadow_stock_into_educational_stock(dehumanize(stock_id), body, current_user)
+        stock = offers_api.transform_shadow_stock_and_create_collective_offer(dehumanize(stock_id), body, current_user)
     except educational_exceptions.OfferIsNotShowcase:
         raise ApiErrors({"code": "OFFER_IS_NOT_SHOWCASE"}, status_code=400)
     return stock_serialize.StockEditionResponseModel.from_orm(stock)

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -11,6 +11,7 @@ from pydantic import validator
 from pcapi.core.bookings.api import compute_cancellation_limit_date
 from pcapi.core.categories.conf import can_create_from_isbn
 from pcapi.core.categories.subcategories import SubcategoryIdEnum
+from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers.models import Stock
 from pcapi.models.feature import FeatureToggle
@@ -128,7 +129,7 @@ class EducationalOfferExtraDataOfferVenueBodyModel(BaseModel):
 
 
 class PostEducationalOfferExtraDataBodyModel(BaseModel):
-    students: list[str]
+    students: list[StudentLevels]
     offer_venue: EducationalOfferExtraDataOfferVenueBodyModel
     contact_email: str
     contact_phone: str

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1515,33 +1515,6 @@ class CreateOfferTest:
 
         assert offer.isEducational
 
-    def test_cannot_create_educational_offer_when_is_duo(self):
-
-        # Given
-        venue = offer_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        user_offerer = offer_factories.UserOffererFactory(offerer=offerer)
-        user = user_offerer.user
-        data = offers_serialize.PostOfferBodyModel(
-            venueId=humanize(venue.id),
-            name="A pretty good offer",
-            subcategoryId=subcategories.SEANCE_CINE.id,
-            externalTicketOfficeUrl="http://example.net",
-            isEducational=True,
-            isDuo=True,
-            audioDisabilityCompliant=True,
-            mentalDisabilityCompliant=True,
-            motorDisabilityCompliant=True,
-            visualDisabilityCompliant=True,
-        )
-
-        # When
-        with pytest.raises(offer_exceptions.OfferCannotBeDuoAndEducational) as error:
-            api.create_offer(data, user)
-
-        # Then
-        assert error.value.errors["offer"] == ["Une offre ne peut être à la fois 'duo' et 'éducationnelle'."]
-
     def test_cannot_create_educational_offer_when_not_eligible_subcategory(self):
 
         # Given

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -394,27 +394,6 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json["offer"] == ["Cette catégorie d'offre n'est pas éligible aux offres éducationnelles"]
 
-    def test_fail_when_educational_and_duo(self, app):
-        # Given
-        venue = offers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
-
-        # When
-        data = {
-            "venueId": humanize(venue.id),
-            "name": "An unacceptable name",
-            "subcategoryId": "SEANCE_CINE",
-            "isEducational": True,
-            "isDuo": True,
-        }
-        client = TestClient(app.test_client()).with_session_auth("user@example.com")
-        response = client.post("/offers", json=data)
-
-        # Then
-        assert response.status_code == 400
-        assert response.json["offer"] == ["Une offre ne peut être à la fois 'duo' et 'éducationnelle'."]
-
     def test_fail_when_offer_subcategory_is_offline_only_and_venue_is_virtuel(self, app):
         # Given
         venue = offers_factories.VirtualVenueFactory()

--- a/api/tests/routes/pro/post_shadow_stock_for_educational_showcase_offer_test.py
+++ b/api/tests/routes/pro/post_shadow_stock_for_educational_showcase_offer_test.py
@@ -17,7 +17,9 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class Return200Test:
     def test_create_valid_shadow_stock_for_educational_offer(self, client):
         # Given
-        offer = offer_factories.EducationalEventOfferFactory(extraData={"isShowcase": False})
+        offer = offer_factories.EducationalEventOfferFactory(
+            extraData={"isShowcase": False, "contactEmail": "toto@example.com", "contactPhone": "0101010101"}
+        )
         offer_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13545

## But de la pull request

- Dupliquer la création d'offre dans les nouveaux modèles CollectiveOffer et CollectiveOfferTemplate

## Implémentation

3 étapes:
- à la création d'offre DRAFT, avant la création du stock, on duplique l'offre actuelle dans une CollectiveOffer
- à la réception du stock côté API:
      - Si l'option offre vitrine a été sélectionnée : Création d'une CollectiveOfferTemplate et suppression de la CollectiveOffer précédente
- au switch offre vitrine -> offre collective effective => suppression du template et recréation d'une CollectiveOffer

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
