### PR TITLE
(PC-13609)[API] feat:search: theater distinct vo vf

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -393,6 +393,7 @@ class AlgoliaBackend(base.SearchBackend):
         # Field used by Algolia (not the frontend) to deduplicate results
         # https://www.algolia.com/doc/api-reference/api-parameters/distinct/
         distinct = extra_data.get("isbn") or extra_data.get("visa") or str(offer.id)
+        distinct += extra_data.get("diffusionVersion", "")
 
         object_to_index = {
             "distinct": distinct,

--- a/api/src/pcapi/core/search/backends/base.py
+++ b/api/src/pcapi/core/search/backends/base.py
@@ -62,16 +62,16 @@ class SearchBackend:
     ) -> None:
         raise NotImplementedError()
 
-    def index_venues(self, offers: "Iterable[offerers_models.Venue]") -> None:
+    def index_venues(self, venues: "Iterable[offerers_models.Venue]") -> None:
         raise NotImplementedError()
 
-    def unindex_offer_ids(self, offers: Iterable[int]) -> None:
+    def unindex_offer_ids(self, offer_ids: Iterable[int]) -> None:
         raise NotImplementedError()
 
     def unindex_all_offers(self) -> None:
         raise NotImplementedError()
 
-    def unindex_venue_ids(self, venues: Iterable[int]) -> None:
+    def unindex_venue_ids(self, venue_ids: Iterable[int]) -> None:
         raise NotImplementedError()
 
     def unindex_collective_offer_ids(self, venues: Iterable[int]) -> None:
@@ -83,7 +83,7 @@ class SearchBackend:
     def unindex_all_venues(self) -> None:
         raise NotImplementedError()
 
-    def pop_venue_ids_from_queue(self, count: int, from_queue: bool = False) -> set[int]:
+    def pop_venue_ids_from_queue(self, count: int, from_error_queue: bool = False) -> set[int]:
         raise NotImplementedError()
 
     def pop_collective_offer_ids_from_queue(

--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -169,6 +169,7 @@ class AllocineStocks(LocalProvider):
         allocine_offer.name = f"{self.movie_information['title']} - {movie_version}"
         allocine_offer.subcategoryId = subcategories.SEANCE_CINE.id
         allocine_offer.productId = self.last_product_id
+        allocine_offer.extraData["diffusionVersion"] = movie_version
 
         is_new_offer_to_insert = allocine_offer.id is None
 

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -94,6 +94,8 @@ def test_serialize_offer_event():
         [{}, "1"],
         [{"visa": "56070"}, "56070"],
         [{"isbn": "123456789"}, "123456789"],
+        [{"visa": "56070", "diffusionVersion": "VO"}, "56070VO"],
+        [{"visa": "56070", "diffusionVersion": "VF"}, "56070VF"],
     ),
 )
 def test_serialize_offer_distinct(extra_data, expected_distinct):

--- a/api/tests/local_providers/allocine_stocks_test.py
+++ b/api/tests/local_providers/allocine_stocks_test.py
@@ -222,6 +222,7 @@ class UpdateObjectsTest:
         )
         assert created_offer.durationMinutes == 46
         assert created_offer.extraData == {
+            "diffusionVersion": "VF",
             "visa": "2009993528",
             "stageDirector": "Farkhondeh Torabi",
             "theater": {"allocine_movie_id": 37832, "allocine_room_id": "PXXXXX"},
@@ -339,6 +340,7 @@ class UpdateObjectsTest:
         assert original_version_offer.durationMinutes == 46
         assert original_version_offer.extraData["visa"] == "2009993528"
         assert original_version_offer.extraData["stageDirector"] == "Farkhondeh Torabi"
+        assert original_version_offer.extraData["diffusionVersion"] == "VO"
         assert not original_version_offer.isDuo
         assert original_version_offer.name == "Les Contes de la mère poule - VO"
         assert original_version_offer.product == created_products[0]
@@ -353,6 +355,7 @@ class UpdateObjectsTest:
         assert dubbed_version_offer.durationMinutes == 46
         assert dubbed_version_offer.extraData["visa"] == "2009993528"
         assert dubbed_version_offer.extraData["stageDirector"] == "Farkhondeh Torabi"
+        assert dubbed_version_offer.extraData["diffusionVersion"] == "VF"
         assert not dubbed_version_offer.isDuo
         assert dubbed_version_offer.name == "Les Contes de la mère poule - VF"
         assert dubbed_version_offer.product == created_products[0]
@@ -610,6 +613,7 @@ class UpdateObjectsTest:
             "cast": ["Chloë Grace Moretz", "Michael Peña"],
         }
         assert created_offer.extraData == {
+            "diffusionVersion": "VF",
             "visa": "2009993528",
             "stageDirector": "Farkhondeh Torabi",
             "theater": {"allocine_movie_id": 37832, "allocine_room_id": "P12345"},


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13609

## But de la pull request

Actuellement, s'il y a des séances de cinéma en VO et VF, on ne voit qu'une seule offre

Il nous a été demandé d'afficher 2 offres

## Implémentation

- on stock l'information de la version de la séance diffusée qui nous est donné par Allociné
- on change ajoute la version de la séance diffusée sur le champ qui permet de distinguer 2 offres sur Algolia

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai tenté d'améliorer la dette technique pylint qui ralait
