### PR TITLE
(BSR)[API] doc: indicate which version of Python to use

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -27,7 +27,7 @@ Spectree:
 Avec `venv` (vous pouvez aussi utiliser `virtualenv` si vous préférez, voire `virtualenvwrapper`):
 
 ```shell
-python3.9 -m venv ./venv
+python3.9.10 -m venv ./venv
 source venv/bin/activate
 pip install -e .
 pip install -r requirements.txt


### PR DESCRIPTION
Lien vers le ticket Jira : pas de tiquet

## But de la pull request

Indiquer dans la doc la version de Python pour éviter des problèmes à l'installation

## Implémentation

- README
