### PR TITLE
PC-13955 fix password theft vulnerability

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -22,6 +22,7 @@ class TransactionalEmail(Enum):
     BOOKING_SOON_TO_BE_EXPIRED_TO_BENEFICIARY = Template(
         id_prod=144, id_not_prod=42, tags=["jeunes_reservation_bientot_expiree"]
     )
+    EMAIL_ALREADY_EXISTS = Template(id_prod=617, id_not_prod=79, tags=["email_existant_en_base"])
     EMAIL_CHANGE_CONFIRMATION = Template(
         id_prod=253, id_not_prod=18, tags=["changement_email_confirmation"], use_priority_queue=True
     )

--- a/api/src/pcapi/core/mails/transactional/users/reset_password.py
+++ b/api/src/pcapi/core/mails/transactional/users/reset_password.py
@@ -1,30 +1,37 @@
 from pcapi.core import mails
-from pcapi.core.mails.models.sendinblue_models import SendinblueTransactionalEmailData
+from pcapi.core.mails.models import sendinblue_models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.users import api as users_api
-from pcapi.core.users.models import Token
-from pcapi.core.users.models import User
+from pcapi.core.users import models as user_models
 from pcapi.utils.urls import generate_firebase_dynamic_link
 
 
-def send_reset_password_email_to_user(user: User) -> bool:
+def send_reset_password_email_to_user(user: user_models.User) -> bool:
     token = users_api.create_reset_password_token(user)
-    data = get_reset_password_email_data(user, token)
+    data = get_reset_password_email_data(user, token, TransactionalEmail.NEW_PASSWORD_REQUEST.value)
     return mails.send(recipients=[user.email], data=data)
 
 
-def get_reset_password_email_data(user: User, token: Token) -> SendinblueTransactionalEmailData:
+def send_email_already_exists_email(user: user_models.User) -> bool:
+    token = users_api.create_reset_password_token(user)
+    data = get_reset_password_email_data(user, token, TransactionalEmail.EMAIL_ALREADY_EXISTS.value)
+    return mails.send(recipients=[user.email], data=data)
+
+
+def get_reset_password_email_data(
+    user: user_models.User, token: user_models.Token, email_template: sendinblue_models.Template
+) -> sendinblue_models.SendinblueTransactionalEmailData:
     reset_password_link = generate_firebase_dynamic_link(
         path="mot-de-passe-perdu",
         params={
             "token": token.value,
-            "expiration_timestamp": int(token.expirationDate.timestamp()),
+            "expiration_timestamp": int(token.expirationDate.timestamp()),  # type: ignore [union-attr]
             "email": user.email,
         },
     )
 
