### PR TITLE
[API] PC 13843 index venues with active offers

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -37,6 +37,7 @@ from pcapi.core.users.models import User
 from pcapi.core.users.repository import get_users_with_validated_attachment_by_offerer
 from pcapi.domain.admin_emails import maybe_send_offerer_validation_email
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
 from pcapi.repository import repository
 from pcapi.routes.serialization import base as serialize_base
 from pcapi.routes.serialization.offerers_serialize import CreateOffererQueryModel
@@ -476,6 +477,9 @@ def is_venue_eligible_for_strict_search(venue: offerers_models.Venue) -> bool:
       1. it is eligible for search and validated/active;
       2. at least one if its offers is eligible for search
     """
+    if not FeatureToggle.ENABLE_VENUE_STRICT_SEARCH.is_active():
+        return True
+
     if not venue.is_eligible_for_search or not venue.isReleased:
         return False
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -31,6 +31,7 @@ from pcapi.core.offerers.repository import find_user_offerer_by_validation_token
 from pcapi.core.offerers.repository import get_all_offerers_for_user
 from pcapi.core.offerers.repository import get_by_collective_offer_id
 from pcapi.core.offerers.repository import get_by_collective_offer_template_id
+from pcapi.core.offers import models as offers_models
 from pcapi.core.users.external import update_external_pro
 from pcapi.core.users.models import User
 from pcapi.core.users.repository import get_users_with_validated_attachment_by_offerer
@@ -467,3 +468,22 @@ def get_offerer_by_collective_offer_id(collective_offer_id: int) -> Offerer:
 
 def get_offerer_by_collective_offer_template_id(collective_offer_id: int) -> Offerer:
     return get_by_collective_offer_template_id(collective_offer_id)
+
+
+def is_venue_eligible_for_strict_search(venue: offerers_models.Venue) -> bool:
+    """
+    A venue is considered eligible for strict search if
+      1. it is eligible for search and validated/active;
+      2. at least one if its offers is eligible for search
+    """
+    if not venue.is_eligible_for_search or not venue.isReleased:
+        return False
+
+    at_least_one_eligible_offer_query = (
+        offers_models.Stock.query.join(offers_models.Offer)
+        .filter(offers_models.Offer.venueId == venue.id)
+        .filter(offers_models.Offer.is_eligible_for_search)
+        .exists()
+    )
+
+    return db.session.query(at_least_one_eligible_offer_query).scalar()

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -226,7 +226,8 @@ class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixi
 
     @property
     def is_eligible_for_search(self) -> bool:
-        return self.isPermanent and self.managingOfferer.isActive and self.venueTypeCode != VenueTypeCode.ADMINISTRATIVE  # type: ignore [return-value, attr-defined]
+        not_administrative = self.venueTypeCode != VenueTypeCode.ADMINISTRATIVE  # type: ignore [attr-defined]
+        return self.isPermanent and self.managingOfferer.isActive and not_administrative  # type: ignore [return-value]
 
     def store_departement_code(self) -> None:
         if not self.postalCode:
@@ -281,6 +282,10 @@ class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixi
         which have at most one banner (thumb).
         """
         return "{}/{}/{}".format(self.thumb_base_url, self.thumb_path_component, humanize(self.id))
+
+    @property
+    def isReleased(self) -> bool:
+        return self.isValidated and self.managingOfferer.isActive and self.managingOfferer.isValidated
 
     @hybrid_property
     def timezone(self) -> str:

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -8,6 +8,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers.models import Offer
 from pcapi.core.search.backends import base
+from pcapi.models.feature import FeatureToggle
 from pcapi.repository import offer_queries
 from pcapi.utils.module_loading import import_string
 
@@ -442,6 +443,9 @@ def _reindex_venues_from_offers(offer_ids: Iterable[int]) -> None:
     """
     Get the offers' venue ids and reindex them
     """
+    if not FeatureToggle.ENABLE_VENUE_STRICT_SEARCH.is_active():
+        return
+
     query = Offer.query.filter(Offer.id.in_(offer_ids)).with_entities(Offer.venueId).distinct()
     venue_ids = [row[0] for row in query]
 

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -9,6 +9,7 @@ import redis
 
 from pcapi import settings
 import pcapi.core.educational.models as educational_models
+import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 from pcapi.core.search.backends import base
@@ -458,6 +459,7 @@ class AlgoliaBackend(base.SearchBackend):
             "tags": [criterion.name for criterion in venue.criteria],
             "banner_url": venue.bannerUrl,
             "_geoloc": position(venue),
+            "is_eligible_for_strict_search": offerers_api.is_venue_eligible_for_strict_search(venue),
         }
 
     @classmethod

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -96,6 +96,9 @@ class FeatureToggle(enum.Enum):
     OFFER_FORM_V3 = "Afficher la version 3 du formulaire d'offre"
     ALLOW_ACCOUNT_REACTIVATION = "Activer le nouveau parcours de réactivation de compte"
     ENABLE_NEW_ALGOLIA_INDEX_ON_ADAGE = "Active l'utilisation des nouveaux indexes algolia sur adage"
