### PR TITLE
(BSR)[API] fix: Order results in `get_bookings_for_educational_year()`

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -314,6 +314,7 @@ def get_bookings_for_educational_year(educational_year_id: str) -> list[educatio
             .load_only(offerers_models.Offerer.postalCode)
         )
         .options(joinedload(educational_models.EducationalBooking.educationalInstitution, innerjoin=True))
+        .order_by(educational_models.EducationalBooking.id)
         .all()
     )
 


### PR DESCRIPTION
It fixes a flaky test: `test_get_all_bookings_per_year`.