### PR TITLE
(PC-14020)[API] fix: check if response contains json before returning…

### DIFF
--- a/api/src/pcapi/connectors/cine_digital_service.py
+++ b/api/src/pcapi/connectors/cine_digital_service.py
@@ -58,7 +58,7 @@ def get_resource(
 
 def put_resource(
     api_url: str, cinema_id: str, token: Optional[str], resource: ResourceCDS, body: BaseModel
-) -> Union[dict, list[dict], list]:
+) -> Optional[Union[dict, list[dict], list]]:
     if settings.IS_DEV:
         return MOCKS[resource]
 
@@ -71,7 +71,10 @@ def put_resource(
     except requests.exceptions.RequestException as e:
         raise cds_exceptions.CineDigitalServiceAPIException(f"API CDS - url : {url} - error : {e}")
 
-    return response.json()
+    response_headers = response.headers.get("Content-Type")
+    if response_headers and "application/json" in response_headers:
+        return response.json()
+    return None
 
 
 def _build_url(

--- a/api/tests/connectors/api_cine_digital_service_test.py
+++ b/api/tests/connectors/api_cine_digital_service_test.py
@@ -98,7 +98,7 @@ class CineDigitalServicePutResourceTest:
 
         response_json = {"111111111111": "BARCODE_NOT_FOUND"}
 
-        response_return_value = mock.MagicMock(status_code=200, text="")
+        response_return_value = mock.MagicMock(status_code=200, text="", headers={"Content-Type": "application/json"})
         response_return_value.json = mock.MagicMock(return_value=response_json)
         request_put.return_value = response_return_value
 


### PR DESCRIPTION
… it in put_resource

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14020

## But de la pull request

Vérifier que la réponse de l'api CDS contient du json avant d'essayer de la parser dans le cas ou on fait un une requête PUT

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
