### PR TITLE
(PC-13207)[API] feat : update dms annotation on success if dossier is in draft mode

### DIFF
--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -126,7 +126,7 @@ class SaveVenueBankInformations:
                 update_demarches_simplifiees_text_annotations(
                     application_details.dossier_id,  # type: ignore [arg-type]
                     application_details.annotation_id,
-                    "Dossier imported Sucessfully",
+                    "Dossier successfully imported",
                 )
         return bank_information
 

--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -128,6 +128,12 @@ class SaveVenueBankInformations:
                     application_details.annotation_id,
                     "Dossier successfully imported",
                 )
+            if application_details.status == BankInformationStatus.DRAFT:
+                update_demarches_simplifiees_text_annotations(
+                    application_details.dossier_id,  # type: ignore [arg-type]
+                    application_details.annotation_id,
+                    "Valid dossier",
+                )
         return bank_information
 
     def get_referent_venue(

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -1215,3 +1215,24 @@ class SaveVenueBankInformationsTest:
                 "ANNOTATION_ID",
                 "Dossier successfully imported",
             )
+
+        @patch("pcapi.connectors.api_entreprises.check_siret_is_still_active", return_value=True)
+        @pytest.mark.usefixtures("db_session")
+        def test_update_text_application_details_on_draft_bank_information(
+            self, siret_active, mock_application_details, mock_update_text_annotation, app
+        ):
+            OffererFactory(siren="999999999")
+            offers_factories.VenueFactory(name="venuedemo", siret="36252187900034", businessUnit=None)
+            mock_application_details.return_value = self.build_application_detail(
+                {"status": BankInformationStatus.DRAFT}
+            )
+
+            self.save_venue_bank_informations.execute(1)
+
+            bank_information_count = BankInformation.query.count()
+            assert bank_information_count == 1
+            mock_update_text_annotation.assert_called_once_with(
+                "DOSSIER_ID",
+                "ANNOTATION_ID",
+                "Valid dossier",
+            )

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -1199,7 +1199,7 @@ class SaveVenueBankInformationsTest:
 
         @patch("pcapi.connectors.api_entreprises.check_siret_is_still_active", return_value=True)
         @pytest.mark.usefixtures("db_session")
-        def test_update_text_application_details_on_bank_information_success(
+        def test_update_text_application_details_on_validated_bank_information(
             self, siret_active, mock_application_details, mock_update_text_annotation, app
         ):
             OffererFactory(siren="999999999")
@@ -1213,5 +1213,5 @@ class SaveVenueBankInformationsTest:
             mock_update_text_annotation.assert_called_once_with(
                 "DOSSIER_ID",
                 "ANNOTATION_ID",
-                "Dossier imported Sucessfully",
+                "Dossier successfully imported",
             )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13207

## But de la pull request

Lorsque nous recevons un dossier dans un état DRAFT (étape "brouillon" ou "en instruction" coté DMS) nous mettons à jour le champ d'annotation DMS avec "Valid dossier"

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
