### PR TITLE
(PC-15177)[API] New back-office: Add roles and isActive in basic user information

### DIFF
--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -3,6 +3,7 @@ import typing
 
 import pydantic
 
+from pcapi.core.users import models as users_models
 from pcapi.routes.serialization import BaseModel
 
 
@@ -46,6 +47,7 @@ class RoleRequestModel(BaseModel):
 class PublicAccount(BaseModel):
     class Config:
         orm_mode = True
+        use_enum_values = True
 
     id: int
     firstName: typing.Optional[str]
@@ -53,6 +55,8 @@ class PublicAccount(BaseModel):
     dateOfBirth: typing.Optional[datetime.datetime]
     email: str
     phoneNumber: typing.Optional[str]
+    roles: list[users_models.UserRole]
+    isActive: bool
 
 
 class PublicAccountSearchQuery(BaseModel):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15177

## But de la pull request

Pour coller aux pastilles de la maquette, il manque ces informations dans `PublicAccount` :
```
roles: list
isActive: bool
```

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
