### PR TITLE
(PC-15177)[API] New back-office: get user basic information

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -26,6 +26,19 @@ def search_public_account(query: PublicAccountSearchQuery) -> ListPublicAccounts
     return ListPublicAccountsResponseModel(accounts=[PublicAccount.from_orm(account) for account in accounts])
 
 
+@blueprint.backoffice_blueprint.route("public_accounts/user/<int:user_id>", methods=["GET"])
+@perm_utils.permission_required(perm_models.Permissions.READ_PUBLIC_ACCOUNT)
+@spectree_serialize(
+    response_model=PublicAccount,
+    on_success_status=200,
+    api=blueprint.api,
+)
+def get_public_account(user_id: int) -> PublicAccount:
+    user = users_repository.get_user_by_id(user_id)
+
+    return PublicAccount.from_orm(user)
+
+
 @blueprint.backoffice_blueprint.route("public_accounts/user/<int:user_id>/credit", methods=["GET"])
 @perm_utils.permission_required(perm_models.Permissions.READ_PUBLIC_ACCOUNT)
 @spectree_serialize(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15177

## But de la pull request

visualiser les données de base d’un utilisateur (données calquées sur les données utilisateurs venant du endpoint de recherche)

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
