### PR TITLE
(BSR)[PRO] do not export adapters from core

### DIFF
--- a/pro/src/core/Offers/index.ts
+++ b/pro/src/core/Offers/index.ts
@@ -1,3 +1,2 @@
 export * from './constants'
 export * from './utils'
-export * from './adapters'

--- a/pro/src/routes/Offers/Offers.tsx
+++ b/pro/src/routes/Offers/Offers.tsx
@@ -7,11 +7,8 @@ import useActiveFeature from 'components/hooks/useActiveFeature'
 import useCurrentUser from 'components/hooks/useCurrentUser'
 import useNotification from 'components/hooks/useNotification'
 import Spinner from 'components/layout/Spinner'
-import {
-  DEFAULT_SEARCH_FILTERS,
-  getOffererAdapter,
-  hasSearchFilters,
-} from 'core/Offers'
+import { DEFAULT_SEARCH_FILTERS, hasSearchFilters } from 'core/Offers'
+import { getOffererAdapter } from 'core/Offers/adapters'
 import { useQuerySearchFilters } from 'core/Offers/hooks'
 import {
   Audience,


### PR DESCRIPTION
L'action de deploy du storybook est cassé depuis peu.

Le probleme vient de babel qui tente, sans y arriver, de compiler le client api généré.

```shell
ERROR in ./src/api/v1/gen/configuration.ts
Module build failed (from ./node_modules/@storybook/core-server/node_modules/babel-loader/lib/index.js):
SyntaxError: /home/rlecellier/work/passculture/pass-culture-main/pro/src/api/v1/gen/configuration.ts: Missing class properties transform.
  25 |    * @memberof APIConfiguration
  26 |    */
> 27 |   apiKey?: string | ((name: string) => string);
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Apres avoir tenter de fixer la configuration webpack sans success, il m'est venu en tete que storybook n'a pas besoin de ce morceau de code.

Il tente de le compiler car dans la storie OfferType nous importons une constante depuis core/Offer.
core/Offer fait une `export * from './adapters'`
Je pense qu'on peu se passé de cette export et aller taper dans le dossier adapter au besoin comme c'est déjà le cas ici: 
```javascript
// src/routes/CollectiveOffers/CollectiveOffers.tsx:
import { getOffererAdapter } from 'core/Offers/adapters'
...
```