### PR TITLE
(PC-13888)[API] chore: add unique constraint on collectiveOfferId field in collective_stock table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-0efdf36fd5d7 (post) (head)
+6ee927d299b1 (post) (head)
 f5a5da60e349 (pre) (head)

--- a/api/src/pcapi/alembic/versions/20220316T115724_6ee927d299b1_make_ix_collective_stock_collectiveofferid_unique.py
+++ b/api/src/pcapi/alembic/versions/20220316T115724_6ee927d299b1_make_ix_collective_stock_collectiveofferid_unique.py
@@ -1,0 +1,36 @@
+"""make_ix_collective_stock_collectiveOfferId_unique
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+revision = "6ee927d299b1"
+down_revision = "0efdf36fd5d7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.drop_index("ix_collective_stock_collectiveOfferId", table_name="collective_stock")
+    op.execute(
+        """
+        SET SESSION statement_timeout = '300s'
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "ix_collective_stock_collectiveOfferId" ON collective_stock ("collectiveOfferId")
+        """
+    )
+    op.execute(
+        f"""
+            SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+            """
+    )
+
+
+def downgrade():
+    op.drop_index("ix_collective_stock_collectiveOfferId", table_name="collective_stock")
+    op.create_index("ix_collective_stock_collectiveOfferId", "collective_stock", ["collectiveOfferId"], unique=False)

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -643,9 +643,8 @@ def create_collective_stock(
         collective_offer = (
             CollectiveOffer.query.filter_by(id=offer_id).options(joinedload(CollectiveOffer.collectiveStock)).one()
         )
-    if collective_offer.collectiveStock:
-        raise exceptions.CollectiveStockAlreadyExists()
 
+    validation.check_collective_offer_number_of_collective_stocks(collective_offer)
     offer_validation.check_validation_status(collective_offer)
     if booking_limit_datetime is None:
         booking_limit_datetime = beginning
@@ -659,7 +658,8 @@ def create_collective_stock(
         priceDetail=educational_price_detail,
         stockId=legacy_id if legacy_id else None,  # FIXME (rpaoloni, 2022-03-7): Remove legacy support layer
     )
-    repository.save(collective_stock)
+    db.session.add(collective_stock)
+    db.session.commit()
     logger.info(
         "Collective stock has been created",
         extra={"collective_offer": collective_offer.id, "collective_stock_id": collective_stock.id},

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -357,11 +357,11 @@ class CollectiveStock(PcObject, Model):  # type: ignore[valid-type, misc]
 
     dateModified = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
-    beginningDatetime = sa.Column(
-        sa.DateTime, index=True, nullable=False
-    )  #  TODO 4 cas a ratrapper avec un beginDatetime NULL
+    beginningDatetime = sa.Column(sa.DateTime, index=True, nullable=False)
 
-    collectiveOfferId = sa.Column(sa.BigInteger, sa.ForeignKey("collective_offer.id"), index=True, nullable=False)
+    collectiveOfferId = sa.Column(
+        sa.BigInteger, sa.ForeignKey("collective_offer.id"), index=True, nullable=False, unique=True
+    )
 
     collectiveOffer = sa.orm.relationship(
         "CollectiveOffer", foreign_keys=[collectiveOfferId], uselist=False, back_populates="collectiveStock"

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -5,8 +5,10 @@ from typing import Union
 from pcapi.core.bookings import exceptions as booking_exceptions
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.educational import exceptions
+from pcapi.core.educational.exceptions import CollectiveStockAlreadyExists
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
+from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import EducationalBooking
 from pcapi.core.educational.models import EducationalBookingStatus
@@ -80,3 +82,10 @@ def check_collective_stock_is_editable(stock: CollectiveStock) -> None:
 def check_collective_booking_status_pending(booking: CollectiveBooking) -> Optional[Exception]:
     if booking.status is not CollectiveBookingStatus.PENDING:
         raise exceptions.CollectiveOfferStockBookedAndBookingNotPending(booking.status, booking.id)
+
+
+def check_collective_offer_number_of_collective_stocks(
+    collective_offer: CollectiveOffer,
+) -> Optional[CollectiveStockAlreadyExists]:
+    if collective_offer.collectiveStock:
+        raise exceptions.CollectiveStockAlreadyExists()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13888

## But de la pull request

Certaines requêtes concurrentes créaient deux stocks pour la même offre collective. Comme il ne peut y avoir qu'un stock par offre collective, nous avons ajouté une contrainte d'unicité sur l'index collectiveOfferId

## Implémentation

À noter qu'il y a juste eu besoin de transformer l'index en index d'unicité. Il n'y a pas eu besoin d'ajouter une contrainte d'unicité ensuite. En effet, [comme indiqué ici](https://www.ibm.com/docs/en/db2/11.5?topic=indexes-unique-non-unique), la contrainte d'unicité correspond à index d'unicité + contrainte NOT NULL. La contrainte NOT NULL est déjà présente sur la colonne.

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
