### PR TITLE
(PC-13871)[API] feat: add duplicate search on married_name field

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -107,9 +107,10 @@ def dms_fraud_checks(
     user: users_models.User, beneficiary_fraud_check: models.BeneficiaryFraudCheck
 ) -> list[models.FraudItem]:
     fraud_items = []
-    fraud_items.append(
-        duplicate_id_piece_number_fraud_item(user, beneficiary_fraud_check.source_data().get_id_piece_number())  # type: ignore [union-attr, arg-type]
-    )
+    id_piece_number = beneficiary_fraud_check.source_data().get_id_piece_number()  # type: ignore [union-attr]
+    fraud_items.append(validate_id_piece_number_format_fraud_item(id_piece_number))
+    if id_piece_number:
+        fraud_items.append(duplicate_id_piece_number_fraud_item(user, id_piece_number))
     return fraud_items
 
 

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -148,12 +148,10 @@ def on_identity_fraud_check_result(
                 excluded_user_id=user.id,
             )
         )
-
-    if content_first_name and content_last_name:
         fraud_items.append(_check_user_names_valid(content_first_name, content_last_name))
-
-    if content_birth_date:
         fraud_items.append(_check_user_eligibility(user, beneficiary_fraud_check.eligibilityType))  # type: ignore [arg-type]
+    else:
+        fraud_items.append(_missing_data_fraud_item())
 
     fraud_items.append(_check_user_has_no_active_deposit(user, beneficiary_fraud_check.eligibilityType))  # type: ignore [arg-type]
     fraud_items.append(_check_user_email_is_validated(user))
@@ -215,6 +213,14 @@ def _duplicate_user_fraud_item(
         )
 
     return models.FraudItem(status=models.FraudStatus.OK, detail="Utilisateur non dupliqué")
