### PR TITLE
(PC-14626)[PRO] fix: display offer creation button if user is not admin

### DIFF
--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -98,13 +98,12 @@ const Offers = ({
     [urlSearchFilters]
   )
 
-  const actionLink =
-    userHasNoOffers || isAdmin ? null : (
-      <Link className="primary-button with-icon" to="/offre/creation">
-        <AddOfferSvg />
-        Créer une offre
-      </Link>
-    )
+  const actionLink = isAdmin ? null : (
+    <Link className="primary-button with-icon" to="/offre/creation">
+      <AddOfferSvg />
+      Créer une offre
+    </Link>
+  )
 
   const nbSelectedOffers = areAllOffersSelected
     ? offers.length


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14626

## But de la pull request

Afficher le bouton création d'offre tout le temps si l'utilisateur n'est pas administrateur.


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
