### PR TITLE
(BSR)[API] chore: remove unused pc set-backend command

### DIFF
--- a/pc
+++ b/pc
@@ -247,13 +247,6 @@ elif [[ "$CMD" == "restore-db-intact" ]]; then
   source "$INFRA_SCRIPTS_PATH"/restore_db.sh
   restore_db_intact $1
 
-# Prepare backend for local use
-elif [[ "$CMD" == "set-backend" ]]; then
-  RUN='cd "$ROOT_PATH";
-    ./pc update-mocks;
-    ./pc update_providables -m -p SpreadsheetExpVenues;
-    ./pc update_providables -m -p SpreadsheetExpOffers;
-    ./pc sandbox --name=light;'
 
 # Start API server with database and nginx server
 elif [[ "$CMD" == "start-backend" ]]; then


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

nettoyage d'une commande `pc set-backend` qui n'était plus utilisée (ni fonctionnelle d'ailleurs)

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
