### PR TITLE
[bsr][api][requirements] Remove dependency on lxml

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -35,7 +35,6 @@ ipaddress
 isort==5.6.4
 itsdangerous==2.0.1
 Jinja2==3.0.3
-lxml
 mailjet-rest==1.3.3
 MarkupSafe==2.0.1
 mypy==0.812


### PR DESCRIPTION
It's not needed anymore since 84bd6afd45ef43365c6abe7af476b7acae5f1.