+    ENABLE_VENUE_STRICT_SEARCH = (
+        "Active le fait d'indiquer si un lieu a un moins une offre éligible lors de l'indexation (Algolia)"
+    )
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -154,6 +157,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.USER_PROFILING_FRAUD_CHECK,
     FeatureToggle.ALLOW_ACCOUNT_REACTIVATION,
     FeatureToggle.ENABLE_NEW_ALGOLIA_INDEX_ON_ADAGE,
+    FeatureToggle.ENABLE_VENUE_STRICT_SEARCH,
 )
 
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -16,6 +16,7 @@ from pcapi.core.offerers.models import ApiKey
 from pcapi.core.offerers.models import Venue
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.core.users import factories as users_factories
 from pcapi.models import api_errors
@@ -724,34 +725,40 @@ def test_delete_business_unit():
 
 
 class IsVenueEligibleForStrictSearchTest:
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_eligible(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
         offers_factories.EventStockFactory(offer__venue=venue)
 
         assert offerers_api.is_venue_eligible_for_strict_search(venue)
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_venue_not_validated(self):
         venue = offerers_factories.VenueFactory(isPermanent=True, validationToken="not_validated_yet")
         offers_factories.EventStockFactory(offer__venue=venue)
 
         assert not offerers_api.is_venue_eligible_for_strict_search(venue)
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_no_offers(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
         assert not offerers_api.is_venue_eligible_for_strict_search(venue)
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_managing_offerer_not_validated(self):
         venue = offerers_factories.VenueFactory(isPermanent=True, managingOfferer__validationToken="not_validated_yet")
         offers_factories.EventStockFactory(offer__venue=venue)
 
         assert not offerers_api.is_venue_eligible_for_strict_search(venue)
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_offer_without_stock(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
         offers_factories.OfferFactory(venue=venue)
 
         assert not offerers_api.is_venue_eligible_for_strict_search(venue)
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_expired_event(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
 
@@ -760,6 +767,7 @@ class IsVenueEligibleForStrictSearchTest:
 
         assert not offerers_api.is_venue_eligible_for_strict_search(venue)
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_only_one_bookable_offer(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
 

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -7,6 +7,7 @@ from pcapi.core.offerers import models as offerers_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.search.testing as search_testing
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 
 
@@ -119,6 +120,7 @@ class ReindexOfferIdsTest:
         assert offer.id in search_testing.search_store["offers"]
         assert app.redis_client.lrange("offer_ids_in_error", 0, 5) == [str(offer.id)]
 
+    @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_reindex_venues_after_reindexing_offers(self, app):
         offer = make_bookable_offer()
         assert search_testing.search_store["offers"] == {}
@@ -196,6 +198,7 @@ class IndexOffersInQueueTest:
         assert app.redis_client.llen("offer_ids") == 0
 
 
+@override_features(ENABLE_VENUE_STRICT_SEARCH=True)
 def test_unindex_offer_ids(app):
     offer1 = make_bookable_offer()
     offer2 = make_bookable_offer()

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -163,7 +163,16 @@ def test_serialize_venue():
         "tags": [],
         "banner_url": venue.bannerUrl,
         "_geoloc": {"lng": float(venue.longitude), "lat": float(venue.latitude)},
+        "is_eligible_for_strict_search": True,
     }
+
+
+def test_serialize_eligible_for_strict_search_venue():
+    venue = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.EventStockFactory(offer__venue=venue)
+
+    serialized = algolia.AlgoliaBackend().serialize_venue(venue)
+    assert serialized["is_eligible_for_strict_search"]
 
 
 def test_serialize_collective_offer():


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13843 

## But de la pull request

Ajouter une information lors de la sérialisation d'un lieu : est-il éligible et a-t-il au moins une offre éligible à l'indexation ?
Ceci permettra de filtrer les lieux à certains endroits (par exemple n'afficher que des lieux qui ont au moins une offre sur la page d'accueil etc).

### Est-ce qu'un lieu a au moins une offre éligible à la recherche : requête SQL

```sql
SELECT EXISTS (
    SELECT 1
    FROM
        stock
    JOIN
        offer ON offer.id = stock."offerId"
    WHERE
        offer."venueId" = <venue_id>
        AND offer."isActive"
        AND offer.validation = 'APPROVED'
        AND NOT (
            stock."beginningDatetime" IS NOT NULL
            AND stock."beginningDatetime" <= now()
            OR stock."bookingLimitDatetime" IS NOT NULL
            AND stock."bookingLimitDatetime" <= now()
        ) AND NOT (
            stock."isSoftDeleted"
            OR (
                stock."beginningDatetime" IS NOT NULL
                AND stock."beginningDatetime" <= now()
            ) OR (
                CASE
                    WHEN (stock.quantity IS NULL)
                    THEN NULL
                    ELSE stock.quantity - stock."dnBookedQuantity"
                END IS NOT NULL
                AND CASE
                    WHEN (stock.quantity IS NULL)
                    THEN NULL
                    ELSE stock.quantity - stock."dnBookedQuantity"
                END <= 0
            )
        )
) AS anon_1
```

La requête est très rapide. J'ai testé en staging avec des lieux qui possèdent un grand nombre d'offres et je n'ai jamais atteint plus de 20-30ms. Mais j'ai peut-être raté quelque chose qui rend la requête fausse mais rapide ?