### PR TITLE
(PC-13672)[API] feat: write script to update all gender and married_name attributes from ubble

### DIFF
--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -180,12 +180,19 @@ class BeneficiaryGrant18Factory(BaseFactory):
         if not create:
             return None
 
+        type_ = kwargs.get(
+            "type",
+            (
+                fraud_models.FraudCheckType.EDUCONNECT
+                if obj.eligibility == users_models.EligibilityType.UNDERAGE
+                else fraud_models.FraudCheckType.UBBLE
+            ),
+        )
+
         return fraud_factories.BeneficiaryFraudCheckFactory(
             user=obj,
             status=fraud_models.FraudCheckStatus.OK,
-            type=fraud_models.FraudCheckType.EDUCONNECT
-            if obj.eligibility == users_models.EligibilityType.UNDERAGE
-            else fraud_models.FraudCheckType.UBBLE,
+            type=type_,
             resultContent=fraud_factories.EduconnectContentFactory(
                 first_name=obj.firstName,
                 last_name=obj.lastName,

--- a/api/src/pcapi/scripts/beneficiary/update_gender_and_married_name_from_ubble.py
+++ b/api/src/pcapi/scripts/beneficiary/update_gender_and_married_name_from_ubble.py
@@ -1,0 +1,50 @@
+import logging
+
+from pcapi.connectors.beneficiaries import ubble
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import models as users_models
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+BATCH_SIZE = 1000
+
+
+def update_gender_and_married_name_from_ubble(dry_run: bool = True) -> None:
+    users_to_update = users_models.User.query.filter(
+        users_models.User.gender.is_(None),
+        users_models.User.married_name.is_(None),
+        users_models.User.roles.contains([users_models.UserRole.BENEFICIARY]),
+        # Ubble did not send gender and married_name before January 1st 2022
+        users_models.User.dateCreated > "2022-01-01",
+    ).yield_per(BATCH_SIZE)
+
+    nb_users_updated = 0
+
+    for user in users_to_update:
+        user_ubble_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.UBBLE
+        ]
+        if not user_ubble_fraud_checks:
+            continue
+        user_ubble_fraud_checks.sort(key=lambda fc: fc.dateCreated)
+
+        latest_ubble_fraud_check = user_ubble_fraud_checks[0]
+        content = ubble.get_content(latest_ubble_fraud_check.thirdPartyId)
+
+        if content.gender is not None or content.married_name is not None:
+            nb_users_updated += 1
+            if not dry_run:
+                user.gender = content.gender
+                user.married_name = content.married_name
+
+                if nb_users_updated % BATCH_SIZE == 0:
+                    db.session.commit()
+
+    if dry_run:
+        logger.info("Would have updated %d users", nb_users_updated)
+    else:
+        db.session.commit()  # Commit the last batch
+        logger.info("Updated %d users", nb_users_updated)

--- a/api/tests/scripts/beneficiary/update_gender_and_married_name_from_ubble_test.py
+++ b/api/tests/scripts/beneficiary/update_gender_and_married_name_from_ubble_test.py
@@ -1,0 +1,102 @@
+import datetime
+import re
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
+from pcapi.scripts.beneficiary.update_gender_and_married_name_from_ubble import (
+    update_gender_and_married_name_from_ubble,
+)
+
+from tests.connectors.beneficiaries.ubble_fixtures import UBBLE_IDENTIFICATION_RESPONSE
+
+
+@pytest.mark.usefixtures("db_session")
+class UpdateGenderAndMarriedNameFromUbbleTest:
+    def setup(self):
+        # Not yet beneficiary
+        self.user_not_beneficiary = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.now() - relativedelta(year=18, month=4),
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=self.user_not_beneficiary,
+            type=fraud_models.FraudCheckType.UBBLE,
+        )
+
+        # Beneficiary with gender
+        self.user_beneficiary_up_to_date = users_factories.BeneficiaryGrant18Factory(gender=users_models.GenderEnum.F)
+
+        # Beneficiary with no gender nor married_name
+        self.user_beneficiary_to_update = users_factories.BeneficiaryGrant18Factory(gender=None, married_name=None)
+
+        # Beneficiary from DMS
+        self.user_beneficiary_dms = users_factories.BeneficiaryGrant18Factory(
+            gender=None, married_name=None, beneficiaryFraudChecks__type=fraud_models.FraudCheckType.DMS
+        )
+        # Beneficiary created before january 1st, 2022
+        self.old_user_beneficiary = users_factories.BeneficiaryGrant18Factory(
+            gender=None,
+            married_name=None,
+            beneficiaryFraudChecks__type=fraud_models.FraudCheckType.DMS,
+            dateCreated=datetime.datetime(2021, 12, 25),
+        )
+
+    @patch("pcapi.scripts.beneficiary.update_gender_and_married_name_from_ubble.logger.info")
+    def test_update_gender_and_married_name_from_ubble_dry_run(self, mock_logger, requests_mock):
+        response = UBBLE_IDENTIFICATION_RESPONSE
+        response["included"][3]["attributes"]["gender"] = "F"
+        response["included"][3]["attributes"]["married-name"] = "Kelly"
+        requests_mock.register_uri(
+            "GET",
+            re.compile("/identifications/[a-zA-Z0-9-]+/"),
+            status_code=200,
+            json=response,
+        )
+
+        # Should not update anything
+        update_gender_and_married_name_from_ubble()
+
+        assert mock_logger.call_args_list[0].args == ("Would have updated %d users", 1)
+
+        assert self.user_not_beneficiary.gender is None
+        assert self.user_not_beneficiary.married_name is None
+        assert self.user_beneficiary_up_to_date.gender == users_models.GenderEnum.F
+        assert self.user_beneficiary_up_to_date.married_name is None
+        assert self.user_beneficiary_dms.gender is None
+        assert self.user_beneficiary_dms.married_name is None
+        assert self.old_user_beneficiary.gender is None
+        assert self.old_user_beneficiary.married_name is None
+        assert self.user_beneficiary_to_update.gender is None
+        assert self.user_beneficiary_to_update.married_name is None
+
+    def test_update_gender_and_married_name_from_ubble(self, requests_mock):
+        response = UBBLE_IDENTIFICATION_RESPONSE
+        response["included"][3]["attributes"]["gender"] = "F"
+        response["included"][3]["attributes"]["married-name"] = "Kelly"
+        requests_mock.register_uri(
+            "GET",
+            re.compile("/identifications/[a-zA-Z0-9-]+/"),
+            status_code=200,
+            json=response,
+        )
+
+        # Should update user_beneficiary_to_update
+        update_gender_and_married_name_from_ubble(dry_run=False)
+
+        assert self.user_not_beneficiary.gender is None
+        assert self.user_not_beneficiary.married_name is None
+        assert self.user_beneficiary_up_to_date.gender == users_models.GenderEnum.F
+        assert self.user_beneficiary_up_to_date.married_name is None
+        assert self.user_beneficiary_dms.gender is None
+        assert self.user_beneficiary_dms.married_name is None
+        assert self.old_user_beneficiary.gender is None
+        assert self.old_user_beneficiary.married_name is None
+
+        # Only user to be updated
+        assert self.user_beneficiary_to_update.gender == users_models.GenderEnum.F
+        assert self.user_beneficiary_to_update.married_name == "Kelly"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13672

## But de la pull request

Depuis janvier, Ubble nous transmet deux champs `gender` et `married_name`
Depuis le ticket [#12929](https://passculture.atlassian.net/browse/PC-13672) on récupère ces données et on les enregistre dans `User`
Ce script a pour but de mettre à jour les utilisateurs qui ont été activés entre début janvier et le moment où ce ticket est passé en prod (Aujourd'hui en fait)

## Implémentation

- Get tout les bénéficiaires sans gender ni married_name, qui sont passés par Ubble, depuis le 1er janvier
- yield_per 1000 
- Update si on a des données chez Ubble
- Avec un dry_run pour tester en prod avant d'update

## Informations supplémentaires

- Ce script a pur but d'être run qu'une seule fois

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
