### PR TITLE
(PC-13921)[PRO] fix: remove condition in recap bookings table for sta…

### DIFF
--- a/pro/src/components/pages/Bookings/BookingsRecapTable/BookingsRecapTable.jsx
+++ b/pro/src/components/pages/Bookings/BookingsRecapTable/BookingsRecapTable.jsx
@@ -86,16 +86,13 @@ class BookingsRecapTable extends Component {
           Cell: ({ row }) => <BookingStatusCell bookingRecapInfo={row} />,
           className: 'column-booking-status',
           disableSortBy: true,
-          HeaderTitleFilter: () =>
-            !props.isBookingFiltersActive ? (
-              <FilterByBookingStatus
-                bookingStatuses={this.state.filters.bookingStatus}
-                bookingsRecap={props.bookingsRecap}
-                updateGlobalFilters={this.updateGlobalFilters}
-              />
-            ) : (
-              <span className="table-head-label">Statut actuel</span>
-            ),
+          HeaderTitleFilter: () => (
+            <FilterByBookingStatus
+              bookingStatuses={this.state.filters.bookingStatus}
+              bookingsRecap={props.bookingsRecap}
+              updateGlobalFilters={this.updateGlobalFilters}
+            />
+          ),
         },
       ],
       currentPage: FIRST_PAGE_INDEX,
@@ -199,7 +196,6 @@ BookingsRecapTable.defaultProps = {
 
 BookingsRecapTable.propTypes = {
   bookingsRecap: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  isBookingFiltersActive: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   locationState: PropTypes.shape({
     venueId: PropTypes.string,

--- a/pro/src/components/pages/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.jsx
+++ b/pro/src/components/pages/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.jsx
@@ -85,7 +85,7 @@ const FilterByBookingStatus = ({
         onFocus={showFilter}
         type="button"
       >
-        <span className="table-head-label">Statut</span>
+        <span className="table-head-label status-filter">Statut</span>
 
         <Icon alt="Filtrer par statut" svg={computeIconSrc()} />
       </button>

--- a/pro/src/styles/components/pages/Bookings/BookingsRecapTable/Table/Head/_Head.scss
+++ b/pro/src/styles/components/pages/Bookings/BookingsRecapTable/Table/Head/_Head.scss
@@ -9,6 +9,11 @@
       min-height: rem(60px);
       padding: rem(14px);
       vertical-align: middle;
+      text-align: left;
+
+      .status-filter {
+        padding-left: 0;
+      }
 
       .sorting-icons {
         display: inline-block;


### PR DESCRIPTION
…tus filters and align head columns

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13921

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

suppression de la condition d'affichage pour le filtre status et alignement des tete des colones 
avant
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/90606397/158392741-3ac24846-2c0c-476a-90a4-b3323daf31b4.png">
 
apres
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/90606397/158392573-0265f156-06b8-449f-b312-fa4c0997f28a.png">
