### PR TITLE
(PC-14542)[PRO] fix: Add frontend validation on addressField

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/LocationFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/LocationFields.jsx
@@ -38,6 +38,7 @@ const LocationFields = ({
           name="address"
           readOnly={readOnly || fieldReadOnlyBecauseFrozenFormSiret}
           withMap
+          required={true}
         />
         <TextField
           autoComplete="postal-code"

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/__specs__/LocationFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/__specs__/LocationFields.spec.jsx
@@ -46,7 +46,7 @@ describe('src | components | pages | Venue | fields | LocationFields', () => {
       expect(addressField.prop('longitude')).toBe(1)
       expect(addressField.prop('name')).toBe('address')
       expect(addressField.prop('readOnly')).toBe(true)
-      expect(addressField.prop('required')).toBe(false)
+      expect(addressField.prop('required')).toBe(true)
       expect(addressField.prop('withMap')).toBe(true)
     })
 


### PR DESCRIPTION
The address field is mandatory for the endpoint POST on "/venues"
Here is the api validator : https://github.com/pass-culture/pass-culture-main/blob/2f2e25507214a094f262dc83648c57e8ab89f005/api/src/pcapi/routes/serialization/venues_serialize.py#L34

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14542

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
