### PR TITLE
(PC-14452)[API] Change CodeNotValid error message to be more explicit

### DIFF
--- a/api/src/pcapi/core/fraud/phone_validation/sending_limit.py
+++ b/api/src/pcapi/core/fraud/phone_validation/sending_limit.py
@@ -25,7 +25,7 @@ def is_SMS_sending_allowed(redis: Redis, user: User) -> bool:
     return not sent_SMS_count or int(sent_SMS_count) < settings.MAX_SMS_SENT_FOR_PHONE_VALIDATION
 
 
-def get_remaining_attempts(redis: Redis, user: User) -> int:
+def get_remaining_sms_sending_attempts(redis: Redis, user: User) -> int:
     sent_SMS_count = redis.get(_sent_SMS_counter_key_name(user))
 
     if sent_SMS_count:

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -686,7 +686,8 @@ def validate_phone_number(user: User, code: str) -> None:
     ).one_or_none()
 
     if not token:
-        raise exceptions.NotValidCode()
+        code_validation_attempts = get_code_validation_attempts(app.redis_client, user)  # type: ignore [attr-defined]
+        raise exceptions.NotValidCode(remaining_attempts=code_validation_attempts.remaining)
 
     if token.expirationDate and token.expirationDate < datetime.utcnow():
         raise exceptions.ExpiredCode()

--- a/api/src/pcapi/core/users/exceptions.py
+++ b/api/src/pcapi/core/users/exceptions.py
@@ -1,3 +1,6 @@
+import typing
+
+
 class CredentialsException(Exception):
     pass
 
@@ -61,7 +64,9 @@ class UserAlreadyBeneficiary(PhoneVerificationException):
 
 
 class NotValidCode(PhoneVerificationException):
-    pass
+    def __init__(self, remaining_attempts: typing.Optional[int] = None):
+        self.remaining_attempts = remaining_attempts
+        super().__init__()
 
 
 class ExpiredCode(NotValidCode):

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -250,8 +250,14 @@ def validate_phone_number(user: User, body: serializers.ValidatePhoneNumberReque
             )
         except exceptions.ExpiredCode:
             raise ApiErrors({"message": "Le code saisi a expiré", "code": "EXPIRED_VALIDATION_CODE"}, status_code=400)
