### PR TITLE
(PC-14831)[PRO] feat: keep params in tabs

### DIFF
--- a/pro/src/new_components/Tabs/Tabs.tsx
+++ b/pro/src/new_components/Tabs/Tabs.tsx
@@ -1,50 +1,48 @@
 import cn from 'classnames'
-import React from 'react'
-import { Link } from 'react-router-dom'
-
-import { Audience } from 'core/shared/types'
-import { ReactComponent as LibraryIcon } from 'icons/library.svg'
-import { ReactComponent as UserIcon } from 'icons/user.svg'
+import React, { FunctionComponent, SVGProps } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 
 import styles from './Tabs.module.scss'
 
-interface ITabsProps {
-  selectedAudience: Audience
-  individualLink: string
-  collectiveLink: string
-  individualLabel: string
-  collectiveLabel: string
+interface ITab {
+  label: string
+  key: string
+  url: string
+  Icon?: FunctionComponent<SVGProps<SVGSVGElement>>
+}
+interface IFilterTabsProps {
+  tabs: ITab[]
+  selectedKey?: string
+  withQueryParams?: boolean
 }
 
 const Tabs = ({
-  selectedAudience,
-  individualLink,
-  collectiveLink,
-  individualLabel,
-  collectiveLabel,
-}: ITabsProps): JSX.Element => {
+  selectedKey,
+  tabs,
+  withQueryParams,
+}: IFilterTabsProps): JSX.Element => {
+  const { search } = useLocation()
+
   return (
     <ul className={styles['tabs']}>
-      <li
-        className={cn(styles['tabs-tab'], {
-          [styles['is-selected']]: selectedAudience === Audience.INDIVIDUAL,
-        })}
-      >
-        <Link className={styles['tabs-tab-link']} to={individualLink}>
-          <UserIcon className={styles['tabs-tab-icon']} />
-          <span>{individualLabel}</span>
-        </Link>
-      </li>
-      <li
-        className={cn(styles['tabs-tab'], {
-          [styles['is-selected']]: selectedAudience === Audience.COLLECTIVE,
-        })}
-      >
-        <Link className={styles['tabs-tab-link']} to={collectiveLink}>
-          <LibraryIcon className={styles['tabs-tab-icon']} />
-          <span>{collectiveLabel}</span>
-        </Link>
-      </li>
+      {tabs.map(({ key, label, url, Icon }) => {
+        const to = withQueryParams
+          ? `${url}?${new URLSearchParams(search).toString()}`
+          : url
+        return (
+          <li
+            className={cn(styles['tabs-tab'], {
+              [styles['is-selected']]: selectedKey === key,
+            })}
+            key={`tab_${url}`}
+          >
+            <Link className={styles['tabs-tab-link']} key={`tab${url}`} to={to}>
+              {Icon && <Icon className={styles['tabs-tab-icon']} />}
+              <span>{label}</span>
+            </Link>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/pro/src/new_components/Tabs/__specs__/Tabs.spec.tsx
+++ b/pro/src/new_components/Tabs/__specs__/Tabs.spec.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router'
+
+import { ReactComponent as LibraryIcon } from 'icons/library.svg'
+import { ReactComponent as UserIcon } from 'icons/user.svg'
+
+import Tabs from '../Tabs'
+
+describe('src | new_components | Tabs', () => {
+  it('should render tabs', () => {
+    render(
+      <MemoryRouter>
+        <Tabs
+          tabs={[
+            {
+              label: 'Offres individuelles',
+              url: '/offres',
+              key: 'individual',
+              Icon: UserIcon,
+            },
+            {
+              label: 'Offres collectives',
+              url: '/offres/collectives',
+              key: 'collective',
+              Icon: LibraryIcon,
+            },
+          ]}
+        />
+      </MemoryRouter>
+    )
+    expect(
+      screen.getByRole('link', {
+        name: 'Offres individuelles',
+      })
+    ).toHaveAttribute('href', '/offres')
+  })
+  it('should use query params', () => {
+    render(
+      <MemoryRouter
+        initialEntries={['http://localhost:3001/offres?filter=test']}
+      >
+        <Tabs
+          tabs={[
+            {
+              label: 'Offres individuelles',
+              url: '/offres',
+              key: 'individual',
+              Icon: UserIcon,
+            },
+            {
+              label: 'Offres collectives',
+              url: '/offres/collectives',
+              key: 'collective',
+              Icon: LibraryIcon,
+            },
+          ]}
+          withQueryParams
+        />
+      </MemoryRouter>
+    )
+    expect(
+      screen.getByRole('link', {
+        name: 'Offres collectives',
+      })
+    ).toHaveAttribute('href', '/offres/collectives?filter=test')
+  })
+})

--- a/pro/src/screens/Bookings/Bookings.tsx
+++ b/pro/src/screens/Bookings/Bookings.tsx
@@ -22,6 +22,8 @@ import {
 } from 'core/Bookings'
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings'
 import { Audience } from 'core/shared/types'
+import { ReactComponent as LibraryIcon } from 'icons/library.svg'
+import { ReactComponent as UserIcon } from 'icons/user.svg'
 import NoData from 'new_components/NoData'
 import Tabs from 'new_components/Tabs'
 
@@ -56,7 +58,6 @@ const Bookings = ({
   const separateIndividualAndCollectiveOffers = useActiveFeature(
     'ENABLE_INDIVIDUAL_AND_COLLECTIVE_OFFER_SEPARATION'
   )
-
   const [appliedPreFilters, setAppliedPreFilters] = useState<TPreFilters>({
     ...DEFAULT_PRE_FILTERS,
     offerVenueId: venueId || DEFAULT_PRE_FILTERS.offerVenueId,
@@ -138,11 +139,21 @@ const Bookings = ({
       <Titles title="Réservations" />
       {separateIndividualAndCollectiveOffers && (
         <Tabs
-          collectiveLabel="Réservations collectives"
-          collectiveLink="/reservations/collectives"
-          individualLabel="Réservations individuelles"
-          individualLink="/reservations"
-          selectedAudience={audience}
+          selectedKey={audience}
+          tabs={[
+            {
+              label: 'Réservations individuelles',
+              url: '/reservations',
+              key: 'individual',
+              Icon: UserIcon,
+            },
+            {
+              label: 'Réservations collectives',
+              url: '/reservations/collectives',
+              key: 'collective',
+              Icon: LibraryIcon,
+            },
+          ]}
         />
       )}
       <PreFilters

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -15,6 +15,8 @@ import {
 import { Offer, Offerer, Option, TSearchFilters } from 'core/Offers/types'
 import { Audience } from 'core/shared'
 import { ReactComponent as AddOfferSvg } from 'icons/ico-plus.svg'
+import { ReactComponent as LibraryIcon } from 'icons/library.svg'
+import { ReactComponent as UserIcon } from 'icons/user.svg'
 import NoOffers from 'new_components/NoData'
 import Tabs from 'new_components/Tabs'
 
@@ -188,11 +190,22 @@ const Offers = ({
       <Titles action={actionLink} title="Offres" />
       {separateIndividualAndCollectiveOffers && (
         <Tabs
-          collectiveLabel="Offres collectives"
-          collectiveLink="/offres/collectives"
-          individualLabel="Offres individuelles"
-          individualLink="/offres"
-          selectedAudience={audience}
+          selectedKey={audience}
+          tabs={[
+            {
+              label: 'Offres individuelles',
+              url: '/offres',
+              key: 'individual',
+              Icon: UserIcon,
+            },
+            {
+              label: 'Offres collectives',
+              url: '/offres/collectives',
+              key: 'collective',
+              Icon: LibraryIcon,
+            },
+          ]}
+          withQueryParams
         />
       )}
       <ActionsBarPortal isVisible={nbSelectedOffers > 0}>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14831

## But de la pull request

Garder les query params quand on passe d'un onglet à l'autre

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
