### PR TITLE
(BSR)[API] perf: Filter on status in `price_bookings()`

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -145,7 +145,10 @@ def price_bookings(min_date: datetime.datetime = MIN_DATE_TO_PRICE):  # type: ig
     threshold = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
     window = (min_date, threshold)
     bookings = (
-        bookings_models.Booking.query.filter(bookings_models.Booking.dateUsed.between(*window))
+        bookings_models.Booking.query.filter(
+            bookings_models.Booking.status == bookings_models.BookingStatus.USED,
+            bookings_models.Booking.dateUsed.between(*window),
+        )
         .join(bookings_models.Booking.stock)
         .outerjoin(
             models.Pricing,


### PR DESCRIPTION
This filter is not strictly required, but it:

- excludes rare bookings that have been used and then cancelled. We
  also check that one last time in `price_booking()`, anyway;

- helps PostgreSQL excludes bookings more quickly. The query is around
  33% faster. It's still relatively slow (around 15 seconds) but we
  can live with that for now.