### PR TITLE
(PC-14339)[API] feat: EAC can't have withdrawal

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -282,7 +282,6 @@ def _check_offer_data_is_valid(
 ) -> None:
     check_offer_subcategory_is_valid(offer_data.subcategory_id)
     check_offer_is_eligible_for_educational(offer_data.subcategory_id, offer_is_educational)
-    check_offer_withdrawal(offer_data.withdrawal_type, offer_data.withdrawal_delay, offer_data.subcategory_id)
 
 
 def update_offer(

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -584,8 +584,6 @@ class GetOfferResponseModel(BaseModel):
     venue: GetOfferVenueResponseModel
     venueId: str
     withdrawalDetails: Optional[str]
-    withdrawalType: Optional[WithdrawalTypeEnum]
-    withdrawalDelay: Optional[int]
     status: OfferStatus
 
     _humanize_id = humanize_field("id")
@@ -610,6 +608,11 @@ class GetOfferResponseModel(BaseModel):
         orm_mode = True
         json_encoders = {datetime: format_into_utc_date}
         use_enum_values = True
+
+
+class GetIndividualOfferResponseModel(GetOfferResponseModel):
+    withdrawalType: Optional[WithdrawalTypeEnum]
+    withdrawalDelay: Optional[int]
 
 
 class ImageBodyModel(BaseModel):

--- a/api/tests/routes/pro/patch_educational_offer_test.py
+++ b/api/tests/routes/pro/patch_educational_offer_test.py
@@ -197,8 +197,6 @@ class Returns200Test:
             "venueId": humanize(venue.id),
             "visualDisabilityCompliant": False,
             "withdrawalDetails": None,
-            "withdrawalType": None,
-            "withdrawalDelay": None,
         }
         updated_offer = Offer.query.get(offer.id)
         assert updated_offer.name == "New name"

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import WithdrawalTypeEnum
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 from pcapi.utils.human_ids import dehumanize
@@ -130,6 +131,7 @@ class Returns200Test:
     @override_settings(ADAGE_API_URL="https://adage-api-url")
     @override_settings(ADAGE_API_KEY="adage-api-key")
     @override_settings(ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpClient")
+    @override_features(PRO_DISABLE_EVENTS_QRCODE=True)
     def test_create_valid_educational_offer_with_new_route_on_old_offer_model(self, client):
         # Given
         venue = offers_factories.VenueFactory()
@@ -144,7 +146,6 @@ class Returns200Test:
             "durationMinutes": 60,
             "name": "La pièce de théâtre",
             "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "withdrawalType": "no_ticket",
             "extraData": {
                 "students": ["Collège - 4e"],
                 "contactEmail": "toto@toto.com",
@@ -510,6 +511,7 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json["externalTicketOfficeUrl"] == ['L\'URL doit terminer par une extension (ex. ".fr")']
 
+    @override_features(PRO_DISABLE_EVENTS_QRCODE=True)
     def test_create_educational_offer_with_wrong_extra_data(self, app, client):
         # Given
         venue = offers_factories.VenueFactory()
@@ -524,7 +526,6 @@ class Returns400Test:
             "durationMinutes": 60,
             "name": "La pièce de théâtre",
             "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "withdrawalType": "no_ticket",
             "extraData": {
                 "students": ["Collège - 4e"],
             },
@@ -618,6 +619,7 @@ class Returns403Test:
     @override_settings(ADAGE_API_URL="https://adage-api-url")
     @override_settings(ADAGE_API_KEY="adage-api-key")
     @override_settings(ADAGE_BACKEND="pcapi.core.educational.adage_backends.adage.AdageHttpClient")
+    @override_features(PRO_DISABLE_EVENTS_QRCODE=True)
     def when_offerer_cannot_create_educational_offer(self, client):
         # Given
         venue = offers_factories.VenueFactory()
@@ -632,7 +634,6 @@ class Returns403Test:
             "durationMinutes": 60,
             "name": "La pièce de théâtre",
             "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
-            "withdrawalType": "no_ticket",
             "extraData": {
                 "students": ["Collège - 4e"],
                 "contactEmail": "toto@toto.com",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14339

## But de la pull request

les offres EAC ne doivent pas avoir d'informations de retrait de billets

**avant** cette PR, ces informations étaient obligatoire lorsque le FF était actif

**avec** cette PR, ces informations ne sont plus obligatoire pour les offres collectives

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires

