### PR TITLE
(PC-12782)[API] feat: sib email first venue approved offer to pro

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
@@ -1,0 +1,32 @@
+from pcapi.core import mails
+from pcapi.core.bookings import constants as booking_constants
+from pcapi.core.categories import subcategories
+from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offers.models import Offer
+from pcapi.utils.mailing import build_pc_pro_offer_link
+
+
+def get_first_venue_approved_offer_email_data(offer: Offer) -> SendinblueTransactionalEmailData:
+    return SendinblueTransactionalEmailData(
+        template=TransactionalEmail.FIRST_VENUE_APPROVED_OFFER_TO_PRO.value,
+        params={
+            "OFFER_NAME": offer.name,
+            "VENUE_NAME": offer.venue.publicName or offer.venue.name,
+            "IS_EVENT": offer.isEvent,
+            "IS_THING": offer.isThing,
+            "IS_DIGITAL": offer.isDigital,
+            "WITHDRAWAL_PERIOD": booking_constants.BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY.days
+            if offer.subcategoryId == subcategories.LIVRE_PAPIER.id
+            else booking_constants.BOOKINGS_AUTO_EXPIRY_DELAY.days,
+            "PC_PRO_OFFER_LINK": build_pc_pro_offer_link(offer),
+        },
+    )
+
+
+def send_first_venue_approved_offer_email_to_pro(offer: Offer) -> bool:
+    recipient = offer.venue.bookingEmail
+    if not recipient:
+        return True
+    data = get_first_venue_approved_offer_email_data(offer)
+    return mails.send(recipients=[recipient], data=data)

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -90,6 +90,7 @@ class TransactionalEmail(Enum):
     EVENT_OFFER_POSTPONED_CONFIRMATION_TO_PRO = TemplatePro(
         id_prod=519, id_not_prod=63, tags=["pro_offre_evenement_reportee"]
     )
+    FIRST_VENUE_APPROVED_OFFER_TO_PRO = TemplatePro(id_prod=569, id_not_prod=74, tags=["pro_premiere_offre"])
     INVOICE_AVAILABLE_TO_PRO = TemplatePro(id_prod=405, id_not_prod=61, tags=["remboursement_justificatif"])
     NEW_BOOKING_TO_PRO = TemplatePro(id_prod=608, id_not_prod=59, tags=["pro_nouvelle_reservation"])
     NEW_OFFERER_VALIDATION = TemplatePro(id_prod=489, id_not_prod=58, tags=["pro_validation_structure"])

