### PR TITLE
(PC-FIX)[API] fix: sandbox: use keep_ratio for mediations

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
@@ -13,7 +13,7 @@ def store_public_object_from_sandbox_assets(folder, model, subcategoryId):  # ty
     picture_path = str(thumbs_folder_path / "mediations" / subcategoryId) + ".jpg"
     with open(picture_path, mode="rb") as thumb_file:
         if folder == "thumbs":
-            create_thumb(model, thumb_file.read(), 0)
+            create_thumb(model, thumb_file.read(), 0, keep_ratio=True)
             model.thumbCount += 1
         else:
             store_public_object(


### PR DESCRIPTION
## But de la pull request

Réparer la sandbox _industrial_ : la création d'image plante à cause de leur ratio hauteur/largeur.

Une fonctionnalité récente a introduit une vérification stricte de ce ratio afin d'empêcher une utilisateur PRO d'enregistrer une image qui ne ressemblerait à rien pour son offre ou son lieu. C'est cette vérification qui plante.

La solution est de contourner cette vérification avec l'option `keep_ratio` de `create_thumb()`, qui va alors appeler une autre fonction de traitement de l'image derrière. Cette dernière fait moins de traitement et de vérifications, notamment aucune vérification du ratio.