### PR TITLE
fix: avoid key error when checking if city is set in a fraud check

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -122,7 +122,7 @@ def _has_completed_profile_in_dms_form(user: users_models.User) -> bool:
         if fraud_check.type == fraud_models.FraudCheckType.DMS
         and fraud_check.status in (fraud_models.FraudCheckStatus.PENDING, fraud_models.FraudCheckStatus.STARTED)
         and fraud_check.resultContent
-        and fraud_check.resultContent["city"] is not None  # TODO: remove when all DMS applications ask for city
+        and fraud_check.resultContent.get("city") is not None  # TODO: remove when all DMS applications ask for city
     ]
     return bool(user_pending_dms_fraud_checks)
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -796,6 +796,20 @@ class CommonSubscritpionTest:
             == fraud_check
         )
 
+    def test__has_completed_profile_in_dms_form(self):
+        # This test reproduces an error that happened with old data, where 'city' was not set in the fraudCheck resultContent
+        user = users_factories.UserFactory()
+        content = fraud_factories.DMSContentFactory()
+        content.__delattr__("city")
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            resultContent=content,
+            type=fraud_models.FraudCheckType.DMS,
+            status=fraud_models.FraudCheckStatus.PENDING,
+        )
+
+        assert not subscription_api._has_completed_profile_in_dms_form(user)
+
 
 @pytest.mark.usefixtures("db_session")
 class HasPassedAllChecksToBecomeBeneficiaryTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14978

## But de la pull request

Corriger https://sentry.internal-passculture.app/organizations/sentry/issues/378077/?project=5&referrer=slack


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