--- a/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
@@ -1,0 +1,85 @@
+import pytest
+
+from pcapi.core.categories import subcategories
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.mails.transactional.pro.first_venue_approved_offer_to_pro import (
+    get_first_venue_approved_offer_email_data,
+)
+from pcapi.core.mails.transactional.pro.first_venue_approved_offer_to_pro import (
+    send_first_venue_approved_offer_email_to_pro,
+)
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+import pcapi.core.offers.factories as offer_factories
+from pcapi.core.offers.factories import OfferFactory
+from pcapi.core.offers.factories import VenueFactory
+from pcapi.settings import PRO_URL
+from pcapi.utils.human_ids import humanize
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class SendinblueSendFirstVenueOfferEmailTest:
+    def test_get_first_venue_approved_offer_correct_email_metadata(self):
+        # Given
+        offer = offer_factories.OfferFactory(name="Ma petite offre", venue__name="Mon stade")
+
+        # When
+        new_offer_validation_email = get_first_venue_approved_offer_email_data(offer)
+
+        # Then
+        assert new_offer_validation_email.template == TransactionalEmail.FIRST_VENUE_APPROVED_OFFER_TO_PRO.value
+        assert new_offer_validation_email.params == {
+            "OFFER_NAME": "Ma petite offre",
+            "VENUE_NAME": "Mon stade",
+            "IS_EVENT": False,
+            "IS_THING": True,
+            "IS_DIGITAL": False,
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/{humanize(offer.id)}/individuel/edition",
+            "WITHDRAWAL_PERIOD": 30,
+        }
+
+    def test_get_first_venue_approved_book_offer_correct_email_metadata(self):
+        # Given
+        product = offer_factories.ProductFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
+        offer = offer_factories.OfferFactory(name="Ma petite offre", venue__name="Mon stade", product=product)
+
+        # When
+        new_offer_validation_email = get_first_venue_approved_offer_email_data(offer)
+
+        # Then
+        assert new_offer_validation_email.template == TransactionalEmail.FIRST_VENUE_APPROVED_OFFER_TO_PRO.value
+        assert new_offer_validation_email.params == {
+            "OFFER_NAME": "Ma petite offre",
+            "VENUE_NAME": "Mon stade",
+            "IS_EVENT": False,
+            "IS_THING": True,
+            "IS_DIGITAL": False,
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/{humanize(offer.id)}/individuel/edition",
+            "WITHDRAWAL_PERIOD": 10,
+        }
+
+    def test_send_offer_approval_email(self):
+        # Given
+        venue = VenueFactory(name="Sibérie orientale", bookingEmail="venue@bookingEmail.com")
+        offer = OfferFactory(name="Michel Strogoff", venue=venue)
+
+        # When
+        send_first_venue_approved_offer_email_to_pro(offer)
+
+        # Then
+        assert len(mails_testing.outbox) == 1  # test number of emails sent
+        assert (
+            mails_testing.outbox[0].sent_data["template"]
+            == TransactionalEmail.FIRST_VENUE_APPROVED_OFFER_TO_PRO.value.__dict__
+        )
+        assert mails_testing.outbox[0].sent_data["To"] == "venue@bookingEmail.com"
+        assert mails_testing.outbox[0].sent_data["params"] == {
+            "OFFER_NAME": offer.name,
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/{humanize(offer.id)}/individuel/edition",
+            "VENUE_NAME": venue.name,
+            "IS_EVENT": False,
+            "IS_THING": True,
+            "IS_DIGITAL": False,
+            "WITHDRAWAL_PERIOD": 30,
+        }

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -626,7 +626,8 @@ class UpsertStocksTest:
         # Then
         assert error.value.errors == {"global": ["Pour les offres importées, certains champs ne sont pas modifiables"]}
 
-    def test_create_stock_for_non_approved_offer_fails(self):
+    @mock.patch("pcapi.core.offers.api.send_first_venue_approved_offer_email_to_pro")
+    def test_create_stock_for_non_approved_offer_fails(self, mocked_send_first_venue_approved_offer_email_to_pro):
         user = users_factories.ProFactory()
         offer = offer_factories.ThingOfferFactory(validation=offer_models.OfferValidationStatus.PENDING)
         created_stock_data = stock_serialize.StockCreationBodyModel(price=10, quantity=7)
@@ -639,7 +640,13 @@ class UpsertStocksTest:
         }
         assert offer_models.Stock.query.count() == 0
 
-    def test_edit_stock_of_non_approved_offer_fails(self):
+        assert not mocked_send_first_venue_approved_offer_email_to_pro.called
+
+    @mock.patch("pcapi.core.offers.api.send_first_venue_approved_offer_email_to_pro")
+    def test_edit_stock_of_non_approved_offer_fails(
+        self,
+        mocked_send_first_venue_approved_offer_email_to_pro,
+    ):
         user = users_factories.ProFactory()
         offer = offer_factories.ThingOfferFactory(validation=offer_models.OfferValidationStatus.PENDING)
         existing_stock = offer_factories.StockFactory(offer=offer, price=10)
@@ -654,10 +661,16 @@ class UpsertStocksTest:
         existing_stock = offer_models.Stock.query.one()
         assert existing_stock.price == 10
 
+        assert not mocked_send_first_venue_approved_offer_email_to_pro.called
+
     @mock.patch("pcapi.domain.admin_emails.send_offer_creation_notification_to_administration")
+    @mock.patch("pcapi.core.offers.api.send_first_venue_approved_offer_email_to_pro")
     @mock.patch("pcapi.core.offers.api.set_offer_status_based_on_fraud_criteria")
     def test_send_email_when_offer_automatically_approved_based_on_fraud_criteria(
-        self, mocked_set_offer_status_based_on_fraud_criteria, mocked_offer_creation_notification_to_admin
+        self,
+        mocked_set_offer_status_based_on_fraud_criteria,
+        mocked_send_first_venue_approved_offer_email_to_pro,
+        mocked_offer_creation_notification_to_admin,
     ):
         user = users_factories.ProFactory()
         offer = offer_factories.ThingOfferFactory(validation=offer_models.OfferValidationStatus.DRAFT)
