### PR TITLE
(PC-14000)[API] fix: sib email when booking cancelled by pro

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -285,6 +285,7 @@ def cancel_booking_by_offerer(booking: Booking) -> None:
     validation.check_booking_can_be_cancelled(booking)
     _cancel_booking(booking, BookingCancellationReasons.OFFERER)
     send_cancel_booking_notification.delay([booking.id])
+    send_booking_cancellation_emails_to_user_and_offerer_job.delay(booking.id)
 
 
 def cancel_bookings_from_stock_by_offerer(stock: offers_models.Stock) -> list[Booking]:

--- a/api/src/pcapi/core/mails/backends/base.py
+++ b/api/src/pcapi/core/mails/backends/base.py
@@ -25,6 +25,6 @@ class BaseBackend:
     def _send(
         self,
         recipients: Iterable,
-        data: Union[SendinblueTransactionalEmailData, dict],
+        data: Union[SendinblueTransactionalEmailData, SendinblueTransactionalWithoutTemplateEmailData, dict],
     ) -> MailResult:
         raise NotImplementedError()

--- a/api/src/pcapi/core/mails/backends/testing.py
+++ b/api/src/pcapi/core/mails/backends/testing.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from typing import Union
 
 from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
+from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalWithoutTemplateEmailData
 
 from .. import testing
 from ..models.models import MailResult
@@ -17,7 +18,7 @@ class TestingBackend(BaseBackend):
     def _send(
         self,
         recipients: Iterable[str],
-        data: Union[SendinblueTransactionalEmailData, dict],
+        data: Union[SendinblueTransactionalEmailData, SendinblueTransactionalWithoutTemplateEmailData, dict],
     ) -> MailResult:
         if not isinstance(data, dict):
             data = asdict(data)
@@ -33,7 +34,7 @@ class FailingBackend(BaseBackend):
     def _send(
         self,
         recipients: Iterable[str],
-        data: Union[SendinblueTransactionalEmailData, dict],
+        data: Union[SendinblueTransactionalEmailData, SendinblueTransactionalWithoutTemplateEmailData, dict],
     ) -> MailResult:
         data["To"] = ", ".join(recipients)
         return MailResult(sent_data=data, successful=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14000

## But de la pull request

relié l'envoi de mail d'annulation de réservation aux jeunes et pro
lorsque l'api contremarque est utilisé (lors de l'annulation d'une réservation par un AC)

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
