### PR TITLE
(PC-13672) Save gender in civility column

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-5c3a992204ff (post) (head)
 f5a5da60e349 (pre) (head)
+635158569c89 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220311T144938_635158569c89_.py
+++ b/api/src/pcapi/alembic/versions/20220311T144938_635158569c89_.py
@@ -1,0 +1,19 @@
+"""Remove gender column (use civility instead)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "635158569c89"
+down_revision = "5c3a992204ff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("user", "gender")
+
+
+def downgrade():
+    op.add_column("user", sa.Column("gender", sa.VARCHAR(length=4), autoincrement=False, nullable=True))

--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -108,7 +108,7 @@ def parse_beneficiary_information_graphql(
 ) -> fraud_models.DMSContent:
 
     application_id = application_detail.number
-    civility = application_detail.applicant.civility.value
+    civility = application_detail.applicant.civility
     email = application_detail.profile.email
     first_name = application_detail.applicant.first_name
     last_name = application_detail.applicant.last_name

--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -32,7 +32,7 @@ class Civility(enum.Enum):
     """https://demarches-simplifiees-graphql.netlify.app/civilite.doc.html"""
 
     M = "M"
-    MME = "MME"
+    MME = "Mme"
 
 
 class Applicant(pydantic.BaseModel):

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -9,6 +9,7 @@ from factory.declarations import LazyAttribute
 import factory.fuzzy
 import pytz
 
+from pcapi.connectors.dms import models as dms_models
 from pcapi.core import testing
 import pcapi.core.fraud.ubble.models as ubble_fraud_models
 from pcapi.core.users import models as users_models
@@ -97,7 +98,7 @@ class DMSContentFactory(factory.Factory):
 
     last_name = factory.Faker("last_name")
     first_name = factory.Faker("first_name")
-    civility = random.choice(["M.", "Mme"])
+    civility = random.choice([civility.value for civility in dms_models.Civility])
     email = factory.Faker("ascii_safe_email")
     application_id = factory.Faker("pyint")
     procedure_id = factory.Faker("pyint")

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -10,6 +10,7 @@ import pydantic.errors
 import pytz
 import sqlalchemy as sa
 
+from pcapi.connectors.dms import models as dms_models
 from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
@@ -166,10 +167,18 @@ class JouveContent(common_models.IdentityCheckContent):
         return self.bodyPieceNumber
 
 
+def _parse_dms_civility(civility: dms_models.Civility) -> typing.Optional[users_models.GenderEnum]:
+    if civility == dms_models.Civility.M:
+        return users_models.GenderEnum.M
+    if civility == dms_models.Civility.MME:
+        return users_models.GenderEnum.F
+    return None
+
+
 class DMSContent(common_models.IdentityCheckContent):
     last_name: str
     first_name: str
-    civility: str
+    civility: typing.Optional[users_models.GenderEnum]
     email: str
     application_id: int
     procedure_id: int
@@ -181,6 +190,8 @@ class DMSContent(common_models.IdentityCheckContent):
     address: typing.Optional[str]
     id_piece_number: typing.Optional[str]
     registration_datetime: typing.Optional[datetime.datetime]
