### PR TITLE
(PC-14539)[API] fix: serialize booking amount as float to display dec…

### DIFF
--- a/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
+++ b/api/src/pcapi/routes/serialization/bookings_recap_serialize.py
@@ -51,7 +51,7 @@ class BookingRecapResponseBookingStatusHistoryModel(BaseModel):
 
 class BookingRecapResponseModel(BaseModel):
     beneficiary: BookingRecapResponseBeneficiaryModel
-    booking_amount: int
+    booking_amount: float
     booking_date: datetime
     booking_is_duo: bool
     booking_status: BookingRecapStatus

--- a/api/tests/routes/serialization/bookings_recap_serialize_test.py
+++ b/api/tests/routes/serialization/bookings_recap_serialize_test.py
@@ -26,7 +26,7 @@ class SerializeBookingRecapTest:
             booking_date=booking_date,
             booking_token="FOND",
             booking_is_used=False,
-            booking_amount=18,
+            booking_amount=18.5,
         )
         thing_booking_recap_2 = create_domain_booking_recap(
             offer_identifier=2,
@@ -73,7 +73,7 @@ class SerializeBookingRecapTest:
                         "date": "2020-01-01T10:00:00",
                     },
                 ],
-                booking_amount=18,
+                booking_amount=18.5,
             ),
             BookingRecapResponseModel(
                 stock={
@@ -104,6 +104,7 @@ class SerializeBookingRecapTest:
             ),
         ]
         assert getattr(result, "bookingsRecap") == expected_bookings_recap
+        assert getattr(result, "bookingsRecap")[0].booking_amount == 18.5
         assert getattr(result, "page") == 0
         assert getattr(result, "pages") == 1
         assert getattr(result, "total") == 2


### PR DESCRIPTION
…imal

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14539

## But de la pull request

Afficher le montant de remboursement des réservations avec des décimales.



## Screenshot 

![DecimaBookingAmount](https://user-images.githubusercontent.com/71768799/166686374-72d15d7f-0c8b-4180-b3db-9b36407cb310.PNG)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
