### PR TITLE
(PC-13700)[api] Show venues for offerers in Flask Admin

### DIFF
--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -31,6 +31,7 @@ from pcapi.admin.custom_views.suspend_fraudulent_users_by_email_providers import
 from pcapi.admin.custom_views.user_email_history_view import UserEmailHistoryView
 from pcapi.admin.custom_views.user_offerer_view import UserOffererView
 from pcapi.admin.custom_views.venue_provider_view import VenueProviderView
+from pcapi.admin.custom_views.venue_view import VenueForOffererSubview
 from pcapi.admin.custom_views.venue_view import VenueView
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
@@ -102,6 +103,14 @@ def install_views(admin: Admin, session: Session) -> None:
         OffererView(offerers_models.Offerer, session, name="Structures", category=Category.OFFRES_STRUCTURES_LIEUX)
     )
     admin.add_view(VenueView(offerers_models.Venue, session, name="Lieux", category=Category.OFFRES_STRUCTURES_LIEUX))
+    admin.add_view(
+        VenueForOffererSubview(
+            offerers_models.Venue,
+            session,
+            name="Lieux pour une structure",
+            endpoint="venue_for_offerer",
+        )
+    )
     admin.add_view(
         UserOffererView(
             UserOfferer, session, name="Lien Utilisateurs/Structures", category=Category.OFFRES_STRUCTURES_LIEUX

--- a/api/src/pcapi/templates/admin/offerer_venues_list.html
+++ b/api/src/pcapi/templates/admin/offerer_venues_list.html
@@ -1,0 +1,24 @@
+{% extends 'admin/model/list.html' %}
+{% import 'admin/bulk_edit_components/bulk_edit_modal.html' as bulk_edit_modal with context %}
+
+{% block body %}
+    <h1>Liste des lieux de la structure {{ offerer_name }}</h1>
+    {% block model_menu_bar %}
+        {{ super() }}
+    {% endblock %}
+
+    {% block model_list_table %}
+        {{ super() }}
+    {% endblock %}
+    {% block actions %}
+        {{ super() }}
+    {% endblock %}
+    {%- if admin_view.edit_modal or admin_view.create_modal or admin_view.details_modal -%}
+        {{ lib.add_modal_window() }}
+    {%- endif -%}
+    {{ bulk_edit_modal.modal_display(lib) }}
+{% endblock %}
+{% block tail %}
+    {{ super() }}
+    {{ bulk_edit_modal.modal_script()}}
+{% endblock tail %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13700

## But de la pull request

Dans la liste des structures dans le backoffice, ajouter une colonne proposant un lien vers les lieux associés, qui ouvre une page avec la liste des lieux de la structure.

## Implémentation

Similaire à l'affichage de la liste des offres pour un lieu.

## Informations supplémentaires

Captures d'écran dans le ticket Jira

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
