### PR TITLE
(PC-14436)[PRO] build: upgrade csv-parse to 5.0.4

### DIFF
--- a/pro/jest.config.js
+++ b/pro/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(png|svg)': '<rootDir>/src/utils/svgrMock.js',
     '\\.(css|less|scss|sass)$': '<rootDir>/src/utils/styleMock.js',
+    '^csv-parse/lib/sync': '<rootDir>/node_modules/csv-parse/dist/cjs/sync.cjs',
   },
   modulePaths: ['node_modules', 'src'],
   preset: 'jest-preset-stylelint',

--- a/pro/package.json
+++ b/pro/package.json
@@ -59,7 +59,7 @@
     "@sentry/tracing": "^6.18.1",
     "@types/node-fetch": "^2.6.1",
     "classnames": "^2.2.6",
-    "csv-parse": "^4.16.3",
+    "csv-parse": "^5.0.4",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.0",
     "env-cmd": "^10.1.0",

--- a/pro/src/utils/csvConverter.ts
+++ b/pro/src/utils/csvConverter.ts
@@ -1,4 +1,4 @@
-import parse from 'csv-parse/lib/sync'
+import { parse } from 'csv-parse/lib/sync'
 const CSV_SEMI_COLON_SEPARATOR = ';'
 
 interface ObjectFromCsv {

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -8853,10 +8853,10 @@ csstype@^3.0.10, csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
   integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
-csv-parse@^4.16.3:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.16.3.tgz#7ca624d517212ebc520a36873c3478fa66efbaf7"
-  integrity sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==
+csv-parse@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.0.4.tgz#97e5e654413bcf95f2714ce09bcb2be6de0eb8e3"
+  integrity sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ==
 
 cuint@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14436

## Informations supplémentaires

- problème rencontré : 
```   /home/romain/pass-culture-main/pro/node_modules/csv-parse/lib/sync.js:2
    import { Parser } from './index.js';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module

    > 1 | import { parse } from 'csv-parse/lib/sync'
```
    


    -> https://github.com/adaltas/node-csv/issues/309
