### PR TITLE
(PC-13699)[api] Deactivate offferers from Flask Admin

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -778,3 +778,12 @@ def venues_have_bookings(*venues: Venue) -> bool:
 def user_has_bookings(user: User) -> bool:
     bookings_query = Booking.query.join(Booking.offerer).join(Offerer.UserOfferers)
     return db.session.query(bookings_query.filter(UserOfferer.userId == user.id).exists()).scalar()
+
+
+def offerer_has_ongoing_bookings(offerer_id: Offerer) -> bool:
+    return db.session.query(
+        Booking.query.filter(
+            Booking.offererId == offerer_id,
+            Booking.status.in_((BookingStatus.PENDING, BookingStatus.CONFIRMED)),
+        ).exists()
+    ).scalar()

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -125,8 +125,13 @@ def find_virtual_venue_by_offerer_id(offerer_id: int) -> Optional[models.Venue]:
     return models.Venue.query.filter_by(managingOffererId=offerer_id, isVirtual=True).first()
 
 
-def find_venues_by_booking_email(email: str) -> list[models.Venue]:
-    return models.Venue.query.filter_by(bookingEmail=email).all()
+def find_active_venues_by_booking_email(email: str) -> list[models.Venue]:
+    return (
+        models.Venue.query.filter_by(bookingEmail=email)
+        .join(models.Offerer)
+        .filter(models.Offerer.isActive == True)
+        .all()
+    )
 
 
 def has_physical_venue_without_draft_or_accepted_bank_information(offerer_id: int) -> bool:
@@ -200,6 +205,10 @@ def venues_have_offers(*venues: models.Venue) -> bool:
             Offer.venueId.in_([venue.id for venue in venues]), Offer.status == OfferStatus.ACTIVE.name
         ).exists()
     ).scalar()
+
+
+def find_venues_by_managing_offerer_id(offerer_id: int) -> list[models.Venue]:
+    return models.Venue.query.filter_by(managingOffererId=offerer_id).all()
 
 
 def find_venues_by_offerers(*offerers: models.Offerer) -> list[models.Venue]:

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -28,6 +28,7 @@ class OffererFactory(BaseFactory):
     postalCode = "75000"
     city = "Paris"
     siren = factory.Sequence(lambda n: f"{n:09}")
+    isActive = True
 
 
 class UserOffererFactory(BaseFactory):

--- a/api/src/pcapi/core/users/external/models.py
+++ b/api/src/pcapi/core/users/external/models.py
@@ -42,20 +42,20 @@ class ProAttributes:
     # Attributes always set:
     is_pro: bool  # Always True
     is_user_email: bool  # Email address is set at least for a user account
-    is_booking_email: bool  # Email address is set as bookingEmail for at least one venue
-    offerer_name: Iterable[str]  # All offerers associated with user account or bookingEmail
-    venue_count: Optional[int] = None  # Total number of venues related to email (by offerer or bookingEmail)
+    is_booking_email: bool  # Email address is set as bookingEmail for at least one active venue
+    offerer_name: Iterable[str]  # All active offerers associated with user account or bookingEmail
+    venue_count: Optional[int] = None  # Total number of active venues related to email (by offerer or bookingEmail)
 
     # Attributes set when is_user_email is True:
     user_id: Optional[int] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     marketing_email_subscription: Optional[bool] = None
-    user_is_attached: Optional[bool] = None  # User is attached to at least one offerer in which he is not the creator
-    user_is_creator: Optional[bool] = None  # User is the creator of at least one offerer
+    user_is_attached: Optional[bool] = None  # User is attached to at least one active offerer, he is not the creator
+    user_is_creator: Optional[bool] = None  # User is the creator of at least one active offerer
 
     # Attributes set when is_booking_email is True:
-    venue_name: Optional[Iterable[str]] = None  # All venues in which contact email is set as bookingEmail
+    venue_name: Optional[Iterable[str]] = None  # All active venues in which contact email is set as bookingEmail
     venue_type: Optional[Iterable[str]] = None  # Distinct venue types of all these venues
     venue_label: Optional[Iterable[str]] = None  # Distinct venue labels of all these venues
     departement_code: Optional[Iterable[str]] = None  # Distinct department codes of all these venues

