### PR TITLE
(PC-13939)[API] fix: Fix batch offer update with no affected offer

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -441,9 +441,12 @@ def update_collective_offer(
 
 
 def batch_update_offers(query, update_fields):
-    offer_ids, venue_ids = zip(
-        *query.filter(Offer.validation == OfferValidationStatus.APPROVED).with_entities(Offer.id, Offer.venueId)
+    raw_results = (
+        query.filter(Offer.validation == OfferValidationStatus.APPROVED).with_entities(Offer.id, Offer.venueId).all()
     )
+    offer_ids, venue_ids = [], []
+    if raw_results:
+        offer_ids, venue_ids = zip(*raw_results)
     venue_ids = sorted(set(venue_ids))
     logger.info(
         "Batch update of offers",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13939

## But de la pull request

Corrige le bon fonctionnement de la mise à jour en masse d'offres quand.... il n'y a pas d'offre mise à jour.
