### PR TITLE
(PC-14083)[API] feat: update notification title

### DIFF
--- a/api/src/pcapi/notifications/push/transactional_notifications.py
+++ b/api/src/pcapi/notifications/push/transactional_notifications.py
@@ -70,8 +70,8 @@ def get_today_stock_notification_data(stock_id: int) -> Optional[TransactionalNo
         group_id=GroupId.TODAY_STOCK.value,
         user_ids=user_ids,
         message=TransactionalNotificationMessage(
-            title=f"{stock.offer.name}, c'est aujourd'hui !",
-            body="Retrouve les détails de la réservation sur l’application pass Culture",
+            title="C'est aujourd'hui !",
+            body=f"Retrouve les détails de la réservation pour {stock.offer.name} sur l’application pass Culture",
         ),
     )
 

--- a/api/tests/scheduled_tasks/clock_test.py
+++ b/api/tests/scheduled_tasks/clock_test.py
@@ -47,7 +47,7 @@ def test_pc_send_today_events_notifications_only_to_individual_bookings_users():
     pc_send_today_events_notifications_metropolitan_france()
 
     assert len(testing.requests) == 1
-    assert all(data["message"]["title"] == "my_offer, c'est aujourd'hui !" for data in testing.requests)
+    assert all(data["message"]["title"] == "C'est aujourd'hui !" for data in testing.requests)
 
     user_ids = {user_id for data in testing.requests for user_id in data["user_ids"]}
     assert user_ids == {user1.id}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14083

## But de la pull request

Modification du titre et du corps de la notification "today stock" : le nom de l'offre est déplacée dans le corps de la notification afin que l'utilisateur voit bien le "C'est aujourd'hui" qui avait vite fait d'être masqué par le nom de l'offre.