### PR TITLE
(PC-13641)[PRO] feat: keep original venue image

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ButtonEditImage/ButtonEditImage.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ButtonEditImage/ButtonEditImage.tsx
@@ -6,26 +6,27 @@ import { Button } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
 import { ImageUploadButton } from '../ImageUploadButton/ImageUploadButton'
+import { IVenueBannerMetaProps } from '../ImageVenueUploaderSection/ImageVenueUploaderSection'
 import { VenueImageUploaderModal } from '../ImageVenueUploaderSection/VenueImageUploaderModal'
 
 import styles from './ButtonEditImage.module.scss'
 
 interface IButtonEditImage {
   venueId: string
-  venueCredit?: string
+  venueBanner?: IVenueBannerMetaProps
   venueImage?: string
   onImageUpload: ({
     bannerUrl,
-    credit,
+    bannerMeta,
   }: {
     bannerUrl: string
-    credit: string
+    bannerMeta: IVenueBannerMetaProps
   }) => void
 }
 
 const ButtonEditImage = ({
   venueId,
-  venueCredit,
+  venueBanner,
   venueImage,
   onImageUpload,
 }: IButtonEditImage): JSX.Element => {
@@ -33,7 +34,7 @@ const ButtonEditImage = ({
 
   return (
     <>
-      {venueImage ? (
+      {venueBanner?.original_image_url ? (
         <Button onClick={showModal} variant={ButtonVariant.TERNARY}>
           <Icon
             alt="Modifier l'image du lieu"
@@ -47,11 +48,11 @@ const ButtonEditImage = ({
       )}
       {!!visible && (
         <VenueImageUploaderModal
-          defaultImage={venueImage || undefined}
           onDismiss={hideModal}
           onImageUpload={onImageUpload}
-          venueCredit={venueCredit || ''}
+          venueBanner={venueBanner}
           venueId={venueId}
+          venueImage={venueImage}
         />
       )}
     </>

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageVenueUploaderSection/ImageVenueUploaderSection.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageVenueUploaderSection/ImageVenueUploaderSection.tsx
@@ -10,21 +10,34 @@ import styles from './ImageVenueUploaderSection.module.scss'
 type ImageVenueUploaderSectionProps = {
   venueId: string
   venueImage: string | null
-  venueCredit: string
+  venueBanner: IVenueBannerMetaProps | null
   onImageUpload: ({
     bannerUrl,
-    credit,
+    bannerMeta,
   }: {
     bannerUrl: string
-    credit: string
+    bannerMeta: IVenueBannerMetaProps
   }) => void
   onDeleteImage: () => void
+}
+
+export interface IVenueBannerMetaProps {
+  image_credit: string
+  original_image_url: string
+  crop_params: IVenueBannerMetaCropParamsProps
+}
+
+export interface IVenueBannerMetaCropParamsProps {
+  x_crop_percent: number
+  y_crop_percent: number
+  height_crop_percent: number
+  width_crop_percent: number
 }
 
 export const ImageVenueUploaderSection = ({
   venueId,
   venueImage,
-  venueCredit,
+  venueBanner,
   onImageUpload,
   onDeleteImage,
 }: ImageVenueUploaderSectionProps): JSX.Element => {
@@ -44,7 +57,7 @@ export const ImageVenueUploaderSection = ({
         <br />
         Elle permettra au public de mieux identifier votre lieu.
       </p>
-      {venueImage ? (
+      {venueImage && venueBanner?.original_image_url ? (
         <div className={styles['image-venue-uploader-section-image-container']}>
           <VenueImage url={venueImage} />
           <div
@@ -52,7 +65,7 @@ export const ImageVenueUploaderSection = ({
           >
             <ButtonEditImage
               onImageUpload={onImageUpload}
-              venueCredit={venueCredit}
+              venueBanner={venueBanner}
               venueId={venueId}
               venueImage={venueImage}
             />

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageVenueUploaderSection/VenueImageUploaderModal.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/ImageVenueUploaderSection/VenueImageUploaderModal.tsx
@@ -5,6 +5,10 @@ import { getDataURLFromImageURL } from 'api/utils/api'
 import useNotification from 'components/hooks/useNotification'
 import { imageConstraints } from 'new_components/ConstraintCheck/imageConstraints'
 import DialogBox from 'new_components/DialogBox'
+import {
+  coordonateToPosition,
+  heightCropPercentToScale,
+} from 'new_components/ImageEditor/utils'
 import { postImageToVenue } from 'repository/pcapi/pcapi'
 
 import { ImportFromComputer } from '../ImportFromComputer/ImportFromComputer'
@@ -52,16 +56,22 @@ export const VenueImageUploaderModal = ({
   const [isUploading, setIsUploading] = useState(false)
   // First version of the back don't use width_crop_percent which is needed to display the original image with the correct crop
   const [editorInitialScale, setEditorInitialScale] = useState(
-    venueBanner ? 1 / venueBanner.crop_params.height_crop_percent : 1
+    venueBanner
+      ? heightCropPercentToScale(venueBanner.crop_params.height_crop_percent)
+      : 1
   )
   const [editorInitialPosition, setEditorInitialPosition] = useState({
     x: venueBanner
-      ? venueBanner.crop_params.x_crop_percent +
-        venueBanner.crop_params.width_crop_percent / 2
+      ? coordonateToPosition(
+          venueBanner.crop_params.x_crop_percent,
+          venueBanner.crop_params.width_crop_percent
+        )
       : 0.5,
     y: venueBanner
-      ? venueBanner.crop_params.y_crop_percent +
-        venueBanner.crop_params.height_crop_percent / 2
+      ? coordonateToPosition(
+          venueBanner.crop_params.y_crop_percent,
+          venueBanner.crop_params.height_crop_percent
+        )
       : 0.5,
   })
   const notification = useNotification()

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
@@ -61,14 +61,11 @@ const VenueEdition = () => {
   )
 
   const onImageUpload = useCallback(
-    ({ bannerUrl, credit }) => {
+    ({ bannerUrl, bannerMeta }) => {
       setVenue({
         ...venue,
         bannerUrl,
-        bannerMeta: {
-          ...venue.bannerMeta,
-          image_credit: credit,
-        },
+        bannerMeta,
       })
     },
     [venue]
@@ -120,10 +117,7 @@ const VenueEdition = () => {
     setVenue({
       ...venue,
       bannerUrl: undefined,
-      bannerMeta: {
-        ...venue.bannerMeta,
-        image_credit: undefined,
-      },
+      bannerMeta: undefined,
     })
   }, [venue])
 
@@ -286,9 +280,7 @@ const VenueEdition = () => {
             <ImageVenueUploaderSection
               onDeleteImage={onDeleteImage}
               onImageUpload={onImageUpload}
-              venueCredit={
-                venue.bannerMeta ? venue.bannerMeta.image_credit : undefined
-              }
+              venueBanner={venue.bannerMeta}
               venueId={venue.id}
               venueImage={venue.bannerUrl}
             />

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueImageEdit/VenueImageEdit.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueImageEdit/VenueImageEdit.tsx
@@ -5,6 +5,7 @@ import useNotification from 'components/hooks/useNotification'
 import { ReactComponent as DownloadIcon } from 'icons/ico-download-filled.svg'
 import { CreditInput } from 'new_components/CreditInput/CreditInput'
 import ImageEditor from 'new_components/ImageEditor/ImageEditor'
+import { coordonateToPosition } from 'new_components/ImageEditor/utils'
 import { Button, Divider } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -55,10 +56,6 @@ export const VenueImageEdit = ({
         const canvas = editorRef.current.getImage()
         const croppingRect = editorRef.current.getCroppingRect()
 
-        // croppingRect give us the top left corner of the cropped area
-        // where AvatarEditor expect the center of it
-        const coordonateToPosition = (coordonate: number, size: number) =>
-          coordonate + size / 2
         saveInitialPosition({
           x: coordonateToPosition(croppingRect.x, croppingRect.width),
           y: coordonateToPosition(croppingRect.y, croppingRect.height),

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
@@ -98,7 +98,8 @@ const OfferDetails = ({
             thumbUrl,
             croppingRect?.x,
             croppingRect?.y,
-            croppingRect?.height
+            croppingRect?.height,
+            croppingRect?.width
           )
         } catch (error) {
           setThumbnailError(true)

--- a/pro/src/new_components/ImageEditor/utils.ts
+++ b/pro/src/new_components/ImageEditor/utils.ts
@@ -1,0 +1,9 @@
+// croppingRect give us the top left corner of the cropped area
+// where AvatarEditor expect the center of it
+export const coordonateToPosition = (coordonate: number, size: number) =>
+  coordonate + size / 2
+
+// height_crop_percent of croppingRect is the ratio of the cropped image height
+// compare to the original image height which corresponds to the inverse of the zoom scale
+export const heightCropPercentToScale = (heightCropPercent: number) =>
+  1 / heightCropPercent

--- a/pro/src/repository/pcapi/__specs__/pcapi.spec.ts
+++ b/pro/src/repository/pcapi/__specs__/pcapi.spec.ts
@@ -249,11 +249,12 @@ describe('pcapi', () => {
       body.append('croppingRectX', '12')
       body.append('croppingRectY', '32')
       body.append('croppingRectHeight', '350')
+      body.append('croppingRectWidth', '220')
       body.append('thumb', file)
       body.append('thumbUrl', '')
 
       // when
-      postThumbnail('AA', 'Mon crédit', file, '', '12', '32', '350')
+      postThumbnail('AA', 'Mon crédit', file, '', '12', '32', '350', '220')
 
       // then
       expect(client.postWithFormData).toHaveBeenCalledWith(

--- a/pro/src/repository/pcapi/pcapi.ts
+++ b/pro/src/repository/pcapi/pcapi.ts
@@ -425,7 +425,9 @@ export const postThumbnail = (
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'y' implicitly has an 'any' type.
   y,
   // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'height' implicitly has an 'any' type.
-  height
+  height,
+  // @ts-expect-error ts-migrate(7006) FIXME: Parameter 'width' implicitly has an 'any' type.
+  width
 ) => {
   const body = new FormData()
   body.append('offerId', offerId)
@@ -433,6 +435,7 @@ export const postThumbnail = (
   body.append('croppingRectX', x)
   body.append('croppingRectY', y)
   body.append('croppingRectHeight', height)
+  body.append('croppingRectWidth', width)
   body.append('thumb', thumb)
   body.append('thumbUrl', thumbUrl)
 

--- a/pro/src/repository/pcapi/pcapi.ts
+++ b/pro/src/repository/pcapi/pcapi.ts
@@ -292,6 +292,8 @@ export const postImageToVenue = async ({
   yCropPercent,
   // @ts-expect-error ts-migrate(7031) FIXME: Binding element 'heightCropPercent' implicitly has... Remove this comment to see the full error message
   heightCropPercent,
+  // @ts-expect-error ts-migrate(7031) FIXME: Binding element 'widthCropPercent' implicitly has... Remove this comment to see the full error message
+  widthCropPercent,
   // @ts-expect-error ts-migrate(7031) FIXME: Binding element 'imageCredit' implicitly has an 'a... Remove this comment to see the full error message
   imageCredit,
 }) => {
@@ -302,6 +304,7 @@ export const postImageToVenue = async ({
     x_crop_percent: xCropPercent,
     y_crop_percent: yCropPercent,
     height_crop_percent: heightCropPercent,
+    width_crop_percent: widthCropPercent,
   }
 
   if (imageCredit) {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13641

## But de la pull request

Lorsque l'on valide une image sur un lieu, le back enregistre l'image telle qu'elle a été uploadée et une autre version éventuellement cropée et zoomée qui est utilisée sur la page du détail du lieu.
Lors de l'édition de l'image il faut afficher l’image originale + les paramètres de zoom + crop plutôt que l'image cropée sans réutiliser les paramètres utilisés pour la zoom/cropée

## Implémentation

-Utilisation de l'objet bannerMeta du lieu qui contient le crédit de l'image, les paramètres de zoom/crop et l'image originale non cropée lors de l'édition de l'image

## Informations supplémentaires

J'ai géré les cas particuliers suivants :
- Affichage de l'image cropée si pas d'image originale
- Si pas de crop_params complet (manque width_crop_percent) dans ce cas là je n'en tiens pas compte et je laisse les valeurs qu'on a par défaut

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
