### PR TITLE
(PC-13818)[API] fix: do not return softDeleted stocks with offer

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -7,8 +7,10 @@ from typing import Optional
 
 from sqlalchemy import and_
 from sqlalchemy import func
+from sqlalchemy import not_
 from sqlalchemy import or_
 from sqlalchemy.orm import Query
+from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import load_only
 from sqlalchemy.orm.exc import NoResultFound
@@ -411,8 +413,9 @@ def get_offer_by_id(offer_id: int) -> Offer:
     try:
         return (
             Offer.query.filter(Offer.id == offer_id)
+            .outerjoin(Stock, and_(Stock.offerId == offer_id, not_(Stock.isSoftDeleted)))
+            .options(contains_eager(Offer.stocks))
             .options(joinedload(Offer.mediations))
-            .options(joinedload(Offer.stocks))
             .options(joinedload(Offer.product, innerjoin=True))
             .options(
                 joinedload(Offer.venue, innerjoin=True,).joinedload(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13818

## But de la pull request

Lorsqu'un AC convertit une offre vitrine en une offre collective, et que cette offre fait l'objet d'une prér-éservation, il ne peut pas annuler cette réservation.
Le comportement attendu est de pouvoir annuler cette pré-réservation.
Ce bug est due au fait que le backend renvoie tous les stocks de l'offre (via la route get_offer), même les stocks qui sont `softDeleted`. Vu que l'offre collective est en fait l'offre vitrine dont on a "soft deleted" le stock vitrine, deux stocks étaient remontés par la route get_offer, alors que la logique métier veut qu'il n'y ait qu'un stock associé à une offre collective. Ce stock n'ayant pas de réservation associée, il n'était pas possible de les annuler depuis le détail de l'offre.

## Implémentation

Ajout d'un filtre en `outerjoin` sur les stocks, afin de ne joindre les offres qu'avec les stocks qui ne sont pas `softDeleted`

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
