### PR TITLE
Pc 14915 use venue id in allocine pivot

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-16ce9f750e7c (pre) (head)
+dd318872da8d (pre) (head)
 beaefcf60bc9 (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-3c19643259f9 (pre) (head)
+16ce9f750e7c (pre) (head)
 beaefcf60bc9 (post) (head)

--- a/api/src/pcapi/admin/custom_views/allocine_pivot_view.py
+++ b/api/src/pcapi/admin/custom_views/allocine_pivot_view.py
@@ -4,15 +4,14 @@ from pcapi.admin.base_configuration import BaseAdminView
 class AllocinePivotView(BaseAdminView):
     can_create = True
     can_edit = True
-    column_list = ["venue.name", "siret", "theaterId", "internalId"]
-    column_searchable_list = ["venue.name", "siret", "theaterId", "internalId"]
+    column_list = ["venue.name", "theaterId", "internalId"]
+    column_searchable_list = ["venue.name", "theaterId", "internalId"]
     column_sortable_list: list[str] = []
     column_labels = {
         "theaterId": "Identifiant Allociné",
-        "siret": "SIRET",
         "venue.id": "Lieu",
         "venueId": "Identifiant lieu",
         "internalId": "Identifiant interne allociné",
     }
     column_filters: list[str] = []
-    form_columns = ["venueId", "siret", "theaterId", "internalId"]
+    form_columns = ["venueId", "theaterId", "internalId"]

--- a/api/src/pcapi/alembic/versions/20220512T091138_16ce9f750e7c_apply_not_null_constraint_on_allocinepivot_venueid.py
+++ b/api/src/pcapi/alembic/versions/20220512T091138_16ce9f750e7c_apply_not_null_constraint_on_allocinepivot_venueid.py
@@ -1,0 +1,18 @@
+"""apply not-null constraint on allocine_pivot.venueId
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "16ce9f750e7c"
+down_revision = "3c19643259f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE allocine_pivot VALIDATE CONSTRAINT venue_id_not_null_constraint;")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20220512T160804_dd318872da8d_remove_not_null_siret_on_allocine_pivot.py
+++ b/api/src/pcapi/alembic/versions/20220512T160804_dd318872da8d_remove_not_null_siret_on_allocine_pivot.py
@@ -1,0 +1,18 @@
+"""remove_not_null_siret_on_allocine_pivot
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "dd318872da8d"
+down_revision = "16ce9f750e7c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE allocine_pivot ALTER COLUMN siret DROP NOT NULL;")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE allocine_pivot ALTER COLUMN siret NOT NULL;")

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -11,7 +11,6 @@ class AllocinePivotFactory(BaseFactory):
         model = models.AllocinePivot
 
     venue = factory.SubFactory(VenueFactory)
-    siret = factory.SelfAttribute("venue.siret")
     theaterId = "XXXXXXXXXXXXXXXXXX=="
     internalId = "PXXXXX"
 

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -200,8 +200,6 @@ class AllocinePivot(PcObject, Model):  # type: ignore [valid-type, misc]
 
     venue = relationship(Venue, foreign_keys=[venueId])
 
-    siret = Column(String(14), nullable=False, unique=True)
-
     theaterId = Column(String(20), nullable=False, unique=True)
 
     internalId = Column(Text, nullable=False, unique=True)

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -55,6 +55,10 @@ def get_providers_enabled_for_pro_excluding_specific_provider(allocine_local_cla
     )
 
 
+def get_allocine_pivot_for_venue(venue: Venue) -> AllocinePivot:
+    return AllocinePivot.query.filter_by(venue=venue).one_or_none()
+
+
 def has_allocine_pivot_for_venue(venue: Venue) -> bool:
-    allocine_link = AllocinePivot.query.filter_by(siret=venue.siret).one_or_none()
-    return allocine_link is not None
+    allocine_pivot = get_allocine_pivot_for_venue(venue)
+    return allocine_pivot is not None

--- a/api/src/pcapi/repository/allocine_pivot_queries.py
+++ b/api/src/pcapi/repository/allocine_pivot_queries.py
@@ -1,6 +1,0 @@
-from pcapi.core.offerers.models import Venue
-from pcapi.core.providers.models import AllocinePivot
-
-
-def get_allocine_pivot_for_venue(venue: Venue) -> AllocinePivot:
-    return AllocinePivot.query.filter_by(siret=venue.siret).one_or_none()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
@@ -129,9 +129,7 @@ def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType
         name="Lieu synchro allociné", siret="87654321", businessUnit__name="Business Unit du Lieu synchro allociné"
     )
     allocine_provider = providers_factories.AllocineProviderFactory(isActive=True)
