### PR TITLE
PC-14196 update subscription messages

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -346,9 +346,9 @@ def _is_ubble_allowed_if_subscription_overflow(user: users_models.User) -> bool:
         user.dateOfBirth,  # type: ignore [arg-type]
         datetime.datetime.utcnow() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore [arg-type]
     )
-    eligbility_ranges = users_constants.ELIGIBILITY_UNDERAGE_RANGE + [users_constants.ELIGIBILITY_AGE_18]
-    eligbility_ranges = [age + 1 for age in eligbility_ranges]
-    if future_age > user.age and future_age in eligbility_ranges:  # type: ignore [operator]
+    eligibility_ranges = users_constants.ELIGIBILITY_UNDERAGE_RANGE + [users_constants.ELIGIBILITY_AGE_18]
+    eligibility_ranges = [age + 1 for age in eligibility_ranges]
+    if future_age > user.age and future_age in eligibility_ranges:  # type: ignore [operator]
         return True
 
     return False

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -258,9 +258,7 @@ class UserProfileResponse(BaseModel):
         signup process UNLESS the beneficiary signup process has been
         deactivated: return a generic maintenance message in this case.
         """
-        if not subscription_api.get_allowed_identity_check_methods(user):
-            # no identity check methods found => no beneficiary signup
-            # available
+        if subscription_api.get_next_subscription_step(user) == subscription_models.SubscriptionStep.MAINTENANCE:
             return SubscriptionMessage.beneficiary_maintenance_message()
 
         latest_message = subscription_api.get_latest_subscription_message(user)

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -36,6 +36,7 @@ from pcapi.core.users import testing as users_testing
 from pcapi.core.users.api import create_phone_validation_token
 from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.email import update as email_update
+from pcapi.core.users.models import ActivityEnum
 from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import PhoneValidationStatusType
 from pcapi.core.users.models import Token
@@ -230,7 +231,19 @@ class AccountTest:
         to /me returns a generic maintenance message.
         """
         user = users_factories.UserFactory(
-            email=self.identifier, dateOfBirth=datetime.utcnow() - relativedelta(years=18, days=5)
+            activity=ActivityEnum.STUDENT.value,
+            dateOfBirth=datetime.utcnow() - relativedelta(years=18, days=5),
+            email=self.identifier,
+            phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.USER_PROFILING,
+            resultContent=fraud_factories.UserProfilingFraudDataFactory(
+                risk_rating=fraud_models.UserProfilingRiskRating.TRUSTED
+            ),
+            eligibilityType=users_models.EligibilityType.AGE18,
+            status=fraud_models.FraudCheckStatus.OK,
         )
         client.with_token(user.email)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14196

## But de la pull request

Mettre à jour le subscriptionMessage avec “La vérification d'identité est momentanément indisponible...”  uniquement si le nextStep = “Maintenance”

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
