### PR TITLE
(PC-14890)[API] feat: add requestId to request details logs

### DIFF
--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -75,6 +75,7 @@ def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Res
         "size": response.headers.get("Content-Length", type=int),
         "deviceId": request.headers.get("device-id"),
         "sourceIp": request.headers.get("X-Forwarded-For"),
+        "requestId": request.headers.get("request-id"),
     }
     try:
         duration = round((time.perf_counter() - g.request_start) * 1000)  # milliseconds

--- a/api/tests/test_flask_app.py
+++ b/api/tests/test_flask_app.py
@@ -1,0 +1,28 @@
+import logging
+
+import pytest
+
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_log_request_details(client, caplog):
+    users_factories.BeneficiaryGrant18Factory(email="email@example.com")
+    client.with_token("email@example.com")
+
+    with caplog.at_level(logging.INFO):
+        client.get(
+            "/native/v1/me",
+            headers={
+                "device-id": "B35033A8-F7D9-4417-8A99-AC43F1ACC552",
+                "request-id": "abcd",
+                "X-Forwarded-For": "82.65.58.211",
+            },
+        )
+        assert caplog.records[0].extra["deviceId"] == "B35033A8-F7D9-4417-8A99-AC43F1ACC552"
+        assert caplog.records[0].extra["requestId"] == "abcd"
+        assert caplog.records[0].extra["sourceIp"] == "82.65.58.211"
+        assert caplog.records[0].extra["route"] == "/native/v1/me"
+        assert caplog.records[0].extra["path"] == "/native/v1/me"


### PR DESCRIPTION
To debug concurrent requests, the app will send a random request id in headers to check if the problem comes from the frontend or elsewhere

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
