### PR TITLE
(PC-13786)[API]feat:move to sib - email xml payment message

### DIFF
--- a/api/src/pcapi/core/mails/backends/testing.py
+++ b/api/src/pcapi/core/mails/backends/testing.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from typing import Union
 
 from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
+from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalWithoutTemplateEmailData
 
 from .. import testing
 from ..models.models import MailResult
@@ -17,7 +18,7 @@ class TestingBackend(BaseBackend):
     def _send(
         self,
         recipients: Iterable[str],
-        data: Union[SendinblueTransactionalEmailData, dict],
+        data: Union[SendinblueTransactionalEmailData, SendinblueTransactionalWithoutTemplateEmailData, dict],
     ) -> MailResult:
         if not isinstance(data, dict):
             data = asdict(data)
@@ -33,7 +34,9 @@ class FailingBackend(BaseBackend):
     def _send(
         self,
         recipients: Iterable[str],
-        data: Union[SendinblueTransactionalEmailData, dict],
+        data: Union[SendinblueTransactionalEmailData, SendinblueTransactionalWithoutTemplateEmailData, dict],
     ) -> MailResult:
+        if not isinstance(data, dict):
+            data = asdict(data)
         data["To"] = ", ".join(recipients)
         return MailResult(sent_data=data, successful=False)

--- a/api/tests/emails/payment_reports_test.py
+++ b/api/tests/emails/payment_reports_test.py
@@ -4,6 +4,8 @@ import zipfile
 
 from freezegun import freeze_time
 
+from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalAttachment
+from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalSender
 from pcapi.utils.mailing import make_payment_details_email
 from pcapi.utils.mailing import make_payment_message_email
 from pcapi.utils.mailing import make_payments_report_email
@@ -30,24 +32,20 @@ def test_make_payment_message_email(app):
 
     email = make_payment_message_email(xml, csv, checksum)
 
-    assert email["FromName"] == "pass Culture Pro"
-    assert email["Subject"] == "Virements XML pass Culture Pro - 2018-10-15"
-    assert email["Attachments"] == [
-        {
-            "ContentType": "text/xml",
-            "Filename": "message_banque_de_france_20181015.xml",
-            "Content": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48RG9j"
+    assert email.sender == SendinblueTransactionalSender.SUPPORT_PRO
+    assert email.subject == "Virements XML pass Culture Pro - 2018-10-15"
+    assert email.attachment == [
+        SendinblueTransactionalAttachment(
+            name="message_banque_de_france_20181015.xml",
+            content="PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48RG9j"
             "dW1lbnQgeG1sbnM9InVybjppc286c3RkOmlzbzoyMDAyMjp0ZWNoOnhz"
             "ZDpwYWluLjAwMS4wMDEuMDMiPjwvRG9jdW1lbnQ+",
-        },
-        {
-            "ContentType": "text/csv",
-            "Filename": "lieux_20181015.csv",
-            "Content": "c29tZSBjc3Y=",
-        },
+        ),
+        SendinblueTransactionalAttachment(name="lieux_20181015.csv", content="c29tZSBjc3Y="),
     ]
-    assert "message_banque_de_france_20181015.xml" in email["Html-part"]
-    assert "16910c117e4873c51aa3573113bf216a7140ea20203c6826ef1faffc7f4fc882" in email["Html-part"]
+
+    assert "message_banque_de_france_20181015.xml" in email.html_content
+    assert "16910c117e4873c51aa3573113bf216a7140ea20203c6826ef1faffc7f4fc882" in email.html_content
 
 
 @freeze_time("2018-10-15 09:21:34")

--- a/api/tests/scripts/payment/batch_steps_test.py
+++ b/api/tests/scripts/payment/batch_steps_test.py
@@ -89,7 +89,7 @@ def test_send_transactions_should_send_an_email_with_xml_and_csv_attachments():
 
     # then
     assert len(mails_testing.outbox) == 1
-    assert len(mails_testing.outbox[0].sent_data["Attachments"]) == 2
+    assert len(mails_testing.outbox[0].sent_data["attachment"]) == 2
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/scripts/payment/batch_test.py
+++ b/api/tests/scripts/payment/batch_test.py
@@ -95,9 +95,9 @@ def test_generate_and_send_payments():
 
     # Check "transaction" e-mail
     email = mails_testing.outbox[0]
-    subject = email.sent_data["Subject"].split("-")[0].strip()  # ignore date
+    subject = email.sent_data["subject"].split("-")[0].strip()  # ignore date
     assert subject == "Virements XML pass Culture Pro"
-    xml = base64.b64decode(email.sent_data["Attachments"][0]["Content"]).decode("utf-8")
+    xml = base64.b64decode(email.sent_data["attachment"][0]["content"]).decode("utf-8")
     assert "<NbOfTxs>4</NbOfTxs>" in xml
     assert "<CtrlSum>40.00</CtrlSum>" in xml
     assert xml.count("<EndToEndId>") == 4


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13786

## But de la pull request
migration vers sendinblue - email sans template - message virement xml avec 2 pj

## Implémentation
N/A

## Informations supplémentaires
N/A - les mails sans template seront déplacés après la migration sib vers pcapi.core.mails.transactional

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
