### PR TITLE
(PC-15181)[API] refactor: remove cds url from exceptions logs and redact api token in request wrapper

### DIFF
--- a/api/src/pcapi/connectors/cine_digital_service.py
+++ b/api/src/pcapi/connectors/cine_digital_service.py
@@ -54,7 +54,7 @@ def get_resource(
         response.raise_for_status()
 
     except requests.exceptions.RequestException as e:
-        raise cds_exceptions.CineDigitalServiceAPIException(f"API CDS - url : {url} - error : {e}")
+        raise cds_exceptions.CineDigitalServiceAPIException(f"Error on CDS API on GET {resource} : {e}")
 
     return response.json()
 
@@ -72,7 +72,7 @@ def put_resource(
         response.raise_for_status()
 
     except requests.exceptions.RequestException as e:
-        raise cds_exceptions.CineDigitalServiceAPIException(f"API CDS - url : {url} - error : {e}")
+        raise cds_exceptions.CineDigitalServiceAPIException(f"Error on CDS API on PUT {resource} : {e}")
 
     response_headers = response.headers.get("Content-Type")
     if response_headers and "application/json" in response_headers:
@@ -88,7 +88,7 @@ def post_resource(api_url: str, cinema_id: str, token: Optional[str], resource: 
         response.raise_for_status()
 
     except requests.exceptions.RequestException as e:
-        raise cds_exceptions.CineDigitalServiceAPIException(f"API CDS - url : {url} - error : {e}")
+        raise cds_exceptions.CineDigitalServiceAPIException(f"Error on CDS API on POST {resource} : {e}")
 
     return response.json()
 

--- a/api/tests/utils/requests_test.py
+++ b/api/tests/utils/requests_test.py
@@ -10,6 +10,7 @@ class RequestWrapperTest:
     def test_call_given_request_function_with_params(self):
         # given
         mocked_request_function = Mock()
+        mocked_request_function.return_value.url = "https://example.net"
 
         # when
         _wrapper(mocked_request_function, "GET", "https://example.net")
@@ -20,6 +21,7 @@ class RequestWrapperTest:
     def test_call_given_request_function_with_custom_timeout_params(self):
         # given
         mocked_request_function = Mock()
+        mocked_request_function.return_value.url = "https://example.net"
 
         # when
         _wrapper(mocked_request_function, "GET", "https://example.net", **dict(timeout=40))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15181

- Supprimer l'URL des logs d'exceptions dans le connector CDS pour ne pas afficher le token d'api.
- Caviarder le query param `api_token` des URLs dans le wrapper de request. 