### PR TITLE
(BSR)[API] chore: Remove mention of deleted `full_extract_offers` script

### DIFF
--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -15,7 +15,6 @@ def install_commands(app: flask.Flask) -> None:
         "pcapi.scripts.clean_database",
         "pcapi.scripts.external_users.commands",
         "pcapi.scripts.force_19yo_dms_import",
-        "pcapi.scripts.full_extract_offers",
         "pcapi.scripts.full_index_offers",
         "pcapi.scripts.generate_invoices",
         "pcapi.scripts.install_data",


### PR DESCRIPTION
Script has been removed in 14513706840a27eba13950774037707480706af4.

(Confession: I cannot grep.)