### PR TITLE
(PC-13693)[API][FlaskAdmin] feat: Permettre une validation manuelle d'un user sur FA

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view/api.py
+++ b/api/src/pcapi/admin/custom_views/support_view/api.py
@@ -1,10 +1,19 @@
 import enum
 import logging
 
+import flask
+
+import pcapi.core.fraud.api as fraud_api
+import pcapi.core.fraud.models as fraud_models
+from pcapi.core.mails.transactional.users.subscription_document_error import send_subscription_document_error_email
+import pcapi.core.payments.exceptions as payment_exceptions
 from pcapi.core.subscription import api as subscription_api
+from pcapi.core.subscription import messages as subscription_messages
+import pcapi.core.subscription.exceptions as subscription_exceptions
 from pcapi.core.subscription.models import SubscriptionItemStatus
 import pcapi.core.users.api as users_api
 import pcapi.core.users.models as users_models
+from pcapi.models import db
 
 
 logger = logging.getLogger(__name__)
@@ -57,3 +66,57 @@ def get_beneficiary_activation_status(user: users_models.User) -> BeneficiaryAct
         return BeneficiaryActivationStatus.INCOMPLETE
 
     return BeneficiaryActivationStatus.NOT_APPLICABLE
+
+
+def on_admin_review(review: fraud_models.BeneficiaryFraudReview, user: users_models.User, data):  # type: ignore [no-untyped-def]
+
+    if review.review == fraud_models.FraudReviewStatus.OK.value:
+        fraud_check = fraud_api.get_last_filled_identity_fraud_check(user)
+        if not fraud_check:
+            flask.flash("Pas de vérification d'identité effectuée", "error")
+            return flask.redirect(flask.url_for(".details_view", id=user.id))
+
+        source_data = fraud_check.source_data()
+
+        users_api.update_user_information_from_external_source(user, source_data)  # type: ignore [arg-type]
+        if data["eligibility"] == "Par défaut":
+            eligibility = fraud_api.decide_eligibility(user, source_data)  # type: ignore [arg-type]
+
+            if not eligibility:
+                flask.flash(
+                    "Aucune éligibilité trouvée. Veuillez choisir une autre Eligibilité que 'Par défaut'", "error"
+                )
+                return flask.redirect(flask.url_for(".details_view", id=user.id))
+        else:
+            eligibility = users_models.EligibilityType[data["eligibility"]]
+        try:
+            subscription_api.activate_beneficiary_for_eligibility(user, fraud_check, eligibility)
+            flask.flash(f"L'utilisateur a bien été activé en tant que bénéficiaire '{eligibility.value}'", "success")
+
+        except subscription_exceptions.InvalidEligibilityTypeException:
+            flask.flash(f"L'égibilité '{eligibility.value}' n'existe pas !", "error")
+            return flask.redirect(flask.url_for(".details_view", id=user.id))
+        except subscription_exceptions.CannotUpgradeBeneficiaryRole:
+            flask.flash(f"L'utilisateur ne peut pas être promu au rôle {eligibility.value}", "error")
+            return flask.redirect(flask.url_for(".details_view", id=user.id))
+        except payment_exceptions.UserHasAlreadyActiveDeposit:
+            flask.flash(f"L'utilisateur bénéficie déjà d'un déposit non expiré du type '{eligibility.value}'", "error")
+            return flask.redirect(flask.url_for(".details_view", id=user.id))
+        except payment_exceptions.DepositTypeAlreadyGrantedException:
+            flask.flash("Un déposit de ce type a déjà été créé", "error")
+            return flask.redirect(flask.url_for(".details_view", id=user.id))
+
+    elif review.review == fraud_models.FraudReviewStatus.REDIRECTED_TO_DMS.value:
+        review.reason += " ; Redirigé vers DMS"  # type: ignore [operator]
+
+        send_subscription_document_error_email(user.email, "unread-document")
+        flask.flash("L'utilisateur  à été redirigé vers DMS")
+        subscription_messages.on_redirect_to_dms_from_idcheck(user)
+    elif review.review == fraud_models.FraudReviewStatus.KO.value:
+        subscription_messages.on_fraud_review_ko(user)
+
+    db.session.add(review)
+    db.session.commit()
+
+    flask.flash("Une revue manuelle ajoutée pour l'utilisateur")
+    return flask.redirect(flask.url_for(".details_view", id=user.id))

--- a/api/src/pcapi/admin/custom_views/support_view/utils.py
+++ b/api/src/pcapi/admin/custom_views/support_view/utils.py
@@ -16,19 +16,25 @@ def beneficiary_fraud_review_formatter(view, context, model, name) -> Markup:  #
         fraud_models.FraudReviewStatus.KO: "badge-danger",
         fraud_models.FraudReviewStatus.REDIRECTED_TO_DMS: "badge-secondary",
     }
-    if model.beneficiaryFraudReview is None:
+    if not model.beneficiaryFraudReviews:
         return Markup("""<span class="badge badge-secondary">inconnu</span>""")
 
