### PR TITLE
(PC-13336)[API] fix: use project id from init in gcp backend

### DIFF
--- a/api/src/pcapi/tasks/cultural_survey_tasks.py
+++ b/api/src/pcapi/tasks/cultural_survey_tasks.py
@@ -14,11 +14,10 @@ CULTURAL_SURVEY_ANSWERS_QUEUE_NAME = settings.GCP_CULTURAL_SURVEY_ANSWERS_QUEUE_
 def upload_answers_task(payload: serializers.CulturalSurveyAnswersForData) -> None:
     BUCKET_NAME = settings.GCP_DATA_BUCKET_NAME
     PROJECT_ID = settings.GCP_DATA_PROJECT_ID
-    today = datetime.date.today().strftime("%Y%m%d")
 
-    STORAGE_PATH = BUCKET_NAME + f"/QPI_exports/qpi_answers_{today}/"
+    STORAGE_PATH = f"QPI_exports/qpi_answers_{datetime.date.today().strftime('%Y%m%d')}/"
     answers_file_name = STORAGE_PATH + f"{payload.user_id}.jsonl"
-    gcp_client = gcp_backend.GCPBackend(BUCKET_NAME, PROJECT_ID)
+    gcp_client = gcp_backend.GCPBackend(bucket_name=BUCKET_NAME, project_id=PROJECT_ID)
 
     gcp_client.store_public_object(
         folder=BUCKET_NAME,

--- a/api/tests/tasks/cultural_survey_tasks_test.py
+++ b/api/tests/tasks/cultural_survey_tasks_test.py
@@ -35,12 +35,10 @@ class CulturalSurveyTasksTest:
             '{"question_id": "FESTIVALS", "choices": ["FESTIVAL_LIVRE"]}]'
         )
 
-        # user_data.update({"answers": self.extract_answers(result["answers"])})
-
         # Note: if the path does not exist, GCP creates the necessary folders
         store_public_object.assert_called_once_with(
             folder="data-bucket-dev",
-            object_id="data-bucket-dev/QPI_exports/qpi_answers_20200101/1.jsonl",
+            object_id="QPI_exports/qpi_answers_20200101/1.jsonl",
             blob=bytes(answers_str, "utf-8"),
             content_type="application/json",
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13336

## But de la pull request

Corrige la définition de project id dans GCP backend

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
