### PR TITLE
(pc-13207)[API] fix: Update user before setting hasSeenProRgs to not Null

### DIFF
--- a/api/src/pcapi/alembic/versions/20220404T071622_11f137937ae5_alter_has_seen_pro_rgs_to_not_null.py
+++ b/api/src/pcapi/alembic/versions/20220404T071622_11f137937ae5_alter_has_seen_pro_rgs_to_not_null.py
@@ -12,6 +12,7 @@ depends_on = None
 
 
 def upgrade():
+    op.execute('UPDATE "user" SET "hasSeenProRgs" = false')
     op.alter_column(
         "user", "hasSeenProRgs", existing_type=sa.BOOLEAN(), server_default=sa.text("false"), nullable=False
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13207

## But de la pull request

Fix : remplir la colonne hasSeenProRgs avant de la passer en NOT NULL

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
