### PR TITLE
(PC-13423)[API] chore: change filter to exclude PENDING collective booking from mark_as_used cron

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -505,7 +505,7 @@ def auto_mark_as_used_after_event() -> None:
 
     collective_bookings_subquery = (
         CollectiveBooking.query.join(CollectiveStock)
-            .filter(CollectiveBooking.status.in_((CollectiveBookingStatus.CONFIRMED, CollectiveBookingStatus.PENDING)))
+            .filter(CollectiveBooking.status == CollectiveBookingStatus.CONFIRMED)
             .filter(CollectiveStock.beginningDatetime < threshold)
             .with_entities(CollectiveBooking.id)
             .subquery()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13423

## But de la pull request

Dans le cron `auto_mark_as_used`, on filtrait sur les reservations collectives CONFIRMED ou PENDING.
Il ne faut filtrer que sur les réservations CONFIRMED.
C'est plus un soucis de cohérence métier qu'un bug, car les réservations PENDING sont annulées lorsqu'on dépasse la date limite de confirmation (qui est au plus tard la date de l'évènement)

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
