### PR TITLE
(PC-13585)[API] feat: Set a timeout for HTTP requests to SendinBlue

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -240,9 +240,6 @@ def price_booking(booking: bookings_models.Booking) -> models.Pricing:
                 sqla_orm.joinedload(bookings_models.Booking.venue, innerjoin=True)
                 .joinedload(offerers_models.Venue.businessUnit, innerjoin=True)
                 .joinedload(models.BusinessUnit.venue_links, innerjoin=True),
-                sqla_orm.joinedload(bookings_models.Booking.venue, innerjoin=True).joinedload(
-                    offerers_models.Venue.businessUnit, innerjoin=True
-                ),
                 sqla_orm.joinedload(bookings_models.Booking.stock, innerjoin=True).joinedload(
                     offers_models.Stock.offer, innerjoin=True
                 ),

--- a/api/src/pcapi/core/monkeypatches.py
+++ b/api/src/pcapi/core/monkeypatches.py
@@ -4,7 +4,7 @@ import time
 from pcapi.utils.requests import logger
 
 
-SENDINBLUE_REQUEST_TIMEOUT = 5
+SENDINBLUE_REQUEST_TIMEOUT = 10
 
 
 def custom_restclient_request(self, method, url, **kwargs):  # type: ignore [no-untyped-def]
@@ -12,9 +12,8 @@ def custom_restclient_request(self, method, url, **kwargs):  # type: ignore [no-
     that sets a default timeout and logs the request.
     """
     start = time.perf_counter()
-    # FIXME (dbaty, 2022-02-21): once we have gathered logs, we can
-    # set an appropriate timeout value with the following line:
-    # kwargs.setdefault("_request_timeout", SENDINBLUE_REQUEST_TIMEOUT)
+    if kwargs.get("_request_timeout") is None:
+        kwargs["_request_timeout"] = SENDINBLUE_REQUEST_TIMEOUT
     try:
         response = self.__orig_request(method, url, **kwargs)
     except Exception as exc:


### PR DESCRIPTION
See PC-13585 for an analysis of SendinBlue response times and why this
timeout value was chosen.


---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13585