--- a/api/tests/admin/custom_views/offerer_view_test.py
+++ b/api/tests/admin/custom_views/offerer_view_test.py
@@ -1,5 +1,9 @@
 from unittest.mock import patch
 
+import pytest
+
+import pcapi.core.bookings.factories as booking_factories
+from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offerers.models import Offerer
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.users import testing as sendinblue_testing
@@ -30,6 +34,7 @@ class OffererViewTest:
                 "postalCode": offerer.postalCode,
                 "address": offerer.address,
                 "tags": [tag1.id, tag2.id],  # Add both tags
+                "isActive": offerer.isActive,
             },
         )
 
@@ -58,6 +63,7 @@ class OffererViewTest:
                 "postalCode": offerer.postalCode,
                 "address": offerer.address,
                 "tags": [],  # Remove both tags
+                "isActive": offerer.isActive,
             },
         )
 
@@ -66,13 +72,116 @@ class OffererViewTest:
         assert offerer.name == "Updated offerer"
         assert len(offerer.tags) == 0
 
+    @pytest.mark.parametrize(
+        "booking_status", [None, BookingStatus.USED, BookingStatus.CANCELLED, BookingStatus.REIMBURSED]
+    )
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_deactivate_offerer(self, mocked_validate_csrf_token, client, booking_status):
+        admin = users_factories.AdminFactory(email="user@example.com")
+        venue = offers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        pro_user = users_factories.ProFactory()
+        offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        if booking_status is not None:
+            booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
+
+        api_client = client.with_session_auth(admin.email)
+        response = api_client.post(
+            f"/pc/back-office/offerer/edit/?id={offerer.id}",
+            form={
+                "name": offerer.name,
+                "siren": offerer.siren,
+                "city": offerer.city,
+                "postalCode": offerer.postalCode,
+                "address": offerer.address,
+                # "isActive" is not sent in request when unchecked
+            },
+        )
+
+        assert response.status_code == 302
+
+        db.session.refresh(offerer)
+        db.session.refresh(venue)
+
+        assert not offerer.isActive
+        assert len(sendinblue_testing.sendinblue_requests) == 2
+        assert {req["email"] for req in sendinblue_testing.sendinblue_requests} == {pro_user.email, venue.bookingEmail}
+
+    @pytest.mark.parametrize("booking_status", [BookingStatus.PENDING, BookingStatus.CONFIRMED])
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_deactivate_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
+        admin = users_factories.AdminFactory(email="user@example.com")
+        venue = offers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        offers_factories.UserOffererFactory(offerer=offerer)
+        booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
+
+        api_client = client.with_session_auth(admin.email)
+        response = api_client.post(
+            f"/pc/back-office/offerer/edit/?id={offerer.id}",
+            form={
+                "name": offerer.name,
+                "siren": offerer.siren,
+                "city": offerer.city,
+                "postalCode": offerer.postalCode,
+                "address": offerer.address,
+                # "isActive" is not sent in request when unchecked
+            },
+        )
+
+        assert response.status_code == 200
+        assert (
+            "Impossible de désactiver une structure juridique pour laquelle des réservations sont en cours."
+            in response.data.decode("utf8")
+        )
+
+        db.session.refresh(offerer)
+        db.session.refresh(venue)
+
+        assert offerer.isActive
+        assert len(sendinblue_testing.sendinblue_requests) == 0
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_reactivate_offerer(self, mocked_validate_csrf_token, client):
+        admin = users_factories.AdminFactory(email="user@example.com")
+        offerer = offers_factories.OffererFactory(isActive=False)
+        venue = offers_factories.VenueFactory(managingOfferer=offerer)
+        pro_user = users_factories.ProFactory()
+        offers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+
+        api_client = client.with_session_auth(admin.email)
+        response = api_client.post(
+            f"/pc/back-office/offerer/edit/?id={offerer.id}",
+            form={
+                "name": offerer.name,
+                "siren": offerer.siren,
+                "city": offerer.city,
+                "postalCode": offerer.postalCode,
+                "address": offerer.address,
+                "isActive": "y",
+            },
+        )
+
+        assert response.status_code == 302
+
+        db.session.refresh(offerer)
+        db.session.refresh(venue)
+
+        assert offerer.isActive
+        assert len(sendinblue_testing.sendinblue_requests) == 2
+        assert {req["email"] for req in sendinblue_testing.sendinblue_requests} == {pro_user.email, venue.bookingEmail}
+
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_offerer(self, mocked_validate_csrf_token, client):
         # Can delete offerer because there is no booking
         admin = users_factories.AdminFactory(email="user@example.com")
