### PR TITLE
(PC-14675)[API] New back-office: get user subscription history

### DIFF
--- a/api/src/pcapi/admin/custom_views/support_view/api.py
+++ b/api/src/pcapi/admin/custom_views/support_view/api.py
@@ -12,6 +12,7 @@ from pcapi.core.payments import exceptions as payment_exceptions
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import exceptions as subscription_exceptions
 from pcapi.core.subscription import messages as subscription_messages
+from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription.models import SubscriptionItemStatus
 from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
@@ -39,7 +40,9 @@ SUBSCRIPTION_ITEM_METHODS = [
 ]
 
 
-def get_subscription_items_by_eligibility(user: users_models.User):  # type: ignore [no-untyped-def]
+def get_subscription_items_by_eligibility(
+    user: users_models.User,
+) -> list[dict[str, subscription_models.SubscriptionItem]]:
     subscription_items = []
     for method in SUBSCRIPTION_ITEM_METHODS:
         subscription_items.append(

--- a/api/src/pcapi/core/fraud/common/models.py
+++ b/api/src/pcapi/core/fraud/common/models.py
@@ -1,8 +1,6 @@
 import datetime
 import typing
 
-import pydantic
-import pydantic.datetime_parse
 import pydantic.errors
 
 from pcapi.core.users import models as users_models

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -14,6 +14,7 @@ from pcapi.core.users import models as users_models
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.repository.beneficiary_import_queries import get_beneficiary_import_for_application_id_and_source_id
 
 from .common import models as common_models
 from .ubble import models as ubble_fraud_models
@@ -228,6 +229,14 @@ class DMSContent(common_models.IdentityCheckContent):
 
     def get_department_code(self) -> typing.Optional[str]:
         return PostalCode(self.postal_code).get_departement_code() if self.postal_code else None
+
+    def get_author_email(self) -> typing.Optional[str]:
+        beneficiary_import = get_beneficiary_import_for_application_id_and_source_id(
+            self.application_id, self.procedure_id
+        )
+        if beneficiary_import:
+            return beneficiary_import.authorEmail  # type: ignore [return-value]
+        return None
 
 
 class UserProfilingRiskRating(enum.Enum):

--- a/api/src/pcapi/repository/beneficiary_import_queries.py
+++ b/api/src/pcapi/repository/beneficiary_import_queries.py
@@ -1,0 +1,11 @@
+import typing
+
+from pcapi.models.beneficiary_import import BeneficiaryImport
+
+
+def get_beneficiary_import_for_application_id_and_source_id(
+    application_id: int, source_id: int
+) -> typing.Optional[BeneficiaryImport]:
+    return BeneficiaryImport.query.filter(
+        BeneficiaryImport.applicationId == application_id, BeneficiaryImport.sourceId == source_id
+    ).one_or_none()

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -1,15 +1,31 @@
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.permissions import utils as perm_utils
+from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import api as users_api
+from pcapi.core.users import models as users_models
 from pcapi.core.users import repository as users_repository
 from pcapi.models.api_errors import ApiErrors
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
+from .serialization import EligibilitySubscriptionHistoryModel
 from .serialization import GetBeneficiaryCreditResponseModel
+from .serialization import GetUserSubscriptionHistoryResponseModel
+from .serialization import IdCheckItemModel
 from .serialization import ListPublicAccountsResponseModel
 from .serialization import PublicAccount
 from .serialization import PublicAccountSearchQuery
+from .serialization import SubscriptionItemModel
+
+
+# Same methods as called from legacy backoffice with Flask-Admin
+SUBSCRIPTION_ITEM_METHODS = [
+    subscription_api.get_email_validation_subscription_item,
+    subscription_api.get_phone_validation_subscription_item,
+    subscription_api.get_profile_completion_subscription_item,
+    subscription_api.get_identity_check_subscription_item,
+    subscription_api.get_honor_statement_subscription_item,
+]
 
 
 @blueprint.backoffice_blueprint.route("public_accounts/search", methods=["GET"])
@@ -60,3 +76,32 @@ def get_beneficiary_credit(user_id: int) -> GetBeneficiaryCreditResponseModel:
         if domains_credit and domains_credit.digital
         else 0.0,
     )
