### PR TITLE
(PC-15131)[API] fix: get departement from postal code in dms applications

### DIFF
--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -61,9 +61,6 @@ class DmsField(pydantic.BaseModel):
 class FieldLabel(enum.Enum):
     """
     Ces champs sont tirés des labels des questions des démarches DMS
-    2 procédures sont acceptées:
-    - Jeune de nationalité étrangère: DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v4_ET
-    - Jeune de nationalité française: DEMARCHES_SIMPLIFIEES_ENROLLMENT_PROCEDURE_ID_v4_FR
     """
 
     ACTIVITY_ET = "Merci d' indiquer ton statut"
@@ -74,9 +71,6 @@ class FieldLabel(enum.Enum):
     BIRTH_DATE_FR = "Quelle est votre date de naissance"
     CITY_FR = "Quelle est ta ville de résidence ?"
     CITY_ET = "Quelle est ta ville de résidence ?"
-    DEPARTMENT_ET = "Veuillez indiquer votre département"
-    DEPARTMENT_FR = "Veuillez indiquer votre département"
-    DEPARTMENT_OLD = "Veuillez indiquer votre département de résidence"
     ID_PIECE_NUMBER_ET = "Quel est le numéro de la pièce que tu viens de saisir ?"
     ID_PIECE_NUMBER_FR = "Quel est le numéro de la pièce que tu viens de saisir ?"
     ID_PIECE_NUMBER_PROCEDURE_4765 = "Quel est le numéro de la pièce que vous venez de saisir ?"

--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -43,13 +43,7 @@ def parse_beneficiary_information_graphql(
         label = field.label
         value = field.value
 
-        if label in (
-            dms_models.FieldLabel.DEPARTMENT_FR.value,
-            dms_models.FieldLabel.DEPARTMENT_ET.value,
-            dms_models.FieldLabel.DEPARTMENT_OLD.value,
-        ):
-            department = re.search("^[0-9]{2,3}|[2BbAa]{2}", value).group(0)  # type: ignore [type-var, union-attr]
-        elif label in (dms_models.FieldLabel.BIRTH_DATE_ET.value, dms_models.FieldLabel.BIRTH_DATE_FR.value):
+        if label in (dms_models.FieldLabel.BIRTH_DATE_ET.value, dms_models.FieldLabel.BIRTH_DATE_FR.value):
             try:
                 birth_date = date_parser.parse(value, FrenchParserInfo())  # type: ignore [arg-type]
             except Exception:  # pylint: disable=broad-except

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 
 from pcapi.connectors.dms import models as dms_models
 from pcapi.core.users import models as users_models
+from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 
@@ -193,7 +194,7 @@ class DMSContent(common_models.IdentityCheckContent):
     city: typing.Optional[str]
     civility: typing.Optional[users_models.GenderEnum]
     deletion_datetime: typing.Optional[datetime.datetime]
-    department: typing.Optional[str]
+    department: typing.Optional[str]  # this field is not filled anymore
     email: str
     first_name: str
     id_piece_number: typing.Optional[str]
@@ -224,6 +225,9 @@ class DMSContent(common_models.IdentityCheckContent):
 
     def get_registration_datetime(self) -> typing.Optional[datetime.datetime]:
         return dms_models.parse_dms_datetime(self.registration_datetime) if self.registration_datetime else None
+
+    def get_department_code(self) -> typing.Optional[str]:
+        return PostalCode(self.postal_code).get_departement_code() if self.postal_code else None
 
 
 class UserProfilingRiskRating(enum.Enum):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -201,7 +201,8 @@ def update_user_information_from_external_source(
         user.lastName = data.last_name
         user.firstName = data.first_name
         user.publicName = "%s %s" % (data.first_name, data.last_name)
-        user.departementCode = data.department
+        if data.get_department_code():
+            user.departementCode = data.get_department_code()
         user.postalCode = data.postal_code
         user.address = data.address
         user.civility = data.civility.value if data.civility else None

--- a/api/src/pcapi/scripts/beneficiary/handle_inactive_dms_applications.py
+++ b/api/src/pcapi/scripts/beneficiary/handle_inactive_dms_applications.py
@@ -110,7 +110,7 @@ def _is_never_eligible_applicant(dms_application: dms_models.DmsApplicationRespo
     except subscription_exceptions.DMSParsingError:
         return True
     applicant_birth_date = application_content.get_birth_date()
-    applicant_department = application_content.department
+    applicant_department = application_content.get_department_code()
     if applicant_birth_date is None or applicant_department is None:
         return True
 

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -64,11 +64,6 @@ def make_graphql_application(
                 "stringValue": "",
             },
             {
-                "id": "Q2hhbXAtNTk2NDUz",
-                "label": "Veuillez indiquer votre département",
-                "stringValue": department_code,
-            },
-            {
                 "id": "Q2hhbXAtNTgyMjIw",
                 "label": "Quelle est votre date de naissance",
                 "stringValue": babel.dates.format_date(birth_date, format="long", locale="fr"),

--- a/api/tests/scripts/beneficiary/handle_inactive_dms_applications_test.py
+++ b/api/tests/scripts/beneficiary/handle_inactive_dms_applications_test.py
@@ -68,7 +68,7 @@ class HandleInactiveApplicationTest:
             state="en_construction",
             last_modification_date="2021-11-11T00:00:00+02:00",
             birth_date=datetime.datetime(2002, 1, 1),
-            department_code="12",
+            postal_code="12400",
         )
 
         inactive_fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
@@ -95,7 +95,7 @@ class IsNeverEligibleTest:
             application_id=1,
             state="en_construction",
             birth_date=datetime.datetime(2002, 1, 1),
-            department_code="12",
+            postal_code="12400",
         )
         assert _is_never_eligible_applicant(inactive_application, 1)
 
@@ -105,7 +105,7 @@ class IsNeverEligibleTest:
             application_id=1,
             state="en_construction",
             birth_date=datetime.datetime(2002, 1, 1),
-            department_code="56",
+            postal_code="56510",
         )
         assert not _is_never_eligible_applicant(inactive_application, 1)
 
@@ -115,7 +115,7 @@ class IsNeverEligibleTest:
             application_id=1,
             state="en_construction",
             birth_date=datetime.datetime(2002, 6, 1),
-            department_code="12",
+            postal_code="12400",
         )
         assert not _is_never_eligible_applicant(inactive_application, 1)
 

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -146,7 +146,7 @@ class RunTest:
                 email="john.doe@test.com",
                 application_id=123,
                 procedure_id=6712558,
