### PR TITLE
(PC-14574)[API] fix: add check on resultContent nullability

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -533,6 +533,7 @@ def get_last_filled_identity_fraud_check(user: users_models.User) -> typing.Opti
         fraud_check
         for fraud_check in user.beneficiaryFraudChecks
         if fraud_check.type in models.IDENTITY_CHECK_TYPES
+        and fraud_check.resultContent is not None
         and fraud_check.source_data().get_last_name() is not None
         and fraud_check.source_data().get_first_name() is not None
         and fraud_check.source_data().get_birth_date() is not None


### PR DESCRIPTION
some fraud_checks are identity_fraud_check but do not have any resultContent, for example the ones created after migration of benficiary_imports

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14574

## But de la pull request

Erreur sentry : https://sentry.internal-passculture.app/organizations/sentry/issues/373422/?project=5&referrer=slack