-    reviewer = model.beneficiaryFraudReview.author
-    reviewer_name = f"{reviewer.firstName} {reviewer.lastName}"
-    review_result = model.beneficiaryFraudReview.review
-    badge = result_mapping_class[review_result]
-    return Markup(
-        """
-          <div><span>{reviewer_name}</span></div>
-          <span class="badge {badge}">{review_result_value}</span>
-        """
-    ).format(reviewer_name=reviewer_name, badge=badge, review_result_value=review_result.value)
+    ordered_fraud_reviews = sorted(model.beneficiaryFraudReviews, key=lambda review: review.dateReviewed)
+    html = Markup("<ul>")
+
+    for beneficiary_fraud_review in ordered_fraud_reviews:
+        reviewer = beneficiary_fraud_review.author
+        reviewer_name = f"{reviewer.firstName} {reviewer.lastName}"
+        review_result = beneficiary_fraud_review.review
+        badge = result_mapping_class[review_result]
+        html += Markup(
+            """
+              <div><span>{reviewer_name}</span></div>
+              <span class="badge {badge}">{review_result_value}</span>
+            """
+        ).format(reviewer_name=reviewer_name, badge=badge, review_result_value=review_result.value)
+
+    return html
 
 
 def beneficiary_fraud_checks_formatter(view, context, model, name) -> Markup:  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -528,6 +528,23 @@ def has_user_performed_identity_check(user: users_models.User) -> bool:
     )
 
 
