### PR TITLE
(BSR)[PRO] fix: yarn generate:api:client:local

### DIFF
--- a/pro/scripts/generate_api_client_local.sh
+++ b/pro/scripts/generate_api_client_local.sh
@@ -7,7 +7,7 @@ success() {
 
 docker run --network="host" --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli-v3 generate \
         -l typescript-fetch `# client type` \
-        -i http://localhost/apidoc/openapi.json `# schema location` \
+        -i http://localhost/pro/openapi.json `# schema location` \
         -c /local/swagger_codegen/swagger_codegen_config.json `# swagger codegen config` \
         -t /local/swagger_codegen/gen_templates `# templates directory` \
         -o /local/src/api/v1/gen `# output directory`


### PR DESCRIPTION
Le nom du blueprint utilisé sur pro.
Celui ci avait été mise à jours pour la génération depuis testing et pas pour la génération depuis l'api en locale.