### PR TITLE
(PC-14518)[API] fix: stop sending user phone number to ubble

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -92,7 +92,6 @@ def _extract_useful_content_from_response(
 
 def start_identification(
     user_id: int,
-    phone_number: str,
     first_name: str,
     last_name: str,
     webhook_url: str,
@@ -106,7 +105,7 @@ def start_identification(
             "attributes": {
                 "identification-form": {
                     "external-user-id": user_id,
-                    "phone-number": phone_number,
+                    "phone-number": None,
                 },
                 "reference-data": {
                     "first-name": first_name,

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -87,7 +87,6 @@ def update_ubble_workflow(
 def start_ubble_workflow(user: users_models.User, redirect_url: str) -> str:
     content = ubble.start_identification(
         user_id=user.id,
-        phone_number=user.phoneNumber,  # type: ignore [arg-type]
         first_name=user.firstName,  # type: ignore [arg-type]
         last_name=user.lastName,  # type: ignore [arg-type]
         webhook_url=flask.url_for("Public API.ubble_webhook_update_application_status", _external=True),

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -18,7 +18,6 @@ class StartIdentificationTest:
         with caplog.at_level(logging.INFO):
             response = ubble.start_identification(
                 user_id=123,
-                phone_number="+33601232323",
                 first_name="prenom",
                 last_name="nom",
                 webhook_url="http://webhook/url/",
@@ -30,7 +29,7 @@ class StartIdentificationTest:
 
         attributes = ubble_mock.last_request.json()["data"]["attributes"]
         assert attributes["identification-form"]["external-user-id"] == 123
-        assert attributes["identification-form"]["phone-number"] == "+33601232323"
+        assert attributes["identification-form"]["phone-number"] == None
 
         assert attributes["reference-data"]["first-name"] == "prenom"
         assert attributes["reference-data"]["last-name"] == "nom"
@@ -49,7 +48,6 @@ class StartIdentificationTest:
             with caplog.at_level(logging.ERROR):
                 ubble.start_identification(
                     user_id=123,
-                    phone_number="+33601232323",
                     first_name="prenom",
                     last_name="nom",
                     webhook_url="http://webhook/url/",
@@ -67,7 +65,6 @@ class StartIdentificationTest:
         with pytest.raises(exceptions.IdentificationServiceError):
             ubble.start_identification(
                 user_id=123,
-                phone_number="+33601232323",
                 first_name="prenom",
                 last_name="nom",
                 webhook_url="http://webhook/url/",

--- a/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
+++ b/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
@@ -73,7 +73,7 @@ class UbbleEndToEndTest:
         assert requests_mocker.last_request.json() == {
             "data": {
                 "attributes": {
-                    "identification-form": {"external-user-id": user.id, "phone-number": "+33612345678"},
+                    "identification-form": {"external-user-id": user.id, "phone-number": None},
                     "redirect_url": "https://passculture.app/verification-identite/fin",
                     "reference-data": {"first-name": "Raoul", "last-name": "de Toul"},
                     "webhook": flask.url_for("Public API.ubble_webhook_update_application_status", _external=True),


### PR DESCRIPTION
Lien vers le ticket Jira  https://passculture.atlassian.net/browse/PC-14518

The phonenumber is only useful to prefill the user phonenumber when the user starts an identification on desktop (face verification cannot be performed on desktop so the user can scan a qr code on the computer with the user's smartphone or fill the user's number to receive an sms with the identification url) ; we remove it because sometimes the user phone number is not formatted with the international format, which results in a 400 error from ubble when we start the identification procedure ; we will try to understand later why some numbers have a wrong format ; sentry error : https://sentry.internal-passculture.app/organizations/sentry/issues/240585


![ubble start](https://user-images.githubusercontent.com/22373097/163549383-d28d7575-4db7-40be-abeb-f835b3c689ec.jpg)
![ubble num](https://user-images.githubusercontent.com/22373097/163549390-3b0d1995-a439-45e2-a393-d592eb24d2d4.jpg)




## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
