### PR TITLE
[API] PC 13890 fix save crop params

### DIFF
--- a/api/src/pcapi/connectors/thumb_storage.py
+++ b/api/src/pcapi/connectors/thumb_storage.py
@@ -1,6 +1,9 @@
+import typing
+
 from pcapi import settings
 from pcapi.core import object_storage
 from pcapi.models import Model
+from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.image_conversion import IMAGE_RATIO_PORTRAIT_DEFAULT
 from pcapi.utils.image_conversion import process_original_image
 from pcapi.utils.image_conversion import standardize_image
@@ -10,14 +13,14 @@ def create_thumb(
     model_with_thumb: Model,  # type: ignore [valid-type]
     image_as_bytes: bytes,
     image_index: int,
-    crop_params: tuple = None,
+    crop_params: typing.Optional[CropParams] = None,
     ratio: float = IMAGE_RATIO_PORTRAIT_DEFAULT,
     keep_ratio: bool = False,
 ) -> None:
     if keep_ratio:
         image_as_bytes = process_original_image(image_as_bytes)
     else:
-        image_as_bytes = standardize_image(image_as_bytes, ratio=ratio, crop_params=crop_params)  # type: ignore [arg-type]
+        image_as_bytes = standardize_image(image_as_bytes, ratio=ratio, crop_params=crop_params)
 
     object_storage.store_public_object(
         folder=settings.THUMBS_FOLDER_NAME,

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -391,6 +391,7 @@ def save_venue_banner(
         "image_credit": image_credit,
         "author_id": user.id,
         "original_image_url": f"{venue.thumbUrl}_{original_image_timestamp}",
+        "crop_params": crop_params,
     }
 
     repository.save(venue)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -99,6 +99,7 @@ from pcapi.routes.serialization.stock_serialize import EducationalStockCreationB
 from pcapi.routes.serialization.stock_serialize import StockCreationBodyModel
 from pcapi.routes.serialization.stock_serialize import StockEditionBodyModel
 from pcapi.utils.human_ids import dehumanize
+from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.utils.rest import load_or_raise_error
 from pcapi.workers.push_notification_job import send_cancel_booking_notification
@@ -875,7 +876,7 @@ def create_mediation(
     offer: Offer,
     credit: str,
     image_as_bytes: bytes,
-    crop_params: tuple = None,
+    crop_params: Optional[CropParams] = None,
 ) -> Mediation:
     # checks image type, min dimensions
     validation.check_image(image_as_bytes)

--- a/api/src/pcapi/routes/serialization/thumbnails_serialize.py
+++ b/api/src/pcapi/routes/serialization/thumbnails_serialize.py
@@ -5,6 +5,7 @@ from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import dehumanize_field
 from pcapi.serialization.utils import humanize_field
 from pcapi.serialization.utils import to_camel
+from pcapi.utils.image_conversion import CropParams
 
 
 class CreateThumbnailBodyModel(BaseModel):
@@ -20,10 +21,15 @@ class CreateThumbnailBodyModel(BaseModel):
         alias_generator = to_camel
 
     @property
-    def crop_params(self):  # type: ignore [no-untyped-def]
+    def crop_params(self) -> Optional[CropParams]:
         if {self.cropping_rect_x, self.cropping_rect_y, self.cropping_rect_height} == {None}:
             return None
-        return (self.cropping_rect_x, self.cropping_rect_y, self.cropping_rect_height)
+
+        return CropParams.build(
+            x_crop_percent=self.cropping_rect_x,
+            y_crop_percent=self.cropping_rect_y,
+            height_crop_percent=self.cropping_rect_height,
+        )
 
     def get_image_as_bytes(self, request) -> bytes:  # type: ignore [no-untyped-def]
         """

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -314,4 +314,9 @@ class VenueBannerContentModel(BaseModel):
     def crop_params(self) -> Optional[CropParams]:
         if {self.x_crop_percent, self.y_crop_percent, self.height_crop_percent} == {None}:
             return None
-        return (self.x_crop_percent, self.y_crop_percent, self.height_crop_percent)
+
+        return CropParams(
+            x_crop_percent=self.x_crop_percent,
+            y_crop_percent=self.y_crop_percent,
+            height_crop_percent=self.height_crop_percent,
+        )

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -126,6 +126,7 @@ class GetVenueManagingOffererResponseModel(BaseModel):
 class BannerMetaModel(TypedDict, total=False):
     image_credit: Optional[base.VenueImageCredit]  # type: ignore [valid-type]
     original_image_url: Optional[str]
+    crop_params: Optional[CropParams]
 
 
 class GetVenueResponseModel(base.BaseVenueResponse):

--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -19,7 +19,7 @@ from pydantic import confloat
 if TYPE_CHECKING:
     CropParam = float
 else:
-    CropParam = confloat(gt=0.0, lt=1.0)
+    CropParam = confloat(ge=0.0, le=1.0)
 
 
 @dataclass

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -585,6 +585,7 @@ class VenueBannerTest:
                 "author_id": user.id,
                 "image_credit": "none",
                 "original_image_url": str(directory / f"{humanize(venue.id)}_1602720001"),
+                "crop_params": None,
             }
 
             mock_search_async_index_venue_ids.assert_called_once_with([venue.id])

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -267,6 +267,11 @@ class VenueBannerTest:
             assert response.json["bannerMeta"] == {
                 "image_credit": "none",
                 "original_image_url": str(url_prefix / f"{humanize(venue.id)}_{original_banner_url_timestamp}"),
+                "crop_params": {
+                    "x_crop_percent": 0.8,
+                    "y_crop_percent": 0.7,
+                    "height_crop_percent": 0.6,
+                },
             }
 
     def test_upload_image_missing(self, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13890 

## But de la pull request

Sauvegarder et renvoyer les `crop_params` au client PRO.
➕  modifier les contraintes de `CropParam` : les valeurs doivent être supérieures **ou égales** à 0 et inférieures **ou égales** à 1, ces deux bornes sont des valeurs valides qui étaient refusées avant.

## Implémentation

`CropParams` devient une `dataclass`, cela facilite la sérialisation et rend le code plus explicite. 