### PR TITLE
(PC-13537)[api] Clear user profile from Flask Admin

### DIFF
--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -232,9 +232,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
             "needsToFillCulturalSurvey",
         )
         if self.check_super_admins():
-            fields += ("firstName", "lastName", "comment")
-        if settings.IS_TESTING or settings.IS_STAGING:
-            fields += ("idPieceNumber",)
+            fields += ("firstName", "lastName", "idPieceNumber", "comment")
 
         return fields
 

--- a/api/src/pcapi/admin/custom_views/partner_user_view.py
+++ b/api/src/pcapi/admin/custom_views/partner_user_view.py
@@ -64,6 +64,8 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
         postalCode="Code postal",
         isEmailValidated="Email validé ?",
         suspension_history="Historique de suspension",
+        city="Ville",
+        idPieceNumber="N° de pièce d'identité",
     )
 
     column_searchable_list = ["id", "publicName", "email", "firstName", "lastName"]
@@ -72,16 +74,26 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
 
     @property
     def form_columns(self):
-        fields = ("email", "firstName", "lastName", "dateOfBirth", "departementCode", "postalCode", "phoneNumber")
+        fields = (
+            "email",
+            "firstName",
+            "lastName",
+            "dateOfBirth",
+            "departementCode",
+            "postalCode",
+            "city",
+            "phoneNumber",
+        )
         if self.check_super_admins():
-            fields += ("comment",)
+            fields += (
+                "idPieceNumber",
+                "comment",
+            )
         return fields
 
     def scaffold_form(self) -> BaseForm:
         form_class = super().scaffold_form()
         form_class.email = StringField("Email", [DataRequired()], filters=[filter_email])
-        form_class.firstName = StringField("Prenom", [DataRequired()])
-        form_class.lastName = StringField("Nom", [DataRequired()])
         form_class.dateOfBirth = DateField("Date de naissance", [validators.Optional()])
         form_class.departementCode = StringField(
             "Département", [DataRequired(), Length(min=2, max=3, message="Mauvais format de département")]

--- a/api/src/pcapi/admin/install.py
+++ b/api/src/pcapi/admin/install.py
@@ -147,13 +147,15 @@ def install_views(admin: Admin, session: Session) -> None:
         BeneficiaryUserView(
             User,
             session,
-            name="Comptes Jeunes",
+            name="Comptes Bénéficiaires",
             category=Category.USERS,
             endpoint="/beneficiary_users",
         )
     )
     admin.add_view(
-        PartnerUserView(User, session, name="Comptes Grand Public", category=Category.USERS, endpoint="/partner_users")
+        PartnerUserView(
+            User, session, name="Comptes Jeune et Grand Public", category=Category.USERS, endpoint="/partner_users"
+        )
     )
     admin.add_view(FeatureView(Feature, session, name="Feature Flipping", category=None))
     admin.add_view(BeneficiaryImportView(BeneficiaryImport, session, name="Imports DMS", category=Category.USERS))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13537

## But de la pull request

Permettre à un admin de réinitialiser le profil d'un utilisateur éligible (erreur de saisie avant l'id check), et à un superadmin de corriger ou réinitialiser le n° de pièce d'identité (mauvaise reconnaissance par Jouve)

## Implémentation

voir ticket Jira

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
