### PR TITLE
(BSR)[API] test: Turn warnings into exceptions when running pytest

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,5 +1,15 @@
 [pytest]
-addopts=-v --tb=short
+addopts=
+    --verbose
+    --tb=short
+    -Werror
+    # Raised by SQLAlchemy (>=1.3.17, see https://github.com/sqlalchemy/sqlalchemy/commit/916e1fea25afcd07fa1d1d2f72043b372cd02223) because of pytest-flask-sqlalchemy.
+    # FIXME (dbaty, 2020-10-21): Follow https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/36
+    # for a possible fix.
+    -W"ignore:Reset agent is not active:sqlalchemy.exc.SAWarning"
+    # FIXME (jsdupuis, 2022-04-14): can be removed when we use flask-sqlalchemy >=2.5
+    # (https://github.com/pallets-eco/flask-sqlalchemy/commit/3565f0587519168c5ea4301f6e4bfba8c2ac4dee)
+    -W"ignore:'__ident_func__' is deprecated and will be removed in Werkzeug 2.1.:DeprecationWarning"
 testpaths=tests
 norecursedirs=.git venv/ .pytest_cache/
 # Synchronize these globs with `TEST_FILES` in CircleCI configuration
@@ -9,11 +19,3 @@ python_functions=test_* when_* expect_* should_*
 env_files=local_test_env_file
 mocked-sessions=pcapi.models.db.session
 junit_family=xunit1
-filterwarnings =
-    # Raised by SQLAlchemy (>=1.3.17, see https://github.com/sqlalchemy/sqlalchemy/commit/916e1fea25afcd07fa1d1d2f72043b372cd02223) because of pytest-flask-sqlalchemy.
-    # FIXME (dbaty, 2020-10-21): Follow https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/36
-    # for a possible fix.
-    ignore:Reset agent is not active:sqlalchemy.exc.SAWarning
-    # FIXME (jsdupuis, 2022-02-18): can be removed when we use flask-sqlalchemy >=2.5
-    # (https://github.com/pallets-eco/flask-sqlalchemy/commit/3565f0587519168c5ea4301f6e4bfba8c2ac4dee)
-    ignore:'__ident_func__' is deprecated and will be removed in Werkzeug 2.1.:DeprecationWarning

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -14,11 +14,6 @@ filterwarnings =
     # FIXME (dbaty, 2020-10-21): Follow https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/36
     # for a possible fix.
     ignore:Reset agent is not active:sqlalchemy.exc.SAWarning
-    # FIXME (dbaty, 2021-11-19): consider using hiredis as suggested by redis-py
-    ignore:redis-py works best with hiredis. Please consider installing:UserWarning
-    # FIXME (jsdupuis, 2022-02-18): deprecation of werkzeug must be fix in Flask future release.
-    # to be remove when version 2.1 of Werkzeug is reached
-    ignore:'BaseResponse' is deprecated and will be removed in Werkzeug 2.1:DeprecationWarning
     # FIXME (jsdupuis, 2022-02-18): deprecation of werkzeug must be fix in werkzeug future release.
     # to be remove when version 2.1 of Werkzeug is reached
     ignore:'__ident_func__' is deprecated and will be removed in Werkzeug 2.1.:DeprecationWarning

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -14,6 +14,6 @@ filterwarnings =
     # FIXME (dbaty, 2020-10-21): Follow https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/36
     # for a possible fix.
     ignore:Reset agent is not active:sqlalchemy.exc.SAWarning
-    # FIXME (jsdupuis, 2022-02-18): deprecation of werkzeug must be fix in werkzeug future release.
-    # to be remove when version 2.1 of Werkzeug is reached
+    # FIXME (jsdupuis, 2022-02-18): can be removed when we use flask-sqlalchemy >=2.5
+    # (https://github.com/pallets-eco/flask-sqlalchemy/commit/3565f0587519168c5ea4301f6e4bfba8c2ac4dee)
     ignore:'__ident_func__' is deprecated and will be removed in Werkzeug 2.1.:DeprecationWarning

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -601,8 +601,9 @@ def test_generate_business_units_file():
     with assert_num_queries(n_queries):
         path = api._generate_business_units_file()
 
-    reader = csv.DictReader(path.open(encoding="utf-8"), quoting=csv.QUOTE_NONNUMERIC)
-    rows = list(reader)
+    with path.open(encoding="utf-8") as fp:
+        reader = csv.DictReader(fp, quoting=csv.QUOTE_NONNUMERIC)
+        rows = list(reader)
     assert len(rows) == 2
     assert rows[0] == {
         "Identifiant de la BU": human_ids.humanize(venue1.id),

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -777,9 +777,9 @@ class UbbleWebhookTest:
         signature = self._get_signature(payload)
 
         with mock.patch(
-            "pcapi.routes.external.users_subscription.ubble_webhook_update_application_status"
-        ) as update_mock:
-            update_mock.return_value = Exception
+            "pcapi.core.subscription.ubble.api.update_ubble_workflow",
+            side_effect=Exception(),
+        ):
             response = client.post(
                 "/webhooks/ubble/application_status",
                 headers={"Ubble-Signature": signature},


### PR DESCRIPTION
**Commits à relire séparément.**

Tous les warnings ont été traités (ou sont "temporairement" désactivés dans "pytest.ini"). Pour éviter la survenue de nouveaux "warnings" qu'on ignorerait (comme on l'a fait jusque là, dont certains étaient pourtant importants [*]), on force une levée d'erreur pour tout warning (non ignoré), lors du lancement des tests.

[*] Exemple : "hé, on dirait que tu surcharges un formulaire et que la validation du jeton CSRF est désactivée". On avait de tels warnings qu'on ignorait royalement (jusqu'à la correction du problème, cf. #2015).