### PR TITLE
(PC-14770) fix : Siret field on venue form

### DIFF
--- a/pro/src/api/entreprise/apiEntreprise.ts
+++ b/pro/src/api/entreprise/apiEntreprise.ts
@@ -29,7 +29,7 @@ export default {
     const data = response.etablissement
 
     return {
-      address: data.geo_l4,
+      address: data.geo_l4 || data.unite_legale.etablissement_siege.geo_l4,
       city: data.libelle_commune,
       latitude: data.latitude !== null ? parseFloat(data.latitude) : null,
       longitude: data.longitude !== null ? parseFloat(data.longitude) : null,

--- a/pro/src/api/entreprise/apiEntreprise.ts
+++ b/pro/src/api/entreprise/apiEntreprise.ts
@@ -28,11 +28,15 @@ export default {
     )
     const data = response.etablissement
 
+    const latitude =
+      data.latitude || data.unite_legale.etablissement_siege.latitude
+    const longitude =
+      data.longitude || data.unite_legale.etablissement_siege.longitude
     return {
       address: data.geo_l4 || data.unite_legale.etablissement_siege.geo_l4,
       city: data.libelle_commune,
-      latitude: data.latitude !== null ? parseFloat(data.latitude) : null,
-      longitude: data.longitude !== null ? parseFloat(data.longitude) : null,
+      latitude: latitude !== null ? parseFloat(latitude) : null,
+      longitude: longitude !== null ? parseFloat(longitude) : null,
       name:
         data.enseigne_1 ||
         data.unite_legale.denomination ||

--- a/pro/src/api/entreprise/types.ts
+++ b/pro/src/api/entreprise/types.ts
@@ -48,6 +48,9 @@ export interface IEntrepriseApiJson {
       nom: string | null
       denomination: string | null
       etat_administratif: string
+      etablissement_siege: {
+        geo_l4: string
+      }
       siren: string
     }
     etat_administratif: string

--- a/pro/src/api/entreprise/types.ts
+++ b/pro/src/api/entreprise/types.ts
@@ -50,6 +50,8 @@ export interface IEntrepriseApiJson {
       etat_administratif: string
       etablissement_siege: {
         geo_l4: string
+        longitude: string
+        latitude: string
       }
       siren: string
     }

--- a/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
@@ -1,8 +1,59 @@
 import fetch from 'jest-fetch-mock'
 
+import getSiretData from 'core/Venue/adapters/getSiretDataAdapter'
+
 import siretApiValidate from '../validators/siretApiValidate'
 
 describe('components | SiretField', () => {
+  describe('getSiretData', () => {
+    beforeEach(() => {
+      fetch.resetMocks()
+    })
+    it('should have a latitude and longitude if provided', async () => {
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          etablissement: {
+            geo_l4: '19 RUE LAITIERE',
+            libelle_commune: 'BAYEUX',
+            latitude: null,
+            longitude: null,
+            enseigne_1: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+            code_postal: '14400',
+            siret: '12345178901834',
+            etat_administratif: 'A',
+            unite_legale: {
+              etat_administratif: 'A',
+              etablissement_siege: {
+                geo_l4: '19 RUE LAITIERE',
+                longitude: '1.9',
+                latitude: '1.9',
+              },
+            },
+          },
+        })
+      )
+      const siret = '12345178901834'
+      const values = await getSiretData(siret)
+
+      expect(values).toStrictEqual({
+        isOk: true,
+        message: `Informations récupéré avec success pour le SIRET: ${siret} :`,
+        payload: {
+          values: {
+            address: '19 RUE LAITIERE',
+            city: 'BAYEUX',
+            companyStatus: 'A',
+            latitude: 1.9,
+            legalUnitStatus: 'A',
+            longitude: 1.9,
+            name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+            postalCode: '14400',
+            siret: siret,
+          },
+        },
+      })
+    })
+  })
   describe('siretApiValidate', () => {
     beforeEach(() => {
       fetch.resetMocks()

--- a/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
@@ -1,0 +1,131 @@
+import fetch from 'jest-fetch-mock'
+
+import siretApiValidate from '../validators/siretApiValidate'
+
+describe('components | SiretField', () => {
+  describe('siretApiValidate', () => {
+    beforeEach(() => {
+      fetch.resetMocks()
+    })
+
+    it('should call the INSEE API with the formatted SIRET', async () => {
+      // given
+      fetch.mockResponseOnce(JSON.stringify({ message: 'no results found' }), {
+        status: 404,
+      })
+      const siret = '12345678901234'
+      const humanSiret = '123 456 789 01234'
+
+      // when
+      await siretApiValidate(humanSiret, '')
+
+      // then
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(fetch).toHaveBeenCalledWith(
+        `https://entreprise.data.gouv.fr/api/sirene/v3/etablissements/${siret}`
+      )
+    })
+    it('should not return an error message when SIRET exists in INSEE registry', async () => {
+      // given
+      const siret = '17345678901734'
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          etablissement: {
+            geo_l4: '19 RUE LAITIERE',
+            libelle_commune: 'BAYEUX',
+            latitude: null,
+            longitude: null,
+            enseigne_1: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+            code_postal: '14400',
+            siret: '17345678901734',
+            etat_administratif: 'A',
+            unite_legale: {
+              etat_administratif: 'A',
+              etablissement_siege: {},
+            },
+          },
+        })
+      )
+
+      // when
+      const errorMessage = await siretApiValidate(siret, '')
+
+      // then
+      expect(errorMessage).toBeUndefined()
+    })
+    it('should not return an error message when SIRET exists in INSEE registry without etablissement.geo_l4', async () => {
+      // given
+      const siret = '12345678101234'
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          etablissement: {
+            libelle_commune: 'BAYEUX',
+            latitude: null,
+            longitude: null,
+            enseigne_1: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+            code_postal: '14400',
+            siret: '12345678101234',
+            etat_administratif: 'A',
+            unite_legale: {
+              etat_administratif: 'A',
+              etablissement_siege: {
+                geo_l4: '19 RUE LAITIERE',
+              },
+            },
+          },
+        })
+      )
+
+      // when
+      const errorMessage = await siretApiValidate(siret, '')
+
+      // then
+      expect(errorMessage).toBeUndefined()
+    })
+    it('should return another error message when API returns a status code >=400 and != 404', async () => {
+      // given
+      const siret = '12345678901534'
+      fetch.mockResponseOnce(JSON.stringify({ message: 'Gateway timeout' }), {
+        status: 504,
+      })
+
+      // when
+      const errorMessage = await siretApiValidate(siret, '')
+
+      // then
+      expect(errorMessage).toBe(
+        'L’Annuaire public des Entreprises est indisponible. Veuillez réessayer plus tard.'
+      )
+    })
+    it('should return an error message when SIREN does not exist in INSEE registry', async () => {
+      // given
+      const siret = '12945678901534'
+      fetch.mockResponseOnce(JSON.stringify({ message: 'no results found' }), {
+        status: 404,
+      })
+
+      // when
+      const errorMessage = await siretApiValidate(siret, '')
+
+      // then
+      expect(errorMessage).toBe("Ce SIRET n'est pas reconnu")
+    })
+    it('should check once for same SIRET called in INSEE registery', async () => {
+      // given
+      const siret = '12945678901539'
+      fetch.mockResponse(JSON.stringify({ message: 'no results found' }), {
+        status: 404,
+      })
+
+      // when
+      await siretApiValidate(siret, '')
+      await siretApiValidate(siret, '')
+
+      // then
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(fetch).toHaveBeenCalledWith(
+        `https://entreprise.data.gouv.fr/api/sirene/v3/etablissements/${siret}`
+      )
+    })
+  })
+})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14770

## But de la pull request

Ce champ siret, ou plutot l'api de l'insee (https://entreprise.data.gouv.fr/api/sirene/v3) est pleine de surprises et pas documentée. Pour ce SIRET : 21140047800338 les champs geo_l4 (qui est la ligne "12 rue duhesme") est vide alors qu'on a la ville et le code postal. Nous pouvons récupérer l'adresse dans l'unite_legale comme c'est fait ici https://github.com/pass-culture/pass-culture-main/blob/5790cea84c2b85ea05231a62ede7a3d03a6326eb/pro/src/api/entreprise/apiEntreprise.ts#L68

J'en ai profité pour ajouter la longitute/latitude dans ces cas là aussi

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
