### PR TITLE
(PC-14887)[API] fix: add filter on eligibility to find first recent registration date

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -44,6 +44,9 @@ def activate_beneficiary_for_eligibility(
         user.add_underage_beneficiary_role()
         age_at_registration = get_age_at_first_registration(user, users_models.EligibilityType.UNDERAGE)
 
+        if age_at_registration not in users_constants.ELIGIBILITY_UNDERAGE_RANGE:
+            raise exceptions.InvalidAgeException(age=age_at_registration)
+
     elif eligibility == users_models.EligibilityType.AGE18:
         user.validate_user_identity_18()
         user.add_beneficiary_role()

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -83,7 +83,7 @@ def get_activable_identity_fraud_check(user: users_models.User) -> typing.Option
         if fraud_check.status == fraud_models.FraudCheckStatus.OK
         and fraud_check.type in fraud_models.IDENTITY_CHECK_TYPES
         and users_api.is_eligible_for_beneficiary_upgrade(user, fraud_check.eligibilityType)
-        and users_api.is_user_age_compatible_with_eligibility(user, fraud_check.eligibilityType)
+        and users_api.is_user_age_compatible_with_eligibility(user.age, fraud_check.eligibilityType)
     ]
     if not user_identity_fraud_checks:
         return None
@@ -134,7 +134,7 @@ def is_eligibility_activable(
     return (
         user.eligibility == eligibility
         and users_api.is_eligible_for_beneficiary_upgrade(user, eligibility)
-        and users_api.is_user_age_compatible_with_eligibility(user, eligibility)
+        and users_api.is_user_age_compatible_with_eligibility(user.age, eligibility)
     )
 
 
@@ -549,8 +549,10 @@ def get_first_registration_date(
         fraud_check.get_min_date_between_creation_and_registration()
         for fraud_check in fraud_checks
         if fraud_check.eligibilityType == eligibility
-        and users_utils.get_age_at_date(user.dateOfBirth, fraud_check.get_min_date_between_creation_and_registration())
-        >= users_constants.ELIGIBILITY_UNDERAGE_RANGE[0]
+        and users_api.is_user_age_compatible_with_eligibility(
+            users_utils.get_age_at_date(user.dateOfBirth, fraud_check.get_min_date_between_creation_and_registration()),
+            eligibility,
+        )
     ]
 
     return min(registration_dates_when_eligible) if registration_dates_when_eligible else None

--- a/api/src/pcapi/core/subscription/exceptions.py
+++ b/api/src/pcapi/core/subscription/exceptions.py
@@ -1,9 +1,18 @@
+from typing import Optional
+
+
 class SubscriptionException(Exception):
     pass
 
 
 class InvalidEligibilityTypeException(SubscriptionException):
     pass
+
+
+class InvalidAgeException(SubscriptionException):
+    def __init__(self, age: Optional[int]) -> None:
+        super().__init__()
+        self.age = age
 
 
 class BeneficiaryFraudCheckMissingException(SubscriptionException):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -887,9 +887,9 @@ def is_eligible_for_beneficiary_upgrade(user: models.User, eligibility: Optional
     )
 
 
-def is_user_age_compatible_with_eligibility(user: models.User, eligibility: Optional[EligibilityType]) -> bool:
+def is_user_age_compatible_with_eligibility(user_age: Optional[int], eligibility: Optional[EligibilityType]) -> bool:
     if eligibility == EligibilityType.UNDERAGE:
-        return user.age in constants.ELIGIBILITY_UNDERAGE_RANGE
+        return user_age in constants.ELIGIBILITY_UNDERAGE_RANGE
     if eligibility == EligibilityType.AGE18:
-        return user.age is not None and user.age >= constants.ELIGIBILITY_AGE_18
+        return user_age is not None and user_age >= constants.ELIGIBILITY_AGE_18
     return False

--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -22,7 +22,9 @@ RECREDIT_BATCH_SIZE = 1000
 
 
 def has_celebrated_birthday_since_registration(user: users_models.User) -> bool:
-    first_registration_datetime = subscription_api.get_first_registration_date(user)
+    first_registration_datetime = subscription_api.get_first_registration_date(
+        user, users_models.EligibilityType.UNDERAGE
+    )
     if first_registration_datetime is None:
         logger.error("No registration date for user to be recredited", extra={"user_id": user.id})
         return False

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -123,7 +123,11 @@ class BeneficiaryValidationViewTest:
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_from_educonnect(self, client):
         user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
-        check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.EDUCONNECT)
+        check = fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.EDUCONNECT,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+        )
         admin = users_factories.AdminFactory()
         client.with_session_auth(admin.email)
 

