### PR TITLE
(PC-14353)[PRO] feat: add banner when first structure is not validated

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
@@ -48,7 +48,7 @@ const FormVenue = ({
           options={offerersOptions}
         />
       </FormLayout.Row>
-      {isEligible === false && (
+      {isEligible === false && offerersOptions.length !== 0 && (
         <Banner
           href="https://passculture.typeform.com/to/WHrAY5KB"
           linkTitle="Faire une demande de référencement"
@@ -58,13 +58,20 @@ const FormVenue = ({
           du ministère de la Culture.
         </Banner>
       )}
-      {venuesOptions.length === 0 && (
+
+      {venuesOptions.length === 0 && offerersOptions.length !== 0 && (
         <Banner
           href={`/structures/${values.offererId}/lieux/creation`}
           linkTitle="Renseigner un lieu"
         >
           Pour proposer des offres à destination d’un groupe scolaire, vous
           devez renseigner un lieu pour pouvoir être remboursé.
+        </Banner>
+      )}
+      {offerersOptions.length === 0 && (
+        <Banner>
+          Vous ne pouvez pas créer d’offre collective tant que votre structure
+          n’est pas validée.
         </Banner>
       )}
       {isEligible === true && venuesOptions.length > 0 && (

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
@@ -80,6 +80,37 @@ describe('screens | OfferEducational : creation offerer step', () => {
       ).not.toBeInTheDocument()
     })
   })
+  describe('when the offerer is not validated', () => {
+    beforeEach(() => {
+      props = {
+        ...props,
+        userOfferers: userOfferersFactory([
+          {
+            managedVenues: managedVenuesFactory([{}]),
+          },
+        ]),
+      }
+    })
+
+    it('should display specific banner instead of place and referencing banner', async () => {
+      renderEACOfferForm({ ...props, userOfferers: [] })
+      expect(
+        await screen.findByText(
+          /Vous ne pouvez pas créer d’offre collective tant que votre structure n’est pas validée./
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(
+          /Pour proposer des offres à destination d’un groupe scolaire, vous devez renseigner un lieu pour pouvoir être remboursé./
+        )
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(
+          /Pour proposer des offres à destination d’un groupe scolaire, vous devez être référencé/
+        )
+      ).not.toBeInTheDocument()
+    })
+  })
   describe('when there is only one managed venue associated with the offerer and offerer is eligible', () => {
     beforeEach(() => {
       props = {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14353

## But de la pull request

Afficher un bandeau quand la première structure n'est pas validée,
à la place des bandeaux sur le lieu et le référencement

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
