### PR TITLE
(BSR)[PRO] Typescript : Nettoyage de la racine de l'application

### DIFF
--- a/pro/.hygen/new/component/test.tsx.ejs.t
+++ b/pro/.hygen/new/component/test.tsx.ejs.t
@@ -4,8 +4,7 @@ to: <%= absPath %>/__specs__/<%= component_name %>.spec.tsx
 // react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import React, { useState } from 'react'
+import React from 'react'
 
 import { <%= component_name %> } from '../'
 

--- a/pro/package.json
+++ b/pro/package.json
@@ -128,7 +128,7 @@
     "@types/react-datepicker": "^4.3.2",
     "@types/react-dom": "^17.0.9",
     "@types/react-redux": "^7.1.18",
-    "@types/react-router-dom": "^5.1.8",
+    "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.5.0",
     "autoprefixer": "^9.6.1",

--- a/pro/src/README.md
+++ b/pro/src/README.md
@@ -1,20 +1,55 @@
-# DOCS
+# Documentation
 
-## [HOOKS](./components/hooks/README.md)
-## [UI_KIT](./ui-kit/README.md)
-## [COMPONENTS](./new_components/README.md)
-## [SCREENS](./screens/README.md)
-## [ROUTES](./routes/README.md)
-## [REPOSITORY](./repository/README.md)
-## [HOCS](./components/hocs/README.md) (DEPRECATED : utiliser les hooks)
-## [LAYOUT](./components/layout/README.md) (DEPRECATED : à migrer au sein de components et ui-kit)
-## [PAGES](./components/pages/README.md) (DEPRECATED : à migrer dans screens et routes)
-## [ROUTER](./components/router/README.md) (DEPRECATED? : à migrer déterminer si migration complète dans routes)
+## Accès rapide
+* [hooks](./components/hooks/README.md)
+* [ui-kit](./ui-kit/README.md)
+* [components](./new_components/README.md)
+* [screens](./screens/README.md)
+* [routes](./routes/README.md)
+* [repository](./repository/README.md)
+* [hocs](./components/hocs/README.md) (DEPRECATED : utiliser les hooks)
+* [layout](./components/layout/README.md) (DEPRECATED : à migrer au sein de components et ui-kit)
+* [pages](./components/pages/README.md) (DEPRECATED : à migrer dans screens et routes)
+* [router](./components/router/README.md) (DEPRECATED? : à migrer déterminer si migration complète dans routes)
 
 
-## Architecture générale : 
+## Architecture de l'application:
 
