### PR TITLE
(PC-13927)[API] fix: fix recredit underage users script

### DIFF
--- a/api/tests/scripts/payment/user_recredit_test.py
+++ b/api/tests/scripts/payment/user_recredit_test.py
@@ -32,7 +32,10 @@ class UserRecreditTest:
         )
         fraud_check_result_content = fraud_factories.UbbleContentFactory(registration_datetime=registration_datetime)
         fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user, resultContent=fraud_check_result_content, type=fraud_models.FraudCheckType.UBBLE
+            user=user,
+            resultContent=fraud_check_result_content,
+            type=fraud_models.FraudCheckType.UBBLE,
+            dateCreated=datetime.datetime(2021, 5, 1),
         )
         assert has_celebrated_birthday_since_registration(user) == expected_result
 
@@ -73,6 +76,30 @@ class UserRecreditTest:
             assert user.deposit.recredits[1].recreditType == payments_models.RecreditType.RECREDIT_17
             assert user.recreditAmountToShow == 30
             assert can_be_recredited(user) is False
+
+    def test_can_be_recredited_no_registration_datetime(self):
+        with freeze_time("2020-05-02"):
+            user = user_factories.UnderageBeneficiaryFactory(subscription_age=15, dateOfBirth=datetime.date(2005, 5, 1))
+            # I voluntarily don't use the EduconnectContentFactory to be allowed to omit registration_datetime
+            content = {
+                "birth_date": "2020-05-02",
+                "educonnect_id": "educonnect_id",
+                "first_name": "first_name",
+                "ine_hash": "ine_hash",
+                "last_name": "last_name",
+                "school_uai": "school_uai",
+                "student_level": "student_level",
+            }
+            fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
+                user=user,
+                type=fraud_models.FraudCheckType.EDUCONNECT,
+                status=fraud_models.FraudCheckStatus.OK,
+                resultContent={},
+                dateCreated=datetime.datetime(2020, 5, 1),  # first fraud check created
+            )
+            fraud_check.resultContent = content
+        with freeze_time("2022-05-02"):
+            assert can_be_recredited(user) is True
 
     def test_can_be_recredited_no_identity_fraud_check(self):
         user = user_factories.UserFactory(dateOfBirth=datetime.date(2005, 5, 1))
@@ -148,6 +175,7 @@ class UserRecreditTest:
 
             id_check_application_date = datetime.datetime(2019, 7, 31)  # Asked for credit before birthday
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_15,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,
@@ -156,6 +184,7 @@ class UserRecreditTest:
                 ),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_16_not_recredited,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,
@@ -166,6 +195,7 @@ class UserRecreditTest:
                 ),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_16_already_recredited,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,
@@ -176,6 +206,7 @@ class UserRecreditTest:
                 ),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_17_not_recredited,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,
@@ -186,6 +217,7 @@ class UserRecreditTest:
                 ),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_17_only_recredited_at_16,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,
@@ -196,6 +228,7 @@ class UserRecreditTest:
                 ),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_17_already_recredited,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,
@@ -206,6 +239,7 @@ class UserRecreditTest:
                 ),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=datetime.datetime(2019, 12, 31),
                 user=user_17_already_recredited_twice,
                 type=fraud_models.FraudCheckType.EDUCONNECT,
                 status=fraud_models.FraudCheckStatus.OK,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13927

## But de la pull request

- Ce matin, aucun des jeunes éligible à leur recrédit n'était recrédité
- Pourquoi ? Parce que le script a planté
- Pourquoi ? Parce que d'anciens fraud checks n'avaient pas de `reistration_datetime` et qu'on ne catchait pas d'erreurs

## Implémentation

- Catch et utiliser la date de création du fraud check à la place

## Informations supplémentaires

RAS

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
