### PR TITLE
(PC-13813)[PRO] fix: check if the selectedOfferer.isValidated is set to false

### DIFF
--- a/pro/src/components/pages/Home/Offerers/Offerers.jsx
+++ b/pro/src/components/pages/Home/Offerers/Offerers.jsx
@@ -113,7 +113,7 @@ const Offerers = () => {
   }
 
   const isOffererSoftDeleted =
-    selectedOfferer && !selectedOfferer.isActive && !selectedOfferer.isValidated
+    selectedOfferer && selectedOfferer.isActive === false
   const userHasOfferers = offererOptions.length > 0
   return (
     <>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13813

## But de la pull request

Empêcher l'affichage du bloc Structure désactivée quand l'ajout est en cours de validation

## Implémentation

- mise à jour de la condition pour vérifier si l'offerer a bien été récupérée (`selectedOfferer` ne suffisait pas car quand on a une 403 on le set ligne 78, et `!selectedOfferer.isActive` était vraie aussi quand `isActive` était `undefined`)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