+
+
+def _missing_data_fraud_item() -> models.FraudItem:
+    return models.FraudItem(
+        status=models.FraudStatus.SUSPICIOUS,
+        reason_code=models.FraudReasonCode.MISSING_REQUIRED_DATA,
+        detail="Des informations obligatoires (prénom, nom ou date de naissance) sont absentes du dossier",
+    )
 
 
 def find_duplicate_beneficiary(

--- a/api/src/pcapi/core/fraud/common/models.py
+++ b/api/src/pcapi/core/fraud/common/models.py
@@ -18,6 +18,9 @@ class IdentityCheckContent(pydantic.BaseModel):
     def get_last_name(self) -> typing.Optional[str]:
         raise NotImplementedError()
 
+    def get_married_name(self) -> typing.Optional[str]:
+        raise NotImplementedError()
+
     def get_birth_date(self) -> typing.Optional[datetime.date]:
         raise NotImplementedError()
 

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -325,6 +325,7 @@ class FraudReasonCode(enum.Enum):
     ID_CHECK_UNPROCESSABLE = "id_check_unprocessable"
     INVALID_ID_PIECE_NUMBER = "invalid_id_piece_number"
     INE_NOT_WHITELISTED = "ine_not_whitelisted"  # the value is kept because it still exists in the database
+    MISSING_REQUIRED_DATA = "missing_required_data"
     NAME_INCORRECT = "name_incorrect"
     NOT_ELIGIBLE = "not_eligible"
     PHONE_NOT_VALIDATED = "phone_not_validated"

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -113,6 +113,9 @@ class EduconnectContent(common_models.IdentityCheckContent):
     def get_last_name(self) -> str:
         return self.last_name
 
+    def get_married_name(self) -> None:
+        return None
+
     def get_birth_date(self) -> datetime.date:
         return self.birth_date
 
@@ -165,6 +168,9 @@ class JouveContent(common_models.IdentityCheckContent):
     def get_last_name(self) -> typing.Optional[str]:
         return self.lastName
 
+    def get_married_name(self) -> None:
+        return None
+
     def get_birth_date(self) -> typing.Optional[datetime.date]:
         return self.birthDateTxt.date() if self.birthDateTxt else None
 
@@ -210,6 +216,9 @@ class DMSContent(common_models.IdentityCheckContent):
 
     def get_last_name(self) -> str:
         return self.last_name
+
+    def get_married_name(self) -> None:
+        return None
 
     def get_registration_datetime(self) -> typing.Optional[datetime.datetime]:
         return (

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -86,10 +86,8 @@ def _ubble_result_fraud_item(content: ubble_fraud_models.UbbleContent) -> fraud_
 
 
 def ubble_fraud_checks(
-    user: users_models.User, beneficiary_fraud_check: fraud_models.BeneficiaryFraudCheck
+    user: users_models.User, content: ubble_fraud_models.UbbleContent
 ) -> list[fraud_models.FraudItem]:
-    content = ubble_fraud_models.UbbleContent(**beneficiary_fraud_check.resultContent)  # type: ignore [arg-type]
-
     ubble_fraud_models_item = _ubble_result_fraud_item(content)
     fraud_items = [ubble_fraud_models_item]
 

--- a/api/src/pcapi/core/fraud/ubble/constants.py
+++ b/api/src/pcapi/core/fraud/ubble/constants.py
@@ -6,6 +6,7 @@ RESTARTABLE_FRAUD_CHECK_REASON_CODES = (
     fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED,
     fraud_models.FraudReasonCode.ID_CHECK_EXPIRED,
     fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE,
+    fraud_models.FraudReasonCode.MISSING_REQUIRED_DATA,
 )
 
 MAX_UBBLE_RETRIES = 3

--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -69,6 +69,9 @@ class UbbleContent(IdentityCheckContent):
     def get_last_name(self) -> typing.Optional[str]:
         return self.last_name
 
+    def get_married_name(self) -> typing.Optional[str]:
+        return self.married_name
+
     def get_birth_date(self) -> typing.Optional[datetime.date]:
         return self.birth_date
 

--- a/api/src/pcapi/core/mails/transactional/users/duplicate_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/duplicate_beneficiary.py
@@ -24,6 +24,7 @@ def send_duplicate_beneficiary_email(
         duplicate_beneficiary = fraud_api.find_duplicate_beneficiary(
             identity_content.get_first_name(),  # type: ignore [arg-type]
             identity_content.get_last_name(),  # type: ignore [arg-type]
+            identity_content.get_married_name(),
             identity_content.get_birth_date(),  # type: ignore [arg-type]
             rejected_user.id,
         )

--- a/api/src/pcapi/scripts/force_19yo_dms_import.py
+++ b/api/src/pcapi/scripts/force_19yo_dms_import.py
@@ -76,12 +76,15 @@ def force_19yo_dms_import(dry_run: bool = True) -> None:
             user, "honor statement contained in DMS application", eligibility_type
         )
         fraud_items = fraud_api.dms_fraud_checks(user, fraud_check)
+        content = fraud_check.source_data()
         fraud_items.append(
-            fraud_api._duplicate_user_fraud_item(user.firstName, user.lastName, None, user.dateOfBirth, user.id)
+            fraud_api._duplicate_user_fraud_item(
+                content.get_first_name(), content.get_last_name(), content.get_married_name(), user.dateOfBirth, user.id
+            )
         )
         if all(fraud_item.status == fraud_models.FraudStatus.OK for fraud_item in fraud_items):
             try:
-                subscription_api.on_successful_application(user, fraud_check.source_data())
+                subscription_api.on_successful_application(user, content)
             except Exception:  # pylint: disable=broad-except
                 logger.warning("Cannot activate user %d", user.id, exc_info=True)
                 continue

--- a/api/src/pcapi/scripts/force_19yo_dms_import.py
+++ b/api/src/pcapi/scripts/force_19yo_dms_import.py
@@ -75,8 +75,8 @@ def force_19yo_dms_import(dry_run: bool = True) -> None:
         fraud_api.create_honor_statement_fraud_check(
             user, "honor statement contained in DMS application", eligibility_type
         )
-        fraud_items = fraud_api.dms_fraud_checks(user, fraud_check)
         content = fraud_check.source_data()
+        fraud_items = fraud_api.dms_fraud_checks(user, content)
         fraud_items.append(
             fraud_api._duplicate_user_fraud_item(
                 content.get_first_name(), content.get_last_name(), content.get_married_name(), user.dateOfBirth, user.id

--- a/api/src/pcapi/scripts/force_19yo_dms_import.py
+++ b/api/src/pcapi/scripts/force_19yo_dms_import.py
@@ -77,7 +77,7 @@ def force_19yo_dms_import(dry_run: bool = True) -> None:
         )
         fraud_items = fraud_api.dms_fraud_checks(user, fraud_check)
         fraud_items.append(
-            fraud_api._duplicate_user_fraud_item(user.firstName, user.lastName, user.dateOfBirth, user.id)
+            fraud_api._duplicate_user_fraud_item(user.firstName, user.lastName, None, user.dateOfBirth, user.id)
         )
         if all(fraud_item.status == fraud_models.FraudStatus.OK for fraud_item in fraud_items):
             try:

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -411,7 +411,7 @@ class EduconnectFraudTest:
             resultContent=fraud_factories.EduconnectContentFactory(age=age),
             user=user,
         )
-        result = fraud_api.educonnect_fraud_checks(user, beneficiary_fraud_check=fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, fraud_check.source_data())
 
         age_check = next(
             fraud_check
@@ -430,7 +430,7 @@ class EduconnectFraudTest:
             type=fraud_models.FraudCheckType.EDUCONNECT,
             resultContent=fraud_factories.EduconnectContentFactory(age=age),
         )
-        result = fraud_api.educonnect_fraud_checks(user, beneficiary_fraud_check=fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user, fraud_check.source_data())
 
         age_check = next(
             (
@@ -477,7 +477,7 @@ class EduconnectFraudTest:
             user=underage_user,
             eligibilityType=users_models.EligibilityType.UNDERAGE,
         )
-        result = fraud_api.educonnect_fraud_checks(underage_user, fraud_check)
+        result = fraud_api.educonnect_fraud_checks(underage_user, fraud_check.source_data())
 
         assert not any(fraud_item.reason_code == fraud_models.FraudReasonCode.DUPLICATE_USER for fraud_item in result)
 
@@ -489,7 +489,7 @@ class EduconnectFraudTest:
             resultContent=fraud_factories.EduconnectContentFactory(ine_hash=same_ine_user.ineHash),
             user=user_in_validation,
         )
-        result = fraud_api.educonnect_fraud_checks(user_in_validation, fraud_check)
+        result = fraud_api.educonnect_fraud_checks(user_in_validation, fraud_check.source_data())
 
         duplicate_ine_check = next(
             fraud_check

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -127,7 +127,11 @@ class CommonFraudCheckTest:
 
     def test_duplicate_user_fraud_ok(self):
         fraud_item = fraud_api._duplicate_user_fraud_item(
-            first_name="Jean", last_name="Michel", birth_date=datetime.date.today(), excluded_user_id=1
+            first_name="Jean",
+            last_name="Michel",
+            married_name=None,
+            birth_date=datetime.date.today(),
+            excluded_user_id=1,
         )
 
         assert fraud_item.status == fraud_models.FraudStatus.OK
@@ -137,6 +141,7 @@ class CommonFraudCheckTest:
         fraud_item = fraud_api._duplicate_user_fraud_item(
             first_name=user.firstName,
             last_name=user.lastName,
+            married_name=None,
             birth_date=user.dateOfBirth.date(),
             excluded_user_id=1,
         )
@@ -148,6 +153,7 @@ class CommonFraudCheckTest:
         fraud_item = fraud_api._duplicate_user_fraud_item(
             first_name=user.firstName,
             last_name=user.lastName,
+            married_name=None,
             birth_date=user.dateOfBirth.date(),
             excluded_user_id=user.id,
         )
@@ -222,7 +228,9 @@ class FindDuplicateUserTest:
         )
 
         assert (
-            fraud_api.find_duplicate_beneficiary("Alice", "RAVINEAU ", self.birth_date.date(), existing_user.id + 1)
+            fraud_api.find_duplicate_beneficiary(
+                "Alice", "RAVINEAU ", None, self.birth_date.date(), existing_user.id + 1
+            )
             == existing_user
         )
 
@@ -235,7 +243,9 @@ class FindDuplicateUserTest:
         )
 
         assert (
-            fraud_api.find_duplicate_beneficiary(self.first_name, self.last_name, self.birth_date, existing_user.id)
+            fraud_api.find_duplicate_beneficiary(
+                self.first_name, self.last_name, None, self.birth_date, existing_user.id
+            )
             is None
         )
 
@@ -247,8 +257,42 @@ class FindDuplicateUserTest:
         )
 
         assert (
-            fraud_api.find_duplicate_beneficiary(self.first_name, self.last_name, self.birth_date, existing_user.id + 1)
+            fraud_api.find_duplicate_beneficiary(
+                self.first_name, self.last_name, None, self.birth_date, existing_user.id + 1
+            )
             is None
+        )
+
+    def test_duplicate_user_with_married_name(self):
+        existing_user = users_factories.UserFactory(
+            firstName=self.first_name,
+            lastName=self.last_name,
+            married_name=None,
+            dateOfBirth=self.birth_date,
+            roles=[users_models.UserRole.BENEFICIARY],
+        )
+
+        assert (
+            fraud_api.find_duplicate_beneficiary(
+                "Alice", "Nom de jeune fille ", "RAVINEAU", self.birth_date.date(), existing_user.id + 1
+            )
+            == existing_user
+        )
+
+    def test_duplicate_user_with_last_name_matching_married_name(self):
+        existing_user = users_factories.UserFactory(
+            firstName=self.first_name,
+            lastName="Nom de jeune fille",
+            married_name="RAVINEAU",
+            dateOfBirth=self.birth_date,
+            roles=[users_models.UserRole.BENEFICIARY],
+        )
+
+        assert (
+            fraud_api.find_duplicate_beneficiary(
+                "Alice", "Ravineau", None, self.birth_date.date(), existing_user.id + 1
+            )
+            == existing_user
         )
 
 

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -1699,6 +1699,7 @@ class UbbleWebhookTest:
         assert not user.has_beneficiary_role
         assert ubble_fraud_check.status == fraud_models.FraudCheckStatus.SUSPICIOUS
         assert fraud_models.FraudReasonCode.ID_CHECK_EXPIRED in ubble_fraud_check.reasonCodes
+        assert fraud_models.FraudReasonCode.MISSING_REQUIRED_DATA in ubble_fraud_check.reasonCodes
 
         assert ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, user.eligibility)  # retry allowed
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13871

## But de la pull request

Renforcer la détection d'utilisateur en doublon en faisant une correspondance sur le "married_name" ou "nom d'usage" en français.

ex : 
Je fais ubble avec mon passeport, prénom : 'Alphonse', nom : 'Brown' ( il n'y a pas de nom d'usage sur mon passeport). Puis je crée un autre compte et je fais ubble avec ma carte d'identité :  prénom : 'Alphonse', nom : 'Daudet',  nom d'usage : 'Brown'.

Il faut réussir à matcher ces deux utilisateurs derrière lesquels se cache en fait un unique jeune de 18 ans.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
