### PR TITLE
(PC-14020)[API] fix: change barcodes type to cancel booking to int (a…

### DIFF
--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -60,7 +60,7 @@ class SeatmapCDS(BaseModel):
 
 
 class CancelBookingCDS(BaseModel):
-    barcodes: list[str]
+    barcodes: list[int]
     paiement_type_id: int = Field(alias="paiementtypeid")
 
 

--- a/api/src/pcapi/core/booking_providers/cds/client.py
+++ b/api/src/pcapi/core/booking_providers/cds/client.py
@@ -125,6 +125,12 @@ class CineDigitalServiceAPI(BookingProviderClientAPI):
 
     def cancel_booking(self, barcodes: list[str]) -> None:
         paiement_type_id = self.get_payment_type().id
+        barcodes_int = []
+        for barcode in barcodes:
+            if not barcode.isdigit():
+                raise ValueError(f"Barcode {barcode} contains one or more invalid char (only digit allowed)")
+            barcodes_int.append(int(barcode))
+
         cancel_body = cds_serializers.CancelBookingCDS(barcodes=barcodes, paiementtypeid=paiement_type_id)
         api_response = put_resource(self.api_url, self.cinema_id, self.token, ResourceCDS.CANCEL_BOOKING, cancel_body)
 

--- a/api/tests/connectors/api_cine_digital_service_test.py
+++ b/api/tests/connectors/api_cine_digital_service_test.py
@@ -94,7 +94,7 @@ class CineDigitalServicePutResourceTest:
         api_url = "test_url/"
         token = "test_token"
         resource = ResourceCDS.CANCEL_BOOKING
-        body = CancelBookingCDS(barcodes=["111111111111"], paiementtypeid=5)
+        body = CancelBookingCDS(barcodes=[111111111111], paiementtypeid=5)
 
         response_json = {"111111111111": "BARCODE_NOT_FOUND"}
 
@@ -109,6 +109,6 @@ class CineDigitalServicePutResourceTest:
         request_put.assert_called_once_with(
             "https://test_id.test_url/transaction/cancel?api_token=test_token",
             headers={"Content-Type": "application/json"},
-            data='{"barcodes": ["111111111111"], "paiementtypeid": 5}',
+            data='{"barcodes": [111111111111], "paiementtypeid": 5}',
         )
         assert json_data == response_json

--- a/api/tests/core/booking_providers/cds/test_client.py
+++ b/api/tests/core/booking_providers/cds/test_client.py
@@ -394,7 +394,7 @@ class CineDigitalServiceCancelBookingTest:
 
         # When
         try:
-            cine_digital_service.cancel_booking(["3107362853729", "0312079646868"])
+            cine_digital_service.cancel_booking(["3107362853729", "1312079646868"])
         except cds_exceptions.CineDigitalServiceAPIException:
             assert False, "Should not raise exception"
 


### PR DESCRIPTION
…ctual str)

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14020

## But de la pull request

Modifier le typing des barcodes envoyés à l'api CDS pour annuler une réservation : actuellement en string, le type attendu est un entier

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
