### PR TITLE
Pc 12934/get educational institution info for cancellation email to pro

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -312,10 +312,15 @@ def find_expired_educational_bookings() -> list[EducationalBooking]:
             .load_only(Stock.beginningDatetime)
             .joinedload(Stock.offer, innerjoin=True)
             .load_only(Offer.name)
+            .joinedload(Offer.venue, innerjoin=True)
+            .load_only(Venue.name)
         )
         .options(
-            joinedload(EducationalBooking.educationalRedactor, innerjoin=True).load_only(EducationalRedactor.email)
+            joinedload(EducationalBooking.educationalRedactor, innerjoin=True).load_only(
+                EducationalRedactor.email, EducationalRedactor.firstName, EducationalRedactor.lastName
+            )
         )
+        .options(joinedload(EducationalBooking.educationalInstitution, innerjoin=True))
         .all()
     )
 

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -347,8 +347,15 @@ def refuse_educational_booking(educational_booking_id: int) -> EducationalBookin
             template=TransactionalEmail.EDUCATIONAL_BOOKING_CANCELLATION_BY_INSTITUTION.value,
             params={
                 "OFFER_NAME": stock.offer.name,
-                "EVENT_BEGINNING_DATETIME": stock.beginningDatetime.strftime("%d/%m/%Y à %H:%M"),
-                "EDUCATIONAL_REDACTOR_EMAIL": educational_booking.educationalRedactor.email,
+                "EDUCATIONAL_INSTITUTION_NAME": educational_booking.educationalInstitution.name,
+                "VENUE_NAME": stock.offer.venue.name,
+                "EVENT_DATE": stock.beginningDatetime.strftime("%d/%m/%Y"),
+                "EVENT_HOUR": stock.beginningDatetime.strftime("%H:%M"),
+                "REDACTOR_FIRSTNAME": educational_booking.educationalRedactor.firstName,
+                "REDACTOR_LASTNAME": educational_booking.educationalRedactor.lastName,
+                "REDACTOR_EMAIL": educational_booking.educationalRedactor.email,
+                "EDUCATIONAL_INSTITUTION_CITY": educational_booking.educationalInstitution.city,
+                "EDUCATIONAL_INSTITUTION_POSTAL_CODE": educational_booking.educationalInstitution.postalCode,
             },
         )
         mails.send(recipients=[booking_email], data=data)

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -37,6 +37,9 @@ from pcapi.core.educational.repository import find_collective_booking_by_booking
 from pcapi.core.educational.repository import get_and_lock_collective_stock
 from pcapi.core.educational.utils import compute_educational_booking_cancellation_limit_date
 from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
+from pcapi.core.mails.transactional.bookings.booking_cancellation_by_institution import (
+    send_education_booking_cancellation_by_institution_email,
+)
 from pcapi.core.mails.transactional.educational.eac_new_booking_to_pro import send_eac_new_booking_email_to_pro
 from pcapi.core.mails.transactional.educational.eac_new_prebooking_to_pro import send_eac_new_prebooking_email_to_pro
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
@@ -344,22 +347,7 @@ def refuse_educational_booking(educational_booking_id: int) -> EducationalBookin
 
     booking_email = booking.stock.offer.bookingEmail
     if booking_email and not FeatureToggle.ENABLE_NEW_COLLECTIVE_MODEL.is_active():
-        data = SendinblueTransactionalEmailData(
-            template=TransactionalEmail.EDUCATIONAL_BOOKING_CANCELLATION_BY_INSTITUTION.value,
-            params={
-                "OFFER_NAME": stock.offer.name,
-                "EDUCATIONAL_INSTITUTION_NAME": educational_booking.educationalInstitution.name,
-                "VENUE_NAME": stock.offer.venue.name,
-                "EVENT_DATE": stock.beginningDatetime.strftime("%d/%m/%Y"),
-                "EVENT_HOUR": stock.beginningDatetime.strftime("%H:%M"),
-                "REDACTOR_FIRSTNAME": educational_booking.educationalRedactor.firstName,
-                "REDACTOR_LASTNAME": educational_booking.educationalRedactor.lastName,
-                "REDACTOR_EMAIL": educational_booking.educationalRedactor.email,
-                "EDUCATIONAL_INSTITUTION_CITY": educational_booking.educationalInstitution.city,
-                "EDUCATIONAL_INSTITUTION_POSTAL_CODE": educational_booking.educationalInstitution.postalCode,
-            },
-        )
-        mails.send(recipients=[booking_email], data=data)
+        send_education_booking_cancellation_by_institution_email(educational_booking)
 
     search.async_index_offer_ids([stock.offerId])
 

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -33,6 +33,7 @@ from pcapi.core.educational.models import EducationalInstitution
 from pcapi.core.educational.models import EducationalRedactor
 from pcapi.core.educational.models import EducationalYear
 from pcapi.core.educational.models import Ministry
