### PR TITLE
(PC-13334)[API] feat: add cultural survey questions to back office

### DIFF
--- a/api/src/pcapi/admin/custom_views/cultural_survey_view.py
+++ b/api/src/pcapi/admin/custom_views/cultural_survey_view.py
@@ -1,0 +1,33 @@
+from dataclasses import fields
+
+from flask import Response
+from flask_admin import expose
+
+from pcapi.admin.base_configuration import BaseCustomAdminView
+from pcapi.core.cultural_survey.cultural_survey import ALL_CULTURAL_SURVEY_ANSWERS
+from pcapi.core.cultural_survey.cultural_survey import ALL_CULTURAL_SURVEY_QUESTIONS
+from pcapi.core.cultural_survey.cultural_survey import CulturalSurveyAnswer
+
+
+class CulturalSurveyView(BaseCustomAdminView):
+    @expose("/", methods=["GET"])
+    def cultural_survey(self) -> Response:
+        answers_column_names = [field.name for field in fields(CulturalSurveyAnswer)]
+        column_names = ["Question"]
+        column_names += answers_column_names
+
+        column_labels = {
+            "id": "Clé de réponse",
+            "sub_question": "Déclenche la sous-question suivante",
+            "title": "Titre",
+            "subtitle": "Sous-titre",
+        }
+
+        return self.render(
+            "admin/cultural_survey.html",
+            questions=ALL_CULTURAL_SURVEY_QUESTIONS,
+            answers=ALL_CULTURAL_SURVEY_ANSWERS,
+            column_names=column_names,
+            answers_column_names=answers_column_names,
+            column_labels=column_labels,
+        )

--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -15,6 +15,7 @@ from pcapi.admin.custom_views.booking_view import BookingView
 from pcapi.admin.custom_views.category_view import CategoryView
 from pcapi.admin.custom_views.category_view import SubcategoryView
 from pcapi.admin.custom_views.criteria_view import CriteriaView
+from pcapi.admin.custom_views.cultural_survey_view import CulturalSurveyView
 from pcapi.admin.custom_views.custom_reimbursement_rule_view import CustomReimbursementRuleView
 from pcapi.admin.custom_views.feature_view import FeatureView
 from pcapi.admin.custom_views.many_offers_operations_view import ManyOffersOperationsView
@@ -223,6 +224,14 @@ def install_views(admin: Admin, session: Session) -> None:
         CategoryView(
             name="Catégories",
             endpoint="/categories",
+            category=Category.CUSTOM_OPERATIONS,
+        )
+    )
+
+    admin.add_view(
+        CulturalSurveyView(
+            name="Questionnaire de pratiques initiales",
+            endpoint="/cultural_survey_answers",
             category=Category.CUSTOM_OPERATIONS,
         )
     )

--- a/api/src/pcapi/core/cultural_survey/cultural_survey.py
+++ b/api/src/pcapi/core/cultural_survey/cultural_survey.py
@@ -257,3 +257,10 @@ ACTIVITES = CulturalSurveyQuestion(
         SANS_ACTIVITES,
     ],
 )
+
+ALL_CULTURAL_SURVEY_QUESTIONS = (
+    SORTIES,
+    FESTIVALS,
+    SPECTACLES,
+    ACTIVITES,
+)

--- a/api/src/pcapi/core/cultural_survey/cultural_survey.py
+++ b/api/src/pcapi/core/cultural_survey/cultural_survey.py
@@ -10,7 +10,7 @@ class CulturalSurveyAnswer:
     id: str
     title: str
     subtitle: Optional[str] = None
-    sub_question: Optional[CulturalSurveyQuestionEnum] = []
+    sub_question: Optional[CulturalSurveyQuestionEnum] = None
 
 
 @dataclass(frozen=True)

--- a/api/src/pcapi/templates/admin/cultural_survey.html
+++ b/api/src/pcapi/templates/admin/cultural_survey.html
@@ -1,0 +1,43 @@
+{% extends 'admin/base.html' %}
+
+{% block body %}
+<style>
+    .sticky-top {
+        z-index: 0;
+    }
+</style>
+<br>
+<h2>Liste des réponses au questionnaire de pratiques initiales</h2>
+<br>
+<table class="table table-striped table-bordered table-hover">
+    <thead class="thead-dark sticky-top">
+        <tr>
+            {% for column_name in column_names %}
+                {% if column_labels[column_name] %}
+                    <th> {{ column_labels[column_name] }}</th>
+                {% else %}
+                    <th> {{ column_name }}</th>
+                {% endif %}
+            {% endfor %}
+        </tr>
+    </thead>
+    {% for question in questions %}
+        {% for answer in question.answers %}
+        <tr>
+            <td>
+                {{ question.id.value }}
+            </td>
+            {% for column_name in answers_column_names %}
+            <td>
+                {% if column_name == 'sub_question' %}
+                    {{ answer[column_name].value }}
+                {% else %}
+                    {{ answer[column_name] }}
+                {% endif %}
+            </td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    {% endfor %}
+</table>
+{% endblock %}

--- a/api/tests/admin/custom_views/cultural_survey_view_test.py
+++ b/api/tests/admin/custom_views/cultural_survey_view_test.py
@@ -1,0 +1,19 @@
+import pcapi.core.users.factories as users_factories
+
+
+class CulturalSurveyViewTest:
+    def test_authorized_user(self, app, db_session, client):
+        admin = users_factories.AdminFactory(email="admin@example.com")
+        client.with_session_auth(admin.email)
+
+        response = client.get("/pc/back-office/cultural_survey_answers")
+
+        assert response.status_code == 200
+
+    def test_unauthorized_user(self, app, db_session, client):
+        user = users_factories.UserFactory(email="admin@example.com")
+        client.with_session_auth(user.email)
+
+        response = client.get("/pc/back-office/cultural_survey_answers")
+
+        assert response.status_code == 403


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13334

## But de la pull request

Ajout des questions et réponses correspondantes du Questionnaire de Pratiques initiales dans la route `pc/back-office/cultural_survey_answers/` sur FlaskAdmin

## Implémentation

- Création d'un template html dédié

## Informations supplémentaires

<img width="1440" alt="Capture d’écran 2022-03-02 à 16 35 10" src="https://user-images.githubusercontent.com/44037911/156394258-11886f45-e88b-4e7c-9835-30eee3e45ad6.png">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