-    pivot = providers_factories.AllocinePivotFactory(
-        venue=venue_synchronized_with_allocine, siret=venue_synchronized_with_allocine.siret
-    )
+    pivot = providers_factories.AllocinePivotFactory(venue=venue_synchronized_with_allocine)
     venue_provider = providers_factories.AllocineVenueProviderFactory(
         venue=venue_synchronized_with_allocine, provider=allocine_provider, venueIdAtOfferProvider=pivot.theaterId
     )

--- a/api/src/pcapi/use_cases/connect_venue_to_allocine.py
+++ b/api/src/pcapi/use_cases/connect_venue_to_allocine.py
@@ -8,9 +8,9 @@ from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.providers.models import VenueProviderCreationPayload
+from pcapi.core.providers.repository import get_allocine_pivot_for_venue
 from pcapi.domain.price_rule import PriceRule
 from pcapi.repository import repository
-from pcapi.repository.allocine_pivot_queries import get_allocine_pivot_for_venue
 
 
 ERROR_CODE_PROVIDER_NOT_SUPPORTED = 400

--- a/api/tests/models/allocine_pivot_queries_test.py
+++ b/api/tests/models/allocine_pivot_queries_test.py
@@ -2,16 +2,17 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.providers.factories import AllocinePivotFactory
+from pcapi.core.providers.repository import get_allocine_pivot_for_venue
 from pcapi.core.providers.repository import has_allocine_pivot_for_venue
-from pcapi.repository.allocine_pivot_queries import get_allocine_pivot_for_venue
 
 
 class HasAllocinePivotForVenueTest:
     @pytest.mark.usefixtures("db_session")
-    def test_should_return_false_when_venue_has_no_siret(self, app):
+    def test_should_return_false(self, app):
         # Given
-        venue = offerers_factories.VenueFactory(siret=None, comment="En attente de siret")
-        AllocinePivotFactory(siret="12345678912345")
+        venue = offerers_factories.VenueFactory(id=1234)
+        another_venue = offerers_factories.VenueFactory(id=4567)
+        AllocinePivotFactory(venue=another_venue)
 
         # When
         has_allocine_pivot = has_allocine_pivot_for_venue(venue)
@@ -19,25 +20,27 @@ class HasAllocinePivotForVenueTest:
         # Then
         assert not has_allocine_pivot
 
+    @pytest.mark.usefixtures("db_session")
+    def test_should_return_true(self, app):
+        # Given
+        venue_id = 1234
+        venue = offerers_factories.VenueFactory(id=venue_id)
+        AllocinePivotFactory(venue=venue)
+
+        # When
+        has_allocine_pivot = has_allocine_pivot_for_venue(venue)
+
+        # Then
+        assert has_allocine_pivot
+
 
 class GetAllocinePivotForVenueTest:
     @pytest.mark.usefixtures("db_session")
-    def test_should_not_return_value_when_venue_siret_is_none(self, app):
-        # Given
-        venue = offerers_factories.VenueFactory(siret=None, comment="En attente de siret")
-        AllocinePivotFactory(siret="12345678912345")
-
-        # When
-        allocine_pivot = get_allocine_pivot_for_venue(venue)
-
-        # Then
-        assert not allocine_pivot
-
-    @pytest.mark.usefixtures("db_session")
     def test_should_not_return_value_when_not_matching_in_allocine_pivot(self, app):
         # Given
-        venue = offerers_factories.VenueFactory(siret="12345678912346")
-        AllocinePivotFactory(siret="12345678912345")
+        venue = offerers_factories.VenueFactory()
+        another_venue = offerers_factories.VenueFactory()
+        AllocinePivotFactory(venue=another_venue)
 
         # When
         allocine_pivot = get_allocine_pivot_for_venue(venue)
@@ -46,10 +49,10 @@ class GetAllocinePivotForVenueTest:
         assert not allocine_pivot
 
     @pytest.mark.usefixtures("db_session")
-    def test_should_return_allocine_pivot_when_siret_is_present_in_allocine_pivot(self, app):
+    def test_should_return_allocine_pivot_when_venue_is_present_in_allocine_pivot(self, app):
         # Given
-        venue = offerers_factories.VenueFactory(siret="12345678912345")
-        allocine_pivot = AllocinePivotFactory(siret="12345678912345")
+        venue = offerers_factories.VenueFactory()
+        allocine_pivot = AllocinePivotFactory(venue=venue)
 
         # When
         allocine_pivot_from_venue = get_allocine_pivot_for_venue(venue)

