### PR TITLE
(BSR)[API] Utilisation de `datetime.utcnow()` au lieu de `datetime.now()`

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view/view.py
+++ b/api/src/pcapi/admin/custom_views/support_view/view.py
@@ -245,7 +245,7 @@ class BeneficiaryView(base_configuration.BaseAdminView):
                         thirdPartyId="admin_validation",
                         resultContent={
                             "id": 0,
-                            "registrationDate": datetime.datetime.now().isoformat(),
+                            "registrationDate": datetime.datetime.utcnow().isoformat(),
                         },
                     )
 

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -149,7 +149,7 @@ def _get_mocked_user_for_performance_tests(user_id: str) -> models.EduconnectUse
 
     return users_factories.EduconnectUserFactory(
         birth_date=user.dateOfBirth.date(),
-        connection_datetime=datetime.now(),
+        connection_datetime=datetime.utcnow(),
         educonnect_id=f"educonnect-id_perf-test_{user.id}",
         first_name="".join(random.choice(string.ascii_letters) for _ in range(10)),
         ine_hash=f"inehash_perf-test_{user.id}",

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -486,7 +486,7 @@ def auto_mark_as_used_after_event() -> None:
     if not FeatureToggle.UPDATE_BOOKING_USED.is_active():
         raise ValueError("This function is behind a deactivated feature flag.")
 
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     threshold = now - constants.AUTO_USE_AFTER_EVENT_TIME_DELAY
     # fmt: off
     bookings_subquery = (

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -764,7 +764,7 @@ def offerer_has_ongoing_bookings(offerer_id: Offerer) -> bool:
 
 
 def find_educational_bookings_done_yesterday() -> list[EducationalBooking]:
-    yesterday = datetime.now() - timedelta(days=1)
+    yesterday = datetime.utcnow() - timedelta(days=1)
     yesterday_min = datetime.combine(yesterday, time.min)
     yesterday_max = datetime.combine(yesterday, time.max)
 

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -30,7 +30,7 @@ class CollectiveOfferFactory(BaseFactory):
     mentalDisabilityCompliant = False
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=5))
+    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=5))
     students = [StudentLevels.GENERAL2]
     contactEmail = "collectiveofferfactory+contact@example.com"
     bookingEmail = "collectiveofferfactory+booking@example.com"
@@ -65,7 +65,7 @@ class CollectiveOfferTemplateFactory(BaseFactory):
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
 
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=5))
+    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=5))
     students = [StudentLevels.GENERAL2]
     contactEmail = "collectiveofferfactory+contact@example.com"
     contactPhone = "+33199006328"
@@ -91,10 +91,10 @@ class CollectiveStockFactory(BaseFactory):
         model = models.CollectiveStock
 
     collectiveOffer = factory.SubFactory(CollectiveOfferFactory)
-    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=1))
+    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=1))
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=3))
-    dateModified = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=1))
+    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=3))
+    dateModified = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
     numberOfTickets = 25
     price = 100
 
@@ -185,11 +185,11 @@ class CollectiveBookingFactory(BaseFactory):
         model = models.CollectiveBooking
 
     collectiveStock = factory.SubFactory(CollectiveStockFactory)
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=2))
+    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=2))
     venue = factory.SubFactory(VenueFactory)
     offerer = factory.SubFactory(OffererFactory)
-    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=1))
-    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=1))
+    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
+    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
     educationalInstitution = factory.SubFactory(EducationalInstitutionFactory)
     educationalYear = factory.SubFactory(EducationalYearFactory)
     educationalRedactor = factory.SubFactory(EducationalRedactorFactory)
@@ -197,6 +197,6 @@ class CollectiveBookingFactory(BaseFactory):
 
 
 class PendingCollectiveBookingFactory(CollectiveBookingFactory):
