### PR TITLE
[bsr][api][requirements] Revert "reqs: Pin requests_mock"

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -58,13 +58,7 @@ pytest-dotenv==0.5.2
 python-dotenv==0.14.0
 python-swiftclient==3.10.1
 requests==2.26.0
-# FIXME (dbaty, 2021-04-28): as of version 1.9 [1], requests_mock
-# quotes URLs passed to Mocker. If we send a request on a URL that is
-# not quoted, requests_mock does not find a match anymore and the test
-# fails. This is the case on a few tests of the Mailjet client, which
-# does not quote URLs in its `build_url()` function.
-# [1] https://github.com/jamielennox/requests-mock/commit/f072845c0cb13c6c0fb18824160639a8bb3c7fe8
-requests_mock==1.8.0
+requests_mock
 rq==1.5.2
 schwifty==2020.9.0
 semver==2.13.0


### PR DESCRIPTION
This reverts commit 6aadab167e91af21d49c8e5afe11e013d8831099.

requests_mock 1.9.2 has been released with a rollback of the change
mentioned in 6aadab167e91af21d49c8e5afe11e013d8831099. We can now
unpin it (as it were).