### PR TITLE
(PC-14202)[API] fix: Show less data in offerer internal validation e-mail

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -273,7 +273,11 @@ def create_offerer(user: User, offerer_informations: CreateOffererQueryModel):  
         user_offerer = grant_user_offerer_access(offerer, user)
         repository.save(offerer, digital_venue, user_offerer)
 
-    _send_to_pc_admin_offerer_to_validate_email(offerer, user_offerer)
+    if not maybe_send_offerer_validation_email(offerer, user_offerer):
+        logger.warning(
+            "Could not send validation email to offerer",
+            extra={"user_offerer": user_offerer.id},
+        )
 
     update_external_pro(user.email)
 
@@ -282,14 +286,6 @@ def create_offerer(user: User, offerer_informations: CreateOffererQueryModel):  
 
 def grant_user_offerer_access(offerer: Offerer, user: User) -> UserOfferer:
     return UserOfferer(offerer=offerer, user=user)
-
-
-def _send_to_pc_admin_offerer_to_validate_email(offerer: Offerer, user_offerer: UserOfferer) -> None:
-    if not maybe_send_offerer_validation_email(offerer, user_offerer):
-        logger.warning(
-            "Could not send validation email to offerer",
-            extra={"user_offerer": user_offerer.id},
-        )
 
 
 def validate_offerer_attachment(token: str) -> None:

--- a/api/src/pcapi/templates/mails/internal_validation_email.html
+++ b/api/src/pcapi/templates/mails/internal_validation_email.html
@@ -26,37 +26,7 @@
 
         <hr/>
 
-        <section data-testId="user_offerer">
-            {% if user_offerer.isValidated %}
-                <h2>Rattachement :</h2>
-            {% else %}
-                <h2>Nouveau rattachement :</h2>
-                <strong class="validation">
-                    Pour valider, <a href="{{ api_url }}/validate/user-offerer/{{ user_offerer.validationToken }}">cliquez ici</a>
-                </strong>
-            {% endif %}
-
-            <h3>Utilisateur :</h3>
-            <pre>{{ user_vars }}</pre>
-            <h3>Structure :</h3>
-            <pre>{{ offerer_vars_user_offerer }} </pre>
-        </section>
-
-        <hr/>
-
-        <section data-testId="offerer">
-            {% if offerer.isValidated %}
-                <h2>Structure :</h2>
-            {% else %}
-                <h2>Nouvelle structure :</h2>
-                <strong class="validation">
-                    Pour valider, <a href="{{ api_url }}/validate/offerer/{{ offerer.validationToken }}">cliquez ici</a>
-                </strong>
-            {% endif %}
-
-            <pre class="offerer-data">{{ offerer_vars }}</pre>
-            <h3>Infos API entreprise :</h3>
-            <pre class="api-entreprise-data">{{ api_entreprise }}</pre>
-        </section>
+        <h2>Infos API entreprise :</h3>
+        <pre class="api-entreprise-data">{{ api_entreprise }}</pre>
     </body>
 </html>

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -74,8 +74,6 @@ def make_offerer_internal_validation_email(  # type: ignore [no-untyped-def]
     user_offerer: offerers_models.UserOfferer,
     get_by_siren=api_entreprises.get_by_offerer,
 ) -> dict:
-    vars_obj_user = vars(user_offerer.user)
-    vars_obj_user.pop("clearTextPassword", None)
     api_entreprise = get_by_siren(offerer)
 
     offerer_departement_code = PostalCode(offerer.postalCode).get_departement_code()
@@ -83,10 +81,7 @@ def make_offerer_internal_validation_email(  # type: ignore [no-untyped-def]
     email_html = render_template(
         "mails/internal_validation_email.html",
         user_offerer=user_offerer,
-        user_vars=pformat(vars_obj_user),
         offerer=offerer,
-        offerer_vars_user_offerer=pformat(vars(user_offerer.offerer)),
-        offerer_vars=pformat(vars(offerer)),
         offerer_pro_link=build_pc_pro_offerer_link(offerer),
         offerer_summary=pformat(_summarize_offerer_vars(offerer, api_entreprise)),
         user_summary=pformat(_summarize_user_vars(user_offerer)),


### PR DESCRIPTION
More specifically, do not show technical (and possibly sensitive)
information through the use of `vars()`.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14202