--- a/api/tests/scripts/payment/user_recredit_test.py
+++ b/api/tests/scripts/payment/user_recredit_test.py
@@ -9,6 +9,7 @@ from pcapi.core.fraud import models as fraud_models
 from pcapi.core.payments import factories as payments_factories
 from pcapi.core.payments import models as payments_models
 from pcapi.core.users import factories as user_factories
+from pcapi.core.users.models import EligibilityType
 from pcapi.scripts.payment.user_recredit import can_be_recredited
 from pcapi.scripts.payment.user_recredit import has_been_recredited
 from pcapi.scripts.payment.user_recredit import has_celebrated_birthday_since_registration
@@ -36,6 +37,7 @@ class UserRecreditTest:
             resultContent=fraud_check_result_content,
             type=fraud_models.FraudCheckType.UBBLE,
             dateCreated=registration_datetime,
+            eligibilityType=EligibilityType.UNDERAGE,
         )
         assert has_celebrated_birthday_since_registration(user) == expected_result
 
@@ -53,6 +55,7 @@ class UserRecreditTest:
                 status=fraud_models.FraudCheckStatus.OK,
                 resultContent=content,
                 dateCreated=datetime.datetime(2020, 5, 1),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             assert user.deposit.recredits == []
             assert can_be_recredited(user) is False
@@ -96,6 +99,7 @@ class UserRecreditTest:
                 status=fraud_models.FraudCheckStatus.OK,
                 resultContent={},
                 dateCreated=datetime.datetime(2020, 5, 1),  # first fraud check created
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_check.resultContent = content
         with freeze_time("2022-05-02"):
@@ -182,6 +186,7 @@ class UserRecreditTest:
                 resultContent=fraud_factories.EduconnectContentFactory(
                     user=user_15, birth_date="2004-08-01", registration_datetime=id_check_application_date
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 dateCreated=datetime.datetime(2019, 12, 31),
@@ -193,6 +198,7 @@ class UserRecreditTest:
                     birth_date="2003-08-01",
                     registration_datetime=id_check_application_date,
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 dateCreated=datetime.datetime(2019, 12, 31),
@@ -204,6 +210,7 @@ class UserRecreditTest:
                     birth_date="2003-08-01",
                     registration_datetime=id_check_application_date,
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 dateCreated=datetime.datetime(2019, 12, 31),
@@ -215,6 +222,7 @@ class UserRecreditTest:
                     birth_date="2002-08-01",
                     registration_datetime=id_check_application_date,
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 dateCreated=datetime.datetime(2019, 12, 31),
@@ -226,6 +234,7 @@ class UserRecreditTest:
                     birth_date="2002-08-01",
                     registration_datetime=id_check_application_date,
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 dateCreated=datetime.datetime(2019, 12, 31),
@@ -237,6 +246,7 @@ class UserRecreditTest:
                     birth_date="2002-08-01",
                     registration_datetime=id_check_application_date,
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
                 dateCreated=datetime.datetime(2019, 12, 31),
@@ -248,6 +258,7 @@ class UserRecreditTest:
                     birth_date="2002-08-01",
                     registration_datetime=id_check_application_date,
                 ),
+                eligibilityType=EligibilityType.UNDERAGE,
             )
 
             # Not beneficiary user


### PR DESCRIPTION
Otherwise we could consider an attempt before 15-17 opening to be the first registration date

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14887

## But de la pull request

Avec ça on gère normalement tous les cas : 
Ça devrait gérer tous les cas :
- les utilisateurs qui ont tenté à 15 ans et réussi à 16 ans : ils auront bien un FraudCheck avec le eligibilityType rempli
- les utilisateurs qui ont tenté à 14 ans et réussi à 15 (ou +) : le eligibilityType ne sera pas rempli ; on peut garder le check sur l’âge
- les utilisateurs qui ont tenté de s’inscrire à 15 ans avant l’ouverture aux 15-17 : ils n’auront pas de eligibilityType rempli


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
