### PR TITLE
[bsr][api][qa] Bump mypy version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -37,7 +37,7 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 mailjet-rest==1.3.3
 MarkupSafe==2.0.1
-mypy==0.812
+mypy==0.941
 notion-client==0.9.0
 pgcli==2.2.0
 phonenumberslite==8.12.23


### PR DESCRIPTION
Version 0.812 requires `typed-ast<1.5`, for which there is no wheel
for one of our colleagues who uses a Mac M1, who hence has to compile
the library, which does not work, yada yada yada...

Let's use the latest version of mypy instead (which now requires
`typed-ast<2`, for which there _is_ a wheel).

(We should probably unpin mypy but it's not my call to make because I
don't use it.)