### PR TITLE
(PC-FIX)[API] FIX: image conversion: remove ratio check

### DIFF
--- a/api/src/pcapi/utils/image_conversion.py
+++ b/api/src/pcapi/utils/image_conversion.py
@@ -8,7 +8,6 @@ from the PIL library:
 from dataclasses import dataclass
 import enum
 import io
-import math
 from typing import Optional
 from typing import TYPE_CHECKING
 
@@ -98,8 +97,6 @@ def standardize_image(content: bytes, ratio: ImageRatio, crop_params: Optional[C
         preprocessed_image,
     )
     resized_image = _resize_image(cropped_image, ratio)
-    resized_image = _check_ratio(resized_image, ratio)
-
     return _post_process_image(resized_image)
 
 
@@ -136,13 +133,6 @@ def _post_process_image(image: PIL.Image) -> bytes:
 
 def _transpose_image(raw_image: PIL.Image) -> PIL.Image:
     return ImageOps.exif_transpose(raw_image)
-
-
-def _check_ratio(image: PIL.Image, ratio: ImageRatio) -> PIL.Image:
-    image_ratio = image.width / image.height
-    if not math.isclose(image_ratio, ratio.value, abs_tol=0.04):
-        raise ImageRatioError(expected=ratio.value, found=image_ratio)
-    return image
 
 
 def _crop_image(

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -300,24 +300,3 @@ class VenueBannerTest:
 
         assert response.status_code == 400
         assert response.json["code"] == "INVALID_BANNER_PARAMS"
-
-    def test_upload_image_bad_ratio(self, client, tmpdir):
-        user_offerer = offerers_factories.UserOffererFactory()
-        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
-
-        # this image is too small to be resized and has a 1:1 ratio
-        # it should be rejected
-        image_content = (IMAGES_DIR / "mouette_small.jpg").read_bytes()
-        file = {"banner": (io.BytesIO(image_content), "upsert_banner.jpg")}
-
-        client = client.with_session_auth(email=user_offerer.user.email)
-        url = f"/venues/{humanize(venue.id)}/banner"
-        url += "?x_crop_percent=0.0&y_crop_percent=0.0&height_crop_percent=1.0&width_crop_percent=1.0&image_credit=none"
-
-        # Override storage url otherwise it would be, well, an URL
-        # (like http://localhost) and make some checks more difficult.
-        # Override local storage and use a temporary directory instead.
-        with override_settings(OBJECT_STORAGE_URL=tmpdir.dirname, LOCAL_STORAGE_DIR=pathlib.Path(tmpdir.dirname)):
-            response = client.post(url, files=file)
-            assert response.status_code == 400
-            assert response.json["code"] == "BAD_RATIO"

--- a/api/tests/utils/image_conversion_test.py
+++ b/api/tests/utils/image_conversion_test.py
@@ -4,9 +4,7 @@ import pathlib
 import PIL
 import pytest
 
-from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.image_conversion import ImageRatio
-from pcapi.utils.image_conversion import ImageRatioError
 from pcapi.utils.image_conversion import _crop_image
 from pcapi.utils.image_conversion import _resize_image
 from pcapi.utils.image_conversion import _transpose_image
@@ -83,13 +81,6 @@ class ImageConversionTest:
 
         result_image = PIL.Image.open(io.BytesIO(standardized_image)).convert("RGB")
         assert (result_image.width / result_image.height) == pytest.approx(ImageRatio.LANDSCAPE.value, 0.01)
-
-    def test_crop_with_incorrect_ratio(self):
-        image_as_bytes = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()
-
-        with pytest.raises(ImageRatioError):
-            crop_params = CropParams(height_crop_percent=0.3, width_crop_percent=0.3)
-            standardize_image(image_as_bytes, crop_params=crop_params, ratio=ImageRatio.LANDSCAPE)
 
     def test_image_shrink_with_same_ratio(self):
         image_as_bytes = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()


### PR DESCRIPTION
## But de la pull request

Supprimer la vérification du ratio des images.
C'était mal géré, il faudrait reprendre ça pour ne plus avoir cette erreur qui part dans la nature.