### PR TITLE
(PC-13813)[PRO] fix: add condition to hide SoftDeleted message when the structure is not validated

### DIFF
--- a/pro/src/components/pages/Home/Offerers/Offerers.jsx
+++ b/pro/src/components/pages/Home/Offerers/Offerers.jsx
@@ -112,7 +112,8 @@ const Offerers = () => {
     )
   }
 
-  const isOffererSoftDeleted = selectedOfferer && !selectedOfferer.isActive
+  const isOffererSoftDeleted =
+    selectedOfferer && !selectedOfferer.isActive && !selectedOfferer.isValidated
   const userHasOfferers = offererOptions.length > 0
   return (
     <>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13813

## But de la pull request
Ne pas afficher le message Structure désactivée quand la structure n'est pas encore validée

## Implémentation

- ajout d'une condition pour définir la constante `isOffererSoftDeleted`

## Informations complémentaires

- pour reproduire, se connecter avec marie.destandau@passculture.app et aller sur https://pro.testing.passculture.team/accueil?structure=3Y


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
