### PR TITLE
(PC-13890)[API] feat: save original venue banner

### DIFF
--- a/api/src/pcapi/connectors/thumb_storage.py
+++ b/api/src/pcapi/connectors/thumb_storage.py
@@ -2,6 +2,7 @@ from pcapi import settings
 from pcapi.core import object_storage
 from pcapi.models import Model
 from pcapi.utils.image_conversion import IMAGE_RATIO_PORTRAIT_DEFAULT
+from pcapi.utils.image_conversion import process_original_image
 from pcapi.utils.image_conversion import standardize_image
 
 
@@ -11,8 +12,12 @@ def create_thumb(
     image_index: int,
     crop_params: tuple = None,
     ratio: float = IMAGE_RATIO_PORTRAIT_DEFAULT,
+    keep_ratio: bool = False,
 ) -> None:
-    image_as_bytes = standardize_image(image_as_bytes, ratio=ratio, crop_params=crop_params)
+    if keep_ratio:
+        image_as_bytes = process_original_image(image_as_bytes)
+    else:
+        image_as_bytes = standardize_image(image_as_bytes, ratio=ratio, crop_params=crop_params)
 
     object_storage.store_public_object(
         folder=settings.THUMBS_FOLDER_NAME,

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -303,6 +303,28 @@ def validate_offerer(token: str) -> None:
         )
 
 
