### PR TITLE
(PC-11415)[api] Save validation type (auto or manual) to offers

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 5c3a992204ff (post) (head)
-22873a9e00e1 (pre) (head)
+f5a5da60e349 (pre) (head)

--- a/api/src/pcapi/admin/custom_views/offer_view.py
+++ b/api/src/pcapi/admin/custom_views/offer_view.py
@@ -55,6 +55,7 @@ from pcapi.domain.admin_emails import send_offer_validation_notification_to_admi
 from pcapi.models import db
 from pcapi.models.criterion import Criterion
 from pcapi.models.offer_criterion import OfferCriterion
+from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.repository import repository
 from pcapi.settings import IS_PROD
 from pcapi.utils.human_ids import humanize
@@ -123,9 +124,17 @@ class OfferView(BaseAdminView):
         "rankingWeight",
         "validation",
         "lastValidationDate",
+        "lastValidationType",
         "isEducational",
     ]
-    column_sortable_list = ["name", "criteria", "rankingWeight", "validation", "lastValidationDate"]
+    column_sortable_list = [
+        "name",
+        "criteria",
+        "rankingWeight",
+        "validation",
+        "lastValidationDate",
+        "lastValidationType",
+    ]
     column_labels = {
         "name": "Nom",
         "subcategoryId": "Sous-catégorie",
@@ -134,6 +143,7 @@ class OfferView(BaseAdminView):
         "criteria.name": "Tag",
         "rankingWeight": "Pondération",
         "lastValidationDate": "Dernière date de validation",
+        "lastValidationType": "Type de valid.",  # "Dernier type de validation" would create a large column
         "isEducational": "Offre EAC",
     }
     # Do not add searchable column on offer view for performance reasons
@@ -147,6 +157,7 @@ class OfferView(BaseAdminView):
         "rankingWeight",
         "validation",
         "lastValidationDate",
+        "lastValidationType",
         "isEducational",
         ExtraDataFilterEqual(column=Offer.extraData["isbn"], name="ISBN"),
         ExtraDataFilterEqual(column=Offer.extraData["visa"], name="Visa d'exploitation"),
@@ -278,6 +289,7 @@ class OfferView(BaseAdminView):
             new_validation = offer.validation
             if previous_validation != new_validation:
                 offer.lastValidationDate = datetime.utcnow()
+                offer.lastValidationType = OfferValidationType.MANUAL
                 if new_validation == OfferValidationStatus.APPROVED:
                     offer.isActive = True
                 if new_validation == OfferValidationStatus.REJECTED:
@@ -475,6 +487,7 @@ class ValidationView(BaseAdminView):
                 if is_offer_updated:
                     count += 1
                     offer.lastValidationDate = datetime.utcnow()
