### PR TITLE
(PC-14528)[API] fix: validate booking_limit_datetime on pro stocks route

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -69,6 +69,7 @@ from pcapi.core.offers.offer_validation import parse_offer_validation_config
 import pcapi.core.offers.repository as offers_repository
 from pcapi.core.offers.utils import as_utc_without_timezone
 from pcapi.core.offers.validation import KEY_VALIDATION_CONFIG
+from pcapi.core.offers.validation import check_booking_limit_datetime
 from pcapi.core.offers.validation import check_offer_is_eligible_for_educational
 from pcapi.core.offers.validation import check_offer_subcategory_is_valid
 from pcapi.core.offers.validation import check_offer_withdrawal
@@ -617,6 +618,7 @@ def upsert_stocks(
                 )
                 errors.status_code = 403
                 raise errors
+            check_booking_limit_datetime(stock, stock_data.beginning_datetime, stock_data.booking_limit_datetime)
             edited_stocks_previous_beginnings[stock.id] = stock.beginningDatetime
             edited_stock = _edit_stock(
                 stock,
@@ -628,6 +630,8 @@ def upsert_stocks(
             edited_stocks.append(edited_stock)
             stocks.append(edited_stock)
         else:
+            check_booking_limit_datetime(None, stock_data.beginning_datetime, stock_data.booking_limit_datetime)
+
             activation_codes_exist = stock_data.activation_codes is not None and len(stock_data.activation_codes) > 0
 
             if activation_codes_exist:

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -1,4 +1,3 @@
-import copy
 from datetime import datetime
 from datetime import timedelta
 from io import BytesIO
@@ -364,13 +363,15 @@ def check_stock_booking_status(booking: Booking) -> Union[None, Exception]:
 
 
 def check_booking_limit_datetime(
-    stock: Union[CollectiveStock, Stock], beginning: Optional[datetime], booking_limit_datetime: Optional[datetime]
+    stock: Optional[Union[CollectiveStock, Stock]],
+    beginning: Optional[datetime],
+    booking_limit_datetime: Optional[datetime],
 ) -> None:
-    beginning = copy.deepcopy(beginning)
-    booking_limit_datetime = copy.deepcopy(booking_limit_datetime)
+    if stock:
+        if beginning is None:
+            beginning = stock.beginningDatetime
+        if booking_limit_datetime is None:
+            booking_limit_datetime = stock.bookingLimitDatetime
 
-    beginning = stock.beginningDatetime if beginning is None else beginning
-    booking_limit_datetime = stock.bookingLimitDatetime if booking_limit_datetime is None else booking_limit_datetime
-
-    if booking_limit_datetime > beginning:  # type: ignore [operator]
+    if beginning and booking_limit_datetime and booking_limit_datetime > beginning:
         raise exceptions.BookingLimitDatetimeTooLate()

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -71,7 +71,14 @@ def upsert_stocks(body: StocksUpsertBodyModel) -> StockIdsResponseModel:
         raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
     check_user_has_access_to_offerer(current_user, offerer.id)
 
-    stocks = offers_api.upsert_stocks(body.offer_id, body.stocks, current_user)
+    try:
+        stocks = offers_api.upsert_stocks(body.offer_id, body.stocks, current_user)
+    except offers_exceptions.BookingLimitDatetimeTooLate:
+        raise ApiErrors(
+            {"stocks": ["La date limite de réservation ne peut être postérieure à la date de début de l'événement"]},
+            status_code=400,
+        )
+
     return StockIdsResponseModel(
         stockIds=[StockIdResponseModel.from_orm(stock) for stock in stocks],
     )

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -544,15 +544,11 @@ class UpsertStocksTest:
         )
 
         # When
-        with pytest.raises(api_errors.ApiErrors) as error:
+        with pytest.raises(exceptions.BookingLimitDatetimeTooLate):
             api.upsert_stocks(offer_id=offer.id, stock_data_list=[created_stock_data], user=user)
 
         # Then
-        assert error.value.errors == {
-            "bookingLimitDatetime": [
-                "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement"
-            ]
-        }
+        assert models.Stock.query.count() == 0
 
     def test_does_not_allow_edition_of_a_past_event_stock(self):
         # Given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14528

## But de la pull request

Stocks - Valider la date limite de réservation sur la route `"/stocks/bulk"` (pro)

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
