### PR TITLE
(PC-14336)[API] feat: Add BusinessUnitVenueLink model

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d6d472d2dfad (pre) (head)
-11f137937ae5 (post) (head)
+a02d2297669c (pre) (head)
+b63eb1053857 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220406T115030_a02d2297669c_add_business_unit_venue_link_table.py
+++ b/api/src/pcapi/alembic/versions/20220406T115030_a02d2297669c_add_business_unit_venue_link_table.py
@@ -1,0 +1,39 @@
+"""Add business_unit_venue_link table."""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "a02d2297669c"
+down_revision = "d6d472d2dfad"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "business_unit_venue_link",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("venueId", sa.BigInteger(), nullable=False),
+        sa.Column("businessUnitId", sa.BigInteger(), nullable=False),
+        sa.Column("timespan", postgresql.TSRANGE(), nullable=False),
+        postgresql.ExcludeConstraint((sa.column("venueId"), "="), (sa.column("timespan"), "&&"), using="gist"),
+        sa.ForeignKeyConstraint(
+            ["businessUnitId"],
+            ["business_unit.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["venueId"],
+            ["venue.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_business_unit_venue_link_businessUnitId"), "business_unit_venue_link", ["businessUnitId"], unique=False
+    )
+    op.create_index(op.f("ix_business_unit_venue_link_venueId"), "business_unit_venue_link", ["venueId"], unique=False)
+
+
+def downgrade():
+    op.drop_table("business_unit_venue_link")

--- a/api/src/pcapi/alembic/versions/20220406T143007_b63eb1053857_populate_business_unit_venue_link_table.py
+++ b/api/src/pcapi/alembic/versions/20220406T143007_b63eb1053857_populate_business_unit_venue_link_table.py
@@ -1,0 +1,37 @@
+"""Populate business_unit_venue_link table."""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b63eb1053857"
+down_revision = "11f137937ae5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create a row in business_unit_venue_link for each venue that is
+    # linked to a business unit. The lower bound of the timespan is
+    # set to the Epoch to make it clearer that the information is
+    # fabricated.
+    op.execute(
+        """
+        INSERT INTO business_unit_venue_link ("venueId", "businessUnitId", timespan)
+        SELECT
+          venue.id,
+          venue."businessUnitId",
+          tsrange('1970-01-01', NULL, '[)')
+        FROM venue
+        LEFT OUTER JOIN
+          business_unit_venue_link AS link
+          ON link."businessUnitId" = venue."businessUnitId"
+          AND link."venueId" = venue.id
+        WHERE
+          venue."businessUnitId" IS NOT NULL
+          AND link.id IS NULL
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -6,6 +6,7 @@ import factory
 from factory.declarations import LazyAttribute
 
 import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.testing import BaseFactory
 from pcapi.domain import reimbursement
@@ -22,6 +23,20 @@ class BusinessUnitFactory(BaseFactory):
     status = models.BusinessUnitStatus.ACTIVE
 
     bankAccount = factory.SubFactory("pcapi.core.offers.factories.BankInformationFactory")
+
+
+class BusinessUnitVenueLinkFactory(BaseFactory):
+    class Meta:
+        model = models.BusinessUnitVenueLink
+
+    businessUnit = factory.SelfAttribute("venue.businessUnit")
+    venue = factory.SubFactory(offerers_factories.VenueFactory)
+    timespan = factory.LazyFunction(
+        lambda: [
+            datetime.datetime.utcnow() - datetime.timedelta(days=365),
+            None,
+        ]
+    )
 
 
 class PricingFactory(BaseFactory):

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -44,6 +44,7 @@ def clean_all_database(*args, **kwargs):
     finance_models.Pricing.query.delete()
     finance_models.InvoiceLine.query.delete()
     finance_models.Invoice.query.delete()
+    finance_models.BusinessUnitVenueLink.query.delete()
     payments_models.CustomReimbursementRule.query.delete()
     educational_models.CollectiveBooking.query.delete()
     bookings_models.Booking.query.delete()


### PR DESCRIPTION
This new model is used to store the period of time during which a
venue is linked to a business unit. This information will soon be used
to control the order in which bookings are priced.


Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14336