-        venue = offers_factories.VenueFactory()
-        offers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+        venue = offers_factories.VenueFactory(bookingEmail="booking@example.com")
+        pro_user = users_factories.ProFactory()
+        offers_factories.UserOffererFactory(user=pro_user, offerer=venue.managingOfferer)
 
         api_client = client.with_session_auth(admin.email)
         response = api_client.post(
@@ -81,4 +190,42 @@ class OffererViewTest:
 
         assert response.status_code == 302
         assert len(Offerer.query.all()) == 0
-        assert len(sendinblue_testing.sendinblue_requests) == 1
+        assert len(sendinblue_testing.sendinblue_requests) == 2
+        assert {req["email"] for req in sendinblue_testing.sendinblue_requests} == {
+            pro_user.email,
+            "booking@example.com",
+        }
+
+    @pytest.mark.parametrize(
+        "booking_status",
+        [
+            BookingStatus.PENDING,
+            BookingStatus.USED,
+            BookingStatus.CONFIRMED,
+            BookingStatus.CANCELLED,
+            BookingStatus.REIMBURSED,
+        ],
+    )
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_delete_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
+        admin = users_factories.AdminFactory(email="user@example.com")
+        venue = offers_factories.VenueFactory()
+        booking_factories.BookingFactory(stock__offer__venue=venue, status=booking_status)
+        offers_factories.UserOffererFactory(offerer=venue.managingOfferer)
+
+        api_client = client.with_session_auth(admin.email)
+        response = api_client.post(
+            "/pc/back-office/offerer/delete/", form={"id": venue.managingOfferer.id, "url": "/pc/back-office/offerer/"}
+        )
+
+        assert response.status_code == 302
+
+        list_response = api_client.get(response.headers["location"])
+        assert (
+            "Impossible d&#39;effacer une structure juridique pour laquelle il existe des réservations."
+            in list_response.data.decode("utf8")
+        )
+
+        assert len(Offerer.query.all()) == 1
+        assert len(sendinblue_testing.sendinblue_requests) == 0

--- a/api/tests/core/users/external/external_pro_test.py
+++ b/api/tests/core/users/external/external_pro_test.py
@@ -182,6 +182,21 @@ def test_update_external_pro_user_attributes(
         BankInformationFactory(venue=venue4, status=BankInformationStatus.ACCEPTED)
         BankInformationFactory(venue=venue1, status=BankInformationStatus.REJECTED)
 
+    # Create inactive offerer and its venue, linked to email, which should not be taken into account in any attribute
+    inactive_offerer = OffererFactory(siren="999999999", name="Structure désactivée", isActive=False)
+    UserOffererFactory(user=pro_user, offerer=inactive_offerer)
+    VenueFactory(
+        managingOfferer=inactive_offerer,
+        name="Salle de concert des calanques",
+        departementCode="13",  # different from others
+        postalCode="13260",
+        city="Cassis",
+        bookingEmail=email,
+        siret="99999999900009",
+        isPermanent=create_permanent,
+        venueTypeCode=VenueTypeCode.CONCERT_HALL,  # different from others
+    )
+
     attributes = get_pro_attributes(pro_user.email)
 
     assert attributes.is_pro is True


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13699

## But de la pull request

Désactivation de structures depuis Flask Admin

## Implémentation

Reprise partielle de la PR https://github.com/pass-culture/pass-culture-main/pull/1591 après discussion avec Charlotte, Damien, Hadidja. On enlève la désactivation des lieux car l'équipe pro n'a pas la bande passante pour interpréter ce nouveau statut et gérer l'affichage ou non en conséquence dans le portail pro.

## Informations supplémentaires

+ Test de la suppression et correction de la sélection des emails dont les attributs pro sont à mettre à jour
+ On ne prend pas les structures désactivées, ni les lieux associés aux structures désactivées, dans le calcul des attributs pro.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
