### PR TITLE
(PC-14491) Fix dms files archive

### DIFF
--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -83,7 +83,7 @@ def import_dms_users(procedure_id: int) -> None:
         procedure_id,
     )
 
-    existing_applications_ids = dms_repository.get_already_processed_applications_ids(procedure_id)
+    already_processed_applications_ids = dms_repository.get_already_processed_applications_ids(procedure_id)
     client = dms_connector_api.DMSGraphQLClient()
     processed_count = 0
 
@@ -91,7 +91,7 @@ def import_dms_users(procedure_id: int) -> None:
         procedure_id, dms_models.GraphQLApplicationStates.accepted
     ):
         application_id = application_details.number
-        if application_id in existing_applications_ids:
+        if application_id in already_processed_applications_ids:
             continue
         processed_count += 1
         try:

--- a/api/src/pcapi/core/subscription/dms/repository.py
+++ b/api/src/pcapi/core/subscription/dms/repository.py
@@ -38,9 +38,9 @@ def _get_already_processed_applications_ids_from_fraud_checks(procedure_id: int)
     fraud_checks = fraud_models.BeneficiaryFraudCheck.query.filter(
         fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.DMS,
         or_(
-            fraud_models.BeneficiaryFraudCheck.resultContent["procedure_id"].astext.cast(Integer) == procedure_id,
             fraud_models.BeneficiaryFraudCheck.resultContent
             == None,  # If there was a parsing error, a fraudCheck exists but no resultContent
+            fraud_models.BeneficiaryFraudCheck.resultContent["procedure_id"].astext.cast(Integer) == procedure_id,
         ),
         fraud_models.BeneficiaryFraudCheck.status.notin_(
             [

--- a/api/src/pcapi/scripts/beneficiary/archive_dms_applications.py
+++ b/api/src/pcapi/scripts/beneficiary/archive_dms_applications.py
@@ -3,11 +3,7 @@ import logging
 from pcapi import settings
 from pcapi.connectors.dms import api as api_dms
 from pcapi.connectors.dms import models as dms_models
-from pcapi.core.users import models as users_models
-from pcapi.models import db
-from pcapi.models.beneficiary_import import BeneficiaryImport
-from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
-from pcapi.models.beneficiary_import_status import ImportStatus
+from pcapi.core.subscription.dms import repository as dms_repository
 
 
 logger = logging.getLogger()
@@ -16,32 +12,29 @@ logger = logging.getLogger()
 def archive_applications(procedure_id: int, dry_run: bool = True) -> None:
     total_applications = 0
     archived_applications = 0
+
+    already_processed_applications_ids = dms_repository.get_already_processed_applications_ids(procedure_id)
     client = api_dms.DMSGraphQLClient()
+
     for application_details in client.get_applications_with_details(
         procedure_id, dms_models.GraphQLApplicationStates.accepted
     ):
+        total_applications += 1
+
         application_techid = application_details.id
         application_number = application_details.number
-        total_applications += 1
-        bi = (
-            BeneficiaryImport.query.join(users_models.User, users_models.User.id == BeneficiaryImport.beneficiaryId)
-            .join(BeneficiaryImportStatus, BeneficiaryImportStatus.beneficiaryImportId == BeneficiaryImport.id)
-            .filter(BeneficiaryImport.applicationId == application_number, BeneficiaryImport.sourceId == procedure_id)
-            .filter(BeneficiaryImportStatus.status == ImportStatus.CREATED)
-        ).one_or_none()
-        if bi and bi.beneficiary.has_beneficiary_role:
-            instructeur_techid = settings.DMS_ENROLLMENT_INSTRUCTOR
-            if not dry_run:
-                client.archive_application(application_techid, instructeur_techid)
-            logger.info(
-                "Archiving application %d on procedure %d for user_id %d",
-                application_number,
-                procedure_id,
-                bi.beneficiaryId,
-            )
-            archived_applications += 1
-        # remove object from SQLAlchemy session's cache and release read locks
-        db.session.rollback()
+
+        if application_number not in already_processed_applications_ids:
+            continue
+
+        if not dry_run:
+            try:
+                client.archive_application(application_techid, settings.DMS_ENROLLMENT_INSTRUCTOR)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("error while archiving application %d", application_number)
+        logger.info("Archiving application %d on procedure %d", application_number, procedure_id)
+        archived_applications += 1
+
     logger.info(
         "script ran : total applications : %d to archive applications : %d", total_applications, archived_applications
     )

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -206,13 +206,14 @@ def test_reset_password_success(client):
     assert response.status_code == 204
     db.session.refresh(user)
     assert user.password == crypto.hash_password(new_password)
-    assert user.is_subscriptionState_email_validated()
 
     token = Token.query.get(token.id)
     assert token.isUsed
+    assert user.is_subscriptionState_email_validated()
 
 
-def test_reset_password_for_unvalidated_email(client):
+@patch("pcapi.core.subscription.dms.api.try_dms_orphan_adoption")
+def test_reset_password_for_unvalidated_email(try_dms_orphan_adoption_mock, client):
     new_password = "New_password1998!"
 
     user = users_factories.UserFactory(isEmailValidated=False)
@@ -224,6 +225,7 @@ def test_reset_password_for_unvalidated_email(client):
     assert response.status_code == 204
     db.session.refresh(user)
     assert user.password == crypto.hash_password(new_password)
+    try_dms_orphan_adoption_mock.assert_called_once_with(user)
     assert user.isEmailValidated
     assert user.is_subscriptionState_email_validated()
 

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -35,12 +35,13 @@ def make_graphql_application(
     postal_code: int = 67200,
     processed_datetime: Optional[str] = "2020-05-13T10:41:21+02:00",
     messages: Optional[list] = None,
+    application_techid: Optional[str] = None,
 ) -> dict:
     if messages is None:
         messages = DEFAULT_MESSAGES
 
     data = {
-        "id": "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
+        "id": application_techid or "".join(random.choice(string.ascii_uppercase + string.digits) for _ in range(20)),
         "number": application_id,
         "archived": False,
         "state": state,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14491

## But de la pull request

Archiver les dossier dms pour ne pas les récupérer dans le cron `import_dms_users` . Dans le cron, la méthode `get_application_details` récupère tous les dossiers "Acceptés" qui ne sont pas archivés. On regarde si on les a déjà traités avec la méthode `get_arlready_processed_application_ids`. Du coup il suffit de réutiliser cette dernière méthode pour savoir s'il faut archiver ou non le dossier.

NB : un dossier archivé peut toujours être récupéré avec `get_single_application_details`, appelée par exemple lors de l'"adoption" d'un dossier dms qui vient de trouver un papa ou une maman. Par contre, il faut avoir en tête qu'un dossier archivé est supprimé au bout de 18 mois et qu'il ne sera plus récupérable.


## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
