### PR TITLE
(PC-13711)[API] feat: Add Technical Message ID in Logger

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -183,12 +183,11 @@ def _cancel_booking(
         booking.cancellationReason = reason
         stock.dnBookedQuantity -= booking.quantity
         repository.save(booking, stock)
+
     logger.info(
         "Booking has been cancelled",
-        extra={
-            "booking": booking.id,
-            "reason": str(reason),
-        },
+        extra={"booking_id": booking.id, "reason": str(reason)},
+        technical_message_id="booking.cancelled",
     )
 
     if booking.individualBooking is not None:
@@ -352,7 +351,8 @@ def mark_as_used(booking: Booking) -> None:
     validation.check_is_usable(booking)
     booking.mark_as_used()
     repository.save(booking)
-    logger.info("Booking was marked as used", extra={"bookingId": booking.id})
+
+    logger.info("Booking was marked as used", extra={"booking_id": booking.id}, technical_message_id="booking.used")
 
     if booking.individualBookingId is not None:
         update_external_user(booking.individualBooking.user)
@@ -410,7 +410,8 @@ def mark_as_unused(booking: Booking) -> None:
         finance_api.cancel_pricing(booking, finance_models.PricingLogReason.MARK_AS_UNUSED)
     booking.mark_as_unused_set_confirmed()
     repository.save(booking)
-    logger.info("Booking was marked as unused", extra={"booking": booking.id})
+
+    logger.info("Booking was marked as unused", extra={"booking_id": booking.id}, technical_message_id="booking.unused")
 
     if booking.individualBookingId is not None:
         update_external_user(booking.individualBooking.user)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -194,7 +194,12 @@ def create_offer(
     _complete_common_offer_fields(offer, offer_data, venue)
 
     repository.save(offer)
-    logger.info("Offer has been created", extra={"offer": offer.id, "venue": venue.id, "product": offer.productId})
+
+    logger.info(
+        "Offer has been created",
+        extra={"offer_id": offer.id, "venue_id": venue.id, "product_id": offer.productId},
+        technical_message_id="offer.created",
+    )
 
     update_external_pro(venue.bookingEmail)
 
@@ -322,7 +327,8 @@ def update_offer(
         offer.fieldsUpdated = list(set(offer.fieldsUpdated) | set(modifications))
 
     repository.save(offer)
-    logger.info("Offer has been updated", extra={"offer": offer.id})
+
+    logger.info("Offer has been updated", extra={"offer_id": offer.id}, technical_message_id="offer.updated")
     if product_has_been_updated:
         repository.save(offer.product)
         logger.info("Product has been updated", extra={"product": offer.product.id})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13711

## But de la pull request

En tant que DS,

J’aimerai avoir un nouveau champs dans les logs backend indiquant si la log doit aller dans la base analytics

Afin d’automatiser l’import de nouveaux types de logs en se basant uniquement sur ce champs lors du sink

## Implémentation

Un nouveau champs booléen présent dans toutes les logs backend et set à False par défault

Le champs est set à True pour les logs de la fiche [notion suivante ](https://www.notion.so/passcultureapp/Liste-de-logs-pour-la-V0-ff1c55243e7f426b848da94926c2041f)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`