### PR TITLE
(PC-13426)[API] Handle collective pricing creation

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-b5d269da9bb3 (pre) (head)
+8b8b73636328 (pre) (head)
 beaefcf60bc9 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220421T082905_8b8b73636328_add_collective_booking_ref_on_pricing_model.py
+++ b/api/src/pcapi/alembic/versions/20220421T082905_8b8b73636328_add_collective_booking_ref_on_pricing_model.py
@@ -1,0 +1,27 @@
+"""add_collective_booking_ref_on_pricing_model
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8b8b73636328"
+down_revision = "b5d269da9bb3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("pricing", sa.Column("collectiveBookingId", sa.BigInteger(), nullable=True))
+    op.alter_column("pricing", "bookingId", existing_type=sa.BIGINT(), nullable=True)
+    op.create_index(op.f("ix_pricing_collectiveBookingId"), "pricing", ["collectiveBookingId"], unique=False)
+    op.create_foreign_key(
+        "pricing_collective_booking_fkey", "pricing", "collective_booking", ["collectiveBookingId"], ["id"]
+    )
+
+
+def downgrade():
+    op.drop_constraint("pricing_collective_booking_fkey", "pricing", type_="foreignkey")
+    op.drop_index(op.f("ix_pricing_collectiveBookingId"), table_name="pricing")
+    op.alter_column("pricing", "bookingId", existing_type=sa.BIGINT(), nullable=False)
+    op.drop_column("pricing", "collectiveBookingId")

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -628,22 +628,16 @@ def generate_cashflows(cutoff: datetime.datetime) -> int:
     """Generate a new CashflowBatch and a new cashflow for each business
     unit for which there is money to transfer.
     """
+    is_new_collective_model_enabled = FeatureToggle.ENABLE_NEW_COLLECTIVE_MODEL.is_active()
     logger.info("Started to generate cashflows")
     batch = models.CashflowBatch(cutoff=cutoff)
     db.session.add(batch)
     db.session.flush()
     batch_id = batch.id  # access _before_ COMMIT to avoid extra SELECT
     db.session.commit()
-
-    filters = (
+    filters: typing.Tuple = (
         models.Pricing.status == models.PricingStatus.VALIDATED,
         models.Pricing.valueDate < cutoff,
-        # Even if a booking is marked as used prematurely, we should
-        # wait for the event to happen.
-        sqla.or_(
-            offers_models.Stock.beginningDatetime.is_(None),
-            offers_models.Stock.beginningDatetime < cutoff,
-        ),
         # We should not have any validated pricing with a cashflow,
         # this is a safety belt.
         models.CashflowPricing.pricingId.is_(None),
@@ -651,6 +645,40 @@ def generate_cashflows(cutoff: datetime.datetime) -> int:
         # but to generate cashflows we definitely need it.
         BankInformation.status == BankInformationStatus.ACCEPTED,
     )
+
+    if is_new_collective_model_enabled:
+        filters = (
+            *filters,
+            # Even if a booking is marked as used prematurely, we should
+            # wait for the event to happen.
+            # Either the Pricing has a bookingId and we want the filter to be
+            # applied on the Stock model or the Pricing has a collectiveBookingId
+            # and we want the filter to be applied on the CollectiveStock model
+            sqla.or_(
+                sqla.and_(
+                    models.Pricing.bookingId.isnot(None),
+                    sqla.or_(
+                        offers_models.Stock.beginningDatetime.is_(None), offers_models.Stock.beginningDatetime < cutoff
+                    ),
+                ),
+                sqla.and_(
+                    models.Pricing.collectiveBookingId.isnot(None),
+                    educational_models.CollectiveStock.beginningDatetime < cutoff,
+                ),
+            ),
+            # We do not want to include educational booking since we include collective bookings
+            bookings_models.Booking.educationalBookingId.is_(None),
+        )
+    else:
+        filters = (
+            *filters,
+            # Even if a booking is marked as used prematurely, we should
+            # wait for the event to happen.
+            sqla.or_(
+                offers_models.Stock.beginningDatetime.is_(None),
+                offers_models.Stock.beginningDatetime < cutoff,
+            ),
+        )
 
     def _mark_as_processed(pricings):  # type: ignore [no-untyped-def]
         pricings_to_update = models.Pricing.query.filter(
@@ -661,14 +689,29 @@ def generate_cashflows(cutoff: datetime.datetime) -> int:
             synchronize_session=False,
         )
 
-    business_unit_ids_and_bank_account_ids = (
-        models.Pricing.query.filter(
-            models.BusinessUnit.bankAccountId.isnot(None),
-            *filters,
+    if is_new_collective_model_enabled:
+        business_unit_ids_and_bank_account_ids_base_query = (
+            models.Pricing.query.filter(
+                models.BusinessUnit.bankAccountId.isnot(None),
+                *filters,
+            )
+            .outerjoin(models.Pricing.booking)
+            .outerjoin(models.Pricing.collectiveBooking)
+            .outerjoin(bookings_models.Booking.stock)
+            .outerjoin(educational_models.CollectiveBooking.collectiveStock)
         )
-        .join(models.Pricing.booking)
-        .join(bookings_models.Booking.stock)
-        .join(models.Pricing.businessUnit)
+    else:
+        business_unit_ids_and_bank_account_ids_base_query = (
+            models.Pricing.query.filter(
+                models.BusinessUnit.bankAccountId.isnot(None),
+                *filters,
+            )
+            .join(models.Pricing.booking)
+            .join(bookings_models.Booking.stock)
+        )
+
+    business_unit_ids_and_bank_account_ids = (
+        business_unit_ids_and_bank_account_ids_base_query.join(models.Pricing.businessUnit)
         .join(models.BusinessUnit.bankAccount)
         .outerjoin(models.CashflowPricing)
         .with_entities(models.Pricing.businessUnitId, models.BusinessUnit.bankAccountId)
@@ -678,11 +721,20 @@ def generate_cashflows(cutoff: datetime.datetime) -> int:
         logger.info("Generating cashflow", extra={"business_unit": business_unit_id})
         try:
             with transaction():
+                if is_new_collective_model_enabled:
+                    pricing_base_query = (
+                        models.Pricing.query.outerjoin(models.Pricing.booking)
+                        .outerjoin(bookings_models.Booking.stock)
+                        .outerjoin(models.Pricing.collectiveBooking)
+                        .outerjoin(educational_models.CollectiveBooking.collectiveStock)
+                    )
+                else:
+                    pricing_base_query = models.Pricing.query.join(models.Pricing.booking).join(
+                        bookings_models.Booking.stock
+                    )
                 pricings = (
-                    models.Pricing.query.join(models.BusinessUnit)
+                    pricing_base_query.join(models.BusinessUnit)
                     .join(models.BusinessUnit.bankAccount)
-                    .join(models.Pricing.booking)
-                    .join(bookings_models.Booking.stock)
                     .outerjoin(models.CashflowPricing)
                     .filter(
                         models.Pricing.businessUnitId == business_unit_id,

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -6,6 +6,7 @@ import factory
 from factory.declarations import LazyAttribute
 
 import pcapi.core.bookings.factories as bookings_factories
+from pcapi.core.educational.factories import UsedCollectiveBookingFactory
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.payments.factories as payments_factories
 from pcapi.core.testing import BaseFactory
@@ -65,6 +66,20 @@ class EducationalPricingFactory(BaseFactory):
     amount = LazyAttribute(lambda pricing: -int(100 * pricing.booking.total_amount))
     revenue = LazyAttribute(lambda pricing: int(100 * pricing.booking.total_amount))
     standardRule = "Remboursement total"
+
+
+class CollectivePricingFactory(BaseFactory):
+    class Meta:
+        model = models.Pricing
+
+    status = models.PricingStatus.VALIDATED
+    collectiveBooking = factory.SubFactory(UsedCollectiveBookingFactory)
+    businessUnit = factory.SelfAttribute("collectiveBooking.venue.businessUnit")
+    siret = factory.SelfAttribute("collectiveBooking.venue.siret")
+    valueDate = factory.SelfAttribute("collectiveBooking.dateUsed")
+    amount = LazyAttribute(lambda pricing: -int(100 * pricing.collectiveBooking.collectiveStock.price))
+    standardRule = "Remboursement total pour les offres éducationnelles"
+    revenue = LazyAttribute(lambda pricing: int(100 * pricing.collectiveBooking.collectiveStock.price))
 
 
 class PricingLineFactory(BaseFactory):

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -128,7 +128,7 @@ class Pricing(Model):  # type: ignore [valid-type, misc]
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
     )
-    collectiveBooking = sqla_orm.relationship(
+    collectiveBooking = sqla_orm.relationship(  # type: ignore [misc]
         "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
     )
 

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -122,8 +122,16 @@ class Pricing(Model):  # type: ignore [valid-type, misc]
 
     status = sqla.Column(db_utils.MagicEnum(PricingStatus), index=True, nullable=False)
 
-    bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=False)
+    bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking = sqla_orm.relationship("Booking", foreign_keys=[bookingId], backref="pricings")  # type: ignore [misc]
+
+    collectiveBookingId = sqla.Column(
+        sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
+    )
+    collectiveBooking = sqla_orm.relationship(
+        "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
+    )
+
     businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=False)
     businessUnit = sqla_orm.relationship("BusinessUnit", foreign_keys=[businessUnitId])
     # `siret` is either the SIRET of the venue if it has one, or the


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13426

## But de la pull request

Créer les pricings des bookings collectifs lorsque le FF `ENABLE_NEW_COLLECTIVE_MODEL` est activé
⚠️⚠️⚠️ Lorsque ce FF est **activé** on ne veut plus pricer les bookings du modèle `Booking` qui sont de type éducationnel (donc reliés à des educational bookings - `EducationalBooking`) pour ne pas pricer 2 fois la même chose. En effet, les bookings éducationnels sont doublonnés dans la table des bookings collectif