### PR TITLE
Bsr align db and model

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -153,7 +153,7 @@ class Booking(PcObject, Model):  # type: ignore [valid-type, misc]
     status = Column("status", Enum(BookingStatus), nullable=False, default=BookingStatus.CONFIRMED)
     Index("ix_booking_status", status)
 
-    reimbursementDate = Column(DateTime, nullable=True)
+    reimbursementDate = Column(DateTime, nullable=True, index=True)
 
     educationalBookingId = Column(
         BigInteger,

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -377,7 +377,7 @@ class InvoiceCashflow(Model):  # type: ignore [valid-type, misc]
     cashflowId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("cashflow.id"), index=True, primary_key=True)
 
     __table_args__ = (
-        sqla.UniqueConstraint(
+        sqla.PrimaryKeyConstraint(
             "invoiceId",
             "cashflowId",
             name="unique_invoice_cashflow_association",

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -325,7 +325,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ValidationMixin, 
         nullable=True,
     )
 
-    isEducational = sa.Column(sa.Boolean, server_default=sa.false(), default=False, nullable=False)
+    isEducational = sa.Column(sa.Boolean, server_default=sa.false(), default=False, nullable=False, index=True)
 
     subcategoryId = sa.Column(sa.Text, nullable=False, index=True)
 


### PR DESCRIPTION
Lors de la génération automatique de migration, il y avait 3 migrations : 
```
    op.drop_index('ix_booking_reimbursementDate', table_name='booking')
    op.create_unique_constraint('unique_invoice_cashflow_association', 'invoice_cashflow', ['invoiceId', 'cashflowId'])
    op.drop_index('ix_offer_isEducational', table_name='offer')
```

Cette PR ajoute les bonnes définitions sur les modèles.

Il faudrait comprendre pourquoi le script dans check_db_schema ne détecte pas ces différences sur les index.