### PR TITLE
(PC-13711)[API] feat: Update custom logger to have technical_message_id in test environments

### DIFF
--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -192,6 +192,8 @@ class JsonFormatter(logging.Formatter):
 
 
 def install_logging():
+    monkey_patch_logger_makeRecord()
+    monkey_patch_logger_log()
     if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
         # JSON is hard to read, keep the default plain text logger.
         logging.basicConfig(level=settings.LOG_LEVEL)
@@ -205,8 +207,6 @@ def install_logging():
     if _internal_logger is not None:
         return
 
-    monkey_patch_logger_makeRecord()
-    monkey_patch_logger_log()
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setFormatter(JsonFormatter())
     handlers = [handler]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13711

## But de la pull request

En tant que DS,

J’aimerai avoir un nouveau champs dans les logs backend indiquant si la log doit aller dans la base analytics

Afin d’automatiser l’import de nouveaux types de logs en se basant uniquement sur ce champs lors du sink

## Implémentation

Un nouveau champs booléen présent dans toutes les logs backend et set à False par défault

Le champs est set à True pour les logs de la fiche [notion suivante ](https://www.notion.so/passcultureapp/Liste-de-logs-pour-la-V0-ff1c55243e7f426b848da94926c2041f)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`