### PR TITLE
(PC-13530)[PRO] fix: design reset filters link

### DIFF
--- a/pro/src/components/pages/Offers/Offers/Offers.scss
+++ b/pro/src/components/pages/Offers/Offers/Offers.scss
@@ -40,7 +40,7 @@
 
   .input-select {
     margin-top: rem(24px);
-    width: rem(162px);
+    width: rem(169px);
   }
 
   .period-filter {

--- a/pro/src/screens/Offers/SearchFilters/SearchFilters.module.scss
+++ b/pro/src/screens/Offers/SearchFilters/SearchFilters.module.scss
@@ -19,6 +19,7 @@
   display: flex;
   align-items: center;
   margin-top: rem(36px);
+  justify-content: end;
 
   color: $primary;
   line-height: rem(22px);


### PR DESCRIPTION
Le bouton pour réinitialiser les filtres doit être à droite
Il y avait un défaut d'alignement sur l'onglet individuel donc j'ai agrandi un peu les champs pour que tout soit aligné sur la droite

<img width="883" alt="Capture d’écran 2022-04-05 à 11 29 03" src="https://user-images.githubusercontent.com/35567446/161724116-b65796f6-94f2-4883-9b7e-24f36dd4722e.png">
<img width="860" alt="Capture d’écran 2022-04-05 à 11 29 08" src="https://user-images.githubusercontent.com/35567446/161724131-6d97546f-9631-46dd-b885-8205127d075a.png">
