### PR TITLE
[PC-13748][api][finance] Do not use `swap` CSS directive for invoice PDF

### DIFF
--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Justificatif de remboursement</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400');
 
         @page {
             size: A4;

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Justificatif de remboursement</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400');
 
         @page {
             size: A4;


### PR DESCRIPTION
The HTML template uses the `font-display: swap` CSS directive that is
only useful for the HTML version of the invoice. As per the
documentation of Google Fonts [1]:

    swap gives the font face a zero second block period and an
    infinite swap period. This means the browser draws text
    immediately with a fallback if the font face isn’t loaded, but
    swaps the font face in as soon as it loads.

weasyprint (that transforms HTML into PDF) does not support it and
issues multiple warnings for each generated PDF file, such as:

    Ignored `font-display: swap` at 5:3, descriptor not supported.

Since we do not display the HTML and only convert it to PDF, we can
get rid of the CSS directive.

[1] https://developers.google.com/web/updates/2016/02/font-display#swap:


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13748