### PR TITLE
(PC-13519)[PRO] Visualize collective offers

### DIFF
--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -34,9 +34,10 @@ class Returns200Test:
         client = TestClient(app.test_client()).with_session_auth(email=admin.email)
         path = f"/offers?venueId={humanize(requested_venue.id)}"
         select_offers_nb_queries = 1
+        select_feature_nb_queries = 1
 
         # when
-        with assert_num_queries(testing.AUTHENTICATION_QUERIES + select_offers_nb_queries):
+        with assert_num_queries(testing.AUTHENTICATION_QUERIES + select_offers_nb_queries + select_feature_nb_queries):
             response = client.get(path)
 
         # then

--- a/pro/src/api/v1/gen/api.ts
+++ b/pro/src/api/v1/gen/api.ts
@@ -94,6 +94,33 @@ export interface CategoryResponseModel {
     proLabel: string;
 }
 
+export interface CollectiveOfferResponseModel {
+    hasBookingLimitDatetimesPassed: boolean;
+    id: string;
+    isActive: boolean;
+    isEditable: boolean;
+    isEducational: boolean;
+    isEvent: boolean;
+    isShowcase?: boolean | null;
+    isThing: boolean;
+    name: string;
+    productIsbn?: string | null;
+    status: string;
+    stocks: Array<CollectiveOffersStockResponseModel>;
+    subcategoryId: SubcategoryIdEnum;
+    thumbUrl?: string | null;
+    venue: ListOffersVenueResponseModel;
+    venueId: string;
+}
+
+export interface CollectiveOffersStockResponseModel {
+    beginningDatetime?: Date | null;
+    hasBookingLimitDatetimePassed: boolean;
+    id: string;
+    offerId: string;
+    remainingQuantity: number | string;
+}
+
 export interface CreateOffererQueryModel {
     address?: string | null;
     city: string;
@@ -548,6 +575,20 @@ export interface ListBookingsResponseModel {
     page: number;
     pages: number;
     total: number;
+}
+
+export interface ListCollectiveOffersQueryModel {
+    categoryId?: string | null;
+    creationMode?: string | null;
+    nameOrIsbn?: string | null;
+    offererId?: number | null;
+    periodBeginningDate?: string | null;
+    periodEndingDate?: string | null;
+    status?: string | null;
+    venueId?: number | null;
+}
+
+export interface ListCollectiveOffersResponseModel extends Array<CollectiveOfferResponseModel> {
 }
 
 export interface ListFeatureResponseModel extends Array<FeatureResponseModel> {
@@ -1216,6 +1257,62 @@ export const DefaultApiFetchParamCreator = function (configuration?: APIConfigur
             }
             if (extra !== undefined) {
                 localVarQueryParameter['extra'] = extra;
+            }
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            localVarUrlObj.search = null;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary list_collective_offers <GET>
+         * @param {string} [nameOrIsbn] 
+         * @param {number} [offererId] 
+         * @param {string} [status] 
+         * @param {number} [venueId] 
+         * @param {string} [categoryId] 
+         * @param {string} [creationMode] 
+         * @param {string} [periodBeginningDate] 
+         * @param {string} [periodEndingDate] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getCollectiveListCollectiveOffers(nameOrIsbn?: string | null, offererId?: number | null, status?: string | null, venueId?: number | null, categoryId?: string | null, creationMode?: string | null, periodBeginningDate?: string | null, periodEndingDate?: string | null, options: any = {}): Promise<FetchArgs> {
+            const localVarPath = `/collective/offers`;
+            const localVarUrlObj = url.parse(localVarPath, true);
+            const localVarRequestOptions = Object.assign({
+                method: 'GET',
+                credentials: 'includes',
+            }, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+            if (nameOrIsbn !== undefined) {
+                localVarQueryParameter['nameOrIsbn'] = nameOrIsbn;
+            }
+            if (offererId !== undefined) {
+                localVarQueryParameter['offererId'] = offererId;
+            }
+            if (status !== undefined) {
+                localVarQueryParameter['status'] = status;
+            }
+            if (venueId !== undefined) {
+                localVarQueryParameter['venueId'] = venueId;
+            }
+            if (categoryId !== undefined) {
+                localVarQueryParameter['categoryId'] = categoryId;
+            }
+            if (creationMode !== undefined) {
+                localVarQueryParameter['creationMode'] = creationMode;
+            }
+            if (periodBeginningDate !== undefined) {
+                localVarQueryParameter['periodBeginningDate'] = periodBeginningDate;
+            }
+            if (periodEndingDate !== undefined) {
+                localVarQueryParameter['periodEndingDate'] = periodEndingDate;
             }
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
@@ -2540,6 +2637,25 @@ export const DefaultApiFp = function(api: DefaultApi, configuration?: APIConfigu
         },
         /**
          * 
+         * @summary list_collective_offers <GET>
+         * @param {string} [nameOrIsbn] 
+         * @param {number} [offererId] 
+         * @param {string} [status] 
+         * @param {number} [venueId] 
+         * @param {string} [categoryId] 
+         * @param {string} [creationMode] 
+         * @param {string} [periodBeginningDate] 
+         * @param {string} [periodEndingDate] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+         async getCollectiveListCollectiveOffers(basePath: string, nameOrIsbn?: string | null, offererId?: number | null, status?: string | null, venueId?: number | null, categoryId?: string | null, creationMode?: string | null, periodBeginningDate?: string | null, periodEndingDate?: string | null, options?: any): Promise<ListCollectiveOffersResponseModel> {
+            const localVarFetchArgs = await DefaultApiFetchParamCreator(configuration).getCollectiveListCollectiveOffers(nameOrIsbn, offererId, status, venueId, categoryId, creationMode, periodBeginningDate, periodEndingDate, options);
+            const response = await safeFetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options)
+            return handleGeneratedApiResponse(response)
+        },
+        /**
+         * 
          * @summary list_features <GET>
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -3100,6 +3216,23 @@ export interface DefaultApiInterface {
      */
     getBookingsGetBookingsPro(bookingStatusFilter: BookingStatusFilter, bookingPeriodBeginningDate: string, bookingPeriodEndingDate: string, page?: number, venueId?: number | null, eventDate?: Date | null, offerType?: OfferType, extra?: string, options?: any): Promise<ListBookingsResponseModel>;
 
+     /**
+     * 
+     * @summary list_collective_offers <GET>
+     * @param {string} [nameOrIsbn] 
+     * @param {number} [offererId] 
+     * @param {string} [status] 
+     * @param {number} [venueId] 
+     * @param {string} [categoryId] 
+     * @param {string} [creationMode] 
+     * @param {string} [periodBeginningDate] 
+     * @param {string} [periodEndingDate] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApiInterface
+     */
+    getCollectiveListCollectiveOffers(nameOrIsbn?: string | null, offererId?: number | null, status?: string | null, venueId?: number | null, categoryId?: string | null, creationMode?: string | null, periodBeginningDate?: string | null, periodEndingDate?: string | null, options?: any): Promise<ListCollectiveOffersResponseModel>;
+
     /**
      * 
      * @summary list_features <GET>
@@ -3583,6 +3716,25 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     public async getBookingsGetBookingsPro(bookingStatusFilter: BookingStatusFilter, bookingPeriodBeginningDate: string, bookingPeriodEndingDate: string, page?: number, venueId?: number | null, eventDate?: Date | null, offerType?: OfferType, extra?: string, options?: any) {
         const functionalApi = DefaultApiFp(this, this.configuration)
         return functionalApi.getBookingsGetBookingsPro(this.basePath, bookingStatusFilter, bookingPeriodBeginningDate, bookingPeriodEndingDate, page, venueId, eventDate, offerType, extra, options)
+    }
+    /**
+     * 
+     * @summary list_collective_offers <GET>
+     * @param {string} [nameOrIsbn] 
+     * @param {number} [offererId] 
+     * @param {string} [status] 
+     * @param {number} [venueId] 
+     * @param {string} [categoryId] 
+     * @param {string} [creationMode] 
+     * @param {string} [periodBeginningDate] 
+     * @param {string} [periodEndingDate] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+     public async getCollectiveListCollectiveOffers(nameOrIsbn?: string | null, offererId?: number | null, status?: string | null, venueId?: number | null, categoryId?: string | null, creationMode?: string | null, periodBeginningDate?: string | null, periodEndingDate?: string | null, options?: any) {
+        const functionalApi = DefaultApiFp(this, this.configuration)
+        return functionalApi.getCollectiveListCollectiveOffers(this.basePath, nameOrIsbn, offererId, status, venueId, categoryId, creationMode, periodBeginningDate, periodEndingDate, options)
     }
     /**
      * 

--- a/pro/src/routes/Offers/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/routes/Offers/CollectiveOffers/CollectiveOffers.tsx
@@ -1,0 +1,144 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+
+import useCurrentUser from 'components/hooks/useCurrentUser'
+import useNotification from 'components/hooks/useNotification'
+import Spinner from 'components/layout/Spinner'
+import { computeOffersUrl } from 'components/pages/Offers/utils/computeOffersUrl'
+import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { Audience, Offer, Offerer, TSearchFilters } from 'core/Offers/types'
+import OffersScreen from 'screens/Offers'
+import { savePageNumber, saveSearchFilters } from 'store/offers/actions'
+
+import { getFilteredCollectiveOffersAdapter } from '../adapters'
+
+interface ICollectiveOffersProps {
+  urlPageNumber: number
+  urlSearchFilters: TSearchFilters
+  offerer: Offerer | null
+  setOfferer: (offerer: Offerer | null) => void
+  separateIndividualAndCollectiveOffers: boolean
+}
+
+const CollectiveOffers = ({
+  urlPageNumber,
+  urlSearchFilters,
+  offerer,
+  setOfferer,
+  separateIndividualAndCollectiveOffers,
+}: ICollectiveOffersProps): JSX.Element => {
+  const history = useHistory()
+  const notify = useNotification()
+  const { currentUser } = useCurrentUser()
+  const dispatch = useDispatch()
+
+  const [offers, setOffers] = useState<Offer[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [initialSearchFilters, setInitialSearchFilters] =
+    useState<TSearchFilters | null>(null)
+
+  const loadAndUpdatCollectiveOffers = useCallback(
+    async (filters: TSearchFilters) => {
+      const apiFilters = {
+        ...DEFAULT_SEARCH_FILTERS,
+        ...filters,
+      }
+      const { isOk, message, payload } =
+        await getFilteredCollectiveOffersAdapter(apiFilters)
+
+      if (!isOk) {
+        setIsLoading(false)
+        return notify.error(message)
+      }
+
+      setIsLoading(false)
+      setOffers(payload.offers)
+    },
+    [notify]
+  )
+
+  const redirectWithUrlFilters = useCallback(
+    (
+      filters: TSearchFilters & {
+        page?: number
+        audience?: Audience
+      }
+    ) => {
+      const newUrl = computeOffersUrl(filters, filters.page)
+
+      history.push(newUrl)
+    },
+    [history]
+  )
+
+  useEffect(() => {
+    const filters = { ...DEFAULT_SEARCH_FILTERS, ...urlSearchFilters }
+    if (currentUser.isAdmin) {
+      const isVenueFilterSelected =
+        urlSearchFilters.venueId !== DEFAULT_SEARCH_FILTERS.venueId
+      const isOffererFilterApplied =
+        urlSearchFilters.offererId !== DEFAULT_SEARCH_FILTERS.offererId
+      const isFilterByVenueOrOfferer =
+        isVenueFilterSelected || isOffererFilterApplied
+
+      if (!isFilterByVenueOrOfferer) {
+        filters.status = DEFAULT_SEARCH_FILTERS.status
+      }
+    }
+    setInitialSearchFilters(filters)
+  }, [setInitialSearchFilters, urlSearchFilters, currentUser.isAdmin])
+
+  useEffect(() => {
+    dispatch(
+      saveSearchFilters({
+        nameOrIsbn:
+          urlSearchFilters.nameOrIsbn || DEFAULT_SEARCH_FILTERS.nameOrIsbn,
+        offererId:
+          urlSearchFilters.offererId || DEFAULT_SEARCH_FILTERS.offererId,
+        venueId: urlSearchFilters.venueId || DEFAULT_SEARCH_FILTERS.venueId,
+        categoryId:
+          urlSearchFilters.categoryId || DEFAULT_SEARCH_FILTERS.categoryId,
+        status: urlSearchFilters.status
+          ? urlSearchFilters.status
+          : DEFAULT_SEARCH_FILTERS.status,
+        creationMode: urlSearchFilters.creationMode
+          ? urlSearchFilters.creationMode
+          : DEFAULT_SEARCH_FILTERS.creationMode,
+        periodBeginningDate:
+          urlSearchFilters.periodBeginningDate ||
+          DEFAULT_SEARCH_FILTERS.periodBeginningDate,
+        periodEndingDate:
+          urlSearchFilters.periodEndingDate ||
+          DEFAULT_SEARCH_FILTERS.periodEndingDate,
+      })
+    )
+    dispatch(savePageNumber(urlPageNumber))
+  }, [dispatch, urlPageNumber, urlSearchFilters])
+
+  if (!initialSearchFilters) {
+    return <Spinner />
+  }
+
+  return (
+    <OffersScreen
+      currentPageNumber={urlPageNumber ?? DEFAULT_PAGE}
+      currentUser={currentUser}
+      initialSearchFilters={initialSearchFilters}
+      isLoading={isLoading}
+      loadAndUpdateOffers={loadAndUpdatCollectiveOffers}
+      offerer={offerer}
+      offers={offers}
+      redirectWithUrlFilters={redirectWithUrlFilters}
+      separateIndividualAndCollectiveOffers={
+        separateIndividualAndCollectiveOffers
+      }
+      setIsLoading={setIsLoading}
+      setOfferer={setOfferer}
+      urlAudience={Audience.COLLECTIVE}
+      urlSearchFilters={urlSearchFilters}
+    />
+  )
+}
+
+export default CollectiveOffers

--- a/pro/src/routes/Offers/CollectiveOffers/index.ts
+++ b/pro/src/routes/Offers/CollectiveOffers/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CollectiveOffers'

--- a/pro/src/routes/Offers/IndividualOffers/IndividualOffers.tsx
+++ b/pro/src/routes/Offers/IndividualOffers/IndividualOffers.tsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+
+import useCurrentUser from 'components/hooks/useCurrentUser'
+import useNotification from 'components/hooks/useNotification'
+import Spinner from 'components/layout/Spinner'
+import { computeOffersUrl } from 'components/pages/Offers/utils/computeOffersUrl'
+import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
+import { Audience, Offer, Offerer, TSearchFilters } from 'core/Offers/types'
+import OffersScreen from 'screens/Offers'
+import { savePageNumber, saveSearchFilters } from 'store/offers/actions'
+
+import { getFilteredOffersAdapter } from '../adapters'
+
+interface IIndividualOffersProps {
+  urlPageNumber: number
+  urlSearchFilters: TSearchFilters
+  offerer: Offerer | null
+  setOfferer: (offerer: Offerer | null) => void
+  separateIndividualAndCollectiveOffers: boolean
+}
+
+const IndividualOffers = ({
+  urlPageNumber,
+  urlSearchFilters,
+  offerer,
+  setOfferer,
+  separateIndividualAndCollectiveOffers,
+}: IIndividualOffersProps): JSX.Element => {
+  const history = useHistory()
+  const notify = useNotification()
+  const { currentUser } = useCurrentUser()
+  const dispatch = useDispatch()
+
+  const [offers, setOffers] = useState<Offer[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [initialSearchFilters, setInitialSearchFilters] =
+    useState<TSearchFilters | null>(null)
+
+  const loadAndUpdateOffers = useCallback(
+    async (filters: TSearchFilters) => {
+      const apiFilters = {
+        ...DEFAULT_SEARCH_FILTERS,
+        ...filters,
+      }
+      const { isOk, message, payload } = await getFilteredOffersAdapter(
+        apiFilters
+      )
+
+      if (!isOk) {
+        setIsLoading(false)
+        return notify.error(message)
+      }
+
+      setIsLoading(false)
+      setOffers(payload.offers)
+    },
+    [notify]
+  )
+
+  const redirectWithUrlFilters = useCallback(
+    (
+      filters: TSearchFilters & {
+        page?: number
+        audience?: Audience
+      }
+    ) => {
+      const newUrl = computeOffersUrl(filters, filters.page)
+
+      history.push(newUrl)
+    },
+    [history]
+  )
+
+  useEffect(() => {
+    const filters = { ...DEFAULT_SEARCH_FILTERS, ...urlSearchFilters }
+    if (currentUser.isAdmin) {
+      const isVenueFilterSelected =
+        urlSearchFilters.venueId !== DEFAULT_SEARCH_FILTERS.venueId
+      const isOffererFilterApplied =
+        urlSearchFilters.offererId !== DEFAULT_SEARCH_FILTERS.offererId
+      const isFilterByVenueOrOfferer =
+        isVenueFilterSelected || isOffererFilterApplied
+
+      if (!isFilterByVenueOrOfferer) {
+        filters.status = DEFAULT_SEARCH_FILTERS.status
+      }
+    }
+    setInitialSearchFilters(filters)
+  }, [setInitialSearchFilters, urlSearchFilters, currentUser.isAdmin])
+
+  useEffect(() => {
+    dispatch(
+      saveSearchFilters({
+        nameOrIsbn:
+          urlSearchFilters.nameOrIsbn || DEFAULT_SEARCH_FILTERS.nameOrIsbn,
+        offererId:
+          urlSearchFilters.offererId || DEFAULT_SEARCH_FILTERS.offererId,
+        venueId: urlSearchFilters.venueId || DEFAULT_SEARCH_FILTERS.venueId,
+        categoryId:
+          urlSearchFilters.categoryId || DEFAULT_SEARCH_FILTERS.categoryId,
+        status: urlSearchFilters.status
+          ? urlSearchFilters.status
+          : DEFAULT_SEARCH_FILTERS.status,
+        creationMode: urlSearchFilters.creationMode
+          ? urlSearchFilters.creationMode
+          : DEFAULT_SEARCH_FILTERS.creationMode,
+        periodBeginningDate:
+          urlSearchFilters.periodBeginningDate ||
+          DEFAULT_SEARCH_FILTERS.periodBeginningDate,
+        periodEndingDate:
+          urlSearchFilters.periodEndingDate ||
+          DEFAULT_SEARCH_FILTERS.periodEndingDate,
+      })
+    )
+    dispatch(savePageNumber(urlPageNumber))
+  }, [dispatch, urlPageNumber, urlSearchFilters])
+
+  if (!initialSearchFilters) {
+    return <Spinner />
+  }
+
+  return (
+    <OffersScreen
+      currentPageNumber={urlPageNumber ?? DEFAULT_PAGE}
+      currentUser={currentUser}
+      initialSearchFilters={initialSearchFilters}
+      isLoading={isLoading}
+      loadAndUpdateOffers={loadAndUpdateOffers}
+      offerer={offerer}
+      offers={offers}
+      redirectWithUrlFilters={redirectWithUrlFilters}
+      separateIndividualAndCollectiveOffers={
+        separateIndividualAndCollectiveOffers
+      }
+      setIsLoading={setIsLoading}
+      setOfferer={setOfferer}
+      urlAudience={Audience.INDIVIDUAL}
+      urlSearchFilters={urlSearchFilters}
+    />
+  )
+}
+
+export default IndividualOffers

--- a/pro/src/routes/Offers/IndividualOffers/index.tsx
+++ b/pro/src/routes/Offers/IndividualOffers/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './IndividualOffers'

--- a/pro/src/routes/Offers/adapters/getFilteredCollectiveOffersAdapter.ts
+++ b/pro/src/routes/Offers/adapters/getFilteredCollectiveOffersAdapter.ts
@@ -1,0 +1,61 @@
+import { api } from 'api/v1/api'
+import { Offer, TSearchFilters } from 'core/Offers/types'
+
+import { serializeOffers, serializeApiFilters } from './serializers'
+
+type IPayload = {
+  offers: Offer[]
+}
+
+type GetFilteredCollectiveOffersAdapter = Adapter<
+  TSearchFilters,
+  IPayload,
+  IPayload
+>
+
+const FAILING_RESPONSE: AdapterFailure<IPayload> = {
+  isOk: false,
+  message: 'Nous avons rencontré un problème lors du chargemement des données',
+  payload: {
+    offers: [],
+  },
+}
+
+export const getFilteredCollectiveOffersAdapter: GetFilteredCollectiveOffersAdapter =
+  async apiFilters => {
+    try {
+      const {
+        nameOrIsbn,
+        offererId,
+        venueId,
+        categoryId,
+        status,
+        creationMode,
+        periodBeginningDate,
+        periodEndingDate,
+      } = serializeApiFilters(apiFilters)
+
+      const offers = await api.getCollectiveListCollectiveOffers(
+        nameOrIsbn,
+        offererId,
+        status,
+        venueId,
+        categoryId,
+        creationMode,
+        periodBeginningDate,
+        periodEndingDate
+      )
+
+      return {
+        isOk: true,
+        message: null,
+        payload: {
+          offers: serializeOffers(offers),
+        },
+      }
+    } catch (e) {
+      return FAILING_RESPONSE
+    }
+  }
+
+export default getFilteredCollectiveOffersAdapter

--- a/pro/src/routes/Offers/adapters/index.ts
+++ b/pro/src/routes/Offers/adapters/index.ts
@@ -1,2 +1,3 @@
 export { default as getFilteredOffersAdapter } from './getFilteredOffersAdapter'
+export { default as getFilteredCollectiveOffersAdapter } from './getFilteredCollectiveOffersAdapter'
 export { default as getOffererAdapter } from './getOffererAdapter'

--- a/pro/src/routes/Offers/adapters/serializers.ts
+++ b/pro/src/routes/Offers/adapters/serializers.ts
@@ -1,4 +1,5 @@
 import {
+  ListCollectiveOffersResponseModel,
   ListOffersOfferResponseModel,
   ListOffersQueryModel,
   ListOffersResponseModel,
@@ -24,7 +25,9 @@ const serializeStocks = (
     remainingQuantity: stock.remainingQuantity,
   }))
 
-export const serializeOffers = (offers: ListOffersResponseModel): Offer[] =>
+export const serializeOffers = (
+  offers: ListOffersResponseModel | ListCollectiveOffersResponseModel
+): Offer[] =>
   offers.map(offer => ({
     id: offer.id,
     status: offer.status,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13519

## Implémentation
- Création de 2 nouveaux composants dans le dossier `routes/Offers`
  - `InvidividualOffers` et `CollectiveOffers`
  - la logique est dupliquée pour l'instant (dans un prochain ticket les filtres vont changer)
- La route appelle l'un ou l'autre en fonction de la valeur du query param