-                department="67",
+                department=None,
                 phone="0123456789",
                 birth_date=AGE18_ELIGIBLE_BIRTH_DATE.date(),
                 activity="Étudiant",
@@ -161,15 +161,6 @@ class RunTest:
 
 
 class ParseBeneficiaryInformationTest:
-    @pytest.mark.parametrize(
-        "department_code,expected_code",
-        [("67 - Bas-Rhin", "67"), ("973 - Guyane", "973"), ("2B - Haute-Corse", "2B"), ("2a - Corse-du-Sud", "2a")],
-    )
-    def test_handles_department_code(self, department_code, expected_code):
-        application_detail = fixture.make_parsed_graphql_application(1, "accepte", department_code=department_code)
-        information = dms_serializer.parse_beneficiary_information_graphql(application_detail, procedure_id=201201)
-        assert information.department == expected_code
-
     @pytest.mark.parametrize(
         "postal_code,expected_code",
         [
@@ -484,6 +475,7 @@ class RunIntegrationTest:
 
         assert user.firstName == "John"
         assert user.postalCode == "67200"
+        assert user.departementCode == "67"
         assert user.address == "3 La Bigotais 22800 Saint-Donan"
         assert user.has_beneficiary_role
         assert user.phoneNumber == "0123456789"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15131

## But de la pull request

Cf enquête dans le ticket. -> maintenant dans le formulaire on ne demande plus le département. Il faut se baser sur le code postal.

## Implémentation

En bdd si on n'a pas le code postal alors on n'a pas le département non plus. Donc autant toujours se baser sur le code postal.

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
