### PR TITLE
(PC-14398)[API] fix: do not use yield_per

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -5,6 +5,7 @@ import typing
 
 import pydantic
 import sqlalchemy
+from sqlalchemy.orm import Query
 
 from pcapi import settings
 from pcapi.core.fraud.utils import is_latin
@@ -633,7 +634,7 @@ def decide_eligibility(
 UserGenerator = typing.Generator[users_models.User, None, None]
 
 
-def get_suspended_upon_user_request_accounts_since(expiration_delta_in_days: int) -> UserGenerator:
+def get_suspended_upon_user_request_accounts_since(expiration_delta_in_days: int) -> Query:
     start = datetime.date.today() - datetime.timedelta(days=expiration_delta_in_days)
 
     # distinct keeps the first row if duplicates are found. Since rows
@@ -661,5 +662,4 @@ def get_suspended_upon_user_request_accounts_since(expiration_delta_in_days: int
         user_ids_and_latest_events.c.reasonCode == users_models.SuspensionReason.UPON_USER_REQUEST,
     )
 
-    for user in query.yield_per(1_000):
-        yield user
+    return query

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -307,8 +307,8 @@ def delete_suspended_accounts_after_withdrawal_period() -> None:
     if not FeatureToggle.ALLOW_ACCOUNT_REACTIVATION:
         return
 
-    users = fraud_api.get_suspended_upon_user_request_accounts_since(settings.DELETE_SUSPENDED_ACCOUNTS_SINCE)
-    for user in users:
+    query = fraud_api.get_suspended_upon_user_request_accounts_since(settings.DELETE_SUSPENDED_ACCOUNTS_SINCE)
+    for user in query:
         users_api.suspend_account(user, users_constants.SuspensionReason.DELETED, None)
 
 

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -740,8 +740,8 @@ class GetSuspendedAccountsUponUserRequestSinceTest:
         expected_user_ids = {expected_suspension.userId}
 
         with assert_num_queries(1):
-            users = fraud_api.get_suspended_upon_user_request_accounts_since(5)
-            user_ids = {user.id for user in users}
+            query = fraud_api.get_suspended_upon_user_request_accounts_since(5)
+            user_ids = {user.id for user in query}
             assert user_ids == expected_user_ids
 
     def test_unsuspended_account(self) -> None:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14398

## But de la pull request

**FIX**

`yield_per` + `session.commit` = 💣 
Ou plus exactement, les modifications peuvent passer mais psycopg2 va renvoyer une erreur.

On ne devrait pas récupérer un très grand nombre d'utilisateurs à chaque fois, donc ça devrait pas être (trop) un problème.