### PR TITLE
(PC-13790)[api] Add unique constraints for offer_criterion and venue_criterion

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 5c3a992204ff (post) (head)
-75adc304cc89 (pre) (head)
+25666068cabb (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220303T150600_7ffe3aac83d2_unique_offer_criterion.py
+++ b/api/src/pcapi/alembic/versions/20220303T150600_7ffe3aac83d2_unique_offer_criterion.py
@@ -1,0 +1,35 @@
+"""unique_offer_criterion
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "7ffe3aac83d2"
+down_revision = "75adc304cc89"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Delete duplicates before creating unique constraint
+    op.execute(
+        """
+        DELETE
+        FROM offer_criterion
+        WHERE id IN (
+            SELECT DISTINCT
+                oc1.id
+            FROM
+                offer_criterion oc1, offer_criterion oc2
+            WHERE
+                oc1.id > oc2.id
+                AND oc1."offerId" = oc2."offerId"
+                AND oc1."criterionId" = oc2."criterionId"
+        );
+        """
+    )
+    op.create_unique_constraint("unique_offer_criterion", "offer_criterion", ["offerId", "criterionId"])
+
+
+def downgrade():
+    op.drop_constraint("unique_offer_criterion", "offer_criterion", type_="unique")

--- a/api/src/pcapi/alembic/versions/20220303T150700_25666068cabb_unique_venue_criterion.py
+++ b/api/src/pcapi/alembic/versions/20220303T150700_25666068cabb_unique_venue_criterion.py
@@ -1,0 +1,35 @@
+"""unique_venue_criterion
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "25666068cabb"
+down_revision = "7ffe3aac83d2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Delete duplicates before creating unique constraint
+    op.execute(
+        """
+        DELETE
+        FROM venue_criterion
+        WHERE id IN (
+            SELECT DISTINCT
+                vc1.id
+            FROM
+                venue_criterion vc1, venue_criterion vc2
+            WHERE
+                vc1.id > vc2.id
+                AND vc1."venueId" = vc2."venueId"
+                AND vc1."criterionId" = vc2."criterionId"
+        );
+        """
+    )
+    op.create_unique_constraint("unique_venue_criterion", "venue_criterion", ["venueId", "criterionId"])
+
+
+def downgrade():
+    op.drop_constraint("unique_venue_criterion", "venue_criterion", type_="unique")

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -4,8 +4,10 @@ import factory
 
 from pcapi.core.offerers import models
 from pcapi.core.offerers.models import ApiKey
+from pcapi.core.offerers.models import VenueCriterion
 from pcapi.core.offerers.models import VenueLabel
 from pcapi.core.offerers.models import VenueType
+from pcapi.core.offers.factories import CriterionFactory
 from pcapi.core.offers.factories import OffererFactory
 from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.testing import BaseFactory
@@ -43,6 +45,14 @@ class VenueContactFactory(BaseFactory):
     website = "https://my@website.com"
     phone_number = "+33102030405"
     social_medias = {"instagram": "http://instagram.com/@venue"}
+
+
+class VenueCriterionFactory(BaseFactory):
+    class Meta:
+        model = VenueCriterion
+
+    venue = factory.SubFactory(VenueFactory)
+    criterion = factory.SubFactory(CriterionFactory)
 
 
 DEFAULT_PREFIX = "development_prefix"

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -377,6 +377,14 @@ class VenueCriterion(PcObject, Model):
 
     criterion = relationship("Criterion", foreign_keys=[criterionId])
 
+    __table_args__ = (
+        UniqueConstraint(
+            "venueId",
+            "criterionId",
+            name="unique_venue_criterion",
+        ),
+    )
+
 
 @listens_for(Venue, "before_insert")
 def before_insert(mapper, connect, self):

--- a/api/src/pcapi/models/offer_criterion.py
+++ b/api/src/pcapi/models/offer_criterion.py
@@ -1,6 +1,7 @@
 from sqlalchemy import BigInteger
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from pcapi.models import Model
@@ -15,3 +16,11 @@ class OfferCriterion(PcObject, Model):
     criterionId = Column(BigInteger, ForeignKey("criterion.id", ondelete="CASCADE"), nullable=False)
 
     criterion = relationship("Criterion", foreign_keys=[criterionId])
+
+    __table_args__ = (
+        UniqueConstraint(
+            "offerId",
+            "criterionId",
+            name="unique_offer_criterion",
+        ),
+    )

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -1,10 +1,14 @@
 from unittest.mock import patch
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
+from pcapi.core.offerers.factories import VenueCriterionFactory
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers.factories import CriterionFactory
+from pcapi.core.offers.factories import VenueFactory
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.users import factories as users_factories
 
@@ -146,3 +150,13 @@ class OffererGrantAccessTest:
 
         # Then
         assert created_user_offerer is None
+
+
+@pytest.mark.usefixtures("db_session")
+class VenueCriterionTest:
+    def test_unique_venue_criterion(self):
+        venue = VenueFactory()
+        criterion = CriterionFactory()
+        VenueCriterionFactory(venue=venue, criterion=criterion)
+        with pytest.raises(IntegrityError):
+            VenueCriterionFactory(venue=venue, criterion=criterion)

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -1,12 +1,16 @@
 import datetime
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 import pcapi.core.bookings.constants as bookings_constants
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offers import factories
 from pcapi.core.offers import models
+from pcapi.core.offers.factories import CriterionFactory
+from pcapi.core.offers.factories import OfferCriterionFactory
+from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.offers.models import Stock
@@ -581,3 +585,12 @@ class StockIsEventDeletableTest:
         dt = datetime.datetime.utcnow() - bookings_constants.AUTO_USE_AFTER_EVENT_TIME_DELAY
         stock = factories.EventStockFactory(beginningDatetime=dt)
         assert not stock.isEventDeletable
+
+
+class OfferCriterionTest:
+    def test_unique_offer_criterion(self):
+        offer = OfferFactory()
+        criterion = CriterionFactory()
+        OfferCriterionFactory(offer=offer, criterion=criterion)
+        with pytest.raises(IntegrityError):
+            OfferCriterionFactory(offer=offer, criterion=criterion)


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13790

## But de la pull request

Ajouter des containtes `UNIQUE` sur les tables `offer_criterion` et `venue_criterion`, de la même manière que ce qui existe dans la table `offerer_tag_mapping`, afin d'éviter les doublons.

Ce ticket vient d'une exception remontée par Sentry à la suppression.

## Implémentation

À la migration, suppression de tous les doublons. 12002 lignes sont concernées sur staging.

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
