### PR TITLE
[bsr][api] Order heads in `alembic_version_conflict_detection.txt`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-6ee927d299b1 (post) (head)
 f5f77c745513 (pre) (head)
+6ee927d299b1 (post) (head)


### PR DESCRIPTION
List "pre" first, "post" second, like the pre-commit hook does
since it has been updated in b02628dea737f7ebc8b2d158419c8dc0913f9b36.