### PR TITLE
(PC-14644)[API] fix: use more adequate error message 

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -228,7 +228,7 @@ def send_phone_validation_code(user: User, body: serializers.SendPhoneValidation
     except (exceptions.PhoneAlreadyExists):
         raise ApiErrors(
             {
-                "message": "Un compte est déjà associé à ce numéro. Renseigne un autre numéro ou connecte-toi.",
+                "message": "Un compte est déjà associé à ce numéro. Renseigne un autre numéro ou connecte-toi au compte existant.",
                 "code": "PHONE_ALREADY_EXISTS",
             },
             status_code=400,

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1045,7 +1045,7 @@ class SendPhoneValidationCodeTest:
         db.session.refresh(user)
         assert user.phoneNumber == "+33601020304"
         assert response.json == {
-            "message": "Un compte est déjà associé à ce numéro. Renseigne un autre numéro ou connecte-toi.",
+            "message": "Un compte est déjà associé à ce numéro. Renseigne un autre numéro ou connecte-toi au compte existant.",
             "code": "PHONE_ALREADY_EXISTS",
         }
 


### PR DESCRIPTION
Use more adequate error message if phone already exists

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14644

## But de la pull request

Correction des wordings ajotués dans [cette PR](https://github.com/pass-culture/pass-culture-main/pull/2232)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
