### PR TITLE
(PC-14349)[api] Whitelisted emails on staging

### DIFF
--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -66,5 +66,9 @@ class ToDevSendinblueBackend(SendinblueBackend):
         recipients: Iterable,
         data: typing.Union[SendinblueTransactionalEmailData, SendinblueTransactionalWithoutTemplateEmailData, dict],
     ) -> MailResult:
-        recipients = [settings.DEV_EMAIL_ADDRESS]
+        whitelisted_recipients = set(recipients) & set(settings.WHITELISTED_EMAIL_RECIPIENTS)
+        if whitelisted_recipients:
+            recipients = list(whitelisted_recipients)
+        else:
+            recipients = [settings.DEV_EMAIL_ADDRESS]
         return super().send_mail(recipients=recipients, data=data)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14349

## But de la pull request

Les emails sur testing ou staging sont respectivement envoyés vers dev+testing@pc ou dev+staging@pc.
Nous avons besoin que les hackers du Bug Bounty YesWeHack puissent recevoir les emails liés à leurs comptes.
## Implémentation

Similaire au fonctionnement implémenté pour MailJet précédemment : `settings.WHITELISTED_EMAIL_RECIPIENTS`
La liste blanche est dans le secret `pcapi-staging_whitelisted_email_recipients` (qui contient déjà pas mal d'emails) 

## Informations supplémentaires

Quick win compte tenu de l'urgence

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
