### PR TITLE
[PC-13881][api][finance] Include unlinked business units in CSV files

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -675,7 +675,7 @@ def _generate_payments_file(batch_id: int) -> pathlib.Path:
     # the business unit ; and once to get the venue of the offer. To
     # distinguish them in `with_entities()`, we need aliases.
     BusinessUnitVenue = sqla_orm.aliased(offerers_models.Venue)
-    OfferVenue = sqla_orm.aliased(offerers_models.Venue)
+    OfferVenue = sqla_orm.aliased(offers_models.Offer.venue)
     query = (
         models.Pricing.query.filter_by(status=models.PricingStatus.PROCESSED)
         .join(models.Pricing.cashflows)


### PR DESCRIPTION
The SIRET of some venues have been edited but we forgot to update the
same SIRET of their business unit. Thus, we have some business units
that have a SIRET that is not a SIRET of any venue. As such, the
current _inner_ join excludes them in `business_units.csv` and their
pricings from `payments_details.csv`.

The bogus SIRET edition should not happen and it will soon be blocked.
In the meantime, we must not exclude these business units and their
pricings from those files. We do that by using an _outer_ join.


---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13881