### PR TITLE
(BSR)[PRO] fix: Only initialize firebase userId once

### DIFF
--- a/pro/src/app/App.jsx
+++ b/pro/src/app/App.jsx
@@ -20,6 +20,7 @@ export const App = props => {
   } = props
 
   const [isReady, setIsReady] = useState(false)
+  const [isAnalyticsInitialized, setIsAnalyticsInitialized] = useState(false)
   const { isUserInitialized, currentUser } = useCurrentUser()
   const analytics = useAnalytics()
   const currentPathname = window.location.pathname
@@ -50,7 +51,10 @@ export const App = props => {
 
     if (isUserInitialized && currentUser) {
       setSentryUser({ id: currentUser.id })
-      analytics.setAnalyticsUserId(currentUser.id)
+      if (!isAnalyticsInitialized) {
+        analytics.setAnalyticsUserId(currentUser.id)
+        setIsAnalyticsInitialized(true)
+      }
       setIsReady(true)
     }
   }, [
@@ -60,6 +64,7 @@ export const App = props => {
     history,
     location,
     isUserInitialized,
+    isAnalyticsInitialized,
   ])
 
   useEffect(() => {


### PR DESCRIPTION
## But de la pull request

La multiple configuration de userId a l'air de poser des problèmes à firebase/GA pour les comptes d'event par utilisateur. 


## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