+
+    _parse_civility = pydantic.validator("civility", pre=True, allow_reuse=True)(_parse_dms_civility)
 
     def get_registration_datetime(self) -> typing.Optional[datetime.datetime]:
         return (

--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -103,7 +103,7 @@ class UbbleIdentificationDocuments(UbbleIdentificationObject):
     document_number: str = pydantic.Field(None, alias="document-number")
     document_type: str = pydantic.Field(None, alias="document-type")
     first_name: str = pydantic.Field(None, alias="first-name")
-    gender: users_models.GenderEnum = pydantic.Field(None)
+    gender: str = pydantic.Field(None)
     last_name: str = pydantic.Field(None, alias="last-name")
     married_name: str = pydantic.Field(None, alias="married-name")
     signed_image_front_url: str = pydantic.Field(None, alias="signed-image-front-url")

--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -25,6 +25,14 @@ class UbbleScore(enum.Enum):
     UNDECIDABLE = -1.0
 
 
+def _parse_ubble_gender(ubble_gender: typing.Optional[str]) -> typing.Optional[users_models.GenderEnum]:
+    if ubble_gender == "M":
+        return users_models.GenderEnum.M
+    if ubble_gender == "F":
+        return users_models.GenderEnum.F
+    return None
+
+
 class UbbleContent(IdentityCheckContent):
     birth_date: typing.Optional[datetime.date]
     comment: typing.Optional[str]
@@ -48,6 +56,7 @@ class UbbleContent(IdentityCheckContent):
     _parse_birth_date = pydantic.validator("birth_date", pre=True, allow_reuse=True)(
         lambda d: datetime.datetime.strptime(d, "%Y-%m-%d").date() if d is not None else None
     )
+    _parse_gender = pydantic.validator("gender", pre=True, allow_reuse=True)(_parse_ubble_gender)
 
     def get_registration_datetime(self) -> typing.Optional[datetime.datetime]:
         return (

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -64,14 +64,14 @@ def update_ubble_workflow(
         if fraud_check.status != fraud_models.FraudCheckStatus.OK:
             can_retry = ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, fraud_check.eligibilityType)
             handle_validation_errors(user, fraud_check.reasonCodes, can_retry=can_retry)
-            subscription_api.update_user_birth_date(user, fraud_check.source_data().get_birth_date())
+            subscription_api.update_user_birth_date(user, content.get_birth_date())
             return
 
         payload = ubble_tasks.StoreIdPictureRequest(identification_id=fraud_check.thirdPartyId)
         ubble_tasks.store_id_pictures_task.delay(payload)
 
         try:
-            subscription_api.on_successful_application(user=user, source_data=fraud_check.source_data())
+            subscription_api.on_successful_application(user=user, source_data=content)
         except Exception:  # pylint: disable=broad-except
             logger.exception("Failure after ubble successful result", extra={"user_id"})
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -34,6 +34,7 @@ from pcapi.core.users.external import update_external_user
 from pcapi.core.users.models import Credit
 from pcapi.core.users.models import DomainsCredit
 from pcapi.core.users.models import EligibilityType
+from pcapi.core.users.models import GenderEnum
 from pcapi.core.users.models import NotificationSubscriptions
 from pcapi.core.users.models import PhoneValidationStatusType
 from pcapi.core.users.models import Token
@@ -255,9 +256,9 @@ def update_user_information_from_external_source(
     elif isinstance(data, ubble_fraud_models.UbbleContent):
         user.firstName = data.first_name
         user.lastName = data.last_name
-        user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0))
+        user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0)) if data.birth_date else None
         user.idPieceNumber = data.get_id_piece_number()
-        user.gender = data.gender
+        user.civility = GenderEnum(data.gender).value if data.gender else None
         user.married_name = data.married_name
 
     # update user fields to be correctly initialized

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -222,7 +222,7 @@ def update_user_information_from_external_source(
         if data.city:
             user.city = data.city
         if data.gender:
-            user.civility = "Mme" if data.gender == "F" else "M."
+            user.civility = GenderEnum.F if data.gender == "F" else GenderEnum.M
         if data.birthDateTxt:
             user.dateOfBirth = data.birthDateTxt
         if data.firstName:
@@ -258,7 +258,7 @@ def update_user_information_from_external_source(
         user.lastName = data.last_name
         user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0)) if data.birth_date else None
         user.idPieceNumber = data.get_id_piece_number()
-        user.civility = GenderEnum(data.gender).value if data.gender else None
+        user.civility = data.gender if data.gender else None
         user.married_name = data.married_name
 
     # update user fields to be correctly initialized

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -157,9 +157,8 @@ class SchoolTypeEnum(enum.Enum):
 
 
 class GenderEnum(enum.Enum):