-        except exceptions.NotValidCode:
-            raise ApiErrors({"message": "Le code est invalide", "code": "INVALID_VALIDATION_CODE"}, status_code=400)
+        except exceptions.NotValidCode as error:
+            raise ApiErrors(
+                {
+                    "message": f"Le code est invalide. Saisis le dernier code reçu par SMS. Il te reste {error.remaining_attempts} tentative{'s' if error.remaining_attempts and error.remaining_attempts > 1 else ''}.",
+                    "code": "INVALID_VALIDATION_CODE",
+                },
+                status_code=400,
+            )
         except exceptions.InvalidPhoneNumber:
             raise ApiErrors(
                 {"message": "Le numéro de téléphone est invalide", "code": "INVALID_PHONE_NUMBER"}, status_code=400

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -251,6 +251,11 @@ def validate_phone_number(user: User, body: serializers.ValidatePhoneNumberReque
         except exceptions.ExpiredCode:
             raise ApiErrors({"message": "Le code saisi a expiré", "code": "EXPIRED_VALIDATION_CODE"}, status_code=400)
         except exceptions.NotValidCode as error:
+            if error.remaining_attempts == 0:
+                raise ApiErrors(
+                    {"message": "Le nombre de tentatives maximal est dépassé", "code": "TOO_MANY_VALIDATION_ATTEMPTS"},
+                    status_code=400,
+                )
             raise ApiErrors(
                 {
                     "message": f"Le code est invalide. Saisis le dernier code reçu par SMS. Il te reste {error.remaining_attempts} tentative{'s' if error.remaining_attempts and error.remaining_attempts > 1 else ''}.",

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -264,7 +264,7 @@ def validate_phone_number(user: User, body: serializers.ValidatePhoneNumberReque
 @spectree_serialize(api=blueprint.api, response_model=serializers.PhoneValidationRemainingAttemptsRequest)
 @authenticated_and_active_user_required
 def phone_validation_remaining_attempts(user: User) -> serializers.PhoneValidationRemainingAttemptsRequest:
-    remaining_attempts = sending_limit.get_remaining_attempts(app.redis_client, user)  # type: ignore [attr-defined]
+    remaining_attempts = sending_limit.get_remaining_sms_sending_attempts(app.redis_client, user)  # type: ignore [attr-defined]
     expiration_time = sending_limit.get_attempt_limitation_expiration_time(app.redis_client, user)  # type: ignore [attr-defined]
     return serializers.PhoneValidationRemainingAttemptsRequest(
         remainingAttempts=remaining_attempts, counterResetDatetime=expiration_time

--- a/api/tests/core/fraud/phone_validation/test_sending_limit.py
+++ b/api/tests/core/fraud/phone_validation/test_sending_limit.py
@@ -7,22 +7,22 @@ import pcapi.core.users.factories as users_factories
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-def test_get_remaining_attempts(app):
+def test_get_remaining_sms_sending_attempts(app):
     user = users_factories.UserFactory()
     app.redis_client.set(f"sent_SMS_counter_user_{user.id}", 0)
 
-    assert sending_limit.get_remaining_attempts(app.redis_client, user) == 3
+    assert sending_limit.get_remaining_sms_sending_attempts(app.redis_client, user) == 3
 
     sending_limit.update_sent_SMS_counter(app.redis_client, user)
     sending_limit.update_sent_SMS_counter(app.redis_client, user)
 
-    assert sending_limit.get_remaining_attempts(app.redis_client, user) == 1
+    assert sending_limit.get_remaining_sms_sending_attempts(app.redis_client, user) == 1
 
     sending_limit.update_sent_SMS_counter(app.redis_client, user)
     sending_limit.update_sent_SMS_counter(app.redis_client, user)
 
     # test that remaining attempts don't go under 0
-    assert sending_limit.get_remaining_attempts(app.redis_client, user) == 0
+    assert sending_limit.get_remaining_sms_sending_attempts(app.redis_client, user) == 0
 
 
 def test_get_attempt_limitation_expiration_time(app):

--- a/api/tests/core/fraud/phone_validation/test_sending_limit.py
+++ b/api/tests/core/fraud/phone_validation/test_sending_limit.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pcapi.core.fraud.phone_validation import sending_limit
+from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
 
 
@@ -33,3 +34,11 @@ def test_get_attempt_limitation_expiration_time(app):
     sending_limit.update_sent_SMS_counter(app.redis_client, user)
 
     assert sending_limit.get_attempt_limitation_expiration_time(app.redis_client, user) is not None
+
+
+@override_settings(MAX_PHONE_VALIDATION_ATTEMPTS=1)
+def test_get_code_validation_attempts(app):
+    user = users_factories.UserFactory()
+
+    assert sending_limit.get_code_validation_attempts(app.redis_client, user).attempts == 0
+    assert sending_limit.get_code_validation_attempts(app.redis_client, user).remaining == 1

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1296,6 +1296,10 @@ class ValidatePhoneNumberTest:
             response.json["message"]
             == "Le code est invalide. Saisis le dernier code reçu par SMS. Il te reste 1 tentative."
         )
+        response = client.post("/native/v1/validate_phone_number", {"code": "mauvais-code"})
+        assert response.status_code == 400
+        assert response.json["code"] == "TOO_MANY_VALIDATION_ATTEMPTS"
+        assert response.json["message"] == "Le nombre de tentatives maximal est dépassé"
 
         assert not User.query.get(user.id).is_phone_validated
         assert user.is_subscriptionState_phone_validation_ko

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1285,6 +1285,17 @@ class ValidatePhoneNumberTest:
 
         assert response.status_code == 400
         assert response.json["code"] == "INVALID_VALIDATION_CODE"
+        assert (
+            response.json["message"]
+            == "Le code est invalide. Saisis le dernier code reçu par SMS. Il te reste 2 tentatives."
+        )
+        response = client.post("/native/v1/validate_phone_number", {"code": "mauvais-code"})
+        assert response.status_code == 400
+        assert response.json["code"] == "INVALID_VALIDATION_CODE"
+        assert (
+            response.json["message"]
+            == "Le code est invalide. Saisis le dernier code reçu par SMS. Il te reste 1 tentative."
+        )
 
         assert not User.query.get(user.id).is_phone_validated
         assert user.is_subscriptionState_phone_validation_ko


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14452

## But de la pull request

Cette PR vise à rendre plus explicite le message d'erreur présenté à l'utilisateur lorsqu'il entre un code erroné au moment de la validation du numéro de téléphone.

## Implémentation

- Création d'une classe `PhoneValidationCodeAttempts` pour récupérer rapidement et le nombre d'essais de code et le nombre restant d'essais possible
- Ajout d'un attribut à l'erreur `NotValidCode` pour y intégrer le nombre d'essais restants


## Informations supplémentaires

- On envoie désormais l'erreur `PhoneValidationAttemptsLimitReached` dès l'échec du dernier code, et non plus après l'envoi d'un code supplémentaire. Cela permet à l'utilisateur de naviguer vers la page d'erreur associée au nombre trop important de tentatives dès le dernier code erroné

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
