### PR TITLE
(PC-14836)[API] fix: fix update offer NoneType error when extraData is none

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -385,6 +385,8 @@ def check_offer_extra_data(offer: Optional[Offer], subcategory_id: str, extra_da
     api_errors = ApiErrors()
     subcategory = ALL_SUBCATEGORIES_DICT[subcategory_id]
     mandatory_fields = OFFER_EXTRA_DATA_MANDATORY_FIELDS & set(subcategory.conditional_fields)
+    if not extra_data:
+        extra_data = {}
 
     for field in mandatory_fields:
         if offer and offer.extraData and offer.extraData.get(field):  # type: ignore [union-attr]

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1687,6 +1687,15 @@ class UpdateOfferTest:
 
         assert error.value.errors == {"showType": ["Ce champ est obligatoire"]}
 
+    def test_should_be_able_to_update_offer_when_extra_data_is_none(self):
+        offer = factories.OfferFactory(
+            subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id, extraData={"showType": 200}
+        )
+
+        offer = api.update_offer(offer, extraData=None)
+
+        assert offer.extraData == {"showType": 200}
+
     def test_update_product_if_owning_offerer_is_the_venue_managing_offerer(self):
         offerer = offerers_factories.OffererFactory()
         product = factories.ProductFactory(owningOfferer=offerer)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14836

Correction de l'erreur TypeError("'NoneType' object does not support item assignment") lorsque l'extraData envoyé du front est `null`

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
