### PR TITLE
(PC-14020)[API] fix: use cast barcodes instead of string bardcodes to…

### DIFF
--- a/api/src/pcapi/core/booking_providers/cds/client.py
+++ b/api/src/pcapi/core/booking_providers/cds/client.py
@@ -125,13 +125,13 @@ class CineDigitalServiceAPI(BookingProviderClientAPI):
 
     def cancel_booking(self, barcodes: list[str]) -> None:
         paiement_type_id = self.get_payment_type().id
-        barcodes_int = []
+        barcodes_int: list[int] = []
         for barcode in barcodes:
             if not barcode.isdigit():
                 raise ValueError(f"Barcode {barcode} contains one or more invalid char (only digit allowed)")
             barcodes_int.append(int(barcode))
 
-        cancel_body = cds_serializers.CancelBookingCDS(barcodes=barcodes, paiementtypeid=paiement_type_id)
+        cancel_body = cds_serializers.CancelBookingCDS(barcodes=barcodes_int, paiementtypeid=paiement_type_id)
         api_response = put_resource(self.api_url, self.cinema_id, self.token, ResourceCDS.CANCEL_BOOKING, cancel_body)
 
         if api_response:


### PR DESCRIPTION
… cancel cds booking

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14020

## But de la pull request

Quick fix pour effectivement utiliser les barcodes numeriques plutôt que les chaines de caractères pour annuler une résa CDS


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
