### PR TITLE
Pc 14813 route suspension date

### DIFF
--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -403,7 +403,7 @@ class UserSuspensionFactory(BaseFactory):
 
 
 class UnsuspendedSuspensionFactory(UserSuspensionFactory):
-    eventType = users_constants.SuspensionEventType.SUSPENDED
+    eventType = users_constants.SuspensionEventType.UNSUSPENDED
 
 
 class SuspendedUponUserRequestFactory(UserSuspensionFactory):

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -391,24 +391,28 @@ class EmailAdminValidationEntryFactory(UserEmailHistoryFactory):
     eventType = users_models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION.value
 
 
-class UserSuspensionFactory(BaseFactory):
+class UserSuspensionBaseFactory(BaseFactory):
     class Meta:
         model = users_models.UserSuspension
+        abstract = True
 
     user = factory.SubFactory(UserFactory, isActive=False)
     actorUser = factory.SubFactory(AdminFactory)
     eventType = users_models.SuspensionEventType.SUSPENDED
     eventDate = factory.LazyFunction(lambda: datetime.utcnow() - relativedelta(days=1))
+
+
+class UserSuspensionByFraudFactory(UserSuspensionBaseFactory):
     reasonCode = users_constants.SuspensionReason.FRAUD_SUSPICION
 
 
-class UnsuspendedSuspensionFactory(UserSuspensionFactory):
+class UnsuspendedSuspensionFactory(UserSuspensionBaseFactory):
     eventType = users_constants.SuspensionEventType.UNSUSPENDED
 
 
-class SuspendedUponUserRequestFactory(UserSuspensionFactory):
+class SuspendedUponUserRequestFactory(UserSuspensionBaseFactory):
     reasonCode = users_constants.SuspensionReason.UPON_USER_REQUEST
 
 
-class DeletedAccountSuspensionFactory(UserSuspensionFactory):
+class DeletedAccountSuspensionFactory(UserSuspensionByFraudFactory):
     reasonCode = users_constants.SuspensionReason.DELETED

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -408,3 +408,7 @@ class UnsuspendedSuspensionFactory(UserSuspensionFactory):
 
 class SuspendedUponUserRequestFactory(UserSuspensionFactory):
     reasonCode = users_constants.SuspensionReason.UPON_USER_REQUEST
+
+
+class DeletedAccountSuspensionFactory(UserSuspensionFactory):
+    reasonCode = users_constants.SuspensionReason.DELETED

--- a/api/src/pcapi/routes/native/security.py
+++ b/api/src/pcapi/routes/native/security.py
@@ -22,7 +22,7 @@ RouteFunc = typing.Callable[..., typing.Any]
 RouteDecorator = typing.Callable[..., typing.Any]
 
 
-def authenticated_user_required(route_function: RouteFunc) -> RouteDecorator:
+def authenticated_and_active_user_required(route_function: RouteFunc) -> RouteDecorator:
     add_security_scheme(route_function, JWT_AUTH)
 
     @wraps(route_function)

--- a/api/src/pcapi/routes/native/security.py
+++ b/api/src/pcapi/routes/native/security.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import logging
+import typing
 
 from flask import _request_ctx_stack
 from flask import request
@@ -7,6 +8,7 @@ from flask_jwt_extended.utils import get_jwt_identity
 from flask_jwt_extended.view_decorators import jwt_required
 import sentry_sdk
 
+from pcapi.core.users.models import User
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.models.api_errors import ForbiddenError
 from pcapi.routes.native.v1.blueprint import JWT_AUTH
@@ -16,27 +18,56 @@ from pcapi.serialization.spec_tree import add_security_scheme
 logger = logging.getLogger(__name__)
 
 
-def authenticated_user_required(route_function):  # type: ignore
+RouteFunc = typing.Callable[..., typing.Any]
+RouteDecorator = typing.Callable[..., typing.Any]
+
+
+def authenticated_user_required(route_function: RouteFunc) -> RouteDecorator:
     add_security_scheme(route_function, JWT_AUTH)
 
     @wraps(route_function)
     @jwt_required()
