### PR TITLE
(PC-13974)[PRO] debt-collector: create or update comment

### DIFF
--- a/.github/workflows/debt-collector-pro.yml
+++ b/.github/workflows/debt-collector-pro.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           filters: |
             src:
-              - 'pro/**'      
+              - 'pro/**'
       - uses: actions/setup-node@v2
         if: steps.changes.outputs.src == 'true'
         with:
@@ -32,17 +32,30 @@ jobs:
           cd pro
           git fetch origin master:master
           yarn debt:compare
-      - uses: actions/github-script@v5
-        if: steps.changes.outputs.src == 'true'
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const fs = require('fs')
-            const path = require('path')
-            const data = fs.readFileSync(path.resolve(process.cwd(), './pro/node_modules/.cache/debt-collector/report.html'), 'utf8')
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: data
-            })
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Debt collector report
+      - id: get-comment-body
+        run: |
+          body="$(cat ./pro/node_modules/.cache/debt-collector/report.html)"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
+      - name: Create comment
+        if: ${{ steps.changes.outputs.src == 'true' && steps.fc.outputs.comment-id == '' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.get-comment-body.outputs.body }}
+      - name: Update comment
+        if: ${{ steps.changes.outputs.src == 'true' && steps.fc.outputs.comment-id != '' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: ${{ steps.get-comment-body.outputs.body }}

--- a/pro/.debt-collector/README.md
+++ b/pro/.debt-collector/README.md
@@ -1,0 +1,24 @@
+## Debt-collector ([documentation externe](https://github.com/gael-boyenval/debt-collector))
+
+### Utilisation
+> :warning: Sometimes debt-collector get stuck in a detached branche.
+When it finish, you may have to checkout the branch you were on.
+
+debt-collector create debt report in three ways:
+* on github: a comment on each PR with points recap per changed files
+* on a dev branch: a details report, for each rules in each changed files
+* on master: a report.html that render a graph with points changes by rule for last 10 release
+
+```shell
+# check change on a branch compare to master
+# "debt:walk": "debt-collector walk -c ./.debt-collector/config.js -n 10"
+yarn debt:check:changed
+# create report.html about last 10 releases
+# "debt:check:changed": "debt-collector check -c ./.debt-collector/config.js -s master",
+yarn debt:walk
+```
+
+## Configuration
+
+* Le workflow github pour poster les commentaire est [disponible ici](../../.github/workflows/debt-collector-pro.yml)
+* Les regles de validation du code sont définies dans [config.js](./config.js)

--- a/pro/README.md
+++ b/pro/README.md
@@ -57,11 +57,11 @@ Vous trouverez une documentation générale ainsi que des liens vers les différ
 
 ## Dette technique
 
-Nous utilisons une petite librairie faite sur-mesure pour monitorer la dette technique. 
+Nous utilisons une bibliotèque faite sur-mesure pour monitorer la dette technique.
 
 voir la documentation ici : https://github.com/gael-boyenval/debt-collector
 
-4 commandes pré-établies sont à disposition : 
+4 commandes pré-établies sont à disposition :
 
 ```
 yarn debt:check:changed
@@ -69,6 +69,8 @@ yarn debt:check:all
 yarn debt:compare
 yarn debt:walk
 ```
+
+Pour plus de details sur sont utilisations sur le portail-pro, vous pouvez consulter la section [debt-collector](./.debt-collector/README.md).
 
 ### 1) yarn debt:check:changed
 
@@ -89,8 +91,8 @@ Vérifie chaque tag de release, et produit un rapport html complet avec un histo
 
 ### options
 
-De nombreuse options de filtrages sont disponible en ligne de commande. 
-référez-vous à la [documentation](https://github.com/gael-boyenval/debt-collector) de l'outil pour cela, ou à l'aide du CLI : 
+De nombreuse options de filtrages sont disponible en ligne de commande.
+référez-vous à la [documentation](https://github.com/gael-boyenval/debt-collector) de l'outil pour cela, ou à l'aide du CLI :
 
 ```
 yarn debt-collector check --help


### PR DESCRIPTION
Nous somme spamés par debt-collector qui poste un commentaire à chaque push.

En suivant [cette documentation](https://github.com/marketplace/actions/create-or-update-comment), je tente ici de résoudre ce problème en mettant le commentaire existant à jours.

Voici une PR sur le laquelle ces changement on été testé: https://github.com/pass-culture/pass-culture-main/pull/1704 