### PR TITLE
(PC-14611)[API] feat: add barcodes and seatbar to BookingResponse in …

### DIFF
--- a/api/src/pcapi/core/booking_providers/factories.py
+++ b/api/src/pcapi/core/booking_providers/factories.py
@@ -3,6 +3,8 @@ import factory
 from pcapi.core.booking_providers.models import BookingProvider
 from pcapi.core.booking_providers.models import BookingProviderName
 from pcapi.core.booking_providers.models import VenueBookingProvider
+from pcapi.core.bookings.factories import IndividualBookingFactory
+from pcapi.core.bookings.models import ExternalBooking
 from pcapi.core.offerers.factories import VenueFactory
 from pcapi.core.testing import BaseFactory
 from pcapi.utils.token import random_token
@@ -24,3 +26,12 @@ class VenueBookingProviderFactory(BaseFactory):
     bookingProvider = factory.SubFactory(BookingProviderFactory)
     idAtProvider = factory.Sequence("idProvider{}".format)
     token = factory.LazyFunction(random_token)
+
+
+class ExternalBookingFactory(BaseFactory):
+    class Meta:
+        model = ExternalBooking
+
+    booking = factory.SubFactory(IndividualBookingFactory)
+    barcode = factory.Sequence(lambda n: f"{n:13}")
+    seat = factory.Sequence("A_{}".format)

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -127,6 +127,7 @@ def get_bookings(user: User) -> BookingsResponse:
             .joinedload(Offer.mediations)
         )
         .options(joinedload(IndividualBooking.booking).joinedload(Booking.activationCode))
+        .options(joinedload(IndividualBooking.booking).joinedload(Booking.externalBookings))
     ).all()
 
     ended_bookings = []

--- a/api/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -87,6 +87,14 @@ class BookingActivationCodeResponse(BaseModel):
         orm_mode = True
 
 
+class ExternalBookingResponse(BaseModel):
+    barcode: str
+    seat: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
 class BookingReponse(BaseModel):
     id: int
     cancellationDate: Optional[datetime]
@@ -101,6 +109,7 @@ class BookingReponse(BaseModel):
     total_amount: int
     token: str
     activationCode: Optional[BookingActivationCodeResponse]
+    externalBookings: Optional[list[ExternalBookingResponse]]
 
     _convert_total_amount = validator("total_amount", pre=True, allow_reuse=True)(convert_to_cent)
 

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -127,6 +127,12 @@ def test_public_api(client, app):
                             "title": "Expirationdate",
                             "type": "string",
                         },
+                        "externalBookings": {
+                            "items": {"$ref": "#/components/schemas/ExternalBookingResponse"},
+                            "nullable": True,
+                            "title": "Externalbookings",
+                            "type": "array",
+                        },
                         "id": {"title": "Id", "type": "integer"},
                         "qrCodeData": {"nullable": True, "title": "Qrcodedata", "type": "string"},
                         "quantity": {"title": "Quantity", "type": "integer"},
@@ -887,6 +893,15 @@ def test_public_api(client, app):
                     "description": "An enumeration.",
                     "enum": ["all", "digital", "physical"],
                     "title": "ExpenseDomain",
+                },
+                "ExternalBookingResponse": {
+                    "properties": {
+                        "barcode": {"title": "Barcode", "type": "string"},
+                        "seat": {"nullable": True, "title": "Seat", "type": "string"},
+                    },
+                    "required": ["barcode"],
+                    "title": "ExternalBookingResponse",
+                    "type": "object",
                 },
                 "FavoriteMediationResponse": {
                     "properties": {


### PR DESCRIPTION
…get_bookings

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14611

## But de la pull request

Renvoyer les informations liées à une réservation issue d'une api de billetterie lors de l'appel à la route get_bookings côté app native.  

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
