### PR TITLE
(PC-13860)[API] feat: hook commit_msg, add prefixes

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -4,7 +4,7 @@ name = "cz_customize"
 [tool.commitizen.customize]
 message_template = "({{jira_ticket}}){% if affected_repository %}[{{affected_repository}}]{% endif %} {{change_type}}: {{message}}"
 schema = "(<ticket_number>)[<affected_repository>] <type>: <commit_message>"
-schema_pattern = "\\(PC-\\d+\\)(\\[(API|PRO|ADAGE)\\])? ?(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\\[[\\w\\s]+\\])?:[\\w\\s]+"
+schema_pattern = "\\(PC-\\d+\\)(\\[((API|PRO|ADAGE),?){1,3}\\])? ?(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\\[[\\w\\s]+\\])?:[\\w\\s]+"
 example = "(PC-88888)[API] feat: this is such a great commit"
 
 

--- a/api/hooks/commit-msg
+++ b/api/hooks/commit-msg
@@ -2,6 +2,39 @@
 
 echo -e "Checking commit message format"
 MSG_FILE=$1
+
+INPUT_MSG=$(cat $MSG_FILE)
+
+HAVE_PREFIX=$(echo $INPUT_MSG | grep -E '.*(PC-[0-9]+).*')
+if [ -z "$HAVE_PREFIX" ]; then
+    CURRENT_BRANCH=$(git br --show-current)
+    JIRA_ID=$(echo $CURRENT_BRANCH | sed -E 's/.*(PC-[0-9]+).*/\1/')
+    HAVE_CHANGE_ADAGE=`git diff --cached --name-only | grep ^adage-front/`
+    HAVE_CHANGE_API=`git diff --cached --name-only | grep ^api/`
+    HAVE_CHANGE_PRO=`git diff --cached --name-only | grep ^pro/`
+
+    REPOSITORY_SCOOP_LIST=()
+    if [ "$HAVE_CHANGE_API" ]; then
+        REPOSITORY_SCOOP_LIST+=("API")
+    fi;
+
+    if [ "$HAVE_CHANGE_PRO" ]; then
+        REPOSITORY_SCOOP_LIST+=("PRO")
+    fi;
+
+    if [ "$HAVE_CHANGE_ADAGE" ]; then
+        REPOSITORY_SCOOP_LIST+=("ADAGE")
+    fi;
+    SEPARATOR=','
+    REPOSITORY_SCOOP=$(printf "$SEPARATOR%s" "${REPOSITORY_SCOOP_LIST[@]}")
+    REPOSITORY_SCOOP=${REPOSITORY_SCOOP:${#SEPARATOR}}
+
+    if [ "$REPOSITORY_SCOOP" ]; then
+        COMMIT_MSG="($JIRA_ID)[$REPOSITORY_SCOOP] $INPUT_MSG"
+        echo "$COMMIT_MSG" > $MSG_FILE
+    fi;
+fi;
+
 if cz -n cz_customize check --commit-msg-file $MSG_FILE ; then
     echo "Commit message correctly formated"
 else


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13860

[commitizen ](https://commitizen-tools.github.io/)nous de demande de formater nos commit d’une certaine manière, par exemple : 
"(PC-88888)[API] feat: this is such a great commit

J’aimerai essayer d’automatiser les préfixes qui peuvent l’être: numéro de ticket, scoop technique (api, pro, adage)

/!\ J'ai changer la regexp de commitizen afin d'accepter plusieurs scoop de repertoir sous la forme : `[API,PRO,ADAGE]`

ici la commande : 
```shell
git ci -m 'feat: hook commit_msg, add prefixes'
```
génère le message de commit: 
```shell
'(PC-13860)[API] feat: hook commit_msg, add prefixes'
```
Car je me trouve sur la branche `rlecellier/PC-13860_git_hook_commit_msg_add_prefix`
et que j'ai des changements dans le répertoire `/api/`