### PR TITLE
(PC-14979)[API] fix: Exclude pro users in "partner user" Flask admin page

### DIFF
--- a/api/src/pcapi/admin/custom_views/partner_user_view.py
+++ b/api/src/pcapi/admin/custom_views/partner_user_view.py
@@ -130,6 +130,7 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
             .filter(UserOfferer.userId.is_(None))
             .filter(User.is_beneficiary.is_(False))  # type: ignore [attr-defined]
             .filter(User.has_admin_role.is_(False))  # type: ignore [attr-defined]
+            .filter(User.has_pro_role.is_(False))  # type: ignore [attr-defined]
         )
 
     def get_count_query(self) -> BaseQuery:
@@ -140,4 +141,5 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
             .filter(UserOfferer.userId.is_(None))
             .filter(User.is_beneficiary.is_(False))  # type: ignore [attr-defined]
             .filter(User.has_admin_role.is_(False))  # type: ignore [attr-defined]
+            .filter(User.has_pro_role.is_(False))  # type: ignore [attr-defined]
         )

--- a/api/tests/admin/custom_views/partner_user_view_test.py
+++ b/api/tests/admin/custom_views/partner_user_view_test.py
@@ -7,11 +7,12 @@ from wtforms import Form
 from pcapi.admin.custom_views.partner_user_view import PartnerUserView
 import pcapi.core.fraud.factories as fraud_factories
 import pcapi.core.fraud.models as fraud_models
+import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.subscription.api as subscription_api
 import pcapi.core.subscription.models as subscription_models
 from pcapi.core.testing import override_settings
-from pcapi.core.users import models as users_models
 import pcapi.core.users.factories as users_factories
+import pcapi.core.users.models as users_models
 from pcapi.core.users.models import User
 
 from tests.conftest import TestClient
@@ -221,3 +222,23 @@ class PartnerUserViewTest:
         )
 
         assert user.idPieceNumber is None
+
+
+def test_query(db_session):
+    partner_user = users_factories.UserFactory(roles=[])
+    _beneficiary = users_factories.BeneficiaryGrant18Factory()
+    _pro_with_offerer = offerers_factories.UserOffererFactory().user
+    _pro_without_offerer = users_factories.UserFactory(roles=[users_models.UserRole.PRO])
+    view = PartnerUserView(users_models.User, db_session)
+    users = list(view.get_query())
+    assert users == [partner_user]
+
+
+def test_count_query(db_session):
+    _partner_user = users_factories.UserFactory(roles=[])
+    _beneficiary = users_factories.BeneficiaryGrant18Factory()
+    _pro_with_offerer = offerers_factories.UserOffererFactory().user
+    _pro_without_offerer = users_factories.UserFactory(roles=[users_models.UserRole.PRO])
+    view = PartnerUserView(users_models.User, db_session)
+    count = view.get_count_query().scalar()
+    assert count == 1


### PR DESCRIPTION
This page wrongly included pro users who were not linked to any offerer.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14979