### PR TITLE
(PC-14444)[API] feat: update booking educational year if needed

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -146,7 +146,7 @@ def find_by_pro_user(
     )
 
 
-def find_unique_eac_booking_if_any(stock_id: int) -> list[Booking]:
+def find_unique_eac_booking_if_any(stock_id: int) -> Optional[Booking]:
     return Booking.query.filter(
         Booking.stockId == stock_id, not_(Booking.status == BookingStatus.CANCELLED)
     ).one_or_none()

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -768,17 +768,18 @@ def edit_educational_stock(stock: Stock, stock_data: dict) -> Stock:
     if educational_stock_unique_booking:
         validation.check_stock_booking_status(educational_stock_unique_booking)  # type: ignore [arg-type]
 
-        educational_stock_unique_booking.educationalBooking.confirmationLimitDate = updatable_fields[  # type: ignore [attr-defined]
+        educational_stock_unique_booking.educationalBooking.confirmationLimitDate = updatable_fields[  # type: ignore [attr-defined, union-attr]
             "bookingLimitDatetime"
         ]
         db.session.add(educational_stock_unique_booking.educationalBooking)  # type: ignore [attr-defined]
 
         if beginning:
             _update_educational_booking_cancellation_limit_date(educational_stock_unique_booking, beginning)  # type: ignore [arg-type]
+            educational_api._update_educational_booking_educational_year_id(educational_stock_unique_booking, beginning)
             db.session.add(educational_stock_unique_booking)
 
         if stock_data.get("price"):
-            educational_stock_unique_booking.amount = stock_data.get("price")  # type: ignore [attr-defined]
+            educational_stock_unique_booking.amount = stock_data.get("price")  # type: ignore [attr-defined, assignment]
             db.session.add(educational_stock_unique_booking)
 
     validation.check_educational_stock_is_editable(stock)

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -897,8 +897,12 @@ class EditCollectiveOfferStocksTest:
         stock = CollectiveStock.query.filter_by(id=stock_to_be_updated.id).first()
         assert stock.price == 1200
 
+    @freeze_time("2020-11-17 15:00:00")
     def should_update_bookings_cancellation_limit_date_if_event_postponed(self):
         # Given
+        educational_year = educational_factories.EducationalYearFactory(
+            beginningDate=datetime.datetime(2020, 9, 1), expirationDate=datetime.datetime(2021, 8, 31)
+        )
         initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=20)
         cancellation_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(beginningDatetime=initial_event_date)
@@ -907,6 +911,7 @@ class EditCollectiveOfferStocksTest:
             status=CollectiveBookingStatus.PENDING,
             cancellationLimitDate=cancellation_limit_date,
             confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=30),
+            educationalYear=educational_year,
         )
 
         new_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=25, hours=5)
@@ -926,6 +931,9 @@ class EditCollectiveOfferStocksTest:
     @freeze_time("2020-11-17 15:00:00")
     def should_update_bookings_cancellation_limit_date_if_beginningDatetime_earlier(self):
         # Given
+        educational_year = educational_factories.EducationalYearFactory(
+            beginningDate=datetime.datetime(2020, 9, 1), expirationDate=datetime.datetime(2021, 8, 31)
+        )
         initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=20)
         cancellation_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(beginningDatetime=initial_event_date)
@@ -934,6 +942,7 @@ class EditCollectiveOfferStocksTest:
             status=CollectiveBookingStatus.PENDING,
             cancellationLimitDate=cancellation_limit_date,
             confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=30),
+            educationalYear=educational_year,
         )
 
         new_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5, hours=5)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -18,6 +18,7 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 import pcapi.core.criteria.factories as criteria_factories
 from pcapi.core.educational import exceptions as educational_exceptions
+from pcapi.core.educational.factories import EducationalYearFactory
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 import pcapi.core.offerers.factories as offerers_factories
@@ -1054,15 +1055,22 @@ class EditEducationalOfferStocksTest:
         stock = models.Stock.query.filter_by(id=stock_to_be_updated.id).first()
         assert stock.price == 1200
 
+    @freeze_time("2020-11-17 15:00:00")
     def should_update_bookings_cancellation_limit_date_if_event_postponed(self):
         # Given
+        educational_year = EducationalYearFactory(
+            beginningDate=datetime(2020, 9, 1), expirationDate=datetime(2021, 8, 31)
+        )
         initial_event_date = datetime.utcnow() + timedelta(days=20)
         cancellation_limit_date = datetime.utcnow() + timedelta(days=5)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date, quantity=1, dnBookedQuantity=1
         )
         booking = bookings_factories.EducationalBookingFactory(
-            stock=stock_to_be_updated, status=BookingStatus.PENDING, cancellation_limit_date=cancellation_limit_date
+            stock=stock_to_be_updated,
+            status=BookingStatus.PENDING,
+            cancellation_limit_date=cancellation_limit_date,
+            educationalBooking__educationalYear=educational_year,
         )
 
         new_event_date = datetime.utcnow() + timedelta(days=25, hours=5)
@@ -1080,13 +1088,19 @@ class EditEducationalOfferStocksTest:
     @freeze_time("2020-11-17 15:00:00")
     def should_update_bookings_cancellation_limit_date_if_beginningDatetime_earlier(self):
         # Given
+        educational_year = EducationalYearFactory(
+            beginningDate=datetime(2020, 9, 1), expirationDate=datetime(2021, 8, 31)
+        )
         initial_event_date = datetime.utcnow() + timedelta(days=20)
         cancellation_limit_date = datetime.utcnow() + timedelta(days=5)
         stock_to_be_updated = factories.EducationalEventStockFactory(
             beginningDatetime=initial_event_date, quantity=1, dnBookedQuantity=1
         )
         booking = bookings_factories.EducationalBookingFactory(
-            stock=stock_to_be_updated, status=BookingStatus.PENDING, cancellation_limit_date=cancellation_limit_date
+            stock=stock_to_be_updated,
+            status=BookingStatus.PENDING,
+            cancellation_limit_date=cancellation_limit_date,
+            educationalBooking__educationalYear=educational_year,
         )
 
         new_event_date = datetime.utcnow() + timedelta(days=5, hours=5)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14444

## But de la pull request

Si un AC modifie la date de l'événement pour une année scolaire différente de celle de base, on modifie l'année scolaire du booking associé pour que le budget soit prélevé sur la bonne année scolaire
