### PR TITLE
(BSR)[PRO] chore: jest.setup: add console.error calls count

### DIFF
--- a/pro/jest.setup.js
+++ b/pro/jest.setup.js
@@ -8,6 +8,13 @@ configure({ adapter: new Adapter() })
 global.fetch = fetch
 const originalGetComputedStyle = window.getComputedStyle
 
+const originalConsoleError = window.console.error
+let nbCalls = 0
+window.console.error = (msg) => {
+  nbCalls += 1
+  originalConsoleError(`[call count: ${nbCalls}] ${msg}`)
+}
+
 // required for setting 0 values and to avoid warnings like "NAN is not a number" within jest tests
 // getComputedStyle is used by react calendar and cause this issue
 const getComputedStyle = (...args) => {
@@ -48,3 +55,4 @@ fetch.mockResponse(req => {
 
 jest.mock('tracking/mediaCampaignsTracking')
 jest.mock('components/hooks/useAnalytics')
+


### PR DESCRIPTION
Il y à trop de warning pour voir si de nouveau apparaisse lorsque l'on fait des changement.
Je propose ici d'ajouter un count afin d'avoir un moyen de surveiller les changements:
```sh
 [call count: 65] Warning: An update to %s inside a test was not wrapped in act(...).
```

J'aurais aimer trouver une solution pour afficher un recap à la fin des test mais mes recherches on été infructueuse.