### PR TITLE
PC-14168 dms completes the profile

### DIFF
--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -59,7 +59,7 @@ class EduconnectFlowTest:
 
         assert user.city == "Uneville"
         assert user.activity == "Lycéen"
-        assert subscription_api.has_completed_profile(user)
+        assert not subscription_api.should_complete_profile(user)
 
         # Get educonnect login form with saml protocol
         response = client.get("/saml/educonnect/login")
@@ -426,21 +426,21 @@ class NextSubscriptionStepTest:
         with override_features(**feature_flags):
             assert subscription_api.get_allowed_identity_check_methods(user) == expected_result
 
-    def test_has_completed_profile_names_mandatory(self):
+    def test_should_complete_profile_names_mandatory(self):
         user = users_factories.UserFactory(
             dateOfBirth=self.eighteen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             address="3 rue du quai",
             activity=users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
         )
-        assert subscription_api.has_completed_profile(user)
+        assert not subscription_api.should_complete_profile(user)
 
         user = users_factories.UserFactory(
             dateOfBirth=self.eighteen_years_ago,
             firstName=None,
             lastName=None,
         )
-        assert not subscription_api.has_completed_profile(user)
+        assert subscription_api.should_complete_profile(user)
 
     @pytest.mark.parametrize(
         "feature_flags,user_age,expected_result",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14168

## But de la pull request

Quand un dossier DMS est pending, on ne demande pas de remplir le profile - il sera rempli par DMS a priori. 
On le redemandera en cas de KO


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
