### PR TITLE
(PC-14543)[PRO] fix: Only require Address for venue creation form

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
@@ -227,6 +227,7 @@ class VenueCreation extends PureComponent {
             formLongitude === '' ? FRANCE_POSITION.longitude : formLongitude
           }
           readOnly={readOnly}
+          isAddressRequired={true}
         />
         <AccessibilityFields />
         <ContactInfosFields readOnly={false} />

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
@@ -315,6 +315,7 @@ const VenueEdition = () => {
                     : formLongitude
                 }
                 readOnly={readOnly}
+                isAddressRequired={false}
               />
               <AccessibilityFields
                 formValues={values}

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/LocationFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/LocationFields.jsx
@@ -19,6 +19,7 @@ const LocationFields = ({
   formLongitude,
   formIsLocationFrozen,
   readOnly,
+  isAddressRequired,
 }) => {
   const fieldIsFrozen =
     readOnly || formIsLocationFrozen || fieldReadOnlyBecauseFrozenFormSiret
@@ -37,7 +38,7 @@ const LocationFields = ({
           name="address"
           readOnly={readOnly || fieldReadOnlyBecauseFrozenFormSiret}
           withMap
-          required={true}
+          required={isAddressRequired}
         />
         <TextField
           autoComplete="postal-code"

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/__specs__/LocationFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/__specs__/LocationFields.spec.jsx
@@ -17,6 +17,7 @@ describe('src | components | pages | Venue | fields | LocationFields', () => {
       formLatitude: 1,
       formLongitude: 1,
       readOnly: true,
+      isAddressRequired: false
     }
   })
 
@@ -44,8 +45,19 @@ describe('src | components | pages | Venue | fields | LocationFields', () => {
       expect(addressField.prop('longitude')).toBe(1)
       expect(addressField.prop('name')).toBe('address')
       expect(addressField.prop('readOnly')).toBe(true)
-      expect(addressField.prop('required')).toBe(true)
+      expect(addressField.prop('required')).toBe(false)
       expect(addressField.prop('withMap')).toBe(true)
+    })
+
+    it('should display an AddressField component with required address field', () => {
+      // when
+      props.isAddressRequired = true
+      const wrapper = shallow(<LocationFields {...props} />)
+
+      // then
+      const addressField = wrapper.find(AddressField)
+      expect(addressField).toHaveLength(1)
+      expect(addressField.prop('required')).toBe(true)
     })
 
     it('should display two TextField components with the right props', () => {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14543

## But de la pull request

Le backend interdit d'avoir des lieux sans adresse à la création mais pas à l'édition. 
Il faut garder ce comportement. (Il y a beaucoup de lieux en base sans adresse, ils ne pourraient pas valider le formulaire)

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