--- a/api/tests/routes/pro/get_providers_by_venue_test.py
+++ b/api/tests/routes/pro/get_providers_by_venue_test.py
@@ -11,8 +11,8 @@ from pcapi.utils.human_ids import humanize
 def test_venue_has_known_allocine_id(client):
     # Given
     user = UserFactory()
-    venue = offerers_factories.VenueFactory(siret="12345678912345")
-    AllocinePivotFactory(siret="12345678912345")
+    venue = offerers_factories.VenueFactory()
+    AllocinePivotFactory(venue=venue)
 
     allocine_provider = providers_factories.ProviderFactory(localClass="AllocineStocks")
     other_provider = providers_factories.ProviderFactory(localClass="B provider")

--- a/api/tests/routes/pro/post_venue_provider_test.py
+++ b/api/tests/routes/pro/post_venue_provider_test.py
@@ -54,7 +54,7 @@ class Returns201Test:
         # Given
         venue = offerers_factories.VenueFactory(managingOfferer__siren="775671464")
         user = user_factories.AdminFactory()
-        providers_factories.AllocinePivotFactory(siret=venue.siret)
+        providers_factories.AllocinePivotFactory(venue=venue)
         provider = providers_factories.AllocineProviderFactory()
 
         venue_provider_data = {"providerId": humanize(provider.id), "venueId": humanize(venue.id), "price": "9.99"}
@@ -77,7 +77,7 @@ class Returns201Test:
         # Given
         venue = offerers_factories.VenueFactory(managingOfferer__siren="775671464")
         user = user_factories.AdminFactory()
-        providers_factories.AllocinePivotFactory(siret=venue.siret)
+        providers_factories.AllocinePivotFactory(venue=venue)
         provider = providers_factories.AllocineProviderFactory()
 
         venue_provider_data = {
@@ -227,7 +227,7 @@ class Returns400Test:
         # Given
         venue = offerers_factories.VenueFactory(managingOfferer__siren="775671464")
         user = user_factories.AdminFactory()
-        providers_factories.AllocinePivotFactory(siret=venue.siret)
+        providers_factories.AllocinePivotFactory(venue=venue)
         provider = providers_factories.AllocineProviderFactory()
 
         venue_provider_data = {
@@ -251,7 +251,7 @@ class Returns400Test:
         # Given
         venue = offerers_factories.VenueFactory(managingOfferer__siren="775671464")
         user = user_factories.AdminFactory()
-        providers_factories.AllocinePivotFactory(siret=venue.siret)
+        providers_factories.AllocinePivotFactory(venue=venue)
         provider = providers_factories.AllocineProviderFactory()
 
         venue_provider_data = {
@@ -398,8 +398,8 @@ class ConnectProviderToVenueTest:
     ):
         # Given
         user = user_factories.AdminFactory()
-        venue = offerers_factories.VenueFactory(siret="12345678912345")
-        providers_factories.AllocinePivotFactory(siret=venue.siret)
+        venue = offerers_factories.VenueFactory()
+        providers_factories.AllocinePivotFactory(venue=venue)
         provider = providers_factories.AllocineProviderFactory()
 
         venue_provider_data = {"providerId": humanize(provider.id), "venueId": humanize(venue.id), "price": "33.33"}

--- a/api/tests/use_cases/connect_allocine_to_venue_test.py
+++ b/api/tests/use_cases/connect_allocine_to_venue_test.py
@@ -14,7 +14,7 @@ def test_connect_venue_to_allocine_provider():
     venue = offerers_factories.VenueFactory()
     allocine_provider = providers_factories.AllocineProviderFactory()
     providers_factories.AllocinePivotFactory(
-        siret=venue.siret,
+        venue=venue,
         internalId="PXXXXXX",
         theaterId="123VHJ==",
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14915

## But de la pull request

Dans la mesure où le siret n'existe pas forcément pour certains lieux,
nous devons remplacer le siret par le venue_id dans allocine_pivot.

## Implémentation

- Premier commit : validation de la contrainte non-null sur `allocine_pivot.venue_id`
- Second commit : modification du code source pour utiliser le venue_id à la place du siret. A noter que le modèle n'a plus de propriété siret, mais la colonne en base de données est conservée temporairement (elle sera supprimée lors d'un prochain commit).

## Informations supplémentaires

- ajout d'ignore pylint dans le fichier `run_migration`
- ajout d'un mecanisme d'ignore pour les contraintes sur les tables lors de la génération automatique de migration
- déplacement d'une requête isolée vers le repository du core

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
