### PR TITLE
(PC-13820)[PRO] feat: add password instructions tool tip on lost pass…

### DIFF
--- a/pro/src/components/pages/LostPassword/LostPassword.jsx
+++ b/pro/src/components/pages/LostPassword/LostPassword.jsx
@@ -175,6 +175,7 @@ class LostPassword extends PureComponent {
                           label="Nouveau mot de passe"
                           name="newPasswordValue"
                           placeholder="Mon nouveau mot de passe"
+                          showTooltip
                         />
                         <button
                           className="primary-button submit-button"

--- a/pro/src/styles/components/pages/LostPassword/_LostPassword.scss
+++ b/pro/src/styles/components/pages/LostPassword/_LostPassword.scss
@@ -1,5 +1,15 @@
 .password-reset-request-form,
 .password-reset-request {
+  .field-password {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+  }
+  .field-password > img {
+    position: absolute;
+    right: rem(38px);
+    top: rem(37px);
+  }
   h1 {
     margin-bottom: rem(16px);
   }


### PR DESCRIPTION
…word screen

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13820

## But de la pull request

Rajouter un tooltip à droite du champ mot de passe sur la page de réinitialisation de mdp pour indiquer à l'utilisateur le format du mot de passe attendu (comme au moment de la création du compte)

## Screenshot

![ReinitPwd](https://user-images.githubusercontent.com/71768799/157049717-d8ef22ea-a2f3-477e-9b78-f2de029fb60f.PNG)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
