### PR TITLE
Pc-14110 Add new column hasSeenRgs to user table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-6ee927d299b1 (post) (head)
-f5f77c745513 (pre) (head)
+61006d347cb2 (post) (head)
+707aec075ae8 (pre) (head)

--- a/api/src/pcapi/admin/custom_views/admin_user_view.py
+++ b/api/src/pcapi/admin/custom_views/admin_user_view.py
@@ -94,6 +94,7 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
         model.publicName = f"{model.firstName} {model.lastName}"
         model.add_admin_role()
         model.hasSeenProTutorials = True
+        model.hasSeenProRgs = True
         model.needsToFillCulturalSurvey = False
 
         users_api.fulfill_account_password(model)

--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -152,6 +152,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
         "firstName",
         "hasSeenTutorials",
         "hasSeenProTutorials",
+        "hasSeenProRgs",
         "idPieceNumber",
         "ineHash",
         "isActive",

--- a/api/src/pcapi/alembic/versions/20220330T212833_707aec075ae8_add_has_seen_pro_rgs_to_user.py
+++ b/api/src/pcapi/alembic/versions/20220330T212833_707aec075ae8_add_has_seen_pro_rgs_to_user.py
@@ -1,0 +1,19 @@
+"""Add column has seen pro rgs to user table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "707aec075ae8"
+down_revision = "f5f77c745513"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("hasSeenProRgs", sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "hasSeenProRgs")

--- a/api/src/pcapi/alembic/versions/20220330T215520_61006d347cb2_alter_has_seen_pro_rgs_to_not_null.py
+++ b/api/src/pcapi/alembic/versions/20220330T215520_61006d347cb2_alter_has_seen_pro_rgs_to_not_null.py
@@ -1,0 +1,21 @@
+"""Alter hasSeenProRgs Column of User table to not null defaulting to False.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "61006d347cb2"
+down_revision = "6ee927d299b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "user", "hasSeenProRgs", existing_type=sa.BOOLEAN(), server_default=sa.text("false"), nullable=False
+    )
+
+
+def downgrade():
+    op.alter_column("user", "hasSeenProRgs", existing_type=sa.BOOLEAN(), server_default=None, nullable=True)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -633,6 +633,11 @@ def set_pro_tuto_as_seen(user: User) -> None:
     repository.save(user)
 
 
+def set_pro_rgs_as_seen(user: User) -> None:
+    user.hasSeenProRgs = True
+    repository.save(user)
+
+
 def change_user_phone_number(user: User, phone_number: str) -> None:
     _check_phone_number_validation_is_authorized(user)
 

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -133,6 +133,7 @@ class BeneficiaryGrant18Factory(BaseFactory):
     isEmailValidated = True
     roles = [users_models.UserRole.BENEFICIARY]
     hasSeenProTutorials = True
+    hasSeenProRgs = False
     subscriptionState = users_models.SubscriptionState.beneficiary_18
 
     @classmethod

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -181,6 +181,7 @@ class User(PcObject, Model, NeedsValidationMixin):
     firstName = sa.Column(sa.String(128), nullable=True)
     hasSeenTutorials = sa.Column(sa.Boolean, nullable=True)
     hasSeenProTutorials = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
+    hasSeenProRgs = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     idPieceNumber = sa.Column(sa.String, nullable=True, unique=True)
     ineHash = sa.Column(sa.Text, nullable=True, unique=True)
 

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -29,6 +29,14 @@ def patch_user_tuto_seen() -> None:
     users_api.set_pro_tuto_as_seen(user)
 
 
+@blueprint.pro_private_api.route("/users/rgs-seen", methods=["PATCH"])
+@login_required
+@spectree_serialize(response_model=None, on_success_status=204, api=blueprint.pro_private_schema)
+def patch_pro_user_rgs_seen() -> None:
+    user = current_user._get_current_object()  # get underlying User object from proxy
+    users_api.set_pro_rgs_as_seen(user)
+
+
 @blueprint.pro_private_api.route("/users/current", methods=["GET"])
 @login_required
 @spectree_serialize(response_model=users_serializers.SharedCurrentUserResponseModel, api=blueprint.pro_private_schema)

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -94,6 +94,7 @@ class SharedLoginUserResponseModel(BaseModel):
     firstName: Optional[str]
     hasPhysicalVenues: Optional[bool]
     hasSeenProTutorials: Optional[bool]
