### PR TITLE
(PC-14271)[api] Sendinblue pro attributes: force email subscription for booking emails only

### DIFF
--- a/api/src/pcapi/core/users/external/__init__.py
+++ b/api/src/pcapi/core/users/external/__init__.py
@@ -107,7 +107,6 @@ def get_pro_attributes(email: str) -> ProAttributes:
                 "user_id": user.id,
                 "first_name": user.firstName,
                 "last_name": user.lastName,
-                "marketing_email_subscription": user.get_notification_subscriptions().marketing_email,
                 "user_is_attached": user_is_attached,
                 "user_is_creator": user_is_creator,
             }
@@ -132,10 +131,19 @@ def get_pro_attributes(email: str) -> ProAttributes:
             }
         )
 
+    marketing_email_subscription = (
+        # Force email subscription to True when email is used only as bookingEmail
+        # Force to False when email has been removed from db, maybe replaced with another one in user and/or venue
+        user.get_notification_subscriptions().marketing_email
+        if user
+        else bool(venues)
+    )
+
     return ProAttributes(
         is_pro=True,
         is_user_email=bool(user),
         is_booking_email=bool(venues),
+        marketing_email_subscription=marketing_email_subscription,
         offerer_name=set(offerer_name),
         venue_count=len(all_venue_ids),
         **attributes,

--- a/api/src/pcapi/core/users/external/models.py
+++ b/api/src/pcapi/core/users/external/models.py
@@ -44,6 +44,7 @@ class ProAttributes:
     is_pro: bool  # Always True
     is_user_email: bool  # Email address is set at least for a user account
     is_booking_email: bool  # Email address is set as bookingEmail for at least one active venue
+    marketing_email_subscription: bool
     offerer_name: Iterable[str]  # All active offerers associated with user account or bookingEmail
     venue_count: Optional[int] = None  # Total number of active venues related to email (by offerer or bookingEmail)
 
@@ -51,7 +52,6 @@ class ProAttributes:
     user_id: Optional[int] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None
-    marketing_email_subscription: Optional[bool] = None
     user_is_attached: Optional[bool] = None  # User is attached to at least one active offerer, he is not the creator
     user_is_creator: Optional[bool] = None  # User is the creator of at least one active offerer
 

--- a/api/tests/core/users/external/external_pro_test.py
+++ b/api/tests/core/users/external/external_pro_test.py
@@ -202,6 +202,7 @@ def test_update_external_pro_user_attributes(
     assert attributes.is_pro is True
     assert attributes.is_user_email is True
     assert attributes.is_booking_email is True
+    assert attributes.marketing_email_subscription is enable_subscription
     assert (
         attributes.offerer_name == {"Culture en ligne", "Juste Libraire", "Plage Culture", "Plage Events"}
         if create_virtual
@@ -212,7 +213,6 @@ def test_update_external_pro_user_attributes(
     assert attributes.user_id == pro_user.id
     assert attributes.first_name == pro_user.firstName
     assert attributes.last_name == pro_user.lastName
-    assert attributes.marketing_email_subscription is enable_subscription
     assert attributes.user_is_attached is (attached in ("one", "all"))
     assert attributes.user_is_creator is not (attached == "all")
 
@@ -245,13 +245,13 @@ def test_update_external_pro_user_attributes_no_offerer_no_venue():
     assert attributes.is_pro is True
     assert attributes.is_user_email is True
     assert attributes.is_booking_email is False
+    assert attributes.marketing_email_subscription is True
     assert attributes.offerer_name == set()
     assert attributes.venue_count == 0
 
     assert attributes.user_id == user.id
     assert attributes.first_name == user.firstName
     assert attributes.last_name == user.lastName
-    assert attributes.marketing_email_subscription is True
     assert attributes.user_is_attached is False
     assert attributes.user_is_creator is False
 
@@ -286,13 +286,13 @@ def test_update_external_pro_booking_email_attributes():
     assert attributes.is_pro is True
     assert attributes.is_user_email is False
     assert attributes.is_booking_email is True
+    assert attributes.marketing_email_subscription is True
     assert attributes.offerer_name == {offerer.name}
     assert attributes.venue_count == 1
 
     assert attributes.user_id is None
     assert attributes.first_name is None
     assert attributes.last_name is None
-    assert attributes.marketing_email_subscription is None
     assert attributes.user_is_attached is None
     assert attributes.user_is_creator is None
 
@@ -306,3 +306,31 @@ def test_update_external_pro_booking_email_attributes():
     assert attributes.isPermanent is True
     assert attributes.has_offers is False
     assert attributes.has_bookings is False
+
+
+def test_update_external_pro_removed_email_attributes():
+    attributes = get_pro_attributes("removed@example.net")
+
+    assert attributes.is_pro is True
+    assert attributes.is_user_email is False
+    assert attributes.is_booking_email is False
+    assert attributes.marketing_email_subscription is False
+    assert attributes.offerer_name == set()
+    assert attributes.venue_count == 0
+
+    assert attributes.user_id is None
+    assert attributes.first_name is None
+    assert attributes.last_name is None
+    assert attributes.user_is_attached is None
+    assert attributes.user_is_creator is None
+
+    assert attributes.venue_name is None
+    assert attributes.venue_type is None
+    assert attributes.venue_label is None
+    assert attributes.departement_code is None
+    assert attributes.dms_application_submitted is None
+    assert attributes.dms_application_approved is None
+    assert attributes.isVirtual is None
+    assert attributes.isPermanent is None
+    assert attributes.has_offers is None
+    assert attributes.has_bookings is None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14271

## But de la pull request

Demande marketing : Forcer MARKETING_EMAIL_SUBSCRIPTION à Yes dans Sendinblue pour les attributs pro, lorsque ce champ était laissé à vide = pour les emails utilisés seulement comme bookingEmail d'un lieu, sans être l'email d'un compte utilisateur.

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