-    M: str = "M"
-    F: str = "F"
-    NULL: str = "NULL"
+    M: str = "M."
+    F: str = "Mme"
 
 
 class User(PcObject, Model, NeedsValidationMixin):
@@ -168,7 +167,7 @@ class User(PcObject, Model, NeedsValidationMixin):
     activity = sa.Column(sa.String(128), nullable=True)
     address = sa.Column(sa.Text, nullable=True)
     city = sa.Column(sa.String(100), nullable=True)
-    civility = sa.Column(sa.String(20), nullable=True)
+    civility = sa.Column(sa.Enum(GenderEnum, create_constraint=False), nullable=True)
     clearTextPassword = None
     comment = sa.Column(sa.Text(), nullable=True)
     culturalSurveyFilledDate = sa.Column(sa.DateTime, nullable=True)

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -180,7 +180,6 @@ class User(PcObject, Model, NeedsValidationMixin):
     externalIds = sa.Column(postgresql.json.JSONB, nullable=True, default={}, server_default="{}")
     extraData = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=True, default={}, server_default="{}")
     firstName = sa.Column(sa.String(128), nullable=True)
-    gender = sa.Column(sa.Enum(GenderEnum, create_constraint=False), nullable=True)
     hasSeenTutorials = sa.Column(sa.Boolean, nullable=True)
     hasSeenProTutorials = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     idPieceNumber = sa.Column(sa.String, nullable=True, unique=True)

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -86,7 +86,7 @@ class SharedLoginUserResponseModel(BaseModel):
     activity: Optional[str]
     address: Optional[str]
     city: Optional[str]
-    civility: Optional[str]
+    civility: Optional[user_models.GenderEnum]
     dateCreated: datetime
     dateOfBirth: Optional[datetime]
     departementCode: Optional[str]
@@ -127,7 +127,7 @@ class SharedCurrentUserResponseModel(BaseModel):
     activity: Optional[str]
     address: Optional[str]
     city: Optional[str]
-    civility: Optional[str]
+    civility: Optional[user_models.GenderEnum]
     dateCreated: datetime
     dateOfBirth: Optional[datetime]
     departementCode: Optional[str]

--- a/api/src/pcapi/scripts/beneficiary/update_gender_and_married_name_from_ubble.py
+++ b/api/src/pcapi/scripts/beneficiary/update_gender_and_married_name_from_ubble.py
@@ -4,6 +4,7 @@ from pcapi.connectors.beneficiaries import ubble
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import requests
 
 
 logger = logging.getLogger(__name__)
@@ -11,8 +12,8 @@ BATCH_SIZE = 1000
 
 
 def update_gender_and_married_name_from_ubble(dry_run: bool = True) -> None:
