### PR TITLE
(PC-14778)[API] fix: admin publicName on staging after import_users

### DIFF
--- a/api/src/pcapi/scripts/beneficiary/import_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_users.py
@@ -120,7 +120,7 @@ def create_or_update_users(rows: Iterable[dict]) -> list[User]:
     admin.add_admin_role()
     admin.firstName = "Jeanne"
     admin.lastName = "Admin"
-    admin.publicName = f"{user.firstName} {user.lastName}"  # type: ignore [union-attr]
+    admin.publicName = f"{admin.firstName} {admin.lastName}"
     repository.save(admin)
     logger.info("Created or updated admin user=%s", admin.id)
     return users


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14778

## But de la pull request

fix : le “publicName” de l’utilisateur [admin@example.com](mailto:admin@example.com) sur staging est celui du dernier utilisateur importé par le script import_users

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
