### PR TITLE
(PC-14073)[PRO] fix: Desk displayed error message

### DIFF
--- a/pro/src/api/helpers.ts
+++ b/pro/src/api/helpers.ts
@@ -106,7 +106,7 @@ export function extractApiErrorMessageForKey(
 ): string {
   let errorMessages = ''
   if (isApiError(error)) {
-    const { content } = error as ApiError
+    const { content } = error
     if (errorKey in content) {
       errorMessages = content[errorKey][0]
     }
@@ -122,4 +122,16 @@ export function extractApiGlobalErrorMessage(error: unknown) {
     message = globalErrorMessages
   }
   return message
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function extractApiFirstErrorMessage(error: unknown) {
+  if (isApiError(error)) {
+    const { content } = error
+    const errorsList: string[][] = Object.values(content)
+    if (errorsList.length && errorsList[0].length) {
+      return errorsList[0][0]
+    }
+  }
+  return ''
 }

--- a/pro/src/routes/Desk/adapters/getBooking.ts
+++ b/pro/src/routes/Desk/adapters/getBooking.ts
@@ -1,6 +1,7 @@
 import { apiV2 } from 'api/api'
 import {
   HTTP_STATUS,
+  extractApiFirstErrorMessage,
   extractApiErrorMessageForKey,
   ApiError,
 } from 'api/helpers'
@@ -30,7 +31,7 @@ const getBookingSuccess = (
 const getBookingFailure = (
   apiResponseError: ApiError
 ): IDeskGetBookingResponse => {
-  const errorMessage = extractApiErrorMessageForKey(apiResponseError, 'global')
+  const errorMessage = extractApiFirstErrorMessage(apiResponseError)
   if (apiResponseError.statusCode === HTTP_STATUS.GONE) {
     // api return HTTP_STATUS.GONE when :
     // * booking is already been validated


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14073

suite au changement fait dans la migration de Desk vers "functional component", nous recuperons uniquement la clef "global" au lieu de "la premier clef d'erreur".

l'ancien code : 
```javascript
getErrorMessageFromApi = errorResponse => {
    const errorKey = this.firstErrorMessageFromApi(errorResponse.errors)
    return errorResponse.errors[errorKey]
  }
```