### PR TITLE
(PC-13937)[PRO] feat: add RGS informative banner on SignUp page

### DIFF
--- a/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
@@ -9,6 +9,7 @@ import PasswordField from 'components/layout/form/fields/PasswordField'
 import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import LegalInfos from 'components/layout/LegalInfos/LegalInfos'
 import { redirectLoggedUser } from 'components/router/helpers'
+import { BannerRGS } from 'new_components/Banner'
 import bindAddressAndDesignationFromSiren from 'repository/siren/bindSirenFieldToDesignation'
 
 import OperatingProcedures from './OperationProcedures'
@@ -204,6 +205,7 @@ class SignupForm extends PureComponent {
                   className="sign-up-infos-before-signup"
                   title="Créer mon compte"
                 />
+                <BannerRGS />
                 <div className="buttons-field">
                   <Link className="secondary-link" to="/connexion">
                     J’ai déjà un compte

--- a/pro/src/components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
@@ -300,6 +300,21 @@ describe('src | components | pages | Signup | SignupForm', () => {
       expect(link.prop('to')).toBe('/connexion')
     })
 
+    it('should render a link to RGS information', () => {
+      // when
+      const wrapper = mount(
+        <Router history={history}>
+          <SignupForm {...props} />
+        </Router>
+      )
+
+      // then
+      const RGSLink = wrapper.find('a').at(4)
+      expect(RGSLink.prop('href')).toBe(
+        'https://aide.passculture.app/hc/fr/articles/4458607720732--Acteurs-Culturels-Comment-assurer-la-s%C3%A9curit%C3%A9-de-votre-compte-'
+      )
+    })
+
     it('should render a SubmitButton component with the right props', () => {
       // when
       const wrapper = mount(

--- a/pro/src/new_components/Banner/BannerRGS.tsx
+++ b/pro/src/new_components/Banner/BannerRGS.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import Banner from 'ui-kit/Banner'
 
 const BannerRGS = (): JSX.Element => (

--- a/pro/src/new_components/Banner/BannerRGS.tsx
+++ b/pro/src/new_components/Banner/BannerRGS.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import Banner from 'ui-kit/Banner'
+
+const BannerRGS = (): JSX.Element => (
+  <Banner
+    href="https://aide.passculture.app/hc/fr/articles/4458607720732--Acteurs-Culturels-Comment-assurer-la-s%C3%A9curit%C3%A9-de-votre-compte-"
+    linkTitle="Consulter nos recommendations de sécurité"
+    type="attention"
+  >
+    <strong>Soyez vigilant !</strong>
+    <br />
+    Vos identifiants de connexion sont personnels et ne doivent pas être
+    partagés. Pour assurer la protection de votre compte, découvrez nos
+    recommendations.
+  </Banner>
+)
+
+export default BannerRGS

--- a/pro/src/new_components/Banner/__specs__/BannerRGS.spec.tsx
+++ b/pro/src/new_components/Banner/__specs__/BannerRGS.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import '@testing-library/jest-dom'
+
+import BannerRGS from '../BannerRGS'
+
+describe('src | new_components | BannerRGS', () => {
+  it('should render a link to RGS information', () => {
+    render(<BannerRGS />)
+    expect(
+      screen.getByRole('link', {
+        name: 'Consulter nos recommendations de sécurité',
+      })
+    ).toHaveAttribute(
+      'href',
+      'https://aide.passculture.app/hc/fr/articles/4458607720732--Acteurs-Culturels-Comment-assurer-la-s%C3%A9curit%C3%A9-de-votre-compte-'
+    )
+  })
+})

--- a/pro/src/new_components/Banner/index.ts
+++ b/pro/src/new_components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { default as BannerRGS } from './BannerRGS'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13937

## But de la pull request

Ajout d'un bandeau informatif RGS sur la page de création de compte

## Implémentation

- ui-kit component Banner

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
