### PR TITLE
(PC-13950)[PRO] add eslint autofix on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ pro-packed-staging/
 tests/result_output.txt
 
 # misc
-.vscode/
+/.vscode/
 .dccache

--- a/pro/.gitignore
+++ b/pro/.gitignore
@@ -12,9 +12,7 @@
 target.zip
 
 # misc
-.vscode/
 .DS_Store
-.vscode/
 .env.local
 .env.development.local
 .env.staging.local

--- a/pro/.vscode/extensions.json
+++ b/pro/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/pro/.vscode/settings.json
+++ b/pro/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.formatOnSave": true,
+  "eslint.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13950

## But de la pull request

👇  Ceci est une proposition !

Dans la config de VSCode sur Pro, ajouter l'autofix on save d'ESLint, et commiter cette config commune.

⚠️ config VSCode que pour PRO, en ouvrant VSCode au niveau du dossier `pro/`, pas à la racine de pass-culture-main.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
