### PR TITLE
(PC-15525)[API] fix: Avoid JSONDecodeError when Sendinblue connection fails

### DIFF
--- a/api/src/pcapi/core/users/external/sendinblue.py
+++ b/api/src/pcapi/core/users/external/sendinblue.py
@@ -403,7 +403,10 @@ def add_contacts_to_list(user_emails: Iterable[str], sib_list_id: int, clear_lis
                 # Handled first because response is a generic html page, not the expected json body
                 logger.exception("Timeout when calling ContactsApi->remove_contact_from_list(%d)", sib_list_id)
                 return False
-            message = json.loads(exception.body).get("message")
+            try:
+                message = json.loads(exception.body).get("message")
+            except json.JSONDecodeError:
+                message = exception.body
             if exception.status == 400 and message == "Contacts already removed from list and/or does not exist":
                 logger.info("ContactsApi->remove_contact_from_list(%d): list was already empty", sib_list_id)
             else:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15525

## But de la pull request

Éviter une exception dans le traitement de l'exception ; erreur Sentry : 
https://sentry.internal-passculture.app/organizations/sentry/issues/380328/?project=5

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
