### PR TITLE
(PC-14151)[api] Fix DMS application failure with no eligibility

### DIFF
--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -149,15 +149,15 @@ def parse_beneficiary_information_graphql(
 
         if label in (dms_models.FieldLabel.DEPARTMENT_FR.value, dms_models.FieldLabel.DEPARTMENT_ET.value):
             department = re.search("^[0-9]{2,3}|[2BbAa]{2}", value).group(0)
-        if label in (dms_models.FieldLabel.BIRTH_DATE_ET, dms_models.FieldLabel.BIRTH_DATE_FR.value):
+        elif label in (dms_models.FieldLabel.BIRTH_DATE_ET.value, dms_models.FieldLabel.BIRTH_DATE_FR.value):
             try:
                 birth_date = date_parser.parse(value, FrenchParserInfo())
             except Exception:  # pylint: disable=broad-except
                 parsing_errors["birth_date"] = value
 
-        if label in (dms_models.FieldLabel.TELEPHONE_FR.value, dms_models.FieldLabel.TELEPHONE_ET.value):
+        elif label in (dms_models.FieldLabel.TELEPHONE_FR.value, dms_models.FieldLabel.TELEPHONE_ET.value):
             phone = value.replace(" ", "")
-        if label in (
+        elif label in (
             dms_models.FieldLabel.POSTAL_CODE_ET.value,
             dms_models.FieldLabel.POSTAL_CODE_FR.value,
         ):
@@ -167,14 +167,14 @@ def parse_beneficiary_information_graphql(
             except Exception:  # pylint: disable=broad-except
                 parsing_errors["postal_code"] = value
 
-        if label in (dms_models.FieldLabel.ACTIVITY_FR.value, dms_models.FieldLabel.ACTIVITY_ET.value):
+        elif label in (dms_models.FieldLabel.ACTIVITY_FR.value, dms_models.FieldLabel.ACTIVITY_ET.value):
             activity = value
-        if label in (
+        elif label in (
             dms_models.FieldLabel.ADDRESS_ET.value,
             dms_models.FieldLabel.ADDRESS_FR.value,
         ):
             address = value
-        if label in (
+        elif label in (
             dms_models.FieldLabel.ID_PIECE_NUMBER_FR.value,
             dms_models.FieldLabel.ID_PIECE_NUMBER_ET.value,
         ):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14151

## But de la pull request

L'équipe support nous a remonté plusieurs utilisateurs dont le dossier DMS a été importé avec un statut OK mais ça n’a pas donné lieu à l’attribution du crédit car le champ ‘Éligibilité’ du Fraud Check est vide.

Exemple : https://backend.passculture.beta.gouv.fr/pc/back-office/support_beneficiary/details/?id=212885&url=%2Fpc%2Fback-office%2Fsupport_beneficiary%2F%3Fsearch%3D2802462

## Implémentation
## Informations supplémentaires

Régression apportée par ce commit du 14 mars : [f0bd9f49a1504ba3f780d096c9915ecb17c5eab4](https://github.com/pass-culture/pass-culture-main/commit/f0bd9f49a1504ba3f780d096c9915ecb17c5eab4)
Il manque `.value` sur `dms_models.FieldLabel.BIRTH_DATE_ET` (il y est bien partout ailleurs dans la fonction), donc aucune date de naissance n'est extraite, donc non éligible.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
