### PR TITLE
(PC-14644)[API] feat: raise more specific error message if phone already exists in base

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -218,9 +218,17 @@ def send_phone_validation_code(user: User, body: serializers.SendPhoneValidation
             {"message": "Le numéro de téléphone est déjà validé", "code": "PHONE_NUMBER_ALREADY_VALIDATED"},
             status_code=400,
         )
-    except (exceptions.PhoneAlreadyExists, exceptions.InvalidPhoneNumber):
+    except (exceptions.InvalidPhoneNumber):
         raise ApiErrors(
             {"message": "Le numéro de téléphone est invalide", "code": "INVALID_PHONE_NUMBER"}, status_code=400
+        )
+    except (exceptions.PhoneAlreadyExists):
+        raise ApiErrors(
+            {
+                "message": "Un compte est déjà associé à ce numéro. Renseigne un autre numéro ou connecte-toi.",
+                "code": "PHONE_ALREADY_EXISTS",
+            },
+            status_code=400,
         )
     except exceptions.PhoneVerificationException:
         raise ApiErrors({"message": "L'envoi du code a échoué", "code": "CODE_SENDING_FAILURE"}, status_code=400)

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1044,7 +1044,10 @@ class SendPhoneValidationCodeTest:
         assert not Token.query.filter_by(userId=user.id).first()
         db.session.refresh(user)
         assert user.phoneNumber == "+33601020304"
-        assert response.json == {"message": "Le numéro de téléphone est invalide", "code": "INVALID_PHONE_NUMBER"}
+        assert response.json == {
+            "message": "Un compte est déjà associé à ce numéro. Renseigne un autre numéro ou connecte-toi.",
+            "code": "PHONE_ALREADY_EXISTS",
+        }
 
         # check that a fraud check has been created
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14644

## But de la pull request

Il n'y avait pas de distinguo entre un numéro de téléphone invalide et un numéro de téléphone refusé car déjà existant en base. Cette PR résout ce problème.

## Implémentation

Ajout d'un message d'erreur spécifique dans le cas où le numéro existe déjà.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
