### PR TITLE
(PC-14678)[API] feat: use generic validation errors

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -437,10 +437,10 @@ def mark_as_cancelled(booking: Booking) -> None:
     admin user.
     """
     if booking.status == BookingStatus.CANCELLED:
-        raise exceptions.BookingAlreadyCancelled("la réservation a déjà été annulée")
+        raise exceptions.BookingIsAlreadyCancelled()
 
     if finance_repository.has_reimbursement(booking):
-        raise exceptions.BookingAlreadyRefunded("la réservation a déjà été remboursée")
+        raise exceptions.BookingIsAlreadyRefunded()
 
     _cancel_booking(booking, BookingCancellationReasons.BENEFICIARY, cancel_even_if_used=True, raise_if_error=True)
     send_booking_cancellation_by_beneficiary_to_pro_email(booking)

--- a/api/src/pcapi/core/bookings/exceptions.py
+++ b/api/src/pcapi/core/bookings/exceptions.py
@@ -60,9 +60,8 @@ class UserHasInsufficientFunds(ClientError):
         super().__init__("insufficientFunds", "Le solde de votre pass est insuffisant pour réserver cette offre.")
 
 
-class BookingIsAlreadyUsed(ClientError):
-    def __init__(self) -> None:
-        super().__init__("booking", "Impossible d'annuler une réservation consommée")
+class BookingIsAlreadyUsed(Exception):
+    pass
 
 
 class BookingHasAlreadyBeenUsed(ClientError):
@@ -70,9 +69,12 @@ class BookingHasAlreadyBeenUsed(ClientError):
         super().__init__("booking", "Cette offre a déjà été utilisée")
 
 
-class BookingIsAlreadyCancelled(ClientError):
-    def __init__(self) -> None:
-        super().__init__("booking", "Cette réservation a déjà été annulée")
+class BookingIsAlreadyRefunded(Exception):
+    pass
+
+
+class BookingIsAlreadyCancelled(Exception):
+    pass
 
 
 class BookingIsNotCancelledCannotBeUncancelled(ClientError):
@@ -83,6 +85,14 @@ class BookingIsNotCancelledCannotBeUncancelled(ClientError):
 class BookingIsCancelled(ClientError):
     def __init__(self) -> None:
         super().__init__("booking", "Cette réservation a été annulée et ne peut être marquée comme étant utilisée")
+
+
+class BookingRefused(Exception):
+    pass
+
+
+class BookingIsNotConfirmed(Exception):
+    pass
 
 
 class CannotCancelConfirmedBooking(ClientError):
@@ -109,14 +119,6 @@ class CannotDeleteVenueWithBookingsException(ClientError):
             "cannotDeleteVenueWithBookingsException",
             "Lieu non supprimable car il contient des réservations",
         )
-
-
-class BookingAlreadyCancelled(Exception):
-    pass
-
-
-class BookingAlreadyRefunded(Exception):
-    pass
 
 
 class CannotMarkAsConfirmedIndividualBooking(Exception):

--- a/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -1,9 +1,14 @@
+from flask import Response
 from flask import current_app as app
 from flask import jsonify
 
 from pcapi.core.bookings import exceptions
+from pcapi.domain.client_exceptions import ClientError
 from pcapi.domain.users import UnauthorizedForAdminUser
 from pcapi.models import api_errors
+
+
+JsonResponse = tuple[Response, int]
 
 
 @app.errorhandler(exceptions.OfferIsAlreadyBooked)  # type: ignore [arg-type]
@@ -14,33 +19,33 @@ from pcapi.models import api_errors
 @app.errorhandler(exceptions.PhysicalExpenseLimitHasBeenReached)
 @app.errorhandler(exceptions.DigitalExpenseLimitHasBeenReached)
 @app.errorhandler(exceptions.OfferCategoryNotBookableByUser)
-def handle_book_an_offer(exception):  # type: ignore [no-untyped-def]
+def handle_book_an_offer(exception: ClientError) -> JsonResponse:
     return jsonify(exception.errors), 400
 
 
 @app.errorhandler(UnauthorizedForAdminUser)
-def handle_get_all_bookings_exceptions(exception):  # type: ignore [no-untyped-def]
+def handle_get_all_bookings_exceptions(exception: UnauthorizedForAdminUser) -> JsonResponse:
     return jsonify(exception.errors), 401
 
 
 @app.errorhandler(exceptions.CannotCancelConfirmedBooking)
-def handle_cancel_a_booking(exception):  # type: ignore [no-untyped-def]
+def handle_cancel_a_booking(exception: ClientError) -> JsonResponse:
     return jsonify(exception.errors), 400
 
 
 @app.errorhandler(exceptions.BookingDoesntExist)
-def handle_cancel_a_booking_not_found(exception):  # type: ignore [no-untyped-def]
+def handle_cancel_a_booking_not_found(exception: exceptions.BookingDoesntExist) -> JsonResponse:
     return jsonify(exception.errors), 404
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyRefunded)
-def handle_booking_is_already_refunded(exception):  # type: ignore [no-untyped-def]
+def handle_booking_is_already_refunded(exception: exceptions.BookingIsAlreadyRefunded) -> JsonResponse:
     error = {"payment": ["Cette réservation a été remboursée"]}
     return jsonify(error), api_errors.ForbiddenError.status_code
 
 
 @app.errorhandler(exceptions.BookingRefused)
-def handle_booking_refused(exception):  # type: ignore [no-untyped-def]
+def handle_booking_refused(exception: exceptions.BookingRefused) -> JsonResponse:
     error = {
         "educationalBooking": (
             "Cette réservation pour une offre éducationnelle a été refusée par le chef d'établissement"
@@ -56,7 +61,7 @@ def handle_booking_is_not_confirmed(exception: exceptions.BookingIsNotConfirmed)
 
 
 @app.errorhandler(exceptions.BookingIsAlreadyUsed)
-def handle_booking_is_already_used(exception):  # type: ignore [no-untyped-def]
+def handle_booking_is_already_used(exception: exceptions.BookingIsAlreadyUsed) -> JsonResponse:
     error = {"booking": ["Cette réservation a déjà été validée"]}
     return jsonify(error), api_errors.ResourceGoneError.status_code
 

--- a/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/bookings_error_handlers.py
@@ -1,28 +1,19 @@
 from flask import current_app as app
 from flask import jsonify
 
-from pcapi.core.bookings.exceptions import BookingDoesntExist
-from pcapi.core.bookings.exceptions import BookingIsAlreadyUsed
-from pcapi.core.bookings.exceptions import CannotBookFreeOffers
-from pcapi.core.bookings.exceptions import CannotCancelConfirmedBooking
-from pcapi.core.bookings.exceptions import DigitalExpenseLimitHasBeenReached
-from pcapi.core.bookings.exceptions import OfferCategoryNotBookableByUser
-from pcapi.core.bookings.exceptions import OfferIsAlreadyBooked
-from pcapi.core.bookings.exceptions import PhysicalExpenseLimitHasBeenReached
-from pcapi.core.bookings.exceptions import QuantityIsInvalid
-from pcapi.core.bookings.exceptions import StockIsNotBookable
-from pcapi.core.bookings.exceptions import UserHasInsufficientFunds
+from pcapi.core.bookings import exceptions
 from pcapi.domain.users import UnauthorizedForAdminUser
+from pcapi.models import api_errors
 
 
-@app.errorhandler(OfferIsAlreadyBooked)  # type: ignore [arg-type]
-@app.errorhandler(QuantityIsInvalid)
-@app.errorhandler(StockIsNotBookable)
-@app.errorhandler(CannotBookFreeOffers)
-@app.errorhandler(UserHasInsufficientFunds)
-@app.errorhandler(PhysicalExpenseLimitHasBeenReached)
-@app.errorhandler(DigitalExpenseLimitHasBeenReached)
-@app.errorhandler(OfferCategoryNotBookableByUser)
+@app.errorhandler(exceptions.OfferIsAlreadyBooked)  # type: ignore [arg-type]
+@app.errorhandler(exceptions.QuantityIsInvalid)
+@app.errorhandler(exceptions.StockIsNotBookable)
+@app.errorhandler(exceptions.CannotBookFreeOffers)
+@app.errorhandler(exceptions.UserHasInsufficientFunds)
+@app.errorhandler(exceptions.PhysicalExpenseLimitHasBeenReached)
+@app.errorhandler(exceptions.DigitalExpenseLimitHasBeenReached)
+@app.errorhandler(exceptions.OfferCategoryNotBookableByUser)
 def handle_book_an_offer(exception):  # type: ignore [no-untyped-def]
     return jsonify(exception.errors), 400
 
@@ -32,12 +23,45 @@ def handle_get_all_bookings_exceptions(exception):  # type: ignore [no-untyped-d
     return jsonify(exception.errors), 401
 
 
-@app.errorhandler(BookingIsAlreadyUsed)  # type: ignore [arg-type]
-@app.errorhandler(CannotCancelConfirmedBooking)
+@app.errorhandler(exceptions.CannotCancelConfirmedBooking)
 def handle_cancel_a_booking(exception):  # type: ignore [no-untyped-def]
     return jsonify(exception.errors), 400
 
 
-@app.errorhandler(BookingDoesntExist)
+@app.errorhandler(exceptions.BookingDoesntExist)
 def handle_cancel_a_booking_not_found(exception):  # type: ignore [no-untyped-def]
     return jsonify(exception.errors), 404
+
+
+@app.errorhandler(exceptions.BookingIsAlreadyRefunded)
+def handle_booking_is_already_refunded(exception):  # type: ignore [no-untyped-def]
+    error = {"payment": ["Cette réservation a été remboursée"]}
+    return jsonify(error), api_errors.ForbiddenError.status_code
+
+
+@app.errorhandler(exceptions.BookingRefused)
+def handle_booking_refused(exception):  # type: ignore [no-untyped-def]
+    error = {
+        "educationalBooking": (
+            "Cette réservation pour une offre éducationnelle a été refusée par le chef d'établissement"
+        )
+    }
+    return jsonify(error), api_errors.ForbiddenError.status_code
+
+
+@app.errorhandler(exceptions.BookingIsNotConfirmed)
+def handle_booking_is_not_confirmed(exception: exceptions.BookingIsNotConfirmed) -> JsonResponse:
+    error = {"booking": [str(exception)]}
+    return jsonify(error), api_errors.ForbiddenError.status_code
+
+
+@app.errorhandler(exceptions.BookingIsAlreadyUsed)
+def handle_booking_is_already_used(exception):  # type: ignore [no-untyped-def]
+    error = {"booking": ["Cette réservation a déjà été validée"]}
+    return jsonify(error), api_errors.ResourceGoneError.status_code
+
+
+@app.errorhandler(exceptions.BookingIsAlreadyCancelled)
+def handle_booking_is_already_cancelled(exception: exceptions.BookingIsAlreadyCancelled) -> JsonResponse:
+    error = {"booking_cancelled": ["Cette réservation a été annulée"]}
+    return jsonify(error), api_errors.ResourceGoneError.status_code

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -9,6 +9,7 @@ import pydantic
 
 from pcapi.connectors import api_recaptcha
 from pcapi.connectors import user_profiling
+import pcapi.core.bookings.exceptions as bookings_exceptions
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud.phone_validation import sending_limit
 from pcapi.core.logging import get_or_set_correlation_id
@@ -295,8 +296,13 @@ def phone_validation_remaining_attempts(user: users_models.User) -> serializers.
 @spectree_serialize(api=blueprint.api, on_success_status=204)
 @authenticated_and_active_user_required
 def suspend_account(user: users_models.User) -> None:
-    api.suspend_account(user, constants.SuspensionReason.UPON_USER_REQUEST, actor=user)
-    send_user_request_to_delete_account_reception_email(user)
+    try:
+        api.suspend_account(user, constants.SuspensionReason.UPON_USER_REQUEST, actor=user)
+        send_user_request_to_delete_account_reception_email(user)
+    except bookings_exceptions.BookingIsAlreadyCancelled:
+        raise api_errors.ResourceGoneError()
+    except bookings_exceptions.BookingIsAlreadyRefunded:
+        raise api_errors.ForbiddenError()
 
 
 @blueprint.native_v1.route("/account/suspension_date", methods=["GET"])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14678

## But de la pull request

**Nettoyage**

Utiliser des erreurs génériques plutôt que des erreurs héritant de `ApiErrors` dans `pcapi/core/bookings/validation.py`.

Ceci est la première étape. Il en reste encore un peu. Pas eu le temps de terminer, en même temps... ce sera plus simple à relire et ça permet d'avoir des exemples à reprendre une fois corrigé et validé.