### PR TITLE
[bsr][api][git hooks] Sort Alembic heads in `alembic_version_conflict_detection.txt`

### DIFF
--- a/api/hooks/pre-commit
+++ b/api/hooks/pre-commit
@@ -14,7 +14,8 @@ if [[ "$ALEMBIC_STAGED_FILES" != "" ]]; then
   echo -e "\033[0;96mUpdating alembic_version_conflict_detection.txt \033[0m\n"
   pushd `pwd`
   cd api
-  alembic --config alembic.ini heads > alembic_version_conflict_detection.txt
+  # Sort heads: "pre" then "post" (the output of Alembic is not stable)
+  alembic --config alembic.ini heads | sort --key 2 --reverse  > alembic_version_conflict_detection.txt
   git add alembic_version_conflict_detection.txt
   popd
 fi


### PR DESCRIPTION
Alembic's output is not stable. Which means that sometimes the "pre"
branch appears first, and sometime it's the "post" branch. It makes
diff (slightly) harder to read than necessary.

Now branches are sorted: "pre" is always on the first line, "post" is
always on the second line".