### PR TITLE
[API](PC-FIX)[API] fix: add response_model parameter

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -62,12 +62,9 @@ def update_user_profile(user: User, body: serializers.UserProfileUpdateRequest) 
 
 
 @blueprint.native_v1.route("/reset_recredit_amount_to_show", methods=["POST"])
-@spectree_serialize(
-    on_success_status=200,
-    api=blueprint.api,
-)
+@spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.UserProfileResponse)
 @authenticated_and_active_user_required
-def reset_recredit_amount_to_show(user: User) -> None:
+def reset_recredit_amount_to_show(user: User) -> serializers.UserProfileResponse:
     api.reset_recredit_amount_to_show(user)
 
     return serializers.UserProfileResponse.from_orm(user)
@@ -283,7 +280,7 @@ def suspend_account(user: User) -> None:
 
 
 @blueprint.native_v1.route("/account/suspension_date", methods=["GET"])
-@spectree_serialize(api=blueprint.api, on_success_status=200)
+@spectree_serialize(response_model=serializers.UserSuspensionDateResponse, api=blueprint.api, on_success_status=200)
 @authenticated_maybe_inactive_user_required
 def get_account_suspension_date(user: User) -> serializers.UserSuspensionDateResponse:
     reason = user.suspension_reason
@@ -296,7 +293,7 @@ def get_account_suspension_date(user: User) -> serializers.UserSuspensionDateRes
 
 
 @blueprint.native_v1.route("/account/suspension_status", methods=["GET"])
-@spectree_serialize(api=blueprint.api, on_success_status=200)
+@spectree_serialize(response_model=serializers.UserSuspensionStatusResponse, api=blueprint.api, on_success_status=200)
 @authenticated_maybe_inactive_user_required
 def get_account_suspension_status(user: User) -> serializers.UserSuspensionStatusResponse:
     return serializers.UserSuspensionStatusResponse(status=user.account_state)

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -831,6 +831,19 @@ def test_public_api(client, app):
                     "title": "SigninResponse",
                     "type": "object",
                 },
+                "UserSuspensionDateResponse": {
+                    "properties": {
+                        "date": {"format": "date-time", "nullable": True, "title": "Date", "type": "string"}
+                    },
+                    "title": "UserSuspensionDateResponse",
+                    "type": "object",
+                },
+                "UserSuspensionStatusResponse": {
+                    "properties": {"status": {"$ref": "#/components/schemas/AccountState"}},
+                    "required": ["status"],
+                    "title": "UserSuspensionStatusResponse",
+                    "type": "object",
+                },
                 "ValidateEmailRequest": {
                     "properties": {"emailValidationToken": {"title": "Emailvalidationtoken", "type": "string"}},
                     "required": ["emailValidationToken"],
@@ -1472,6 +1485,11 @@ def test_public_api(client, app):
                     "title": "ProfileUpdateRequest",
                     "type": "object",
                 },
+                "AccountState": {
+                    "description": "An enumeration.",
+                    "enum": ["ACTIVE", "INACTIVE", "SUSPENDED", "SUSPENDED_UPON_USER_REQUEST", "DELETED"],
+                    "title": "AccountState",
+                },
                 "ActivityIdEnum": {
                     "description": "An enumeration.",
                     "enum": [
@@ -1557,7 +1575,14 @@ def test_public_api(client, app):
                     "operationId": "get_/native/v1/account/suspension_date",
                     "parameters": [],
                     "responses": {
-                        "200": {"description": "OK"},
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/UserSuspensionDateResponse"}
+                                }
+                            },
+                            "description": "OK",
+                        },
                         "403": {"description": "Forbidden"},
                         "422": {
                             "content": {
@@ -1577,7 +1602,14 @@ def test_public_api(client, app):
                     "operationId": "get_/native/v1/account/suspension_status",
                     "parameters": [],
                     "responses": {
-                        "200": {"description": "OK"},
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/UserSuspensionStatusResponse"}
+                                }
+                            },
+                            "description": "OK",
+                        },
                         "403": {"description": "Forbidden"},
                         "422": {
                             "content": {
@@ -2299,7 +2331,12 @@ def test_public_api(client, app):
                     "operationId": "post_/native/v1/reset_recredit_amount_to_show",
                     "parameters": [],
                     "responses": {
-                        "200": {"description": "OK"},
+                        "200": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/UserProfileResponse"}}
+                            },
+                            "description": "OK",
+                        },
                         "403": {"description": "Forbidden"},
                         "422": {
                             "content": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-NOPE

## But de la pull request

Ajout de paramètres manquants dans l'utilisation du décorateur `spectree_serialize` : certaines routes ne précisaient pas le `response_model` alors qu'elles renvoyaient un objet JSON.