### PR TITLE
(PC-14382)[api] Links to PC PRO from Flask-Admin (offerers, venues, offers)

### DIFF
--- a/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -12,7 +12,6 @@ import wtforms.fields.core as wtf_fields
 import wtforms.fields.html5 as wtf_html5_fields
 import wtforms.validators as wtf_validators
 
-from pcapi import settings
 from pcapi.admin import fields
 from pcapi.admin import permissions
 from pcapi.admin import widgets
@@ -25,9 +24,10 @@ import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 import pcapi.core.payments.api as payments_api
 import pcapi.core.payments.exceptions as payments_exceptions
-from pcapi.utils import human_ids
 import pcapi.utils.date as date_utils
 from pcapi.utils.mailing import build_pc_pro_offer_link
+from pcapi.utils.mailing import build_pc_pro_offerer_link
+from pcapi.utils.mailing import build_pc_pro_venue_link
 
 
 def _get_subcategory_choices():  # type: ignore [no-untyped-def]
@@ -123,8 +123,7 @@ def format_offer(view, context, model, name):  # type: ignore [no-untyped-def]
 
 def format_offerer(view, context, model, name):  # type: ignore [no-untyped-def]
     offerer = model.offerer or model.offer.venue.managingOfferer
-    humanized_id = human_ids.humanize(offerer.id)
-    url = f"{settings.PRO_URL}/accueil?structure={humanized_id}"
+    url = build_pc_pro_offerer_link(offerer)
     return markupsafe.Markup('<a href="{url}">{offerer.name}</a>').format(
         url=url,
         offerer=offerer,
@@ -169,12 +168,7 @@ def format_venue(view, context, model, name):  # type: ignore [no-untyped-def]
     if model.offererId:
         return None
     venue = model.offer.venue
-    humanized_offerer_id = human_ids.humanize(venue.managingOffererId)
-    if venue.isVirtual:
-        url = f"{settings.PRO_URL}/accueil?structure={humanized_offerer_id}"
-    else:
-        humanized_venue_id = human_ids.humanize(venue.id)
-        url = f"{settings.PRO_URL}/structures/{humanized_offerer_id}/lieux/{humanized_venue_id}"
+    url = build_pc_pro_venue_link(venue)
     return markupsafe.Markup('<a href="{url}">{name}</a>').format(
         url=url,
         name=venue.publicName or venue.name,

--- a/api/src/pcapi/admin/custom_views/user_offerer_view.py
+++ b/api/src/pcapi/admin/custom_views/user_offerer_view.py
@@ -1,17 +1,16 @@
+from jinja2.runtime import Context
 import markupsafe
 import sqlalchemy.orm as sqla_orm
 
-from pcapi import settings
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.core.offerers.models import UserOfferer
 from pcapi.core.users.external import update_external_pro
-from pcapi.utils import human_ids
+from pcapi.utils.mailing import build_pc_pro_offerer_link
 
 
-def format_offerer_name(view, context, model, name):  # type: ignore [no-untyped-def]
+def _format_offerer_name(view: BaseAdminView, context: Context, model: UserOfferer, name: str) -> markupsafe.Markup:
     offerer = model.offerer
-    humanized_id = human_ids.humanize(offerer.id)
-    url = f"{settings.PRO_URL}/accueil?structure={humanized_id}"
+    url = build_pc_pro_offerer_link(offerer)
     return markupsafe.Markup('<a href="{url}">{offerer.name}</a>').format(
         url=url,
         offerer=offerer,
@@ -60,7 +59,7 @@ class UserOffererView(BaseAdminView):
         "offerer.name",
     ]
     column_formatters = {
-        "offerer.name": format_offerer_name,
+        "offerer.name": _format_offerer_name,
     }
 
     def delete_model(self, user_offerer: UserOfferer) -> bool:

--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional
 
 from flask import flash
 from flask import redirect
@@ -12,6 +12,7 @@ from flask_admin.contrib.sqla import tools
 from flask_admin.contrib.sqla.fields import QuerySelectMultipleField
 from flask_admin.helpers import get_redirect_target
 from flask_sqlalchemy import BaseQuery
+from jinja2.runtime import Context
 from markupsafe import Markup
 from markupsafe import escape
 from sqlalchemy import func
@@ -36,22 +37,34 @@ from pcapi.core.users.external import update_external_pro
 from pcapi.models import db
 from pcapi.models.criterion import Criterion
 from pcapi.scripts.offerer.delete_cascade_venue_by_id import delete_cascade_venue_by_id
+from pcapi.utils.mailing import build_pc_pro_offerer_link
+from pcapi.utils.mailing import build_pc_pro_venue_link
 
 
-def _offers_link(view, context, model, name) -> Markup:  # type: ignore [no-untyped-def]
+def _format_offers_link(view: BaseAdminView, context: Context, model: Venue, name: str) -> Markup:
     url = url_for("offer_for_venue.index", id=model.id)
     return Markup('<a href="{}">Offres associées</a>').format(escape(url))
 
 
-def _get_venue_provider_link(view, context, model, name) -> Union[Markup, None]:  # type: ignore [no-untyped-def]
+def _format_venue_provider(view: BaseAdminView, context: Context, model: Venue, name: str) -> Optional[Markup]:
     if not model.venueProviders:
         return None
     url = url_for("venue_providers.index_view", id=model.id)
     return Markup('<a href="{url}">{text}</a>').format(url=url, text=model.venueProviders[0].provider.name)
 
 
-def _get_venue_type_code_formatter(view, context, model, name) -> Union[Markup, None]:  # type: ignore [no-untyped-def]
-    return Markup("<span>{text}</span>").format(text=model.venueTypeCode.value if model.venueTypeCode else "")
+def _format_venue_type_code(view: BaseAdminView, context: Context, model: Venue, name: str) -> Markup:
+    return Markup("<span>{text}</span>").format(text=model.venueTypeCode.value if model.venueTypeCode else "")  # type: ignore [attr-defined]
+
+
+def _format_venue_name(view: BaseAdminView, context: Context, model: Venue, name: str) -> Markup:
+    url = build_pc_pro_venue_link(model)
+    return Markup('<a href="{url}">{name}</a>').format(url=url, name=model.name)
+
+
+def _format_offerer_name(view: BaseAdminView, context: Context, model: Venue, name: str) -> Markup:
+    url = build_pc_pro_offerer_link(model.managingOfferer)
+    return Markup('<a href="{url}">{name}</a>').format(url=url, name=model.managingOfferer.name)
 
 
 def _get_emails_by_venue(venue: Venue) -> set[str]:
@@ -186,9 +199,15 @@ class VenueView(BaseAdminView):
     @property
     def column_formatters(self):  # type: ignore [no-untyped-def]
         formatters = super().column_formatters
-        formatters.update(offres=_offers_link)
-        formatters.update(provider_name=_get_venue_provider_link)
-        formatters.update(venueTypeCode=_get_venue_type_code_formatter)
+        formatters.update(
+            {
+                "name": _format_venue_name,
+                "venueTypeCode": _format_venue_type_code,
+                "provider_name": _format_venue_provider,
+                "offres": _format_offers_link,
+                "managingOfferer.name": _format_offerer_name,
+            }
+        )
         return formatters
 
     def delete_model(self, venue: Venue) -> bool:

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -737,7 +737,7 @@ def user_has_bookings(user: User) -> bool:
     return db.session.query(bookings_query.filter(UserOfferer.userId == user.id).exists()).scalar()
 
 
-def offerer_has_ongoing_bookings(offerer_id: Offerer) -> bool:
+def offerer_has_ongoing_bookings(offerer_id: int) -> bool:
     return db.session.query(
         Booking.query.filter(
             Booking.offererId == offerer_id,

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -32,6 +32,12 @@ def build_pc_pro_offerer_link(offerer: offerers_models.Offerer) -> str:
     return f"{settings.PRO_URL}/accueil?structure={humanize(offerer.id)}"
 
 
+def build_pc_pro_venue_link(venue: offerers_models.Venue) -> str:
+    if venue.isVirtual:
+        return build_pc_pro_offerer_link(venue.managingOfferer)
+    return f"{settings.PRO_URL}/structures/{humanize(venue.managingOffererId)}/lieux/{humanize(venue.id)}"
+
+
 def build_pc_pro_create_password_link(token_value: str) -> str:
     return f"{settings.PRO_URL}/creation-de-mot-de-passe/{token_value}"
 

--- a/api/tests/admin/custom_views/venue_view_test.py
+++ b/api/tests/admin/custom_views/venue_view_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.admin.custom_views.venue_view import _get_venue_provider_link
+from pcapi.admin.custom_views.venue_view import _format_venue_provider
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import BookingStatus
 import pcapi.core.finance.factories as finance_factories
@@ -355,7 +355,7 @@ class GetVenueProviderLinkTest:
         venue = offers_factories.VenueFactory()
 
         # When
-        link = _get_venue_provider_link(None, None, venue, None)
+        link = _format_venue_provider(None, None, venue, None)
 
         # Then
         assert not link
@@ -367,7 +367,7 @@ class GetVenueProviderLinkTest:
         venue = venue_provider.venue
 
         # When
-        link = _get_venue_provider_link(None, None, venue, None)
+        link = _format_venue_provider(None, None, venue, None)
 
         # Then
         assert str(venue.id) in link


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14382

## But de la pull request

Ajouter des liens qui redirigent vers les pages lieux et structures du portail pro, sur les noms de structures et noms de lieux dans ces deux pages du backoffice :  
`/pc/back-office/offerer/`
`/pc/back-office/venue/`

## Informations supplémentaires

En bonus : 

- Liens sur les noms d'offres : `/pc/back-office/offer/`
- Utilisation des générateurs de liens vers PC pro plutôt que forger l'URL à chaque fois
- Typage sur les _formatters_ dans les fichiers modifiés

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
