### PR TITLE
(BSR)[PRO] chore: bump react-final-form to 6.8.1

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -86,7 +86,7 @@
     "react-datepicker": "^3.8.0",
     "react-dom": "^16.13.1",
     "react-dotdotdot": "^1.2.3",
-    "react-final-form": "^5.1.2",
+    "react-final-form": "^6.5.8",
     "react-final-form-utils": "^1.4.0",
     "react-leaflet": "^2.7.0",
     "react-loading-infinite-scroller": "^1.5.1",

--- a/pro/src/components/layout/form/fields/TextField.jsx
+++ b/pro/src/components/layout/form/fields/TextField.jsx
@@ -95,7 +95,7 @@ TextField.defaultProps = {
   autoComplete: null,
   className: '',
   disabled: false,
-  format: null,
+  format: undefined,
   id: null,
   innerClassName: null,
   label: '',

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/AddressField.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/AddressField.jsx
@@ -138,7 +138,7 @@ export const AddressField = ({
 AddressField.defaultProps = {
   className: '',
   disabled: false,
-  format: null,
+  format: undefined,
   id: null,
   innerClassName: null,
   label: '',

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -18254,13 +18254,12 @@ react-final-form-utils@^1.4.0:
     react-router-dom "^4.3.1"
     reselect "^3.0.1"
 
-react-final-form@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-5.1.2.tgz#e3fc04d14906d56387fa70e0f60f5a1cc0b2d983"
-  integrity sha512-p0OQeW3KGJ36DIN5hVVgzJbdTCfZxZrhcL+lXMRE/AJj4CziKM686LnaQAa+BsNZ2Ha265xp0UIfAZpqc85LuQ==
+react-final-form@^6.5.8:
+  version "6.5.8"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.8.tgz#08b17bc6d4124300a9f2ea1f6b2e608150d3bab0"
+  integrity sha512-j8Rmr5zAaMliNbh+CPnY734exHfk7MjQ8I6ZcykcChmPDFPV2aF40PFAcmQ/KreA10AI8ew0tff6q0gVqwFaGA==
   dependencies:
-    "@babel/runtime" "^7.4.4"
-    ts-essentials "^2.0.2"
+    "@babel/runtime" "^7.15.4"
 
 react-focus-lock@^2.5.1:
   version "2.8.1"
@@ -21539,7 +21538,7 @@ ts-dedent@^2.1.1:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-ts-essentials@^2.0.2, ts-essentials@^2.0.3:
+ts-essentials@^2.0.3:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==


### PR DESCRIPTION
Le passage à type-script des composants utilisant react-final-form nécessite de mettre à jours les types de la bibliothèque.
Voici une maj + fix vers la 6.8.1.