### PR TITLE
[bsr][api][qa] Fix listing of test files in CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,8 @@ jobs:
       - run:
           name: Running tests
           command: |
-            TEST_FILES=$(circleci tests glob "tests/**/*.py" | circleci tests split)
+            # Synchronize these globs with `python_files` in `pytest.ini`
+            TEST_FILES=$(circleci tests glob "tests/**/*_test.py" "tests/**/test_*.py" "tests/**/tests.py" | circleci tests split)
             mkdir -p test-results
             RUN_ENV=tests venv/bin/pytest $TEST_FILES --durations=10 --junitxml=test-results/junit.xml
           working_directory: api

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -2,6 +2,7 @@
 addopts=-v --tb=short
 testpaths=tests
 norecursedirs=.git venv/ .pytest_cache/
+# Synchronize these globs with `TEST_FILES` in CircleCI configuration
 python_files=*_test.py test_*.py tests.py
 python_classes=*Test
 python_functions=test_* when_* expect_* should_*


### PR DESCRIPTION
The glob was too laxist and caught non-test files, such as files in
`tests/files/` (amongst other directories). This caused an error
because there is a `pylint.py` file in this directory. Therefore,
`import pylint.testutils` (which appeared in a real test file) failed
with an ImportError because `import pylint` would import that
file (and not the `pylint` package).

I thought about using `pytest --collect-only` but it does not output
the path of all test files: sometimes the full path is displayed,
sometimes only the filename.