### PR TITLE
(PC-14103)[API] feat: change ubble image archive rules for passport

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -204,6 +204,7 @@ def get_content(identification_id: str) -> ubble_fraud_models.UbbleContent:
             "score": content.score,
             "status": content.status.value,
             "request_type": "get-content",
+            "document_type": content.document_type,
         },
     )
     return content

--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -117,6 +117,7 @@ class UbbleIdentificationDocuments(UbbleIdentificationObject):
     married_name: str = pydantic.Field(None, alias="married-name")
     signed_image_front_url: str = pydantic.Field(None, alias="signed-image-front-url")
     signed_image_back_url: str = pydantic.Field(None, alias="signed-image-back-url")
+    document_type: str = pydantic.Field(None, alias="document-type")
 
 
 class UbbleIdentificationDocumentChecks(UbbleIdentificationObject):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14103

## But de la pull request

Evolution du statut pour le stockage des images d'identité Ubble.
Avant : On considérait que les images étaient stockées si on avait archivé l'image Front et l'image Back.
Désormais: On considère la réussite de l'archive si les images fournies par ubble sont bien stockées sur le bucket sécurisé.

Pourquoi ? 
Pour certain type de pièce d'identité (passport), Ubble nous remonte uniquement l'image Front ce qui était considéré comme une erreur jusqu'alors.

## Implémentation

- changement de critère de succès sur le stockage froid des images d'identification des jeunes.


## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