+
+
+@blueprint.backoffice_blueprint.route("public_accounts/user/<int:user_id>/history", methods=["GET"])
+@perm_utils.permission_required(perm_models.Permissions.READ_PUBLIC_ACCOUNT)
+@spectree_serialize(
+    response_model=GetUserSubscriptionHistoryResponseModel,
+    on_success_status=200,
+    api=blueprint.api,
+)
+def get_user_subscription_history(user_id: int) -> GetUserSubscriptionHistoryResponseModel:
+    user = users_repository.get_user_by_id(user_id)
+    if not user:
+        raise ApiErrors(errors={"user_id": "User does not exist"})
+
+    subscriptions = {}
+
+    for eligibility in list(users_models.EligibilityType):
+        subscriptions[eligibility.name] = EligibilitySubscriptionHistoryModel(
+            subscriptionItems=[
+                SubscriptionItemModel.from_orm(method(user, eligibility)) for method in SUBSCRIPTION_ITEM_METHODS
+            ],
+            idCheckHistory=[
+                IdCheckItemModel.from_orm(fraud_check)
+                for fraud_check in user.beneficiaryFraudChecks
+                if fraud_check.eligibilityType == eligibility
+            ],
+        )
+
+    return GetUserSubscriptionHistoryResponseModel(subscriptions=subscriptions)

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -3,6 +3,8 @@ import typing
 
 import pydantic
 
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import models as users_models
 from pcapi.routes.serialization import BaseModel
 
@@ -74,3 +76,48 @@ class GetBeneficiaryCreditResponseModel(BaseModel):
     initialCredit: float
     remainingCredit: float
     remainingDigitalCredit: float
+
+
+class SubscriptionItemModel(BaseModel):
+    class Config:
+        orm_mode = True
+        use_enum_values = True
+
+    type: subscription_models.SubscriptionStep
+    status: subscription_models.SubscriptionItemStatus
+
+
+class IdCheckItemModel(BaseModel):
+    class Config:
+        orm_mode = True
+        use_enum_values = True
+
+    @classmethod
+    def from_orm(cls: typing.Any, fraud_check: fraud_models.BeneficiaryFraudCheck):  # type: ignore
+        fraud_check.technicalDetails = fraud_check.resultContent
+
+        if fraud_check.type == fraud_models.FraudCheckType.DMS and fraud_check.resultContent is not None:
+            dms_content = fraud_models.DMSContent(**fraud_check.resultContent)  # type: ignore [arg-type]
+            fraud_check.sourceId = str(dms_content.procedure_id)
+            fraud_check.authorEmail = dms_content.get_author_email()
+
+        return super().from_orm(fraud_check)
+
+    type: fraud_models.FraudCheckType
+    dateCreated: datetime.datetime
+    thirdPartyId: str
+    status: typing.Optional[fraud_models.FraudCheckStatus]
+    reason: typing.Optional[str]
+    reasonCodes: typing.Optional[list[fraud_models.FraudReasonCode]]
+    technicalDetails: typing.Optional[dict]
+    sourceId: typing.Optional[str] = None  # DMS only
+    authorEmail: typing.Optional[str] = None  # DMS only
+
+
+class EligibilitySubscriptionHistoryModel(BaseModel):
+    subscriptionItems: list[SubscriptionItemModel]
+    idCheckHistory: list[typing.Union[IdCheckItemModel]]
+
+
+class GetUserSubscriptionHistoryResponseModel(BaseModel):
+    subscriptions: dict[str, EligibilitySubscriptionHistoryModel]

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1,15 +1,23 @@
+from datetime import date
+from datetime import datetime
+from datetime import time
 from unittest import mock
 
+from dateutil.relativedelta import relativedelta
 from flask import url_for
 import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.fraud import factories as fraud_factories
+import pcapi.core.fraud.models as fraud_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.permissions.factories import RoleFactory
 from pcapi.core.permissions.models import Permission
 from pcapi.core.permissions.models import Permissions
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as user_factories
+from pcapi.core.users import models as users_models
+from pcapi.models.beneficiary_import_status import ImportStatus
 from pcapi.repository import repository
 
 
@@ -348,6 +356,257 @@ class GetBeneficiaryCreditTest:
 
         # when
         response = client.get(url_for("backoffice_blueprint.get_beneficiary_credit", user_id=1))
