### PR TITLE
(BSR)[API] fix: Remove unused Offerer.offerer_tags backref

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -425,9 +425,7 @@ class Offerer(
 
     dateValidated = Column(DateTime, nullable=True, default=None)
 
-    tags = sa.orm.relationship(
-        "OffererTag", backref=db.backref("offerer_tags", lazy="dynamic"), secondary="offerer_tag_mapping"
-    )
+    tags = sa.orm.relationship("OffererTag", secondary="offerer_tag_mapping")
 
     thumb_path_component = "offerers"
 


### PR DESCRIPTION
It's not used, but it causes a warning when the Flask-Admin
OffererTagView is loaded:

    .../flask_admin/model/base.py:1416: UserWarning: Fields missing from ruleset: offerer_tags