### PR TITLE
(PC-15056)[API] feat: add suspension status route

### DIFF
--- a/api/src/pcapi/admin/templating.py
+++ b/api/src/pcapi/admin/templating.py
@@ -24,6 +24,7 @@ def account_state_format(state: users_models.AccountState) -> str:
         users_models.AccountState.ACTIVE: {"css_class": "success", "text": "Activé"},
         users_models.AccountState.INACTIVE: {"css_class": "danger", "text": "Non activé"},
         users_models.AccountState.SUSPENDED: {"css_class": "info", "text": "Suspendu"},
+        users_models.AccountState.SUSPENDED_UPON_USER_REQUEST: {"css_class": "info", "text": "Suspendu"},
         users_models.AccountState.DELETED: {"css_class": "warning", "text": "Supprimé"},
     }
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -164,6 +164,7 @@ class AccountState(enum.Enum):
     ACTIVE = "ACTIVE"
     INACTIVE = "INACTIVE"
     SUSPENDED = "SUSPENDED"
+    SUSPENDED_UPON_USER_REQUEST = "SUSPENDED_UPON_USER_REQUEST"
     DELETED = "DELETED"
 
 
@@ -434,9 +435,10 @@ class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, 
 
             if suspension_event.eventType == SuspensionEventType.SUSPENDED:
 
-                # DELETED is a very specific suspension reason
                 if suspension_event.reasonCode == SuspensionReason.DELETED:
                     return AccountState.DELETED
+                if suspension_event.reasonCode == SuspensionReason.UPON_USER_REQUEST:
+                    return AccountState.SUSPENDED_UPON_USER_REQUEST
 
                 return AccountState.SUSPENDED
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -282,6 +282,13 @@ def get_account_suspension_date(user: User) -> serializers.UserSuspensionDateRes
     return serializers.UserSuspensionDateResponse(date=user.suspension_date)
 
 
+@blueprint.native_v1.route("/account/suspension_status", methods=["GET"])
+@spectree_serialize(api=blueprint.api, on_success_status=200)
+@authenticated_maybe_inactive_user_required
+def get_account_suspension_status(user: User) -> serializers.UserSuspensionStatusResponse:
+    return serializers.UserSuspensionStatusResponse(status=user.account_state)
+
+
 @blueprint.native_v1.route("/user_profiling", methods=["POST"])
 @spectree_serialize(api=blueprint.api, on_success_status=204)
 @authenticated_and_active_user_required

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -28,6 +28,7 @@ from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import api as users_api
 from pcapi.core.users import constants as users_constants
+import pcapi.core.users.models as users_models
 from pcapi.core.users.models import ActivityEnum
 from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
@@ -390,3 +391,7 @@ class UserSuspensionDateResponse(BaseModel):
 
     class Config:
         json_encoders = {datetime.datetime: format_into_utc_date}
+
+
+class UserSuspensionStatusResponse(BaseModel):
+    status: users_models.AccountState

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1944,3 +1944,34 @@ class GetAccountSuspendedDateTest:
             response = client.get("/native/v1/account/suspension_date")
 
             assert response.status_code == 403
+
+
+class SuspensionStatusTest:
+    def test_fraud_suspicion_account_status(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(isActive=False)
+        users_factories.UserSuspensionByFraudFactory(user=user)
+
+        self.assert_status(client, user, "SUSPENDED")
+
+    def test_suspended_upon_user_request_status(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(isActive=False)
+        users_factories.SuspendedUponUserRequestFactory(user=user)
+
+        self.assert_status(client, user, "SUSPENDED_UPON_USER_REQUEST")
+
+    def test_deleted_account_status(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(isActive=False)
+        users_factories.DeletedAccountSuspensionFactory(user=user)
+
+        self.assert_status(client, user, "DELETED")
+
+    def test_active_account(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(isActive=True)
+        self.assert_status(client, user, "ACTIVE")
+
+    def assert_status(self, client, user, status):
+        client.with_token(email=user.email)
+        response = client.get("/native/v1/account/suspension_status")
+
+        assert response.status_code == 200
+        assert response.json["status"] == status

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1557,6 +1557,26 @@ def test_public_api(client, app):
                     "tags": [],
                 }
             },
+            "/native/v1/account/suspension_status": {
+                "get": {
+                    "description": "",
+                    "operationId": "get_/native/v1/account/suspension_status",
+                    "parameters": [],
+                    "responses": {
+                        "200": {"description": "OK"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "security": [{"JWTAuth": []}],
+                    "summary": "get_account_suspension_status <GET>",
+                    "tags": [],
+                }
+            },
             "/native/v1/bookings": {
                 "get": {
                     "description": "",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15056

## But de la pull request

Ajout d'une route native qui retourne le statut de suspension d'un compte utilisateur. Cette information permettra au client de savoir où rediriger l'utilisateur en fonction : parcours normal si non suspendu, parcours de réactivation si suspendu à sa demande, page de suspension si suspendu pour une autre raison, etc.