-La structure des composants visuels suit une organisation par couches : 
+Voir aussi une structure possible [en suivant atomic design](./doc/structure-atomic-design.md)
+
+```
+    // Root.tsx est l'entré de l'application.
+    // On y:
+    //   * fait les appel api necessaire à la configuration général et
+    //   * configure l'application ( features / user )
+    //   * fait les appel api necessaire à la configuration général et
+    //   * instancie les Providers globaux et App.
+├── Root.tsx
+|
+├── api/  // toutes nos interaction avec fetch, notamment notre client api généré via swagger codegen
+|
+|   // ui-kit est une bibliotéque de petit composant réutilisable
+|   // Button, Select, Title, etc
+├── ui-kit/
+|
+|   // components contient tout les composants réutilisé/
+├── components/
+|
+|   // routes gére les appel api et la mise en forme des données necessaire à chaque screen
+├── routes/
+|
+|   // templates contient tout les tempalte de page ou de morceau de page réutilisable
+|   // App, Form, Page, Filters, etc
+├── templates/
+|
+|   // screen fait la glue entre les donné et fourni par la route, les element de template et les composants.
+└── screens/
+```
+
+## Architecture générale :
+
+
+La structure des composants visuels suit une organisation par couches :
 
 ```
 +---------------------------------------------------------------+
@@ -45,16 +80,16 @@ La structure des composants visuels suit une organisation par couches :
 
 ### Ne pas sur-optimiser
 
-Garder un code simple et lisible avant tout. 
+Garder un code simple et lisible avant tout.
 Optimiser le code avant de rencontrer des problèmes de performances peut nous faire risquer la lisibilité et la compréhension du code.
 
 ### Garder des fichiers de petite taille
 
-Un fichier est une unité de travail, un développeur devrait pouvoir lire un fichier dans sa totalité et comprendre le fonctionnement général. 
+Un fichier est une unité de travail, un développeur devrait pouvoir lire un fichier dans sa totalité et comprendre le fonctionnement général.
 Si il est dificile de mémoriser l'ensemble des règles et fonctionnement d'un fichier, c'est le signe qu'il faut découper.
 
 
-## Styles : 
+## Styles :
 
 ### Partager les styles à travers les composants
 
@@ -66,7 +101,7 @@ Si il est dificile de mémoriser l'ensemble des règles et fonctionnement d'un f
 À travers l'usage de feuilles de styles globales, il est difficile de déterminer le code utilisé ou mort
 et de quantifier l'impact d'un changement sur le produit.
 
- 
+
 ### Eviter la surcharge
 
 Ne pas surcharger un élément depuis la feuille de style d'un parent. Cela crée au sein du code base de nombreux couplages qui peuvent avoir des effets de bord sur le long terme. Préférer des composants et l'usage de props pour créer les variantes nécéssaires. (principe Ouvert/fermé)

--- a/pro/src/Root.tsx
+++ b/pro/src/Root.tsx
@@ -7,18 +7,21 @@ import AppLayout from 'app/AppLayout'
 import NotFound from 'components/pages/Errors/NotFound/NotFound'
 import FeaturedRoute from 'components/router/FeaturedRoute'
 import NavigationLogger from 'components/router/NavigationLogger'
+import { routes, routesWithMain, IRouteData, RedirectLogin } from 'routes'
 import configureStore from 'store'
-import routes, { routesWithMain } from 'utils/routes_map'
 
 const { store } = configureStore()
 
-const Root = () => {
+const Root = (): JSX.Element => {
   return (
     <Provider store={store}>
       <BrowserRouter>
         <NavigationLogger />
         <AppContainer>
           <Switch>
+            <Route exact path="/">
+              <RedirectLogin />
+            </Route>
             <Redirect
               from="/offres/:offerId([A-Z0-9]+)/edition"
               to="/offre/:offerId([A-Z0-9]+)/individuel/edition"
@@ -27,30 +30,30 @@ const Root = () => {
               from="/offre/:offerId([A-Z0-9]+)/scolaire/edition"
               to="/offre/:offerId([A-Z0-9]+)/collectif/edition"
             />
-            {routes.map(route => {
+            {routes.map((routeData: IRouteData) => {
               return (
                 <FeaturedRoute
-                  exact={route.exact}
-                  featureName={route.featureName}
-                  key={route.path}
-                  path={route.path}
+                  exact={routeData.exact}
+                  featureName={routeData.featureName}
+                  key={routeData.path as string}
+                  path={routeData.path}
                 >
                   <AppLayout
-                    layoutConfig={route.meta && route.meta.layoutConfig}
+                    layoutConfig={routeData.meta && routeData.meta.layoutConfig}
                   >
-                    <route.component />
+                    <routeData.component />
                   </AppLayout>
                 </FeaturedRoute>
               )
             })}
 
-            {routesWithMain.map(route => {
+            {routesWithMain.map((routeData: IRouteData) => {
               // first props, last overrides
               return (
                 <FeaturedRoute
-                  {...route}
-                  exact={route.exact}
-                  key={route.path}
+                  {...routeData}
+                  exact={routeData.exact}
+                  key={routeData.path as string}
                 />
               )
             })}

--- a/pro/src/app/App.jsx
+++ b/pro/src/app/App.jsx
@@ -5,7 +5,7 @@ import { matchPath } from 'react-router'
 
 import useCurrentUser from 'components/hooks/useCurrentUser'
 import Spinner from 'components/layout/Spinner'
-import routes, { routesWithMain } from 'utils/routes_map'
+import { routes, routesWithMain } from 'routes'
 
 import RedirectToMaintenance from './RedirectToMaintenance'
 

--- a/pro/src/components/pages/Offers/Offer/__specs__/render.jsx
+++ b/pro/src/components/pages/Offers/Offer/__specs__/render.jsx
@@ -4,8 +4,8 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router'
 
 import OfferLayoutContainer from 'components/pages/Offers/Offer/OfferLayoutContainer'
+import { routes } from 'routes'
 import { configureTestStore } from 'store/testUtils'
-import routes from 'utils/routes_map'
 
 export const renderOffer = async (initialEntries, store) => {
   const defaultStore = configureTestStore({

--- a/pro/src/components/router/FeaturedRoute.tsx
+++ b/pro/src/components/router/FeaturedRoute.tsx
@@ -1,19 +1,23 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 import { useSelector } from 'react-redux'
 import { Route } from 'react-router-dom'
+import type { RouteProps } from 'react-router-dom'
 
 import useActiveFeature from 'components/hooks/useActiveFeature'
 import Spinner from 'components/layout/Spinner'
 import NotMatch from 'components/pages/Errors/NotFound/NotFound'
 import { selectFeaturesInitialized } from 'store/features/selectors'
 
-const FeaturedRoute = props => {
+interface IFeaturedRouteProps extends RouteProps {
+  featureName?: string | null
+}
+
+const FeaturedRoute = (props: IFeaturedRouteProps): JSX.Element => {
   const { children, featureName, ...routeProps } = props
   const { path } = routeProps
 
   const isFeaturesInitialized = useSelector(selectFeaturesInitialized)
-  const isActive = useActiveFeature(featureName)
+  const isActive = useActiveFeature(featureName || null)
 
   if (!isFeaturesInitialized) {
     return (
@@ -28,16 +32,6 @@ const FeaturedRoute = props => {
   }
 
   return <Route {...routeProps}>{children}</Route>
-}
-
-FeaturedRoute.defaultProps = {
-  children: null,
-  featureName: null,
-}
-
-FeaturedRoute.propTypes = {
-  children: PropTypes.node,
-  featureName: PropTypes.string,
 }
 
 export default FeaturedRoute

--- a/pro/src/doc/structure-atomic-design.md
+++ b/pro/src/doc/structure-atomic-design.md
@@ -1,0 +1,47 @@
+## Structure du projet
+
+### Proposition de structure cible
+
+Voir le live disponible en ligne [à cette address](https://atomicdesign.bradfrost.com/table-of-contents/)
+
+Architecture cible atomic design
+
+```
+├── Root.tsx // entré de l'application
+|
+├── components/ // composants réutilisé parmis plusieurs screen et features
+|   ├── atoms/  // composant visuel sans state ni interactions.
+|   |   └── ...
+|   ├── moleculs/  // group de 2 à 3 atoms, gère leurs interaction et leurs dépendences de styles
+|   |   └── ...
+|   └── organisms/  // composant implementant de grosse fonctionalités. Peut contenir des atoms, moleculs ou d'autre organisms.
+|       └── ...
+|
+├── features/ // grandes section fonctionnel: auth, offer, booking, etc
+|   ├── booking
+|   |   ├── adaptors/ // adateur api réutilisé par plusieurs routes (type api -> type composant)
+|   |   |   └── ...
+|   |   ├── atoms/  // composant visuel sans state ni interactions.
+|   |   |   └── ...
+|   |   ├── moleculs/  // group de 2 à 3 atoms, gère leurs interaction et leurs dépendences de styles
+|   |   |   └── ...
+|   |   ├── organisms/  // composant implementant de grosse fonctionalités. Peut contenir des atoms, moleculs ou d'autre organisms.
+|   |   |   └── ...
+|   |   ├── types.ts
+|   |   └── constants.ts
+|   └── etc
+|
+├── templates/  // tempalte de page ou de morceau de page réutilisable
+|   ├── App
+|   ├── Page
+|   ├── Form
+|   ├── SearchFilters
+|   └── etc
+├── routes/  // contient des routes qui gère les interaction api et leurs transformation (adapteur api -> screen)
+|   └── etc
+|
+|   // utilise un ou plusieurs template, des données et callback api et
+|   // des composants venant de ui-kit et/ou feature pour rendre une page ou un morceau de page.
+└── pages/
+    └── etc
+```

--- a/pro/src/routes/RedirectLogin/RedirectLogin.tsx
+++ b/pro/src/routes/RedirectLogin/RedirectLogin.tsx
@@ -1,0 +1,11 @@
+// react hooks and usages doc : https://reactjs.org/docs/hooks-intro.html
+import type { Location } from 'history'
+import React from 'react'
+import { useLocation, Redirect } from 'react-router-dom'
+
+const RedirectLogin = (): JSX.Element => {
+  const location: Location = useLocation()
+  return <Redirect to={`/connexion${location.search}`} />
+}
+
+export default RedirectLogin

--- a/pro/src/routes/RedirectLogin/__specs__/RedirectLogin.spec.tsx
+++ b/pro/src/routes/RedirectLogin/__specs__/RedirectLogin.spec.tsx
@@ -1,0 +1,14 @@
+// react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { RedirectLogin } from '../'
+
+describe('routes:RedirectLogin', () => {
+  it('renders component successfully', () => {
+    render(<RedirectLogin />)
+    const element = screen.getByTestId(/test-redirect-login/i)
+    expect(element).toBeInTheDocument()
+  })
+})

--- a/pro/src/routes/RedirectLogin/index.ts
+++ b/pro/src/routes/RedirectLogin/index.ts
@@ -1,0 +1,1 @@
+export { default as RedirectLogin } from './RedirectLogin'

--- a/pro/src/routes/index.ts
+++ b/pro/src/routes/index.ts
@@ -1,0 +1,3 @@
+export { default as routes, routesWithMain } from './map'
+export { RedirectLogin } from './RedirectLogin'
+export type { IRouteData } from './types'

--- a/pro/src/routes/map.ts
+++ b/pro/src/routes/map.ts
@@ -1,7 +1,3 @@
-import React from 'react'
-import { Redirect } from 'react-router'
-import { useLocation } from 'react-router-dom'
-
 import CsvDetailViewContainer from 'components/layout/CsvTable/CsvTableContainer'
 import BookingsRecapContainer from 'components/pages/Bookings/BookingsRecapContainer'
 import Unavailable from 'components/pages/Errors/Unavailable/Unavailable'
@@ -26,19 +22,11 @@ import OfferEducationalStockEdition from 'routes/OfferEducationalStockEdition/Of
 import OfferType from 'routes/OfferType'
 import { UNAVAILABLE_ERROR_PAGE } from 'utils/routes'
 
-const RedirectToConnexionComponent = () => {
-  const location = useLocation()
-  return <Redirect to={`/connexion${location.search}`} />
-}
+import { IRouteData } from './'
 
 // NOTE: routes are sorted by PATH alphabetical order
 // DEPRECATED: Pages are currently be rework to not use <Main> component
-export const routesWithMain = [
-  {
-    component: RedirectToConnexionComponent,
-    exact: true,
-    path: '/',
-  },
+export const routesWithMain: IRouteData[] = [
   {
     component: SignupContainer,
     exact: true,

--- a/pro/src/routes/types.ts
+++ b/pro/src/routes/types.ts
@@ -1,0 +1,18 @@
+import type { RouteProps } from 'react-router'
+
+interface ILayoutConfig {
+  fullscreen?: boolean
+  pageName?: string
+}
+
+interface IRouteDataMeta {
+  layoutConfig?: ILayoutConfig
+  public?: boolean
+}
+
+export interface IRouteData extends RouteProps {
+  component: React.ComponentType
+  featureName?: string
+  meta?: IRouteDataMeta
+  title: string
+}

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -5307,7 +5307,7 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-router-dom@^5.1.8":
+"@types/react-router-dom@^5.3.3":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
   integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==


### PR DESCRIPTION
J'aimerai pouvoir nettoyer l'usage d'AppLayout et des routes.

Pour cela j'ai besoin d'avoir une racine de l'application un peu nettoyé, notamment quelques migrations Typescript et au passage le fait de regrouper nos routes dans `src/routes`.

Petite mise à jours de la documentation, surtout de la mise en forme.
