### PR TITLE
(PC-14653)[API] fix: Fix DMS when no entreprise is specified

### DIFF
--- a/api/src/pcapi/domain/demarches_simplifiees.py
+++ b/api/src/pcapi/domain/demarches_simplifiees.py
@@ -94,7 +94,7 @@ def parse_raw_bic_data(data: dict) -> dict:
             result[ID_TO_NAME_MAPPING[field["id"]]] = field["value"]
         elif field["id"] == "Q2hhbXAtNzgyODAw":
             result["siret"] = field["etablissement"]["siret"]
-            result["siren"] = field["etablissement"]["entreprise"]["siren"]
+            result["siren"] = field["etablissement"]["siret"][:9]
 
     result["annotation_id"] = None
     for annotation in data["dossier"]["annotations"]:

--- a/api/tests/domain/demarches_simplifiees_test.py
+++ b/api/tests/domain/demarches_simplifiees_test.py
@@ -232,7 +232,28 @@ class GetStatusFromDemarchesSimplifieesApplicationStateTest:
 
 
 class ParseRawBicDataTest:
-    def test_parsing_works(self):
+    @pytest.mark.parametrize(
+        "entreprise",
+        [
+            {
+                "capitalSocial": "38130",
+                "codeEffectifEntreprise": "12",
+                "dateCreation": "2001-06-27",
+                "formeJuridique": "SAS, " "société " "par " "actions " "simplifiée",
+                "formeJuridiqueCode": "5710",
+                "inlineAdresse": "2 " "RUE " "LAMENNAIS, " "75008 " "PARIS " "8",
+                "nom": None,
+                "nomCommercial": "",
+                "numeroTvaIntracommunautaire": "FR67438391195",
+                "prenom": None,
+                "raisonSociale": "GAUMONT " "ALESIA",
+                "siren": "438391195",
+                "siretSiegeSocial": "43839119500056",
+            },
+            None,
+        ],
+    )
+    def test_parsing_works(self, entreprise):
         INPUT_DATA = {
             "dossier": {
                 "id": "Q2zzbXAtNzgyODAw",
@@ -311,21 +332,7 @@ class ParseRawBicDataTest:
                                 "type": "housenumber",
                             },
                             "association": None,
-                            "entreprise": {
-                                "capitalSocial": "38130",
-                                "codeEffectifEntreprise": "12",
-                                "dateCreation": "2001-06-27",
-                                "formeJuridique": "SAS, " "société " "par " "actions " "simplifiée",
-                                "formeJuridiqueCode": "5710",
-                                "inlineAdresse": "2 " "RUE " "LAMENNAIS, " "75008 " "PARIS " "8",
-                                "nom": None,
-                                "nomCommercial": "",
-                                "numeroTvaIntracommunautaire": "FR67438391195",
-                                "prenom": None,
-                                "raisonSociale": "GAUMONT " "ALESIA",
-                                "siren": "438391195",
-                                "siretSiegeSocial": "43839119500056",
-                            },
+                            "entreprise": entreprise,
                             "libelleNaf": "Projection de films " "cinématographiques",
                             "naf": "5914Z",
                             "siegeSocial": True,


### PR DESCRIPTION
Lorsqu'un dossier est créé sur DMS, nous requêtons leur API pour récupérer des infos sur l'entreprise. Si nous le faisons trop tot après la création, ce champ peut être vide. Nous l'utilisons uniquement pour récupérer le champ siren que nous pouvons récupérer en gardant les 9 premiers caractères du siret.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14653

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
