### PR TITLE
(PC-14178)[API] fix: fix CollectiveOffer.isSoldOut in queries

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -128,15 +128,11 @@ class CollectiveOffer(PcObject, ValidationMixin, AccessibilityMixin, StatusMixin
 
     @isSoldOut.expression  # type: ignore[no-redef]
     def isSoldOut(cls):  # pylint: disable=no-self-argument
-        return sa.exists(
-            sa.select(CollectiveStock)
-            .join(CollectiveBooking, CollectiveBooking.collectiveStockId == CollectiveStock.id)
-            .where(
-                sa.and_(
-                    CollectiveStock.collectiveOfferId == cls.id,
-                    CollectiveBooking.status != CollectiveBookingStatus.CANCELLED,
-                )
-            )
+        return (
+            sa.exists()
+            .where(CollectiveStock.collectiveOfferId == cls.id)
+            .where(CollectiveBooking.collectiveStockId == CollectiveStock.id)
+            .where(CollectiveBooking.status != CollectiveBookingStatus.CANCELLED)
         )
 
     @property


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14178

## But de la pull request
réparer l'attribut isSoldOut  des collectiveOffer colrs de son usage dans des query sqlalchemy