+    hasSeenProRgs: Optional[bool]
     id: str
     isAdmin: bool
     isEmailValidated: bool
@@ -136,6 +137,7 @@ class SharedCurrentUserResponseModel(BaseModel):
     firstName: Optional[str]
     hasPhysicalVenues: Optional[bool]
     hasSeenProTutorials: Optional[bool]
+    hasSeenProRgs: Optional[bool]
     id: str
     idPieceNumber: Optional[str]
     isAdmin: bool

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -46,6 +46,7 @@ class AdminUserViewTest:
         assert not user_created.has_beneficiary_role
         assert user_created.has_admin_role
         assert user_created.hasSeenProTutorials is True
+        assert user_created.hasSeenProRgs is True
         assert user_created.needsToFillCulturalSurvey is False
 
         token = Token.query.filter_by(userId=user_created.id).first()

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -33,6 +33,7 @@ from pcapi.core.users.api import fulfill_beneficiary_data
 from pcapi.core.users.api import generate_and_save_token
 from pcapi.core.users.api import get_domains_credit
 from pcapi.core.users.api import get_eligibility_at_date
+from pcapi.core.users.api import set_pro_rgs_as_seen
 from pcapi.core.users.api import set_pro_tuto_as_seen
 from pcapi.core.users.constants import SuspensionEventType
 from pcapi.core.users.factories import UserFactory
@@ -528,6 +529,19 @@ class SetProTutoAsSeenTest:
 
         # Then
         assert User.query.one().hasSeenProTutorials == True
+
+
+@pytest.mark.usefixtures("db_session")
+class SetProRgsAsSeenTest:
+    def should_set_has_seen_pro_rgs_to_true_for_user(self):
+        # Given
+        user = users_factories.UserFactory(hasSeenProRgs=False)
+
+        # When
+        set_pro_rgs_as_seen(user)
+
+        # Then
+        assert User.query.one().hasSeenProRgs == True
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -47,6 +47,7 @@ class Returns200Test:
             "firstName": "Jean",
             "hasPhysicalVenues": False,
             "hasSeenProTutorials": True,
+            "hasSeenProRgs": False,
             "id": humanize(user.id),
             "idPieceNumber": None,
             "isAdmin": False,

--- a/api/tests/routes/pro/patch_pro_user_has_seen_rgs_test.py
+++ b/api/tests/routes/pro/patch_pro_user_has_seen_rgs_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import TestClient
+
+
+@pytest.mark.usefixtures("db_session")
+def test_mark_as_seen(app):
+    user = users_factories.UserFactory(hasSeenProRgs=False)
+
+    client = TestClient(app.test_client()).with_session_auth(user.email)
+    response = client.patch("/users/rgs-seen")
+
+    assert response.status_code == 204
+    assert user.hasSeenProRgs == True
+
+
+@pytest.mark.usefixtures("db_session")
+def test_mark_as_seen_without_auth(app):
+    user = users_factories.UserFactory(hasSeenProRgs=False)
+
+    client = TestClient(app.test_client())
+    response = client.patch("/users/rgs-seen")
+
+    assert response.status_code == 401
+    assert user.hasSeenProRgs == False

--- a/api/tests/routes/pro/signin_test.py
+++ b/api/tests/routes/pro/signin_test.py
@@ -50,6 +50,7 @@ class Returns200Test:
             "firstName": "Jean",
             "hasPhysicalVenues": False,
             "hasSeenProTutorials": True,
+            "hasSeenProRgs": False,
             "id": humanize(user.id),
             "isAdmin": False,
             "isEmailValidated": True,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14110

## But de la pull request

Ajout d'une colonne hasSeenProRgs qui permet l'affichage ou non d'un panneau d'information sur la page d'accueil.

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
