### PR TITLE
(PC-14776)[API] feat: make offer showType and musicType required and not editable

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -249,6 +249,8 @@ def _check_offer_data_is_valid(
 ) -> None:
     check_offer_subcategory_is_valid(offer_data.subcategory_id)
     check_offer_is_eligible_for_educational(offer_data.subcategory_id, offer_is_educational)  # type: ignore [arg-type]
+    if not offer_is_educational:
+        validation.check_offer_extra_data(None, offer_data.subcategory_id, offer_data.extra_data)  # type: ignore [arg-type]
 
 
 def update_offer(
@@ -278,6 +280,9 @@ def update_offer(
     visualDisabilityCompliant: bool = UNCHANGED,  # type: ignore [assignment]
 ) -> Offer:
     validation.check_validation_status(offer)
+    if extraData != UNCHANGED:
+        extraData = validation.check_offer_extra_data(offer, offer.subcategoryId, extraData)
+
     # fmt: off
     modifications = {
         field: new_value

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -30,7 +30,7 @@ class Returns200Test:
             "name": "La pièce de théâtre",
             "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
             "withdrawalType": "no_ticket",
-            "extraData": {"toto": "text"},
+            "extraData": {"toto": "text", "showType": 200},
             "externalTicketOfficeUrl": "http://example.net",
             "audioDisabilityCompliant": False,
             "mentalDisabilityCompliant": True,
@@ -45,7 +45,7 @@ class Returns200Test:
         offer = Offer.query.get(offer_id)
         assert offer.bookingEmail == "offer@example.com"
         assert offer.subcategoryId == subcategories.SPECTACLE_REPRESENTATION.id
-        assert offer.extraData == {"toto": "text"}
+        assert offer.extraData == {"toto": "text", "showType": 200}
         assert offer.externalTicketOfficeUrl == "http://example.net"
         assert offer.venue == venue
         assert offer.product.durationMinutes == 60
@@ -111,7 +111,7 @@ class Returns200Test:
             "name": "La pièce de théâtre",
             "subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id,
             "withdrawalType": "no_ticket",
-            "extraData": {"toto": "text"},
+            "extraData": {"toto": "text", "showType": 300},
             "externalTicketOfficeUrl": "http://example.net",
             "audioDisabilityCompliant": False,
             "mentalDisabilityCompliant": True,
@@ -299,6 +299,7 @@ class Returns200Test:
             "subcategoryId": subcategories.CONCERT.id,
             "withdrawalDetails": "Veuillez récuperer vos billets à l'accueil :)",
             "withdrawalType": "no_ticket",
+            "extraData": {"musicType": 300},
         }
         response = client.with_session_auth("user@example.com").post("/offers", json=data)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14776

## But de la pull request

Rendre les champs Genre Musical (`musicType`) et Type de Spectacle (`showType`) obligatoires pour la création d'offre, et non modifiable à l'édition de l'offre à l'exception du cas ou ils ne sont pas encore renseignés.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
