### PR TITLE
(PC-13800)[API] fix: return 400 code on user error

### DIFF
--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -28,3 +28,11 @@ class CannotFindOffererSiren(Exception):
 
 class MissingOffererIdQueryParameter(Exception):
     pass
+
+
+class InvalidVenueBannerContent(Exception):
+    pass
+
+
+class VenueBannerTooBig(Exception):
+    pass

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -12,6 +12,7 @@ from pydantic import root_validator
 from pydantic import validator
 from typing_extensions import TypedDict
 
+from pcapi.core.offerers import exceptions
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.validation import VENUE_BANNER_MAX_SIZE
 from pcapi.routes.serialization import BaseModel
@@ -301,10 +302,10 @@ class VenueBannerContentModel(BaseModel):
         try:
             file = request.files["banner"]
         except (AttributeError, KeyError):
-            raise ValueError("Image manquante")
+            raise exceptions.InvalidVenueBannerContent("Image manquante")
 
         if file.content_length and file.content_length > VENUE_BANNER_MAX_SIZE:
-            raise ValueError(f"Image trop grande, max: {VENUE_BANNER_MAX_SIZE / 1_000}Ko")
+            raise exceptions.VenueBannerTooBig(f"Image trop grande, max: {VENUE_BANNER_MAX_SIZE / 1_000}Ko")
 
         return request
 

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -267,3 +267,30 @@ class VenueBannerTest:
                 assert len(f.read()) < len(image_content)
 
             assert venue.bannerMeta == {"author_id": user_offerer.user.id, "image_credit": "none"}
+
+    def test_upload_image_missing(self, client):
+        user_offerer = offers_factories.UserOffererFactory()
+        venue = offers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+
+        client = client.with_session_auth(email=user_offerer.user.email)
+        url = f"/venues/{humanize(venue.id)}/banner"
+        response = client.post(url)
+
+        assert response.status_code == 400
+        assert response.json["code"] == "INVALID_BANNER_CONTENT"
+
+    def test_upload_image_invalid_query_param(self, client):
+        user_offerer = offers_factories.UserOffererFactory()
+        venue = offers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+
+        url = f"/venues/{humanize(venue.id)}/banner"
+        url += "?x_crop_percent=0.8&y_crop_percent=invalid_value"
+
+        image_content = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()
+        file = {"banner": (io.BytesIO(image_content), "upsert_banner.jpg")}
+
+        client = client.with_session_auth(email=user_offerer.user.email)
+        response = client.post(url, files=file)
+
+        assert response.status_code == 400
+        assert response.json["code"] == "INVALID_BANNER_PARAMS"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13800

## But de la pull request

Renvoyer une erreur 400, au lieu d'une 500, lorsque l'utilisateur (PRO) qui souhaite ajouter une image à un lieu n'envoie pas les bons paramètres (image manquante, etc.)

Le problème était lié au fait qu'on générait des erreurs via le modèle pydantic et qu'on ne les ignorait royalement.

![oops](https://media4.giphy.com/media/FGTVmzksb2j0k/giphy.gif)