### PR TITLE
(PC-14362)[API] feat: allow underage user to book 'carte jeune' categ…

### DIFF
--- a/api/src/pcapi/core/categories/subcategories.py
+++ b/api/src/pcapi/core/categories/subcategories.py
@@ -660,7 +660,7 @@ CARTE_JEUNES = Subcategory(
     is_digital_deposit=False,
     is_physical_deposit=True,
     reimbursement_rule=ReimbursementRuleChoices.STANDARD.value,
-    is_bookable_by_underage_when_not_free=False,
+    is_bookable_by_underage_when_not_free=True,
 )
 # endregion
 # region VISITE


### PR DESCRIPTION
…ory when not free

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14352

## But de la pull request

Rendre éligible  aux jeunes de 15-17ans la réservation des offres payantes de la sous-catégorie Carte jeunes  

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
