### PR TITLE
(PC-10441)[API] fix: Fix list/create on shared (Google) drives

### DIFF
--- a/api/src/pcapi/connectors/googledrive.py
+++ b/api/src/pcapi/connectors/googledrive.py
@@ -95,6 +95,8 @@ class GoogleDriveBackend(BaseBackend):
                 f"and name = '{name}'"
             ),
             fields="files (id)",
+            includeItemsFromAllDrives=True,
+            supportsAllDrives=True,
         )
         response = request.execute()
         if not response["files"]:
@@ -115,6 +117,7 @@ class GoogleDriveBackend(BaseBackend):
                 "mimeType": "application/vnd.google-apps.folder",
             },
             fields="id",  # yes, it's a string, not a list
+            supportsAllDrives=True,
         )
         response = request.execute()
         return response["id"]
@@ -128,6 +131,7 @@ class GoogleDriveBackend(BaseBackend):
             },
             media_body=MediaFileUpload(filename=str(local_path)),
             fields="id",  # yes, it's a string, not a list
+            supportsAllDrives=True,
         )
         response = request.execute()
         return response["id"]

--- a/api/tests/connectors/googledrive_test.py
+++ b/api/tests/connectors/googledrive_test.py
@@ -2,6 +2,7 @@ import functools
 import io
 import json
 from unittest import mock
+import urllib.parse
 
 import httplib2
 
@@ -55,10 +56,14 @@ def test_get_folder(mocked_request):
     url = mocked_request.call_args_list[0].args[5]
     url, query = url.split("?")
     assert url == "https://www.googleapis.com/drive/v3/files"
-    assert (
-        query
-        == "q=mimeType+%3D+%27application%2Fvnd.google-apps.folder%27+and+%27parent-folder-id%27+in+parents+and+name+%3D+%27name%27&fields=files+%28id%29&alt=json"
-    )
+    query = urllib.parse.parse_qs(query)
+    assert query == {
+        "q": ["mimeType = 'application/vnd.google-apps.folder' and 'parent-folder-id' in parents and name = 'name'"],
+        "fields": ["files (id)"],
+        "includeItemsFromAllDrives": ["true"],
+        "supportsAllDrives": ["true"],
+        "alt": ["json"],
+    }
 
 
 @override_settings(GOOGLE_DRIVE_BACKEND="pcapi.connectors.googledrive.GoogleDriveBackend")


### PR DESCRIPTION
Some of our files are shared on a so-called "shared drive" on Google
Drive, not in the "regular" drive. Access to a shared drive need
specific API arguments. Quoting https://developers.google.com/drive/api/guides/enable-shareddrives:

    Shared drives follow different organization, sharing, and
    ownership models from My Drive. If your app is going to create and
    manage files on shared drives, you must implement shared drive
    support in your app.

    [...]

    To begin, you need to include the supportsAllDrives=true query
    parameter in your requests when your app performs the operations
    listed below:

        files.list
        files.create
        [...]

    [...]

    The files.list method contains the following shared drive-specific
    fields and query modes:

        [...]
        includeItemsFromAllDrives — Whether shared drive items
        should be included in results. If not present or set to false,
        then shared drive items are not returned.

Credits go to @prouzet who figured it all out and pointed me to the
documentation.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10441