### PR TITLE
(PC-14573) Avoid JSONDecodeError reported by Sentry (Sendinblue timeout)

### DIFF
--- a/api/src/pcapi/core/users/external/sendinblue.py
+++ b/api/src/pcapi/core/users/external/sendinblue.py
@@ -392,6 +392,10 @@ def add_contacts_to_list(user_emails: Iterable[str], sib_list_id: int, clear_lis
                 _wait_for_process(process_api_instance, remove_response.contacts.process_id)
 
         except SendinblueApiException as exception:
+            if exception.status == 524:
+                # Handled first because response is a generic html page, not the expected json body
+                logger.exception("Timeout when calling ContactsApi->remove_contact_from_list(%d)", sib_list_id)
+                return False
             message = json.loads(exception.body).get("message")
             if exception.status == 400 and message == "Contacts already removed from list and/or does not exist":
                 logger.info("ContactsApi->remove_contact_from_list(%d): list was already empty", sib_list_id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14573

## But de la pull request

Éviter une exception JSONDecodeError remontée par Sentry lorsque l'API Sendinblue utilisée par les automations est en timeout.

## Implémentation

Même chose que plus haut dans make_update_request.

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
