### PR TITLE
(PC-14065)[ADAGE] feat: handle mail in description

### DIFF
--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -260,7 +260,8 @@ describe('offer', () => {
         ...offerInParis,
         description: `lien 1 : www.lien1.com
           https://lien2.com et http://lien3.com
-          https://\nurl.com http://unlien avecuneespace`,
+          https://\nurl.com http://unlien avecuneespace
+          contact: toto@toto.com`,
       })
 
       // When
@@ -277,7 +278,7 @@ describe('offer', () => {
 
       const links = within(descriptionParagraph).getAllByRole('link')
 
-      expect(links).toHaveLength(5)
+      expect(links).toHaveLength(6)
       expect((links[0] as HTMLLinkElement).href).toBe('https://www.lien1.com/')
       expect((links[0] as HTMLLinkElement).childNodes[0].nodeValue).toBe(
         'www.lien1.com'
@@ -286,6 +287,7 @@ describe('offer', () => {
       expect((links[2] as HTMLLinkElement).href).toBe('http://lien3.com/')
       expect((links[3] as HTMLLinkElement).href).toBe('https://')
       expect((links[4] as HTMLLinkElement).href).toBe('http://unlien/')
+      expect((links[5] as HTMLLinkElement).href).toBe('mailto:toto@toto.com')
     })
   })
 })

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/utils/formatDescription.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/utils/formatDescription.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 
-type WordOrLinkItem = { type: 'word' | 'link'; value: string }
+type WordOrLinkItem = { type: 'word' | 'link' | 'mail'; value: string }
+
+// Found here: http://emailregex.com/
+const EMAIL_REGEXP = new RegExp(
+  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+)
 
 const addLinkItemWithSpace = (value: string, list: WordOrLinkItem[]) => {
   list.push({ type: 'link', value })
@@ -9,6 +14,11 @@ const addLinkItemWithSpace = (value: string, list: WordOrLinkItem[]) => {
 
 const addWordItemWithSpace = (value: string, list: WordOrLinkItem[]) => {
   list.push({ type: 'word', value })
+  list.push({ type: 'word', value: ' ' })
+}
+
+const addMailItemWithSpace = (value: string, list: WordOrLinkItem[]) => {
+  list.push({ type: 'mail', value })
   list.push({ type: 'word', value: ' ' })
 }
 
@@ -23,11 +33,16 @@ export const formatDescription = (description: string): React.ReactNode => {
         )
       ) {
         // add link with following space
-        addLinkItemWithSpace(wordOrLink, descriptionWordsItems)
-      } else {
-        // add word with following space
-        addWordItemWithSpace(wordOrLink, descriptionWordsItems)
+        return addLinkItemWithSpace(wordOrLink, descriptionWordsItems)
       }
+
+      if (wordOrLink.match(EMAIL_REGEXP)) {
+        // add mail with following space
+        return addMailItemWithSpace(wordOrLink, descriptionWordsItems)
+      }
+
+      // add word with following space
+      return addWordItemWithSpace(wordOrLink, descriptionWordsItems)
     })
 
     // re add line break
@@ -50,6 +65,10 @@ export const formatDescription = (description: string): React.ReactNode => {
           {value}
         </a>
       )
+    }
+
+    if (type === 'mail') {
+      return <a href={`mailto:${value}`}>{value}</a>
     }
 
     return value


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14065

## But de la pull request

Si un AC écrit un mail dans la description de son offre, on veut pouvoir ouvrir directement le client mail au clic

<img width="783" alt="Capture d’écran 2022-03-21 à 10 22 09" src="https://user-images.githubusercontent.com/35567446/159235122-465e8940-0e6d-4e64-8ece-414ac48e4c75.png">
