### PR TITLE
(BSR) Use circle ci parallelism instead of custom config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,7 @@ jobs:
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
+    parallelism: 4
     steps:
       - checkout
       - skip_unchanged:
@@ -419,11 +420,14 @@ jobs:
           working_directory: api
       - run:
           name: Running tests
-          command: >
-            RUN_ENV=tests venv/bin/pytest << parameters.pytest_extra_args >> --durations=10
-            --junitxml=test-results/junit.xml
+          command: |
+            TEST_FILES=$(circleci tests glob "tests/**/*.py" | circleci tests split --split-by=timings)
+            mkdir -p test-results
+            RUN_ENV=tests venv/bin/pytest $TEST_FILES --durations=10 --junitxml=test-results/junit.xml
           working_directory: api
       - store_test_results:
+          path: api/test-results
+      - store_artifacts:
           path: api/test-results
       - when:
           condition:
@@ -1043,38 +1047,6 @@ workflows:
                - integration
          context: Slack
       - tests-api:
-         name: "Run core tests (except core/users/external)"
-         pytest_extra_args: "tests/core --ignore=tests/core/users/external"
-         filters:
-           branches:
-             ignore:
-               - production
-               - staging
-               - integration
-         context: Slack
-      - tests-api:
-         name: "Run core/users/external"
-         pytest_extra_args: "tests/core/users/external"
-         filters:
-           branches:
-             ignore:
-               - production
-               - staging
-               - integration
-         context: Slack
-      - tests-api:
-         name: "Run routes tests"
-         pytest_extra_args: "tests/routes"
-         filters:
-           branches:
-             ignore:
-               - production
-               - staging
-               - integration
-         context: Slack
-      - tests-api:
-         name: "Run other tests"
-         pytest_extra_args: "tests --ignore=tests/core --ignore=tests/routes"
          filters:
            branches:
              ignore:
@@ -1118,10 +1090,7 @@ workflows:
              only:
                - master
          requires:
-           - "Run core tests (except core/users/external)"
-           - "Run routes tests"
-           - "Run other tests"
-           - "Run core/users/external"
+           - tests-api
            - quality-api
          context:
            - GCP

--- a/api/README.md
+++ b/api/README.md
@@ -1,5 +1,5 @@
 # pass-culture-api
-
+'to be dropped, used for example'
 [![Coverage Status](https://coveralls.io/repos/github/betagouv/pass-culture-api/badge.svg?branch=master)](https://coveralls.io/github/betagouv/pass-culture-api?branch=master)
 
 Voici le backend de l'application Pass Culture; il est lancé via `docker-compose` en utilisant le fichier

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -7,6 +7,7 @@ python_classes=*Test
 python_functions=test_* when_* expect_* should_*
 env_files=local_test_env_file
 mocked-sessions=pcapi.models.db.session
+junit_family=xunit1
 filterwarnings =
     # Raised by SQLAlchemy (>=1.3.17, see https://github.com/sqlalchemy/sqlalchemy/commit/916e1fea25afcd07fa1d1d2f72043b372cd02223) because of pytest-flask-sqlalchemy.
     # FIXME (dbaty, 2020-10-21): Follow https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/36


### PR DESCRIPTION
CircleCI got a parallelism mechanism which check for tests timing before separating the different files.
This pull request aims to use this mechanism instead of the home-made one to go faster and have a more sustainable solution