+def get_last_filled_identity_fraud_check(user: users_models.User) -> typing.Optional[models.BeneficiaryFraudCheck]:
+    user_identity_fraud_checks = [
+        fraud_check
+        for fraud_check in user.beneficiaryFraudChecks
+        if fraud_check.type in models.IDENTITY_CHECK_TYPES
+        and fraud_check.source_data().get_last_name() is not None
+        and fraud_check.source_data().get_first_name() is not None
+        and fraud_check.source_data().get_birth_date() is not None
+    ]
+
+    return (
+        max(user_identity_fraud_checks, key=lambda fraud_check: fraud_check.dateCreated)
+        if user_identity_fraud_checks
+        else None
+    )
+
+
 def is_risky_user_profile(user: users_models.User) -> bool:
     # No need to filter on eligibilityType ; profiling is performed only for AGE18 users.
     user_profiling = (

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -430,9 +430,7 @@ class BeneficiaryFraudReview(PcObject, Model):  # type: ignore [valid-type, misc
 
     userId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
 
-    user = sa.orm.relationship(  # type: ignore [misc]
-        "User", foreign_keys=[userId], backref=sa.orm.backref("beneficiaryFraudReview", uselist=False)
-    )
+    user = sa.orm.relationship("User", foreign_keys=[userId], backref=sa.orm.backref("beneficiaryFraudReviews"))  # type: ignore [misc]
 
     authorId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
 

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -34,17 +34,10 @@ def get_latest_subscription_message(user: users_models.User) -> typing.Optional[
     return models.SubscriptionMessage.query.filter_by(user=user).order_by(models.SubscriptionMessage.id.desc()).first()
 
 
-def activate_beneficiary(user: users_models.User, deposit_source: str = None) -> users_models.User:
-    fraud_check = users_api.get_activable_identity_fraud_check(user)
-    if not fraud_check:
-        raise exceptions.BeneficiaryFraudCheckMissingException(
-            f"No validated Identity fraudCheck found when trying to activate user {user.id}"
-        )
-    eligibility = fraud_check.eligibilityType
+def activate_beneficiary_for_eligibility(
+    user: users_models.User, fraud_check: fraud_models.BeneficiaryFraudCheck, eligibility: users_models.EligibilityType
+) -> users_models.User:
     deposit_source = fraud_check.get_detailed_source()
-
-    if not users_api.is_eligible_for_beneficiary_upgrade(user, eligibility):  # type: ignore [arg-type]
-        raise exceptions.CannotUpgradeBeneficiaryRole()
 
     if eligibility == users_models.EligibilityType.UNDERAGE:
         user.validate_user_identity_15_17()
@@ -78,8 +71,21 @@ def activate_beneficiary(user: users_models.User, deposit_source: str = None) ->
 
     if not accepted_as_beneficiary.send_accepted_as_beneficiary_email(user=user):
         logger.warning("Could not send accepted as beneficiary email to user", extra={"user": user.id})
-
     return user
+
+
+def activate_beneficiary(user: users_models.User, deposit_source: str = None) -> users_models.User:
+    fraud_check = users_api.get_activable_identity_fraud_check(user)
+    if not fraud_check:
+        raise exceptions.BeneficiaryFraudCheckMissingException(
+            f"No validated Identity fraudCheck found when trying to activate user {user.id}"
+        )
+    eligibility = fraud_check.eligibilityType
+
+    if not users_api.is_eligible_for_beneficiary_upgrade(user, eligibility):  # type: ignore [arg-type]
+        raise exceptions.CannotUpgradeBeneficiaryRole()
+
+    return activate_beneficiary_for_eligibility(user, fraud_check, eligibility)  # type: ignore [arg-type]
 
 
 def has_completed_profile(user: users_models.User) -> bool:

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -11,378 +11,403 @@
 {% block details_table %}
 
 <div class="modal fade" id="userValidationModal" tabindex="-1" role="dialog" aria-labelledby="userValidationModalTitle"
-  aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="userValidationModalTitle">Validation de l'utilisateur {{ model.firstName}}
-          {{model.lastName}}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <form method="POST" action="{{ url_for('support_beneficiary.validate_beneficiary', user_id=model.id)}}">
-        <div class="modal-body">
-          <div class="form-group row">
-            <label for="review" class="col-4 col-form-label">Revue</label>
-            <div class="col-8">
-              <select id="review" name="review" class="form-control">
-                <option></option>
-                <option value="OK">OK</option>
-                <option value="KO">KO</option>
-                <option value="REDIRECTED_TO_DMS">Renvoi vers DMS</option>
-              </select>
+     aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="userValidationModalTitle">Validation de l'utilisateur
+                    {% if model.firstName and model.lastName %}
+                    {{ model.firstName}}&nbsp;{{model.lastName}}
+                    {% else %}
+                    {{ model.email }}
+                    {% endif %}
+                </h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
             </div>
-          </div>
-          <div class="form-group row">
-            <label for="reason" class="col-4 col-form-label">Raison</label>
-            <div class="col-8">
+            <form method="POST" action="{{ url_for('support_beneficiary.validate_beneficiary', user_id=model.id)}}">
+                <div class="modal-body">
+                    <div class="form-group row">
+                        <label for="review" class="col-4 col-form-label">Revue</label>
+                        <div class="col-8">
+                            <select id="review" name="review" class="form-control">
+                                <option></option>
+                                <option value="OK">OK</option>
+                                <option value="KO">KO</option>
+                                <option value="REDIRECTED_TO_DMS">Renvoi vers DMS</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="eligibility" class="col-4 col-form-label">Eligibilité</label>
+                        <div class="col-8">
+                            <select id="eligibility" name="eligibility" class="form-control">
+                                <option>Par défaut</option>
+                                <option value="UNDERAGE">Pass 15-17</option>
+                                <option value="AGE18">Pass 18 ans</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="reason" class="col-4 col-form-label">Raison</label>
+                        <div class="col-8">
               <textarea id="reason" name="reason" cols="40" rows="5" class="form-control"
-                required="required"></textarea>
-            </div>
-          </div>
+                        required="required"></textarea>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Fermer</button>
+                    <button name="submit" type="submit" class="btn btn-primary">Valider</button>
+                </div>
+            </form>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Fermer</button>
-          <button name="submit" type="submit" class="btn btn-primary">Valider</button>
-        </div>
-      </form>
     </div>
-  </div>
 </div>
 
 <div class="row">
-  <div class="col">
-    {% if has_performed_identity_check and not model.beneficiaryFraudReview and (current_user.has_jouve_role or
-    current_user.is_super_admin()) %}
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#userValidationModal">
-      Soumettre une revue manuelle
-    </button>
-    {% endif %}
-    {% if current_user.has_admin_role %}
-    <button name="submit" form="validate_form_button" type="submit" class="btn btn-primary">Valider le n° de
-      téléphone</button>
-    {# avoid putting the button inside the form to get the buttons aligned on the same grid #}
-    <form id="validate_form_button" method="POST"
-      action="{{ url_for('support_beneficiary.validate_phone_number', user_id=model.id)}}">
-    </form>
-    {% endif %}
-  </div>
+    <div class="col">
+        {% if has_filled_identity_check and (current_user.is_super_admin()) %}
+        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#userValidationModal">
+            Soumettre une revue manuelle
+        </button>
+        {% else %}
+        <button type="button" class="btn btn-danger" disabled>
+            Revue manuelle non disponible (aucun fraud check avec nom, prénom, date de naissance)
+        </button>
+        {% endif %}
+        {% if current_user.has_admin_role %}
+        <button name="submit" form="validate_form_button" type="submit" class="btn btn-primary">Valider le n° de
+            téléphone
+        </button>
+        {# avoid putting the button inside the form to get the buttons aligned on the same grid #}
+        <form id="validate_form_button" method="POST"
+              action="{{ url_for('support_beneficiary.validate_phone_number', user_id=model.id)}}">
+        </form>
+        {% endif %}
+    </div>
 </div>
 <div class="section row-section">
-  <div class="row-element">
-    <h3>Utilisateur</h3>
-    <table class="table">
-      <tr>
-        <th scope="row">Id</th>
-        <td>{{ model.id }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Nom</th>
-        <td>{{ model.lastName }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Prénom</th>
-        <td>{{ model.firstName }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Email</th>
-        <td>{{ model.email }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Numéro de téléphone</th>
-        <td>{{ model.phoneNumber }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Date de naissance</th>
-        <td>{% if model.dateOfBirth %}{{ model.dateOfBirth.strftime('%d/%m/%Y') }}{% else %}Inconnue{% endif %}</td>
-      </tr>
-      <tr>
-        <th scope="row">Date de création du compte</th>
-        <td>{{ model.dateCreated.strftime('%d/%m/%Y') }}</td>
-      </tr>
-      <tr>
-        <th scope="row">N° de la pièce d'identité</th>
-        <td>{{ model.idPieceNumber }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Commentaire</th>
-        <td>{% if model.comment %} {{ model.comment }} {% endif %}</td>
-      </tr>
-      <tr>
-        <th scope="row">Compte actif</th>
-        <td>{{ model.isActive|yesno }}</td>
-      </tr>
-      {% if model.suspension_reason %}
-      <tr>
-        <th scope="row">L'utilisateur est suspendu</th>
-        <td>{{ model.suspension_reason|suspension_reason_format }}</td>
-      </tr>
-      {% endif %}
-      <tr>
-        <th scope="row">Bénéficiaire 15-17</th>
-        <td>{{ model.has_underage_beneficiary_role|yesno }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Bénéficiaire 18</th>
-        <td>{{ model.has_beneficiary_role|yesno }}</td>
-      </tr>
-      <tr>
-    </table>
-    </dl>
-  </div>
-  <div class="row-element subscription-info">
-    <h3>Parcours d'inscription</h3>
-    <div class="table subscription-info">
-      <table class="table">
-        <tr>
-          <th />
-          <th scope="col" style="text-align: center;">pass 15-17</th>
-          <th scope="col" style="text-align: center;">pass 18</th>
-        </tr>
-        {% for item in subscription_items %}
-        <tr>
-          <th scope="row">{{item.UNDERAGE.type.name}}</th>
-          <td style="text-align: center;">{{ item.UNDERAGE.status|subscription_status_format }}</td>
-          <td style="text-align: center;">{{ item.AGE18.status|subscription_status_format }}</td>
-        </tr>
-        {% endfor %}
-      </table>
+    <div class="row-element">
+        <h3>Utilisateur</h3>
+        <table class="table">
+            <tr>
+                <th scope="row">Id</th>
+                <td>{{ model.id }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Nom</th>
+                <td>{{ model.lastName }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Prénom</th>
+                <td>{{ model.firstName }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Email</th>
+                <td>{{ model.email }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Numéro de téléphone</th>
+                <td>{{ model.phoneNumber }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Date de naissance</th>
+                <td>{% if model.dateOfBirth %}{{ model.dateOfBirth.strftime('%d/%m/%Y') }}{% else %}Inconnue{% endif
+                    %}
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">Date de création du compte</th>
+                <td>{{ model.dateCreated.strftime('%d/%m/%Y') }}</td>
+            </tr>
+            <tr>
+                <th scope="row">N° de la pièce d'identité</th>
+                <td>{{ model.idPieceNumber }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Commentaire</th>
+                <td>{% if model.comment %} {{ model.comment }} {% endif %}</td>
+            </tr>
+            <tr>
+                <th scope="row">Compte actif</th>
+                <td>{{ model.isActive|yesno }}</td>
+            </tr>
+            {% if model.suspension_reason %}
+            <tr>
+                <th scope="row">L'utilisateur est suspendu</th>
+                <td>{{ model.suspension_reason|suspension_reason_format }}</td>
+            </tr>
+            {% endif %}
+            <tr>
+                <th scope="row">Bénéficiaire 15-17</th>
+                <td>{{ model.has_underage_beneficiary_role|yesno }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Bénéficiaire 18</th>
+                <td>{{ model.has_beneficiary_role|yesno }}</td>
+            </tr>
+            <tr></tr>
+        </table>
     </div>
-    <div class="table additional-subscription-info">
-      <h4>Autres</h4>
-      <table>
-        <tr>
-          <th scope="row">Éligibilité</th>
-          <td>{{ model.eligibility|eligibility_format }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Prochaine étape sur l'app</th>
-          <td>{% if next_subscription_step %} {{ next_subscription_step.name }} {% else %}Aucune{% endif %}</td>
-        </tr>
-      </table>
+    <div class="row-element subscription-info">
+        <h3>Parcours d'inscription</h3>
+        <div class="table subscription-info">
+            <table class="table">
+                <tr>
+                    <th/>
+                    <th scope="col" style="text-align: center;">pass 15-17</th>
+                    <th scope="col" style="text-align: center;">pass 18</th>
+                </tr>
+                {% for item in subscription_items %}
+                <tr>
+                    <th scope="row">{{item.UNDERAGE.type.name}}</th>
+                    <td style="text-align: center;">{{ item.UNDERAGE.status|subscription_status_format }}</td>
+                    <td style="text-align: center;">{{ item.AGE18.status|subscription_status_format }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+        <div class="table additional-subscription-info">
+            <h4>Autres</h4>
+            <table>
+                <tr>
+                    <th scope="row">Éligibilité</th>
+                    <td>{{ model.eligibility|eligibility_format }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Prochaine étape sur l'app</th>
+                    <td>{% if next_subscription_step %} {{ next_subscription_step.name }} {% else %}Aucune{% endif %}
+                    </td>
+                </tr>
+            </table>
+        </div>
     </div>
-  </div>
-  {% if model.beneficiaryFraudReview %}
-  <div class="row-element">
-    <h3>Revue manuelle</h3>
-    <table class="table">
-      <tr>
-        <th scope="row">Auteur</th>
-        <td>{{ model.beneficiaryFraudReview.author.firstName }} {{ model.beneficiaryFraudReview.author.lastName }}</td>
-      </tr>
+    {% if model.beneficiaryFraudReviews %}
+    <div class="row-element">
+        <h3>Revue(s) manuelle(s)</h3>
+        {% for review in model.beneficiaryFraudReviews %}
 
-      <tr>
-        <th scope="row">Etat</th>
-        <td>{{ model.beneficiaryFraudReview.review.value }}</td>
-      </tr>
-      <tr>
-        <th scope="row">Date de création</th>
-        <td>{{ model.beneficiaryFraudReview.dateReviewed.strftime('le %d/%m/%Y à %H:%M:%S') }}</dd>
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">Explication</th>
-        <td>{{ model.beneficiaryFraudReview.reason }}</dd>
-        </td>
-      </tr>
-    </table>
-  </div>
-  {% endif %}
+        <table class="table" style="border-style: solid; border-width:1px;">
+            <tr>
+                <th scope="row">Auteur</th>
+                <td>{{ review.author.firstName }} {{ review.author.lastName }}</td>
+            </tr>
+
+            <tr>
+                <th scope="row">Etat</th>
+                <td>{{ review.review.value }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Date de création</th>
+                <td>{{ review.dateReviewed.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Explication</th>
+                <td>{{ review.reason }}</td>
+            </tr>
+        </table>
+        {% endfor %}
+
+    </div>
+    {% endif %}
 </div>
 
 {% if model.suspension_history|length > 0 %}
 <div class="section">
-  <h3>Historique des suspensions de compte</h3>
-  <table class="table table-striped table-hover">
-    <thead>
-      <tr>
-        <th scope="col">Événement</th>
-        <th scope="col">Date</th>
-        <th scope="col">Auteur</th>
-        <th scope="col">Explication</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for suspension_event in model.suspension_history %}
-      <tr>
-        <td>{{ suspension_event.eventType|suspension_event_format }}</td>
-        <td>
-          {% if suspension_event.eventDate %}
-            {{ suspension_event.eventDate.strftime('le %d/%m/%Y à %H:%M:%S') }}
-          {% else %}
-            -
-          {% endif %}
-        </td>
-        <td>
-          {% if suspension_event.actorUser %}
-            {{ suspension_event.actorUser.firstName }} {{ suspension_event.actorUser.lastName }}
-          {% else %}
-            -
-          {% endif %}
-        </td>
-        <td>{{ suspension_event.reasonCode|suspension_reason_format }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+    <h3>Historique des suspensions de compte</h3>
+    <table class="table table-striped table-hover">
+        <thead>
+        <tr>
+            <th scope="col">Événement</th>
+            <th scope="col">Date</th>
+            <th scope="col">Auteur</th>
+            <th scope="col">Explication</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for suspension_event in model.suspension_history %}
+        <tr>
+            <td>{{ suspension_event.eventType|suspension_event_format }}</td>
+            <td>
+                {% if suspension_event.eventDate %}
+                {{ suspension_event.eventDate.strftime('le %d/%m/%Y à %H:%M:%S') }}
+                {% else %}
+                -
+                {% endif %}
+            </td>
+            <td>
+                {% if suspension_event.actorUser %}
+                {{ suspension_event.actorUser.firstName }} {{ suspension_event.actorUser.lastName }}
+                {% else %}
+                -
+                {% endif %}
+            </td>
+            <td>{{ suspension_event.reasonCode|suspension_reason_format }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
 </div>
 {% endif %}
 
 <div class="section">
-  <h3>Historique des changements d'adresse email</h3>
-  {% if model.email_history|length == 0 %}
-  <p class="card card-body">
-    Pas de changement d'adresse email pour le moment
-  </p>
-  {% else %}
-  <a href="{{ url_for('user_email_history.index_view', flt1_0=model.id ) }}">Vue détaillée</a>
-  <table class="table table-striped table-hover">
-    <thead>
-      <tr>
-        {% if current_user.is_super_admin() %}
-        <th scope="col">Validation</th>
-        {% endif %}
-        <th scope="col">Ancienne adresse email</th>
-        <th scope="col">Nouvelle adresse email</th>
-        <th scope="col">Date</th>
-        <th scope="col">Type d'événement</th>
-        <th scope="col">Device ID</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for email_history in model.email_history %}
-      <tr>
-        {% if current_user.is_super_admin() %}
-        <td>
-          {% if email_history.eventType.value == enum_update_request_value %}
-          <form action={{ url_for("user_email_history.validate_user_email", entry_id=email_history.id,
-            next="support_beneficiary.details_view" , id=model.id) }} method="POST">
-            <button class="btn btn-secondary"
-              onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
-              title="Approve">
-              Valider
-            </button>
-          </form>
-          {% endif %}
-        </td>
-        {% endif %}
-        <td>{{ email_history.oldEmail }}</td>
-        <td>{{ email_history.newEmail }}</td>
-        <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
-        <td>{{ email_history.eventType.value }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% endif %}
+    <h3>Historique des changements d'adresse email</h3>
+    {% if model.email_history|length == 0 %}
+    <p class="card card-body">
+        Pas de changement d'adresse email pour le moment
+    </p>
+    {% else %}
+    <a href="{{ url_for('/user_email_history.index_view', flt1_0=model.id ) }}">Vue détaillée</a>
+    <table class="table table-striped table-hover">
+        <thead>
+        <tr>
+            {% if current_user.is_super_admin() %}
+            <th scope="col">Validation</th>
+            {% endif %}
+            <th scope="col">Ancienne adresse email</th>
+            <th scope="col">Nouvelle adresse email</th>
+            <th scope="col">Date</th>
+            <th scope="col">Type d'événement</th>
+            <th scope="col">Device ID</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for email_history in model.email_history %}
+        <tr>
+            {% if current_user.is_super_admin() %}
+            <td>
+                {% if email_history.eventType.value == enum_update_request_value %}
+                <form action={{ url_for(
+                "/user_email_history.validate_user_email", entry_id=email_history.id,
+                next="support_beneficiary.details_view" , id=model.id) }} method="POST">
+                <button class="btn btn-secondary"
+                        onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
+                        title="Approve">
+                    Valider
+                </button>
+                </form>
+                {% endif %}
+            </td>
+            {% endif %}
+            <td>{{ email_history.oldEmail }}</td>
+            <td>{{ email_history.newEmail }}</td>
+            <td>{{ email_history.creationDate.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+            <td>{{ email_history.eventType.value }}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
 </div>
 
 <div class="section">
-  <h3>Vérification des données utilisateurs</h3>
-  <div class="row">
-    {% for check in model.beneficiaryFraudChecks %}
-    <div class="col-lg-4">
-      <table class="table">
-        <tr>
-          <th scope="row">Éligibilité</th>
-          <td>{{ check.eligibilityType|eligibility_format }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Type</th>
-          <td>{{ check.type.value }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Statut</th>
-          <td>{{ check.status|fraud_check_status_format }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Date de création</th>
-          <td>{{ check.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Identifiant technique</th>
-          <td>{{ check.thirdPartyId }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Explication</th>
-          <td>{{ check.reason|default("Aucune") }}</td>
-        </tr>
-        <tr>
-          <th>Codes d'erreurs</th>
-          <td>
-            <ul>
-              {% for code in check.reasonCodes|default([], true) %}
-              <li>{{code.value}}</li>
-              {% else %}
-              Aucune erreur
-              {% endfor %}
-            </ul>
-          </td>
-        </tr>
+    <h3>Vérification des données utilisateurs</h3>
+    <div class="row">
+        {% for check in model.beneficiaryFraudChecks %}
+        <div class="col-lg-4">
+            <table class="table">
+                <tr>
+                    <th scope="row">Éligibilité</th>
+                    <td>{{ check.eligibilityType|eligibility_format }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Type</th>
+                    <td>{{ check.type.value }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Statut</th>
+                    <td>{{ check.status|fraud_check_status_format }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Date de création</th>
+                    <td>{{ check.dateCreated.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Identifiant technique</th>
+                    <td>{{ check.thirdPartyId }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Explication</th>
+                    <td>{{ check.reason|default("Aucune") }}</td>
+                </tr>
+                <tr>
+                    <th>Codes d'erreurs</th>
+                    <td>
+                        <ul>
+                            {% for code in check.reasonCodes|default([], true) %}
+                            <li>{{code.value}}</li>
+                            {% else %}
+                            Aucune erreur
+                            {% endfor %}
+                        </ul>
+                    </td>
+                </tr>
 
-      </table>
-      <h4>Détails techniques</h4>
-      <div class="row">
-        <pre class="pre-scrollable"><code>{{ check.resultContent|pprint }}</code></pre>
-      </div>
+            </table>
+            <h4>Détails techniques</h4>
+            <div class="row">
+                <pre class="pre-scrollable"><code>{{ check.resultContent|pprint }}</code></pre>
+            </div>
+        </div>
+        {% else %}
+        <div class="card card-body">
+            Aucune vérification externe (Jouve, DMS)
+        </div>
+        {% endfor %}
     </div>
-    {% else %}
-    <div class="card card-body">
-      Aucune vérification externe (Jouve, DMS)
-    </div>
-    {% endfor %}
-  </div>
 </div>
 
-  <h1>{{has_dms_fraud_check}}</h1>
+<h1>{{has_dms_fraud_check}}</h1>
 
 {% if display_beneficiary_imports%}
 <div class="section">
-  <h3>Beneficiary Imports -- Deprécié</h3>
-  <p>Catgorie dépréciée au profit des "Vérification des données utilisateurs" ci-dessus</p>
-  <div class="row">
-    {% for import in model.beneficiaryImports %}
-    <div class="col-lg-4">
+    <h3>Beneficiary Imports -- Deprécié</h3>
+    <p>Catgorie dépréciée au profit des "Vérification des données utilisateurs" ci-dessus</p>
+    <div class="row">
+        {% for import in model.beneficiaryImports %}
+        <div class="col-lg-4">
 
-      <table class="table">
-        <tr>
-          <th scope="row">Auteur</th>
-          <td>{{ import.author|default("Aucun") }}</td>
-        </tr>
+            <table class="table">
+                <tr>
+                    <th scope="row">Auteur</th>
+                    <td>{{ import.author|default("Aucun") }}</td>
+                </tr>
 
-        <tr>
-          <th scope="row">Application ID</th>
-          <td>{{ import.applicationId }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Source ID</th>
-          <td>{{ import.sourceId }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Source</th>
-          <td>{{ import.source }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Etat</th>
-          <td>{{ import.currentStatus.value }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Historique</th>
-          <td>
-            <ul>
-              {% for status in import.statuses %}
-              <li>{{ status.status.value }} - {{ status.detail }} - {% if status.date %}le {{ status.date.strftime('le
-                %d/%m/%Y à %H:%M:%S') }} {% endif %}
-              </li>
-              {% endfor %}
-            </ul>
-          </td>
-        </tr>
-      </table>
+                <tr>
+                    <th scope="row">Application ID</th>
+                    <td>{{ import.applicationId }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Source ID</th>
+                    <td>{{ import.sourceId }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Source</th>
+                    <td>{{ import.source }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Etat</th>
+                    <td>{{ import.currentStatus.value }}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Historique</th>
+                    <td>
+                        <ul>
+                            {% for status in import.statuses %}
+                            <li>{{ status.status.value }} - {{ status.detail }} - {% if status.date %}le {{
+                                status.date.strftime('le
+                                %d/%m/%Y à %H:%M:%S') }} {% endif %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </td>
+                </tr>
+            </table>
+        </div>
+        {% endfor %}
     </div>
-    {% endfor %}
-  </div>
 </div>
 {% endif %}
 {% endblock %}

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -1,4 +1,3 @@
-import dataclasses
 from datetime import datetime
 import logging
 
@@ -10,8 +9,7 @@ from pcapi.admin.custom_views.support_view.api import BeneficiaryActivationStatu
 from pcapi.admin.custom_views.support_view.api import get_beneficiary_activation_status
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
-import pcapi.core.mails.testing as mails_testing
-from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+import pcapi.core.fraud.ubble.models as ubble_models
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
@@ -74,39 +72,32 @@ class BeneficiaryValidationViewTest:
         assert response.headers["Location"] == "http://localhost/pc/back-office/"
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
-    def test_validation_view_validate_user_from_jouve_data_staging(self, client):
-        user = users_factories.UserFactory(dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE)
-
-        content = fraud_factories.JouveContentFactory(birthDateTxt=f"{AGE18_ELIGIBLE_BIRTH_DATE:%d/%m/%Y}")
+    def test_override_validation_for_fraud_check_is_ko(self, client):
+        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user,
-            type=fraud_models.FraudCheckType.JOUVE,
-            resultContent=content,
+            user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.KO
         )
         admin = users_factories.AdminFactory()
         client.with_session_auth(admin.email)
 
         response = client.post(
             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
         )
         assert response.status_code == 302
-
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
-
+        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
         assert review.review == fraud_models.FraudReviewStatus.OK
         assert review.reason == "User is granted"
-
         user = users_models.User.query.get(user.id)
         assert user.has_beneficiary_role is True
-        assert len(user.deposits) == 1
-        assert mails_testing.outbox[0].sent_data["template"] == dataclasses.asdict(
-            TransactionalEmail.ACCEPTED_AS_BENEFICIARY.value
-        )
 
-        jouve_content = fraud_models.JouveContent(**check.resultContent)
-        assert user.firstName == jouve_content.firstName
-        assert user.lastName == jouve_content.lastName
+        dms_content = fraud_models.DMSContent(**check.resultContent)
+        assert user.firstName == dms_content.first_name
+        assert user.lastName == dms_content.last_name
+        assert user.idPieceNumber == dms_content.id_piece_number
+
+        fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).first()
+        assert fraud_check.status == check.status
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_from_dms_data_staging(self, client):
@@ -117,11 +108,10 @@ class BeneficiaryValidationViewTest:
 
         response = client.post(
             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
         )
         assert response.status_code == 302
-
-        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one()
+        review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).first()
         assert review.review == fraud_models.FraudReviewStatus.OK
         assert review.reason == "User is granted"
         user = users_models.User.query.get(user.id)
@@ -142,7 +132,7 @@ class BeneficiaryValidationViewTest:
 
         response = client.post(
             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
         )
         assert response.status_code == 302
 
@@ -167,7 +157,7 @@ class BeneficiaryValidationViewTest:
 
         response = client.post(
             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+            form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
         )
         assert response.status_code == 302
 
@@ -192,7 +182,7 @@ class BeneficiaryValidationViewTest:
 
         response = client.post(
             f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-            form={"user_id": user.id, "badkey": "User is granted", "review": "OK"},
+            form={"user_id": user.id, "badkey": "User is granted", "review": "OK", "eligibility": "Par défaut"},
         )
         assert response.status_code == 302
         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
@@ -226,7 +216,7 @@ class BeneficiaryValidationViewTest:
         with override_settings(IS_PROD=True):
             response = client.post(
                 f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-                form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+                form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
             )
         assert response.status_code == 302
         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
@@ -236,14 +226,14 @@ class BeneficiaryValidationViewTest:
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_prod_requires_super_admin(self, client):
         user = users_factories.UserFactory()
-        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.JOUVE)
+        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         admin = users_factories.AdminFactory()
         client.with_session_auth(admin.email)
 
         with override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[admin.email]):
             response = client.post(
                 f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-                form={"user_id": user.id, "reason": "User is granted", "review": "OK"},
+                form={"user_id": user.id, "reason": "User is granted", "review": "OK", "eligibility": "Par défaut"},
             )
         assert response.status_code == 302
         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
@@ -251,20 +241,20 @@ class BeneficiaryValidationViewTest:
         assert review.author == admin
         assert user.has_beneficiary_role is True
 
-        jouve_content = fraud_models.JouveContent(**check.resultContent)
-        assert user.firstName == jouve_content.firstName
-        assert user.lastName == jouve_content.lastName
+        ubble_content = ubble_models.UbbleContent(**check.resultContent)
+        assert user.firstName == ubble_content.get_first_name()
+        assert user.lastName == ubble_content.get_last_name()
 
     def test_review_ko_does_not_activate_the_beneficiary(self, client):
         user = users_factories.UserFactory()
-        fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.JOUVE)
+        fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         admin = users_factories.AdminFactory()
         client.with_session_auth(admin.email)
 
         with override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[admin.email]):
             response = client.post(
                 f"/pc/back-office/support_beneficiary/validate/beneficiary/{user.id}",
-                form={"user_id": user.id, "reason": "User is denied", "review": "KO"},
+                form={"user_id": user.id, "reason": "User is denied", "review": "KO", "eligibility": "Par défaut"},
             )
         assert response.status_code == 302
         review = fraud_models.BeneficiaryFraudReview.query.filter_by(user=user, author=admin).one_or_none()
@@ -280,47 +270,7 @@ class BeneficiaryValidationViewTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class JouveAccessTest:
-    """Specific tests to ensure JOUVE does not access anything else"""
-
-    def test_access_index(self, client):
-        user = users_factories.UserFactory(roles=[users_models.UserRole.JOUVE])
-        client.with_session_auth(user.email)
-        response = client.get("/pc/back-office/")
-        assert response.status_code == 200
-
-    @pytest.mark.parametrize(
-        "url",
-        [
-            "/pc/back-office/pro_users",
-            "/pc/back-office/admin_users",
-            "/pc/back-office/beneficiary_users",
-        ],
-    )
-    def test_access_forbidden_views(self, client, url):
-        user = users_factories.UserFactory(roles=[users_models.UserRole.JOUVE])
-        client.with_session_auth(user.email)
-        response = client.get(url)
-        assert response.status_code == 302
-        assert response.headers["Location"] == "http://localhost/pc/back-office/"
-
-
-@pytest.mark.usefixtures("db_session")
 class ValidatePhoneNumberTest:
-    def test_jouve_has_no_access(self, client):
-        user = users_factories.UserFactory(
-            phoneValidationStatus=users_models.PhoneValidationStatusType.BLOCKED_TOO_MANY_CODE_SENDINGS,
-        )
-        jouve_admin = users_factories.UserFactory(roles=[users_models.UserRole.JOUVE])
-        client.with_session_auth(jouve_admin.email)
-
-        response = client.get("/pc/back-office/support_beneficiary/?id={user.id}")
-        assert "Valider le n° de télépone" not in response.data.decode()
-
-        response = client.post(f"/pc/back-office/support_beneficiary/validate/beneficiary/phone_number/{user.id}")
-        assert response.status_code == 302
-        assert user.phoneValidationStatus == users_models.PhoneValidationStatusType.BLOCKED_TOO_MANY_CODE_SENDINGS
-
     def test_phone_validation(self, client, caplog):
         admin = users_factories.AdminFactory()
         user = users_factories.UserFactory(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13693

## But de la pull request

En tant que admin au pass Culture
J'aimerais pouvoir valider un dossier utilisateur depuis FA
Afin de créditer le compte de l’utilisateur sans passer par les devs

## Implémentation

Stratégie tech

Dans src/pcapi/admin/custom_views/support_view/view.py

  refacto: déplacer la logique dans des fonctions dans api.py 

Ajouter Eligibility dans la modale (dropdown)

Retirer le check if user.beneficiaryFraudReview:.

Dans BeneficiaryFraudReview user devient une relation one to many

user = sqlalchemy.orm.relationship(
        "User", foreign_keys=[userId], backref=sqlalchemy.orm.backref("beneficiaryFraudReviews")
    )

remplacer tous les user.beneficiaryFraudReviewpar des user.beneficiaryFraudReviews[?] (choisir lequel on veut récupérer)

Retirer de src/pcapi/templates/admin/support_beneficiary_details.html la condition and not model.beneficiaryFraudReview pour l’affichage du bouton

Créer une méthode get_last_filled_identity_fraud_check(user) qui retourne le dernier fraud_check de type IDENTITY_CHECK_TYPES avec Nom, Prénom et date de naissance (None sinon)

Utiliser cette méthode pour afficher le bouton a la place de has_performed_identity_check

Dans le cas “review OK”

Utiliser cette méthode dans le cas “Review OK” pour récupérer le bon fraud_check

Factoriser la seconde partie de activate_beneficiary dans une fonction activate_beneficiary_for_eligibility 

Appeler activate_beneficiary_for_eligibility dans le cas de review OK

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`

![Capture d’écran 2022-04-05 à 12 04 20](https://user-images.githubusercontent.com/9610732/161749969-abd5df45-1e95-4ab7-b43f-42f6d46f5873.png)
)