### PR TITLE
(PC-13207) - Update DMS Text annotation in for dossier in DRAFT 

### DIFF
--- a/api/src/pcapi/domain/bank_information.py
+++ b/api/src/pcapi/domain/bank_information.py
@@ -38,9 +38,14 @@ def check_new_bank_information_has_a_more_advanced_status(
         bank_information.status and status_weight[status] < status_weight[bank_information.status]
     )
     if is_new_bank_information_status_more_important_than_saved_one:
-        api_errors.add_error(
-            "BankInformation", "Received application details state does not allow to change bank information"
-        )
+        if status == BankInformationStatus.DRAFT:
+            api_errors.add_error(
+                "BankInformation", "Received dossier is in draft state. Move it to 'Accepté' to save it."
+            )
+        else:
+            api_errors.add_error(
+                "BankInformation", "Received application details state does not allow to change bank information"
+            )
 
 
 def check_new_bank_information_valid(

--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -136,8 +136,13 @@ class SaveVenueBankInformations:
             venue = self.venue_repository.find_by_siret(siret)
             if not venue:
                 api_errors.add_error("Venue", "Venue not found")
-            if not api_entreprises.check_siret_is_still_active(siret):
-                api_errors.add_error("Venue", "SIRET is no longer active")
+            try:
+                is_siret_active = api_entreprises.check_siret_is_still_active(siret)
+                if not is_siret_active:
+                    api_errors.add_error("Venue", "SIRET is no longer active")
+            except api_entreprises.ApiEntrepriseException:
+                api_errors.add_error("Venue", "Error while checking SIRET on Api Entreprise")
+
         else:
             if not offerer:
                 return None

--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -121,7 +121,11 @@ class SaveVenueBankInformations:
             offerers_api.set_business_unit_to_venue_id(business_unit.id, venue.identifier)
 
         update_external_pro(venue.bookingEmail)
-
+        if application_details.annotation_id is not None:
+            if application_details.status == BankInformationStatus.ACCEPTED:
+                update_demarches_simplifiees_text_annotations(
+                    application_details.dossier_id, application_details.annotation_id, "Dossier imported Sucessfully"
+                )
         return bank_information
 
     def get_referent_venue(

--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -57,14 +57,15 @@ class SaveVenueBankInformations:
         business_unit = BusinessUnit.query.filter(BusinessUnit.siret == siret).one_or_none()
 
         if api_errors.errors:
-            if application_details.status == BankInformationStatus.ACCEPTED:
-                if application_details.annotation_id is not None:
+            if application_details.annotation_id is not None:
+                if application_details.status != BankInformationStatus.REJECTED:
                     update_demarches_simplifiees_text_annotations(
                         application_details.dossier_id,
                         application_details.annotation_id,
                         format_error_to_demarches_simplifiees_text(api_errors),
                     )
-                    return None
+                return None
+            if application_details.status == BankInformationStatus.ACCEPTED:
                 raise api_errors
             return None
 

--- a/api/tests/use_cases/save_offerer_bank_informations_test.py
+++ b/api/tests/use_cases/save_offerer_bank_informations_test.py
@@ -410,7 +410,7 @@ class SaveOffererBankInformationsTest:
             assert bank_information.status == BankInformationStatus.ACCEPTED
             assert bank_information.applicationId == 79
             assert error.value.errors == {
-                "BankInformation": ["Received application details state does not allow to change bank information"]
+                "BankInformation": ["Received dossier is in draft state. Move it to 'Accepté' to save it."]
             }
 
         @pytest.mark.usefixtures("db_session")

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -991,6 +991,30 @@ class SaveVenueBankInformationsTest:
                 self.dossier_id, self.annotation_id, "Offerer: Offerer not found"
             )
 
+        def test_update_text_offerer_not_found_for_draft(
+            self, mock_application_details, mock_update_text_annotation, app
+        ):
+            mock_application_details.return_value = self.build_application_detail(
+                {"status": BankInformationStatus.DRAFT}
+            )
+
+            self.save_venue_bank_informations.execute(self.application_id)
+
+            mock_update_text_annotation.assert_called_once_with(
+                self.dossier_id, self.annotation_id, "Offerer: Offerer not found"
+            )
+
+        def test_update_text_offerer_not_found_for_rejected(
+            self, mock_application_details, mock_update_text_annotation, app
+        ):
+            mock_application_details.return_value = self.build_application_detail(
+                {"status": BankInformationStatus.REJECTED}
+            )
+
+            self.save_venue_bank_informations.execute(self.application_id)
+
+            mock_update_text_annotation.assert_not_called()
+
         @pytest.mark.usefixtures("db_session")
         def test_update_text_venue_not_found(self, mock_application_details, mock_update_text_annotation, app):
             OffererFactory(siren="999999999")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13207

## But de la pull request

Remonter les erreurs à DMS au plus tôt dans la relecture par l'équipe support. 
Précision d'une erreur lorsqu'un dossier reçu est en DRAFT et qu'on a déjà des coordonnées bancaires pour ce lieu.

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
