### PR TITLE
Pc 14025 cds validation rule external booking status to used 48h after event

### DIFF
--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -132,3 +132,12 @@ class CancelledIndividualBookingFactory(CancelledBookingFactory):
 class UsedIndividualBookingFactory(UsedBookingFactory):
     individualBooking = factory.SubFactory(IndividualBookingSubFactory)
     user = None
+
+
+class ExternalBookingFactory(BaseFactory):
+    class Meta:
+        model = models.ExternalBooking
+
+    booking = factory.SubFactory(BookingFactory)
+    barcode = "1111111"
+    seat = "A15"

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -852,6 +852,16 @@ class AutoMarkAsUsedAfterEventTest:
         booking = Booking.query.first()
         assert booking.status is BookingStatus.CANCELLED
 
+    def test_update_external_booking_if_not_used(self):
+        event_date = datetime.utcnow() - timedelta(days=3)
+        booking_factories.ExternalBookingFactory(
+            booking__stock__beginningDatetime=event_date,
+        )
+        api.auto_mark_as_used_after_event()
+
+        validated_external_booking = Booking.query.first()
+        assert validated_external_booking.status is BookingStatus.USED
+
     def test_update_educational_booking_if_not_used(self):
         event_date = datetime.utcnow() - timedelta(days=3)
         booking_factories.EducationalBookingFactory(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14025

## But de la pull request

Ajouter les externalBooking au cron update_booking_used

## Implémentation

Ajout externalbooking à la fonction auto_mark_as_used_after_event

## Informations supplémentaires

Création factory pour externalbooking

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
