### PR TITLE
(PC-13938)[PRO] Fix bu name when not correponding to venue name

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -811,7 +811,8 @@ def edit_business_unit(business_unit: models.BusinessUnit, siret: str) -> None:
         raise ValueError("Cannot edit a business unit that already has a SIRET.")
 
     validation.check_business_unit_siret(business_unit, siret)
-
+    venue = offerers_models.Venue.query.filter(offerers_models.Venue.siret == siret).one()
+    business_unit.name = venue.publicName or venue.name
     business_unit.siret = siret
     db.session.add(business_unit)
     db.session.commit()

--- a/api/src/pcapi/scripts/business_unit/rename_bu_not_matching_venue_public_name.py
+++ b/api/src/pcapi/scripts/business_unit/rename_bu_not_matching_venue_public_name.py
@@ -1,0 +1,26 @@
+import sqlalchemy.sql.functions as sqla_func
+
+from pcapi.core.finance.models import BusinessUnit
+from pcapi.core.offerers.models import Venue
+from pcapi.models import db
+
+
+# FIXME (amarinier 24/03/2022): to delete when PC-13938 is merged
+
+
+def rename_bu_not_matching_venue_public_name():
+    print("Renaming bu with invalid name...")
+    invalid_bu = (
+        BusinessUnit.query.join(Venue, BusinessUnit.siret == Venue.siret)
+        .filter(BusinessUnit.siret.isnot(None))
+        .filter(BusinessUnit.name != sqla_func.coalesce(Venue.publicName, Venue.name))
+        .all()
+    )
+    for bu in invalid_bu:
+        bu_venue = Venue.query.filter(Venue.siret == bu.siret).first()
+        print(f"Updating Business unit {bu.id} with siret {bu.siret}")
+        if bu_venue:
+            bu.name = bu_venue.publicName or bu_venue.name
+            db.session.add(bu)
+    print("Done : all bu have been renamed")
+    db.session.commit()

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -900,6 +900,7 @@ class EditBusinessUnitTest:
         venue = offerers_factories.VenueFactory(
             businessUnit__siret=None,
             managingOfferer__siren="123456789",
+            siret="12345678901234",
         )
         business_unit = venue.businessUnit
 
@@ -907,6 +908,7 @@ class EditBusinessUnitTest:
 
         business_unit = models.BusinessUnit.query.one()
         assert business_unit.siret == "12345678901234"
+        assert business_unit.name == venue.publicName
 
     def test_cannot_edit_siret_if_one_is_already_set(self):
         venue = offerers_factories.VenueFactory(

--- a/api/tests/routes/pro/edit_business_unit_test.py
+++ b/api/tests/routes/pro/edit_business_unit_test.py
@@ -10,8 +10,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 def test_edit_business_unit(client):
     venue = offerers_factories.VenueFactory(
-        businessUnit__siret=None,
-        managingOfferer__siren="123456789",
+        businessUnit__siret=None, managingOfferer__siren="123456789", siret="12345678901234"
     )
     business_unit = venue.businessUnit
     pro = users_factories.ProFactory(offerers=[venue.managingOfferer])

--- a/api/tests/scripts/business_unit/rename_bu_not_matching_venue_public_name_test.py
+++ b/api/tests/scripts/business_unit/rename_bu_not_matching_venue_public_name_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+import pcapi.core.offers.factories as offers_factories
+from pcapi.scripts.business_unit.rename_bu_not_matching_venue_public_name import (
+    rename_bu_not_matching_venue_public_name,
+)
+
+
+@pytest.mark.usefixtures("db_session")
+class RenameBuNotMatchingVenuePublicNameTest:
+    def test_rename_bu_not_matching_venue_public_name(self):
+        # Given
+        venue1 = offers_factories.VenueFactory(
+            businessUnit__name="Point de remboursement #1",
+            businessUnit__siret="11111111100000",
+            managingOfferer__siren="111111111",
+            siret="11111111100000",
+        )
+        venue2 = offers_factories.VenueFactory(
+            businessUnit__name="Point de remboursement #2",
+            businessUnit__siret=None,
+            managingOfferer__siren="222222222",
+            siret="22222222200000",
+        )
+        venue3 = offers_factories.VenueFactory(
+            businessUnit__name="Point de remboursement #3",
+            businessUnit__siret="33333333300000",
+            managingOfferer__siren="333333333",
+            siret="33333333300000",
+            publicName=None,
+        )
+
+        bu_with_siret = venue1.businessUnit
+        bu_without_siret = venue2.businessUnit
+        bu_venue_without_public_name = venue3.businessUnit
+
+        # When
+        rename_bu_not_matching_venue_public_name()
+
+        # Assert
+        assert bu_with_siret.name == venue1.publicName
+        assert bu_without_siret.name != venue2.publicName
+        assert bu_venue_without_public_name.name == venue3.name


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13938

## But de la pull request

Certains noms de business unit ne correspondent pas au nom du lieu auquel elles sont rattachées, l'objectif de cette PR est double : 

- Corriger via un script les noms incorrect quand la business unit possède un siret 
- Corriger la route permettant d'éditer le siret d'une business unit pour modifier le nom à ce moment là

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
