### PR TITLE
Pc 14440 add mandatory constraint to price in provider sync

### DIFF
--- a/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -77,6 +77,14 @@ class ProviderAPI:
                 )
                 continue
 
+            if "price" not in stock_response:
+                logger.exception(
+                    "[%s SYNC] missing price key in response with ref %s",
+                    self.name,
+                    stock_response_ref,
+                )
+                continue
+
             validated_stock_responses.append(stock_response)
 
         api_responses["stocks"] = validated_stock_responses

--- a/api/src/pcapi/routes/serialization/base.py
+++ b/api/src/pcapi/routes/serialization/base.py
@@ -39,7 +39,7 @@ class VenueContactModel(BaseModel):
 
     @validator("website")
     def validate_website_url(cls, website: str) -> str:  # pylint: disable=no-self-argument
-        pattern = "^(?:http(s)?:\/\/)?[\w.-\.-\.@]+(?:\.[\w\.-\.@]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$"  # pylint: disable=anomalous-backslash-in-string
+        pattern = r"^(?:http(s)?:\/\/)?[\w.-\.-\.@]+(?:\.[\w\.-\.@]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$"
         if website is None or re.match(pattern, website):
             return website
         raise ValueError(f"url du site web invalide: {website}")

--- a/api/tests/scripts/stock/fully_sync_venue_test.py
+++ b/api/tests/scripts/stock/fully_sync_venue_test.py
@@ -26,7 +26,7 @@ def test_fully_sync_venue():
     with requests_mock.Mocker() as mock:
         response = {
             "total": 1,
-            "stocks": [{"ref": "1234", "available": 5}],
+            "stocks": [{"ref": "1234", "available": 5, "price": 10}],
         }
         mock.get(f"{api_url}/{venue_provider.venueIdAtOfferProvider}", [{"json": response}, {"json": {"stocks": []}}])
         fully_sync_venue.fully_sync_venue(venue)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14440

## But de la pull request

Rendre obligatoire le prix dans la synchro provider.

## Implémentation

- ajout de la contrainte

## Informations supplémentaires

- bsr : modif d'une string regex qui sortait en erreur sur mon IDE (et suppression de l'exception pylint)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
