### PR TITLE
(PC-15039)[PRO] fix: add offer image error message 

### DIFF
--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
@@ -44,6 +44,7 @@ const OfferDetails = ({ isUserAdmin, offer, reloadOffer, userEmail }) => {
   const [showThumbnailForm, setShowThumbnailForm] = useState(false)
   const [thumbnailInfo, setThumbnailInfo] = useState({})
   const [thumbnailError, setThumbnailError] = useState(false)
+  const [thumbnailMsgError, setThumbnailMsgError] = useState('')
   const { categories, subCategories } = useSelector(
     state => state.offers.categories
   )
@@ -79,6 +80,22 @@ const OfferDetails = ({ isUserAdmin, offer, reloadOffer, userEmail }) => {
     }
   }, [categories, subCategories])
 
+  const goToStockAndPrice = async(offerId) => {
+    let queryString = ''
+  
+    if (formInitialValues.current.offererId !== undefined) {
+      queryString = `?structure=${formInitialValues.current.offererId}`
+    }
+
+    if (formInitialValues.current.venueId !== undefined) {
+      queryString += `&lieu=${formInitialValues.current.venueId}`
+    }
+
+    history.push(
+      `/offre/${offerId}/individuel/stocks${queryString}`
+    )
+  }
+
   const postThumbnail = useCallback(
     async (offerId, thumbnailInfo) => {
       const offerThumbnailHasBeenUpdated =
@@ -86,8 +103,7 @@ const OfferDetails = ({ isUserAdmin, offer, reloadOffer, userEmail }) => {
       if (offerThumbnailHasBeenUpdated) {
         const { credit, thumbnail, croppingRect, thumbUrl } = thumbnailInfo
 
-        try {
-          await pcapi.postThumbnail(
+        await pcapi.postThumbnail(
             offerId,
             credit,
             thumbnail,
@@ -96,13 +112,24 @@ const OfferDetails = ({ isUserAdmin, offer, reloadOffer, userEmail }) => {
             croppingRect?.y,
             croppingRect?.height,
             croppingRect?.width
-          )
-        } catch (error) {
-          setThumbnailError(true)
-          showErrorNotification()
+          ).then(() => {
+            setThumbnailError(false)
+            setThumbnailMsgError('')
 
-          throw error
-        }
+            if (!offer) {
+              goToStockAndPrice(offerId)
+            }
+          })
+          .catch((error) => {
+            setThumbnailInfo({})
+            setThumbnailError(true)
+            if (error.errors?.errors?.length > 0) {
+              setThumbnailMsgError(error.errors.errors[0])
+            }
+            showErrorNotification()
+
+            throw error
+          })
       }
     },
     [showErrorNotification]
@@ -116,24 +143,17 @@ const OfferDetails = ({ isUserAdmin, offer, reloadOffer, userEmail }) => {
           notification.success('Votre offre a bien été modifiée')
           reloadOffer()
           setFormErrors({})
+          setThumbnailError(false)
+          setThumbnailMsgError('')
         } else {
           const response = await pcapi.createOffer(offerValues)
           const createdOfferId = response.id
           await postThumbnail(createdOfferId, thumbnailInfo)
 
-          let queryString = ''
-
-          if (formInitialValues.current.offererId !== undefined) {
-            queryString = `?structure=${formInitialValues.current.offererId}`
+          if (Object.keys(thumbnailInfo).length === 0) {
+            await goToStockAndPrice(createdOfferId)
           }
 
-          if (formInitialValues.current.venueId !== undefined) {
-            queryString += `&lieu=${formInitialValues.current.venueId}`
-          }
-
-          history.push(
-            `/offre/${createdOfferId}/individuel/stocks${queryString}`
-          )
           return Promise.resolve()
         }
       } catch (error) {
@@ -224,7 +244,10 @@ const OfferDetails = ({ isUserAdmin, offer, reloadOffer, userEmail }) => {
                 offerId={offer?.id}
                 postThumbnail={postThumbnail}
                 setThumbnailInfo={setThumbnailInfo}
+                setThumbnailError={setThumbnailError}
+                setThumbnailMsgError={setThumbnailMsgError}
                 thumbnailError={thumbnailError}
+                thumbnailMsgError={thumbnailMsgError}
                 url={offer?.thumbUrl}
               />
               <OfferPreview offerPreviewData={offerPreviewData} />

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferThumbnail/OfferThumbnail.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferThumbnail/OfferThumbnail.jsx
@@ -11,7 +11,10 @@ const OfferThumbnail = ({
   offerId,
   postThumbnail,
   setThumbnailInfo,
+  setThumbnailError,
+  setThumbnailMsgError,
   thumbnailError,
+  thumbnailMsgError,
   url,
 }) => {
   const [isModalOpened, setIsModalOpened] = useState(false)
@@ -20,6 +23,8 @@ const OfferThumbnail = ({
 
   const openModal = useCallback(e => {
     e.target.blur()
+    setThumbnailError(false),
+    setThumbnailMsgError(''),
     setIsModalOpened(true)
   }, [])
 
@@ -40,15 +45,15 @@ const OfferThumbnail = ({
     <>
       <button
         className={`of-placeholder
-        ${preview ? 'of-image' : ''}
+        ${preview && !thumbnailError ? 'of-image' : ''}
         ${thumbnailError ? 'of-thumbnail-error' : ''}`}
         disabled={isDisabled}
         onClick={openModal}
         ref={thumbnailButtonRef}
-        title={`${preview ? 'Modifier l’image' : 'Ajouter une image'}`}
+        title={`${preview && !thumbnailError ? 'Modifier l’image' : 'Ajouter une image'}`}
         type="button"
       >
-        {preview ? (
+        {preview && !thumbnailError ? (
           <Icon alt="Image de l’offre" src={preview} />
         ) : (
           <>
@@ -60,7 +65,7 @@ const OfferThumbnail = ({
         {thumbnailError && (
           <span className="of-error-message">
             <ErrorAlertIcon />
-            L’image n’a pas pu être ajoutée. Veuillez réessayer.
+            {thumbnailMsgError !== '' ? thumbnailMsgError : `L’image n’a pas pu être ajoutée. Veuillez réessayer.`}
           </span>
         )}
       </button>

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
@@ -2295,7 +2295,7 @@ describe('offerDetails - Creation - pro user', () => {
       expect(errorNotification).toBeInTheDocument()
 
       const thumbnailUploadError = await screen.findByText(
-        'L’image n’a pas pu être ajoutée. Veuillez réessayer.'
+        'Utilisez une image plus grande (supérieure à 400px par 400px)'
       )
       expect(thumbnailUploadError).toBeInTheDocument()
     })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15039

## But de la pull request

-Ajout d'un message d'erreur explicite lorsque l'image n'est pas conforme aux attentes de l'API
-Ne pas afficher dans l'encart l'image non enregistrée comme c'était le cas au bout de la 2ème tentative

## Implémentation

-Remplacement du try/catch par une gestion de la promise par then/catch + ajout d'une props pour enregistrer le message d'erreur pour qu'il soit utilisable par le composant OfferThumbnail + tenir compte de la prop thumbnailError pour gérer l'affichage de la preview
- Adaptations effectuées pour que ça fonctionne en création et modification

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
