### PR TITLE
(PC-13673)[API] fix: allow yyyy-mm-dd format in jouve birthDate

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -65,8 +65,14 @@ def _parse_jouve_date(date: typing.Optional[str]) -> typing.Optional[datetime.da
         return pydantic.datetime_parse.parse_datetime(date)
     except pydantic.DateTimeError:
         pass
+
     try:
         return datetime.datetime.strptime(date, "%d/%m/%Y")
+    except ValueError:
+        pass
+
+    try:
+        return datetime.datetime.strptime(date, "%Y-%m-%d")
     except ValueError:
         return None
 

--- a/api/tests/core/fraud/test_models.py
+++ b/api/tests/core/fraud/test_models.py
@@ -1,6 +1,9 @@
+import datetime
+
 import pytest
 
 from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud.models import _parse_jouve_date
 
 
 class GetRegistrationDatetimeTest:
@@ -16,11 +19,34 @@ class GetRegistrationDatetimeTest:
     def test_has_no_timezone(self, factory_class):
         content = factory_class()
 
-        datetime = content.get_registration_datetime()
-        assert not datetime.tzinfo
+        registration_datetime = content.get_registration_datetime()
+        assert not registration_datetime.tzinfo
 
 
 class OrphanDmsApplicationTest:
     def test_default_values_on_creation(self):
         orphan = fraud_factories.OrphanDmsFraudCheckFactory(process_id=1, application_id=2)
         assert orphan.email is None
+
+
+class FraudHelperFunctionsTest:
+    @pytest.mark.parametrize(
+        "date",
+        [
+            "2020-01-01",
+            "01/01/2020",
+            "2020-01-01T00:00:00",
+        ],
+    )
+    def test__parse_jouve_date_success(self, date):
+        assert _parse_jouve_date(date) == datetime.datetime(2020, 1, 1, 0, 0)
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            "Yesteryear",
+            "2020/01/01",
+        ],
+    )
+    def test__parse_jouve_date_error(self, date):
+        assert _parse_jouve_date(date) is None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13673

## But de la pull request

Les formats de dates de naissance sur les fraud checks jouve ressemblent à ceci:
![image](https://user-images.githubusercontent.com/14235661/159051343-802b3d00-7581-458c-aefa-91fe07e05e3b.png)

On veut pouvoir les lire à l'activation de l'utilisateur

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
