### PR TITLE
(PC-15015)[API] feat: get movies from cds api

### DIFF
--- a/api/src/pcapi/connectors/cine_digital_service.py
+++ b/api/src/pcapi/connectors/cine_digital_service.py
@@ -18,6 +18,7 @@ from pcapi.utils import requests
 class ResourceCDS(enum.Enum):
     TARIFFS = "tariffs"
     SHOWS = "shows"
+    MEDIA = "media"
     PAYMENT_TYPE = "paiementtype"
     VOUCHER_TYPE = "vouchertype"
     SCREENS = "screens"

--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -32,6 +32,17 @@ class ShowCDS(BaseModel):
         allow_population_by_field_name = True
 
 
+class MediaCDS(BaseModel):
+    id: int
+    title: str
+    duration: int
+    storyline: str
+    visanumber: str
+
+    class Config:
+        allow_population_by_field_name = True
+
+
 class PaymentTypeCDS(BaseModel):
     id: int
     internal_code: str = Field(alias="internalcode")

--- a/api/src/pcapi/core/booking_providers/cds/client.py
+++ b/api/src/pcapi/core/booking_providers/cds/client.py
@@ -48,6 +48,11 @@ class CineDigitalServiceAPI(BookingProviderClientAPI):
             f"Show #{show_id} not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.api_url}"
         )
 
+    def get_cinema_movies(self) -> cds_serializers.MediaCDS:
+        data = get_resource(self.api_url, self.cinema_id, self.token, ResourceCDS.MEDIA)
+        movies = parse_obj_as(list[cds_serializers.MediaCDS], data)
+        return movies
+
     def get_voucher_payment_type(self) -> cds_serializers.PaymentTypeCDS:
         data = get_resource(self.api_url, self.cinema_id, self.token, ResourceCDS.PAYMENT_TYPE)
         payment_types = parse_obj_as(list[cds_serializers.PaymentTypeCDS], data)

--- a/api/tests/core/booking_providers/cds/test_client.py
+++ b/api/tests/core/booking_providers/cds/test_client.py
@@ -848,3 +848,43 @@ class CineDigitalServiceBookTicketTest:
         assert len(tickets) == 1
         assert tickets[0].barcode == "141414141414"
         assert not tickets[0].seat_number
+
+
+class CineDigitalServiceGetMoviesTest:
+    @patch("pcapi.core.booking_providers.cds.client.get_resource")
+    def test_should_return_movies_information(self, mocked_get_resource):
+
+        # Given
+        cinema_id = "cinemaid_test"
+        token = "token_test"
+        api_url = "apiUrl_test/"
+        resource = ResourceCDS.MEDIA
+
+        json_movies = [
+            {
+                "id": 1,
+                "title": "Test movie #1",
+                "duration": 7200,
+                "storyline": "Test description #1",
+                "visanumber": "123",
+            },
+            {
+                "id": 2,
+                "title": "Test movie #2",
+                "duration": 5400,
+                "storyline": "Test description #2",
+                "visanumber": "456",
+            },
+        ]
+
+        mocked_get_resource.return_value = json_movies
+
+        # when
+        cine_digital_service = CineDigitalServiceAPI(
+            cinema_id="cinemaid_test", token="token_test", api_url="apiUrl_test/"
+        )
+        movies = cine_digital_service.get_cinema_movies()
+
+        # then
+        mocked_get_resource.assert_called_once_with(api_url, cinema_id, token, resource)
+        assert len(movies) == 2


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15105

## But de la pull request

Appeler la route de récupération des média sur l’API CDS, récupérer les informations lié aux films 

[Lien de la documentation CDS](https://docs.cineoffice.fr/vad/#:~:text=1.3%20R%C3%A9cup%C3%A9ration%20medias%20(films%20planifi%C3%A9s))

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