+
+        # then
+        assert response.status_code == 401
+
+
+class GetUserHistoryTest:
+    def _test_user_history(self, client, user) -> dict:
+        # given
+        role = create_read_account_role()
+        admin = user_factories.UserFactory()
+
+        with mock.patch("flask_login.utils._get_user") as current_user_mock:
+            admin.groups = [role.name]
+            current_user_mock.return_value = admin
+
+            # when
+            response = client.with_session_auth(admin.email).get(
+                url_for("backoffice_blueprint.get_user_subscription_history", user_id=user.id)
+            )
+
+        # then
+        assert response.status_code == 200
+        return response.json["subscriptions"]
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_get_user_history_16y_no_subscription(self, client):
+        user = user_factories.UserFactory(
+            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=16, days=5)
+        )
+
+        data = self._test_user_history(client, user)
+
+        assert data == {
+            "UNDERAGE": {
+                "idCheckHistory": [],
+                "subscriptionItems": [
+                    {"status": "ok", "type": "email-validation"},
+                    {"status": "not-applicable", "type": "phone-validation"},
+                    {"status": "todo", "type": "profile-completion"},
+                    {"status": "todo", "type": "identity-check"},
+                    {"status": "todo", "type": "honor-statement"},
+                ],
+            },
+            "AGE18": {
+                "idCheckHistory": [],
+                "subscriptionItems": [
+                    {"status": "ok", "type": "email-validation"},
+                    {"status": "void", "type": "phone-validation"},
+                    {"status": "void", "type": "profile-completion"},
+                    {"status": "void", "type": "identity-check"},
+                    {"status": "void", "type": "honor-statement"},
+                ],
+            },
+        }
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_get_user_history_18y_no_subscription(self, client):
+        user = user_factories.UserFactory(
+            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=18, days=5)
+        )
+
+        data = self._test_user_history(client, user)
+
+        assert data == {
+            "UNDERAGE": {
+                "idCheckHistory": [],
+                "subscriptionItems": [
+                    {"status": "ok", "type": "email-validation"},
+                    {"status": "not-applicable", "type": "phone-validation"},
+                    {"status": "void", "type": "profile-completion"},
+                    {"status": "void", "type": "identity-check"},
+                    {"status": "void", "type": "honor-statement"},
+                ],
+            },
+            "AGE18": {
+                "idCheckHistory": [],
+                "subscriptionItems": [
+                    {"status": "ok", "type": "email-validation"},
+                    {"status": "todo", "type": "phone-validation"},
+                    {"status": "todo", "type": "profile-completion"},
+                    {"status": "todo", "type": "identity-check"},
+                    {"status": "todo", "type": "honor-statement"},
+                ],
+            },
+        }
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_get_user_subscription_history_ubble(self, client):
+        user = user_factories.UserFactory(
+            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=18, days=5),
+            activity=users_models.ActivityEnum.STUDENT.value,
+        )
+        user.phoneValidationStatus = users_models.PhoneValidationStatusType.VALIDATED
+
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            eligibilityType=users_models.EligibilityType.AGE18,
+            type=fraud_models.FraudCheckType.UBBLE,
+            status=fraud_models.FraudCheckStatus.SUSPICIOUS,
+            reasonCodes=[fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED],
+            resultContent=fraud_factories.UbbleContentFactory(),
+        )
+
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            eligibilityType=users_models.EligibilityType.AGE18,
+            type=fraud_models.FraudCheckType.HONOR_STATEMENT,
+            status=fraud_models.FraudCheckStatus.OK,
+        )
+
+        data = self._test_user_history(client, user)
+
+        assert data["UNDERAGE"] == {
+            "idCheckHistory": [],
+            "subscriptionItems": [
+                {"status": "ok", "type": "email-validation"},
+                {"status": "not-applicable", "type": "phone-validation"},
+                {"status": "ok", "type": "profile-completion"},
+                {"status": "void", "type": "identity-check"},
+                {"status": "void", "type": "honor-statement"},
+            ],
+        }
+
+        assert data["AGE18"]["subscriptionItems"] == [
+            {"status": "ok", "type": "email-validation"},
+            {"status": "ok", "type": "phone-validation"},
+            {"status": "ok", "type": "profile-completion"},
+            {"status": "todo", "type": "identity-check"},
+            {"status": "ok", "type": "honor-statement"},
+        ]
+
+        # "idCheckHistory" contains timestamped/random data generated by factories
+
+        assert len(data["AGE18"]["idCheckHistory"]) == 2
+
+        assert data["AGE18"]["idCheckHistory"][0]["type"] == "ubble"
+        assert data["AGE18"]["idCheckHistory"][0]["dateCreated"]
+        assert data["AGE18"]["idCheckHistory"][0]["thirdPartyId"]
+        assert data["AGE18"]["idCheckHistory"][0]["status"] == "suspiscious"
+        assert data["AGE18"]["idCheckHistory"][0]["reason"] is None
+        assert data["AGE18"]["idCheckHistory"][0]["reasonCodes"] == ["id_check_not_supported"]
+        assert isinstance(data["AGE18"]["idCheckHistory"][0]["technicalDetails"], dict)
+
+        assert data["AGE18"]["idCheckHistory"][1]["type"] == "honor_statement"
+        assert data["AGE18"]["idCheckHistory"][1]["dateCreated"]
+        assert data["AGE18"]["idCheckHistory"][1]["status"] == "ok"
+        assert data["AGE18"]["idCheckHistory"][1]["reason"] is None
+        assert not data["AGE18"]["idCheckHistory"][1]["reasonCodes"]
+        assert not data["AGE18"]["idCheckHistory"][1]["technicalDetails"]
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_get_user_subscription_history_dms(self, client):
+        user = user_factories.UserFactory(
+            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=15, days=5),
+            activity=users_models.ActivityEnum.HIGH_SCHOOL_STUDENT.value,
+        )
+
+        # 15-17: no phone validation
+
+        beneficiary_import = user_factories.BeneficiaryImportFactory(
+            applicationId=24680,
+            beneficiary=user,
+            source=user_factories.BeneficiaryImportSources.demarches_simplifiees.value,
+            sourceId=13579,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+        )
+
+        dms_author = user_factories.UserFactory(email="dms_author@exemple.com")
+        beneficiary_import.setStatus(ImportStatus.CREATED, author=dms_author)
+
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+            type=fraud_models.FraudCheckType.DMS,
+            status=fraud_models.FraudCheckStatus.OK,
+            thirdPartyId="24680",
+            resultContent=fraud_factories.DMSContentFactory(procedure_id=13579, application_id=24680),
+        )
+
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+            type=fraud_models.FraudCheckType.HONOR_STATEMENT,
+            status=fraud_models.FraudCheckStatus.OK,
+        )
+
+        data = self._test_user_history(client, user)
+
+        assert data["AGE18"] == {
+            "idCheckHistory": [],
+            "subscriptionItems": [
+                {"status": "ok", "type": "email-validation"},
+                {"status": "void", "type": "phone-validation"},
+                {"status": "ok", "type": "profile-completion"},
+                {"status": "void", "type": "identity-check"},
+                {"status": "void", "type": "honor-statement"},
+            ],
+        }
+
+        assert data["UNDERAGE"]["subscriptionItems"] == [
+            {"status": "ok", "type": "email-validation"},
+            {"status": "not-applicable", "type": "phone-validation"},
+            {"status": "ok", "type": "profile-completion"},
+            {"status": "ok", "type": "identity-check"},
+            {"status": "ok", "type": "honor-statement"},
+        ]
+
+        # "idCheckHistory" contains timestamped/random data generated by factories
+
+        assert len(data["UNDERAGE"]["idCheckHistory"]) == 2
+
+        assert data["UNDERAGE"]["idCheckHistory"][0]["type"] == "dms"
+        assert data["UNDERAGE"]["idCheckHistory"][0]["dateCreated"]
+        assert data["UNDERAGE"]["idCheckHistory"][0]["thirdPartyId"] == "24680"
+        assert data["UNDERAGE"]["idCheckHistory"][0]["status"] == "ok"
+        assert data["UNDERAGE"]["idCheckHistory"][0]["reason"] is None
+        assert data["UNDERAGE"]["idCheckHistory"][0]["sourceId"] == "13579"
+        assert data["UNDERAGE"]["idCheckHistory"][0]["authorEmail"] == "dms_author@exemple.com"
+
+        assert data["UNDERAGE"]["idCheckHistory"][1]["type"] == "honor_statement"
+        assert data["UNDERAGE"]["idCheckHistory"][1]["dateCreated"]
+        assert data["UNDERAGE"]["idCheckHistory"][1]["status"] == "ok"
+        assert data["UNDERAGE"]["idCheckHistory"][1]["reason"] is None
+        assert not data["UNDERAGE"]["idCheckHistory"][1]["reasonCodes"]
+        assert not data["UNDERAGE"]["idCheckHistory"][1]["technicalDetails"]
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_get_user_subscription_history_without_permission(self, client):
+        # given
+        no_perm_role = RoleFactory(name="no read user")
+        user = user_factories.UserFactory()
+
+        with mock.patch("flask_login.utils._get_user") as current_user_mock:
+            user.groups = [no_perm_role.name]
+            current_user_mock.return_value = user
+
+            # when
+            response = client.with_session_auth(user.email).get(
+                url_for("backoffice_blueprint.get_user_subscription_history", user_id=1)
+            )
+
+        # then
+        assert response.status_code == 403
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_get_user_subscription_history_as_anonymous(self, client):
+        # given
+        create_search_role()
+
+        # when
+        response = client.get(url_for("backoffice_blueprint.get_user_subscription_history", user_id=1))
 
         # then
         assert response.status_code == 401


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14675

## But de la pull request

API pour fournir les infos de l'état du dossier de souscription du jeune, avec les retours sur l'état du dossier DMS, Ubble, Educonnect, Jouve, l’éligibilité du compte (bénéficiaire ou non), plus la date de dépôt du dossier, pour chaque étape.

Champs adaptés au design fourni dans le ticket front

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