-    def retrieve_authenticated_user(*args, **kwargs):  # type: ignore
-        email = get_jwt_identity()
-        user = find_user_by_email(email)
-        if user is None or not user.isActive:
-            logger.info("Authenticated user with email %s not found or inactive", email)
-            raise ForbiddenError({"email": ["Utilisateur introuvable"]})
-
-        # push the user to the current context - similar to flask-login
-        ctx = _request_ctx_stack.top
-        ctx.user = user
-
-        # the user is set in sentry in before_request, way before we do the
-        # token auth so it needs to be also set here.
-        sentry_sdk.set_user({"id": user.id})
-        sentry_sdk.set_tag("device.id", request.headers.get("device-id", None))
-
+    def retrieve_authenticated_user(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        user = setup_context()
         return route_function(user, *args, **kwargs)
 
     return retrieve_authenticated_user
+
+
+def authenticated_maybe_inactive_user_required(route_function: RouteFunc) -> RouteDecorator:
+    add_security_scheme(route_function, JWT_AUTH)
+
+    @wraps(route_function)
+    @jwt_required()
+    def retrieve_authenticated_user(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        user = setup_context(must_be_active=False)
+        return route_function(user, *args, **kwargs)
+
+    return retrieve_authenticated_user
+
+
+def setup_context(must_be_active: bool = True) -> User:
+    email = get_jwt_identity()
+    user = find_user_by_email(email)
+
+    if must_be_active:
+        invalid_user = user is None or not user.isActive
+    else:
+        invalid_user = user is None
+
+    if invalid_user:
+        logger.info("Authenticated user with email %s not found or inactive", email)
+        raise ForbiddenError({"email": ["Utilisateur introuvable"]})
+
+    user = typing.cast(User, user)
+
+    # push the user to the current context - similar to flask-login
+    ctx = _request_ctx_stack.top
+    ctx.user = user
+
+    # the user is set in sentry in before_request, way before we do the
+    # token auth so it needs to be also set here.
+    sentry_sdk.set_user({"id": user.id})
+    sentry_sdk.set_tag("device.id", request.headers.get("device-id", None))
+
+    return user

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -17,7 +17,7 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ForbiddenError
 from pcapi.models.feature import FeatureToggle
 from pcapi.repository import repository
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.routes.native.v1.serialization.authentication import ChangePasswordRequest
 from pcapi.routes.native.v1.serialization.authentication import RequestPasswordResetRequest
 from pcapi.routes.native.v1.serialization.authentication import ResetPasswordRequest
@@ -116,7 +116,7 @@ def reset_password(body: ResetPasswordRequest) -> None:
 
 @blueprint.native_v1.route("/change_password", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api, on_error_statuses=[400])
-@authenticated_user_required
+@authenticated_and_active_user_required
 def change_password(user: User, body: ChangePasswordRequest) -> None:
     try:
         users_repo.check_user_and_credentials(user, body.current_password)

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -17,7 +17,7 @@ from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.product import Product
 from pcapi.repository import repository
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.routes.native.v1.serialization.bookings import BookOfferRequest
 from pcapi.routes.native.v1.serialization.bookings import BookOfferResponse
 from pcapi.routes.native.v1.serialization.bookings import BookingDisplayStatusRequest
@@ -33,7 +33,7 @@ from . import blueprint
 
 @blueprint.native_v1.route("/bookings", methods=["POST"])
 @spectree_serialize(api=blueprint.api, response_model=BookOfferResponse, on_error_statuses=[400])
-@authenticated_user_required
+@authenticated_and_active_user_required
 def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
     stock = Stock.query.get(body.stock_id)
     if not stock:
@@ -79,7 +79,7 @@ def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
 
 @blueprint.native_v1.route("/bookings", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=BookingsResponse)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def get_bookings(user: User) -> BookingsResponse:
     individual_bookings = (
         IndividualBooking.query.filter_by(userId=user.id)
@@ -186,7 +186,7 @@ def is_ended_booking(booking: Booking) -> bool:
 
 @blueprint.native_v1.route("/bookings/<int:booking_id>/cancel", methods=["POST"])
 @spectree_serialize(api=blueprint.api, on_success_status=204, on_error_statuses=[400, 404])
-@authenticated_user_required
+@authenticated_and_active_user_required
 def cancel_booking(user: User, booking_id: int) -> None:
     booking = (
         Booking.query.join(IndividualBooking)
@@ -206,7 +206,7 @@ def cancel_booking(user: User, booking_id: int) -> None:
 
 @blueprint.native_v1.route("/bookings/<int:booking_id>/toggle_display", methods=["POST"])
 @spectree_serialize(api=blueprint.api, on_success_status=204, on_error_statuses=[400])
-@authenticated_user_required
+@authenticated_and_active_user_required
 def flag_booking_as_used(user: User, booking_id: int, body: BookingDisplayStatusRequest) -> None:
     individual_booking = (
         IndividualBooking.query.join(IndividualBooking.booking)

--- a/api/src/pcapi/routes/native/v1/cultural_survey.py
+++ b/api/src/pcapi/routes/native/v1/cultural_survey.py
@@ -4,7 +4,7 @@ import logging
 from pcapi.core.cultural_survey import cultural_survey
 from pcapi.core.users import models as users_models
 from pcapi.repository import transaction
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.tasks.cultural_survey_tasks import upload_answers_task
 from pcapi.tasks.serialization.cultural_survey_tasks import CulturalSurveyAnswersForData
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
     on_success_status=200,
     api=blueprint.api,
 )
-@authenticated_user_required
+@authenticated_and_active_user_required
 def get_cultural_survey_questions(user: users_models.User) -> serializers.CulturalSurveyQuestionsResponse:
     return serializers.CulturalSurveyQuestionsResponse(
         questions=cultural_survey.ALL_CULTURAL_SURVEY_QUESTIONS,
@@ -35,7 +35,7 @@ def get_cultural_survey_questions(user: users_models.User) -> serializers.Cultur
     on_error_statuses=[400],
     api=blueprint.api,
 )
-@authenticated_user_required
+@authenticated_and_active_user_required
 def post_cultural_survey_answers(user: users_models.User, body: serializers.CulturalSurveyAnswersRequest) -> None:
     payload = CulturalSurveyAnswersForData(
         user_id=user.id,

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -22,7 +22,7 @@ from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.product import Product
 from pcapi.repository import transaction
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
@@ -75,7 +75,7 @@ def _fill_favorite_offer(
 
 @blueprint.native_v1.route("/me/favorites/count", methods=["GET"])
 @spectree_serialize(response_model=serializers.FavoritesCountResponse, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def get_favorites_count(user: User) -> serializers.FavoritesCountResponse:
     return serializers.FavoritesCountResponse(count=Favorite.query.filter_by(user=user).count())
 
@@ -170,7 +170,7 @@ def get_favorites_for(user: User, favorite_id: Optional[int] = None) -> list[Fav
 
 @blueprint.native_v1.route("/me/favorites", methods=["GET"])
 @spectree_serialize(response_model=serializers.PaginatedFavoritesResponse, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def get_favorites(user: User) -> serializers.PaginatedFavoritesResponse:
     favorites = get_favorites_for(user)
 
@@ -184,7 +184,7 @@ def get_favorites(user: User) -> serializers.PaginatedFavoritesResponse:
 
 @blueprint.native_v1.route("/me/favorites", methods=["POST"])
 @spectree_serialize(response_model=serializers.FavoriteResponse, on_error_statuses=[400], api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def create_favorite(user: User, body: serializers.FavoriteRequest) -> serializers.FavoriteResponse:
     if settings.MAX_FAVORITES:
         if Favorite.query.filter_by(user=user).count() >= settings.MAX_FAVORITES:
@@ -213,7 +213,7 @@ def create_favorite(user: User, body: serializers.FavoriteRequest) -> serializer
 
 @blueprint.native_v1.route("/me/favorites/<int:favorite_id>", methods=["DELETE"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def delete_favorite(user: User, favorite_id: int) -> None:
     with transaction():
         favorite = Favorite.query.filter_by(id=favorite_id, user=user).first_or_404()

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -12,7 +12,7 @@ from pcapi.core.users.models import User
 from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.product import Product
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.workers.push_notification_job import send_offer_link_by_push_job
 
@@ -48,7 +48,7 @@ def get_offer(offer_id: str) -> serializers.OfferResponse:
 
 @blueprint.native_v1.route("/offer/<int:offer_id>/report", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def report_offer(user: User, offer_id: int, body: serializers.OfferReportRequest) -> None:
     offer = Offer.query.get_or_404(offer_id)
 
@@ -60,21 +60,21 @@ def report_offer(user: User, offer_id: int, body: serializers.OfferReportRequest
 
 @blueprint.native_v1.route("/offer/report/reasons", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.OfferReportReasons)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def report_offer_reasons(user: User) -> serializers.OfferReportReasons:
     return serializers.OfferReportReasons(reasons=Reason.get_full_meta())
 
 
 @blueprint.native_v1.route("/offers/reports", methods=["GET"])
 @spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.UserReportedOffersResponse)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def user_reported_offers(user: User) -> serializers.UserReportedOffersResponse:
     return serializers.UserReportedOffersResponse(reportedOffers=user.reported_offers)
 
 
 @blueprint.native_v1.route("/send_offer_webapp_link_by_email/<int:offer_id>", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def send_offer_app_link(user: User, offer_id: int) -> None:
     """
     On iOS native app, users cannot book numeric offers with price > 0, so
@@ -86,7 +86,7 @@ def send_offer_app_link(user: User, offer_id: int) -> None:
 
 @blueprint.native_v1.route("/send_offer_link_by_push/<int:offer_id>", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def send_offer_link_by_push(user: User, offer_id: int) -> None:
     Offer.query.get_or_404(offer_id)
     send_offer_link_by_push_job.delay(user.id, offer_id)

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -383,3 +383,7 @@ class UserProfilingFraudRequest(BaseModel):
 
 class UserProfilingSessionIdResponse(BaseModel):
     sessionId: str
+
+
+class UserSuspensionDateResponse(BaseModel):
+    date: Optional[datetime.datetime]

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -9,7 +9,7 @@ from pcapi.core.subscription import profile_options
 from pcapi.core.subscription.ubble import api as ubble_subscription_api
 from pcapi.core.users import models as users_models
 from pcapi.models import api_errors
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
     on_success_status=200,
     api=blueprint.api,
 )
-@authenticated_user_required
+@authenticated_and_active_user_required
 def next_subscription_step(
     user: users_models.User,
 ) -> Optional[serializers.NextSubscriptionStepResponse]:
@@ -41,7 +41,7 @@ def next_subscription_step(
 
 @blueprint.native_v1.route("/subscription/profile", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def complete_profile(user: users_models.User, body: serializers.ProfileUpdateRequest) -> None:
     subscription_api.complete_profile(
         user,
@@ -75,7 +75,7 @@ def get_profile_options() -> serializers.ProfileOptionsResponse:
 
 @blueprint.native_v1.route("/subscription/honor_statement", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def create_honor_statement_fraud_check(user: users_models.User) -> None:
     fraud_api.create_honor_statement_fraud_check(user, "statement from /subscription/honor_statement endpoint")
 
@@ -84,7 +84,7 @@ def create_honor_statement_fraud_check(user: users_models.User) -> None:
 
 @blueprint.native_v1.route("/ubble_identification", methods=["POST"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.IdentificationSessionResponse)
-@authenticated_user_required
+@authenticated_and_active_user_required
 def start_identification_session(
     user: users_models.User, body: serializers.IdentificationSessionRequest
 ) -> serializers.IdentificationSessionResponse:

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -17,7 +17,7 @@ from pcapi.core.subscription.educonnect import exceptions as educonnect_subscrip
 from pcapi.core.users import models as users_models
 from pcapi.core.users import utils as users_utils
 from pcapi.core.users.constants import ELIGIBILITY_AGE_18
-from pcapi.routes.native.security import authenticated_user_required
+from pcapi.routes.native.security import authenticated_and_active_user_required
 
 from . import blueprint
 
@@ -29,7 +29,7 @@ SUCCESS_PAGE_URL = f"{settings.WEBAPP_V2_URL}/educonnect/validation?"
 
 
 @blueprint.saml_blueprint.route("educonnect/login", methods=["GET"])
-@authenticated_user_required
+@authenticated_and_active_user_required
 def login_educonnect(user: users_models.User) -> Response:
     should_redirect = request.args.get("redirect", default=True, type=lambda v: v.lower() == "true")
     redirect_url = educonnect_connector.get_login_redirect_url(user)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -731,7 +731,7 @@ class GetSuspendedAccountsUponUserRequestSinceTest:
         expected_suspension = users_factories.SuspendedUponUserRequestFactory(eventDate=one_week_ago)
 
         # not suspended upon user request: should be ignored
-        users_factories.UserSuspensionFactory(eventDate=one_week_ago)
+        users_factories.UserSuspensionByFraudFactory(eventDate=one_week_ago)
 
         # suspended less than 5 days ago (see below): should be ignored
         yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -750,7 +750,7 @@ class GetSuspendedAccountsUponUserRequestSinceTest:
         suspension event occurred more than N days ago.
         """
         one_week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
-        user_suspension = users_factories.UserSuspensionFactory(eventDate=one_week_ago)
+        user_suspension = users_factories.UserSuspensionByFraudFactory(eventDate=one_week_ago)
 
         yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         users_factories.UnsuspendedSuspensionFactory(user=user_suspension.user, eventDate=yesterday)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -295,7 +295,7 @@ class SuspendAccountTest:
 
 class UnsuspendAccountTest:
     def test_unsuspend_account(self):
-        suspension = users_factories.UserSuspensionFactory()
+        suspension = users_factories.UserSuspensionByFraudFactory()
         user = suspension.user
 
         users_api.unsuspend_account(user, suspension.actorUser)
@@ -310,9 +310,9 @@ class UnsuspendAccountTest:
 
     def test_bulk_unsuspend_account(self):
         actor = users_factories.AdminFactory()
-        suspension1 = users_factories.UserSuspensionFactory(actorUser=actor)
-        suspension2 = users_factories.UserSuspensionFactory(actorUser=actor)
-        suspension3 = users_factories.UserSuspensionFactory(actorUser=actor)
+        suspension1 = users_factories.UserSuspensionByFraudFactory(actorUser=actor)
+        suspension2 = users_factories.UserSuspensionByFraudFactory(actorUser=actor)
+        suspension3 = users_factories.UserSuspensionByFraudFactory(actorUser=actor)
 
         users_api.bulk_unsuspend_account([suspension1.user.id, suspension2.user.id, suspension3.user.id], actor)
 

--- a/api/tests/core/users/test_factories.py
+++ b/api/tests/core/users/test_factories.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 class UsersFactoriesTest:
     def test_user_suspension_factory(self):
-        suspension = users_factories.UserSuspensionFactory()
+        suspension = users_factories.UserSuspensionByFraudFactory()
 
         assert not suspension.user.isActive
         assert suspension.user.suspension_reason

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -73,7 +73,7 @@ class ZendeskWebhookTest:
             phoneValidationStatus=PhoneValidationStatusType.BLOCKED_TOO_MANY_CODE_SENDINGS,
             isActive=False,
         )
-        users_factories.UserSuspensionFactory(
+        users_factories.UserSuspensionByFraudFactory(
             user=user, eventDate=datetime(2022, 3, 22, 15), reasonCode=SuspensionReason.FRAUD_HACK
         )
 

--- a/api/tests/routes/native/security_test.py
+++ b/api/tests/routes/native/security_test.py
@@ -1,0 +1,67 @@
+import pytest
+
+import pcapi.core.users.factories as users_factories
+from pcapi.routes.native.security import authenticated_and_active_user_required
+from pcapi.routes.native.security import authenticated_maybe_inactive_user_required
+
+from tests.serialization.serialization_decorator_test import test_blueprint
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+@test_blueprint.route("/authenticated_and_active_user_required", methods=["GET"])
+@authenticated_and_active_user_required
+def authenticated_and_active_user_required_route(*args, **kwargs) -> None:
+    return "", 204
+
+
+@test_blueprint.route("/authenticated_maybe_inactive_user_required", methods=["GET"])
+@authenticated_maybe_inactive_user_required
+def authenticated_maybe_inactive_user_required_route(*args, **kwargs) -> None:
+    return "", 204
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/test-blueprint/authenticated_and_active_user_required",
+        "/test-blueprint/authenticated_maybe_inactive_user_required",
+    ],
+)
+def test_get_active_user(client, path):
+    user = users_factories.UserFactory(isActive=True)
+
+    client.with_token(user.email)
+    response = client.get(path)
+    assert response.status_code == 204
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/test-blueprint/authenticated_and_active_user_required",
+        "/test-blueprint/authenticated_maybe_inactive_user_required",
+    ],
+)
+def test_get_unauthenticated_active_user(client, path):
+    response = client.get(path)
+    assert response.status_code == 401
+
+
+def test_inactive_user_when_active_required(client):
+    user = users_factories.UserFactory(isActive=False)
+    path = "/test-blueprint/authenticated_and_active_user_required"
+
+    client.with_token(user.email)
+    response = client.get(path)
+    assert response.status_code == 403
+
+
+def test_inactive_user_when_may_be_inactive(client):
+    user = users_factories.UserFactory(isActive=False)
+    path = "/test-blueprint/authenticated_maybe_inactive_user_required"
+
+    client.with_token(user.email)
+    response = client.get(path)
+    assert response.status_code == 204

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1368,7 +1368,7 @@ class SuspendAccountTest:
     def test_suspend_suspended_account(self, client, app):
         # Ensure that a beneficiary user can't change the reason for being suspended
         user = users_factories.BeneficiaryGrant18Factory(isActive=False)
-        user_suspension = users_factories.UserSuspensionFactory(user=user)
+        user_suspension = users_factories.UserSuspensionByFraudFactory(user=user)
 
         client.with_token(email=user.email)
         response = client.post("/native/v1/account/suspend")

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1529,6 +1529,26 @@ def test_public_api(client, app):
                     "tags": [],
                 }
             },
+            "/native/v1/account/suspension_date": {
+                "get": {
+                    "description": "",
+                    "operationId": "get_/native/v1/account/suspension_date",
+                    "parameters": [],
+                    "responses": {
+                        "200": {"description": "OK"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "security": [{"JWTAuth": []}],
+                    "summary": "get_account_suspension_date <GET>",
+                    "tags": [],
+                }
+            },
             "/native/v1/bookings": {
                 "get": {
                     "description": "",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14813
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14814

(deux en un, Les deux tickets auraient probablement dû être fusionné, tant pis)

## But de la pull request

Permettre à un utilisateur suspendu de connaître sa date de suspension.

Cette route nécessite d'être authentifié, le problème est que le décorateur `authenticated_user_required` bloque les utilisateurs inactifs (`user.isActive == False`). Cette PR ajoute donc un second décorateur qui autorise les utilisateurs inactifs.
