### PR TITLE
(BSR)[API] chore: unpin email validator version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,7 +16,6 @@ blinker==1.4
 boto3==1.21.9
 coveralls==2.1.2
 debugpy
-email-validator==1.1.2
 factory-boy
 Flask==2.0.*
 Flask-Admin==1.6.0


### PR DESCRIPTION
We had pinned email-validator version because they banned example.com from their valid domain names in test environments.

They went back on this decision, hence we can unpin this dependency (which is, in fact, an undirect dependency due to Pydantic)