### PR TITLE
(PC-14022)[API] feat: CDS barcode saved when book_offer is called

### DIFF
--- a/api/src/pcapi/core/booking_providers/api.py
+++ b/api/src/pcapi/core/booking_providers/api.py
@@ -4,6 +4,7 @@ from pcapi.core.booking_providers.cds.client import CineDigitalServiceAPI
 from pcapi.core.booking_providers.models import BookingProviderClientAPI
 from pcapi.core.booking_providers.models import BookingProviderName
 from pcapi.core.booking_providers.models import SeatMap
+from pcapi.core.booking_providers.models import Ticket
 from pcapi.core.booking_providers.models import VenueBookingProvider
 
 
@@ -25,6 +26,11 @@ def get_available_seats(venue_id: int, show_id: int) -> SeatMap:
 def cancel_booking(venue_id: int, barcodes: list[str]) -> None:
     client = _get_booking_provider_client_api(venue_id)
     client.cancel_booking(barcodes)
+
+
+def book_ticket(venue_id: int, show_id: int, quantity: int) -> list[Ticket]:
+    client = _get_booking_provider_client_api(venue_id)
+    return client.book_ticket(show_id, quantity)
 
 
 def _get_booking_provider_client_api(venue_id: int) -> BookingProviderClientAPI:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14022

## But de la pull request
Enregistrement de ExternalBooking quand un bénéficiaire fait une réservation

## Implémentation
Appel de la fonction book_ticket si le FF ENABLE_CDS_IMPLEMENTATION est actif 
et que la catégorie de l'offre est de type SEANCE_CINE


## Informations supplémentaires
N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