+from pcapi.core.educational.repository import find_collective_booking_by_booking_id
 from pcapi.core.educational.repository import get_and_lock_collective_stock
 from pcapi.core.educational.utils import compute_educational_booking_cancellation_limit_date
 from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
@@ -371,9 +372,7 @@ def refuse_collective_booking(educational_booking_id: int) -> Optional[Collectiv
     if educational_booking is None:
         raise exceptions.EducationalBookingNotFound()
 
-    collective_booking = CollectiveBooking.query.filter(
-        CollectiveBooking.bookingId == educational_booking.booking.id
-    ).first()
+    collective_booking = find_collective_booking_by_booking_id(educational_booking.booking.id)
 
     if collective_booking is None:
         # FIXME (MathildeDuboille - 2022-03-03): raise an error once data has been migrated to the new model

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -33,6 +33,7 @@ class CollectiveOfferFactory(BaseFactory):
     dateCreated = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=5))
     students = [StudentLevels.GENERAL2]
     contactEmail = "collectiveofferfactory+contact@example.com"
+    bookingEmail = "collectiveofferfactory+booking@example.com"
     contactPhone = "+33199006328"
     offerVenue = {
         "addressType": "other",

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -104,6 +104,11 @@ class EducationalInstitutionFactory(BaseFactory):
         model = models.EducationalInstitution
 
     institutionId = factory.Sequence("{}470009E".format)
+    name = factory.Sequence("Collège de la tour{}".format)
+    city = "Paris"
+    postalCode = "75000"
+    email = "contact+collegelatour@example.com"
+    phoneNumber = None
 
 
 class EducationalYearFactory(BaseFactory):

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -20,6 +20,7 @@ from pcapi.core.educational.exceptions import StockDoesNotExist
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
 
@@ -69,12 +70,22 @@ def find_educational_booking_by_id(
         educational_models.EducationalBooking.query.filter(
             educational_models.EducationalBooking.id == educational_booking_id
         )
-        .join(Booking)
         .options(
-            joinedload(educational_models.EducationalBooking.educationalRedactor).load_only(
-                educational_models.EducationalRedactor.email
+            joinedload(educational_models.EducationalBooking.booking, innerjoin=True)
+            .joinedload(Booking.stock, innerjoin=True)
+            .joinedload(Stock.offer, innerjoin=True)
+            .load_only(Offer.name)
+            .joinedload(Offer.venue, innerjoin=True)
+            .load_only(Venue.name)
+        )
+        .options(
+            joinedload(educational_models.EducationalBooking.educationalRedactor, innerjoin=True).load_only(
+                educational_models.EducationalRedactor.email,
+                educational_models.EducationalRedactor.firstName,
+                educational_models.EducationalRedactor.lastName,
             )
         )
+        .options(joinedload(educational_models.EducationalBooking.educationalInstitution, innerjoin=True))
         .one_or_none()
     )
 

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -90,6 +90,28 @@ def find_educational_booking_by_id(
     )
 
 
+def find_collective_booking_by_booking_id(booking_id: int) -> Optional[educational_models.CollectiveBooking]:
+    return (
+        CollectiveBooking.query.filter(educational_models.CollectiveBooking.bookingId == booking_id)
+        .options(
+            joinedload(educational_models.CollectiveBooking.collectiveStock, innerjoin=True)
+            .joinedload(educational_models.CollectiveStock.collectiveOffer, innerjoin=True)
+            .load_only(educational_models.CollectiveOffer.name)
+            .joinedload(educational_models.CollectiveOffer.venue, innerjoin=True)
+            .load_only(Venue.name)
+        )
+        .options(joinedload(educational_models.CollectiveBooking.educationalInstitution, innerjoin=True))
+        .options(
+            joinedload(educational_models.CollectiveBooking.educationalRedactor, innerjoin=True).load_only(
+                educational_models.EducationalRedactor.email,
+                educational_models.EducationalRedactor.firstName,
+                educational_models.EducationalRedactor.lastName,
+            )
+        )
+        .one_or_none()
+    )
+
+
 def find_educational_year_by_date(date_searched: datetime) -> Optional[educational_models.EducationalYear]:
     return educational_models.EducationalYear.query.filter(
         date_searched >= educational_models.EducationalYear.beginningDate,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_institution.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_institution.py
@@ -7,14 +7,22 @@ from pcapi.core.mails.transactional.sendinblue_template_ids import Transactional
 def get_education_booking_cancellation_by_institution_email_data(
     educational_booking: EducationalBooking,
 ) -> SendinblueTransactionalEmailData:
+    stock = educational_booking.booking.stock
+    institution = educational_booking.educationalInstitution
+    redactor = educational_booking.educationalRedactor
     return SendinblueTransactionalEmailData(
         template=TransactionalEmail.EDUCATIONAL_BOOKING_CANCELLATION_BY_INSTITUTION.value,
         params={
-            "OFFER_NAME": educational_booking.booking.stock.offer.name,
-            "EVENT_BEGINNING_DATETIME": educational_booking.booking.stock.beginningDatetime.strftime(
-                "%d/%m/%Y à %H:%M"
-            ),
-            "EDUCATIONAL_REDACTOR_EMAIL": educational_booking.educationalRedactor.email,
+            "OFFER_NAME": stock.offer.name,
+            "EDUCATIONAL_INSTITUTION_NAME": institution.name,
+            "VENUE_NAME": stock.offer.venue.name,
+            "EVENT_DATE": stock.beginningDatetime.strftime("%d/%m/%Y"),
+            "EVENT_HOUR": stock.beginningDatetime.strftime("%H:%M"),
+            "REDACTOR_FIRSTNAME": redactor.firstName,
+            "REDACTOR_LASTNAME": redactor.lastName,
+            "REDACTOR_EMAIL": redactor.email,
+            "EDUCATIONAL_INSTITUTION_CITY": institution.city,
+            "EDUCATIONAL_INSTITUTION_POSTAL_CODE": institution.postalCode,
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -23,7 +23,7 @@ class TransactionalEmail(Enum):
         id_prod=144, id_not_prod=42, tags=["jeunes_reservation_bientot_expiree"]
     )
     EDUCATIONAL_BOOKING_CANCELLATION_BY_INSTITUTION = Template(
-        id_prod=406, id_not_prod=41, tags=["eac_annulationoffre"]
+        id_prod=522, id_not_prod=65, tags=["eac_annulationoffre"]
     )
     EMAIL_CHANGE_CONFIRMATION = Template(
         id_prod=253, id_not_prod=18, tags=["changement_email_confirmation"], use_priority_queue=True

--- a/api/tests/routes/adage/v1/refuse_prebookings_test.py
+++ b/api/tests/routes/adage/v1/refuse_prebookings_test.py
@@ -225,6 +225,7 @@ class Returns200Test:
 
         assert response.status_code == 200
         assert refused_collective_booking.status == CollectiveBookingStatus.CANCELLED
+        assert len(mails_testing.outbox) == 0
 
 
 @pytest.mark.usefixtures("db_session")
@@ -238,8 +239,8 @@ class Returns400Test:
         response = client.post(f"/adage/v1/prebookings/{booking.educationalBookingId}/refuse")
 
         assert response.status_code == 422
-
         assert response.json == {"code": "EDUCATIONAL_BOOKING_NOT_REFUSABLE"}
+        assert len(mails_testing.outbox) == 0
 
     def test_returns_error_when_already_cancelled(self, client) -> None:
         booking = EducationalBookingFactory(
@@ -250,16 +251,16 @@ class Returns400Test:
         response = client.post(f"/adage/v1/prebookings/{booking.educationalBookingId}/refuse")
 
         assert response.status_code == 422
-
         assert response.json == {"code": "EDUCATIONAL_BOOKING_ALREADY_CANCELLED"}
+        assert len(mails_testing.outbox) == 0
 
     def test_returns_error_when_no_educational_booking_found(self, client) -> None:
         client = client.with_eac_token()
         response = client.post("/adage/v1/prebookings/123/refuse")
 
         assert response.status_code == 404
-
         assert response.json == {"code": "EDUCATIONAL_BOOKING_NOT_FOUND"}
+        assert len(mails_testing.outbox) == 0
 
     def test_returns_error_when_cancellation_limit_date_is_passed(self, client) -> None:
         booking = EducationalBookingFactory(
@@ -271,5 +272,5 @@ class Returns400Test:
         response = client.post(f"/adage/v1/prebookings/{booking.educationalBookingId}/refuse")
 
         assert response.status_code == 422
-
         assert response.json == {"code": "EDUCATIONAL_BOOKING_NOT_REFUSABLE"}
+        assert len(mails_testing.outbox) == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12934

## But de la pull request

- Utilisation du nouveau template d'email envoyé aux AC lorsqu'une réservation collective est annulée
- Il s'agit en fait du cas où une réservation est annulée par le chef d'établissement

## Implémentation

- dans les fonctions api `refuse_educational_booking` et `refuse_collective_booking`, changement des data pour les envoyer au nouveau template
- changement du template dans la config SiB

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