+                    offer.lastValidationType = OfferValidationType.MANUAL
                     recipients = (
                         [offer.venue.bookingEmail]
                         if offer.venue.bookingEmail
@@ -523,6 +536,7 @@ class ValidationView(BaseAdminView):
                 if is_offer_updated:
                     flash("Le statut de l'offre a bien été modifié", "success")
                     offer.lastValidationDate = datetime.utcnow()
+                    offer.lastValidationType = OfferValidationType.MANUAL
                     recipients = (
                         [offer.venue.bookingEmail]
                         if offer.venue.bookingEmail

--- a/api/src/pcapi/alembic/versions/20220309T101015_f5a5da60e349_add_validation_type_to_offer.py
+++ b/api/src/pcapi/alembic/versions/20220309T101015_f5a5da60e349_add_validation_type_to_offer.py
@@ -1,0 +1,28 @@
+"""add_validation_type_to_offer
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f5a5da60e349"
+down_revision = "22873a9e00e1"
+branch_labels = None
+depends_on = None
+
+
+ValidationType = sa.Enum("AUTO", "MANUAL", name="validation_type")
+
+
+def upgrade():
+    ValidationType.create(op.get_bind(), checkfirst=True)
+    op.add_column("collective_offer", sa.Column("lastValidationType", ValidationType, nullable=True))
+    op.add_column("collective_offer_template", sa.Column("lastValidationType", ValidationType, nullable=True))
+    op.add_column("offer", sa.Column("lastValidationType", ValidationType, nullable=True))
+
+
+def downgrade():
+    op.drop_column("offer", "lastValidationType")
+    op.drop_column("collective_offer_template", "lastValidationType")
+    op.drop_column("collective_offer", "lastValidationType")
+    ValidationType.drop(op.get_bind())

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -42,6 +42,7 @@ from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.repository import repository
 from pcapi.repository import transaction
 from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingEdition
@@ -553,6 +554,7 @@ def create_collective_stock(
     else:
         collective_offer.validation = OfferValidationStatus.APPROVED
         collective_offer.lastValidationDate = datetime.datetime.utcnow()
+        collective_offer.lastValidationType = OfferValidationType.AUTO
         repository.save(collective_offer)
 
     search.async_index_collective_offer_ids([collective_offer.id])

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -78,6 +78,7 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.models.criterion import Criterion
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_criterion import OfferCriterion
+from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.models.product import Product
 from pcapi.repository import offer_queries
 from pcapi.repository import repository
@@ -576,6 +577,7 @@ def _update_offer_fraud_information(
     offer.validation = set_offer_status_based_on_fraud_criteria(offer)
     offer.author = user
     offer.lastValidationDate = datetime.datetime.utcnow()
+    offer.lastValidationType = OfferValidationType.AUTO
     if offer.validation == OfferValidationStatus.PENDING or offer.validation == OfferValidationStatus.REJECTED:
         offer.isActive = False
     repository.save(offer)

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -13,6 +13,7 @@ from pcapi.models.bank_information import BankInformation
 from pcapi.models.bank_information import BankInformationStatus
 from pcapi.models.criterion import Criterion
 from pcapi.models.offer_criterion import OfferCriterion
+from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.models.product import Product
 from pcapi.models.user_offerer import UserOfferer
 
@@ -133,6 +134,7 @@ class OfferFactory(BaseFactory):
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
     isEducational = False
+    lastValidationType = OfferValidationType.AUTO
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/models/offer_mixin.py
+++ b/api/src/pcapi/models/offer_mixin.py
@@ -20,6 +20,16 @@ class OfferValidationStatus(enum.Enum):
     REJECTED = "REJECTED"
 
 
+class OfferValidationType(enum.Enum):
+    """
+    How the last validation status was set:
+    automatically by code at API call or manually from backoffice by pass Culture team.
+    """
+
+    AUTO = "AUTO"
+    MANUAL = "MANUAL"
+
+
 class AccessibilityMixin:
     audioDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
 
@@ -72,6 +82,8 @@ class StatusMixin:
 
 class ValidationMixin:
     lastValidationDate = sa.Column(sa.DateTime, index=True, nullable=True)
+
+    lastValidationType = sa.Column(sa.Enum(OfferValidationType, name="validation_type"), nullable=True)
 
     validation = sa.Column(
         sa.Enum(OfferValidationStatus, name="validation_status"),

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -29,6 +29,7 @@ from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 from pcapi.models import api_errors
+from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.models.product import Product
 from pcapi.notifications.push import testing as push_testing
 from pcapi.routes.serialization import offers_serialize
@@ -103,9 +104,11 @@ class UpsertStocksTest:
         assert draft_approvable_offer.validation == offer_models.OfferValidationStatus.APPROVED
         assert draft_approvable_offer.isActive
         assert draft_approvable_offer.lastValidationDate == datetime(2020, 11, 17, 15, 0)
+        assert draft_approvable_offer.lastValidationType == OfferValidationType.AUTO
         assert draft_suspicious_offer.validation == offer_models.OfferValidationStatus.PENDING
         assert not draft_suspicious_offer.isActive
         assert draft_suspicious_offer.lastValidationDate == datetime(2020, 11, 17, 15, 0)
+        assert draft_suspicious_offer.lastValidationType == OfferValidationType.AUTO
 
     def test_upsert_stocks_does_not_trigger_approved_offer_validation(self):
         # Given offers with stock and new stock data
@@ -772,9 +775,11 @@ class CreateEducationalOfferStocksTest:
         assert draft_approvable_offer.validation == offer_models.OfferValidationStatus.APPROVED
         assert draft_approvable_offer.isActive
         assert draft_approvable_offer.lastValidationDate == datetime(2020, 11, 17, 15, 0)
+        assert draft_approvable_offer.lastValidationType == OfferValidationType.AUTO
         assert draft_suspicious_offer.validation == offer_models.OfferValidationStatus.PENDING
         assert not draft_suspicious_offer.isActive
         assert draft_suspicious_offer.lastValidationDate == datetime(2020, 11, 17, 15, 0)
+        assert draft_suspicious_offer.lastValidationType == OfferValidationType.AUTO
 
     def test_create_stock_for_non_approved_offer_fails(self):
         # Given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-11415

## But de la pull request

Conserver et afficher le type de validation d'une offre :
- AUTO si elle a été validée automatiquement par le code (respectant les règles de conformité)
- MANUAL si le dernier état de validation vient d'une action sur le backoffice

## Implémentation

Mise à jour de `lastValidationType` synchronisée avec le champ `lastValidationDate` déjà présent

## Informations supplémentaires

L'idée de créer une table d'historique des actions manuelles de validation a été écartée au niveau PM car ne correspond pas à un besoin exprimé par le métier. Le besoin aujourd'hui est à des fins statistiques sur metabase.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
