### PR TITLE
(PC-14915)[API] feat: add not null constraint on allocine pivot

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d1a514ca8bd1 (pre) (head)
+3c19643259f9 (pre) (head)
 beaefcf60bc9 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220511T090506_3c19643259f9_add_not_null_constraint_to_allocine_pivot.py
+++ b/api/src/pcapi/alembic/versions/20220511T090506_3c19643259f9_add_not_null_constraint_to_allocine_pivot.py
@@ -1,0 +1,22 @@
+"""add not-null constraint on venueId to allocine pivot
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3c19643259f9"
+down_revision = "d1a514ca8bd1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+            ALTER TABLE allocine_pivot ADD CONSTRAINT venue_id_not_null_constraint CHECK ("venueId" IS NOT NULL) NOT VALID;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("venue_id_not_null_constraint", table_name="allocine_pivot")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14915

## But de la pull request

Ajout d'une contrainte non null sur le venueId de AlloCinePivot.
La contrainte est en "NOT VALID" le temps de remplir les données sur tous les envs.

## Implémentation

- Ajout d'un migration

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
