### PR TITLE
(PC-13207)[API] fix: dossierModifierAnnotationText expects a "dossier_id" not an "application_id"

### DIFF
--- a/api/src/pcapi/connectors/dms/graphql/pro/get_banking_info_v2.graphql
+++ b/api/src/pcapi/connectors/dms/graphql/pro/get_banking_info_v2.graphql
@@ -1,5 +1,6 @@
 query get_banking_info($dossierNumber: Int!) {
   dossier(number: $dossierNumber) {
+    id
     state
     dateDerniereModification
     champs {

--- a/api/src/pcapi/domain/demarches_simplifiees.py
+++ b/api/src/pcapi/domain/demarches_simplifiees.py
@@ -42,6 +42,7 @@ class ApplicationDetail:
         siret: Optional[str] = None,
         venue_name: Optional[str] = None,
         annotation_id: Optional[str] = None,
+        dossier_id: str = None,
     ):
         self.siren = siren
         self.status = status
@@ -52,6 +53,7 @@ class ApplicationDetail:
         self.venue_name = venue_name
         self.modification_date = modification_date
         self.annotation_id = annotation_id
+        self.dossier_id = dossier_id
 
 
 def get_offerer_bank_information_application_details_by_application_id(application_id: str) -> ApplicationDetail:
@@ -78,6 +80,7 @@ def parse_raw_bic_data(data: dict) -> dict:
     result = {
         "status": data["dossier"]["state"],
         "updated_at": data["dossier"]["dateDerniereModification"],
+        "dossier_id": data["dossier"]["id"],
     }
     ID_TO_NAME_MAPPING = {
         "Q2hhbXAtNDA3ODg5": "firstname",
@@ -145,6 +148,7 @@ def get_venue_bank_information_application_details_by_application_id(
             siret=data["siret"],
             modification_date=datetime.fromisoformat(data["updated_at"]).astimezone().replace(tzinfo=None),
             annotation_id=data["annotation_id"],
+            dossier_id=data["dossier_id"],
         )
     raise ValueError("Unknown version %s" % version)
 
@@ -185,9 +189,9 @@ def _find_value_in_fields(fields: list[dict], value_name: str) -> Optional[dict]
     return None
 
 
-def update_demarches_simplifiees_text_annotations(application_id: str, annotation_id: str, message: str) -> None:
+def update_demarches_simplifiees_text_annotations(dossier_id: str, annotation_id: str, message: str) -> None:
     client = api_dms.DMSGraphQLClient()
-    client.update_text_annotation(application_id, settings.DMS_INSTRUCTOR_ID, annotation_id, message)
+    client.update_text_annotation(dossier_id, settings.DMS_INSTRUCTOR_ID, annotation_id, message)
 
 
 def format_error_to_demarches_simplifiees_text(api_error: CannotRegisterBankInformation) -> str:

--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -60,7 +60,7 @@ class SaveVenueBankInformations:
             if application_details.status == BankInformationStatus.ACCEPTED:
                 if application_details.annotation_id is not None:
                     update_demarches_simplifiees_text_annotations(
-                        application_id,
+                        application_details.dossier_id,
                         application_details.annotation_id,
                         format_error_to_demarches_simplifiees_text(api_errors),
                     )
@@ -91,7 +91,7 @@ class SaveVenueBankInformations:
         if api_errors.errors:
             if application_details.annotation_id is not None:
                 update_demarches_simplifiees_text_annotations(
-                    application_id,
+                    application_details.dossier_id,
                     application_details.annotation_id,
                     format_error_to_demarches_simplifiees_text(api_errors),
                 )

--- a/api/tests/connector_creators/demarches_simplifiees_creators.py
+++ b/api/tests/connector_creators/demarches_simplifiees_creators.py
@@ -161,6 +161,7 @@ def venue_demarche_simplifiee_application_detail_response_without_siret(
 def venue_demarche_simplifiee_get_bic_response_v2(annotation: dict):
     return {
         "dossier": {
+            "id": "Q2zzbXAtNzgyODAw",
             "champs": [
                 {
                     "etablissement": {

--- a/api/tests/domain/demarches_simplifiees_test.py
+++ b/api/tests/domain/demarches_simplifiees_test.py
@@ -127,7 +127,7 @@ class GetVenueBankInformation_applicationDetailsByApplicationIdTest:
         assert application_details.iban == "FR7630007000111234567890144"
         assert application_details.bic == "SOGEFRPP"
         assert application_details.siret == "12345678900014"
-        # assert application_details.venue_name == "VENUE_NAME"
+        assert application_details.dossier_id == "Q2zzbXAtNzgyODAw"
         assert application_details.modification_date == updated_at
         assert application_details.annotation_id == (
             annotation["id"] if annotation["label"] == "Erreur traitement pass Culture" else None
@@ -235,6 +235,7 @@ class ParseRawBicDataTest:
     def test_parsing_works(self):
         INPUT_DATA = {
             "dossier": {
+                "id": "Q2zzbXAtNzgyODAw",
                 "champs": [
                     {"id": "Q2hhbXAtNDA3ODk1", "label": "Mes informations", "stringValue": "", "value": None},
                     {"id": "Q2hhbXAtNDA3ODg5", "label": "Mon prénom", "stringValue": "John", "value": "John"},
@@ -374,4 +375,5 @@ class ParseRawBicDataTest:
             "iban": "FR7630001007941234567890185",
             "bic": "QSDFGH8Z",
             "annotation_id": "InterestingId",
+            "dossier_id": "Q2zzbXAtNzgyODAw",
         }

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -958,6 +958,7 @@ class SaveVenueBankInformationsTest:
     class SaveBankInformationUpdateTextOnErrorTest:
         application_id = 1
         annotation_id = "Q4hhaXAtOEE1NSg5"
+        dossier_id = "Q4zzaXAtOEE1NSg5"
 
         def setup_method(self):
             self.save_venue_bank_informations = SaveVenueBankInformations(
@@ -975,6 +976,7 @@ class SaveVenueBankInformationsTest:
                 "modification_date": datetime.utcnow(),
                 "venue_name": "venuedemo",
                 "annotation_id": self.annotation_id,
+                "dossier_id": self.dossier_id,
             }
             if updated_field:
                 application_data.update(updated_field)
@@ -986,7 +988,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id, self.annotation_id, "Offerer: Offerer not found"
+                self.dossier_id, self.annotation_id, "Offerer: Offerer not found"
             )
 
         @pytest.mark.usefixtures("db_session")
@@ -997,7 +999,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id, self.annotation_id, "Venue: Venue name not found"
+                self.dossier_id, self.annotation_id, "Venue: Venue name not found"
             )
 
         @pytest.mark.usefixtures("db_session")
@@ -1011,7 +1013,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id, self.annotation_id, "Venue: Multiple venues found"
+                self.dossier_id, self.annotation_id, "Venue: Multiple venues found"
             )
 
         @pytest.mark.usefixtures("db_session")
@@ -1025,7 +1027,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id, self.annotation_id, "Venue: Venue not found"
+                self.dossier_id, self.annotation_id, "Venue: Venue not found"
             )
 
         @pytest.mark.usefixtures("db_session")
@@ -1040,7 +1042,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id, self.annotation_id, "Venue: SIRET is no longer active"
+                self.dossier_id, self.annotation_id, "Venue: SIRET is no longer active"
             )
 
         @patch("pcapi.connectors.api_entreprises.check_siret_is_still_active", return_value=True)
@@ -1059,7 +1061,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id,
+                self.dossier_id,
                 self.annotation_id,
                 "BankInformation: Received application details are older than saved one",
             )
@@ -1079,7 +1081,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id,
+                self.dossier_id,
                 self.annotation_id,
                 "BankInformation: Received application details state does not allow to change bank information",
             )
@@ -1098,7 +1100,7 @@ class SaveVenueBankInformationsTest:
             self.save_venue_bank_informations.execute(self.application_id)
 
             mock_update_text_annotation.assert_called_once_with(
-                self.application_id,
+                self.dossier_id,
                 self.annotation_id,
                 'iban: L’IBAN renseigné ("INVALID") est invalide; bic: Cette information est obligatoire',
             )


### PR DESCRIPTION
application_id et dossier_id sont 2 représentations de l'id d'un dossier, le premier un "Number" (entier), l'autre une string

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13207

cc [erreur sentry1](https://sentry.internal-passculture.app/organizations/sentry/issues/367384/?environment=testing&project=5&query=is%3Aunresolved&statsPeriod=14d) [erreur sentry2](https://sentry.internal-passculture.app/organizations/sentry/issues/367423/?environment=testing&project=5&query=is%3Aunresolved&statsPeriod=14d)

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