-    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=10))
-    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.now() - datetime.timedelta(days=10))
+    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
+    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=10))
     status = models.CollectiveBookingStatus.PENDING

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -589,7 +589,7 @@ def decide_eligibility(
     user_age_today = users_utils.get_age_from_birth_date(birth_date)
     eligibility_at_registration = users_api.get_eligibility_at_date(birth_date, registration_datetime)
 
-    eligibility_today = users_api.get_eligibility_at_date(birth_date, datetime.datetime.now())
+    eligibility_today = users_api.get_eligibility_at_date(birth_date, datetime.datetime.utcnow())
 
     if eligibility_at_registration is None and eligibility_today is None and user_age_today == 19:
         earliest_identity_check_date = users_repository.get_earliest_identity_check_date_of_eligibility(

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -131,7 +131,7 @@ class UbbleContentFactory(factory.Factory):
     supported = None
     identification_id = None
     identification_url = None
-    registration_datetime = datetime.now()
+    registration_datetime = factory.LazyFunction(datetime.utcnow)
 
 
 class EduconnectContentFactory(factory.Factory):
@@ -146,7 +146,7 @@ class EduconnectContentFactory(factory.Factory):
     first_name = factory.Faker("first_name")
     ine_hash = factory.Sequence(lambda _: "".join(random.choices(string.ascii_lowercase + string.digits, k=32)))
     last_name = factory.Faker("last_name")
-    registration_datetime = datetime.now()
+    registration_datetime = factory.LazyFunction(datetime.utcnow)
 
 
 FRAUD_CHECK_TYPE_MODEL_ASSOCIATION = {

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
@@ -17,7 +17,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
     beneficiary = individual_booking.user
     offer = stock.offer
     is_free_offer = stock.price == 0
-    can_book_again = beneficiary.deposit.expirationDate > datetime.datetime.now()
+    can_book_again = beneficiary.deposit.expirationDate > datetime.datetime.utcnow()
 
     if offer.isEvent:
         beginning_date_time_in_tz = utc_datetime_to_department_timezone(

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -346,7 +346,7 @@ def save_venue_banner(
     """
     rm_previous_venue_thumbs(venue)
 
-    banner_timestamp = int(datetime.now().timestamp())
+    banner_timestamp = int(datetime.utcnow().timestamp())
     storage.create_thumb(
         model_with_thumb=venue,
         image_as_bytes=content,

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -195,7 +195,7 @@ class StockFactory(BaseFactory):
 
     beginningDatetime = factory.Maybe(
         "offer.isEvent",
-        factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=5)),
+        factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=5)),
         None,
     )
     bookingLimitDatetime = factory.Maybe(
@@ -211,7 +211,7 @@ class ThingStockFactory(StockFactory):
 
 class EventStockFactory(StockFactory):
     offer = factory.SubFactory(EventOfferFactory)
-    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=5))
+    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=5))
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
 
 
@@ -221,7 +221,7 @@ class EducationalThingStockFactory(StockFactory):
 
 class EducationalEventStockFactory(StockFactory):
     offer = factory.SubFactory(EducationalEventOfferFactory)
-    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.now() + datetime.timedelta(days=5))
+    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=5))
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
     numberOfTickets = 30
     educationalPriceDetail = (

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -472,7 +472,7 @@ def check_stock_consistency() -> list[int]:
 
 
 def find_event_stocks_happening_in_x_days(number_of_days: int) -> set[int]:
-    tomorrow = datetime.now() + timedelta(days=number_of_days)
+    tomorrow = datetime.utcnow() + timedelta(days=number_of_days)
     tomorrow_min = datetime.combine(tomorrow, time.min)
     tomorrow_max = datetime.combine(tomorrow, time.max)
 

--- a/api/src/pcapi/core/payments/factories.py
+++ b/api/src/pcapi/core/payments/factories.py
@@ -17,8 +17,8 @@ class CustomReimbursementRuleFactory(BaseFactory):
     offer = factory.SubFactory(offers_factories.OfferFactory)
     timespan = factory.LazyFunction(
         lambda: [
-            datetime.datetime.now() - datetime.timedelta(days=365),
-            datetime.datetime.now() + datetime.timedelta(days=365),
+            datetime.datetime.utcnow() - datetime.timedelta(days=365),
+            datetime.datetime.utcnow() + datetime.timedelta(days=365),
         ]
     )
     amount = 5

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -350,7 +350,7 @@ def _build_stock_from_stock_detail(
         bookingLimitDatetime=None,
         offerId=offers_id,
         price=price,
-        dateModified=datetime.now(),
+        dateModified=datetime.utcnow(),
         idAtProviders=stock_detail.stocks_provider_reference,
         lastProviderId=provider_id,
     )

--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -28,7 +28,7 @@ def handle_educonnect_authentication(
         first_name=educonnect_user.first_name,
         ine_hash=educonnect_user.ine_hash,
         last_name=educonnect_user.last_name,
-        registration_datetime=datetime.datetime.now(),
+        registration_datetime=datetime.datetime.utcnow(),
         school_uai=educonnect_user.school_uai,
         student_level=educonnect_user.student_level,
     )
@@ -73,7 +73,7 @@ def _handle_validation_errors(
         message = f"La date de naissance de ton dossier Educonnect ({educonnect_user.birth_date.strftime('%d/%m/%Y')}) indique que tu n'es pas éligible."
         eligibity_start = users_api.get_eligibility_start_datetime(educonnect_user.birth_date)
 
-        if datetime.datetime.now() < eligibity_start:
+        if datetime.datetime.utcnow() < eligibity_start:
             message += f" Tu seras éligible le {eligibity_start.strftime('%d/%m/%Y')}."
 
         subscription_messages.add_error_message(user, message)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -100,7 +100,7 @@ def generate_and_save_token(
 ) -> Token:
     assert token_type.name in TokenType.__members__, "Only registered token types are allowed"
 
-    expiration_date = datetime.now() + life_time if life_time else None
+    expiration_date = datetime.utcnow() + life_time if life_time else None
 
     if settings.IS_PERFORMANCE_TESTS:
         token_value = f"performance-tests_{token_type.value}_{user.id}"
@@ -114,7 +114,7 @@ def generate_and_save_token(
 
 
 def delete_expired_tokens() -> None:
-    Token.query.filter(Token.expirationDate < datetime.now()).delete()
+    Token.query.filter(Token.expirationDate < datetime.utcnow()).delete()
 
 
 def delete_all_users_tokens(user: User) -> None:
@@ -145,7 +145,7 @@ def create_account(
         hasSeenTutorials=False,
         notificationSubscriptions=asdict(NotificationSubscriptions(marketing_email=marketing_email_subscription)),
         phoneNumber=phone_number,
-        lastConnectionDate=datetime.now(),
+        lastConnectionDate=datetime.utcnow(),
         subscriptionState=models.SubscriptionState.account_created,
     )
 
@@ -684,7 +684,7 @@ def validate_phone_number(user: User, code: str) -> None:
     if not token:
         raise exceptions.NotValidCode()
 
-    if token.expirationDate and token.expirationDate < datetime.now():
+    if token.expirationDate and token.expirationDate < datetime.utcnow():
         raise exceptions.ExpiredCode()
 
     db.session.delete(token)

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -75,11 +75,11 @@ def get_active_token_expiration(user) -> typing.Optional[datetime]:
     if ttl < 0:
         return None
 
-    return datetime.now() + timedelta(seconds=ttl)
+    return datetime.utcnow() + timedelta(seconds=ttl)
 
 
 def generate_token_expiration_date() -> datetime:
-    return datetime.now() + constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
+    return datetime.utcnow() + constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
 
 
 def check_user_password(user: User, password: str) -> None:

--- a/api/src/pcapi/core/users/external/__init__.py
+++ b/api/src/pcapi/core/users/external/__init__.py
@@ -54,7 +54,7 @@ def update_external_pro(email: Optional[str]) -> None:
     from pcapi.tasks.serialization.sendinblue_tasks import UpdateProAttributesRequest
 
     if email:
-        now = datetime.now()
+        now = datetime.utcnow()
         update_pro_attributes_task.delay(
             UpdateProAttributesRequest(email=email, time_id=f"{now.hour}:{now.minute // 15}")
         )

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -295,12 +295,12 @@ class TokenFactory(BaseFactory):
 
 class ResetPasswordToken(TokenFactory):
     type = models.TokenType.RESET_PASSWORD
-    expirationDate = factory.LazyFunction(lambda: datetime.now() + constants.RESET_PASSWORD_TOKEN_LIFE_TIME)
+    expirationDate = factory.LazyFunction(lambda: datetime.utcnow() + constants.RESET_PASSWORD_TOKEN_LIFE_TIME)
 
 
 class EmailValidationToken(TokenFactory):
     type = models.TokenType.EMAIL_VALIDATION
-    expirationDate = factory.LazyFunction(lambda: datetime.now() + constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME)
+    expirationDate = factory.LazyFunction(lambda: datetime.utcnow() + constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME)
 
 
 class UserSessionFactory(BaseFactory):

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -348,7 +348,7 @@ class User(PcObject, Model, NeedsValidationMixin):
     def eligibility(self) -> Optional[EligibilityType]:
         from pcapi.core.users import api as users_api
 
-        return users_api.get_eligibility_at_date(self.dateOfBirth, datetime.now())
+        return users_api.get_eligibility_at_date(self.dateOfBirth, datetime.utcnow())
 
     @property
     def has_active_deposit(self):

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -70,7 +70,7 @@ def get_user_with_valid_token(
     if not token:
         return None
 
-    if token.expirationDate and token.expirationDate < datetime.now():
+    if token.expirationDate and token.expirationDate < datetime.utcnow():
         return None
 
     if use_token:

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -96,4 +96,4 @@ def get_age_at_date(birth_date: Union[date, datetime], specified_datetime: datet
 
 
 def get_age_from_birth_date(birth_date: Union[date, datetime]) -> int:
-    return get_age_at_date(birth_date, datetime.now())
+    return get_age_at_date(birth_date, datetime.utcnow())

--- a/api/src/pcapi/model_creators/generic_creators.py
+++ b/api/src/pcapi/model_creators/generic_creators.py
@@ -98,7 +98,7 @@ def create_venue(
     thumb_count: int = 0,
     validation_token: Optional[str] = None,
     venue_type_code: Optional[offerers_models.VenueTypeCode] = None,
-    date_created: Optional[datetime] = datetime.now(),
+    date_created: Optional[datetime] = datetime.utcnow(),
 ) -> Venue:
     venue = Venue()
     venue.bookingEmail = booking_email

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -149,7 +149,7 @@ def update_cultural_survey(user: User, body: serializers.CulturalSurveyRequest) 
         if body.cultural_survey_id:
             logger.info("User %s updated cultural survey", user.id, extra={"actor": user.id})
             user.culturalSurveyId = body.cultural_survey_id
-            user.culturalSurveyFilledDate = datetime.now()
+            user.culturalSurveyFilledDate = datetime.utcnow()
     return
 
 

--- a/api/src/pcapi/routes/native/v1/cultural_survey.py
+++ b/api/src/pcapi/routes/native/v1/cultural_survey.py
@@ -39,11 +39,11 @@ def get_cultural_survey_questions(user: users_models.User) -> serializers.Cultur
 def post_cultural_survey_answers(user: users_models.User, body: serializers.CulturalSurveyAnswersRequest) -> None:
     payload = CulturalSurveyAnswersForData(
         user_id=user.id,
-        submitted_at=datetime.datetime.now().isoformat(),
+        submitted_at=datetime.datetime.utcnow().isoformat(),
         answers=body.answers,
     )
 
     upload_answers_task.delay(payload)
     with transaction():
         user.needsToFillCulturalSurvey = False
-        user.culturalSurveyFilledDate = datetime.datetime.now()
+        user.culturalSurveyFilledDate = datetime.datetime.utcnow()

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -64,7 +64,7 @@ class OfferStockResponse(BaseModel):
     @staticmethod
     def _get_cancellation_limit_datetime(stock: Stock) -> Optional[datetime]:
         # compute date as if it were booked now
-        return compute_cancellation_limit_date(stock.beginningDatetime, datetime.now())
+        return compute_cancellation_limit_date(stock.beginningDatetime, datetime.utcnow())
 
     @staticmethod
     def _get_non_scrappable_activation_code(stock: Stock) -> Optional[dict]:

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -430,7 +430,7 @@ class GetOfferStockResponseModel(BaseModel):
 
     @validator("cancellationLimitDate", pre=True, always=True)
     def validate_cancellation_limit_date(cls, cancellation_limit_date, values):  # pylint: disable=no-self-argument
-        return compute_cancellation_limit_date(values.get("beginningDatetime"), datetime.now())
+        return compute_cancellation_limit_date(values.get("beginningDatetime"), datetime.utcnow())
 
     class Config:
         allow_population_by_field_name = True

--- a/api/src/pcapi/sandboxes/scripts/creators/beneficiaries/beneficiaries.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/beneficiaries/beneficiaries.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_future_beneficiaries() -> None:
-    coming_saturday = datetime.now() + relativedelta(weekday=SA)
+    coming_saturday = datetime.utcnow() + relativedelta(weekday=SA)
     eighteen_on_saturday = coming_saturday + relativedelta(years=-18)
     users_factories.UserFactory(
         email="pctest.non-beneficiary.17-going-on-18.v1@example.com",
@@ -31,7 +31,7 @@ def create_future_beneficiaries() -> None:
 
 
 def create_expiring_beneficiary() -> None:
-    coming_saturday = datetime.now() + relativedelta(weekday=SA)
+    coming_saturday = datetime.utcnow() + relativedelta(weekday=SA)
     users_factories.BeneficiaryGrant18Factory(
         email="pctest.beneficiary.deposit-expires-soon@example.com",
         deposit__expirationDate=coming_saturday,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -81,7 +81,7 @@ def save_industrial_sandbox() -> None:
     # Now that they booked, we can expire these users' deposit.
     for name, user in users_by_name.items():
         if "has-booked-some-but-deposit-expired" in name:
-            user.deposit.expirationDate = datetime.datetime.now()
+            user.deposit.expirationDate = datetime.datetime.utcnow()
             repository.save(user.deposit)
 
     create_industrial_invoices()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_app_users.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_app_users.py
@@ -85,7 +85,7 @@ def create_industrial_app_beneficiaries():
             deposit__version=deposit_version,
         )
         users_factories.DepositGrantFactory(
-            user=user, expirationDate=datetime.now(), source="sandbox", type=DepositType.GRANT_15_17
+            user=user, expirationDate=datetime.utcnow(), source="sandbox", type=DepositType.GRANT_15_17
         )
 
         user_key = f"jeune{departement_code} {tag} v{deposit_version}"

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
@@ -95,8 +95,8 @@ def _create_bookings_for_other_beneficiaries(
                 is_used = offer_index % BOOKINGS_USED_REMOVE_MODULO != 0
 
             if is_used:
-                stock.beginningDatetime = datetime.now() - timedelta(days=2)
-                stock.bookingLimitDatetime = datetime.now() - timedelta(days=5)
+                stock.beginningDatetime = datetime.utcnow() - timedelta(days=2)
+                stock.bookingLimitDatetime = datetime.utcnow() - timedelta(days=5)
                 repository.save(stock)
 
             if user_should_have_no_more_money and user not in list_of_users_with_no_more_money:
@@ -111,7 +111,7 @@ def _create_bookings_for_other_beneficiaries(
                 individualBooking__user=user,
                 status=BookingStatus.USED if is_used else BookingStatus.CONFIRMED,
                 stock=stock,
-                dateUsed=datetime.now() - timedelta(days=2) if is_used else None,
+                dateUsed=datetime.utcnow() - timedelta(days=2) if is_used else None,
                 amount=booking_amount if booking_amount is not None else stock.price,
                 token=str(token),
                 offerer=offer.venue.managingOfferer,
@@ -153,15 +153,15 @@ def _create_has_booked_some_bookings(bookings_by_name, offers_by_name, user, use
             is_used = offer_index % BOOKINGS_USED_REMOVE_MODULO != 0
 
         if is_used:
-            stock.beginningDatetime = datetime.now() - timedelta(days=2)
-            stock.bookingLimitDatetime = datetime.now() - timedelta(days=5)
+            stock.beginningDatetime = datetime.utcnow() - timedelta(days=2)
+            stock.bookingLimitDatetime = datetime.utcnow() - timedelta(days=5)
             repository.save(stock)
 
         booking = IndividualBookingFactory(
             individualBooking__user=user,
             status=BookingStatus.USED if is_used else BookingStatus.CONFIRMED,
             stock=stock,
-            dateUsed=datetime.now() - timedelta(days=2) if is_used else None,
+            dateUsed=datetime.utcnow() - timedelta(days=2) if is_used else None,
         )
         booking_name = "{} / {} / {}".format(offer_name, user_name, booking.token)
         bookings_by_name[booking_name] = booking

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
@@ -74,7 +74,7 @@ def create_industrial_educational_bookings() -> None:
         educational_factories.EducationalInstitutionFactory(institutionId="0560071Y"),
     ]
 
-    now = datetime.datetime.now(datetime.timezone.utc)
+    now = datetime.datetime.utcnow()
     stocks = []
     venue = VenueFactory(
         name="Opéra Royal de Versailles",

--- a/api/src/pcapi/sandboxes/scripts/utils/helpers.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/helpers.py
@@ -66,6 +66,6 @@ def get_venue_helper(venue):
 
 def _get_reset_password_token(user: User):
     for token in user.tokens:
-        if token.type == TokenType.RESET_PASSWORD and token.expirationDate > datetime.now():
+        if token.type == TokenType.RESET_PASSWORD and token.expirationDate > datetime.utcnow():
             return token.value
     return None

--- a/api/src/pcapi/scripts/booking/cancel_old_unused_bookings_for_venue.py
+++ b/api/src/pcapi/scripts/booking/cancel_old_unused_bookings_for_venue.py
@@ -26,7 +26,7 @@ def cancel_old_unused_bookings_for_venue(humanized_venue_id: str, reason: Bookin
     if venue is None:
         raise Exception(f"There is no venue with id {humanized_venue_id}")
 
-    limit_date = datetime.now() - timedelta(days=30)
+    limit_date = datetime.utcnow() - timedelta(days=30)
 
     old_unused_bookings = _get_old_unused_bookings_from_venue_id(venue.id, limit_date)
 

--- a/api/src/pcapi/scripts/educational/import_educational_institutions_and_deposits.py
+++ b/api/src/pcapi/scripts/educational/import_educational_institutions_and_deposits.py
@@ -39,7 +39,7 @@ def _process_educational_csv(
     ministry: Ministry,
     educational_year_beginning: Optional[int] = None,
 ) -> None:
-    current_year = educational_year_beginning if educational_year_beginning is not None else datetime.now().year
+    current_year = educational_year_beginning if educational_year_beginning is not None else datetime.utcnow().year
     try:
         educational_year = educational_repository.get_educational_year_beginning_at_given_year(current_year)
     except exceptions.EducationalYearNotFound:

--- a/api/src/pcapi/scripts/educational/update_educational_institutions_deposits.py
+++ b/api/src/pcapi/scripts/educational/update_educational_institutions_deposits.py
@@ -34,7 +34,7 @@ def update_educational_institutions_deposits(
 def _process_educational_csv(
     educational_institutions_rows: Iterable[dict], educational_year_beginning: int = None
 ) -> None:
-    current_year = educational_year_beginning if educational_year_beginning is not None else datetime.now().year
+    current_year = educational_year_beginning if educational_year_beginning is not None else datetime.utcnow().year
     try:
         educational_year = educational_repository.get_educational_year_beginning_at_given_year(current_year)
     except exceptions.EducationalYearNotFound:

--- a/api/src/pcapi/scripts/full_extract_offers.py
+++ b/api/src/pcapi/scripts/full_extract_offers.py
@@ -51,7 +51,7 @@ def save_offers(operation_id, offers: Iterable[offers_models.Offer]) -> None:
 def _get_eta(end, current, elapsed_per_batch):
     left_to_do = end - current
     eta = left_to_do / BATCH_SIZE * statistics.mean(elapsed_per_batch)
-    eta = datetime.datetime.now() + datetime.timedelta(seconds=eta)
+    eta = datetime.utcdatetime.utcnow() + datetime.timedelta(seconds=eta)
     eta = eta.astimezone(pytz.timezone("Europe/Paris"))
     eta = eta.strftime("%d/%m/%Y %H:%M:%S")
     return eta

--- a/api/src/pcapi/scripts/full_index_offers.py
+++ b/api/src/pcapi/scripts/full_index_offers.py
@@ -23,7 +23,7 @@ blueprint = Blueprint(__name__, __name__)
 def _get_eta(end, current, elapsed_per_batch):
     left_to_do = end - current
     eta = left_to_do / BATCH_SIZE * statistics.mean(elapsed_per_batch)
-    eta = datetime.datetime.now() + datetime.timedelta(seconds=eta)
+    eta = datetime.datetime.utcnow() + datetime.timedelta(seconds=eta)
     eta = eta.astimezone(pytz.timezone("Europe/Paris"))
     eta = eta.strftime("%d/%m/%Y %H:%M:%S")
     return eta

--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -66,8 +66,8 @@ def has_been_recredited(user: users_models.User) -> bool:
 
 
 def recredit_underage_users() -> None:
-    sixteen_years_ago = datetime.now() - relativedelta(years=16)
-    eighteen_years_ago = datetime.now() - relativedelta(years=18)
+    sixteen_years_ago = datetime.utcnow() - relativedelta(years=16)
+    eighteen_years_ago = datetime.utcnow() - relativedelta(years=18)
 
     user_ids = [
         result

--- a/api/src/pcapi/tasks/cloud_task.py
+++ b/api/src/pcapi/tasks/cloud_task.py
@@ -109,7 +109,7 @@ def enqueue_internal_task(queue, path, payload, deduplicate: bool = False, delay
     # id is recommended".
     task_id = hashlib.sha1(json.dumps(payload, sort_keys=True).encode()).hexdigest() if deduplicate else None
 
-    schedule_time = datetime.now() + relativedelta(seconds=delayed_seconds) if delayed_seconds else None
+    schedule_time = datetime.utcnow() + relativedelta(seconds=delayed_seconds) if delayed_seconds else None
 
     return enqueue_task(queue, http_request, task_id=task_id, schedule_time=schedule_time)
 

--- a/api/src/pcapi/workers/decorators.py
+++ b/api/src/pcapi/workers/decorators.py
@@ -25,7 +25,7 @@ def job(queue: Queue):
                 return func(*args, **kwargs)
 
             start = time.perf_counter()
-            started_at = current_job.started_at or datetime.now()
+            started_at = current_job.started_at or datetime.utcnow()
             logger.info(
                 "Started job %s",
                 func.__name__,

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -51,7 +51,7 @@ class AdminUserViewTest:
 
         token = Token.query.filter_by(userId=user_created.id).first()
         assert token.type == TokenType.RESET_PASSWORD
-        assert token.expirationDate > datetime.now() + timedelta(hours=20)
+        assert token.expirationDate > datetime.utcnow() + timedelta(hours=20)
 
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -23,7 +23,7 @@ from tests.conftest import clean_database
 
 
 class BeneficiaryUserViewTest:
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")

--- a/api/tests/admin/custom_views/pro_user_view_test.py
+++ b/api/tests/admin/custom_views/pro_user_view_test.py
@@ -76,8 +76,8 @@ class ProUserViewTest:
 
         token = Token.query.filter_by(userId=user_created.id).first()
         assert token.type == TokenType.RESET_PASSWORD
-        assert token.expirationDate > datetime.now() + timedelta(days=29)
-        assert token.expirationDate < datetime.now() + timedelta(days=31)
+        assert token.expirationDate > datetime.utcnow() + timedelta(days=29)
+        assert token.expirationDate < datetime.utcnow() + timedelta(days=31)
 
     def test_it_gives_a_random_password_to_user(self, app, db_session):
         # Given

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -19,7 +19,7 @@ import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
 
 
-AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
 
 @pytest.mark.usefixtures("db_session")
@@ -341,7 +341,7 @@ class ValidatePhoneNumberTest:
 @pytest.mark.usefixtures("db_session")
 class BeneficiaryActivationStatusTest:
     def test_not_eligible(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.now() - relativedelta(years=25))
+        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=25))
         assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.NOT_APPLICABLE
 
     def test_beneficiary(self):
@@ -353,14 +353,14 @@ class BeneficiaryActivationStatusTest:
     def test_ex_underage(self):
         with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
             user = users_factories.UnderageBeneficiaryFactory(
-                dateOfBirth=datetime.now() - relativedelta(years=15, months=5),
+                dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=5),
             )
         assert get_beneficiary_activation_status(user) == BeneficiaryActivationStatus.INCOMPLETE
 
     def test_ex_underage_with_some_fraud_check_ko(self):
         with freezegun.freeze_time(datetime.utcnow() - relativedelta(years=3)):
             user = users_factories.UnderageBeneficiaryFactory(
-                dateOfBirth=datetime.now() - relativedelta(years=15, months=5),
+                dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=5),
             )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.HONOR_STATEMENT, status=fraud_models.FraudCheckStatus.OK

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -197,7 +197,7 @@ class BookOfferTest:
         stock2 = offers_factories.StockFactory(price=10, dnBookedQuantity=5, offer=offer2)
 
         beneficiary = users_factories.BeneficiaryGrant18Factory()
-        date_created = datetime.now() - timedelta(days=5)
+        date_created = datetime.utcnow() - timedelta(days=5)
         booking_factories.IndividualBookingFactory.create_batch(
             3, individualBooking__user=beneficiary, dateCreated=date_created, stock=stock2
         )
@@ -459,7 +459,7 @@ class CancelByBeneficiaryTest:
         assert booking.status is not BookingStatus.CANCELLED
 
     def test_raise_if_event_too_close(self):
-        event_date_too_close_to_cancel_booking = datetime.now() + timedelta(days=1)
+        event_date_too_close_to_cancel_booking = datetime.utcnow() + timedelta(days=1)
         booking = booking_factories.IndividualBookingFactory(
             stock__beginningDatetime=event_date_too_close_to_cancel_booking,
         )
@@ -473,7 +473,7 @@ class CancelByBeneficiaryTest:
         ]
 
     def test_raise_if_booking_created_too_long_ago_to_cancel_booking(self):
-        event_date_far_enough_to_cancel_booking = datetime.now() + timedelta(days=2, minutes=1)
+        event_date_far_enough_to_cancel_booking = datetime.utcnow() + timedelta(days=2, minutes=1)
         booking_date_too_long_ago_to_cancel_booking = datetime.utcnow() - timedelta(days=2, minutes=1)
         booking = booking_factories.IndividualBookingFactory(
             stock__beginningDatetime=event_date_far_enough_to_cancel_booking,
@@ -490,7 +490,7 @@ class CancelByBeneficiaryTest:
 
     def test_raise_if_event_too_close_and_booked_long_ago(self):
         booking_date_too_long_ago_to_cancel_booking = datetime.utcnow() - timedelta(days=2, minutes=1)
-        event_date_too_close_to_cancel_booking = datetime.now() + timedelta(days=1)
+        event_date_too_close_to_cancel_booking = datetime.utcnow() + timedelta(days=1)
         booking = booking_factories.IndividualBookingFactory(
             stock__beginningDatetime=event_date_too_close_to_cancel_booking,
             dateCreated=booking_date_too_long_ago_to_cancel_booking,
@@ -630,7 +630,7 @@ class MarkAsUsedTest:
 
     def test_mark_as_used_when_stock_starts_soon(self):
         booking = booking_factories.IndividualBookingFactory(
-            stock__beginningDatetime=datetime.now() + timedelta(days=1)
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=1)
         )
         api.mark_as_used(booking)
         assert booking.status is BookingStatus.USED
@@ -654,7 +654,7 @@ class MarkAsUsedTest:
 
     def test_raise_if_too_soon_to_mark_as_used(self):
         booking = booking_factories.IndividualBookingFactory(
-            stock__beginningDatetime=datetime.now() + timedelta(days=4)
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=4)
         )
         with pytest.raises(api_errors.ForbiddenError):
             api.mark_as_used(booking)
@@ -709,7 +709,7 @@ class MarkAsUnusedTest:
 
 @pytest.mark.parametrize(
     "booking_date",
-    [datetime(2020, 7, 14, 15, 30), datetime(2020, 10, 25, 1, 45), datetime.now()],
+    [datetime(2020, 7, 14, 15, 30), datetime(2020, 10, 25, 1, 45), datetime.utcnow()],
     ids=["14 Jul", "Daylight Saving Switch", "Now"],
 )
 @pytest.mark.usefixtures("db_session")
@@ -748,14 +748,15 @@ class UpdateCancellationLimitDatesTest:
     def should_update_bookings_cancellation_limit_dates_for_event_beginning_tomorrow(self):
         #  Given
         recent_booking = booking_factories.IndividualBookingFactory(
-            stock__beginningDatetime=datetime.now() + timedelta(days=90)
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=90)
         )
         old_booking = booking_factories.IndividualBookingFactory(
-            stock=recent_booking.stock, dateCreated=(datetime.now() - timedelta(days=7))
+            stock=recent_booking.stock, dateCreated=(datetime.utcnow() - timedelta(days=7))
         )
         # When
         updated_bookings = api.update_cancellation_limit_dates(
-            bookings_to_update=[recent_booking, old_booking], new_beginning_datetime=datetime.now() + timedelta(days=1)
+            bookings_to_update=[recent_booking, old_booking],
+            new_beginning_datetime=datetime.utcnow() + timedelta(days=1),
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
@@ -764,14 +765,15 @@ class UpdateCancellationLimitDatesTest:
     def should_update_bookings_cancellation_limit_dates_for_event_beginning_in_three_days(self):
         #  Given
         recent_booking = booking_factories.IndividualBookingFactory(
-            stock__beginningDatetime=datetime.now() + timedelta(days=90)
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=90)
         )
         old_booking = booking_factories.IndividualBookingFactory(
-            stock=recent_booking.stock, dateCreated=(datetime.now() - timedelta(days=7))
+            stock=recent_booking.stock, dateCreated=(datetime.utcnow() - timedelta(days=7))
         )
         # When
         updated_bookings = api.update_cancellation_limit_dates(
-            bookings_to_update=[recent_booking, old_booking], new_beginning_datetime=datetime.now() + timedelta(days=3)
+            bookings_to_update=[recent_booking, old_booking],
+            new_beginning_datetime=datetime.utcnow() + timedelta(days=3),
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
@@ -780,14 +782,15 @@ class UpdateCancellationLimitDatesTest:
     def should_update_bookings_cancellation_limit_dates_for_event_beginning_in_a_week(self):
         #  Given
         recent_booking = booking_factories.IndividualBookingFactory(
-            stock__beginningDatetime=datetime.now() + timedelta(days=90)
+            stock__beginningDatetime=datetime.utcnow() + timedelta(days=90)
         )
         old_booking = booking_factories.IndividualBookingFactory(
-            stock=recent_booking.stock, dateCreated=(datetime.now() - timedelta(days=7))
+            stock=recent_booking.stock, dateCreated=(datetime.utcnow() - timedelta(days=7))
         )
         # When
         updated_bookings = api.update_cancellation_limit_dates(
-            bookings_to_update=[recent_booking, old_booking], new_beginning_datetime=datetime.now() + timedelta(days=7)
+            bookings_to_update=[recent_booking, old_booking],
+            new_beginning_datetime=datetime.utcnow() + timedelta(days=7),
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
@@ -807,7 +810,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_update_booking_used_when_event_date_is_3_days_before(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         booking_factories.IndividualBookingFactory(stock__beginningDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
@@ -818,7 +821,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_does_not_update_when_event_date_is_only_1_day_before(self):
-        event_date = datetime.now() - timedelta(days=1)
+        event_date = datetime.utcnow() - timedelta(days=1)
         booking_factories.IndividualBookingFactory(stock__beginningDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
@@ -829,7 +832,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_does_not_update_booking_if_already_used(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         booking = booking_factories.UsedIndividualBookingFactory(stock__beginningDatetime=event_date)
         initial_date_used = booking.dateUsed
 
@@ -841,7 +844,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_does_not_update_booking_if_cancelled(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         booking = booking_factories.CancelledIndividualBookingFactory(stock__beginningDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
@@ -850,7 +853,7 @@ class AutoMarkAsUsedAfterEventTest:
         assert booking.status is BookingStatus.CANCELLED
 
     def test_update_educational_booking_if_not_used(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         booking_factories.EducationalBookingFactory(
             stock__beginningDatetime=event_date,
         )
@@ -861,7 +864,7 @@ class AutoMarkAsUsedAfterEventTest:
         assert validated_educational_booking.status is BookingStatus.USED
 
     def test_does_not_update_educational_booking_if_not_used_and_refused_by_principal(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         booking_factories.EducationalBookingFactory(
             stock__beginningDatetime=event_date,
             educationalBooking__status=EducationalBookingStatus.REFUSED,
@@ -873,7 +876,7 @@ class AutoMarkAsUsedAfterEventTest:
         assert validated_educational_booking.status is not BookingStatus.USED
 
     def test_update_educational_booking_if_not_used_and_not_validated_by_principal_yet(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         booking_factories.EducationalBookingFactory(
             stock__beginningDatetime=event_date,
             educationalBooking__status=None,
@@ -886,7 +889,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_update_collective_booking_when_not_used_and_event_date_is_3_days_before(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         educational_factories.CollectiveBookingFactory(collectiveStock__beginningDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
@@ -897,7 +900,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_does_not_update_collective_booking_when_event_date_is_only_1_day_before(self):
-        event_date = datetime.now() - timedelta(days=1)
+        event_date = datetime.utcnow() - timedelta(days=1)
         educational_factories.CollectiveBookingFactory(collectiveStock__beginningDatetime=event_date)
 
         api.auto_mark_as_used_after_event()
@@ -908,7 +911,7 @@ class AutoMarkAsUsedAfterEventTest:
 
     @freeze_time("2021-01-01")
     def test_does_not_update_collective_booking_when_cancelled(self):
-        event_date = datetime.now() - timedelta(days=3)
+        event_date = datetime.utcnow() - timedelta(days=3)
         educational_factories.CollectiveBookingFactory(
             collectiveStock__beginningDatetime=event_date, status=CollectiveBookingStatus.CANCELLED
         )

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -2560,7 +2560,7 @@ class SoonExpiringBookingsTest:
         bookings_factories.CancelledBookingFactory(stock=stock)
         booking = bookings_factories.IndividualBookingFactory(stock=stock)
 
-        creation_date = datetime.now() - timedelta(days=1)
+        creation_date = datetime.utcnow() - timedelta(days=1)
         bookings_factories.IndividualBookingFactory(stock=stock, dateCreated=creation_date)
 
         remaining_days = (booking.expirationDate.date() - date.today()).days

--- a/api/tests/core/bookings/test_validation.py
+++ b/api/tests/core/bookings/test_validation.py
@@ -111,7 +111,7 @@ class CheckStockIsBookableTest:
         validation.check_stock_is_bookable(stock, self.booking_quantity)  # should not raise
 
     def test_raise_if_not_bookable(self):
-        yesterday = datetime.now() - timedelta(days=1)
+        yesterday = datetime.utcnow() - timedelta(days=1)
         stock = offers_factories.StockFactory(bookingLimitDatetime=yesterday)
 
         with pytest.raises(exceptions.StockIsNotBookable) as error:
@@ -202,7 +202,7 @@ class CheckExpenseLimitsDepositVersion2Test:
         return users_factories.BeneficiaryGrant18Factory(deposit__version=2, **kwargs)
 
     def test_raise_if_deposit_expired(self):
-        yesterday = datetime.now() - timedelta(days=1)
+        yesterday = datetime.utcnow() - timedelta(days=1)
         beneficiary = self._get_beneficiary(deposit__expirationDate=yesterday)
         offer = offers_factories.OfferFactory(product__subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         with pytest.raises(exceptions.UserHasInsufficientFunds):
@@ -260,7 +260,7 @@ class CheckExpenseLimitsDepositVersion2Test:
 class InsufficientFundsSQLCheckTest:
     def _expire_deposit(self, user):
         deposit = user.deposits[0]
-        deposit.expirationDate = datetime.now() - timedelta(days=1)
+        deposit.expirationDate = datetime.utcnow() - timedelta(days=1)
         repository.save(deposit)
 
     def test_insufficient_funds_when_user_has_negative_deposit(self):

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -758,8 +758,8 @@ class EditCollectiveOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
-            bookingLimitDatetime=datetime.datetime.now() + datetime.timedelta(days=5, hours=16),
+            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=7, hours=5),
+            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=5, hours=16),
             totalPrice=1500,
             numberOfTickets=35,
         )
@@ -778,8 +778,8 @@ class EditCollectiveOfferStocksTest:
 
     def test_should_update_some_fields_and_keep_non_edited_ones(self):
         # Given
-        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -787,7 +787,7 @@ class EditCollectiveOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=7, hours=5),
             numberOfTickets=35,
         )
 
@@ -805,13 +805,13 @@ class EditCollectiveOfferStocksTest:
 
     def test_should_replace_bookingLimitDatetime_with_new_event_datetime_if_provided_but_none(self):
         # Given
-        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(
             beginningDatetime=initial_event_date,
             bookingLimitDatetime=initial_booking_limit_date,
         )
-        new_event_datetime = datetime.datetime.now() + datetime.timedelta(days=7, hours=5)
+        new_event_datetime = datetime.datetime.utcnow() + datetime.timedelta(days=7, hours=5)
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
             beginningDatetime=new_event_datetime,
             bookingLimitDatetime=None,
@@ -830,8 +830,8 @@ class EditCollectiveOfferStocksTest:
         self,
     ):
         # Given
-        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(
             beginningDatetime=initial_event_date,
             bookingLimitDatetime=initial_booking_limit_date,
@@ -853,8 +853,8 @@ class EditCollectiveOfferStocksTest:
     # @mock.patch("pcapi.core.search.async_index_offer_ids")
     # def test_should_reindex_offer_on_algolia(self, mocked_async_index_offer_ids):
     #     # Given
-    #     initial_event_date = datetime.datetime.now() + datetime.timedelta(days=5)
-    #     initial_booking_limit_date = datetime.datetime.now() + datetime.timedelta(days=3)
+    #     initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+    #     initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
     #     stock_to_be_updated = educational_factories.CollectiveStockFactory(
     #         beginningDatetime=initial_event_date,
     #         price=1200,
@@ -862,7 +862,7 @@ class EditCollectiveOfferStocksTest:
     #         bookingLimitDatetime=initial_booking_limit_date,
     #     )
     #     new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-    #         beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+    #         beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=7, hours=5),
     #         numberOfTickets=35,
     #     )
 
@@ -879,7 +879,7 @@ class EditCollectiveOfferStocksTest:
         # Given
         stock_to_be_updated = educational_factories.CollectiveStockFactory(price=1200)
         educational_factories.CollectiveBookingFactory(
-            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=1337),
+            confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=1337),
             collectiveStock=stock_to_be_updated,
         )
 
@@ -899,17 +899,17 @@ class EditCollectiveOfferStocksTest:
 
     def should_update_bookings_cancellation_limit_date_if_event_postponed(self):
         # Given
-        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=20)
-        cancellation_limit_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=20)
+        cancellation_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(beginningDatetime=initial_event_date)
         booking = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_to_be_updated,
             status=CollectiveBookingStatus.PENDING,
             cancellationLimitDate=cancellation_limit_date,
-            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=30),
+            confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=30),
         )
 
-        new_event_date = datetime.datetime.now() + datetime.timedelta(days=25, hours=5)
+        new_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=25, hours=5)
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
             beginningDatetime=new_event_date,
         )
@@ -933,7 +933,7 @@ class EditCollectiveOfferStocksTest:
             collectiveStock=stock_to_be_updated,
             status=CollectiveBookingStatus.PENDING,
             cancellationLimitDate=cancellation_limit_date,
-            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=30),
+            confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=30),
         )
 
         new_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5, hours=5)
@@ -953,8 +953,8 @@ class EditCollectiveOfferStocksTest:
 
     def test_should_allow_stock_edition_and_not_modify_cancellation_limit_date_when_booking_cancelled(self):
         # Given
-        initial_event_date = datetime.datetime.now() + datetime.timedelta(days=20)
-        cancellation_limit_date = datetime.datetime.now() + datetime.timedelta(days=5)
+        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=20)
+        cancellation_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(
             beginningDatetime=initial_event_date,
         )
@@ -962,10 +962,10 @@ class EditCollectiveOfferStocksTest:
             collectiveStock=stock_to_be_updated,
             status=CollectiveBookingStatus.CANCELLED,
             cancellationLimitDate=cancellation_limit_date,
-            confirmationLimitDate=datetime.datetime.now() + datetime.timedelta(days=30),
+            confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=30),
         )
 
-        new_event_date = datetime.datetime.now() + datetime.timedelta(days=25, hours=5)
+        new_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=25, hours=5)
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
             beginningDatetime=new_event_date,
         )
@@ -983,8 +983,8 @@ class EditCollectiveOfferStocksTest:
 
     def test_does_not_allow_edition_of_an_expired_event_stock(self):
         # Given
-        initial_event_date = datetime.datetime.now() - datetime.timedelta(days=1)
-        initial_booking_limit_date = datetime.datetime.now() - datetime.timedelta(days=10)
+        initial_event_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        initial_booking_limit_date = datetime.datetime.utcnow() - datetime.timedelta(days=10)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -992,7 +992,7 @@ class EditCollectiveOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.datetime.now() + datetime.timedelta(days=7, hours=5),
+            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=7, hours=5),
             numberOfTickets=35,
         )
 

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -462,7 +462,7 @@ class EduconnectFraudTest:
 @pytest.mark.usefixtures("db_session")
 class HasUserPerformedIdentityCheckTest:
     def test_has_not_performed(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=1))
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.JOUVE, eligibilityType=users_models.EligibilityType.UNDERAGE
         )
@@ -481,7 +481,7 @@ class HasUserPerformedIdentityCheckTest:
     @pytest.mark.parametrize("check_type", [fraud_models.FraudCheckType.JOUVE, fraud_models.FraudCheckType.UBBLE])
     @pytest.mark.parametrize("status", [fraud_models.FraudCheckStatus.PENDING, fraud_models.FraudCheckStatus.OK])
     def test_has_user_performed_identity_check(self, age, eligibility_type, check_type, status):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=age, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=age, months=1))
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=check_type, user=user, status=status, eligibilityType=eligibility_type
         )
@@ -492,7 +492,7 @@ class HasUserPerformedIdentityCheckTest:
         )
 
     def test_has_user_performed_identity_check_turned_18(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=1))
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE, user=user, eligibilityType=users_models.EligibilityType.UNDERAGE
         )
@@ -519,7 +519,7 @@ class HasUserPerformedIdentityCheckTest:
         )
 
     def test_has_user_performed_identity_check_ubble_suspicious(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=1))
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             user=user,
@@ -533,7 +533,7 @@ class HasUserPerformedIdentityCheckTest:
         assert ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
     def test_has_user_performed_identity_check_ubble_suspicious_x3(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=1))
         for _ in range(3):
             fraud_factories.BeneficiaryFraudCheckFactory(
                 type=fraud_models.FraudCheckType.UBBLE,
@@ -548,7 +548,7 @@ class HasUserPerformedIdentityCheckTest:
         assert not ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)
 
     def test_has_user_performed_identity_check_ubble_ko(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=1))
         fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             user=user,
@@ -562,13 +562,13 @@ class HasUserPerformedIdentityCheckTest:
 
     def test_user_beneficiary(self):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.now() - relativedelta(years=20, months=1),
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=20, months=1),
             roles=[users_models.UserRole.BENEFICIARY],
         )
         assert fraud_api.has_user_performed_identity_check(user)
 
     def test_user_not_eligible_anymore_but_has_performed(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=20, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=20, months=1))
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.JOUVE, eligibilityType=users_models.EligibilityType.AGE18
         )

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
@@ -56,7 +56,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             individualBooking__user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
             stock=ThingStockFactory(
                 price=10.20,
-                beginningDatetime=datetime.now() - timedelta(days=1),
+                beginningDatetime=datetime.utcnow() - timedelta(days=1),
                 offer__name="Test thing name",
                 offer__id=123456,
             ),

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -135,7 +135,7 @@ class UpsertStocksTest:
         venue = factories.VenueFactory(managingOfferer=offerer, bookingEmail="venue@postponed.net")
         offer = factories.EventOfferFactory(venue=venue, bookingEmail="offer@bookingemail.fr")
         existing_stock = factories.StockFactory(offer=offer, price=10)
-        beginning = datetime.now() + timedelta(days=10)
+        beginning = datetime.utcnow() + timedelta(days=10)
         edited_stock_data = stock_serialize.StockEditionBodyModel(
             id=existing_stock.id,
             beginningDatetime=beginning,
@@ -169,7 +169,7 @@ class UpsertStocksTest:
     def should_update_bookings_cancellation_limit_date_if_report_of_event(self, mock_update_cancellation_limit_dates):
         # Given
         user = users_factories.ProFactory()
-        now = datetime.now()
+        now = datetime.utcnow()
         event_in_4_days = now + timedelta(days=4)
         event_reported_in_10_days = now + timedelta(days=10)
         offer = factories.EventOfferFactory(bookingEmail="test@bookingEmail.fr")
@@ -191,7 +191,7 @@ class UpsertStocksTest:
     def should_invalidate_booking_token_when_event_is_reported(self):
         # Given
         user = users_factories.ProFactory()
-        now = datetime.now()
+        now = datetime.utcnow()
         booking_made_3_days_ago = now - timedelta(days=3)
         event_in_4_days = now + timedelta(days=4)
         event_reported_in_10_days = now + timedelta(days=10)
@@ -219,8 +219,8 @@ class UpsertStocksTest:
     def should_not_invalidate_booking_token_when_event_is_reported_in_less_than_48_hours(self):
         # Given
         user = users_factories.ProFactory()
-        now = datetime.now()
-        date_used_in_48_hours = datetime.now() + timedelta(days=2)
+        now = datetime.utcnow()
+        date_used_in_48_hours = datetime.utcnow() + timedelta(days=2)
         event_in_3_days = now + timedelta(days=3)
         event_reported_in_less_48_hours = now + timedelta(days=1)
         offer = factories.EventOfferFactory(bookingEmail="test@bookingEmail.fr")
@@ -343,7 +343,7 @@ class UpsertStocksTest:
         # Given
         user = users_factories.ProFactory()
         offer = factories.EventOfferFactory()
-        now = datetime.now()
+        now = datetime.utcnow()
         created_stock_data = stock_serialize.StockCreationBodyModel(
             price=301, beginningDatetime=now, bookingLimitDatetime=now
         )
@@ -359,7 +359,7 @@ class UpsertStocksTest:
         # Given
         user = users_factories.ProFactory()
         existing_stock = factories.EventStockFactory(price=10, offer__bookingEmail="test@bookingEmail.fr")
-        now = datetime.now()
+        now = datetime.utcnow()
         edited_stock_data = stock_serialize.StockEditionBodyModel(
             id=existing_stock.id, price=301, beginningDatetime=now, bookingLimitDatetime=now
         )
@@ -459,7 +459,7 @@ class UpsertStocksTest:
         created_stock_data = stock_serialize.StockCreationBodyModel(
             price=0,
             bookingLimitDatetime=None,
-            activationCodesExpirationDatetime=datetime.now(),
+            activationCodesExpirationDatetime=datetime.utcnow(),
             activationCodes=["ABC", "DEF"],
         )
 
@@ -482,7 +482,7 @@ class UpsertStocksTest:
         user = users_factories.ProFactory()
         offer = factories.DigitalOfferFactory()
         existing_stock = factories.StockFactory(offer=offer)
-        factories.ActivationCodeFactory(expirationDate=datetime.now(), stock=existing_stock)
+        factories.ActivationCodeFactory(expirationDate=datetime.utcnow(), stock=existing_stock)
         edited_stock_data = stock_serialize.StockEditionBodyModel(
             id=existing_stock.id, price=0, bookingLimitDatetime=None
         )
@@ -889,8 +889,8 @@ class CreateEducationalOfferStocksTest:
 class EditEducationalOfferStocksTest:
     def test_should_update_all_fields_when_all_changed(self):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=5)
-        initial_booking_limit_date = datetime.now() + timedelta(days=3)
+        initial_event_date = datetime.utcnow() + timedelta(days=5)
+        initial_booking_limit_date = datetime.utcnow() + timedelta(days=3)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -899,8 +899,8 @@ class EditEducationalOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.now() + timedelta(days=7, hours=5),
-            bookingLimitDatetime=datetime.now() + timedelta(days=5, hours=16),
+            beginningDatetime=datetime.utcnow() + timedelta(days=7, hours=5),
+            bookingLimitDatetime=datetime.utcnow() + timedelta(days=5, hours=16),
             totalPrice=1500,
             numberOfTickets=35,
         )
@@ -917,8 +917,8 @@ class EditEducationalOfferStocksTest:
 
     def test_should_update_some_fields_and_keep_non_edited_ones(self):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=5)
-        initial_booking_limit_date = datetime.now() + timedelta(days=3)
+        initial_event_date = datetime.utcnow() + timedelta(days=5)
+        initial_booking_limit_date = datetime.utcnow() + timedelta(days=3)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -927,7 +927,7 @@ class EditEducationalOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.now() + timedelta(days=7, hours=5),
+            beginningDatetime=datetime.utcnow() + timedelta(days=7, hours=5),
             numberOfTickets=35,
         )
 
@@ -943,8 +943,8 @@ class EditEducationalOfferStocksTest:
 
     def test_should_update_educational_booking_amount(self):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=5)
-        initial_booking_limit_date = datetime.now() + timedelta(days=3)
+        initial_event_date = datetime.utcnow() + timedelta(days=5)
+        initial_booking_limit_date = datetime.utcnow() + timedelta(days=3)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -972,13 +972,13 @@ class EditEducationalOfferStocksTest:
 
     def test_should_replace_bookingLimitDatetime_with_new_event_datetime_if_provided_but_none(self):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=5)
-        initial_booking_limit_date = datetime.now() + timedelta(days=3)
+        initial_event_date = datetime.utcnow() + timedelta(days=5)
+        initial_booking_limit_date = datetime.utcnow() + timedelta(days=3)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             bookingLimitDatetime=initial_booking_limit_date,
         )
-        new_event_datetime = datetime.now() + timedelta(days=7, hours=5)
+        new_event_datetime = datetime.utcnow() + timedelta(days=7, hours=5)
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
             beginningDatetime=new_event_datetime,
             bookingLimitDatetime=None,
@@ -995,8 +995,8 @@ class EditEducationalOfferStocksTest:
         self,
     ):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=5)
-        initial_booking_limit_date = datetime.now() + timedelta(days=3)
+        initial_event_date = datetime.utcnow() + timedelta(days=5)
+        initial_booking_limit_date = datetime.utcnow() + timedelta(days=3)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             bookingLimitDatetime=initial_booking_limit_date,
@@ -1015,8 +1015,8 @@ class EditEducationalOfferStocksTest:
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_should_reindex_offer_on_algolia(self, mocked_async_index_offer_ids):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=5)
-        initial_booking_limit_date = datetime.now() + timedelta(days=3)
+        initial_event_date = datetime.utcnow() + timedelta(days=5)
+        initial_booking_limit_date = datetime.utcnow() + timedelta(days=3)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -1025,7 +1025,7 @@ class EditEducationalOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.now() + timedelta(days=7, hours=5),
+            beginningDatetime=datetime.utcnow() + timedelta(days=7, hours=5),
             numberOfTickets=35,
         )
 
@@ -1055,8 +1055,8 @@ class EditEducationalOfferStocksTest:
 
     def should_update_bookings_cancellation_limit_date_if_event_postponed(self):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=20)
-        cancellation_limit_date = datetime.now() + timedelta(days=5)
+        initial_event_date = datetime.utcnow() + timedelta(days=20)
+        cancellation_limit_date = datetime.utcnow() + timedelta(days=5)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date, quantity=1, dnBookedQuantity=1
         )
@@ -1064,7 +1064,7 @@ class EditEducationalOfferStocksTest:
             stock=stock_to_be_updated, status=BookingStatus.PENDING, cancellation_limit_date=cancellation_limit_date
         )
 
-        new_event_date = datetime.now() + timedelta(days=25, hours=5)
+        new_event_date = datetime.utcnow() + timedelta(days=25, hours=5)
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
             beginningDatetime=new_event_date,
         )
@@ -1103,8 +1103,8 @@ class EditEducationalOfferStocksTest:
 
     def test_should_allow_stock_edition_and_not_modify_cancellation_limit_date_when_booking_cancelled(self):
         # Given
-        initial_event_date = datetime.now() + timedelta(days=20)
-        cancellation_limit_date = datetime.now() + timedelta(days=5)
+        initial_event_date = datetime.utcnow() + timedelta(days=20)
+        cancellation_limit_date = datetime.utcnow() + timedelta(days=5)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date, quantity=1, dnBookedQuantity=1
         )
@@ -1112,7 +1112,7 @@ class EditEducationalOfferStocksTest:
             stock=stock_to_be_updated, status=BookingStatus.CANCELLED, cancellation_limit_date=cancellation_limit_date
         )
 
-        new_event_date = datetime.now() + timedelta(days=25, hours=5)
+        new_event_date = datetime.utcnow() + timedelta(days=25, hours=5)
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
             beginningDatetime=new_event_date,
         )
@@ -1128,8 +1128,8 @@ class EditEducationalOfferStocksTest:
 
     def test_does_not_allow_edition_of_an_expired_event_stock(self):
         # Given
-        initial_event_date = datetime.now() - timedelta(days=1)
-        initial_booking_limit_date = datetime.now() - timedelta(days=10)
+        initial_event_date = datetime.utcnow() - timedelta(days=1)
+        initial_booking_limit_date = datetime.utcnow() - timedelta(days=10)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date,
             price=1200,
@@ -1138,7 +1138,7 @@ class EditEducationalOfferStocksTest:
             bookingLimitDatetime=initial_booking_limit_date,
         )
         new_stock_data = stock_serialize.EducationalStockEditionBodyModel(
-            beginningDatetime=datetime.now() + timedelta(days=7, hours=5),
+            beginningDatetime=datetime.utcnow() + timedelta(days=7, hours=5),
             numberOfTickets=35,
         )
 
@@ -1307,7 +1307,7 @@ class DeleteStockTest:
         assert not stock.isSoftDeleted
 
     def test_can_delete_if_event_ended_recently(self):
-        recently = datetime.now() - timedelta(days=1)
+        recently = datetime.utcnow() - timedelta(days=1)
         stock = factories.EventStockFactory(beginningDatetime=recently)
 
         api.delete_stock(stock)
@@ -1315,7 +1315,7 @@ class DeleteStockTest:
         assert stock.isSoftDeleted
 
     def test_cannot_delete_if_too_late(self):
-        too_long_ago = datetime.now() - timedelta(days=3)
+        too_long_ago = datetime.utcnow() - timedelta(days=3)
         stock = factories.EventStockFactory(beginningDatetime=too_long_ago)
 
         with pytest.raises(exceptions.TooLateToDeleteStock):

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -33,8 +33,8 @@ class OfferDateRangeTest:
 
     def test_event_offer(self):
         offer = factories.EventOfferFactory()
-        first = datetime.datetime.now() + datetime.timedelta(days=1)
-        last = datetime.datetime.now() + datetime.timedelta(days=5)
+        first = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        last = datetime.datetime.utcnow() + datetime.timedelta(days=5)
         factories.StockFactory(offer=offer, beginningDatetime=first)
         factories.StockFactory(offer=offer, beginningDatetime=last)
         assert offer.dateRange == DateTimes(first, last)
@@ -66,12 +66,12 @@ class OfferHasBookingLimitDatetimesPassedTest:
     def test_with_stock_with_no_booking_limit_datetime(self):
         stock = factories.StockFactory(bookingLimitDatetime=None)
         offer = stock.offer
-        past = datetime.datetime.now() - datetime.timedelta(days=1)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         stock = factories.StockFactory(offer=offer, isSoftDeleted=True, bookingLimitDatetime=past)
         assert not offer.hasBookingLimitDatetimesPassed
 
     def test_with_stocks_with_booking_limit_datetime(self):
-        past = datetime.datetime.now() - datetime.timedelta(days=1)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         stock = factories.StockFactory(bookingLimitDatetime=past)
         assert stock.offer.hasBookingLimitDatetimesPassed
 
@@ -83,7 +83,7 @@ class OfferHasBookingLimitDatetimesPassedTest:
         assert Offer.query.filter(Offer.hasBookingLimitDatetimesPassed.is_(False)).all() == [offer]
 
     def test_expression_with_stock_with_booking_limit_datetime_passed(self):
-        past = datetime.datetime.now() - datetime.timedelta(days=1)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         stock = factories.StockFactory(bookingLimitDatetime=past)
         offer = stock.offer
 
@@ -91,7 +91,7 @@ class OfferHasBookingLimitDatetimesPassedTest:
         assert Offer.query.filter(Offer.hasBookingLimitDatetimesPassed.is_(False)).all() == []
 
     def test_expression_with_stock_with_booking_limit_datetime_in_the_future(self):
-        future = datetime.datetime.now() + datetime.timedelta(days=2)
+        future = datetime.datetime.utcnow() + datetime.timedelta(days=2)
         stock = factories.StockFactory(bookingLimitDatetime=future)
         offer = stock.offer
 
@@ -105,7 +105,7 @@ class OfferHasBookingLimitDatetimesPassedTest:
         assert Offer.query.filter(Offer.hasBookingLimitDatetimesPassed.is_(False)).all() == [offer]
 
     def test_expression_with_soft_deleted_stock(self):
-        past = datetime.datetime.now() - datetime.timedelta(days=2)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         stock = factories.StockFactory(bookingLimitDatetime=past, isSoftDeleted=True)
         offer = stock.offer
 
@@ -218,7 +218,7 @@ class OfferStatusTest:
         assert Offer.query.filter(Offer.status != OfferStatus.INACTIVE.name).all() == [approved_offer]
 
     def test_expired(self):
-        past = datetime.datetime.now() - datetime.timedelta(days=2)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         expired_stock = factories.StockFactory(bookingLimitDatetime=past)
         expired_offer = factories.OfferFactory(
             validation=OfferValidationStatus.APPROVED,
@@ -262,8 +262,8 @@ class OfferStatusTest:
         assert Offer.query.filter(Offer.status != OfferStatus.SOLD_OUT.name).count() == 0
 
     def test_expression_sold_out_offer_with_passed_stock(self):
-        past = datetime.datetime.now() - datetime.timedelta(days=2)
-        future = datetime.datetime.now() + datetime.timedelta(days=2)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        future = datetime.datetime.utcnow() + datetime.timedelta(days=2)
         offer = factories.OfferFactory()
         factories.StockFactory(offer=offer, quantity=10, beginningDatetime=past, bookingLimitDatetime=past)
         factories.StockFactory(offer=offer, quantity=0, beginningDatetime=future, bookingLimitDatetime=future)
@@ -330,7 +330,7 @@ class OfferIsSoldOutTest:
         assert Offer.query.filter(Offer.isSoldOut.is_(False)).count() == 0
 
     def test_offer_with_passed_stock_date(self):
-        past = datetime.datetime.now() - datetime.timedelta(days=2)
+        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         stock = factories.StockFactory(quantity=10, beginningDatetime=past)
         offer = stock.offer
 

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -585,8 +585,8 @@ class GetCappedOffersForFiltersTest:
                 )
             )
 
-            five_days_ago = datetime.now() - timedelta(days=5)
-            in_five_days = datetime.now() + timedelta(days=5)
+            five_days_ago = datetime.utcnow() - timedelta(days=5)
+            in_five_days = datetime.utcnow() + timedelta(days=5)
             beneficiary = users_factories.BeneficiaryGrant18Factory(email="jane.doe@example.com")
             offers_factories.ThingStockFactory(offer=self.sold_old_thing_offer_with_all_stocks_empty, quantity=0)
             offers_factories.ThingStockFactory(
@@ -697,7 +697,7 @@ class GetCappedOffersForFiltersTest:
                 bookingLimitDatetime=five_days_ago,
                 quantity=0,
             )
-            in_six_days = datetime.now() + timedelta(days=6)
+            in_six_days = datetime.utcnow() + timedelta(days=6)
             self.active_event_in_six_days_offer = offers_factories.EventOfferFactory(venue=self.venue)
             offers_factories.EventStockFactory(
                 offer=self.active_event_in_six_days_offer,
@@ -984,7 +984,7 @@ class GetCappedOffersForFiltersTest:
             # given
             self.init_test_data()
 
-            in_six_days = datetime.now() + timedelta(days=6)
+            in_six_days = datetime.utcnow() + timedelta(days=6)
             in_six_days_beginning = in_six_days.replace(hour=0, minute=0, second=0)
             in_six_days_ending = in_six_days.replace(hour=23, minute=59, second=59)
 
@@ -1136,11 +1136,11 @@ class TomorrowStockTest:
     def test_find_tomorrow_event_stock_ids(self):
         from pcapi.core.offers.models import Stock
 
-        tomorrow = datetime.now() + timedelta(days=1)
+        tomorrow = datetime.utcnow() + timedelta(days=1)
         stocks_tomorrow = EventStockFactory.create_batch(2, beginningDatetime=tomorrow)
         stocks_tomorrow_cancelled = EventStockFactory.create_batch(3, beginningDatetime=tomorrow)
 
-        next_week = datetime.now() + timedelta(days=7)
+        next_week = datetime.utcnow() + timedelta(days=7)
         stocks_next_week = EventStockFactory.create_batch(3, beginningDatetime=next_week)
 
         for stock in stocks_tomorrow:
@@ -1163,11 +1163,11 @@ class TomorrowStockTest:
 class EventStockIn7DaysTest:
     def test_find_event_stocks_happening_in_7_days(self):
         # Given
-        tomorrow = datetime.now() + timedelta(days=1)
+        tomorrow = datetime.utcnow() + timedelta(days=1)
         stocks_tomorrow = EventStockFactory.create_batch(2, beginningDatetime=tomorrow)
         stocks_tomorrow_cancelled = EventStockFactory.create_batch(3, beginningDatetime=tomorrow)
 
-        next_week = datetime.now() + timedelta(days=7)
+        next_week = datetime.utcnow() + timedelta(days=7)
         stocks_next_week = EventStockFactory.create_batch(3, beginningDatetime=next_week)
 
         for stock in stocks_tomorrow:
@@ -1276,7 +1276,7 @@ class AvailableActivationCodeTest:
         booking = bookings_factories.BookingFactory()
         stock = booking.stock
         ActivationCodeFactory(booking=booking, stock=stock)  # booked_code
-        ActivationCodeFactory(stock=stock, expirationDate=datetime.now() - timedelta(days=1))  # expired code
+        ActivationCodeFactory(stock=stock, expirationDate=datetime.utcnow() - timedelta(days=1))  # expired code
 
         # WHEN THEN
         assert not get_available_activation_code(stock)

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -82,7 +82,7 @@ class CheckRequiredDatesForStockTest:
         with pytest.raises(ApiErrors) as error:
             validation.check_required_dates_for_stock(
                 offer,
-                beginning=datetime.datetime.now(),
+                beginning=datetime.datetime.utcnow(),
                 booking_limit_datetime=None,
             )
 
@@ -96,7 +96,7 @@ class CheckRequiredDatesForStockTest:
         validation.check_required_dates_for_stock(
             offer,
             beginning=None,
-            booking_limit_datetime=datetime.datetime.now(),
+            booking_limit_datetime=datetime.datetime.utcnow(),
         )
 
     def test_thing_offer_ok_without_booking_limit_datetime(self):
@@ -115,7 +115,7 @@ class CheckRequiredDatesForStockTest:
             validation.check_required_dates_for_stock(
                 offer,
                 beginning=None,
-                booking_limit_datetime=datetime.datetime.now(),
+                booking_limit_datetime=datetime.datetime.utcnow(),
             )
         assert error.value.errors["beginningDatetime"] == ["Ce paramètre est obligatoire"]
 
@@ -125,7 +125,7 @@ class CheckRequiredDatesForStockTest:
         with pytest.raises(ApiErrors) as error:
             validation.check_required_dates_for_stock(
                 offer,
-                beginning=datetime.datetime.now(),
+                beginning=datetime.datetime.utcnow(),
                 booking_limit_datetime=None,
             )
         assert error.value.errors["bookingLimitDatetime"] == ["Ce paramètre est obligatoire"]
@@ -135,8 +135,8 @@ class CheckRequiredDatesForStockTest:
 
         validation.check_required_dates_for_stock(
             offer,
-            beginning=datetime.datetime.now(),
-            booking_limit_datetime=datetime.datetime.now(),
+            beginning=datetime.datetime.utcnow(),
+            booking_limit_datetime=datetime.datetime.utcnow(),
         )
 
 
@@ -204,13 +204,13 @@ class CheckStockIsDeletableTest:
         assert error.value.errors["global"] == ["Les offres importées ne sont pas modifiables"]
 
     def test_recently_begun_event_stock(self):
-        recently = datetime.datetime.now() - datetime.timedelta(days=1)
+        recently = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         stock = offers_factories.EventStockFactory(beginningDatetime=recently)
 
         validation.check_stock_is_deletable(stock)
 
     def test_long_begun_event_stock(self):
-        too_long_ago = datetime.datetime.now() - datetime.timedelta(days=3)
+        too_long_ago = datetime.datetime.utcnow() - datetime.timedelta(days=3)
         stock = offers_factories.EventStockFactory(beginningDatetime=too_long_ago)
 
         with pytest.raises(exceptions.TooLateToDeleteStock) as error:
@@ -258,7 +258,7 @@ class CheckStockIsUpdatableTest:
         assert error.value.errors["global"] == ["Les offres importées ne sont pas modifiables"]
 
     def test_past_event_stock(self):
-        recently = datetime.datetime.now() - datetime.timedelta(minutes=1)
+        recently = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
         stock = offers_factories.EventStockFactory(beginningDatetime=recently)
 
         with pytest.raises(ApiErrors) as error:

--- a/api/tests/core/payments/test_api.py
+++ b/api/tests/core/payments/test_api.py
@@ -103,9 +103,9 @@ class CreateDepositTest:
 
     def test_cannot_create_twice_a_deposit_of_same_type(self):
         # Given
-        AGE18_ELIGIBLE_BIRTH_DATE = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(
-            years=18, months=2
-        )
+        AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) - relativedelta(years=18, months=2)
         beneficiary = users_factories.BeneficiaryGrant18Factory(dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE)
 
         # When

--- a/api/tests/core/payments/test_validation.py
+++ b/api/tests/core/payments/test_validation.py
@@ -11,7 +11,7 @@ from pcapi.core.payments import validation
 
 class CustomReimbursementRuleValidationTest:
     def _make_rule(self, **kwargs):
-        tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
         kwargs.setdefault("offererId", 1)
         kwargs.setdefault("rate", 0.8)
         kwargs.setdefault("subcategories", [])

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -693,7 +693,7 @@ class CommonSubscritpionTest:
 
 @pytest.mark.usefixtures("db_session")
 class HasPassedAllChecksToBecomeBeneficiaryTest:
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
     def eligible_user(
         self,
@@ -785,7 +785,7 @@ class HasPassedAllChecksToBecomeBeneficiaryTest:
 
 @pytest.mark.usefixtures("db_session")
 class SubscriptionItemTest:
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
     def test_phone_validation_item(self):
         user = users_factories.UserFactory(
@@ -818,9 +818,9 @@ class SubscriptionItemTest:
 
 @pytest.mark.usefixtures("db_session")
 class IdentityCheckSubscriptionStatusTest:
-    AGE16_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=16, months=4)
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
-    AGE20_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=20, months=4)
+    AGE16_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=16, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
+    AGE20_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=20, months=4)
 
     def test_not_eligible(self):
         user = users_factories.UserFactory(dateOfBirth=self.AGE20_ELIGIBLE_BIRTH_DATE)
@@ -941,9 +941,9 @@ class IdentityCheckSubscriptionStatusTest:
 
 @pytest.mark.usefixtures("db_session")
 class NeedsToPerformeIdentityCheckTest:
-    AGE16_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=16, months=4)
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
-    AGE20_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=20, months=4)
+    AGE16_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=16, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
+    AGE20_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=20, months=4)
 
     def test_not_eligible(self):
         user = users_factories.UserFactory(dateOfBirth=self.AGE20_ELIGIBLE_BIRTH_DATE)

--- a/api/tests/core/subscription/test_factories.py
+++ b/api/tests/core/subscription/test_factories.py
@@ -96,12 +96,12 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
 
     @factory.lazy_attribute
     def started_at(self):
-        return None if self.identification_state == IdentificationState.NEW else datetime.datetime.now()
+        return None if self.identification_state == IdentificationState.NEW else datetime.datetime.utcnow()
 
     @factory.lazy_attribute
     def ended_at(self):
         return (
-            datetime.datetime.now()
+            datetime.datetime.utcnow()
             if self.identification_state
             in (IdentificationState.VALID, IdentificationState.INVALID, IdentificationState.UNPROCESSABLE)
             else None
@@ -112,8 +112,8 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
         return {
             IdentificationState.NEW: self.created_at,
             IdentificationState.INITIATED: self.started_at,
-            IdentificationState.ABORTED: datetime.datetime.now(),
-            IdentificationState.PROCESSING: datetime.datetime.now(),
+            IdentificationState.ABORTED: datetime.datetime.utcnow(),
+            IdentificationState.PROCESSING: datetime.datetime.utcnow(),
             IdentificationState.VALID: self.ended_at,
             IdentificationState.INVALID: self.ended_at,
             IdentificationState.UNPROCESSABLE: self.ended_at,
@@ -128,8 +128,8 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
         return {
             IdentificationState.NEW: self.created_at,
             IdentificationState.INITIATED: self.started_at,
-            IdentificationState.ABORTED: datetime.datetime.now(),
-            IdentificationState.PROCESSING: datetime.datetime.now(),
+            IdentificationState.ABORTED: datetime.datetime.utcnow(),
+            IdentificationState.PROCESSING: datetime.datetime.utcnow(),
             IdentificationState.VALID: self.ended_at,
             IdentificationState.INVALID: self.ended_at,
             IdentificationState.UNPROCESSABLE: self.ended_at,

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -124,7 +124,7 @@ class UbbleWorkflowTest:
             assert message.popOverIcon == subscription_models.PopOverIcon.CLOCK
 
     def test_ubble_workflow_rejected_add_inapp_message(self, ubble_mocker):
-        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.now() - relativedelta(years=18, months=1))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=1))
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE, status=fraud_models.FraudCheckStatus.PENDING, user=user
         )

--- a/api/tests/core/users/external/external_users_test.py
+++ b/api/tests/core/users/external/external_users_test.py
@@ -143,7 +143,7 @@ def test_get_user_attributes_beneficiary():
 
 def test_get_user_attributes_not_beneficiary():
     user = UserFactory(
-        dateOfBirth=datetime.now() - relativedelta.relativedelta(years=18, months=3),
+        dateOfBirth=datetime.utcnow() - relativedelta.relativedelta(years=18, months=3),
         firstName="Cou",
         lastName="Zin",
         city="Nice",

--- a/api/tests/core/users/external/sendinblue_test.py
+++ b/api/tests/core/users/external/sendinblue_test.py
@@ -239,7 +239,7 @@ class BulkImportUsersDataTest:
 
     def _test_add_many_contacts_to_list_without_mock(self, count: int, prefix: str):
         # 40 characters per email address
-        test_time = datetime.now().strftime("%y%m%d.%H%M")
+        test_time = datetime.utcnow().strftime("%y%m%d.%H%M")
         thousands_emails = (f"test.{prefix}.{test_time}.{i:06d}@example.net" for i in range(1, count + 1))
 
         result = add_contacts_to_list(
@@ -268,7 +268,7 @@ class BulkImportUsersDataTest:
         # temporarily disabled in make_update_request to really send data to Sendinblue test account.
         assert make_update_request(
             UpdateSendinblueContactRequest(
-                email=f"test.pro.{datetime.now().strftime('%y%m%d.%H%M')}@example.net",
+                email=f"test.pro.{datetime.utcnow().strftime('%y%m%d.%H%M')}@example.net",
                 attributes=format_user_attributes(common_pro_attributes),
                 contact_list_ids=[SENDINBLUE_PRO_TESTING_CONTACT_LIST_ID],
                 emailBlacklisted=False,

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -95,7 +95,7 @@ class ValidateJwtTokenTest:
     def test_get_user_with_valid_token(self):
         user = users_factories.UserFactory()
         token_type = TokenType.RESET_PASSWORD
-        expiration_date = datetime.now() + timedelta(hours=24)
+        expiration_date = datetime.utcnow() + timedelta(hours=24)
 
         saved_token = users_factories.TokenFactory(
             user=user, value=self.token_value, type=token_type, expirationDate=expiration_date
@@ -109,7 +109,7 @@ class ValidateJwtTokenTest:
     def test_get_user_and_mark_token_as_used(self):
         user = users_factories.UserFactory()
         token_type = TokenType.RESET_PASSWORD
-        expiration_date = datetime.now() + timedelta(hours=24)
+        expiration_date = datetime.utcnow() + timedelta(hours=24)
 
         saved_token = users_factories.TokenFactory(
             user=user, value=self.token_value, type=token_type, expirationDate=expiration_date
@@ -158,7 +158,7 @@ class ValidateJwtTokenTest:
         user = users_factories.UserFactory()
         token_type = TokenType.RESET_PASSWORD
 
-        expiration_date = datetime.now() - timedelta(hours=24)
+        expiration_date = datetime.utcnow() - timedelta(hours=24)
         users_factories.TokenFactory(user=user, value=self.token_value, type=token_type, expirationDate=expiration_date)
 
         assert Token.query.filter_by(value=self.token_value).first() is not None
@@ -177,7 +177,7 @@ class DeleteExpiredTokensTest:
         never_expire_token = generate_and_save_token(user, token_type)
         not_expired_token = generate_and_save_token(user, token_type, life_time=life_time)
         # Generate an expired token
-        with freeze_time(datetime.now() - life_time):
+        with freeze_time(datetime.utcnow() - life_time):
             generate_and_save_token(user, token_type, life_time=life_time)
 
         delete_expired_tokens()
@@ -200,7 +200,7 @@ class DeleteUserTokenTest:
 
 
 def _datetime_within_last_5sec(when: datetime) -> bool:
-    return datetime.now() - relativedelta(seconds=5) < when < datetime.now()
+    return datetime.utcnow() - relativedelta(seconds=5) < when < datetime.utcnow()
 
 
 def _assert_user_suspension_history(
@@ -245,7 +245,7 @@ class SuspendAccountTest:
     def test_suspend_beneficiary(self):
         user = users_factories.BeneficiaryGrant18Factory()
         cancellable_booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user)
-        yesterday = datetime.now() - timedelta(days=1)
+        yesterday = datetime.utcnow() - timedelta(days=1)
         confirmed_booking = bookings_factories.IndividualBookingFactory(
             individualBooking__user=user, cancellation_limit_date=yesterday, status=BookingStatus.CONFIRMED
         )
@@ -407,7 +407,7 @@ class ChangeUserEmailTest:
 
 
 class CreateBeneficiaryTest:
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
     def test_with_eligible_user(self):
         user = users_factories.UserFactory(roles=[], dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE)
@@ -452,7 +452,7 @@ class CreateBeneficiaryTest:
 
 
 class FulfillBeneficiaryDataTest:
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
 
     def test_fill_user_with_password_token_and_deposit(self):
         # given
@@ -636,7 +636,7 @@ class DomainsCreditTest:
             stock__offer__subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
         )
 
-        with freeze_time(datetime.now() + relativedelta(years=GRANT_18_VALIDITY_IN_YEARS, days=2)):
+        with freeze_time(datetime.utcnow() + relativedelta(years=GRANT_18_VALIDITY_IN_YEARS, days=2)):
             assert get_domains_credit(user) == DomainsCredit(
                 all=Credit(initial=Decimal(300), remaining=Decimal(0)),
                 digital=Credit(initial=Decimal(100), remaining=Decimal(0)),

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -29,7 +29,7 @@ class UserTest:
         def test_return_expired_deposit_if_only_expired_deposits_exists(self):
             user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18))
             user.add_beneficiary_role()
-            yesterday = datetime.now() - timedelta(days=1)
+            yesterday = datetime.utcnow() - timedelta(days=1)
             users_factories.DepositGrantFactory(user=user, expirationDate=yesterday)
 
             assert user.deposit.type == DepositType.GRANT_18

--- a/api/tests/core/users/test_utils.py
+++ b/api/tests/core/users/test_utils.py
@@ -16,7 +16,7 @@ from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
 class EncodeJWTPayloadTest:
     def test_encode_jwt_payload(self):
         payload = dict(data="value")
-        expiration_date = datetime.now()
+        expiration_date = datetime.utcnow()
 
         jwt_token = encode_jwt_payload(payload, expiration_date)
 

--- a/api/tests/domain/reimbursement_test.py
+++ b/api/tests/domain/reimbursement_test.py
@@ -18,7 +18,7 @@ def create_non_digital_thing_booking(quantity=1, price=10, user=None, date_used=
     booking_kwargs = {}
     if user:
         booking_kwargs["user"] = user
-    booking_kwargs["dateUsed"] = date_used or datetime.now()
+    booking_kwargs["dateUsed"] = date_used or datetime.utcnow()
     offer_kwargs = {}
     if product_subcategory_id:
         offer_kwargs = {"product__subcategoryId": product_subcategory_id}
@@ -39,14 +39,14 @@ def create_digital_booking(quantity=1, price=10, user=None, product_subcategory_
         price=price,
         offer=offers_factories.ThingOfferFactory(product=product),
     )
-    return bookings_factories.UsedBookingFactory(user=user, stock=stock, quantity=quantity, dateUsed=datetime.now())
+    return bookings_factories.UsedBookingFactory(user=user, stock=stock, quantity=quantity, dateUsed=datetime.utcnow())
 
 
 def create_event_booking(quantity=1, price=10, user=None, date_used=None):
     booking_kwargs = {}
     if user:
         booking_kwargs["user"] = user
-    booking_kwargs["dateUsed"] = date_used or datetime.now()
+    booking_kwargs["dateUsed"] = date_used or datetime.utcnow()
     user = user or users_factories.BeneficiaryGrant18Factory()
     stock = offers_factories.StockFactory(
         price=price,
@@ -345,7 +345,7 @@ class ReimbursementRuleIsActiveTest:
         def group(self):
             return None
 
-    booking = Booking(dateCreated=datetime.now() + timedelta(days=365), dateUsed=datetime.now())
+    booking = Booking(dateCreated=datetime.utcnow() + timedelta(days=365), dateUsed=datetime.utcnow())
 
     def test_is_active_if_rule_has_no_start_nor_end(self):
         rule = self.DummyRule(None, None)
@@ -393,8 +393,8 @@ class ReimbursementRuleIsActiveTest:
 @pytest.mark.usefixtures("db_session")
 class CustomRuleFinderTest:
     def test_offer_rule(self):
-        yesterday = datetime.now() - timedelta(days=1)
-        far_in_the_past = datetime.now() - timedelta(days=800)
+        yesterday = datetime.utcnow() - timedelta(days=1)
+        far_in_the_past = datetime.utcnow() - timedelta(days=800)
         booking1 = bookings_factories.UsedBookingFactory()
         offer = booking1.stock.offer
         booking2 = bookings_factories.UsedBookingFactory(stock=booking1.stock, dateUsed=far_in_the_past)
@@ -407,8 +407,8 @@ class CustomRuleFinderTest:
         assert finder.get_rule(booking3) is None  # no rule for this offer
 
     def test_offerer_without_category_rule(self):
-        yesterday = datetime.now() - timedelta(days=1)
-        far_in_the_past = datetime.now() - timedelta(days=800)
+        yesterday = datetime.utcnow() - timedelta(days=1)
+        far_in_the_past = datetime.utcnow() - timedelta(days=800)
         booking1 = bookings_factories.UsedBookingFactory()
         offerer = booking1.offerer
         booking2 = bookings_factories.UsedBookingFactory(offerer=offerer, dateUsed=far_in_the_past)
@@ -421,8 +421,8 @@ class CustomRuleFinderTest:
         assert finder.get_rule(booking3) is None  # no rule for this offerer
 
     def test_offerer_with_category_rule(self):
-        yesterday = datetime.now() - timedelta(days=1)
-        far_in_the_past = datetime.now() - timedelta(days=800)
+        yesterday = datetime.utcnow() - timedelta(days=1)
+        far_in_the_past = datetime.utcnow() - timedelta(days=800)
         booking1 = bookings_factories.UsedBookingFactory(stock__offer__subcategoryId=subcategories.FESTIVAL_CINE.id)
         offerer = booking1.offerer
         booking2 = bookings_factories.UsedBookingFactory(

--- a/api/tests/local_providers/provider_api_stocks_test.py
+++ b/api/tests/local_providers/provider_api_stocks_test.py
@@ -13,8 +13,8 @@ class ProviderApiStocksTest:
     @pytest.mark.usefixtures("db_session")
     def test_synchronize_venue_providers(self, mocked_synchronize_venue_provider, app):
         # Given
-        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
-        two_days_ago = datetime.datetime.now() - datetime.timedelta(days=2)
+        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        two_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=2)
         api_provider_1 = providers_factories.APIProviderFactory()
         api_provider_2 = providers_factories.APIProviderFactory()
         specific_provider = providers_factories.AllocineProviderFactory()

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -689,7 +689,7 @@ class UbbleWebhookTest:
     def _init_test(self, current_identification_state, notified_identification_state):
         user = users_factories.UserFactory(
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            dateOfBirth=datetime.datetime.now() - relativedelta.relativedelta(years=18),
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta.relativedelta(years=18),
             activity="Lycéen",
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -1178,7 +1178,7 @@ class UbbleWebhookTest:
     def _init_decision_test(
         self,
     ) -> typing.Tuple[users_models.User, fraud_models.BeneficiaryFraudCheck, ubble_routes.WebhookRequest]:
-        birth_date = datetime.datetime.now().date() - relativedelta.relativedelta(years=18, months=6)
+        birth_date = datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=6)
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.combine(birth_date, datetime.time(0, 0)))
         profiling_fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -1205,7 +1205,7 @@ class UbbleWebhookTest:
                 "identification_id": identification_id,
                 "identification_url": f"https://id.ubble.ai/{identification_id}",
                 "last_name": None,
-                "registration_datetime": datetime.datetime.now().isoformat(),
+                "registration_datetime": datetime.datetime.utcnow().isoformat(),
                 "score": None,
                 "status": ubble_fraud_models.UbbleIdentificationStatus.PROCESSING.value,
                 "supported": None,
@@ -1283,7 +1283,7 @@ class UbbleWebhookTest:
         ],
     )
     def test_decision_age_cannot_become_beneficiary(self, client, ubble_mocker, age, reason_code, reason, inappmessage):
-        document_birth_date = datetime.datetime.now().date() - relativedelta.relativedelta(years=age)
+        document_birth_date = datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=age)
         user, ubble_fraud_check, request_data = self._init_decision_test()
 
         request_data = self._get_request_body(ubble_fraud_check, ubble_fraud_models.UbbleIdentificationStatus.PROCESSED)
@@ -1347,7 +1347,7 @@ class UbbleWebhookTest:
         assert len(mails_testing.outbox) == 0
 
     def test_decision_duplicate_user(self, client, ubble_mocker):
-        birth_date = datetime.datetime.now().date() - relativedelta.relativedelta(years=18, months=2)
+        birth_date = datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=2)
         existing_user = users_factories.BeneficiaryGrant18Factory(
             firstName="Duplicate",
             lastName="Fraudster",
@@ -1425,7 +1425,7 @@ class UbbleWebhookTest:
 
     def test_decision_duplicate_id_piece_number(self, client, ubble_mocker):
         users_factories.BeneficiaryGrant18Factory(
-            dateOfBirth=datetime.datetime.now().date() - relativedelta.relativedelta(years=18, months=2),
+            dateOfBirth=datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=2),
             idPieceNumber="012345678910",
             email="prems@me.com",
         )
@@ -1438,7 +1438,7 @@ class UbbleWebhookTest:
             included=[
                 test_factories.UbbleIdentificationIncludedDocumentsFactory(
                     attributes__birth_date=(
-                        datetime.datetime.now().date() - relativedelta.relativedelta(years=18, months=1)
+                        datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=1)
                     ).isoformat(),
                     attributes__document_number="012345678910",
                     attributes__document_type="CI",

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -130,7 +130,7 @@ class GetBookingsTest:
             activationCode=second_activation_code,
         )
         expire_tomorrow = booking_factories.IndividualBookingFactory(
-            individualBooking__user=user, dateCreated=datetime.now() - timedelta(days=29)
+            individualBooking__user=user, dateCreated=datetime.utcnow() - timedelta(days=29)
         )
         used_but_in_future = booking_factories.UsedIndividualBookingFactory(
             individualBooking__user=user,
@@ -286,7 +286,7 @@ class CancelBookingTest:
     def test_cancel_confirmed_booking(self, app):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         booking = booking_factories.IndividualBookingFactory(
-            individualBooking__user=user, cancellation_limit_date=datetime.now() - timedelta(days=1)
+            individualBooking__user=user, cancellation_limit_date=datetime.utcnow() - timedelta(days=1)
         )
 
         access_token = create_access_token(identity=self.identifier)
@@ -336,7 +336,7 @@ class ToggleBookingVisibilityTest:
         booking = booking_factories.UsedIndividualBookingFactory(
             individualBooking__user=user,
             displayAsEnded=None,
-            dateUsed=datetime.now(),
+            dateUsed=datetime.utcnow(),
             stock=stock,
             activationCode=activation_code,
         )

--- a/api/tests/routes/native/v1/cultural_survey_test.py
+++ b/api/tests/routes/native/v1/cultural_survey_test.py
@@ -249,8 +249,8 @@ class CulturalSurveyQuestionsTest:
         ]
         upload_answers_task.assert_called_once_with(
             serializers.CulturalSurveyAnswersForData(
-                user_id=user.id, answers=expected_answers, submitted_at=datetime.datetime.now()
+                user_id=user.id, answers=expected_answers, submitted_at=datetime.datetime.utcnow()
             )
         )
         assert not user.needsToFillCulturalSurvey
-        assert user.culturalSurveyFilledDate == datetime.datetime.now()
+        assert user.culturalSurveyFilledDate == datetime.datetime.utcnow()

--- a/api/tests/routes/native/v1/favorites_test.py
+++ b/api/tests/routes/native/v1/favorites_test.py
@@ -39,7 +39,7 @@ class GetTest:
 
         def when_user_is_logged_in_and_has_favorite_offers(self, app):
             # Given
-            today = datetime.now() + timedelta(hours=3)  # offset a bit to make sure it's > now()
+            today = datetime.utcnow() + timedelta(hours=3)  # offset a bit to make sure it's > now()
             yesterday = today - timedelta(days=1)
             tomorow = today + timedelta(days=1)
             user, test_client = utils.create_user_and_test_client(app)
@@ -72,9 +72,9 @@ class GetTest:
             offers_factories.MediationFactory(offer=offer4)
             favorite4 = users_factories.FavoriteFactory(offer=offer4, user=user)
             stock4 = offers_factories.EventStockFactory(
-                offer=offer4, beginningDatetime=datetime.now() + timedelta(minutes=30), price=50
+                offer=offer4, beginningDatetime=datetime.utcnow() + timedelta(minutes=30), price=50
             )
-            assert stock4.bookingLimitDatetime < datetime.now()
+            assert stock4.bookingLimitDatetime < datetime.utcnow()
 
             # Event offer in the past
             offer5 = offers_factories.EventOfferFactory(venue=venue)
@@ -168,7 +168,7 @@ class GetTest:
 
         def test_expired_offer(self, app):
             # Given
-            today = datetime.now() + timedelta(hours=3)  # offset a bit to make sure it's > now()
+            today = datetime.utcnow() + timedelta(hours=3)  # offset a bit to make sure it's > now()
             yesterday = today - timedelta(days=1)
             tomorow = today + timedelta(days=1)
             user, test_client = utils.create_user_and_test_client(app)

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -68,10 +68,10 @@ class Returns200Test:
         offerer = offerer_factories.OffererFactory(users=[user])
         venue = offerer_factories.VenueFactory(managingOfferer=offerer)
         offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.now(), offerId=1
+            venue=venue, dateCreated=datetime.datetime.utcnow(), offerId=1
         )
         template = educational_factories.CollectiveOfferTemplateFactory(
-            venue=venue, dateCreated=datetime.datetime.now() + datetime.timedelta(days=10), offerId=2
+            venue=venue, dateCreated=datetime.datetime.utcnow() + datetime.timedelta(days=10), offerId=2
         )
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, stockId=1)
 
@@ -106,12 +106,12 @@ class Returns200Test:
         for i in range(510):
             if random.randrange(10) % 2:
                 offer = educational_factories.CollectiveOfferFactory(
-                    venue=venue, dateCreated=datetime.datetime.now() + datetime.timedelta(days=i), offerId=1
+                    venue=venue, dateCreated=datetime.datetime.utcnow() + datetime.timedelta(days=i), offerId=1
                 )
                 educational_factories.CollectiveStockFactory(collectiveOffer=offer)
             else:
                 offer = educational_factories.CollectiveOfferTemplateFactory(
-                    venue=venue, dateCreated=datetime.datetime.now() + datetime.timedelta(days=i), offerId=2
+                    venue=venue, dateCreated=datetime.datetime.utcnow() + datetime.timedelta(days=i), offerId=2
                 )
 
             offers.append(offer)
@@ -135,10 +135,10 @@ class Returns200Test:
         offerer = offerer_factories.OffererFactory()
         venue = offerer_factories.VenueFactory(managingOfferer=offerer)
         offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.now(), offerId=1
+            venue=venue, dateCreated=datetime.datetime.utcnow(), offerId=1
         )
         educational_factories.CollectiveOfferTemplateFactory(
-            venue=venue, dateCreated=datetime.datetime.now() + datetime.timedelta(days=10), offerId=2
+            venue=venue, dateCreated=datetime.datetime.utcnow() + datetime.timedelta(days=10), offerId=2
         )
         educational_factories.CollectiveStockFactory(collectiveOffer=offer, stockId=1)
 

--- a/api/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/api/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class Returns200Test:
     def test_when_user_has_rights_and_regular_offer(self, client):
         # Given
-        past = datetime.now() - timedelta(days=2)
+        past = datetime.utcnow() - timedelta(days=2)
         booking = bookings_factories.IndividualBookingFactory(
             individualBooking__user__email="beneficiary@example.com",
             stock__beginningDatetime=past,
@@ -131,7 +131,7 @@ class Returns200Test:
     def test_when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, client):
         # Given
         booking = bookings_factories.IndividualBookingFactory(
-            stock__beginningDatetime=datetime.now() - timedelta(days=2),
+            stock__beginningDatetime=datetime.utcnow() - timedelta(days=2),
         )
         user_offerer = offerers_factories.UserOffererFactory(offerer=booking.offerer)
         pro_user = user_offerer.user

--- a/api/tests/scheduled_tasks/clock_test.py
+++ b/api/tests/scheduled_tasks/clock_test.py
@@ -21,10 +21,10 @@ def test_pc_send_tomorrow_events_notifications_only_to_individual_bookings_users
     creates a job that will send a notification to all of the stock's users
     with a valid (not cancelled) booking, for individual bookings only.
     """
-    tomorrow = datetime.now() + timedelta(days=1)
+    tomorrow = datetime.utcnow() + timedelta(days=1)
     stock_tomorrow = offers_factories.EventStockFactory(beginningDatetime=tomorrow, offer__name="my_offer")
 
-    next_week = datetime.now() + timedelta(days=7)
+    next_week = datetime.utcnow() + timedelta(days=7)
     stock_next_week = offers_factories.EventStockFactory(beginningDatetime=next_week)
 
     user1 = users_factories.BeneficiaryGrant18Factory()
@@ -56,7 +56,7 @@ def test_pc_send_tomorrow_events_notifications_only_to_individual_bookings_users
 def test_pc_notify_users_bookings_not_retrieved() -> None:
     user = users_factories.BeneficiaryGrant18Factory()
     stock = offers_factories.ThingStockFactory()
-    creation_date = datetime.now() - constants.BOOKINGS_AUTO_EXPIRY_DELAY + timedelta(days=3)
+    creation_date = datetime.utcnow() - constants.BOOKINGS_AUTO_EXPIRY_DELAY + timedelta(days=3)
 
     # booking that will expire in three days
     booking = bookings_factories.IndividualBookingFactory(user=user, stock=stock, dateCreated=creation_date)

--- a/api/tests/scripts/beneficiary/import_dms_users_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_users_test.py
@@ -377,7 +377,7 @@ class RunIntegrationTest:
             eligibilityType=users_models.EligibilityType.AGE18,
         )
         details = fixture.make_parsed_graphql_application(application_id=123, state="accepte", email=user.email)
-        details.draft_date = datetime.now().isoformat()
+        details.draft_date = datetime.utcnow().isoformat()
         get_applications_with_details.return_value = [details]
         dms_api.import_dms_users(procedure_id=6712558)
 
@@ -555,7 +555,7 @@ class RunIntegrationTest:
 
     @patch.object(dms_connector_api.DMSGraphQLClient, "get_applications_with_details")
     def test_import_makes_user_beneficiary_after_19_birthday(self, get_applications_with_details):
-        date_of_birth = (datetime.now() - relativedelta(years=19)).strftime("%Y-%m-%dT%H:%M:%S")
+        date_of_birth = (datetime.utcnow() - relativedelta(years=19)).strftime("%Y-%m-%dT%H:%M:%S")
 
         # Create a user that has validated its email and phone number, meaning it
         # should become beneficiary.

--- a/api/tests/scripts/beneficiary/import_users_test.py
+++ b/api/tests/scripts/beneficiary/import_users_test.py
@@ -9,7 +9,7 @@ from pcapi.core.users.models import User
 from pcapi.scripts.beneficiary import import_users
 
 
-AGE18_ELIGIBLE_BIRTH_DATE = datetime.datetime.now() - relativedelta(years=18, months=4)
+AGE18_ELIGIBLE_BIRTH_DATE = datetime.datetime.utcnow() - relativedelta(years=18, months=4)
 
 CSV = f"""Nom,Prénom,Mail,Téléphone,Département,Code postal,Date de naissance
 Doux,Jeanne,jeanne.doux@example.com,0102030405,86,86140,{AGE18_ELIGIBLE_BIRTH_DATE:%Y-%m-%d}

--- a/api/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
+++ b/api/tests/scripts/beneficiary/send_mail_after_idcheck_outage_test.py
@@ -15,17 +15,17 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class SendMailAfterIdcheckOutageTest:
     @freeze_time("2018-01-01 01:00:00")
     def test_get_eligible_users_created_between(self, app):
-        ELIGIBLE_CONDTIONS = {"dateCreated": datetime.now(), "roles": []}
+        ELIGIBLE_CONDTIONS = {"dateCreated": datetime.utcnow(), "roles": []}
         # 19 yo
         factories.UserFactory(dateOfBirth=datetime(1999, 1, 1), **ELIGIBLE_CONDTIONS)
         user_just_18_in_eligible_area = factories.UserFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
         # Beneficiary
         factories.BeneficiaryGrant18Factory(
             dateOfBirth=datetime(2000, 1, 1),
-            dateCreated=datetime.now(),
+            dateCreated=datetime.utcnow(),
         )
         # Admin
-        factories.AdminFactory(dateOfBirth=datetime(2000, 1, 1), dateCreated=datetime.now())
+        factories.AdminFactory(dateOfBirth=datetime(2000, 1, 1), dateCreated=datetime.utcnow())
         # Pro
         pro_user = factories.ProFactory(dateOfBirth=datetime(2000, 1, 1), **ELIGIBLE_CONDTIONS)
         offerers_factories.UserOffererFactory(user=pro_user)
@@ -33,7 +33,7 @@ class SendMailAfterIdcheckOutageTest:
         factories.UserFactory(dateOfBirth=datetime(2000, 1, 2), **ELIGIBLE_CONDTIONS)
 
         result = _get_eligible_users_created_between(
-            datetime.now() - timedelta(days=1), datetime.now() + timedelta(minutes=1)
+            datetime.utcnow() - timedelta(days=1), datetime.utcnow() + timedelta(minutes=1)
         )
 
         assert {u.id for u in result} == {user_just_18_in_eligible_area.id}

--- a/api/tests/scripts/booking/cancel_old_unused_bookings_for_venue_test.py
+++ b/api/tests/scripts/booking/cancel_old_unused_bookings_for_venue_test.py
@@ -18,20 +18,20 @@ def test_should_cancel_old_unused_bookings_for_venue():
     other_venue = offers_factories.VenueFactory()
 
     to_cancel_booking = bookings_factories.BookingFactory(
-        dateCreated=(datetime.now() - timedelta(days=40)), stock__offer__venue=venue
+        dateCreated=(datetime.utcnow() - timedelta(days=40)), stock__offer__venue=venue
     )
 
     used_booking = bookings_factories.UsedBookingFactory(
-        dateCreated=(datetime.now() - timedelta(days=40)),
+        dateCreated=(datetime.utcnow() - timedelta(days=40)),
         stock__offer__venue=venue,
     )
 
     recent_booking = bookings_factories.BookingFactory(
-        dateCreated=(datetime.now() - timedelta(days=10)), stock__offer__venue=venue
+        dateCreated=(datetime.utcnow() - timedelta(days=10)), stock__offer__venue=venue
     )
 
     other_venue_booking = bookings_factories.BookingFactory(
-        dateCreated=(datetime.now() - timedelta(days=40)),
+        dateCreated=(datetime.utcnow() - timedelta(days=40)),
         stock__offer__venue=other_venue,
     )
 

--- a/api/tests/scripts/change_pro_users_to_beneficiary_test.py
+++ b/api/tests/scripts/change_pro_users_to_beneficiary_test.py
@@ -12,7 +12,7 @@ from pcapi.scripts.change_some_pro_users_to_beneficiary import change_pro_users_
 @pytest.mark.usefixtures("db_session")
 def test_should_change_pro_users_to_beneficiary():
     # given
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
     pro_1 = users_factories.ProFactory(dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE, needsToFillCulturalSurvey=False)
     pro_2 = users_factories.ProFactory(dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE)
     offerers_factories.UserOffererFactory(user=pro_1)

--- a/api/tests/scripts/force_19_yo_dms_import_test.py
+++ b/api/tests/scripts/force_19_yo_dms_import_test.py
@@ -15,8 +15,8 @@ from pcapi.scripts.force_19yo_dms_import import force_19yo_dms_import
 class User19YearOldActivationTest:
     def test_user_should_be_activated(self):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
-            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.utcnow() - relativedelta(months=5),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -44,8 +44,8 @@ class User19YearOldActivationTest:
 
     def test_user_required_to_validate_user_profiling(self):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
-            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.utcnow() - relativedelta(months=5),
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -71,8 +71,8 @@ class User19YearOldActivationTest:
 
     def test_user_should_not_be_activated_dry_run(self):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
-            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.utcnow() - relativedelta(months=5),
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -91,8 +91,8 @@ class User19YearOldActivationTest:
 
     def test_user_should_not_be_activated(self):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.now() - relativedelta(years=19, months=4),
-            dateCreated=datetime.datetime.now() - relativedelta(months=5),
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, months=4),
+            dateCreated=datetime.datetime.utcnow() - relativedelta(months=5),
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,

--- a/api/tests/scripts/grant_wallet_to_existing_users_test.py
+++ b/api/tests/scripts/grant_wallet_to_existing_users_test.py
@@ -13,7 +13,7 @@ def test_should_grant_wallet_to_existing_users(app, db_session):
     # given
     # The build method is explicitly called to avoid the deposit generation
     # which is done if the Factory saves the object.
-    AGE18_ELIGIBLE_BIRTH_DATE = datetime.now() - relativedelta(years=18, months=4)
+    AGE18_ELIGIBLE_BIRTH_DATE = datetime.utcnow() - relativedelta(years=18, months=4)
     beneficiary = users_factories.UserFactory.build(dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE, email="email@example.com")
     beneficiary_2 = users_factories.UserFactory.build(dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE, email="email2@example.com")
     repository.save(beneficiary, beneficiary_2)

--- a/api/tests/scripts/payment/user_recredit_test.py
+++ b/api/tests/scripts/payment/user_recredit_test.py
@@ -45,7 +45,7 @@ class UserRecreditTest:
 
             # User turned 15. They are credited a first time
             content = fraud_factories.UbbleContentFactory(
-                user=user, birth_date="2005-05-01", registration_datetime=datetime.datetime.now()
+                user=user, birth_date="2005-05-01", registration_datetime=datetime.datetime.utcnow()
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 user=user,

--- a/api/tests/tasks/cultural_survey_tasks_test.py
+++ b/api/tests/tasks/cultural_survey_tasks_test.py
@@ -25,7 +25,7 @@ class CulturalSurveyTasksTest:
 
         payload = serializers.CulturalSurveyAnswersForData(
             user_id=1,
-            submitted_at=datetime.datetime.now().isoformat(),
+            submitted_at=datetime.datetime.utcnow().isoformat(),
             answers=answers,
         )
         upload_answers_task(payload)


### PR DESCRIPTION
En résumé : en base de données, on stocke systématiquement des datetimes en UTC. Donc partout dans l'implémentation et dans les tests, on devrait utiliser `datetime.utcnow()` et pas `datetime.now()`. En prod et sur CircleCI, la timezone est UTC, donc ça ne change rien. Par contre, sur nos machines de développement qui sont a priori configurées en CET/CEST, il y a une différence. Ce qui donne des tests qui peuvent échouer localement à cause d'une mauvaise utilisation `datetime.now()`... et ce genre d'échec est assez coton à débusquer.

Le seul usage restant de `datetime.now()` est [ici dans cette factory](https://github.com/pass-culture/pass-culture-main/blob/ee13132de858e46367e9fc47fc4a35631f5fcce7/api/tests/core/subscription/test_factories.py#L68), et je pense que c'est licite, car l'API Ubble renvoie une datetime formatée avec la timezone UTC, donc je pense que pydantic convertit effectivement cela comme une datetime "timezone-aware", et donc la factory a raison d'utiliser `datetime.now(tz=pytz.utc)` pour simuler ce qu'on reçoit d'Ubble. (@lixxday : je suis preneur d'une confirmation.)

Les commits peuvent être relus séparément, même si je les ai découpés principalement pour tester mes modifications au fur et à mesure.

Prochaine étape (dans une PR dédiée, plus tard parce que ce rasage de yack m'a bien éloigné de ce que je faisais aujourd'hui ! ;) ) : une règle pour Pylint qui interdit l'usage de `datetime.now()`.