### PR TITLE
fix: harmonize spacing at the end of forms

### DIFF
--- a/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
@@ -145,70 +145,75 @@ class SignupForm extends PureComponent {
           <div className="sign-up-tips">
             Tous les champs sont obligatoires sauf mention contraire
           </div>
-          <div>{}</div>
+
           <Form
             decorators={[addressAndDesignationFromSirenDecorator]}
             onSubmit={this.handleSubmit}
           >
             {({ handleSubmit, valid, values }) => (
               <form onSubmit={handleSubmit}>
-                <Field
-                  component={this.renderEmailTextField}
-                  name="email"
-                  type="text"
-                  validate={required}
-                />
-
-                <PasswordField
-                  errors={errors ? errors.password : null}
-                  label="Mot de passe"
-                  name="password"
-                  showTooltip
-                />
-
-                <Field
-                  component={this.renderNameTextField}
-                  name="lastName"
-                  required
-                  validate={required}
-                />
-
-                <Field
-                  component={this.renderFirstNameTextField}
-                  name="firstName"
-                  validate={required}
-                />
-
-                <Field
-                  component={this.renderPhoneNumberField}
-                  name="phoneNumber"
-                  required
-                  validate={required}
-                />
-
-                <SirenField value={values.name} />
-
-                <label className="sign-up-checkbox" htmlFor="sign-up-checkbox">
+                <div className="sign-up-form">
                   <Field
-                    component="input"
-                    id="sign-up-checkbox"
-                    name="contactOk"
-                    type="checkbox"
+                    component={this.renderEmailTextField}
+                    name="email"
+                    type="text"
+                    validate={required}
                   />
-                  <span>
-                    J’accepte d’être contacté par e-mail pour recevoir les
-                    nouveautés du pass Culture et contribuer à son amélioration
-                    (facultatif)
-                  </span>
-                  <FieldErrors
-                    customMessage={errors ? errors.contactOk : null}
+
+                  <PasswordField
+                    errors={errors ? errors.password : null}
+                    label="Mot de passe"
+                    name="password"
+                    showTooltip
                   />
-                </label>
-                <LegalInfos
-                  className="sign-up-infos-before-signup"
-                  title="Créer mon compte"
-                />
-                <BannerRGS />
+
+                  <Field
+                    component={this.renderNameTextField}
+                    name="lastName"
+                    required
+                    validate={required}
+                  />
+
+                  <Field
+                    component={this.renderFirstNameTextField}
+                    name="firstName"
+                    validate={required}
+                  />
+
+                  <Field
+                    component={this.renderPhoneNumberField}
+                    name="phoneNumber"
+                    required
+                    validate={required}
+                  />
+
+                  <SirenField value={values.name} />
+
+                  <label
+                    className="sign-up-checkbox"
+                    htmlFor="sign-up-checkbox"
+                  >
+                    <Field
+                      component="input"
+                      id="sign-up-checkbox"
+                      name="contactOk"
+                      type="checkbox"
+                    />
+                    <span>
+                      J’accepte d’être contacté par e-mail pour recevoir les
+                      nouveautés du pass Culture et contribuer à son
+                      amélioration (facultatif)
+                    </span>
+                    <FieldErrors
+                      customMessage={errors ? errors.contactOk : null}
+                    />
+                  </label>
+                  <LegalInfos
+                    className="sign-up-infos-before-signup"
+                    title="Créer mon compte"
+                  />
+                  <BannerRGS />
+                </div>
                 <div className="buttons-field">
                   <Link className="secondary-link" to="/connexion">
                     J’ai déjà un compte

--- a/pro/src/styles/components/pages/Signin/_Signin.scss
+++ b/pro/src/styles/components/pages/Signin/_Signin.scss
@@ -51,7 +51,7 @@
   }
 
   .signin-form {
-    margin-bottom: rem(48px);
+    margin-bottom: rem(40px);
   }
 
   .buttons-field {

--- a/pro/src/styles/components/pages/SignupForm/_SignupForm.scss
+++ b/pro/src/styles/components/pages/SignupForm/_SignupForm.scss
@@ -60,6 +60,10 @@
       margin-top: rem(40px);
     }
 
+    .sign-up-form {
+      margin: rem(16px) 0 rem(40px) 0;
+    }
+
     .buttons-field {
       display: flex;
       flex-wrap: wrap;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13936 et https://passculture.atlassian.net/browse/PC-13937

## But de la pull request

Harmoniser l'espace blanc avant les boutons de validation de formulaire

## Implémentation

- SignIn: modification de la valeur de la marge en bas
- Signup: ajout d'une div entourant les champs avant les boutons de validation, sur le même modèle que SignIn, et définition d'une marge en bas (boyscout: remplacement de la div vide d'espacement par une marge en haut sur cette nouvelle div)

## Screenshots

### Avant
<img width="468" alt="Capture d’écran 2022-03-23 à 12 25 11 (2)" src="https://user-images.githubusercontent.com/101103940/159689301-556ff157-a864-43f4-9c04-e5a28f2d0462.png">
<img width="600" alt="Capture d’écran 2022-03-23 à 12 25 14 (2)" src="https://user-images.githubusercontent.com/101103940/159689320-e1299daa-74a8-4111-b4d0-ae54d2370f70.png">

### Après

<img width="562" alt="Capture d’écran 2022-03-23 à 12 24 59 (2)" src="https://user-images.githubusercontent.com/101103940/159689275-a2666434-1e29-4be9-ad73-7cdfc8470c4f.png">
<img width="512" alt="Capture d’écran 2022-03-23 à 12 25 01 (2)" src="https://user-images.githubusercontent.com/101103940/159689285-63851bcb-d8a4-4361-80e6-8683e189099e.png">
