### PR TITLE
PC-13918 make recredit script more punchable

### DIFF
--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+import typing
 
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import joinedload
@@ -21,30 +22,33 @@ logger = logging.getLogger(__name__)
 RECREDIT_BATCH_SIZE = 1000
 
 
-def has_celebrated_birthday_since_registration(user: users_models.User) -> bool:
+def _get_first_created_fraud_check(user: users_models.User) -> typing.Optional[fraud_models.BeneficiaryFraudCheck]:
     user_identity_fraud_checks = [
         fraud_check
         for fraud_check in user.beneficiaryFraudChecks
         if fraud_check.type in fraud_models.IDENTITY_CHECK_TYPES
     ]
-    ordered_fraud_checks = sorted(user_identity_fraud_checks, key=lambda fraud_check: fraud_check.dateCreated)
-    if not ordered_fraud_checks:
+    if not user_identity_fraud_checks:
+        return None
+    return min(user_identity_fraud_checks, key=lambda fraud_check: fraud_check.dateCreated)
+
+
+def has_celebrated_birthday_since_registration(user: users_models.User) -> bool:
+    first_fraud_check = _get_first_created_fraud_check(user)
+    if first_fraud_check is None:
         return False
 
-    first_fraud_check = ordered_fraud_checks[0]
-    try:
-        first_fraud_check_registration_datetime = first_fraud_check.source_data().get_registration_datetime()
-    except ValueError:  # This will happen for older Educonnect fraud checks that do not have registration date in their content
-        if first_fraud_check.type == fraud_models.FraudCheckType.EDUCONNECT:
-            first_fraud_check_registration_datetime = first_fraud_check.dateCreated
-        else:
-            logger.warning("Could not get registration date for fraud check %s", first_fraud_check.id)
-            return False
+    if first_fraud_check.resultContent:
+        try:
+            first_registration_datetime = first_fraud_check.source_data().get_registration_datetime()  # type: ignore [union-attr]
+            if first_registration_datetime is None:
+                return False
+        except ValueError:  # This will happen for older Educonnect fraud checks that do not have registration date in their content
+            first_registration_datetime = first_fraud_check.dateCreated
+    else:
+        first_registration_datetime = first_fraud_check.dateCreated
 
-    if first_fraud_check_registration_datetime is None:
-        first_fraud_check_registration_datetime = first_fraud_check.dateCreated
-
-    return first_fraud_check_registration_datetime.date() < user.latest_birthday
+    return first_registration_datetime.date() < user.latest_birthday
 
 
 def can_be_recredited(user: users_models.User) -> bool:

--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -82,6 +82,7 @@ def recredit_underage_users() -> None:
 
     start_index = 0
     total_users_recredited = 0
+    failed_users = []
 
     while start_index < len(user_ids):
         users = (
@@ -96,18 +97,25 @@ def recredit_underage_users() -> None:
         users_and_recredit_amounts = []
         with transaction():
             for user in users_to_recredit:
-                recredit = payments_models.Recredit(
-                    deposit=user.deposit,
-                    amount=deposit_conf.RECREDIT_TYPE_AMOUNT_MAPPING[deposit_conf.RECREDIT_TYPE_AGE_MAPPING[user.age]],
-                    recreditType=deposit_conf.RECREDIT_TYPE_AGE_MAPPING[user.age],
-                )
-                users_and_recredit_amounts.append((user, recredit.amount))
-                recredit.deposit.amount += recredit.amount
-                user.recreditAmountToShow = recredit.amount if recredit.amount > 0 else None
+                try:
+                    recredit = payments_models.Recredit(
+                        deposit=user.deposit,
+                        amount=deposit_conf.RECREDIT_TYPE_AMOUNT_MAPPING[
+                            deposit_conf.RECREDIT_TYPE_AGE_MAPPING[user.age]
+                        ],
+                        recreditType=deposit_conf.RECREDIT_TYPE_AGE_MAPPING[user.age],
+                    )
+                    users_and_recredit_amounts.append((user, recredit.amount))
+                    recredit.deposit.amount += recredit.amount
+                    user.recreditAmountToShow = recredit.amount if recredit.amount > 0 else None
 
-                db.session.add(user)
-                db.session.add(recredit)
-                total_users_recredited += 1
+                    db.session.add(user)
+                    db.session.add(recredit)
+                    total_users_recredited += 1
+                except Exception as e:  # pylint: disable=broad-except
+                    failed_users.append(user.id)
+                    logger.exception("Could not recredit user %s: %s", user.id, e)
+                    continue
 
         logger.info("Recredited %s underage users deposits", len(users_to_recredit))
 
@@ -118,3 +126,5 @@ def recredit_underage_users() -> None:
 
         start_index += RECREDIT_BATCH_SIZE
     logger.info("Recredited %s users successfully", total_users_recredited)
+    if failed_users:
+        logger.error("Failed to recredit %s users: %s", len(failed_users), failed_users)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13918

## But de la pull request

Rendre le script de recredit plus robuste en cas d'erreur: continuer le recredit si ça plante certains utilisateurs seulement

## Implémentation

- Un bon vieux try/except des familles

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
