### PR TITLE
(PC-14572) Fix exception in FA when an offerer is deleted (crashes if activation code exists)

### DIFF
--- a/api/tests/scripts/offerer/delete_cascade_offerer_by_id_test.py
+++ b/api/tests/scripts/offerer/delete_cascade_offerer_by_id_test.py
@@ -14,6 +14,7 @@ from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import UserOfferer
 from pcapi.core.offerers.models import Venue
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.offers.models import ActivationCode
 from pcapi.core.offers.models import Mediation
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -53,12 +54,14 @@ def test_delete_cascade_offerer_should_abort_when_offerer_has_any_bookings():
 
 
 @pytest.mark.usefixtures("db_session")
-def test_delete_cascade_offerer_should_remove_managed_venues_offers_and_stocks():
+def test_delete_cascade_offerer_should_remove_managed_venues_offers_stocks_and_activation_codes():
     # Given
     offerer_to_delete = offers_factories.OffererFactory()
     offers_factories.OfferFactory(venue__managingOfferer=offerer_to_delete)
-    offers_factories.StockFactory(offer__venue__managingOfferer=offerer_to_delete)
-    offers_factories.StockFactory()
+    stock_1 = offers_factories.StockFactory(offer__venue__managingOfferer=offerer_to_delete)
+    stock_2 = offers_factories.StockFactory()
+    offers_factories.ActivationCodeFactory(stock=stock_1)
+    offers_factories.ActivationCodeFactory(stock=stock_2)
 
     # When
     delete_cascade_offerer_by_id(offerer_to_delete.id)
@@ -68,6 +71,7 @@ def test_delete_cascade_offerer_should_remove_managed_venues_offers_and_stocks()
     assert Venue.query.count() == 1
     assert Offer.query.count() == 1
     assert Stock.query.count() == 1
+    assert ActivationCode.query.count() == 1
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14572

## But de la pull request

Corriger un crash lors de la suppression d'une structure, sans réservation mais ayant des codes d'activation liés à des offres.

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
