### PR TITLE
Bsr sentry tag

### DIFF
--- a/api/src/pcapi/routes/adage/v1/blueprint.py
+++ b/api/src/pcapi/routes/adage/v1/blueprint.py
@@ -3,12 +3,13 @@ from spectree import SecurityScheme
 from spectree import SpecTree
 
 from pcapi.routes.native import utils
+from pcapi.routes.utils import tag_with_stream_name
 from pcapi.serialization.utils import before_handler
 
 
 adage_v1 = Blueprint("adage_v1", __name__)
 adage_v1.before_request(utils.check_client_version)
-
+adage_v1.before_request(lambda: tag_with_stream_name("adage"))
 
 EAC_API_KEY_AUTH = "ApiKeyAuth"
 

--- a/api/src/pcapi/routes/adage_iframe/blueprint.py
+++ b/api/src/pcapi/routes/adage_iframe/blueprint.py
@@ -4,10 +4,12 @@ from spectree import SecurityScheme
 from spectree import SpecTree
 
 from pcapi import settings
+from pcapi.routes.utils import tag_with_stream_name
 from pcapi.serialization.utils import before_handler
 
 
 adage_iframe = Blueprint("adage_iframe", __name__)
+adage_iframe.before_request(lambda: tag_with_stream_name("adage"))
 CORS(
     adage_iframe,
     origins=settings.CORS_ALLOWED_ORIGINS_ADAGE_IFRAME,

--- a/api/src/pcapi/routes/native/v1/blueprint.py
+++ b/api/src/pcapi/routes/native/v1/blueprint.py
@@ -4,12 +4,14 @@ from spectree import SecurityScheme
 
 from pcapi import settings
 from pcapi.routes.native import utils
+from pcapi.routes.utils import tag_with_stream_name
 from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
 
 
 native_v1 = Blueprint("native_v1", __name__)
 native_v1.before_request(utils.check_client_version)
+native_v1.before_request(lambda: tag_with_stream_name("jeunes"))
 CORS(
     native_v1,
     origins=settings.CORS_ALLOWED_ORIGINS_NATIVE,

--- a/api/src/pcapi/routes/saml/blueprint.py
+++ b/api/src/pcapi/routes/saml/blueprint.py
@@ -3,8 +3,10 @@ from flask_cors.extension import CORS
 
 from pcapi import settings
 from pcapi.routes.native import utils
+from pcapi.routes.utils import tag_with_stream_name
 
 
 saml_blueprint = Blueprint("saml_blueprint", __name__)
 saml_blueprint.before_request(utils.check_client_version)
+saml_blueprint.before_request(lambda: tag_with_stream_name("jeunes"))
 CORS(saml_blueprint, origins=settings.CORS_ALLOWED_ORIGINS_NATIVE, supports_credentials=True)

--- a/api/src/pcapi/routes/utils.py
+++ b/api/src/pcapi/routes/utils.py
@@ -1,0 +1,5 @@
+import sentry_sdk
+
+
+def tag_with_stream_name(stream_name: str) -> None:
+    sentry_sdk.set_tag("stream_name", stream_name)


### PR DESCRIPTION
Le but est double : 
- permettre de construire les indicateurs sentry 'nombre d'erreurs unresolved' segmenté par stream
- aider le shérif sentry à dispatcher les erreurs selon le tag -> est-ce que ça va vraiment l'aider ? si la séparation est par blueprint et non pas par squad / stream ?

### Blueprints
- native => 'jeunes'
- adage => 'adage' -> est-ce qu'il faudrait pas le tagger 'EAC'
- public_api => on ne peut pas tagger directement car sont inclus : 
  - webhooks dms, ubble, seninblue -> plutôt relié à 'jeune'
  - bank_informations -> "pro" ?
- pro_public_api_v1, v2 -> 'contremarque'
- pro_public_api_v2, pro_private_api -> 'pro'
- saml => 'jeune' (c'est educonnect)

### TODO
- tagger admin -> idem : est-ce qu'on fait une séparation par vue ?
- tagger les cloud tasks
- tagger les workers
- tagger les crons

### Interrogations
Est-ce que ce serait pas plus simple de tagger avec le nom du blueprint directement ? Ou que les noms des blueprints reflètent directement les séparations ?