### PR TITLE
(PC-13939)[API] feat: add user id to the batch offers deactivation

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -199,7 +199,7 @@ def patch_all_offers_active_status(
         "period_beginning_date": body.period_beginning_date,
         "period_ending_date": body.period_ending_date,
     }
-    update_all_offers_active_status_job.delay(filters, body.is_active)
+    update_all_offers_active_status_job.delay(filters, body.is_active, requesting_user_id=current_user.id)
     return offers_serialize.PatchAllOffersActiveStatusResponseModel()
 
 

--- a/api/src/pcapi/workers/update_all_offers_active_status_job.py
+++ b/api/src/pcapi/workers/update_all_offers_active_status_job.py
@@ -1,11 +1,27 @@
+from typing import Optional
+
+from flask import _request_ctx_stack
+
 import pcapi.core.offers.api as offers_api
 import pcapi.core.offers.repository as offers_repository
+import pcapi.core.users.models as users_models
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
 
 
 @job(worker.low_queue)
-def update_all_offers_active_status_job(filters: dict, is_active: bool) -> None:
+def update_all_offers_active_status_job(
+    filters: dict, is_active: bool, requesting_user_id: Optional[int] = None
+) -> None:
+    # Push the user on behalf of which the action is been performed - similar to flask-login
+    # Since rq forks the worker to process a job, there is no post job cleanup. Might be a gotcha if
+    # another asynchrone job system is used
+    # Pushing the use to the context allows logs to be linked to the user
+    if requesting_user_id:
+        requesting_user = users_models.User.query.get(requesting_user_id)
+        ctx = _request_ctx_stack.top
+        ctx.user = requesting_user
+
     query = offers_repository.get_offers_by_filters(
         user_id=filters["user_id"],
         user_is_admin=filters["is_user_admin"],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13939

## But de la pull request

Ajout de l'utilisateur dans le contexte du traitement en lot d'activation/déactivation des offres afin d'avoir son identifiant dans les logs de la tache asynchrone.