### PR TITLE
(PC-14136)[PRO] fix: add shadow on password input wrapper

### DIFF
--- a/pro/src/components/layout/inputs/TextInputWithIcon/TextInputWithIcon.jsx
+++ b/pro/src/components/layout/inputs/TextInputWithIcon/TextInputWithIcon.jsx
@@ -26,7 +26,7 @@ const TextInputWithIcon = ({
       <span className="it-sub-label">{sublabel}</span>
     </div>
     <div
-      className={`it-with-icon-container ${disabled ? 'disabled' : ''} ${
+      className={`it-with-icon-container${disabled ? ' disabled' : ''} ${
         error ? 'error' : ''
       }`}
     >

--- a/pro/src/styles/components/layout/inputs/TextInputWithIcon/_TextInputWithIcon.scss
+++ b/pro/src/styles/components/layout/inputs/TextInputWithIcon/_TextInputWithIcon.scss
@@ -2,6 +2,7 @@
   align-items: center;
   border: 1px solid $grey-medium;
   border-radius: 22px;
+  box-shadow: 0 2px 6px 0 $black-shadow;
   display: flex;
   height: rem(40px);
   justify-content: space-between;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14136

## But de la pull request

Mettre une ombre autour du champ mot de passe sur le formulaire de création d'un compte

## Implémentation

- ajout d'une propriété css sur le wrapper du champ

## Screenshot
<img width="1519" alt="Capture d’écran 2022-03-29 à 15 08 52 (2)" src="https://user-images.githubusercontent.com/101103940/160618393-a80df65c-5179-409a-8042-98bdb8029714.png">

