### PR TITLE
Pc 12398 fix archive ubble pictures command

### DIFF
--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -68,13 +68,15 @@ def archive_past_identification_pictures(
                 # Catch all exception. Watch logs to find errors during archive
                 result.add_result()
 
-        offset = +limit
+        # Offset and limit are used to window query result inside loop.
+        # For the first request we use offset 0. Offset is updated at each iteration.
+        offset += limit
 
     return result
 
 
 def get_fraud_check_to_archive(
-    start_date: datetime, end_date: datetime, status: Optional[bool], limit: int = DEFAULT_LIMIT, offset=0
+    start_date: datetime, end_date: datetime, status: Optional[bool], limit: int = DEFAULT_LIMIT, offset: int = 0
 ) -> list[BeneficiaryFraudCheck]:
     query = (
         models.BeneficiaryFraudCheck.query.filter(

--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -51,9 +51,10 @@ def archive_past_identification_pictures(
         raise ValueError('"start date" must be before "end date"')
 
     result = UbbleIdentificationPicturesArchiveResult()
+    offset = 0
 
     while True:
-        fraud_checks = get_fraud_check_to_archive(start_date, end_date, status, limit)
+        fraud_checks = get_fraud_check_to_archive(start_date, end_date, status, limit, offset)
 
         current_count = len(fraud_checks)
         if current_count == 0:
@@ -67,11 +68,13 @@ def archive_past_identification_pictures(
                 # Catch all exception. Watch logs to find errors during archive
                 result.add_result()
 
+        offset = +limit
+
     return result
 
 
 def get_fraud_check_to_archive(
-    start_date: datetime, end_date: datetime, status: Optional[bool], limit: int = DEFAULT_LIMIT
+    start_date: datetime, end_date: datetime, status: Optional[bool], limit: int = DEFAULT_LIMIT, offset=0
 ) -> list[BeneficiaryFraudCheck]:
     query = (
         models.BeneficiaryFraudCheck.query.filter(
@@ -82,5 +85,6 @@ def get_fraud_check_to_archive(
         )
         .order_by(BeneficiaryFraudCheck.dateCreated.asc())
         .limit(limit)
+        .offset(offset)
     )
     return query.all()

--- a/api/tests/core/subscription/ubble/archive_past_identifications_test.py
+++ b/api/tests/core/subscription/ubble/archive_past_identifications_test.py
@@ -50,12 +50,21 @@ class ArchivePastIdentificationPicturesTest:
         ]
         mocked_archive_ubble_user_id_pictures.side_effect = [True, False, True]
         expected_result = UbbleIdentificationPicturesArchiveResult(2, 1)
+        expected_default_offset = 0
+        expected_second_offset = 2
+        expected_last_offset = 4
 
         # When
         actual = archive_past_identification_pictures(start_date, end_date, limit)
 
         # Then
-        mocked_get_fraud_check_to_archive.assert_called_with(start_date, end_date, None, limit, 2)
+        mocked_get_fraud_check_to_archive.assert_has_calls(
+            [
+                mock.call(start_date, end_date, None, limit, expected_default_offset),
+                mock.call(start_date, end_date, None, limit, expected_second_offset),
+                mock.call(start_date, end_date, None, limit, expected_last_offset),
+            ]
+        )
         assert mocked_get_fraud_check_to_archive.call_count == 3
         assert mocked_archive_ubble_user_id_pictures.call_count == 3
         assert actual == expected_result


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12398

## But de la pull request

- correction de la requête pour archiver les images ubble.

## Implémentation

- ajout d'une contrainte offset sur la requête sql

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
