### PR TITLE
(PC-14768) Allow 19 users to finish subscription

### DIFF
--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -36,7 +36,11 @@ def create_fraud_check(
     application_id: int,
     source_data: typing.Optional[fraud_models.DMSContent],
 ) -> fraud_models.BeneficiaryFraudCheck:
-    eligibility_type = fraud_api.decide_eligibility(user, source_data) if source_data else None
+    eligibility_type = (
+        fraud_api.decide_eligibility(user, source_data.get_birth_date(), source_data.get_registration_datetime())
+        if source_data
+        else None
+    )
     fraud_check = fraud_models.BeneficiaryFraudCheck(
         user=user,
         type=fraud_models.FraudCheckType.DMS,

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -412,8 +412,12 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
     user: users_models.User,
     fraud_check: fraud_models.BeneficiaryFraudCheck,
 ) -> fraud_models.BeneficiaryFraudCheck:
+    identity_content: common_fraud_models.IdentityCheckContent = fraud_check.source_data()  # type: ignore [assignment]
+
     declared_eligibility = fraud_check.eligibilityType
-    id_provider_detected_eligibility = fraud_api.decide_eligibility(user, fraud_check.source_data())  # type: ignore [arg-type]
+    id_provider_detected_eligibility = fraud_api.decide_eligibility(
+        user, identity_content.get_birth_date(), identity_content.get_registration_datetime()
+    )
 
     if declared_eligibility == id_provider_detected_eligibility or id_provider_detected_eligibility is None:
         return fraud_check

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -111,7 +111,11 @@ def has_completed_profile(user: users_models.User) -> bool:
 def is_eligibility_activable(
     user: users_models.User, eligibility: typing.Optional[users_models.EligibilityType]
 ) -> bool:
-    return user.eligibility == eligibility and users_api.is_eligible_for_beneficiary_upgrade(user, eligibility)
+    return (
+        user.eligibility == eligibility
+        and users_api.is_eligible_for_beneficiary_upgrade(user, eligibility)
+        and users_api.is_user_age_compatible_with_eligibility(user, eligibility)
+    )
 
 
 def get_email_validation_subscription_item(

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -351,9 +351,9 @@ class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, 
 
     @property
     def eligibility(self) -> Optional[EligibilityType]:
-        from pcapi.core.users import api as users_api
+        from pcapi.core.fraud import api as fraud_api
 
-        return users_api.get_eligibility_at_date(self.dateOfBirth, datetime.utcnow())
+        return fraud_api.decide_eligibility(self, self.dateOfBirth, datetime.utcnow())
 
     @property
     def has_active_deposit(self):  # type: ignore [no-untyped-def]

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -640,7 +640,9 @@ class DecideEligibilityTest:
             user=user, type=fraud_models.FraudCheckType.DMS, resultContent=dms_content
         )
 
-        result = fraud_api.decide_eligibility(user, dms_content)
+        result = fraud_api.decide_eligibility(
+            user, dms_content.get_birth_date(), dms_content.get_registration_datetime()
+        )
         assert result == users_models.EligibilityType.AGE18
 
     @freeze_time("2020-01-02")
@@ -655,7 +657,9 @@ class DecideEligibilityTest:
             user=user, type=fraud_models.FraudCheckType.DMS, resultContent=dms_content
         )
 
-        result = fraud_api.decide_eligibility(user, dms_content)
+        result = fraud_api.decide_eligibility(
+            user, dms_content.get_birth_date(), dms_content.get_registration_datetime()
+        )
         assert result == None
 
     @freeze_time("2020-01-02")
@@ -675,7 +679,9 @@ class DecideEligibilityTest:
             user=user, type=fraud_models.FraudCheckType.DMS, resultContent=dms_content
         )
 
-        result = fraud_api.decide_eligibility(user, dms_content)
+        result = fraud_api.decide_eligibility(
+            user, dms_content.get_birth_date(), dms_content.get_registration_datetime()
+        )
         assert result == None
 
     @freeze_time("2020-01-02")
@@ -695,7 +701,9 @@ class DecideEligibilityTest:
             user=user, type=fraud_models.FraudCheckType.DMS, resultContent=dms_content
         )
 
-        result = fraud_api.decide_eligibility(user, dms_content)
+        result = fraud_api.decide_eligibility(
+            user, dms_content.get_birth_date(), dms_content.get_registration_datetime()
+        )
         assert result == users_models.EligibilityType.AGE18
 
     @freeze_time("2020-01-02")
@@ -709,5 +717,7 @@ class DecideEligibilityTest:
             user=user, type=fraud_models.FraudCheckType.DMS, resultContent=dms_content
         )
 
-        result = fraud_api.decide_eligibility(user, dms_content)
+        result = fraud_api.decide_eligibility(
+            user, dms_content.get_birth_date(), dms_content.get_registration_datetime()
+        )
         assert result == users_models.EligibilityType.AGE18

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -869,7 +869,7 @@ class ShowEligibleCardTest:
     def test_against_different_age(self, age, expected):
         date_of_birth = datetime.utcnow() - relativedelta(years=age, days=5)
         date_of_creation = datetime.utcnow() - relativedelta(years=4)
-        user = users_factories.UserFactory.build(dateOfBirth=date_of_birth, dateCreated=date_of_creation)
+        user = users_factories.UserFactory(dateOfBirth=date_of_birth, dateCreated=date_of_creation)
         assert account_serializers.UserProfileResponse._show_eligible_card(user) == expected
 
     @pytest.mark.parametrize("beneficiary,expected", [(False, True), (True, False)])
@@ -877,7 +877,7 @@ class ShowEligibleCardTest:
         date_of_birth = datetime.utcnow() - relativedelta(years=18, days=5)
         date_of_creation = datetime.utcnow() - relativedelta(years=4)
         roles = [UserRole.BENEFICIARY] if beneficiary else []
-        user = users_factories.UserFactory.build(
+        user = users_factories.UserFactory(
             dateOfBirth=date_of_birth,
             dateCreated=date_of_creation,
             roles=roles,
@@ -887,7 +887,7 @@ class ShowEligibleCardTest:
     def test_user_eligible_but_created_after_18(self):
         date_of_birth = datetime.utcnow() - relativedelta(years=18, days=5)
         date_of_creation = datetime.utcnow()
-        user = users_factories.UserFactory.build(dateOfBirth=date_of_birth, dateCreated=date_of_creation)
+        user = users_factories.UserFactory(dateOfBirth=date_of_birth, dateCreated=date_of_creation)
         assert account_serializers.UserProfileResponse._show_eligible_card(user) == False
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14768

## But de la pull request

Le but est de permettre aux jeunes de 19 ans de pouvoir finaliser leur inscription (validation de téléphone, complétion du profil, etc) quand ils avaient initié le parcours à 18 ans.

En toute logique, il faut donc changer le calcul de `user.eligibility` pour se baser sur `decide_eligibility`, déjà implémentée pour gérer les imports.

Conséquences : 
- tout utilisateur qui a fait un FraudCheck à 18 ans aura `user.eligibility == Eligibility.AGE18` là où avant l'éligivilité s'arrêtait à 18 ans. Ça n'a pas beaucoup d'impact
- lorsqu'on appelle `user.eligibility`, par exemple sur la route /me, si l'utilisateur a 19ans, on va faire une requête sql sur la table BeneficiaryFraudCheck 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
