### PR TITLE
(PC-14143)[PRO] fix: SignupForm: fix warnings in test

### DIFF
--- a/pro/.debt-collector/config.js
+++ b/pro/.debt-collector/config.js
@@ -104,7 +104,7 @@ module.exports = {
       debtScore: 0.25,
       tags: ['tests', 'new workshop rules'],
       matchGlob: ['**/*.spec.{ts,tsx,js,jsx}', '**/*.specs.{ts,tsx,js,jsx}'],
-      matchRule: ({ find }) => find('await act') + find('await render'),
+      matchRule: ({ find }) => find('await act') + find('await render('),
     },
     {
       title: 'should not use withQueryRouter or withRouter',

--- a/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/SignupForm.jsx
@@ -240,7 +240,7 @@ SignupForm.defaultProps = {
 SignupForm.propTypes = {
   createNewProUser: PropTypes.func.isRequired,
   currentUser: PropTypes.shape(),
-  history: PropTypes.func.isRequired,
+  history: PropTypes.shape().isRequired,
   location: PropTypes.shape().isRequired,
   notifyError: PropTypes.func.isRequired,
   redirectToConfirmation: PropTypes.func.isRequired,

--- a/pro/src/components/pages/Signup/SignupForm/SirenField/SirenField.jsx
+++ b/pro/src/components/pages/Signup/SignupForm/SirenField/SirenField.jsx
@@ -57,7 +57,7 @@ const SirenField = props => {
               {...input}
               error={meta.modified && meta.error ? meta.error : null}
               label="SIREN de la structure que vous représentez"
-              maxLength="11"
+              maxLength={11}
               name="siren"
               placeholder="123456789"
             />


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14143

Afin de débuger un comportement différent dans le test et dans l'application (voir [cette PR](https://github.com/pass-culture/pass-culture-main/pull/1815))
J'ai besoin de nettoyer les warning du test SignupForm: 
```bash
$ yarn test:unit components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx 2> test_output.txt
$ cat test_output.txt | grep Warning | wc -l
563
$ cat test_output.txt | grep console.error | wc -l
282
```

Cette PR les éliminent tous.