### PR TITLE
(PC-14625)[API] fix: Ignore pricings of the previous year in `_delete_dependent_pricings()`

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -400,7 +400,7 @@ def _delete_dependent_pricings(booking: bookings_models.Booking, log_message: st
     See note in the module docstring for further details.
     """
     siret = booking.venue.siret or booking.venue.businessUnit.siret
-    _start, revenue_period_end = _get_revenue_period(booking.dateUsed)  # type: ignore [arg-type]
+    revenue_period_start, revenue_period_end = _get_revenue_period(booking.dateUsed)  # type: ignore [arg-type]
     pricings = (
         models.Pricing.query.filter(models.Pricing.siret == siret)
         .join(models.Pricing.booking)
@@ -414,7 +414,7 @@ def _delete_dependent_pricings(booking: bookings_models.Booking, log_message: st
             ),
         )
         .filter(
-            models.Pricing.valueDate <= revenue_period_end,
+            models.Pricing.valueDate.between(revenue_period_start, revenue_period_end),
             sqla.func.ROW(*_PRICE_BOOKINGS_ORDER_CLAUSE) > sqla.func.ROW(*_booking_comparison_tuple(booking)),
         )
         .with_entities(

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -349,6 +349,11 @@ class DeleteDependentPricingsTest:
             booking__stock__offer__venue=booking.venue,
             booking__dateUsed=booking.dateUsed - datetime.timedelta(seconds=1),
         )
+        earlier_pricing_previous_year = factories.PricingFactory(
+            booking__stock__offer__venue=booking.venue,
+            booking__dateUsed=booking.dateUsed - datetime.timedelta(days=365),
+            booking__stock__beginningDatetime=booking.dateUsed + datetime.timedelta(seconds=1),
+        )
         later_pricing = factories.PricingFactory(
             booking__stock__offer__venue=booking.venue,
             booking__dateUsed=booking.dateUsed + datetime.timedelta(seconds=1),
@@ -364,8 +369,8 @@ class DeleteDependentPricingsTest:
             valueDate=booking.dateUsed,
         )
         api._delete_dependent_pricings(booking, "some log message")
-        expected_kept = [earlier_pricing, later_pricing_another_year]
-        assert list(models.Pricing.query.all()) == expected_kept
+        expected_kept = {earlier_pricing_previous_year, earlier_pricing, later_pricing_another_year}
+        assert set(models.Pricing.query.all()) == expected_kept
 
     def test_raise_if_a_pricing_is_not_deletable(self):
         booking = create_booking_with_undeletable_dependent()


### PR DESCRIPTION
We delete pricings because we need a stable calculation of the revenue
of each year. As such, here we are only interested in pricings with a
value date within the year of the requested booking. Any pricing that
have a value date in another year should be ignored.

This was not an issue until now, where we are manually creating
pricings for bookings used in 2021 and before (see PC-11627). Some of
them are wrongly deleted.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14625