### PR TITLE
(PC-14083)[API] feat: add booking link to notification

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -542,3 +542,15 @@ def auto_mark_as_used_after_event() -> None:
             "collectiveBookingsUpdatedCount": n_collective_bookings_updated,
         },
     )
+
+
+def get_individual_bookings_from_stock(stock_id: int) -> typing.Generator[Booking, None, None]:
+    query = (
+        Booking.query.filter(Booking.stockId == stock_id, Booking.status != BookingStatus.CANCELLED)
+        .join(Booking.individualBooking)  # exclude collective bookings
+        .with_entities(Booking.id, Booking.userId)
+        .distinct()
+    )
+
+    for booking in query.yield_per(1_000):
+        yield booking

--- a/api/src/pcapi/workers/push_notification_job.py
+++ b/api/src/pcapi/workers/push_notification_job.py
@@ -1,10 +1,12 @@
 import logging
 
+import pcapi.core.bookings.api as bookings_api
+import pcapi.core.offers.models as offers_models
 from pcapi.core.offers.models import Offer
 from pcapi.notifications.push import send_transactional_notification
 from pcapi.notifications.push.transactional_notifications import get_bookings_cancellation_notification_data
 from pcapi.notifications.push.transactional_notifications import get_offer_notification_data
-from pcapi.notifications.push.transactional_notifications import get_today_stock_notification_data
+from pcapi.notifications.push.transactional_notifications import get_today_stock_booking_notification_data
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
 
@@ -21,9 +23,18 @@ def send_cancel_booking_notification(bookings_ids: list[int]) -> None:
 
 @job(worker.default_queue)
 def send_today_stock_notification(stock_id: int) -> None:
-    notification_data = get_today_stock_notification_data(stock_id)
-    if notification_data:
-        send_transactional_notification(notification_data)
+    """
+    Send a notification to all bookings linked to a stock.
+    """
+    offer = offer = (
+        offers_models.Offer.query.join(offers_models.Offer.stocks).filter(offers_models.Stock.id == stock_id).one()
+    )
+    bookings = bookings_api.get_individual_bookings_from_stock(stock_id)
+
+    for booking in bookings:
+        notification_data = get_today_stock_booking_notification_data(booking, offer)
+        if notification_data:
+            send_transactional_notification(notification_data)
 
 
 @job(worker.default_queue)

--- a/api/tests/scheduled_tasks/clock_test.py
+++ b/api/tests/scheduled_tasks/clock_test.py
@@ -34,6 +34,7 @@ def test_pc_send_today_events_notifications_only_to_individual_bookings_users():
 
     # should be fetched
     bookings_factories.IndividualBookingFactory(stock=stock_today, user=user1)
+    bookings_factories.IndividualBookingFactory(stock=stock_today, user=user2)
 
     # should not be fetched: cancelled
     bookings_factories.IndividualBookingFactory(stock=stock_today, status=BookingStatus.CANCELLED, user=user2)
@@ -46,11 +47,11 @@ def test_pc_send_today_events_notifications_only_to_individual_bookings_users():
 
     pc_send_today_events_notifications_metropolitan_france()
 
-    assert len(testing.requests) == 1
+    assert len(testing.requests) == 2
     assert all(data["message"]["title"] == "C'est aujourd'hui !" for data in testing.requests)
 
     user_ids = {user_id for data in testing.requests for user_id in data["user_ids"]}
-    assert user_ids == {user1.id}
+    assert user_ids == {user1.id, user2.id}
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14083

## But de la pull request

Besoin : ajouter un lien vers la page de réservation dans la notification.

Le problème est que cela individualise la notification et on ne peut donc plus faire un appel groupé à l'API de Batch. Cet ajout implique donc de passer en mode "_un appel à l'API de Batch pour une réservation_" (contre _"un appel à l'API de Batch pour toutes les réservation liées au même stock"_ avant).