### PR TITLE
(BSR)[API] chore: update detection of docker-compose version

### DIFF
--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function start_backend {
-    docker_compose_version=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).*/\1\2/");
+    docker_compose_version=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\)*/\1\2\3/");
     if [ "$docker_compose_version" -lt "124" ]; then
         echo "This script requires docker-compose 1.24 or greater"
         exit 1

--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 function start_backend {
-    docker_compose_version=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\)*/\1\2\3/");
-    if [ "$docker_compose_version" -lt "124" ]; then
+    docker_compose_major=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\)*/\1/");
+    docker_compose_minor=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\)*/\2/");
+    if [ "$docker_compose_major" -lt "2"] && [ "$docker_compose_minor" -lt "24"]; then
         echo "This script requires docker-compose 1.24 or greater"
         exit 1
     fi

--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -3,7 +3,7 @@
 function start_backend {
     docker_compose_major=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\)*/\1/");
     docker_compose_minor=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\)*/\2/");
-    if [ "$docker_compose_major" -lt "2"] && [ "$docker_compose_minor" -lt "24"]; then
+    if [ "$docker_compose_major" -le "1"] && [ "$docker_compose_minor" -le "23"]; then
         echo "This script requires docker-compose 1.24 or greater"
         exit 1
     fi


### PR DESCRIPTION
Lien vers le ticket Jira : pas de ticket

## But de la pull request
Réparer le script qui détecte la version de docker-compose (il renvoyait le message "This script requires docker-compose 1.24 or greater" alors que ma version de docker-compose  est 2.3.0)

## Implémentation
- Modification de la regex

## Checklist :
- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
