### PR TITLE
(PC-13389) Ajout de la description des messages d'erreur sur l'API

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -27,6 +27,7 @@ from pcapi.routes.serialization.stock_serialize import StockIdResponseModel
 from pcapi.routes.serialization.thumbnails_serialize import CreateThumbnailBodyModel
 from pcapi.routes.serialization.thumbnails_serialize import CreateThumbnailResponseModel
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.human_ids import dehumanize
 from pcapi.workers.update_all_offers_active_status_job import update_all_offers_active_status_job
 
@@ -76,7 +77,13 @@ def get_offer(offer_id: str) -> offers_serialize.GetOfferResponseModel:
 
 @private_api.route("/offers", methods=["POST"])
 @login_required
-@spectree_serialize(response_model=offers_serialize.OfferResponseIdModel, on_success_status=201, api=blueprint.pro_private_schema)  # type: ignore
+@spectree_serialize(
+    on_success_status=201,
+    api=blueprint.pro_private_schema,
+    resp=SpectreeResponse(
+        HTTP_201=offers_serialize.OfferResponseIdModel,
+    ),
+)  # type: ignore
 def post_offer(body: offers_serialize.PostOfferBodyModel) -> offers_serialize.OfferResponseIdModel:
     try:
         offer = offers_api.create_offer(offer_data=body, user=current_user)

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -256,6 +256,10 @@ class OfferResponseIdModel(BaseModel):
         arbitrary_types_allowed = True
 
 
+class OfferResponseIdError(BaseModel):
+    subcategory: Optional[list[str]]
+
+
 class PatchOfferActiveStatusBodyModel(BaseModel):
     is_active: bool
     ids: list[int]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13389

## But de la pull request

Ajout de la description des messages d'erreur sur l'API

## Implémentation

- Modification du décorateur de spectre pour retourner correctement les codes d'erreur en relation avec la structure retournée par la route.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
