### PR TITLE
(PC-14688)[API] feat: new back-office - add get beneficiary credit endpoint

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -19,6 +19,7 @@ class Permissions(enum.Enum):
 
     MANAGE_PERMISSIONS = "gérer les droits"
     SEARCH_PUBLIC_ACCOUNT = "rechercher un compte bénéficiaire/grand public"
+    READ_PUBLIC_ACCOUNT = "visualiser un compte bénéficiaire/grand public"
 
 
 def sync_enum_with_db_field(session: sa.orm.Session, py_enum: Type[enum.Enum], db_field: sa.Column) -> None:

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -44,6 +44,10 @@ def get_user_with_credentials(identifier: str, password: str) -> models.User:
     return user  # type: ignore [return-value]
 
 
+def get_user_by_id(user_id: int) -> models.User:
+    return models.User.query.get(user_id)
+
+
 def _find_user_by_email_query(email: str):  # type: ignore [no-untyped-def]
     # FIXME (dbaty, 2021-05-02): remove call to `func.lower()` once
     # all emails have been sanitized in the database.

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -1,9 +1,12 @@
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.permissions import utils as perm_utils
-from pcapi.core.users import api as user_api
+from pcapi.core.users import api as users_api
+from pcapi.core.users import repository as users_repository
+from pcapi.models.api_errors import ApiErrors
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
+from .serialization import GetBeneficiaryCreditResponseModel
 from .serialization import ListPublicAccountsResponseModel
 from .serialization import PublicAccount
 from .serialization import PublicAccountSearchQuery
@@ -18,6 +21,29 @@ from .serialization import PublicAccountSearchQuery
 )
 def search_public_account(query: PublicAccountSearchQuery) -> ListPublicAccountsResponseModel:
     terms = query.q.split()
-    accounts = user_api.search_public_account(terms)
+    accounts = users_api.search_public_account(terms)
 
     return ListPublicAccountsResponseModel(accounts=[PublicAccount.from_orm(account) for account in accounts])
+
+
+@blueprint.backoffice_blueprint.route("public_accounts/user/<int:user_id>/credit", methods=["GET"])
+@perm_utils.permission_required(perm_models.Permissions.READ_PUBLIC_ACCOUNT)
+@spectree_serialize(
+    response_model=GetBeneficiaryCreditResponseModel,
+    on_success_status=200,
+    api=blueprint.api,
+)
+def get_beneficiary_credit(user_id: int) -> GetBeneficiaryCreditResponseModel:
+    user = users_repository.get_user_by_id(user_id)
+    if not user:
+        raise ApiErrors(errors={"user_id": "User does not exist"})
+
+    domains_credit = users_api.get_domains_credit(user) if user.is_beneficiary else None
+
+    return GetBeneficiaryCreditResponseModel(
+        initialCredit=float(domains_credit.all.initial) if domains_credit else 0.0,
+        remainingCredit=float(domains_credit.all.remaining) if domains_credit else 0.0,
+        remainingDigitalCredit=float(domains_credit.digital.remaining)
+        if domains_credit and domains_credit.digital
+        else 0.0,
+    )

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -64,3 +64,9 @@ class ListPublicAccountsResponseModel(BaseModel):
         orm_mode = True
 
     accounts: list[PublicAccount]
+
+
+class GetBeneficiaryCreditResponseModel(BaseModel):
+    initialCredit: float
+    remainingCredit: float
+    remainingDigitalCredit: float


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14688

## But de la pull request

Endpoint d'API pour le nouveau backoffice :
En tant que support jeune, J'aimerais consulter le crédit du jeune

Règles de gestion
- Afficher le crédit initial et le crédit restant du jeune 
- Et le montant restant sur son plafond numérique

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
