### PR TITLE
(BSR)[API] chore: ignore deprecation warning in tests for distutils

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -10,6 +10,10 @@ addopts=
     # FIXME (jsdupuis, 2022-04-14): can be removed when we use flask-sqlalchemy >=2.5
     # (https://github.com/pallets-eco/flask-sqlalchemy/commit/3565f0587519168c5ea4301f6e4bfba8c2ac4dee)
     -W"ignore:'__ident_func__' is deprecated and will be removed in Werkzeug 2.1.:DeprecationWarning"
+    # FIXME (rpaoloni, 2022-04-19): some of our dependencies (swift and rq) use `distutils.version.StrictVersion`,
+    # which emits a deprecation warnings with setuptools >=59.6.0. Remove this when we update or remove those
+    # dependencies.
+    -W"ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning"
 testpaths=tests
 norecursedirs=.git venv/ .pytest_cache/
 # Synchronize these globs with `TEST_FILES` in CircleCI configuration


### PR DESCRIPTION
ignore les deprecation warning pour distutils dans les tests pour pouvoir les lancer avec setuptools 60+