### PR TITLE
(PC-14621) Fix recredit bug

### DIFF
--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -20,6 +20,7 @@ from pcapi.core.payments.models import Deposit
 from pcapi.core.payments.models import DepositType
 import pcapi.core.users.api as users_api
 from pcapi.core.users.external import update_external_user
+from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
 from pcapi.core.users.utils import sanitize_email
 
@@ -262,7 +263,7 @@ class BeneficiaryUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdmin
             model.add_beneficiary_role()
 
             deposit_version = int(form.depositVersion.data) if not settings.IS_PROD else None
-            users_api.fulfill_beneficiary_data(model, "pass-culture-admin", deposit_version)
+            users_api.fulfill_beneficiary_data(model, "pass-culture-admin", EligibilityType.AGE18, deposit_version)
 
         super().on_model_change(form, model, is_created)
 

--- a/api/src/pcapi/admin/custom_views/support_view/api.py
+++ b/api/src/pcapi/admin/custom_views/support_view/api.py
@@ -90,7 +90,7 @@ def on_admin_review(review: fraud_models.BeneficiaryFraudReview, user: users_mod
         else:
             eligibility = users_models.EligibilityType[data["eligibility"]]
         try:
-            subscription_api.activate_beneficiary_for_eligibility(user, fraud_check, eligibility)
+            subscription_api.activate_beneficiary_for_eligibility(user, fraud_check.get_detailed_source(), eligibility)
             flask.flash(f"L'utilisateur a bien été activé en tant que bénéficiaire '{eligibility.value}'", "success")
 
         except subscription_exceptions.InvalidEligibilityTypeException:

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -394,6 +394,17 @@ class BeneficiaryFraudCheck(PcObject, Model):  # type: ignore [valid-type, misc]
             return f"démarches simplifiées dossier [{self.thirdPartyId}]"
         return f"dossier {self.type} [{self.thirdPartyId}]"
 
+    def get_min_date_between_creation_and_registration(self) -> datetime.datetime:
+        if self.type not in IDENTITY_CHECK_TYPES or not self.resultContent:
+            return self.dateCreated
+        try:
+            registration_datetime = self.source_data().get_registration_datetime()  # type: ignore [union-attr]
+        except ValueError:  # TODO(viconnex) migrate Educonnect fraud checks that do not have registration date in their content
+            return self.dateCreated
+        if registration_datetime:
+            return min(self.dateCreated, registration_datetime)
+        return self.dateCreated
+
 
 class OrphanDmsApplication(PcObject, Model):  # type: ignore [valid-type, misc]
     # This model is used to store fraud checks that were not associated with a user.

--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -18,7 +18,7 @@ def get_last_user_profiling_fraud_check(user: users_models.User) -> Optional[mod
     )
 
 
-def get_identity_fraud_checks(
+def get_identity_fraud_checks_for_eligibility(
     user: users_models.User, eligibilityType: users_models.EligibilityType
 ) -> list[models.BeneficiaryFraudCheck]:
     return models.BeneficiaryFraudCheck.query.filter(

--- a/api/src/pcapi/core/payments/api.py
+++ b/api/src/pcapi/core/payments/api.py
@@ -57,7 +57,7 @@ def get_granted_deposit(
 def create_deposit(
     beneficiary: users_models.User,
     deposit_source: str,
-    eligibility: Optional[users_models.EligibilityType] = users_models.EligibilityType.AGE18,
+    eligibility: users_models.EligibilityType,
     version: Optional[int] = None,
     age_at_registration: Optional[int] = None,
 ) -> Deposit:
@@ -67,7 +67,7 @@ def create_deposit(
     """
     granted_deposit = get_granted_deposit(
         beneficiary,
-        eligibility,  # type: ignore [arg-type]
+        eligibility,
         age_at_registration=age_at_registration,
         version=version,
     )

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -36,11 +36,9 @@ def get_latest_subscription_message(user: users_models.User) -> typing.Optional[
 
 def activate_beneficiary_for_eligibility(
     user: users_models.User,
-    fraud_check: fraud_models.BeneficiaryFraudCheck,
+    deposit_source: str,
     eligibility: users_models.EligibilityType,
 ) -> users_models.User:
-    deposit_source = fraud_check.get_detailed_source()
-
     if eligibility == users_models.EligibilityType.UNDERAGE:
         user.validate_user_identity_15_17()
         user.add_underage_beneficiary_role()
@@ -86,7 +84,7 @@ def activate_beneficiary(user: users_models.User) -> users_models.User:
     if not users_api.is_eligible_for_beneficiary_upgrade(user, eligibility):  # type: ignore [arg-type]
         raise exceptions.CannotUpgradeBeneficiaryRole()
 
-    return activate_beneficiary_for_eligibility(user, fraud_check, eligibility)  # type: ignore [arg-type]
+    return activate_beneficiary_for_eligibility(user, fraud_check.get_detailed_source(), eligibility)  # type: ignore [arg-type]
 
 
 def has_completed_profile(user: users_models.User) -> bool:

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -74,7 +74,7 @@ def activate_beneficiary_for_eligibility(
     return user
 
 
-def activate_beneficiary(user: users_models.User, deposit_source: str = None) -> users_models.User:
+def activate_beneficiary(user: users_models.User) -> users_models.User:
     fraud_check = users_api.get_activable_identity_fraud_check(user)
     if not fraud_check:
         raise exceptions.BeneficiaryFraudCheckMissingException(

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -303,10 +303,12 @@ def fulfill_account_password(user: User) -> User:
     return user
 
 
-def fulfill_beneficiary_data(user: User, deposit_source: str, deposit_version: int = None) -> User:
+def fulfill_beneficiary_data(
+    user: User, deposit_source: str, eligibility: EligibilityType, deposit_version: int = None
+) -> User:
     _generate_random_password(user)
 
-    deposit = payment_api.create_deposit(user, deposit_source, version=deposit_version)
+    deposit = payment_api.create_deposit(user, deposit_source, eligibility=eligibility, version=deposit_version)
     user.deposits = [deposit]
 
     return user
@@ -607,7 +609,7 @@ def create_pro_user(pro_user: ProUserCreationBodyModel) -> User:
 
     if settings.IS_INTEGRATION:
         new_pro_user.add_beneficiary_role()
-        deposit = payment_api.create_deposit(new_pro_user, "integration_signup")
+        deposit = payment_api.create_deposit(new_pro_user, "integration_signup", EligibilityType.AGE18)
         new_pro_user.deposits = [deposit]
 
     return new_pro_user

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -336,7 +336,7 @@ class DepositGrantFactory(BaseFactory):
             else models.EligibilityType.AGE18
         )
         granted_deposit = payments_api.get_granted_deposit(
-            kwargs["user"], eligibility, user_age_at_registration=age, version=kwargs.get("version")
+            kwargs["user"], eligibility, age_at_registration=age, version=kwargs.get("version")
         )
 
         if "version" not in kwargs:

--- a/api/src/pcapi/sandboxes/scripts/sandbox_payment.py
+++ b/api/src/pcapi/sandboxes/scripts/sandbox_payment.py
@@ -10,6 +10,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 import pcapi.core.payments.api as payments_api
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users.models import EligibilityType
 from pcapi.model_creators.generic_creators import create_offerer
 from pcapi.model_creators.generic_creators import create_stock
 from pcapi.model_creators.generic_creators import create_venue
@@ -33,11 +34,11 @@ def save_users_with_deposits() -> typing.Tuple[users_factories.UserFactory, ...]
     user3 = users_factories.BeneficiaryGrant18Factory(email="user3@test.com")
     user4 = users_factories.BeneficiaryGrant18Factory(email="user4@test.com")
     user5 = users_factories.BeneficiaryGrant18Factory(email="user5@test.com")
-    deposit1 = payments_api.create_deposit(user1, "sandbox")
-    deposit2 = payments_api.create_deposit(user2, "sandbox")
-    deposit3 = payments_api.create_deposit(user3, "sandbox")
-    deposit4 = payments_api.create_deposit(user4, "sandbox")
-    deposit5 = payments_api.create_deposit(user5, "sandbox")
+    deposit1 = payments_api.create_deposit(user1, "sandbox", EligibilityType.AGE18)
+    deposit2 = payments_api.create_deposit(user2, "sandbox", EligibilityType.AGE18)
+    deposit3 = payments_api.create_deposit(user3, "sandbox", EligibilityType.AGE18)
+    deposit4 = payments_api.create_deposit(user4, "sandbox", EligibilityType.AGE18)
+    deposit5 = payments_api.create_deposit(user5, "sandbox", EligibilityType.AGE18)
     repository.save(deposit1, deposit2, deposit3, deposit4, deposit5)
     logger.info("created 5 users with deposits")
     return user1, user2, user3, user4, user5

--- a/api/src/pcapi/scripts/beneficiary/import_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_users.py
@@ -34,7 +34,7 @@ def _create_beneficiary(row: dict, role: Optional[UserRole]) -> User:
         remote_updates=False,
     )
     if role == UserRole.BENEFICIARY:
-        deposit = payments_api.create_deposit(user, "import_users (csv)")
+        deposit = payments_api.create_deposit(user, "import_users (csv)", eligibility=EligibilityType.AGE18)
         repository.save(deposit)
         user.add_beneficiary_role()
     elif role == UserRole.UNDERAGE_BENEFICIARY:

--- a/api/src/pcapi/scripts/change_some_pro_users_to_beneficiary.py
+++ b/api/src/pcapi/scripts/change_some_pro_users_to_beneficiary.py
@@ -10,7 +10,7 @@ def change_pro_users_to_beneficiary(pro_users_ids: list[int]) -> None:
         user.add_beneficiary_role()
         user.remove_pro_role()
         user.needsToFillCulturalSurvey = True
-        deposit = payments_api.create_deposit(user, "public")
+        deposit = payments_api.create_deposit(user, "public", users_models.EligibilityType.AGE18)
         repository.save(user, deposit)
         user_offerer = offerers_models.UserOfferer.query.filter_by(user=user).all()
         repository.delete(*user_offerer)

--- a/api/src/pcapi/scripts/grant_wallet_to_existing_users.py
+++ b/api/src/pcapi/scripts/grant_wallet_to_existing_users.py
@@ -1,5 +1,6 @@
 from pcapi import settings
 import pcapi.core.payments.api as payments_api
+from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
 from pcapi.repository import repository
 
@@ -10,5 +11,5 @@ def grant_wallet_to_existing_users(user_ids: list[int]):  # type: ignore [no-unt
     users = User.query.filter(User.id.in_(user_ids)).all()
     for user in users:
         user.add_beneficiary_role()
-        deposit = payments_api.create_deposit(user, "public")
+        deposit = payments_api.create_deposit(user, "public", EligibilityType.AGE18)
         repository.save(user, deposit)

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -30,6 +30,7 @@ from pcapi.core.offers.factories import EducationalEventStockFactory
 from pcapi.core.payments.api import create_deposit
 from pcapi.core.testing import assert_num_queries
 import pcapi.core.users.factories as users_factories
+from pcapi.core.users.models import EligibilityType
 from pcapi.domain.booking_recap import booking_recap_history
 from pcapi.models import db
 from pcapi.models.api_errors import ResourceNotFoundError
@@ -2615,7 +2616,7 @@ def test_get_deposit_booking():
         previous_deposit_booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user)
         db.session.execute("ALTER TABLE booking ENABLE TRIGGER booking_update;")
 
-    create_deposit(user, "test")
+    create_deposit(user, "test", EligibilityType.AGE18)
 
     current_deposit_booking = bookings_factories.IndividualBookingFactory(individualBooking__user=user)
     current_deposit_booking_2 = bookings_factories.IndividualBookingFactory(individualBooking__user=user)

--- a/api/tests/core/payments/test_api.py
+++ b/api/tests/core/payments/test_api.py
@@ -54,7 +54,7 @@ class CreateDepositTest:
                 resultContent=fraud_factories.EduconnectContentFactory(registration_datetime=datetime.utcnow()),
             )
 
-        deposit = api.create_deposit(beneficiary, "created by test", beneficiary.eligibility)
+        deposit = api.create_deposit(beneficiary, "created by test", beneficiary.eligibility, age_at_registration=age)
 
         assert deposit.type == DepositType.GRANT_15_17
         assert deposit.version == 1

--- a/api/tests/core/payments/test_api.py
+++ b/api/tests/core/payments/test_api.py
@@ -35,7 +35,7 @@ class CreateDepositTest:
             dateOfBirth=datetime.combine(datetime.utcnow(), time(0, 0)) - relativedelta(years=18, months=2)
         )
 
-        deposit = api.create_deposit(beneficiary, "created by test", version=1)
+        deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18, version=1)
 
         assert deposit.version == 1
         assert deposit.amount == Decimal(500)
@@ -67,7 +67,7 @@ class CreateDepositTest:
             dateOfBirth=datetime.combine(datetime.utcnow(), time(0, 0)) - relativedelta(years=18, months=4)
         )
 
-        deposit = api.create_deposit(beneficiary, "created by test")
+        deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
 
         assert deposit.type == DepositType.GRANT_18
         assert deposit.version == 2
@@ -82,7 +82,7 @@ class CreateDepositTest:
         )
 
         # When
-        deposit = api.create_deposit(beneficiary, "integration_signup")
+        deposit = api.create_deposit(beneficiary, "integration_signup", users_models.EligibilityType.AGE18)
 
         # Then
         assert deposit.type == DepositType.GRANT_18
@@ -96,7 +96,7 @@ class CreateDepositTest:
         with freeze_time(datetime.utcnow() - relativedelta(years=3)):
             beneficiary = users_factories.UnderageBeneficiaryFactory(dateOfBirth=birth_date)
 
-        api.create_deposit(beneficiary, "created by test")
+        api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
 
         assert beneficiary.deposit.type == DepositType.GRANT_18
         assert len(beneficiary.deposits) == 2
@@ -110,7 +110,7 @@ class CreateDepositTest:
 
         # When
         with pytest.raises(exceptions.DepositTypeAlreadyGrantedException) as error:
-            api.create_deposit(beneficiary, "created by test")
+            api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
 
         # Then
         assert Deposit.query.filter(Deposit.userId == beneficiary.id).count() == 1

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -474,7 +474,7 @@ class FulfillBeneficiaryDataTest:
         user = users_factories.UserFactory(dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE)
 
         # when
-        user = fulfill_beneficiary_data(user, "deposit_source", None)
+        user = fulfill_beneficiary_data(user, "deposit_source", EligibilityType.AGE18, None)
 
         # then
         assert isinstance(user, User)
@@ -486,7 +486,7 @@ class FulfillBeneficiaryDataTest:
         user = users_factories.UserFactory(dateOfBirth=self.AGE18_ELIGIBLE_BIRTH_DATE)
 
         # when
-        user = fulfill_beneficiary_data(user, "deposit_source", 2)
+        user = fulfill_beneficiary_data(user, "deposit_source", EligibilityType.AGE18, 2)
 
         # then
         assert isinstance(user, User)

--- a/api/tests/core/users/test_users_sql_entity.py
+++ b/api/tests/core/users/test_users_sql_entity.py
@@ -127,7 +127,7 @@ class SQLFunctionsTest:
             bookings_factories.IndividualBookingFactory(individualBooking__user=user, amount=18)
             db.session.execute("ALTER TABLE booking ENABLE TRIGGER booking_update;")
 
-        payments_api.create_deposit(user, "test")
+        payments_api.create_deposit(user, "test", user_models.EligibilityType.AGE18)
 
         bookings_factories.UsedIndividualBookingFactory(individualBooking__user=user, amount=10)
         bookings_factories.IndividualBookingFactory(individualBooking__user=user, amount=1)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14621

## But de la pull request

Réparer le bug : Des utilisateurs de 16 ans ont 60€ au lieu de 50€.

## Implémentation

Il faut aligner la méthode qui attribue le deposit et celle qui recrédite l'utilisateur. Avant, la méthode qui attribuait le deposit se basait sur l'âge lors du premier fraud_check réussi, contrairement à la méthode qui recrédite l'utilisateur qui se base sur le premier fraud check de type identité, pas forcément réussi.

Changements sur la règle de détermination de la première date d'inscription : 
- au lieu de prendre seulement les fraud_checks de type identité, on peut ratisser large en prenant tous les fraud_checks (ex: validation du téléphone, même si ceux-ci ne s'appliquent pas aux UNDERAGE)
- avant on prenait le fraud_check qui a la dateCreated minimale, puis on prenait soit sa dateCreated, soit sa registration_datetime. Mais il se peut qu'il y ait un fraudCheck avec une registrationDatetime inférieure à celle-ci, bien que sa dateCreated soit plus récente (même si a priori ce cas ne s'applique plus depuis que le webhook dms entraine la création d'un fraudCheck dès que l'utilisateur remplit son dossier)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
