### PR TITLE
(PC-14483)[PRO] new siren api responses

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -63,8 +63,7 @@
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.0",
     "env-cmd": "^10.1.0",
-    "final-form": "^4.20.1",
-    "final-form-calculate": "^1.3.2",
+    "final-form": "^4.20.6",
     "formik": "^2.2.9",
     "full-icu": "^1.4.0",
     "leaflet": "^1.7.1",
@@ -85,7 +84,7 @@
     "react-datepicker": "^4.7.0",
     "react-dom": "^16.13.1",
     "react-dotdotdot": "^1.2.3",
-    "react-final-form": "^6.5.8",
+    "react-final-form": "^6.5.9",
     "react-final-form-utils": "^1.4.0",
     "react-leaflet": "^3.2.5",
     "react-loading-infinite-scroller": "^1.5.1",
@@ -218,9 +217,9 @@
   },
   "browserslist": [
     ">0.2%",
-   "not dead",
-   "not op_mini all"
- ],
+    "not dead",
+    "not op_mini all"
+  ],
   "babel": {
     "presets": [
       "react-app"

--- a/pro/src/api/entreprise/apiEntreprise.ts
+++ b/pro/src/api/entreprise/apiEntreprise.ts
@@ -1,4 +1,4 @@
-import { API_ENTREPRISE_BASE_URL } from './constants'
+import { API_ENTREPRISE_BASE_URL, STATUS_ACTIVE } from './constants'
 import type { IEntrepriseData, IEntrepriseDataFail } from './types'
 
 export default {
@@ -14,12 +14,23 @@ export default {
     }
 
     const data = await response.json().then(body => body.etablissement)
+    if (
+      data.etat_administratif !== STATUS_ACTIVE ||
+      data.unite_legale.etat_administratif !== STATUS_ACTIVE
+    ) {
+      return { error: 'SIRET invalide' }
+    }
+
     return {
       address: data.geo_l4,
       city: data.libelle_commune,
       latitude: parseFloat(data.latitude) || null,
       longitude: parseFloat(data.longitude) || null,
-      name: data.enseigne_1 || data.unite_legale.denomination || '',
+      name:
+        data.enseigne_1 ||
+        data.unite_legale.denomination ||
+        `${data.unite_legale.prenom_1} ${data.unite_legale.nom}` ||
+        '',
       postalCode: data.code_postal,
       siret: data.siret,
     }

--- a/pro/src/api/entreprise/constants.ts
+++ b/pro/src/api/entreprise/constants.ts
@@ -1,2 +1,4 @@
+export const STATUS_ACTIVE = 'A'
+
 export const API_ENTREPRISE_BASE_URL =
   'https://entreprise.data.gouv.fr/api/sirene/v3'

--- a/pro/src/components/layout/form/fields/SiretField/SiretField.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/SiretField.tsx
@@ -24,12 +24,15 @@ const SiretField = ({
 
   const siretFormField = useField('siret', {})
   const commentFormField = useField('comment', {})
-  const haveInitialValue = siretFormField.meta.initial !== null
+  const haveInitialValue = ![null, undefined].includes(
+    siretFormField.meta.initial
+  )
   const siretValue = siretFormField.input.value
   const commentValue = commentFormField.input.value
   const isValid = !!siretValue && siretValue.length === 14
 
   let validate: ((siret: string) => Promise<string | undefined>) | null = null
+
   if (!(haveInitialValue || isEntrepriseApiDisabled)) {
     validate = (siret: string) => siretApiValidate(siret, commentValue)
   }

--- a/pro/src/components/layout/form/fields/TextField.jsx
+++ b/pro/src/components/layout/form/fields/TextField.jsx
@@ -25,6 +25,12 @@ function getInputValue(inputType, value) {
 function TextField(props) {
   const inputType = props.readOnly ? 'text' : props.type
   const stepValue = inputType === 'number' ? props.step : undefined
+
+  const handleOnBlur = formOnBlur => e => {
+    formOnBlur(e)
+    if (props.onBlur) props.onBlur(e)
+  }
+
   return (
     <Field
       format={props.format}
@@ -69,7 +75,7 @@ function TextField(props) {
                   className={`field-input field-${props.type}`}
                   disabled={props.disabled || props.readOnly}
                   min={props.min}
-                  onBlur={props.onBlur}
+                  onBlur={handleOnBlur(input.onBlur)}
                   placeholder={props.readOnly ? '' : props.placeholder}
                   readOnly={props.readOnly}
                   required={!!props.required}

--- a/pro/src/core/Venue/adapters/getEntrepriseData.ts
+++ b/pro/src/core/Venue/adapters/getEntrepriseData.ts
@@ -42,9 +42,15 @@ const getEntrepriseDataAdapter: GetEntrepriseDataFromSiretAdapter = async (
     }
   }
   try {
-    const values = (await apiEntreprise.getEntrepriseDataFromSiret(
-      siret
-    )) as IEntrepriseData
+    const values = await apiEntreprise.getEntrepriseDataFromSiret(siret)
+    if ('error' in values) {
+      return {
+        isOk: false,
+        message: values.error,
+        payload: {},
+      }
+    }
+
     return {
       isOk: true,
       message: `Siret ${humanSiret} :`,

--- a/pro/testcafe/helpers/sirenes.js
+++ b/pro/testcafe/helpers/sirenes.js
@@ -12,7 +12,9 @@ export const getSirenRequestMockAs = offerer => {
         unite_legale: {
           denomination: name,
           siren,
+          etat_administratif: 'A',
           etablissement_siege: {
+            etat_administratif: 'A',
             geo_l4: address,
             libelle_commune: city,
             latitude: latitude,
@@ -34,7 +36,9 @@ export const getSiretRequestMockAs = venue => {
     )
     .respond(
       {
+        etat_administratif: 'A',
         etablissement: {
+          etat_administratif: 'A',
           code_postal: postalCode,
           enseigne_1: name,
           geo_l4: address,
@@ -42,6 +46,9 @@ export const getSiretRequestMockAs = venue => {
           latitude: latitude,
           longitude: longitude,
           siret: siret,
+          unite_legale: {
+            etat_administratif: 'A',
+          },
         },
       },
       200,
@@ -60,7 +67,9 @@ export const getSirenRequestMockWithDefaultValues = () =>
           id: 11654265,
           siren: '501106520',
           denomination: 'WEBEDIA',
+          etat_administratif: 'A',
           etablissement_siege: {
+            etat_administratif: 'A',
             code_postal: '92300',
             libelle_commune: 'LEVALLOIS-PERRET',
             enseigne_1: null,

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -2691,7 +2691,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -2702,6 +2702,13 @@
   version "7.13.17"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
   integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.0":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -10855,12 +10862,12 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-final-form-calculate@^1.2.1, final-form-calculate@^1.3.2:
+final-form-calculate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/final-form-calculate/-/final-form-calculate-1.3.2.tgz#a5e1908d1aa34eeec6faccdba3fd9516e7fd3d4f"
   integrity sha512-pon2K9yNbyqmF8UTpDvxwhk+Hvqpl8Fm3qgwkHniNAmCQe+6YxB1aw4cBAHzmRc39jGl2bYsvKyabQOIWLtrPg==
 
-final-form@^4.20.1:
+final-form@^4.20.6:
   version "4.20.6"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.6.tgz#da42f3741db068c0c875e18950a2c4a9a148c63e"
   integrity sha512-fCdwIj49KOaFfDRlXB57Eo+GghIMZQWrA9TakQI3C9uQxHwaFHXqZSNRlUdfnQmNNeySwGOaGPZCvjy58hyv4w==
@@ -18221,10 +18228,10 @@ react-final-form-utils@^1.4.0:
     react-router-dom "^4.3.1"
     reselect "^3.0.1"
 
-react-final-form@^6.5.8:
-  version "6.5.8"
-  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.8.tgz#08b17bc6d4124300a9f2ea1f6b2e608150d3bab0"
-  integrity sha512-j8Rmr5zAaMliNbh+CPnY734exHfk7MjQ8I6ZcykcChmPDFPV2aF40PFAcmQ/KreA10AI8ew0tff6q0gVqwFaGA==
+react-final-form@^6.5.9:
+  version "6.5.9"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.9.tgz#644797d4c122801b37b58a76c87761547411190b"
+  integrity sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==
   dependencies:
     "@babel/runtime" "^7.15.4"
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14483

Deux fixes ici:
* Notre champ de formulaire final form `TextField` ne transférait pas la fonction `onBlur` de final form à la balise `<input>`. De ce fait final form ne peut pas savoir quand le champ passe en `touched` et n'affichait jamais les erreurs.
* Les valeurs de retour de l'api entreprise on changé:
* * `{message: "no results found"}` au lieu de 404
* * les entreprises fermé sont renvoyé avec un "etat_administratif: 'F'" pour "Fermé". Avant nous avions une 404.

Et une amélioration:
* Certain auto-entrepreneur n'ont pas de nom d'entreprise: utilisation de "prenom+nom" lorsque nous n'avons rien d'autre.