### PR TITLE
[API] fix: allow any text for civility to avoid crash on existing data

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -204,7 +204,7 @@ def update_user_information_from_external_source(
         user.departementCode = data.department
         user.postalCode = data.postal_code
         user.address = data.address
-        user.civility = data.civility
+        user.civility = data.civility.value if data.civility else None
         user.activity = data.activity
         user.remove_admin_role()
         user.hasSeenTutorials = False
@@ -222,7 +222,7 @@ def update_user_information_from_external_source(
         if data.city:
             user.city = data.city
         if data.gender:
-            user.civility = GenderEnum.F if data.gender == "F" else GenderEnum.M
+            user.civility = GenderEnum.F.value if data.gender == "F" else GenderEnum.M.value
         if data.birthDateTxt:
             user.dateOfBirth = data.birthDateTxt
         if data.firstName:
@@ -258,7 +258,7 @@ def update_user_information_from_external_source(
         user.lastName = data.last_name
         user.dateOfBirth = datetime.combine(data.birth_date, time(0, 0)) if data.birth_date else None
         user.idPieceNumber = data.get_id_piece_number()
-        user.civility = data.gender if data.gender else None
+        user.civility = data.gender.value if data.gender else None
         user.married_name = data.married_name
 
     # update user fields to be correctly initialized

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -167,7 +167,7 @@ class User(PcObject, Model, NeedsValidationMixin):
     activity = sa.Column(sa.String(128), nullable=True)
     address = sa.Column(sa.Text, nullable=True)
     city = sa.Column(sa.String(100), nullable=True)
-    civility = sa.Column(sa.Enum(GenderEnum, create_constraint=False), nullable=True)
+    civility = sa.Column(sa.Text, nullable=True)
     clearTextPassword = None
     comment = sa.Column(sa.Text(), nullable=True)
     culturalSurveyFilledDate = sa.Column(sa.DateTime, nullable=True)

--- a/api/src/pcapi/scripts/beneficiary/update_gender_and_married_name_from_ubble.py
+++ b/api/src/pcapi/scripts/beneficiary/update_gender_and_married_name_from_ubble.py
@@ -42,7 +42,7 @@ def update_gender_and_married_name_from_ubble(dry_run: bool = True) -> None:
         if content.gender is not None or content.married_name is not None:
             nb_users_updated += 1
             if not dry_run:
-                user.civility = content.gender
+                user.civility = content.gender.value
                 user.married_name = content.married_name
 
                 if nb_users_updated % BATCH_SIZE == 0:

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -29,7 +29,7 @@ class BeneficiaryListViewTest:
         client.with_session_auth(admin.email)
 
         for review_status in fraud_models.FraudReviewStatus:
-            user = users_factories.UserFactory()
+            user = users_factories.UserFactory(civility="M.")
             fraud_factories.BeneficiaryFraudCheckFactory(user=user)
             fraud_factories.BeneficiaryFraudResultFactory(user=user)
             fraud_factories.BeneficiaryFraudReviewFactory(user=user, review=review_status)

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -462,7 +462,7 @@ class OnSuccessfulDMSApplicationTest:
         # then
         first = users_models.User.query.first()
         assert first.email == "jane.doe@example.com"
-        assert first.civility == users_models.GenderEnum.F
+        assert first.civility == users_models.GenderEnum.F.value
         assert first.activity == "Étudiant"
         assert not first.has_beneficiary_role
         assert (
@@ -505,7 +505,7 @@ class OnSuccessfulDMSApplicationTest:
         first = users_models.User.query.first()
         assert first.email == "jane.doe@example.com"
         assert first.wallet_balance == 300
-        assert first.civility == users_models.GenderEnum.F
+        assert first.civility == users_models.GenderEnum.F.value
         assert first.activity == "Étudiant"
         assert first.has_beneficiary_role
         assert len(push_testing.requests) == 2

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -106,7 +106,7 @@ class UbbleWorkflowTest:
         assert fraud_check.status == fraud_check_status
         if fraud_check_status == fraud_models.FraudCheckStatus.OK:
             assert user.married_name is not None
-            assert user.civility in [users_models.GenderEnum.F, users_models.GenderEnum.M]
+            assert user.civility in [users_models.GenderEnum.F.value, users_models.GenderEnum.M.value]
 
     def test_ubble_workflow_processing_add_inapp_message(self, ubble_mocker):
         user = users_factories.UserFactory()

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -710,7 +710,7 @@ class BeneficiaryInformationUpdateTest:
         assert not beneficiary.has_admin_role
         assert beneficiary.password is not None
         assert beneficiary.activity == "Lycéen"
-        assert beneficiary.civility.value == "Mme"
+        assert beneficiary.civility == "Mme"
         assert beneficiary.hasSeenTutorials == False
         assert not beneficiary.deposits
 

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -21,7 +21,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_user_is_logged_in_and_has_no_deposit(self, app):
         user = users_factories.BeneficiaryGrant18Factory(
-            civility=users_models.GenderEnum.M,
+            civility=users_models.GenderEnum.M.value,
             address=None,
             city=None,
             needsToFillCulturalSurvey=False,

--- a/api/tests/routes/pro/signin_test.py
+++ b/api/tests/routes/pro/signin_test.py
@@ -17,7 +17,7 @@ class Returns200Test:
     def when_account_is_known(self, app):
         # given
         user = users_factories.BeneficiaryGrant18Factory(
-            civility=user_models.GenderEnum.M,
+            civility=user_models.GenderEnum.M.value,
             city=None,
             address=None,
             needsToFillCulturalSurvey=False,

--- a/api/tests/scripts/beneficiary/update_gender_and_married_name_from_ubble_test.py
+++ b/api/tests/scripts/beneficiary/update_gender_and_married_name_from_ubble_test.py
@@ -29,7 +29,9 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
         )
 
         # Beneficiary with gender
-        self.user_beneficiary_up_to_date = users_factories.BeneficiaryGrant18Factory(civility=users_models.GenderEnum.F)
+        self.user_beneficiary_up_to_date = users_factories.BeneficiaryGrant18Factory(
+            civility=users_models.GenderEnum.F.value
+        )
 
         # Beneficiary with no gender nor married_name
         self.user_beneficiary_to_update = users_factories.BeneficiaryGrant18Factory(civility=None, married_name=None)
@@ -65,7 +67,7 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
 
         assert self.user_not_beneficiary.civility is None
         assert self.user_not_beneficiary.married_name is None
-        assert self.user_beneficiary_up_to_date.civility == users_models.GenderEnum.F
+        assert self.user_beneficiary_up_to_date.civility == users_models.GenderEnum.F.value
         assert self.user_beneficiary_up_to_date.married_name is None
         assert self.user_beneficiary_dms.civility is None
         assert self.user_beneficiary_dms.married_name is None
@@ -90,7 +92,7 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
 
         assert self.user_not_beneficiary.civility is None
         assert self.user_not_beneficiary.married_name is None
-        assert self.user_beneficiary_up_to_date.civility == users_models.GenderEnum.F
+        assert self.user_beneficiary_up_to_date.civility == users_models.GenderEnum.F.value
         assert self.user_beneficiary_up_to_date.married_name is None
         assert self.user_beneficiary_dms.civility is None
         assert self.user_beneficiary_dms.married_name is None
@@ -98,5 +100,5 @@ class UpdateGenderAndMarriedNameFromUbbleTest:
         assert self.old_user_beneficiary.married_name is None
 
         # Only user to be updated
-        assert self.user_beneficiary_to_update.civility == users_models.GenderEnum.F
+        assert self.user_beneficiary_to_update.civility == users_models.GenderEnum.F.value
         assert self.user_beneficiary_to_update.married_name == "Kelly"


### PR DESCRIPTION
## But de la pull request

Rollback sur le typage de la colonne `civility` de User
A l'affichage dans flask admin, la contrainte sur le type de valeur fait crasher FA sur les valeurs existantes 

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
