### PR TITLE
(PC-14110)[API] fix: Batch update user to alter table

### DIFF
--- a/api/src/pcapi/alembic/versions/20220404T071622_11f137937ae5_alter_has_seen_pro_rgs_to_not_null.py
+++ b/api/src/pcapi/alembic/versions/20220404T071622_11f137937ae5_alter_has_seen_pro_rgs_to_not_null.py
@@ -3,6 +3,8 @@
 from alembic import op
 import sqlalchemy as sa
 
+from pcapi import settings
+
 
 # revision identifiers, used by Alembic.
 revision = "11f137937ae5"
@@ -12,9 +14,39 @@ depends_on = None
 
 
 def upgrade():
-    op.execute('UPDATE "user" SET "hasSeenProRgs" = false where "hasSeenProRgs" IS NULL')
+    op.execute(
+        """
+        SET SESSION statement_timeout = '400s'
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+        DO $$
+        DECLARE
+            min_id bigint; max_id bigint;
+            batch_size int := 100000;
+        BEGIN
+            SELECT Max(id),min(id) INTO max_id, min_id FROM "user";
+            -- This condition is for CirecleCi or empty database initialisation
+            IF max_id is Null THEN max_id:=1; min_id:=1;
+            END IF;
+            FOR j IN min_id..max_id BY batch_size LOOP
+                UPDATE "user" SET "hasSeenProRgs" = False
+                WHERE id >= j AND id < j+batch_size AND "hasSeenProRgs" is Null;
+                COMMIT;
+            END LOOP;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+        )
     op.alter_column(
         "user", "hasSeenProRgs", existing_type=sa.BOOLEAN(), server_default=sa.text("false"), nullable=False
+    )
+    op.execute(
+        f"""
+        SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+        """
     )
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14110

## But de la pull request

L'update d'une colonne sur la table user peut prendre du temps. Réaliser cette modification par lot plutôt que d'un coup.

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
