### PR TITLE
(PC-13726)[PRO] fix: prevent codes activation adding when offer is di…

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
@@ -313,7 +313,7 @@ const StockItem = ({
       <td>{!isNewStock && initialStock.bookingsQuantity}</td>
       <td className="action-column">
         <StockItemOptionsMenu
-          canAddActivationCodes={isDigital}
+          canAddActivationCodes={isDigital && !isEvent}
           deleteButtonTitle={computeStockDeleteButtonTitle()}
           deleteStock={
             isNewStock ? removeNewStockLine : askDeletionConfirmation

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -2939,6 +2939,23 @@ describe('stocks page', () => {
             )
           ).toBeInTheDocument()
         })
+        it('should not allow the user to add activation codes when offer is digital and is event', async () => {
+          let eventOffer = {
+            ...digitalOffer,
+            isEvent: true,
+          }
+          jest.spyOn(apiV1, 'getOffersGetOffer').mockResolvedValue(eventOffer)
+          // given
+          await renderOffers(props, store)
+
+          // when
+          fireEvent.click(screen.getByText('Ajouter une date'))
+
+          // then
+          expect(
+            screen.queryByText('Ajouter des codes d’activation')
+          ).not.toBeInTheDocument()
+        })
 
         it('should display number of activation codes to be added', async () => {
           // Given


### PR DESCRIPTION
…gital and event

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13726

## But de la pull request

Empêcher la possibilité d'ajouter des codes d’activation sur ma page stock pour les offres numériques datées (digital & event)

## Screenshot

![NoActCode](https://user-images.githubusercontent.com/71768799/159560137-642aff16-7cf1-4bff-a731-34e7549fb06b.PNG)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
