### PR TITLE
(PC-13994)[API] fix: commit offer and stock at same time in upsert_stock

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -659,11 +659,12 @@ def upsert_stocks(
 
             stocks.append(created_stock)
 
-    repository.save(*stocks, *activation_codes)
-    logger.info("Stock has been created or updated", extra={"offer": offer_id})
-
     if offer.validation == OfferValidationStatus.DRAFT:
         update_offer_fraud_information(offer, user)
+        repository.save(offer)
+
+    repository.save(*stocks, *activation_codes)
+    logger.info("Stock has been created or updated", extra={"offer": offer_id})
 
     for stock in edited_stocks:
         previous_beginning = edited_stocks_previous_beginnings[stock.id]
@@ -688,7 +689,7 @@ def update_offer_fraud_information(
 
     if offer.validation in (OfferValidationStatus.PENDING, OfferValidationStatus.REJECTED):
         offer.isActive = False
-    repository.save(offer)
+
     if offer.validation == OfferValidationStatus.APPROVED and not silent:
         admin_emails.send_offer_creation_notification_to_administration(offer)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13994

## But de la pull request

_corriger la fonction pour que le commit du stock et de l’offre ait lieu en même temps afin qu'une erreur dans `_update_offer_fraud_information` ne crée pas le stock 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
