### PR TITLE
(PC-14646) Standardize Phone Validation fraud checks

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -284,8 +284,8 @@ class InternalReviewSource(enum.Enum):
 
 
 class PhoneValidationFraudData(pydantic.BaseModel):
-    source: InternalReviewSource
-    message: str
+    source: typing.Optional[InternalReviewSource]  # legacy field, still present in database
+    message: typing.Optional[str]  # legacy field, still present in database
     phone_number: typing.Optional[str]
 
 

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -308,6 +308,7 @@ class FraudReasonCode(enum.Enum):
     AGE_NOT_VALID = "age_is_not_valid"
     AGE_TOO_OLD = "age_too_old"
     AGE_TOO_YOUNG = "age_too_young"
+    BLACKLISTED_PHONE_NUMBER = "blacklisted_phone_number"
     DUPLICATE_ID_PIECE_NUMBER = "duplicate_id_piece_number"
     DUPLICATE_INE = "duplicate_ine"
     DUPLICATE_USER = "duplicate_user"
@@ -326,8 +327,11 @@ class FraudReasonCode(enum.Enum):
     MISSING_REQUIRED_DATA = "missing_required_data"
     NAME_INCORRECT = "name_incorrect"
     NOT_ELIGIBLE = "not_eligible"
+    PHONE_ALREADY_EXISTS = "phone_already_exists"
     PHONE_NOT_VALIDATED = "phone_not_validated"
+    PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED = "phone_validation_attempts_limit_reached"
     REFUSED_BY_OPERATOR = "refused_by_operator"
+    SMS_SENDING_LIMIT_REACHED = "sms_sending_limit_reached"
 
 
 # FIXME: ce status fait un peu doublon avec FraudStatus

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -958,8 +958,8 @@ class SendPhoneValidationCodeTest:
 
         content = fraud_check.resultContent
         expected_reason = "Le nombre maximum de sms envoyés est atteint"
-        assert content["source"] == fraud_models.InternalReviewSource.SMS_SENDING_LIMIT_REACHED.value
-        assert content["message"] == expected_reason
+        assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.SMS_SENDING_LIMIT_REACHED]
+        assert fraud_check.reason == expected_reason
         assert content["phone_number"] == "+33601020304"
 
     def test_send_phone_validation_code_already_beneficiary(self, client, app):
@@ -1061,8 +1061,8 @@ class SendPhoneValidationCodeTest:
         assert fraud_check.eligibilityType == eligibility_type
 
         content = fraud_check.resultContent
-        assert content["source"] == fraud_models.InternalReviewSource.PHONE_ALREADY_EXISTS.value
-        assert content["message"] == f"Le numéro est déjà utilisé par l'utilisateur {orig_user.id}"
+        assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.PHONE_ALREADY_EXISTS]
+        assert fraud_check.reason == f"Le numéro est déjà utilisé par l'utilisateur {orig_user.id}"
         assert content["phone_number"] == "+33102030405"
 
         assert (
@@ -1157,8 +1157,8 @@ class SendPhoneValidationCodeTest:
         assert fraud_check.eligibilityType == eligibility_type
 
         content = fraud_check.resultContent
-        assert content["source"] == fraud_models.InternalReviewSource.BLACKLISTED_PHONE_NUMBER.value
-        assert content["message"] == "Le numéro saisi est interdit"
+        assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.BLACKLISTED_PHONE_NUMBER]
+        assert fraud_check.reason == "Le numéro saisi est interdit"
         assert content["phone_number"] == "+33601020304"
 
 
@@ -1248,8 +1248,9 @@ class ValidatePhoneNumberTest:
 
         expected_reason = f"Le nombre maximum de tentatives de validation est atteint: {attempts_count}"
         content = fraud_check.resultContent
-        assert content["source"] == fraud_models.InternalReviewSource.PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED.value
-        assert content["message"] == expected_reason
+        assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED]
+
+        assert fraud_check.reason == expected_reason
         assert content["phone_number"] == "+33607080900"
 
     def test_wrong_code(self, client, app):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14646

## But de la pull request

Cette PR fait suite à une volonté d'uniformiser la manière dont les FraudCheck sont stockés en base. Jusqu'ici le traitement des FraudCheck pour le processus de validation de numéro de téléphone était légèrement différent. Cette PR permet le stockage des informations dans l'objet FraudCheck générique.

## Implémentation

On rend les attributs de `PhoneValidationFraudData` optionnels pour ne pas rendre invalides les entrées déjà en base. Désormais, on stocke les informations dans `BeneficiaryFraudCheck.reasonCodes` et `BeneficiaryFraudCheck.reason` à la place de `PhoneValidationFraudData['source']` et `PhoneValidationFraudData['message']`.

`PhoneValidationFraudData` ne stocke désormais que le numéro de téléphone.

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