-    return SendinblueTransactionalEmailData(
-        template=TransactionalEmail.NEW_PASSWORD_REQUEST.value,
+    return sendinblue_models.SendinblueTransactionalEmailData(
+        template=email_template,
         params={
             "FIRSTNAME": user.firstName,
             "RESET_PASSWORD_LINK": reset_password_link,

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -24,8 +24,8 @@ from pcapi.core.fraud.common import models as common_fraud_models
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.fraud.ubble.models as ubble_fraud_models
 from pcapi.core.mails.transactional.pro.email_validation import send_email_validation_to_pro_email
+from pcapi.core.mails.transactional.users import reset_password
 from pcapi.core.mails.transactional.users.email_address_change_confirmation import send_email_confirmation_email
-from pcapi.core.mails.transactional.users.reset_password import send_reset_password_email_to_user
 import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.payments.api as payment_api
@@ -280,10 +280,21 @@ def request_password_reset(user: User) -> None:
     if not user or not user.isActive:
         return
 
-    is_email_sent = send_reset_password_email_to_user(user)
+    is_email_sent = reset_password.send_reset_password_email_to_user(user)
 
     if not is_email_sent:
         logger.error("Email service failure when user requested password reset for email '%s'", user.email)
+        raise exceptions.EmailNotSent()
+
+
+def handle_create_account_with_existing_email(user: User) -> None:
+    if not user or not user.isActive:
+        return
+
+    is_email_sent = reset_password.send_email_already_exists_email(user)
+
+    if not is_email_sent:
+        logger.error("Email service failure when user email already exists in database '%s'", user.email)
         raise exceptions.EmailNotSent()
 
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -167,28 +167,18 @@ def create_account(body: serializers.AccountRequest) -> None:
             email=body.email,
             password=body.password,
             birthdate=body.birthdate,
-            marketing_email_subscription=body.marketing_email_subscription,
+            marketing_email_subscription=bool(body.marketing_email_subscription),
             is_email_validated=False,
             apps_flyer_user_id=body.apps_flyer_user_id,
             apps_flyer_platform=body.apps_flyer_platform,
         )
     except exceptions.UserAlreadyExistsException:
         user = find_user_by_email(body.email)
-        if not user.isEmailValidated:
-            try:
-                api.initialize_account(
-                    user,
-                    body.password,
-                    apps_flyer_user_id=body.apps_flyer_user_id,
-                    apps_flyer_platform=body.apps_flyer_platform,
-                )
-            except exceptions.EmailNotSent:
-                raise ApiErrors({"email": ["L'email n'a pas pu être envoyé"]})
-        else:
-            try:
-                api.request_password_reset(user)
-            except exceptions.EmailNotSent:
-                raise ApiErrors({"email": ["L'email n'a pas pu être envoyé"]})
+        try:
+            api.handle_create_account_with_existing_email(user)  # type: ignore [arg-type]
+        except exceptions.EmailNotSent:
+            raise ApiErrors({"email": ["L'email n'a pas pu être envoyé"]})
+
     except exceptions.UnderAgeUserException:
         raise ApiErrors({"dateOfBirth": "The birthdate is invalid"})
 

--- a/api/tests/core/mails/transactional/users/reset_password_test.py
+++ b/api/tests/core/mails/transactional/users/reset_password_test.py
@@ -41,7 +41,9 @@ class SendinblueSendResetPasswordToUserEmailTest:
         )
         users_factories.ResetPasswordToken.build(user=user, value="abc", expirationDate=datetime(2020, 1, 1))
         # When
-        reset_password_email_data = get_reset_password_email_data(user, user.tokens[0])
+        reset_password_email_data = get_reset_password_email_data(
+            user, user.tokens[0], TransactionalEmail.NEW_PASSWORD_REQUEST.value
+        )
 
         # Then
         assert reset_password_email_data.template == TransactionalEmail.NEW_PASSWORD_REQUEST.value

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -155,7 +155,7 @@ def test_request_reset_password_for_existing_email(client):
     assert mails_testing.outbox[0].sent_data["params"]["RESET_PASSWORD_LINK"]
 
 
-@patch("pcapi.core.users.api.send_reset_password_email_to_user")
+@patch("pcapi.core.users.api.reset_password.send_reset_password_email_to_user")
 def test_request_reset_password_for_inactive_account(mock_send_reset_password_email_to_user, client):
     email = "existing_user@example.com"
     data = {"email": email}
@@ -167,7 +167,7 @@ def test_request_reset_password_for_inactive_account(mock_send_reset_password_em
     mock_send_reset_password_email_to_user.assert_not_called()
 
 
-@patch("pcapi.core.users.api.send_reset_password_email_to_user")
+@patch("pcapi.core.users.api.reset_password.send_reset_password_email_to_user")
 def test_request_reset_password_with_mail_service_exception(mock_send_reset_password_email_to_user, client):
     email = "tt_user@example.com"
     data = {"email": email}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13955

## But de la pull request

Corriger la vulnérabilité permettant à un individu de modifier le mot de passe d'un autre utilisateur entre la demande de création de compte et la validation de l'email

## Implémentation
Contexte venant du ticket:

- Quand une nouvelle demande de création de compte est faite avec l’adresse email qui existe en base mais n’a pas encore été validée, au lieu de renvoyer le lien de confirmation, il faudrait envoyer le lien de réinitialisation de mot de passe via [ce template](https://my.sendinblue.com/camp/template/617/message-setup). 

- Quand une nouvelle demande de création de compte est faite avec l’adresse email qui existe en base et qui est validée, au lieu de renvoyer le mail ‘on s’est déjà vu', il faudrait envoyer le lien de réinitialisation de mot de passe via [ce template](https://my.sendinblue.com/camp/template/585/message-setup). 


## Informations supplémentaires

- 2 nouveaux emails sont envoyés dans les cas où l'email existe déjà en base (validé vs non validé)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
