### PR TITLE
(BSR)[PRO] fix: debt-collector should only run..

### DIFF
--- a/.github/workflows/debt-collector-pro.yml
+++ b/.github/workflows/debt-collector-pro.yml
@@ -33,6 +33,7 @@ jobs:
           git fetch origin master:master
           yarn debt:compare
       - name: Find Comment
+        if: steps.changes.outputs.src == 'true'
         uses: peter-evans/find-comment@v1
         id: fc
         with:
@@ -40,6 +41,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Debt collector report
       - id: get-comment-body
+        if: steps.changes.outputs.src == 'true'
         run: |
           body="$(cat ./pro/node_modules/.cache/debt-collector/report.html)"
           body="${body//'%'/'%25'}"


### PR DESCRIPTION
.. when we got changes in /pro
==============

Suite au modification du workflow mergé ce matin, debt-collector se lançait partiellement meme lorsqu'il n'y avait pas de modification sur `/pro/*`.

Let's fix it !