### PR TITLE
(PC-14768)[API] fix: base 19 yo eligibility on dms registration_date instead of fraud_check dateCreated

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -12,7 +12,6 @@ from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import constants
 from pcapi.core.users import models as users_models
-from pcapi.core.users import repository as users_repository
 from pcapi.core.users import utils as users_utils
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
@@ -617,9 +616,8 @@ def decide_eligibility(
     eligibility_today = users_api.get_eligibility_at_date(birth_date, datetime.datetime.utcnow())
 
     if eligibility_at_registration is None and eligibility_today is None and user_age_today == 19:
-        earliest_identity_check_date = users_repository.get_earliest_identity_check_date_of_eligibility(
-            user,
-            users_models.EligibilityType.AGE18,
+        earliest_identity_check_date = subscription_api.get_first_registration_date(
+            user, users_models.EligibilityType.AGE18
         )
         if earliest_identity_check_date:
             return users_api.get_eligibility_at_date(birth_date, earliest_identity_check_date)

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -4,12 +4,9 @@ import logging
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
-import sqlalchemy
 from sqlalchemy.sql.functions import func
 
-import pcapi.core.fraud.models as fraud_models
 import pcapi.core.offerers.models as offerers_models
-from pcapi.models import db
 from pcapi.repository import repository
 from pcapi.utils import crypto
 
@@ -120,18 +117,4 @@ def get_users_with_validated_attachment_by_offerer(offerer: offerers_models.Offe
             offerers_models.UserOfferer.offererId == offerer.id,
         )
         .all()
-    )
-
-
-def get_earliest_identity_check_date_of_eligibility(
-    user: models.User, eligibility: models.EligibilityType
-) -> Optional[datetime]:
-    return (
-        db.session.query(sqlalchemy.func.min(fraud_models.BeneficiaryFraudCheck.dateCreated))
-        .filter(
-            fraud_models.BeneficiaryFraudCheck.type != fraud_models.FraudCheckType.INTERNAL_REVIEW,
-            fraud_models.BeneficiaryFraudCheck.eligibilityType == eligibility,
-            fraud_models.BeneficiaryFraudCheck.user == user,
-        )
-        .scalar()
     )

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -240,6 +240,26 @@ class UserTest:
             )
             assert user.eligibility is user_models.EligibilityType.AGE18
 
+        def test_eligible_when_19_with_subscription_attempt_at_18_without_account(self):
+            user_19_yo_birth_date = datetime.utcnow() - relativedelta(years=19, months=3)
+            dms_registration_date_by_18_yo = datetime.utcnow() - relativedelta(months=6)
+            user_account_creation_date_by_19_yo = datetime.utcnow()
+
+            user = users_factories.UserFactory(dateOfBirth=user_19_yo_birth_date)
+            dms_content_before_account_creation = fraud_factories.DMSContentFactory(
+                user=user,
+                registration_datetime=dms_registration_date_by_18_yo,
+            )
+            fraud_factories.BeneficiaryFraudCheckFactory(
+                dateCreated=user_account_creation_date_by_19_yo,  # the fraud_check was created when user validated its email
+                user=user,
+                type=fraud_models.FraudCheckType.DMS,
+                status=fraud_models.FraudCheckStatus.OK,
+                eligibilityType=user_models.EligibilityType.AGE18,
+                resultContent=dms_content_before_account_creation,
+            )
+            assert user.eligibility is user_models.EligibilityType.AGE18
+
     def test_hasPhysicalVenue(self):
         user = users_factories.UserFactory()
         assert not user.hasPhysicalVenues


### PR DESCRIPTION
[et encore un edge case...]

this is to fix a case when the fraud check is not created in the same time the dms application is created. thanks to webhook that notifies us on each dms application status change, it normally happens; but when the person creates a dms application before creating a passculture account, we cannot create a fraud_check, we create a orphan_dms_application object. the fraud_check is only created when the user validates its email

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14768

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
