### PR TITLE
(PC-13794)(PC-13810)[api] Show venue type and venue label in Flask Admin

### DIFF
--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -98,6 +98,7 @@ class VenueView(BaseAdminView):
         "postalCode",
         "address",
         "venueTypeCode",
+        "venueLabel.label",
         "criteria",
         "offres",
         "publicName",
@@ -116,6 +117,7 @@ class VenueView(BaseAdminView):
         "postalCode": "Code postal",
         "address": "Adresse",
         "venueTypeCode": "Type de lieu",
+        "venueLabel.label": "Label du lieu",
         "criteria": "Tag",
         "publicName": "Nom d'usage",
         "latitude": "Latitude",
@@ -134,6 +136,7 @@ class VenueView(BaseAdminView):
         "id",
         "managingOfferer.name",
         "venueTypeCode",
+        "venueLabel.label",
         VenueCriteriaFilter(Venue.id, "Tag"),
     ]
     form_columns = [
@@ -154,6 +157,7 @@ class VenueView(BaseAdminView):
             self._extend_query(super().get_query())
             .options(joinedload(Venue.managingOfferer))
             .options(joinedload(Venue.venueProviders))
+            .options(joinedload(Venue.venueLabel))
             .options(joinedload(Venue.criteria))
         )
 

--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -48,6 +48,10 @@ def _get_venue_provider_link(view, context, model, name) -> Union[Markup, None]:
     return Markup('<a href="{url}">{text}</a>').format(url=url, text=model.venueProviders[0].provider.name)
 
 
+def _get_venue_type_code_formatter(view, context, model, name) -> Union[Markup, None]:
+    return Markup("<span>{text}</span>").format(text=model.venueTypeCode.value if model.venueTypeCode else "")
+
+
 def _get_emails_by_venue(venue: Venue) -> set[str]:
     """
     Get all emails for which pro attributes may be modified when the venue is updated or deleted.
@@ -93,6 +97,7 @@ class VenueView(BaseAdminView):
         "city",
         "postalCode",
         "address",
+        "venueTypeCode",
         "criteria",
         "offres",
         "publicName",
@@ -110,6 +115,7 @@ class VenueView(BaseAdminView):
         "city": "Ville",
         "postalCode": "Code postal",
         "address": "Adresse",
+        "venueTypeCode": "Type de lieu",
         "criteria": "Tag",
         "publicName": "Nom d'usage",
         "latitude": "Latitude",
@@ -127,6 +133,7 @@ class VenueView(BaseAdminView):
         "publicName",
         "id",
         "managingOfferer.name",
+        "venueTypeCode",
         VenueCriteriaFilter(Venue.id, "Tag"),
     ]
     form_columns = [
@@ -167,6 +174,7 @@ class VenueView(BaseAdminView):
         formatters = super().column_formatters
         formatters.update(offres=_offers_link)
         formatters.update(provider_name=_get_venue_provider_link)
+        formatters.update(venueTypeCode=_get_venue_type_code_formatter)
         return formatters
 
     def delete_model(self, venue: Venue) -> bool:


### PR DESCRIPTION
Lien vers les tickets Jira : 
https://passculture.atlassian.net/browse/PC-13794
https://passculture.atlassian.net/browse/PC-13810

## But de la pull request

Visualiser le type et le label d'un lieu sur Flask Admin

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
