### PR TITLE
(PC-13524)[API] feat:venues: add reindex venues command

### DIFF
--- a/api/src/pcapi/scripts/algolia_indexing/commands.py
+++ b/api/src/pcapi/scripts/algolia_indexing/commands.py
@@ -4,6 +4,7 @@ from pcapi.core import search
 import pcapi.core.educational.api as educational_api
 import pcapi.core.offers.api as offers_api
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_from_database
+from pcapi.scripts.algolia_indexing.indexing import batch_indexing_venues_in_algolia_from_database
 from pcapi.utils.blueprint import Blueprint
 
 
@@ -46,3 +47,13 @@ def process_expired_offers(all_offers: bool):
 @click.option("-a", "--all", help="Bypass the two days limit to delete all expired collective offers", default=False)
 def process_expired_collective_offers(all_offers: bool):
     educational_api.unindex_expired_collective_offers(process_all_expired=all_offers)
+
+
+@blueprint.cli.command("process_venues_from_database")
+@click.option("--clear", help="Clear search index", type=bool, default=False)
+@click.option("--batch-size", help="Batch size (Algolia)", type=int, default=10_000)
+@click.option("--max-venues", help="Max number of venues (total)", type=int, default=10_000)
+def process_venues_from_database(clear: bool, batch_size: int, max_venues: int):
+    if clear:
+        search.unindex_all_venues()
+    batch_indexing_venues_in_algolia_from_database(algolia_batch_size=batch_size, max_venues=max_venues)

--- a/api/src/pcapi/scripts/algolia_indexing/indexing.py
+++ b/api/src/pcapi/scripts/algolia_indexing/indexing.py
@@ -1,7 +1,10 @@
 import logging
+import typing
 
 from pcapi.core import search
+from pcapi.core.offerers import api as offerers_api
 from pcapi.repository import offer_queries
+from pcapi.utils.chunks import get_chunks
 
 
 logger = logging.getLogger(__name__)
@@ -21,3 +24,11 @@ def batch_indexing_offers_in_algolia_from_database(
         search.reindex_offer_ids(offer_ids)
         logger.info("[ALGOLIA] Processed %d offers from page %d", len(offer_ids), page)
         page += 1
+
+
+def batch_indexing_venues_in_algolia_from_database(algolia_batch_size: int, max_venues: typing.Optional[int]) -> None:
+    venues = offerers_api.get_eligible_for_search_venues(max_venues)
+    for page, venue_chunk in enumerate(get_chunks(venues, algolia_batch_size), start=1):
+        venue_ids = [venue.id for venue in venue_chunk]
+        search.reindex_venue_ids(venue_ids)
+        logger.info("[ALGOLIA] Processed %d venues from page %d", len(venue_ids), page)

--- a/api/src/pcapi/utils/chunks.py
+++ b/api/src/pcapi/utils/chunks.py
@@ -1,0 +1,26 @@
+import inspect
+from itertools import islice
+import typing
+
+
+T = typing.TypeVar("T")
+
+
+def get_chunks(input_data: typing.Iterable, chunk_size: int) -> typing.Generator[list[T], None, None]:
+    """
+    Build chunks of `chunk_size` max from an iterable.
+    eg. get_chuks([1, 2, 3], 2) -> ([1, 2], [2])
+    """
+    if not inspect.isgenerator(input_data):
+        # if `input_data` is not a generator, the while loop will not
+        # consume anything and always get the same first items from
+        # `input_data`
+        input_data = (elt for elt in input_data)
+
+    while True:
+        chunk = list(islice(input_data, chunk_size))
+        if chunk:
+            yield chunk
+
+        if len(chunk) < chunk_size:
+            break

--- a/api/tests/utils/chunks_test.py
+++ b/api/tests/utils/chunks_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pcapi.utils.chunks import get_chunks
+
+
+class GetChunksTest:
+    """
+    Ensure that the get_chunks function works properly with a wide
+    variety of input types: it must obviously end (meaning it found a
+    way to consume properly the input data) and build the expected
+    generator
+    """
+
+    @pytest.mark.parametrize(
+        "input_data",
+        [[1, 2, 3, 4, 5], {1, 2, 3, 4, 5}, (x for x in [1, 2, 3, 4, 5]), range(1, 6)],
+    )
+    def test_get_chunks_with_incomplet_last_chunk(self, input_data) -> None:
+        chunks = list(get_chunks(input_data, 2))
+        assert chunks == [[1, 2], [3, 4], [5]]
+
+    @pytest.mark.parametrize(
+        "input_data",
+        [[1, 2, 3, 4, 5], {1, 2, 3, 4, 5}, (x for x in [1, 2, 3, 4, 5]), range(1, 6)],
+    )
+    def test_get_chunks_with_complet_last_chunk(self, input_data) -> None:
+        chunks = list(get_chunks(input_data, 1))
+        assert chunks == [[1], [2], [3], [4], [5]]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13524

## But de la pull request

Ajout d'une commande flask permettant de réindexer des lieux.

## Implémentation

Au passage : ajout d'un nouveau module `pcapi.utils.chunks` qui ne contient qu'une fonction pour l'instant.