### PR TITLE
PC-15089 check cni duplicates ignoring spaces

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -166,24 +166,22 @@ def validate_id_piece_number_format_fraud_item(id_piece_number: typing.Optional[
     # https://regex101.com/ FTW
     regexp = "|".join(
         (
-            r"(^\d{18}$)",  # ID Algérienne
-            r"(^(\w){8,12}|[\s\w]{14}$)",  # ID Europeene ID Française
-            r"(^\w{1}\d{6}$)",  # ID Tunisienne
-            r"(^\w{1}\ *\d{8}$)",  # ID Turque
-            r"(^\w{2}\ *\d{7}$)",  # Ancienne ID Italienne
-            r"(^\d{3}\-\d{7}\-\d{2}$)",  # ID Belge
-            r"(^\d{7}$)",  # ID Congolaise, Camerounaise, Mauricienne
-            r"(^\w{3}\ *\d{6}$)",  # ID Polonaise
-            r"(^(\d\ *){17}$)",  # ID Sénégalaise
-            r"(^\d{6}\w{1}$)",  # Titre de séjour français
-            r"(^\d{6,8}-\d{4}$)",  # ID Suédoise
+            r"^\d{18}$",  # ID Algérienne
+            r"^\w{8,12}$",  # ID Europeene
+            r"^[\s\w]{14}$",  # ID Française
+            r"^\w{1}\d{6}$",  # ID Tunisienne
+            r"^\w{1} *\d{8}$",  # ID Turque
+            r"^\w{2} *\d{7}$",  # Ancienne ID Italienne
+            r"^\d{3}-\d{7}-\d{2}$",  # ID Belge
+            r"^\d{7}$",  # ID Congolaise, Camerounaise, Mauricienne
+            r"^\w{3} *\d{6}$",  # ID Polonaise
+            r"^(\d *){17}$",  # ID Sénégalaise
+            r"^\d{6}\w{1}$",  # Titre de séjour français
+            r"^\d{6,8}-\d{4}$",  # ID Suédoise
         )
     )
-
-    if not re.fullmatch(
-        regexp,
-        id_piece_number,
-    ):
+    match = re.match(regexp, id_piece_number)
+    if not match or match.group(0) != id_piece_number:
         return models.FraudItem(
             status=models.FraudStatus.SUSPICIOUS,
             detail="Le format du numéro de la pièce d'identité n'est pas valide",

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -261,10 +261,19 @@ def duplicate_id_piece_number_fraud_item(user: users_models.User, id_piece_numbe
 
 
 def find_duplicate_id_piece_number_user(
-    id_piece_number: str, excluded_user_id: int
+    id_piece_number: typing.Optional[str], excluded_user_id: int
 ) -> typing.Optional[users_models.User]:
+    if not id_piece_number:
+        return None
     return users_models.User.query.filter(
-        users_models.User.id != excluded_user_id, users_models.User.idPieceNumber == id_piece_number
+        users_models.User.id != excluded_user_id,
+        users_models.User.idPieceNumber.isnot(None),
+        sqlalchemy.sql.func.replace(
+            users_models.User.idPieceNumber,
+            " ",
+            "",
+        )
+        == id_piece_number.replace(" ", ""),
     ).first()
 
 

--- a/api/src/pcapi/core/mails/transactional/users/duplicate_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/duplicate_beneficiary.py
@@ -18,7 +18,7 @@ def send_duplicate_beneficiary_email(
 ) -> bool:
     if is_id_piece_number_duplicate:
         duplicate_beneficiary = fraud_api.find_duplicate_id_piece_number_user(
-            identity_content.get_id_piece_number(), rejected_user.id  # type: ignore [arg-type]
+            identity_content.get_id_piece_number(), rejected_user.id
         )
     else:
         duplicate_beneficiary = fraud_api.find_duplicate_beneficiary(

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -33,12 +33,7 @@ class CommonTest:
 
     @pytest.mark.parametrize(
         "id_piece_number",
-        [
-            "I III1",
-            "I I 1JII 11IB I E",
-            "",
-            "Passeport n: XXXXX",
-        ],
+        ["I III1", "I I 1JII 11IB I E", "", "Passeport n: XXXXX", "15347402 5 ZX9 "],
     )
     def test_id_piece_number_wrong_format(self, id_piece_number):
         item = fraud_api.validate_id_piece_number_format_fraud_item(id_piece_number)

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -109,7 +109,7 @@ class CommonFraudCheckTest:
         assert fraud_item.status == fraud_models.FraudStatus.OK
 
     def test_duplicate_id_piece_number_suspicious(self):
-        user = users_factories.BeneficiaryGrant18Factory()
+        user = users_factories.BeneficiaryGrant18Factory(idPieceNumber="random_id")
         applicant = users_factories.UserFactory()
 
         fraud_item = fraud_api.duplicate_id_piece_number_fraud_item(applicant, user.idPieceNumber)
@@ -290,6 +290,21 @@ class FindDuplicateUserTest:
             )
             == existing_user
         )
+
+    @pytest.mark.parametrize(
+        "existing_id_piece_number,new_id_piece_number",
+        [
+            ("123456789", "123456789"),
+            ("123 456 789", "123456789"),
+            ("123456789", "123 456 789"),
+            ("1 2345678 9", "123 456 789"),
+        ],
+    )
+    def test_find_duplicate_id_piece_number_user(self, existing_id_piece_number, new_id_piece_number):
+        existing_user = users_factories.UserFactory(idPieceNumber=existing_id_piece_number)
+        new_user = users_factories.UserFactory()
+
+        assert fraud_api.find_duplicate_id_piece_number_user(new_id_piece_number, new_user.id) == existing_user
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15089

## But de la pull request

Etre meilleur à trouver les doublons de pieces d'identité

## Implémentation

- Amélioration de la regexp d'acceptation de numéro de piece d'identité
- Checker les doublons en ignorant les espaces


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
