### PR TITLE
(PC-14777)[API] feat: Fix import users on staging with email validated

### DIFF
--- a/api/src/pcapi/admin/custom_views/user_offerer_view.py
+++ b/api/src/pcapi/admin/custom_views/user_offerer_view.py
@@ -28,6 +28,7 @@ class UserOffererView(BaseAdminView):
         "offerer.address",
         "offerer.name",
         "offerer.id",
+        "isValidated",
     ]
     column_labels = {
         "user.email": "Email utilisateur",
@@ -38,6 +39,7 @@ class UserOffererView(BaseAdminView):
         "offerer.address": "Adresse de la structure",
         "offerer.name": "Nom de la structure",
         "offerer.id": "Identifiant de la structure",
+        "isValidated": "Validé",
     }
     column_sortable_list: list[str] = []
     column_searchable_list = [

--- a/api/src/pcapi/scripts/beneficiary/import_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_users.py
@@ -68,6 +68,7 @@ def _create_pro_user(row: dict) -> User:
     offerer.dateValidated = datetime.utcnow()
     repository.save(offerer)
 
+    user.validationToken = None
     user.isEmailValidated = True
     user.add_pro_role()
 
@@ -100,6 +101,7 @@ def create_or_update_users(rows: Iterable[dict]) -> list[User]:
         user.phoneNumber = row["Téléphone"]
         user.departementCode = row["Département"]
         user.postalCode = row["Code postal"]
+        user.comment = row["Type"]
         repository.save(user)
 
         users.append(user)


### PR DESCRIPTION
(pro)

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14777

## But de la pull request

Résoudre des problèmes d'identification avec les comptes pro importés sur staging : un token de validation présent indiquait un email non validé.

Je passe dans cette PR un micro changement pour voir dans le backoffice si un rattachement de structure à un utilisateur est validé (ça ne coûte rien et ça facilite l'investigation).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
