### PR TITLE
(PC-14083)[API] feat:notification: send today instead of tomorrow

### DIFF
--- a/api/src/pcapi/notifications/push/transactional_notifications.py
+++ b/api/src/pcapi/notifications/push/transactional_notifications.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class GroupId(Enum):
     CANCEL_BOOKING = "Cancel_booking"
-    TOMORROW_STOCK = "Tomorrow_stock"
+    TODAY_STOCK = "Today_stock"
     OFFER_LINK = "Offer_link"
     SOON_EXPIRING_BOOKINGS = "Soon_expiring_bookings"
 
@@ -53,7 +53,7 @@ def get_bookings_cancellation_notification_data(booking_ids: list[int]) -> Optio
     )
 
 
-def get_tomorrow_stock_notification_data(stock_id: int) -> Optional[TransactionalNotificationData]:
+def get_today_stock_notification_data(stock_id: int) -> Optional[TransactionalNotificationData]:
     stock = Stock.query.filter_by(id=stock_id).one()
     query = (
         Booking.query.filter(Booking.stockId == stock_id, Booking.status != BookingStatus.CANCELLED)
@@ -67,10 +67,10 @@ def get_tomorrow_stock_notification_data(stock_id: int) -> Optional[Transactiona
         return None
 
     return TransactionalNotificationData(
-        group_id=GroupId.TOMORROW_STOCK.value,
+        group_id=GroupId.TODAY_STOCK.value,
         user_ids=user_ids,
         message=TransactionalNotificationMessage(
-            title=f"{stock.offer.name}, c'est demain !",
+            title=f"{stock.offer.name}, c'est aujourd'hui !",
             body="Retrouve les détails de la réservation sur l’application pass Culture",
         ),
     )

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -23,6 +23,7 @@ from pcapi.core.offers.repository import check_stock_consistency
 from pcapi.core.offers.repository import delete_past_draft_collective_offers
 from pcapi.core.offers.repository import delete_past_draft_offers
 from pcapi.core.offers.repository import find_event_stocks_happening_in_x_days
+from pcapi.core.offers.repository import find_today_event_stock_ids_metropolitan_france
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.core.subscription.dms import api as dms_api
 from pcapi.core.users import api as users_api
@@ -43,7 +44,7 @@ from pcapi.scripts.booking import notify_soon_to_be_expired_bookings
 from pcapi.scripts.payment import user_recredit
 from pcapi.tasks import batch_tasks
 from pcapi.utils.blueprint import Blueprint
-from pcapi.workers.push_notification_job import send_tomorrow_stock_notification
+from pcapi.workers.push_notification_job import send_today_stock_notification
 
 
 blueprint = Blueprint(__name__, __name__)
@@ -165,13 +166,19 @@ def send_yesterday_event_offers_notifications() -> None:
         send_eac_satisfaction_study_email_to_pro(educational_booking)
 
 
-@blueprint.cli.command("send_tomorrow_events_notifications")
+@blueprint.cli.command("send_today_events_notifications_metropolitan_france")
 @log_cron_with_transaction
-def send_tomorrow_events_notifications() -> None:
-    """Triggers notifications to be sent for tomorrow events"""
-    stock_ids = [stock_id for stock_id, in find_event_stocks_happening_in_x_days(1).with_entities(Stock.id)]
+def send_today_events_notifications_metropolitan_france() -> None:
+    """
+    Find bookings (grouped by stocks) that occur today in metropolitan
+    France but not the morning (11h UTC -> 12h/13h local time), and
+    send notification to all the user to remind them of the event.
+    """
+    today_min = datetime.datetime.combine(datetime.date.today(), datetime.time(hour=11))
+    stock_ids = find_today_event_stock_ids_metropolitan_france(today_min)
+
     for stock_id in stock_ids:
-        send_tomorrow_stock_notification.delay(stock_id)
+        send_today_stock_notification.delay(stock_id)
 
 
 @blueprint.cli.command("send_email_reminder_7_days_before_event")

--- a/api/src/pcapi/workers/push_notification_job.py
+++ b/api/src/pcapi/workers/push_notification_job.py
@@ -4,7 +4,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.notifications.push import send_transactional_notification
 from pcapi.notifications.push.transactional_notifications import get_bookings_cancellation_notification_data
 from pcapi.notifications.push.transactional_notifications import get_offer_notification_data
-from pcapi.notifications.push.transactional_notifications import get_tomorrow_stock_notification_data
+from pcapi.notifications.push.transactional_notifications import get_today_stock_notification_data
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
 
@@ -20,8 +20,8 @@ def send_cancel_booking_notification(bookings_ids: list[int]) -> None:
 
 
 @job(worker.default_queue)
-def send_tomorrow_stock_notification(stock_id: int) -> None:
-    notification_data = get_tomorrow_stock_notification_data(stock_id)
+def send_today_stock_notification(stock_id: int) -> None:
+    notification_data = get_today_stock_notification_data(stock_id)
     if notification_data:
         send_transactional_notification(notification_data)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14083

## But de la pull request

La notification qui rappelle à l'utilisateur qu'il a une réservation le lendemain change légèrement
de stratégie et le prévient maintenant le jour-même.

Pour l'instant, on ne s'occupe que des évènements qui ont lieu en métropole (et Corse). Une prochaine PR ajoutera l'envoi de notifications pour le reste du territoire : l'idée est de commencer simple et d'étendre la logique ensuite.

Les tâches cron sont réglées pour 8h UTC donc 9h/10h heure locale et filtrent les évènements qui ont lieu le matin (donc 11h UTC et 12h/13h heure locale) parce que le but de cette notification n'est pas de prévenir au dernier moment.

## Implémentation

Le titre de la notification est modifiée (demain -> aujourd'hui).
L'heure de déclenchement du cron passe à 10h.
Quelques fonctions et variables sont renommées (les tomorrow deviennent today, logique).

Au passage : le second commit essaie de factoriser du code qui a été ajouté ce soir (mardi 29 mars 2022) et qui contenait déjà un peu de copier/coller dans la même logique (cibler les stocks des évènements qui ont lieu dans X jours).