### PR TITLE
Pc 13423/duplicate cron operations for collective offers stocks bookings

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -189,3 +189,9 @@ class CollectiveBookingFactory(BaseFactory):
     educationalRedactor = factory.SubFactory(EducationalRedactorFactory)
     collectiveStock = factory.SubFactory(CollectiveStockFactory)
     confirmationLimitDate = datetime.datetime.utcnow()
+
+
+class PendingCollectiveBookingFactory(CollectiveBookingFactory):
+    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=10))
+    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=10))
+    status = models.CollectiveBookingStatus.PENDING

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -178,10 +178,12 @@ class CollectiveBookingFactory(BaseFactory):
     class Meta:
         model = models.CollectiveBooking
 
+    collectiveStock = factory.SubFactory(CollectiveStockFactory)
     dateCreated = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=2))
     venue = factory.SubFactory(VenueFactory)
     offerer = factory.SubFactory(OffererFactory)
     cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=1))
+    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=1))
     educationalInstitution = factory.SubFactory(EducationalInstitutionFactory)
     educationalYear = factory.SubFactory(EducationalYearFactory)
     educationalRedactor = factory.SubFactory(EducationalRedactorFactory)

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1,4 +1,6 @@
+from datetime import date
 from datetime import datetime
+from datetime import time
 from decimal import Decimal
 from typing import Optional
 from typing import Union
@@ -14,6 +16,8 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.exceptions import EducationalDepositNotFound
 from pcapi.core.educational.exceptions import EducationalYearNotFound
+from pcapi.core.educational.models import CollectiveBooking
+from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -220,3 +224,16 @@ def get_expired_collective_offers(interval: list[datetime]) -> Query:
         .group_by(educational_models.CollectiveOffer.id)
         .order_by(educational_models.CollectiveOffer.id)
     )
+
+
+def find_expiring_collective_bookings_query() -> Query:
+    today_at_midnight = datetime.combine(date.today(), time(0, 0))
+
+    return CollectiveBooking.query.filter(
+        CollectiveBooking.status == CollectiveBookingStatus.PENDING,
+        CollectiveBooking.confirmationLimitDate <= today_at_midnight,
+    )
+
+
+def find_expiring_collective_booking_ids_from_query(query: Query) -> Query:
+    return query.order_by(CollectiveBooking.id).with_entities(CollectiveBooking.id)

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -78,10 +78,10 @@ def find_educational_booking_by_id(
     )
 
 
-def find_educational_year_by_date(date: datetime) -> Optional[educational_models.EducationalYear]:
+def find_educational_year_by_date(date_searched: datetime) -> Optional[educational_models.EducationalYear]:
     return educational_models.EducationalYear.query.filter(
-        date >= educational_models.EducationalYear.beginningDate,
-        date <= educational_models.EducationalYear.expirationDate,
+        date_searched >= educational_models.EducationalYear.beginningDate,
+        date_searched <= educational_models.EducationalYear.expirationDate,
     ).one_or_none()
 
 

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -155,7 +155,6 @@ def lock_business_unit(business_unit_id: int):
 
 
 def price_booking(booking: bookings_models.Booking) -> models.Pricing:
-    # pylint: disable=too-many-return-statements
     business_unit_id = booking.venue.businessUnitId
     if not business_unit_id:
         return None

--- a/api/src/pcapi/core/monkeypatches.py
+++ b/api/src/pcapi/core/monkeypatches.py
@@ -17,7 +17,7 @@ def custom_restclient_request(self, method, url, **kwargs):
     # kwargs.setdefault("_request_timeout", SENDINBLUE_REQUEST_TIMEOUT)
     try:
         response = self.__orig_request(method, url, **kwargs)
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc:
         logger.exception(
             "Call to external service failed with %s",
             # APIException from sib_api_v3_sdk has a status. Other exceptions don't.

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -19,6 +19,7 @@ from sqlalchemy.sql.functions import coalesce
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
+from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
@@ -383,6 +384,14 @@ def delete_past_draft_offers() -> None:
     Mediation.query.filter(Mediation.offerId == Offer.id).filter(*filters).delete(synchronize_session=False)
     OfferCriterion.query.filter(OfferCriterion.offerId == Offer.id).filter(*filters).delete(synchronize_session=False)
     Offer.query.filter(*filters).delete()
+    db.session.commit()
+
+
+def delete_past_draft_collective_offers() -> None:
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    CollectiveOffer.query.filter(
+        and_(CollectiveOffer.dateCreated < yesterday, CollectiveOffer.validation == OfferValidationStatus.DRAFT)
+    ).delete()
     db.session.commit()
 
 

--- a/api/src/pcapi/scheduled_tasks/clock.py
+++ b/api/src/pcapi/scheduled_tasks/clock.py
@@ -13,6 +13,7 @@ from pcapi.core.mails.transactional.users.birthday_to_newly_eligible_user import
     send_birthday_age_18_email_to_newly_eligible_user,
 )
 from pcapi.core.offers.repository import check_stock_consistency
+from pcapi.core.offers.repository import delete_past_draft_collective_offers
 from pcapi.core.offers.repository import delete_past_draft_offers
 from pcapi.core.offers.repository import find_tomorrow_event_stock_ids
 import pcapi.core.payments.utils as payments_utils
@@ -165,6 +166,7 @@ def pc_send_tomorrow_events_notifications() -> None:
 @log_cron_with_transaction
 def pc_clean_past_draft_offers() -> None:
     delete_past_draft_offers()
+    delete_past_draft_collective_offers()
 
 
 @cron_context


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13423

## But de la pull request

Adapter les différents crons liés aux offres aux CollectiveOffers

## Implémentation

update_booking_used
handle_expired_bookings
clean_past_draft_offers


## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