+def get_timestamp_from_url(image_url: str) -> str:
+    return int(image_url.split("_")[-1])
+
+
+def rm_previous_venue_thumbs(venue: Venue) -> None:
+    if not venue.bannerUrl:
+        return
+
+    # handle old banner urls that did not have a timestamp
+    timestamp = get_timestamp_from_url(venue.bannerUrl) if "_" in venue.bannerUrl else 0
+    storage.remove_thumb(venue, image_index=timestamp)
+
+    # some older venues might have a banner but not the original file
+    # note: if bannerUrl is not None, bannerMeta should not be either.
+    if original_image_url := venue.bannerMeta.get("original_image_url"):
+        original_image_timestamp = get_timestamp_from_url(original_image_url)
+        storage.remove_thumb(venue, image_index=original_image_timestamp)
+
+    venue.bannerUrl = None
+    venue.bannerMeta = None
+
+
 def save_venue_banner(
     user: User,
     venue: Venue,
@@ -311,12 +333,16 @@ def save_venue_banner(
     crop_params: Optional[CropParams] = None,
 ) -> None:
     """
-    Use a timestamp as index in order to have a unique URL for each
-    upload
+    Save the new venue's new banner: crop it and resize it if asked
+    or needed, and save the original image too (shrinked if too big,
+    but with the same ratio).
+
+    The previous banner (if any) is removed.
+
+    Use a timestamps as indexes in order to have a unique URL for each
+    upload.
     """
-    if venue.bannerUrl:
-        index = int(venue.bannerUrl.split("_")[-1]) if "_" in venue.bannerUrl else 0
-        storage.remove_thumb(venue, index)
+    rm_previous_venue_thumbs(venue)
 
     banner_timestamp = int(datetime.now().timestamp())
     storage.create_thumb(
@@ -327,8 +353,17 @@ def save_venue_banner(
         ratio=IMAGE_RATIO_LANDSCAPE_DEFAULT,
     )
 
+    original_image_timestamp = banner_timestamp + 1
+    storage.create_thumb(
+        model_with_thumb=venue, image_as_bytes=content, image_index=original_image_timestamp, keep_ratio=True
+    )
+
     venue.bannerUrl = f"{venue.thumbUrl}_{banner_timestamp}"
-    venue.bannerMeta = {"image_credit": image_credit, "author_id": user.id}
+    venue.bannerMeta = {
+        "image_credit": image_credit,
+        "author_id": user.id,
+        "original_image_url": f"{venue.thumbUrl}_{original_image_timestamp}",
+    }
 
     repository.save(venue)
 
@@ -336,15 +371,8 @@ def save_venue_banner(
 
 
 def delete_venue_banner(venue: Venue) -> None:
-    if venue.bannerUrl:
-        timestamp = int(venue.bannerUrl.split("_")[-1]) if "_" in venue.bannerUrl else 0
-        storage.remove_thumb(venue, image_index=timestamp)
-
-    venue.bannerUrl = None
-    venue.bannerMeta = None
-
+    rm_previous_venue_thumbs(venue)
     repository.save(venue)
-
     search.async_index_venue_ids([venue.id])
 
 

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -125,6 +125,7 @@ class GetVenueManagingOffererResponseModel(BaseModel):
 
 class BannerMetaModel(TypedDict, total=False):
     image_credit: Optional[base.VenueImageCredit]
+    original_image_url: Optional[str]
 
 
 class GetVenueResponseModel(base.BaseVenueResponse):

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -11,8 +11,10 @@ class VenuesTest:
         venue = offerer_factories.VenueFactory(
             isPermanent=True,
             bannerMeta={
-                "image_credit": "Wikimedia Commons CC By",
                 "author_id": 1,
+                "original_image_url": "https://ou.ps",
+                # only this field should be sent
+                "image_credit": "Wikimedia Commons CC By",
             },
         )
 
@@ -46,7 +48,9 @@ class VenuesTest:
                 "visualDisability": venue.visualDisabilityCompliant,
             },
             "bannerUrl": venue.bannerUrl,
-            "bannerMeta": {"image_credit": venue.bannerMeta["image_credit"]},
+            "bannerMeta": {
+                "image_credit": venue.bannerMeta["image_credit"],
+            },
         }
 
     def test_get_non_permanent_venue(self, client):

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -258,10 +258,16 @@ class VenueBannerTest:
             response = client.post(url, files=file)
             assert response.status_code == 201
 
-            assert response.json["bannerUrl"] == str(
-                pathlib.Path(tmpdir.dirname) / "thumbs" / "venues" / f"{humanize(venue.id)}_1602720000"
-            )
-            assert response.json["bannerMeta"] == {"image_credit": "none"}
+            url_prefix = pathlib.Path(tmpdir.dirname) / "thumbs" / "venues"
+
+            banner_url_timestamp = 1602720000
+            assert response.json["bannerUrl"] == str(url_prefix / f"{humanize(venue.id)}_{banner_url_timestamp}")
+
+            original_banner_url_timestamp = 1602720001
+            assert response.json["bannerMeta"] == {
+                "image_credit": "none",
+                "original_image_url": str(url_prefix / f"{humanize(venue.id)}_{original_banner_url_timestamp}"),
+            }
 
     def test_upload_image_missing(self, client):
         user_offerer = offers_factories.UserOffererFactory()

--- a/api/tests/utils/image_conversion_test.py
+++ b/api/tests/utils/image_conversion_test.py
@@ -9,6 +9,7 @@ from pcapi.utils.image_conversion import IMAGE_RATIO_PORTRAIT_DEFAULT
 from pcapi.utils.image_conversion import _crop_image
 from pcapi.utils.image_conversion import _resize_image
 from pcapi.utils.image_conversion import _transpose_image
+from pcapi.utils.image_conversion import process_original_image
 from pcapi.utils.image_conversion import standardize_image
 
 import tests
@@ -82,3 +83,17 @@ class ImageConversionTest:
 
         result_image = PIL.Image.open(io.BytesIO(standardized_image)).convert("RGB")
         assert (result_image.width / result_image.height) == pytest.approx(IMAGE_RATIO_LANDSCAPE_DEFAULT, 0.01)
+
+    def test_image_shrink_with_same_ratio(self):
+        image_as_bytes = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()
+        original_image = PIL.Image.open(io.BytesIO(image_as_bytes))
+
+        expected_ratio = original_image.width / original_image.height
+
+        standardized_image = process_original_image(image_as_bytes)
+
+        result_image = PIL.Image.open(io.BytesIO(standardized_image))
+
+        assert result_image.width < original_image.width
+        assert result_image.height < original_image.height
+        assert (result_image.width / result_image.height) == pytest.approx(expected_ratio, 0.01)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13890

## But de la pull request

Sauvegarder l'image originale lors de l'envoi d'une image d'illustration d'un lieu.
Le but est de permettre à l'utilisateur de recadrer l'image de nouveau, sans avoir à renvoyer l'image originale (qu'il n'a peut-être pas si c'est une personne de son équipe qui a fait le premier envoi).