### PR TITLE
(PC-FIX)[API] fix: send_file path instead of fp

### DIFF
--- a/api/src/pcapi/routes/internal/storage.py
+++ b/api/src/pcapi/routes/internal/storage.py
@@ -16,5 +16,4 @@ def send_storage_file(bucketId, objectId):  # type: ignore [no-untyped-def]
         mimetype = type_path.read_text()
     else:
         return "file not found", 404
-    with path.open("rb") as fp:
-        return send_file(fp, mimetype=mimetype)
+    return send_file(path, mimetype=mimetype)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-NOPE

## But de la pull request

En local, on ne peut plus avoir les images : on se retrouve avec l'erreur suivante

```sh
INFO:pcapi.flask_app:HTTP request at /storage/thumbs/venues/H9_1649940478
Debugging middleware caught exception in streamed response at a point where response headers were already sent.
Traceback (most recent call last):
  File "[...]env3.9/lib/python3.9/site-packages/werkzeug/wsgi.py", line 538, in __next__
    data = self.file.read(self.buffer_size)
ValueError: read of closed file
```

Ce qui n'arrive plus lorsque l'on passe le _path_ directement, ce qui est la seconde option possible [selon la doc de send_file](https://flask.palletsprojects.com/en/2.1.x/api/?highlight=send_file#flask.send_file).