### PR TITLE
(PC-13728)[api] Fix exception when an offerer is deleted

### DIFF
--- a/api/src/pcapi/admin/custom_views/offerer_view.py
+++ b/api/src/pcapi/admin/custom_views/offerer_view.py
@@ -44,7 +44,9 @@ class OffererView(BaseAdminView):
 
     def delete_model(self, offerer: Offerer) -> bool:
         # Get users to update before association info is deleted
+        # joined user is no longer available after delete_model()
         users_offerer = user_offerer_queries.find_all_by_offerer_id(offerer.id)
+        emails = [user_offerer.user.email for user_offerer in users_offerer]
 
         try:
             delete_cascade_offerer_by_id(offerer.id)
@@ -52,8 +54,8 @@ class OffererView(BaseAdminView):
             flash("Impossible d'effacer une structure juridique pour laquelle il existe des réservations.", "error")
             return False
 
-        for user_offerer in users_offerer:
-            update_external_pro(user_offerer.user.email)
+        for email in emails:
+            update_external_pro(email)
 
         return True
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13728

## But de la pull request

Corriger une exception remontée par Sentry lorsqu'on tente de supprimer une structure qui :
- n'a pas de réservations
- est liée à au moins un utilisateur pro (relation user_offerer)

## Informations supplémentaires

Même correction que la même exception dans `user_offerer_view.py` vue dans PC-13568

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
