### PR TITLE
(PC 14072)[PRO] test: migrate enzyme tests for SignUp Form to RTL

### DIFF
--- a/pro/src/components/pages/Signup/SignupConfirmation/SignupConfirmation.jsx
+++ b/pro/src/components/pages/Signup/SignupConfirmation/SignupConfirmation.jsx
@@ -20,7 +20,7 @@ const SignupConfirmation = () => (
           </div>
           <div className="information-text flex-left">
             <img
-              alt="picto info"
+              alt="information"
               src={`${ROOT_PATH}/icons/picto-info-grey.svg`}
             />
             <p>

--- a/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
@@ -229,11 +229,9 @@ class SignupForm extends PureComponent {
     )
   }
 }
-
 SignupForm.defaultProps = {
   currentUser: null,
 }
-
 SignupForm.propTypes = {
   createNewProUser: PropTypes.func.isRequired,
   currentUser: PropTypes.shape(),

--- a/pro/src/components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { Router } from 'react-router-dom'
 
-import configureStore from 'store'
+import { configureTestStore } from 'store/testUtils'
 
 import SignupForm from '../SignupForm'
 
@@ -23,26 +23,26 @@ describe('src | components | pages | Signup | SignupForm', () => {
       showNotification: jest.fn(),
     }
     history = createBrowserHistory()
-    store = configureStore({
+    store = configureTestStore({
       data: {
         users: null,
       },
       features: {
         list: [{ isActive: true, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    }).store
+    })
   })
 
   it('should redirect to home page if the user is logged in', async () => {
     // when the user is logged in and lands on signup validation page
-    store = configureStore({
+    store = configureTestStore({
       data: {
         users: [{ id: 'CMOI' }],
       },
       features: {
         list: [{ isActive: true, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    }).store
+    })
     render(
       <Provider store={store}>
         <Router history={history}>

--- a/pro/src/components/pages/Signup/SignupValidation/SignupValidation.jsx
+++ b/pro/src/components/pages/Signup/SignupValidation/SignupValidation.jsx
@@ -14,25 +14,26 @@ class SignupValidation extends PureComponent {
     super(props)
     const { currentUser, location, history } = props
     redirectLoggedUser(history, location, currentUser)
+    this.state = {}
   }
 
   componentDidMount() {
     campaignTracker.signUpValidation()
-
     const {
       match: {
         params: { token },
       },
     } = this.props
-
     this.buildRequestData(token)
   }
 
   buildRequestData = async token => {
-    await pcapi
-      .validateUser(token)
-      .then(() => this.notifySuccess())
-      .catch(payload => this.notifyFailure(payload))
+    if (!this.props.currentUser)
+      await pcapi
+        .validateUser(token)
+        .then(() => this.notifySuccess())
+        .catch(payload => this.notifyFailure(payload))
+        .finally(() => this.setState({ isReady: true }))
   }
 
   notifyFailure = payload => {
@@ -49,17 +50,16 @@ class SignupValidation extends PureComponent {
   }
 
   render() {
-    return <Redirect to="/connexion" />
+    return this.state.isReady ? <Redirect to="/connexion" /> : null
   }
 }
-
 SignupValidation.defaultProps = {
   currentUser: null,
 }
 
 SignupValidation.propTypes = {
   currentUser: PropTypes.shape(),
-  history: PropTypes.func.isRequired,
+  history: PropTypes.shape().isRequired,
   location: PropTypes.shape().isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({

--- a/pro/src/components/pages/Signup/SignupValidation/__specs__/SignupValidation.spec.jsx
+++ b/pro/src/components/pages/Signup/SignupValidation/__specs__/SignupValidation.spec.jsx
@@ -7,7 +7,7 @@ import { Router } from 'react-router-dom'
 
 import * as routerHelpers from 'components/router/helpers'
 import * as pcapi from 'repository/pcapi/pcapi'
-import configureStore from 'store'
+import { configureTestStore } from 'store/testUtils'
 import { campaignTracker } from 'tracking/mediaCampaignsTracking'
 
 import SignupValidation from '../SignupValidation'
@@ -20,14 +20,14 @@ describe('src | components | pages | Signup | validation', () => {
   let store
 
   beforeEach(() => {
-    store = configureStore({
+    store = configureTestStore({
       data: {
         users: null,
       },
       features: {
         list: [{ isActive: true, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    }).store
+    })
     history = createBrowserHistory()
     props = {
       history,

--- a/pro/src/components/pages/Signup/__specs__/Signup.spec.jsx
+++ b/pro/src/components/pages/Signup/__specs__/Signup.spec.jsx
@@ -1,18 +1,14 @@
-import { mount } from 'enzyme'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
-import Logo from 'components/layout/Logo'
 import * as pcapi from 'repository/pcapi/pcapi'
 import configureStore from 'store'
 import { campaignTracker } from 'tracking/mediaCampaignsTracking'
-import { enzymeWaitFor } from 'utils/testHelpers'
 
 import Signup from '../Signup'
-import SignupConfirmation from '../SignupConfirmation/SignupConfirmation'
-import SignupForm from '../SignupForm/SignupForm'
-import SignupUnavailable from '../SignupUnavailable/SignupUnavailable'
 
 jest.mock('repository/pcapi/pcapi', () => ({
   loadFeatures: jest.fn(),
@@ -42,7 +38,7 @@ describe('src | components | pages | Signup', () => {
     }
 
     // when
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter>
           <Signup {...props} />
@@ -51,10 +47,9 @@ describe('src | components | pages | Signup', () => {
     )
 
     // then
-    const logo = wrapper.find(Logo)
-    const signupForm = wrapper.find(SignupForm)
-    expect(logo).toHaveLength(1)
-    expect(signupForm).toHaveLength(1)
+    expect(
+      screen.getByRole('heading', { name: /Créer votre compte professionnel/ })
+    ).toBeInTheDocument()
   })
 
   it('should render logo and confirmation page', () => {
@@ -66,7 +61,7 @@ describe('src | components | pages | Signup', () => {
     }
 
     // when
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter>
           <Signup {...props} />
@@ -75,10 +70,9 @@ describe('src | components | pages | Signup', () => {
     )
 
     // then
-    const logo = wrapper.find(Logo)
-    const signupConfirmation = wrapper.find(SignupConfirmation)
-    expect(logo).toHaveLength(1)
-    expect(signupConfirmation).toHaveLength(1)
+    expect(
+      screen.getByText(/Votre compte est en cours de création./)
+    ).toBeInTheDocument()
   })
 
   it('should render maintenance page when signup is unavailable', async () => {
@@ -95,7 +89,7 @@ describe('src | components | pages | Signup', () => {
     }).store
 
     // when
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter>
           <Signup {...props} />
@@ -104,8 +98,9 @@ describe('src | components | pages | Signup', () => {
     )
 
     // then
-    const unavailablePage = wrapper.find(SignupUnavailable)
-    expect(unavailablePage).toHaveLength(1)
+    expect(
+      screen.getByRole('heading', { name: /Inscription indisponible/ })
+    ).toBeInTheDocument()
   })
 
   it('should call media campaign tracker on mount only', async () => {
@@ -121,26 +116,23 @@ describe('src | components | pages | Signup', () => {
     }
 
     // when
-    const wrapper = mount(
+    const { rerender } = render(
       <Provider store={store}>
         <MemoryRouter>
           <Signup {...props} />
         </MemoryRouter>
       </Provider>
     )
-    wrapper.update()
-
-    // then
-    await enzymeWaitFor(() =>
-      expect(campaignTracker.signUp).toHaveBeenCalledTimes(1)
-    )
-
     // when rerender
-    wrapper.setProps(props)
+    rerender(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Signup {...props} />
+        </MemoryRouter>
+      </Provider>
+    )
 
     // then
-    await enzymeWaitFor(() =>
-      expect(campaignTracker.signUp).toHaveBeenCalledTimes(1)
-    )
+    expect(campaignTracker.signUp).toHaveBeenCalledTimes(1)
   })
 })

--- a/pro/src/components/pages/Signup/__specs__/Signup.spec.jsx
+++ b/pro/src/components/pages/Signup/__specs__/Signup.spec.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
 import * as pcapi from 'repository/pcapi/pcapi'
-import configureStore from 'store'
+import { configureTestStore } from 'store/testUtils'
 import { campaignTracker } from 'tracking/mediaCampaignsTracking'
 
 import Signup from '../Signup'
@@ -17,14 +17,14 @@ jest.mock('repository/pcapi/pcapi', () => ({
 describe('src | components | pages | Signup', () => {
   let store
   beforeEach(() => {
-    store = configureStore({
+    store = configureTestStore({
       data: {
         users: null,
       },
       features: {
         list: [{ isActive: true, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    }).store
+    })
     pcapi.loadFeatures.mockResolvedValue([])
   })
   afterEach(jest.resetAllMocks)
@@ -82,11 +82,11 @@ describe('src | components | pages | Signup', () => {
         pathname: '/inscription',
       },
     }
-    const store = configureStore({
+    const store = configureTestStore({
       features: {
         list: [{ isActive: false, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    }).store
+    })
 
     // when
     render(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14072

## But de la pull request

Migration des tests du SignUp Form

## Implémentation

- transformation des fichiers `SignupValidation.spec.jsx`, `SignupForm.spec.jsx` et `Signup.spec.jsx`

## Informations

- Le fichier `SignupFormContainer.spec.js` n'a pas été migré, je ne vois pas comment le passer en RTL tel quel, je le ferai lors de la refacto
- ajout d'une condition pour éviter l'appel à l'API de validation de token quand l'utilisateur est déjà loggé
- BSR: correction du texte alternatif dans `SignupConfirmation.jsx`


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
