### PR TITLE
(PC-14520)[API] fix: change cashflow date to invoice date

### DIFF
--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -264,7 +264,7 @@
     <tr>
         <td>Virement {{ cashflow.bankAccount.iban }}</td>
         <td class="cashflow_id">{{ cashflow.id }}</td>
-        <td class="cashflow_creation_date">{{ cashflow.creationDate.strftime("%d/%m/%Y") }}</td>
+        <td class="cashflow_creation_date">{{ invoice.date.strftime("%d/%m/%Y") }}</td>
         <td>{{ cashflow.amount|fr_currency }} €</td>
         <td> {{ invoice.businessUnit.name }}</td>
     </tr>

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1820,7 +1820,7 @@ class GenerateInvoiceHtmlTest:
         )
         expected_invoice_html = expected_invoice_html.replace(
             '<td class="cashflow_creation_date">21/12/2021</td>',
-            f'<td class="cashflow_creation_date">{cashflows[0].creationDate.strftime("%d/%m/%Y")}</td>',
+            f'<td class="cashflow_creation_date">{invoice.date.strftime("%d/%m/%Y")}</td>',
         )
         expected_invoice_html = expected_invoice_html.replace(
             'content: "Relevé n°F220000001 du 30/01/2022";',


### PR DESCRIPTION
Les deux dates sont arbitraires et viennent du moment où les scripts sont joués. Nous souhaitons juste harmoniser les dates entre les virements et la génération du justificatif

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14520

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
