### PR TITLE
[PC-13870][api][offers] Properly update `Stock.fieldsUpdated` on Allociné stock edition

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -452,7 +452,7 @@ def _edit_stock(
         }
         # fmt: on
         validation.check_update_only_allowed_stock_fields_for_allocine_offer(updated_fields)
-        stock.fieldsUpdated = list(updated_fields)
+        stock.fieldsUpdated = list(set(stock.fieldsUpdated) | updated_fields)
 
     for model_attr, value in updates.items():
         setattr(stock, model_attr, value)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -234,6 +234,22 @@ class UpsertStocksTest:
         assert updated_booking.status is BookingStatus.USED
         assert updated_booking.dateUsed == date_used_in_48_hours
 
+    def test_update_fields_updated_on_allocine_stocks(self):
+        allocine_provider = providers_factories.ProviderFactory(localClass="AllocineStocks")
+        stock = offer_factories.StockFactory(
+            fieldsUpdated=["price"],  # suppose we already customized the price
+            quantity=5,
+            offer__idAtProvider="dummy",
+            offer__lastProviderId=allocine_provider.id,
+        )
+        stock_data = stock_serialize.StockEditionBodyModel(
+            id=stock.id,
+            price=stock.price,
+            quantity=50,
+        )
+        api.upsert_stocks(stock.offerId, stock_data_list=[stock_data], user="not needed")
+        assert set(stock.fieldsUpdated) == {"quantity", "price"}
+
     def test_does_not_allow_edition_of_stock_of_another_offer_than_given(self):
         # Given
         user = users_factories.ProFactory()


### PR DESCRIPTION
`Stock.fieldsUpdated` indicates which attributes have been customized,
so that they are not overwritten when the stock is synchronized from
Allociné.

If we first customize the quantity and then customize the price, we
must store both attributes, not only the latter.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13870