### PR TITLE
(BSR)[API] feat: add index on user.phoneNumber

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 4400cd98902e (pre) (head)
-beaefcf60bc9 (post) (head)
+06190162f083 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220513T093817_06190162f083_add_phone_number_index.py
+++ b/api/src/pcapi/alembic/versions/20220513T093817_06190162f083_add_phone_number_index.py
@@ -1,0 +1,27 @@
+"""add_phone_number_index
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# revision identifiers, used by Alembic.
+revision = "06190162f083"
+down_revision = "beaefcf60bc9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_user_phoneNumber" ON "user" ("phoneNumber")
+        """
+    )
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_user_phoneNumber;")

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -209,7 +209,7 @@ class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, 
     )
     offerers = orm.relationship("Offerer", secondary="user_offerer")  # type: ignore [misc]
     password = sa.Column(sa.LargeBinary(60), nullable=False)
-    phoneNumber = sa.Column(sa.String(20), nullable=True)
+    phoneNumber = sa.Column(sa.String(20), nullable=True, index=True)
     phoneValidationStatus = sa.Column(sa.Enum(PhoneValidationStatusType, create_constraint=False), nullable=True)
     postalCode = sa.Column(sa.String(5), nullable=True)
     publicName = sa.Column(sa.String(255), nullable=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Résoudre les [problèmes de perf](https://sentry.internal-passculture.app/organizations/sentry/performance/api:fc42986a6d134e73a39a5483de3a37a1/?environment=production&project=5&query=transaction.duration%3A%3C15m+transaction%3A%2Anative%2A+event.type%3Atransaction+http.method%3APOST&statsPeriod=14d&transaction=native_v1.send_phone_validation_code&unselectedSeries=p100%28%29) sur la route `send_phone_validation_code`. La requête faite dans `does_validated_phone_exist` est hyper longue, un index peut résoudre le pb.

La migration prend 30s en production. 