### PR TITLE
(PC-13668)[API] fix: fix dms archive script

### DIFF
--- a/api/src/pcapi/scripts/beneficiary/archive_dms_applications.py
+++ b/api/src/pcapi/scripts/beneficiary/archive_dms_applications.py
@@ -20,8 +20,8 @@ def archive_applications(procedure_id: int, dry_run: bool = True) -> None:
     for application_details in client.get_applications_with_details(
         procedure_id, dms_models.GraphQLApplicationStates.accepted
     ):
-        application_techid = application_details["id"]
-        application_number = application_details["number"]
+        application_techid = application_details.id
+        application_number = application_details.number
         total_applications += 1
         bi = (
             BeneficiaryImport.query.join(users_models.User, users_models.User.id == BeneficiaryImport.beneficiaryId)

--- a/api/tests/scripts/beneficiary/archive_dms_applications_test.py
+++ b/api/tests/scripts/beneficiary/archive_dms_applications_test.py
@@ -9,7 +9,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.models.beneficiary_import_status import ImportStatus
 from pcapi.scripts.beneficiary import archive_dms_applications
 
-from tests.scripts.beneficiary.fixture import make_graphql_application
+from tests.scripts.beneficiary.fixture import make_parsed_graphql_application
 
 
 @pytest.mark.usefixtures("db_session")
@@ -28,7 +28,7 @@ class ArchiveDMSApplicationsTest:
         users_factories.BeneficiaryImportStatusFactory(
             beneficiaryImport=beneficiary_import, status=ImportStatus.CREATED
         )
-        dms_applications.return_value = [make_graphql_application(application_id, "closed", email=user.email)]
+        dms_applications.return_value = [make_parsed_graphql_application(application_id, "accepte", email=user.email)]
 
         archive_dms_applications.archive_applications(self.PROCEDURE_ID, dry_run=False)
         assert dms_archive.call_count == 1
@@ -44,7 +44,7 @@ class ArchiveDMSApplicationsTest:
         users_factories.BeneficiaryImportStatusFactory(
             beneficiaryImport=beneficiary_import, status=ImportStatus.CREATED
         )
-        dms_applications.return_value = [make_graphql_application(application_id, "closed", email=user.email)]
+        dms_applications.return_value = [make_parsed_graphql_application(application_id, "accepte", email=user.email)]
 
         archive_dms_applications.archive_applications(self.PROCEDURE_ID, dry_run=True)
 
@@ -64,14 +64,14 @@ class ArchiveDMSApplicationsTest:
             beneficiaryImport=beneficiary_import, status=ImportStatus.CREATED
         )
         user_to_not_archive = users_factories.UserFactory()
-        application_to_archive = make_graphql_application(application_id, "closed", email=user_to_archive.email)
+        application_to_archive = make_parsed_graphql_application(application_id, "accepte", email=user_to_archive.email)
         dms_applications.return_value = [
-            make_graphql_application(20, "closed", email=user_to_not_archive.email),
+            make_parsed_graphql_application(20, "accepte", email=user_to_not_archive.email),
             application_to_archive,
         ]
         archive_dms_applications.archive_applications(self.PROCEDURE_ID, dry_run=False)
         assert dms_archive.call_count == 1
-        assert dms_archive.call_args == [(application_to_archive["id"], "SomeInstructorId")]
+        assert dms_archive.call_args == [(application_to_archive.id, "SomeInstructorId")]
 
         assert (
             caplog.messages[0]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13668

## But de la pull request

Fixes https://sentry.internal-passculture.app/organizations/sentry/issues/363567/?project=5&referrer=slack

## Implémentation

- Suite à l'oubli du script `archive_applications` lors de la refacto qui type les retours de DMS à l'aide de classes pydantic, on update l'accès aux données dans ce script

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
