### PR TITLE
(PC-14294)[API] fix:ci: let the app start by owning files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,6 +689,7 @@ jobs:
       - checkout
       - skip_unchanged:
           paths: pro
+      - run: sudo chown -R 1000:1000 .
       - run: ./install_lib_ci_with_chrome.sh
       - run: sudo ./pc symlink
       - run: ./scripts/install_dockerize.sh $DOCKERIZE_VERSION


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14294

## But de la pull request

Répare la CI

ça a fonctionné sur cette pipeline https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/13053/workflows/ca9a268f-f90d-4ae1-9054-382ebe035b05/jobs/103472

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`

