### PR TITLE
PC 13935 bandeau RGS home

### DIFF
--- a/pro/src/components/hooks/useCurrentUser.ts
+++ b/pro/src/components/hooks/useCurrentUser.ts
@@ -19,6 +19,7 @@ interface IAPICurrentUser {
   firstName: string | null
   hasPhysicalVenues: boolean
   hasSeenProTutorials: boolean
+  hasSeenProRgs: boolean
   id: string
   idPieceNumber: string | null
   isAdmin: boolean

--- a/pro/src/components/pages/Home/Homepage.tsx
+++ b/pro/src/components/pages/Home/Homepage.tsx
@@ -1,19 +1,34 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 
+import useCurrentUser from 'components/hooks/useCurrentUser'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
+import { BannerRGS } from 'new_components/Banner'
+import { setHasSeenRGSBanner } from 'repository/pcapi/pcapi'
 
 import HomepageBreadcrumb, { STEP_ID_OFFERERS } from './HomepageBreadcrumb'
 import Offerers from './Offerers/Offerers'
 import { ProfileAndSupport } from './ProfileAndSupport'
 
-const Homepage = () => {
+const Homepage = (): JSX.Element => {
   const profileRef = useRef(null)
+  const {
+    currentUser: { hasSeenProRgs },
+  } = useCurrentUser()
+  const [hasClosedRGSBanner, setHasClosedRGSBanner] =
+    useState<boolean>(hasSeenProRgs)
+  const handleCloseRGSBanner = () => {
+    setHasSeenRGSBanner().finally(() => {
+      setHasClosedRGSBanner(true)
+    })
+  }
 
   return (
     <div className="homepage">
       <PageTitle title="Espace acteurs culturels" />
       <h1>Bienvenue dans l’espace acteurs culturels</h1>
-
+      {!hasClosedRGSBanner && (
+        <BannerRGS closable onClose={handleCloseRGSBanner} />
+      )}
       <HomepageBreadcrumb
         activeStep={STEP_ID_OFFERERS}
         profileRef={profileRef}

--- a/pro/src/new_components/Banner/BannerRGS.tsx
+++ b/pro/src/new_components/Banner/BannerRGS.tsx
@@ -2,8 +2,15 @@ import React from 'react'
 
 import Banner from 'ui-kit/Banner'
 
-const BannerRGS = (): JSX.Element => (
+interface Props {
+  closable?: boolean
+  onClose?: () => void
+}
+
+const BannerRGS = ({ closable = false, onClose }: Props): JSX.Element => (
   <Banner
+    closable={closable}
+    handleOnClick={() => onClose?.()}
     href="https://aide.passculture.app/hc/fr/articles/4458607720732--Acteurs-Culturels-Comment-assurer-la-s%C3%A9curit%C3%A9-de-votre-compte-"
     linkTitle="Consulter nos recommandations de sécurité"
     type="attention"

--- a/pro/src/new_components/Banner/__specs__/BannerRGS.spec.tsx
+++ b/pro/src/new_components/Banner/__specs__/BannerRGS.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
-import React from 'react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
+import React from 'react'
 
 import BannerRGS from '../BannerRGS'
 
@@ -15,5 +16,15 @@ describe('src | new_components | BannerRGS', () => {
       'href',
       'https://aide.passculture.app/hc/fr/articles/4458607720732--Acteurs-Culturels-Comment-assurer-la-s%C3%A9curit%C3%A9-de-votre-compte-'
     )
+  })
+  it('should close the banner', () => {
+    const spyClose = jest.fn()
+    render(<BannerRGS closable onClose={spyClose} />)
+    userEvent.click(
+      screen.getByRole('img', {
+        name: 'Masquer le bandeau',
+      })
+    )
+    expect(spyClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/pro/src/repository/pcapi/pcapi.js
+++ b/pro/src/repository/pcapi/pcapi.js
@@ -371,6 +371,12 @@ export const setHasSeenTutos = () => {
   return client.patch(`/users/tuto-seen`)
 }
 
+// RGS Banner
+//
+export const setHasSeenRGSBanner = () => {
+  return client.patch(`/users/rgs-seen`)
+}
+
 //
 // Providers
 //

--- a/pro/src/ui-kit/Banner/Banner.tsx
+++ b/pro/src/ui-kit/Banner/Banner.tsx
@@ -30,7 +30,7 @@ const Banner = ({
     <div className={cn('bi-banner', type, className)}>
       {closable && (
         <button onClick={handleOnClick} type="button">
-          <Icon svg="icons-close" />
+          <Icon alt="Masquer le bandeau" svg="icons-close" />
         </button>
       )}
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13935

## But de la pull request

Ajout d'un bandeau sur la Home jusqu'à ce que l'utilisateur ait cliqué sur Fermer.

## Implémentation
- ajout de la possibilité de fermer le composant `BannerRGS`
- affichage du bandeau sur la home si la propriété `hasSeenProRgs` est `false`
- quand l'utilisateur ferme le bandeau, on masque le bandeau et passe `hasSeenProRgs` à `true`
<img width="1580" alt="Capture d’écran 2022-04-11 à 09 33 13 (2)" src="https://user-images.githubusercontent.com/101103940/162687144-f64ad34f-413e-4d8e-8490-94625c6c2fa5.png">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
