### PR TITLE
(PC-14326)[API] fix: add the correct validation status to newly created collectiveOfferTemplate

### DIFF
--- a/api/tests/routes/pro/post_shadow_stock_for_educational_showcase_offer_test.py
+++ b/api/tests/routes/pro/post_shadow_stock_for_educational_showcase_offer_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
+from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.human_ids import humanize
 
@@ -90,6 +91,7 @@ class Return200Test:
         assert collective_offer_template.contactPhone == collective_offer.contactPhone
         assert collective_offer_template.offerVenue == collective_offer.offerVenue
         assert collective_offer_template.priceDetail == stock_payload["educationalPriceDetail"]
+        assert collective_offer_template.validation == OfferValidationStatus.APPROVED
 
 
 class Return400Test:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14326

## But de la pull request

répare un oublis du status da validation quand on créé un collectiveOfferTemplate a partir d'une offre