### PR TITLE
(PC-14144)[API] fix: commit template offer validation status

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1286,6 +1286,7 @@ def create_collective_offer_template_and_delete_collective_offer(offer: Offer, s
             collective_offer_template.validation = OfferValidationStatus.APPROVED  # type: ignore [assignment]
             collective_offer_template.lastValidationDate = datetime.datetime.utcnow()
             collective_offer_template.lastValidationType = OfferValidationType.AUTO  # type: ignore [assignment]
+            db.session.commit()
 
     search.unindex_collective_offer_ids([collective_offer.id])
     search.async_index_collective_offer_template_ids([collective_offer_template.id])


### PR DESCRIPTION
Oubli : il manquait un db.session.commit() après modification du statut de validation d'une offre template