### PR TITLE
[WIP](PC-13426)[API] Price collective bookings

### DIFF
--- a/api/src/pcapi/alembic/versions/20220407T084812_123fa749e53f_add_collective_booking_ref_on_pricing_model.py
+++ b/api/src/pcapi/alembic/versions/20220407T084812_123fa749e53f_add_collective_booking_ref_on_pricing_model.py
@@ -1,0 +1,27 @@
+"""add_collective_booking_ref_on_pricing_model
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "123fa749e53f"
+down_revision = "a02d2297669c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("pricing", sa.Column("collectiveBookingId", sa.BigInteger(), nullable=True))
+    op.alter_column("pricing", "bookingId", existing_type=sa.BIGINT(), nullable=True)
+    op.create_index(op.f("ix_pricing_collectiveBookingId"), "pricing", ["collectiveBookingId"], unique=False)
+    op.create_foreign_key(
+        "pricing_collective_booking_fkey", "pricing", "collective_booking", ["collectiveBookingId"], ["id"]
+    )
+
+
+def downgrade():
+    op.drop_constraint("pricing_collective_booking_fkey", "pricing", type_="foreignkey")
+    op.drop_index(op.f("ix_pricing_collectiveBookingId"), table_name="pricing")
+    op.alter_column("pricing", "bookingId", existing_type=sa.BIGINT(), nullable=False)
+    op.drop_column("pricing", "collectiveBookingId")

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -784,3 +784,14 @@ def find_educational_bookings_done_yesterday() -> list[EducationalBooking]:
         )
         .all()
     )
+
+
+def get_booking_by_id(booking_id: int) -> Booking:
+    return (
+        Booking.query.filter_by(id=booking_id)
+        .options(
+            joinedload(Booking.venue, innerjoin=True).joinedload(Venue.businessUnit, innerjoin=True),
+            joinedload(Booking.stock, innerjoin=True).joinedload(Stock.offer, innerjoin=True),
+        )
+        .one()
+    )

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -664,3 +664,16 @@ def get_offer_by_id(offer_id: int) -> educational_models.CollectiveOffer:
         )
     except NoResultFound:
         raise CollectiveOfferNotFound()
+
+
+def get_collective_booking_by_id(booking_id: int) -> CollectiveBooking:
+    return (
+        CollectiveBooking.query.filter_by(id=booking_id)
+        .options(
+            joinedload(CollectiveBooking.venue, innerjoin=True).joinedload(Venue.businessUnit, innerjoin=True),
+            joinedload(CollectiveBooking.collectiveStock, innerjoin=True).joinedload(
+                CollectiveStock.collectiveOffer, innerjoin=True
+            ),
+        )
+        .one()
+    )

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -7,6 +7,7 @@ from factory.declarations import LazyAttribute
 
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.educational.factories import UsedCollectiveBookingFactory
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.testing import BaseFactory
 from pcapi.domain import reimbursement
@@ -51,6 +52,20 @@ class PricingFactory(BaseFactory):
     amount = LazyAttribute(lambda pricing: -int(100 * pricing.booking.total_amount))
     standardRule = "Remboursement total pour les offres physiques"
     revenue = LazyAttribute(lambda pricing: int(100 * pricing.booking.total_amount))
+
+
+class CollectivePricingFactory(BaseFactory):
+    class Meta:
+        model = models.Pricing
+
+    status = models.PricingStatus.VALIDATED
+    collectiveBooking = factory.SubFactory(UsedCollectiveBookingFactory)
+    businessUnit = factory.SelfAttribute("collectiveBooking.venue.businessUnit")
+    siret = factory.SelfAttribute("collectiveBooking.venue.siret")
+    valueDate = factory.SelfAttribute("collectiveBooking.dateUsed")
+    amount = LazyAttribute(lambda pricing: -int(100 * pricing.collectiveBooking.collectiveStock.price))
+    standardRule = "Remboursement total pour les offres éducationnelles"
+    revenue = LazyAttribute(lambda pricing: int(100 * pricing.collectiveBooking.collectiveStock.price))
 
 
 class EducationalPricingFactory(BaseFactory):

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -122,8 +122,16 @@ class Pricing(Model):
 
     status = sqla.Column(db_utils.MagicEnum(PricingStatus), index=True, nullable=False)
 
-    bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=False)
+    bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking = sqla_orm.relationship("Booking", foreign_keys=[bookingId], backref="pricings")
+
+    collectiveBookingId = sqla.Column(
+        sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
+    )
+    collectiveBooking = sqla_orm.relationship(
+        "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
+    )
+
     businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=False)
     businessUnit = sqla_orm.relationship("BusinessUnit", foreign_keys=[businessUnitId])
     # `siret` is either the SIRET of the venue if it has one, or the


### PR DESCRIPTION
Dans le cadre du split des modèles de données entre l'individuel et le collectif, il faut pouvoir garder le flux de remboursement existant mais l'adapter au nouveau modèle collectif.

- Association d'un `Pricing` à un `CollectiveBooking`
- ajout du code qui permet de pricer un CollectiveBooking dans le cron `price_booking`
- selon moi, pas d'impact sur les remboursement et les factures à priori pour l'instant sans FF car on ne traite que les Bookings 