### PR TITLE
(bsr) feat: Add a git commit template

### DIFF
--- a/.git-commit-message-template
+++ b/.git-commit-message-template
@@ -1,0 +1,3 @@
+(PC-XXXX|BSR)[API|PRO|ADAGE] <type>: <commit_message>
+
+type: build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump

--- a/pc
+++ b/pc
@@ -425,6 +425,7 @@ elif [[ "$CMD" == "install" ]]; then
   cd $ROOT_PATH/pro && yarn
   cd $ROOT_PATH/adage-front && yarn
   pc install-hooks
+  pc set-git-config
   exit_success_restoring_branch
 
 # Install pre-push and pre-commit hooks in the api submodule
@@ -436,6 +437,11 @@ elif [[ "$CMD" == "install-hooks" ]]; then
     chmod +x .git/hooks/pre-push;
     chmod +x .git/hooks/pre-commit;
     chmod +x .git/hooks/commit-msg;'
+
+# Define a local Git configuration
+elif [[ "$CMD" == "set-git-config" ]]; then
+  RUN='cd $ROOT_PATH;
+    git config --local commit.template .git-commit-message-template'
 
 # Create symlink to use "pc" command (admin rights may be needed)
 elif [[ "$CMD" == "symlink" ]]; then


### PR DESCRIPTION
Set up with this command (which is now included in `pc install`):

    git config --local commit.template .git-commit-message-template

Now when you run `git commit`, your editor/IDE will use this template
and you just have to fill in the blanks.