@@ -667,11 +680,16 @@ class UpsertStocksTest:
         api.upsert_stocks(offer_id=offer.id, stock_data_list=[created_stock_data], user=user)
 
         mocked_offer_creation_notification_to_admin.assert_called_once_with(offer)
+        mocked_send_first_venue_approved_offer_email_to_pro.assert_called_once_with(offer)
 
     @mock.patch("pcapi.domain.admin_emails.send_offer_creation_notification_to_administration")
+    @mock.patch("pcapi.core.offers.api.send_first_venue_approved_offer_email_to_pro")
     @mock.patch("pcapi.core.offers.api.set_offer_status_based_on_fraud_criteria")
     def test_not_send_email_when_offer_pass_to_pending_based_on_fraud_criteria(
-        self, mocked_set_offer_status_based_on_fraud_criteria, mocked_offer_creation_notification_to_admin
+        self,
+        mocked_set_offer_status_based_on_fraud_criteria,
+        mocked_send_first_venue_approved_offer_email_to_pro,
+        mocked_offer_creation_notification_to_admin,
     ):
         user = users_factories.ProFactory()
         offer = offer_factories.ThingOfferFactory(validation=offer_models.OfferValidationStatus.DRAFT)
@@ -681,6 +699,7 @@ class UpsertStocksTest:
         api.upsert_stocks(offer_id=offer.id, stock_data_list=[created_stock_data], user=user)
 
         assert not mocked_offer_creation_notification_to_admin.called
+        assert not mocked_send_first_venue_approved_offer_email_to_pro.called
 
 
 @freeze_time("2020-11-17 15:00:00")
@@ -810,9 +829,13 @@ class CreateEducationalOfferStocksTest:
 
     @override_features(ENABLE_NEW_COLLECTIVE_MODEL=False)
     @mock.patch("pcapi.domain.admin_emails.send_offer_creation_notification_to_administration")
+    @mock.patch("pcapi.core.offers.api.send_first_venue_approved_offer_email_to_pro")
     @mock.patch("pcapi.core.offers.api.set_offer_status_based_on_fraud_criteria")
     def test_send_email_when_offer_automatically_approved_based_on_fraud_criteria(
-        self, mocked_set_offer_status_based_on_fraud_criteria, mocked_offer_creation_notification_to_admin
+        self,
+        mocked_set_offer_status_based_on_fraud_criteria,
+        mocked_send_first_venue_approved_offer_email_to_pro,
+        mocked_offer_creation_notification_to_admin,
     ):
         # Given
         user = users_factories.ProFactory()
@@ -831,11 +854,16 @@ class CreateEducationalOfferStocksTest:
 
         # Then
         mocked_offer_creation_notification_to_admin.assert_called_once_with(offer)
+        assert not mocked_send_first_venue_approved_offer_email_to_pro.called
 
     @mock.patch("pcapi.domain.admin_emails.send_offer_creation_notification_to_administration")
+    @mock.patch("pcapi.core.offers.api.send_first_venue_approved_offer_email_to_pro")
     @mock.patch("pcapi.core.offers.api.set_offer_status_based_on_fraud_criteria")
     def test_not_send_email_when_offer_pass_to_pending_based_on_fraud_criteria(
-        self, mocked_set_offer_status_based_on_fraud_criteria, mocked_offer_creation_notification_to_admin
+        self,
+        mocked_set_offer_status_based_on_fraud_criteria,
+        mocked_send_first_venue_approved_offer_email_to_pro,
+        mocked_offer_creation_notification_to_admin,
     ):
         # Given
         user = users_factories.ProFactory()
@@ -854,6 +882,7 @@ class CreateEducationalOfferStocksTest:
 
         # Then
         assert not mocked_offer_creation_notification_to_admin.called
+        assert not mocked_send_first_venue_approved_offer_email_to_pro.called
 
 
 class EditEducationalOfferStocksTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-12782

## But de la pull request

Envoi un email à l'acteur culturel si c'est la première offre validée d'un lieu 

## Implémentation
1/ check si une première offre approuvée dans le même lieu que l'offre en cours d'approbation existe
2/ si non, on check si l'offre en cours est approuvée puis on envoie le mail

## Informations supplémentaires
N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
