### PR TITLE
(PC-13986)[PRO] fix: allows field to use empty string

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/WithdrawalDetailsFields/WithdrawalDetailsFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/WithdrawalDetailsFields/WithdrawalDetailsFields.jsx
@@ -20,7 +20,8 @@ const WithdrawalDetailsFields = props => {
           maxLength={500}
           name="withdrawalDetails"
           rows={4}
-          value={input.value}
+          // allows empty values to be store
+          value={value => value}
         />
       )
     },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13986

## But de la pull request

les chaines des caractères vides n'étaient pas prise ne compte par le formulaire pour les modalités de retrait 

## Informations supplémentaires

 lien de la documentation => https://final-form.org/docs/react-final-form/types/FieldProps#allownull
