### PR TITLE
(PC-13548)[API] feat: double stock collective update

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -19,6 +19,7 @@ from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalBookingStatus
+from pcapi.core.educational.repository import get_and_lock_collective_stock
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.models as finance_models
 import pcapi.core.finance.repository as finance_repository
@@ -199,9 +200,7 @@ def _cancel_collective_booking(
     reason: CollectiveBookingCancellationReasons,
 ) -> bool:
     with transaction():
-        collective_stock = offers_repository.get_and_lock_collective_stock(
-            stock_id=collective_booking.collectiveStock.stockId
-        )
+        collective_stock = get_and_lock_collective_stock(stock_id=collective_booking.collectiveStock.id)
         db.session.refresh(collective_booking)
         old_status = collective_booking.status
         try:

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -577,8 +577,8 @@ def edit_collective_stock(stock: CollectiveStock, stock_data: dict) -> Collectiv
     # search.async_index_offer_ids([stock.collectiveOfferId])
 
     if FeatureToggle.ENABLE_NEW_COLLECTIVE_MODEL.is_active():
-        notify_educational_redactor_on_educational_offer_or_stock_edit(
-            stock.offerId,
+        notify_educational_redactor_on_collective_offer_or_stock_edit(
+            stock.collectiveOffer.id,
             list(stock_data.keys()),
         )
 

--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -1,4 +1,5 @@
 from pcapi.domain.client_exceptions import ClientError
+from pcapi.models.api_errors import ApiErrors
 
 
 class EducationalInstitutionUnknown(ClientError):
@@ -74,3 +75,13 @@ class OfferIsNotShowcase(Exception):
 
 class CollectiveStockAlreadyExists(Exception):
     pass
+
+
+class StockDoesNotExist(ApiErrors):
+    status_code = 400
+
+
+class CollectiveOfferStockBookedAndBookingNotPending(Exception):
+    def __init__(self, status, booking_id):
+        self.booking_status = status
+        super().__init__()

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -7,12 +7,14 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational import exceptions
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
+from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalBookingStatus
 from pcapi.core.educational.models import EducationalDeposit
 from pcapi.core.educational.models import EducationalInstitution
 from pcapi.core.educational.models import EducationalYear
 from pcapi.core.educational.repository import get_confirmed_educational_bookings_amount
+from pcapi.core.offers import validation as offers_validation
 from pcapi.core.offers.models import Stock
 
 
@@ -68,3 +70,13 @@ def check_collective_booking_status(collective_booking: CollectiveBooking) -> No
 def check_confirmation_limit_date_has_not_passed(booking: Union[EducationalBooking, CollectiveBooking]) -> None:
     if booking.has_confirmation_limit_date_passed():
         raise booking_exceptions.ConfirmationLimitDateHasPassed()
+
+
+def check_collective_stock_is_editable(stock: CollectiveStock) -> None:
+    offers_validation.check_validation_status(stock.collectiveOffer)
+    offers_validation.check_event_expiration(stock)
+
+
+def check_collective_booking_status_pending(booking: CollectiveBooking) -> Optional[Exception]:
+    if booking.status is not CollectiveBookingStatus.PENDING:
+        raise exceptions.CollectiveOfferStockBookedAndBookingNotPending(booking.status, booking.id)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -780,10 +780,11 @@ def edit_educational_stock(stock: Stock, stock_data: dict) -> Stock:
 
     search.async_index_offer_ids([stock.offerId])
 
-    educational_api.notify_educational_redactor_on_educational_offer_or_stock_edit(
-        stock.offerId,
-        list(stock_data.keys()),
-    )
+    if not FeatureToggle.ENABLE_NEW_COLLECTIVE_MODEL.is_active():
+        educational_api.notify_educational_redactor_on_educational_offer_or_stock_edit(
+            stock.offerId,
+            list(stock_data.keys()),
+        )
 
     db.session.refresh(stock)
     return stock
@@ -811,7 +812,7 @@ def _extract_updatable_fields_from_stock_data(
 
 
 def _update_educational_booking_cancellation_limit_date(
-    booking: Booking, new_beginning_datetime: datetime.datetime
+    booking: Union[Booking, educational_models.CollectiveBooking], new_beginning_datetime: datetime.datetime
 ) -> None:
     booking.cancellationLimitDate = compute_educational_booking_cancellation_limit_date(
         new_beginning_datetime, datetime.datetime.utcnow()

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from operator import attrgetter
 from typing import List
 from typing import Optional
-from typing import Union
 
 from sqlalchemy import and_
 from sqlalchemy import func
@@ -451,27 +450,6 @@ def get_and_lock_stock(stock_id: int) -> Stock:
     if not stock:
         raise StockDoesNotExist()
     return stock
-
-
-def get_and_lock_collective_stock(stock_id: Union[int, str]) -> Optional[Stock]:
-    """Returns `stock_id` stock with a FOR UPDATE lock
-    Raises StockDoesNotExist if no stock is found.
-    WARNING: MAKE SURE YOU FREE THE LOCK (with COMMIT or ROLLBACK) and don't hold it longer than
-    strictly necessary.
-    """
-    # Use `with_for_update()` to make sure we lock the collective
-    # stock while creating a collective booking
-    # This is required to prevent bugs due to concurent acces
-    # Also call `populate_existing()` to make sure we don't use something
-    # older from the SQLAlchemy's session.
-    collective_stock = (
-        CollectiveStock.query.filter_by(stockId=stock_id).populate_existing().with_for_update().one_or_none()
-    )
-
-    # FIXME (mathildeduboille, 2022-03-03): raise error if collective_stock does
-    # not exist once this code is on production and all data has been migrated
-    # to the new models (PC-13427)
-    return collective_stock
 
 
 def check_stock_consistency() -> list[int]:

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -13,6 +13,7 @@ from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import CollectiveOfferTemplate
+from pcapi.core.educational.models import CollectiveStock
 import pcapi.core.finance.repository as finance_repository
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -180,7 +181,7 @@ def check_stock_is_updatable(stock: Stock) -> None:
     check_event_expiration(stock)
 
 
-def check_event_expiration(stock):
+def check_event_expiration(stock: Union[CollectiveStock, Stock]):
     if stock.isEventExpired:
         api_errors = ApiErrors()
         api_errors.add_error("global", "Les événements passés ne sont pas modifiables")
@@ -340,7 +341,7 @@ def check_stock_booking_status(booking: Booking) -> Union[None, Exception]:
 
 
 def check_booking_limit_datetime(
-    stock: Stock, beginning: Optional[datetime], booking_limit_datetime: Optional[datetime]
+    stock: Union[CollectiveStock, Stock], beginning: Optional[datetime], booking_limit_datetime: Optional[datetime]
 ) -> None:
     beginning = copy.deepcopy(beginning)
     booking_limit_datetime = copy.deepcopy(booking_limit_datetime)

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -19,6 +19,8 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational import api as educational_api
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import factories as educational_factories
+from pcapi.core.educational.models import CollectiveBooking
+from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalBookingStatus
@@ -722,6 +724,339 @@ class RefuseEducationalBookingTest:
         educational_api.refuse_educational_booking(booking.educationalBookingId)
 
         assert stock.dnBookedQuantity == 21
+
+
+# @freeze_time("2020-11-17 15:00:00")
+@pytest.mark.usefixtures("db_session")
+class EditCollectiveOfferStocksTest:
+    def test_should_update_all_fields_when_all_changed(self):
+        # Given
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=initial_event_date,
+            price=1200,
+            numberOfTickets=30,
+            bookingLimitDatetime=initial_booking_limit_date,
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+            bookingLimitDatetime=datetime.datetime.now() + datetime.timedelta(days=5, hours=16),
+            totalPrice=1500,
+            numberOfTickets=35,
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.beginningDatetime == new_stock_data.beginningDatetime
+        assert stock.bookingLimitDatetime == new_stock_data.bookingLimitDatetime
+        assert stock.price == 1500
+        assert stock.numberOfTickets == 35
+
+    def test_should_update_some_fields_and_keep_non_edited_ones(self):
+        # Given
+        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=initial_event_date,
+            price=1200,
+            numberOfTickets=30,
+            bookingLimitDatetime=initial_booking_limit_date,
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+            numberOfTickets=35,
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.beginningDatetime == new_stock_data.beginningDatetime
+        assert stock.bookingLimitDatetime == initial_booking_limit_date
+        assert stock.price == 1200
+        assert stock.numberOfTickets == 35
+
+    def test_should_replace_bookingLimitDatetime_with_new_event_datetime_if_provided_but_none(self):
+        # Given
+        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=initial_event_date,
+            bookingLimitDatetime=initial_booking_limit_date,
+        )
+        new_event_datetime = datetime.datetime.now() + datetime.timedelta(days=7, hours=5)
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=new_event_datetime,
+            bookingLimitDatetime=None,
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.bookingLimitDatetime == new_event_datetime
+
+    def test_should_replace_bookingLimitDatetime_with_old_event_datetime_if_provided_but_none_and_event_date_unchanged(
+        self,
+    ):
+        # Given
+        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=initial_event_date,
+            bookingLimitDatetime=initial_booking_limit_date,
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            bookingLimitDatetime=None,
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.bookingLimitDatetime == initial_event_date
+
+    # FIXME (rpaoloni, 2022-03-09): Uncomment for when pc-13428 is merged
+    # @mock.patch("pcapi.core.search.async_index_offer_ids")
+    # def test_should_reindex_offer_on_algolia(self, mocked_async_index_offer_ids):
+    #     # Given
+    #     initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
+    #     initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+    #     stock_to_be_updated = educational_factories.CollectiveStockFactory(
+    #         beginningDatetime=initial_event_date,
+    #         price=1200,
+    #         numberOfTickets=30,
+    #         bookingLimitDatetime=initial_booking_limit_date,
+    #     )
+    #     new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+    #         beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+    #         numberOfTickets=35,
+    #     )
+
+    #     # When
+    #     educational_api.edit_collective_stock(
+    #         stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+    #     )
+
+    #     # Then
+    #     stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+    #     mocked_async_index_offer_ids.assert_called_once_with([stock.collectiveOfferId])
+
+    def test_should_not_allow_stock_edition_when_booking_status_is_not_PENDING(self):
+        # Given
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(price=1200)
+        educational_factories.CollectiveBookingFactory(
+            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=1337),
+            collectiveStock=stock_to_be_updated,
+        )
+
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            totalPrice=1500,
+        )
+
+        # When
+        with pytest.raises(exceptions.CollectiveOfferStockBookedAndBookingNotPending):
+            educational_api.edit_collective_stock(
+                stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+            )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).first()
+        assert stock.price == 1200
+
+    def should_update_bookings_cancellation_limit_date_if_event_postponed(self):
+        # Given
+        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=20)
+        cancellation_limit_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(beginningDatetime=initial_event_date)
+        booking = educational_factories.CollectiveBookingFactory(
+            collectiveStock=stock_to_be_updated,
+            status=CollectiveBookingStatus.PENDING,
+            cancellationLimitDate=cancellation_limit_date,
+            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=30),
+        )
+
+        new_event_date = datetime.datetime.now() + datetime.timedelta(days=25, hours=5)
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=new_event_date,
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        booking_updated = CollectiveBooking.query.filter_by(id=booking.id).one()
+        assert booking_updated.cancellationLimitDate == new_event_date - datetime.timedelta(days=15)
+
+    @freeze_time("2020-11-17 15:00:00")
+    def should_update_bookings_cancellation_limit_date_if_beginningDatetime_earlier(self):
+        # Given
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=20)
+        cancellation_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(beginningDatetime=initial_event_date)
+        booking = educational_factories.CollectiveBookingFactory(
+            collectiveStock=stock_to_be_updated,
+            status=CollectiveBookingStatus.PENDING,
+            cancellationLimitDate=cancellation_limit_date,
+            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=30),
+        )
+
+        new_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5, hours=5)
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=new_event_date,
+            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=3, hours=5),
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        booking_updated = CollectiveBooking.query.filter_by(id=booking.id).one()
+        assert booking_updated.cancellationLimitDate == datetime.datetime.utcnow()
+
+    def test_should_allow_stock_edition_and_not_modify_cancellation_limit_date_when_booking_cancelled(self):
+        # Given
+        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=20)
+        cancellation_limit_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=initial_event_date,
+        )
+        booking = educational_factories.CollectiveBookingFactory(
+            collectiveStock=stock_to_be_updated,
+            status=CollectiveBookingStatus.CANCELLED,
+            cancellationLimitDate=cancellation_limit_date,
+            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=30),
+        )
+
+        new_event_date = datetime.datetime.now() + datetime.timedelta(days=25, hours=5)
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=new_event_date,
+        )
+
+        # When
+        educational_api.edit_collective_stock(
+            stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+        )
+
+        # Then
+        booking = CollectiveBooking.query.filter_by(id=booking.id).one()
+        assert booking.cancellationLimitDate == cancellation_limit_date
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.beginningDatetime == new_event_date
+
+    def test_does_not_allow_edition_of_an_expired_event_stock(self):
+        # Given
+        initial_event_date = datetime.datetime.now() - datetime.timedelta(days=1)
+        initial_booking_limit_date = datetime.datetime.now() - datetime.timedelta(days=10)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=initial_event_date,
+            price=1200,
+            numberOfTickets=30,
+            bookingLimitDatetime=initial_booking_limit_date,
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+            numberOfTickets=35,
+        )
+
+        # When
+        with pytest.raises(offers_exceptions.ApiErrors) as error:
+            educational_api.edit_collective_stock(
+                stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+            )
+
+        # Then
+        assert error.value.errors == {"global": ["Les événements passés ne sont pas modifiables"]}
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).first()
+        assert stock.numberOfTickets == 30
+
+    def test_edit_stock_of_non_approved_offer_fails(self):
+        # Given
+        offer = educational_factories.CollectiveOfferFactory(validation=OfferValidationStatus.PENDING)
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            collectiveOffer=offer,
+            price=1200,
+            numberOfTickets=30,
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            numberOfTickets=35,
+        )
+
+        # When
+        with pytest.raises(offers_exceptions.ApiErrors) as error:
+            educational_api.edit_collective_stock(
+                stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+            )
+
+        # Then
+        assert error.value.errors == {
+            "global": ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
+        }
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.numberOfTickets == 30
+
+    @freeze_time("2020-11-17 15:00:00")
+    def test_should_not_allow_stock_edition_when_beginningDatetime_not_provided_and_bookingLimitDatetime_set_after_existing_event_datetime(
+        self,
+    ):
+        # Given
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=datetime.datetime(2021, 12, 10), bookingLimitDatetime=datetime.datetime(2021, 12, 5)
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            bookingLimitDatetime=datetime.datetime(2021, 12, 20)
+        )
+
+        # When
+        with pytest.raises(offers_exceptions.BookingLimitDatetimeTooLate):
+            educational_api.edit_collective_stock(
+                stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+            )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.bookingLimitDatetime == datetime.datetime(2021, 12, 5)
+
+    @freeze_time("2020-11-17 15:00:00")
+    def test_should_not_allow_stock_edition_when_bookingLimitDatetime_not_provided_and_beginningDatetime_set_before_existing_event_datetime(
+        self,
+    ):
+        # Given
+        stock_to_be_updated = educational_factories.CollectiveStockFactory(
+            beginningDatetime=datetime.datetime(2021, 12, 10), bookingLimitDatetime=datetime.datetime(2021, 12, 5)
+        )
+        new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
+            beginningDatetime=datetime.datetime(2021, 12, 4)
+        )
+
+        # When
+        with pytest.raises(offers_exceptions.BookingLimitDatetimeTooLate):
+            educational_api.edit_collective_stock(
+                stock=stock_to_be_updated, stock_data=new_stock_data.dict(exclude_unset=True)
+            )
+
+        # Then
+        stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).one()
+        assert stock.beginningDatetime == datetime.datetime(2021, 12, 10)
 
 
 @freeze_time("2020-11-17 15:00:00")

--- a/api/tests/routes/adage/v1/confirm_prebooking_test.py
+++ b/api/tests/routes/adage/v1/confirm_prebooking_test.py
@@ -142,7 +142,7 @@ class Returns200Test:
             educationalBooking__educationalYear=educational_year,
             educationalBooking__educationalRedactor=redactor,
             status=BookingStatus.PENDING,
-            educationalBooking__confirmationLimitDate=datetime(2021, 10, 15, 10),
+            educationalBooking__confirmationLimitDate=datetime(2021, 10, 15, 15),
         )
         CollectiveBookingFactory(
             collectiveStock__price=Decimal(20.00),
@@ -150,6 +150,7 @@ class Returns200Test:
             educationalYear=educational_year,
             status=CollectiveBookingStatus.PENDING,
             bookingId=booking.id,
+            confirmationLimitDate=datetime(2021, 10, 15, 15),
         )
 
         client = client.with_eac_token()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13548

## But de la pull request
On continue le doublonage pour EAC collectif. Ce coup ci c'est l'edition des bookings.