### PR TITLE
(PC-14815)[API] feat: upon user request: keep password

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -325,13 +325,16 @@ def _generate_random_password(user):  # type: ignore [no-untyped-def]
 def suspend_account(user: User, reason: constants.SuspensionReason, actor: Optional[User]) -> dict[str, int]:
     """
     Suspend a user's account:
+        * mark as inactive;
         * mark as suspended (suspension history);
-        * prevent it to log in and remove its admin role if any;
+        * remove its admin role if any;
         * cancel its bookings;
 
-    Note:
-        `actor` can be None if and only if this function is called from
-        an automated task (eg cron).
+    Notes:
+        * `actor` can be None if and only if this function is called
+        from an automated task (eg cron).
+        * a user who suspends his account should be able to connect to
+        the application in order to access to some restricted actions.
     """
     import pcapi.core.bookings.api as bookings_api  # avoid import loop
 
@@ -343,7 +346,7 @@ def suspend_account(user: User, reason: constants.SuspensionReason, actor: Optio
         reasonCode=reason,
     )
     user.remove_admin_role()
-    user.setPassword(secrets.token_urlsafe(30))
+
     repository.save(user)
     repository.save(user_suspension)
 

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -44,7 +44,8 @@ logger = logging.getLogger(__name__)
 @ip_rate_limiter()
 def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
     try:
-        user = users_repo.get_user_with_credentials(body.identifier, body.password, allow_inactive=True)
+        allow_inactive = FeatureToggle.ALLOW_ACCOUNT_REACTIVATION.is_active()
+        user = users_repo.get_user_with_credentials(body.identifier, body.password, allow_inactive=allow_inactive)
     except users_exceptions.UnvalidatedAccount as exc:
         raise ApiErrors({"code": "EMAIL_NOT_VALIDATED", "general": ["L'email n'a pas été validé."]}) from exc
     except users_exceptions.CredentialsException as exc:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14815

## But de la pull request

Ne pas modifier le mot de passe d'un compte lors de sa suspension s'il l'est à la demande l'utilisateur.
Le but est que l'utilisateur puisse toujours se connecter afin de l'authentifier pour le nouveau parcours de réactivation (à venir). Il pourra se connecter mais n'aura accès qu'à un nombre très restreint d'actions.

Les utilisateurs suspendus pour d'autres raisons, fraude notamment, ne sont pas concernés. Ils le seront peut-être plus tard.

MISE A JOUR : peu import la raison de la suspension, on ne modifie plus le mot de passe. Ce changement est encadré par un FF pour pas qu'un utilisateur qui suspend son compte avant que tout le nouveau parcours de réactivation soit disponible ne se retrouve coincé au milieu de nul part (il se connecte mais n'est redirigé nul part et n'a accès à rien).