### PR TITLE
(PC-13820)[PRO] fix: adjust tooltip margin

### DIFF
--- a/pro/src/styles/components/pages/LostPassword/_LostPassword.scss
+++ b/pro/src/styles/components/pages/LostPassword/_LostPassword.scss
@@ -7,7 +7,7 @@
   }
   .field-password > img {
     position: absolute;
-    right: rem(38px);
+    right: rem(43px);
     top: rem(37px);
   }
   h1 {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13820

## But de la pull request

Ajuster la marge entre le champs texte et le tooltip pour être uniforme avec la page de création de compte


## Screenshot 

![ReinitPwdv2](https://user-images.githubusercontent.com/71768799/157643486-911ad85a-5918-4645-a3c1-c57eeca63245.PNG)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
