### PR TITLE
[API][FIX] (PC-13524)[API] fix:tests: compare sets

### DIFF
--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -656,7 +656,7 @@ class GetEligibleForSearchVenuesTest:
         with assert_num_queries(1):
             venues = list(offerers_api.get_eligible_for_search_venues(max_venues=1))
 
-        assert venues[0].id == eligible_venues[0].id
+        assert venues[0].id in {venue.id for venue in eligible_venues}
 
     def test_only_permantent_venues_are_eligibles(self) -> None:
         eligible_venues = offers_factories.VenueFactory.create_batch(3, isPermanent=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13524

## But de la pull request

Utiliser des sets, plutôt que de partir du principe que le premier élément de `eligible_venues` sera bien celui récupéré : si c'est un autre lieu, le test va planter pour rien.