### PR TITLE
(PC-14274)[API] fix: delete orphan dms application when there is a parsing error

### DIFF
--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -62,7 +62,7 @@ def on_dms_parsing_error(
     application_id: int,
     parsing_error: subscription_exceptions.DMSParsingError,
     extra_data: Optional[dict] = None,
-) -> None:
+) -> fraud_models.BeneficiaryFraudCheck:
     fraud_check = get_or_create_fraud_check(user, application_id)
     fraud_check.reason = (
         "Erreur lors de la récupération de l'application DMS: "
@@ -71,11 +71,9 @@ def on_dms_parsing_error(
     fraud_check.reasonCodes = [fraud_models.FraudReasonCode.ERROR_IN_DATA]
     repository.save(fraud_check)
 
-    logger.info(
-        "Cannot parse DMS application %s in webhook. Errors will be handled in the import_dms_users cron",
-        application_id,
-        extra=extra_data,
-    )
+    logger.info("Cannot parse DMS application %s in webhook.", application_id, extra=extra_data)
+
+    return fraud_check
 
 
 def on_dms_eligibility_error(

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -366,6 +366,7 @@ def try_dms_orphan_adoption(user: users_models.User):
         return
 
     fraud_check = parse_and_handle_dms_application(dms_orphan.application_id, dms_orphan.process_id)
+
     if fraud_check is not None:
         pcapi_repository.repository.delete(dms_orphan)
 
@@ -424,7 +425,6 @@ def parse_and_handle_dms_application(
         if state == dms_models.GraphQLApplicationStates.draft:
             notify_parsing_exception(parsing_error.errors, dossier_id, client)
 
-        fraud_dms_api.on_dms_parsing_error(user, application_id, parsing_error, extra_data=log_extra_data)
-        return None
+        return fraud_dms_api.on_dms_parsing_error(user, application_id, parsing_error, extra_data=log_extra_data)
 
     return handle_dms_state(user, application, procedure_id, application_id, state)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14274

## But de la pull request

La route /validate_email peut se faire spammer...

Impact décrits dans le ticket.

## Implémentation

Retourner le fraud_check créé afin de bien pouvoir supprimer le orphan_dms.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)