-    users_to_update = users_models.User.query.filter(
-        users_models.User.gender.is_(None),
+    users_to_update: list[users_models.User] = users_models.User.query.filter(
+        users_models.User.civility.is_(None),
         users_models.User.married_name.is_(None),
         users_models.User.roles.contains([users_models.UserRole.BENEFICIARY]),
         # Ubble did not send gender and married_name before January 1st 2022
@@ -32,12 +33,16 @@ def update_gender_and_married_name_from_ubble(dry_run: bool = True) -> None:
         user_ubble_fraud_checks.sort(key=lambda fc: fc.dateCreated)
 
         latest_ubble_fraud_check = user_ubble_fraud_checks[0]
-        content = ubble.get_content(latest_ubble_fraud_check.thirdPartyId)
+        try:
+            content = ubble.get_content(latest_ubble_fraud_check.thirdPartyId)
+        except requests.exceptions.HTTPError:
+            logger.warning("Could not retrieve Ubble data for user %s from Ubble.", user.id)
+            continue
 
         if content.gender is not None or content.married_name is not None:
             nb_users_updated += 1
             if not dry_run:
-                user.gender = content.gender
+                user.civility = content.gender
                 user.married_name = content.married_name
 
                 if nb_users_updated % BATCH_SIZE == 0:

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi import settings
+from pcapi.connectors.dms import models as dms_models
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
 import pcapi.core.mails.testing as mails_testing
@@ -446,7 +447,7 @@ class OnSuccessfulDMSApplicationTest:
             address="11 Rue du Test",
             application_id=123,
             procedure_id=123456,
-            civility="Mme",
+            civility=dms_models.Civility.MME,
             activity="Étudiant",
             registration_datetime=datetime.today(),
         )
@@ -461,7 +462,7 @@ class OnSuccessfulDMSApplicationTest:
         # then
         first = users_models.User.query.first()
         assert first.email == "jane.doe@example.com"
-        assert first.civility == "Mme"
+        assert first.civility == users_models.GenderEnum.F
         assert first.activity == "Étudiant"
         assert not first.has_beneficiary_role
         assert (
@@ -482,7 +483,7 @@ class OnSuccessfulDMSApplicationTest:
             address="11 Rue du Test",
             application_id=123,
             procedure_id=123456,
-            civility="Mme",
+            civility=dms_models.Civility.MME,
             activity="Étudiant",
             registration_datetime=datetime.today(),
         )
@@ -504,7 +505,7 @@ class OnSuccessfulDMSApplicationTest:
         first = users_models.User.query.first()
         assert first.email == "jane.doe@example.com"
         assert first.wallet_balance == 300
-        assert first.civility == "Mme"
+        assert first.civility == users_models.GenderEnum.F
         assert first.activity == "Étudiant"
         assert first.has_beneficiary_role
         assert len(push_testing.requests) == 2
@@ -535,19 +536,8 @@ class OnSuccessfulDMSApplicationTest:
             eighteen_years_and_one_month_ago = datetime.today() - relativedelta(years=18, months=1)
 
             # the user deposited their DMS application before turning 18
-            information = fraud_models.DMSContent(
-                department="93",
-                last_name="Doe",
-                first_name="Jane",
+            information = fraud_factories.DMSContentFactory(
                 birth_date=eighteen_years_and_one_month_ago,
-                email="jane.doe@example.com",
-                phone="0612345678",
-                postal_code="93130",
-                address="11 Rue du Test",
-                application_id=123,
-                procedure_id=123456,
-                civility="Mme",
-                activity="Étudiant",
                 registration_datetime=datetime.today(),
             )
             fraud_factories.BeneficiaryFraudCheckFactory(

--- a/api/tests/core/subscription/test_factories.py
+++ b/api/tests/core/subscription/test_factories.py
@@ -11,7 +11,6 @@ import pytz
 
 from pcapi import settings
 from pcapi.core.fraud.ubble import models as ubble_fraud_models
-from pcapi.core.users import models as users_models
 
 
 class IdentificationState(Enum):
@@ -208,7 +207,7 @@ class UbbleIdentificationIncludedDocumentsAttributesFactory(factory.Factory):
     document_type_detailed = None
     expiry_date = None
     first_name = factory.Faker("first_name")
-    gender = factory.LazyFunction(lambda: random.choice([gender.value for gender in users_models.GenderEnum]))
+    gender = "M"
     issue_date = None
     issue_place = None
     issuing_state_code = None

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -106,7 +106,7 @@ class UbbleWorkflowTest:
         assert fraud_check.status == fraud_check_status
         if fraud_check_status == fraud_models.FraudCheckStatus.OK:
             assert user.married_name is not None
-            assert user.civility in ["M", "F", "NULL"]
+            assert user.civility in [users_models.GenderEnum.F, users_models.GenderEnum.M]
 
     def test_ubble_workflow_processing_add_inapp_message(self, ubble_mocker):
         user = users_factories.UserFactory()

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -106,7 +106,7 @@ class UbbleWorkflowTest:
         assert fraud_check.status == fraud_check_status
         if fraud_check_status == fraud_models.FraudCheckStatus.OK:
             assert user.married_name is not None
-            assert user.gender is not None
+            assert user.civility in ["M", "F", "NULL"]
 
     def test_ubble_workflow_processing_add_inapp_message(self, ubble_mocker):
         user = users_factories.UserFactory()

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 import pytest
 import requests_mock
 
+from pcapi.connectors.dms import models as dms_models
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
@@ -683,7 +684,7 @@ class BeneficiaryInformationUpdateTest:
             last_name="Doe",
             first_name="Jane",
             activity="Lycéen",
-            civility="Mme",
+            civility=dms_models.Civility.MME,
             birth_date=date(2000, 5, 1),
             email="jane.doe@test.com",
             phone="0612345678",
@@ -709,7 +710,7 @@ class BeneficiaryInformationUpdateTest:
         assert not beneficiary.has_admin_role
         assert beneficiary.password is not None
         assert beneficiary.activity == "Lycéen"
-        assert beneficiary.civility == "Mme"
+        assert beneficiary.civility.value == "Mme"
         assert beneficiary.hasSeenTutorials == False
         assert not beneficiary.deposits
 

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.core.categories import subcategories
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_user_offerer
 from pcapi.model_creators.generic_creators import create_venue
@@ -20,7 +21,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_is_logged_in_and_has_no_deposit(self, app):
         user = users_factories.BeneficiaryGrant18Factory(
-            civility="M.",
+            civility=users_models.GenderEnum.M,
             address=None,
             city=None,
             needsToFillCulturalSurvey=False,

--- a/api/tests/routes/pro/signin_test.py
+++ b/api/tests/routes/pro/signin_test.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as user_models
 from pcapi.models.user_session import UserSession
 from pcapi.repository import repository
 from pcapi.utils.date import format_into_utc_date
@@ -16,7 +17,7 @@ class Returns200Test:
     def when_account_is_known(self, app):
         # given
         user = users_factories.BeneficiaryGrant18Factory(
-            civility="M.",
+            civility=user_models.GenderEnum.M,
             city=None,
             address=None,
             needsToFillCulturalSurvey=False,

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -229,7 +229,7 @@ def make_graphql_application(
     state: str,
     postal_code: int = 67200,
     department_code: str = "67 - Bas-Rhin",
-    civility: str = "MME",
+    civility: str = "Mme",
     activity: str = "Étudiant",
     id_piece_number: Optional[str] = "123123123",
     email: Optional[str] = "young.individual@example.com",

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -182,7 +182,7 @@ class RunTest:
             source_data=fraud_models.DMSContent(
                 last_name="Doe",
                 first_name="John",
-                civility="MME",
+                civility=dms_models.Civility.MME,
                 email="john.doe@test.com",
                 application_id=123,
                 procedure_id=6712558,
@@ -229,7 +229,7 @@ class ParseBeneficiaryInformationTest:
         information = dms_connector_api.parse_beneficiary_information_graphql(application_detail, procedure_id=201201)
 
         # then
-        assert information.civility == "M"
+        assert information.civility == users_models.GenderEnum.M
 
     @pytest.mark.parametrize("activity", ["Étudiant", None])
     def test_handles_activity(self, activity):
@@ -252,7 +252,7 @@ class ParseBeneficiaryInformationTest:
         )
         assert content.last_name == "VALGEAN"
         assert content.first_name == "Jean"
-        assert content.civility == "M"
+        assert content.civility == users_models.GenderEnum.M
         assert content.email == "jean.valgean@example.com"
         assert content.application_id == 5718303
         assert content.procedure_id == 32
@@ -272,7 +272,7 @@ class ParseBeneficiaryInformationTest:
         )
         assert content.last_name == "VALGEAN"
         assert content.first_name == "Jean"
-        assert content.civility == "M"
+        assert content.civility == users_models.GenderEnum.M
         assert content.email == "jean.valgean@example.com"
         assert content.application_id == 5742994
         assert content.procedure_id == 32

--- a/api/tests/scripts/beneficiary/update_gender_and_married_name_from_ubble_test.py
+++ b/api/tests/scripts/beneficiary/update_gender_and_married_name_from_ubble_test.py
@@ -29,18 +29,18 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
         )
 
         # Beneficiary with gender
-        self.user_beneficiary_up_to_date = users_factories.BeneficiaryGrant18Factory(gender=users_models.GenderEnum.F)
+        self.user_beneficiary_up_to_date = users_factories.BeneficiaryGrant18Factory(civility=users_models.GenderEnum.F)
 
         # Beneficiary with no gender nor married_name
-        self.user_beneficiary_to_update = users_factories.BeneficiaryGrant18Factory(gender=None, married_name=None)
+        self.user_beneficiary_to_update = users_factories.BeneficiaryGrant18Factory(civility=None, married_name=None)
 
         # Beneficiary from DMS
         self.user_beneficiary_dms = users_factories.BeneficiaryGrant18Factory(
-            gender=None, married_name=None, beneficiaryFraudChecks__type=fraud_models.FraudCheckType.DMS
+            civility=None, married_name=None, beneficiaryFraudChecks__type=fraud_models.FraudCheckType.DMS
         )
         # Beneficiary created before january 1st, 2022
         self.old_user_beneficiary = users_factories.BeneficiaryGrant18Factory(
-            gender=None,
+            civility=None,
             married_name=None,
             beneficiaryFraudChecks__type=fraud_models.FraudCheckType.DMS,
             dateCreated=datetime.datetime(2021, 12, 25),
@@ -63,15 +63,15 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
 
         assert mock_logger.call_args_list[0].args == ("Would have updated %d users", 1)
 
-        assert self.user_not_beneficiary.gender is None
+        assert self.user_not_beneficiary.civility is None
         assert self.user_not_beneficiary.married_name is None
-        assert self.user_beneficiary_up_to_date.gender == users_models.GenderEnum.F
+        assert self.user_beneficiary_up_to_date.civility == users_models.GenderEnum.F
         assert self.user_beneficiary_up_to_date.married_name is None
-        assert self.user_beneficiary_dms.gender is None
+        assert self.user_beneficiary_dms.civility is None
         assert self.user_beneficiary_dms.married_name is None
-        assert self.old_user_beneficiary.gender is None
+        assert self.old_user_beneficiary.civility is None
         assert self.old_user_beneficiary.married_name is None
-        assert self.user_beneficiary_to_update.gender is None
+        assert self.user_beneficiary_to_update.civility is None
         assert self.user_beneficiary_to_update.married_name is None
 
     def test_update_gender_and_married_name_from_ubble(self, requests_mock):
@@ -88,15 +88,15 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
         # Should update user_beneficiary_to_update
         update_gender_and_married_name_from_ubble(dry_run=False)
 
-        assert self.user_not_beneficiary.gender is None
+        assert self.user_not_beneficiary.civility is None
         assert self.user_not_beneficiary.married_name is None
-        assert self.user_beneficiary_up_to_date.gender == users_models.GenderEnum.F
+        assert self.user_beneficiary_up_to_date.civility == users_models.GenderEnum.F
         assert self.user_beneficiary_up_to_date.married_name is None
-        assert self.user_beneficiary_dms.gender is None
+        assert self.user_beneficiary_dms.civility is None
         assert self.user_beneficiary_dms.married_name is None
-        assert self.old_user_beneficiary.gender is None
+        assert self.old_user_beneficiary.civility is None
         assert self.old_user_beneficiary.married_name is None
 
         # Only user to be updated
-        assert self.user_beneficiary_to_update.gender == users_models.GenderEnum.F
+        assert self.user_beneficiary_to_update.civility == users_models.GenderEnum.F
         assert self.user_beneficiary_to_update.married_name == "Kelly"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13672

## But de la pull request

La colonne `civility` existe déjà (Anciennement remplie par Jouve) 
La colonne `gender` est donc redondante

## Implémentation

- Retirer la colonne `gender`
- Sauver le gender de Ubble dans `civility`

## Informations supplémentaires

- Ajoute un catch de HTTPError dansle script de rattrapage

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
