### PR TITLE
(PC-14866)[API] fix: filter out registration date where the user is not eligible

### DIFF
--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -24,6 +24,7 @@ RECREDIT_BATCH_SIZE = 1000
 def has_celebrated_birthday_since_registration(user: users_models.User) -> bool:
     first_registration_datetime = subscription_api.get_first_registration_date(user)
     if first_registration_datetime is None:
+        logger.error("No registration date for user to be recredited", extra={"user_id": user.id})
         return False
 
     return first_registration_datetime.date() < user.latest_birthday

--- a/api/tests/scripts/payment/user_recredit_test.py
+++ b/api/tests/scripts/payment/user_recredit_test.py
@@ -22,8 +22,8 @@ class UserRecreditTest:
         "birth_date,registration_datetime,expected_result",
         [
             ("2006-01-01", datetime.datetime(2021, 5, 1), False),
-            ("2006-01-01", datetime.datetime(2020, 5, 1), True),
-            ("2006-07-01", datetime.datetime(2020, 5, 1), True),
+            ("2005-01-01", datetime.datetime(2020, 5, 1), True),
+            ("2005-07-01", datetime.datetime(2021, 5, 1), True),
         ],
     )
     def test_has_celebrated_birthday_since_registration(self, birth_date, registration_datetime, expected_result):
@@ -35,7 +35,7 @@ class UserRecreditTest:
             user=user,
             resultContent=fraud_check_result_content,
             type=fraud_models.FraudCheckType.UBBLE,
-            dateCreated=datetime.datetime(2021, 5, 1),
+            dateCreated=registration_datetime,
         )
         assert has_celebrated_birthday_since_registration(user) == expected_result
 


### PR DESCRIPTION
the following happenned : a user creates an account with 14 yearls old but declares a 15 yo age. the user fails educonnect because the age is too young and we override user dateOfBirth with the right dateOfBirth. when the user comes back with 15 years old, in order to give the right amount for deposit, we look for the age at the first registration. If we consider it is 14 yo, we cannot find the right deposit

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14866

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
