### PR TITLE
(PC-14131)[API] fix: select several bookings given one stock with several bookings

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -928,17 +928,10 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Individual
         .filter(not_(Offer.isDigital))
         .filter(Booking.status != BookingStatus.CANCELLED)
         .options(
-            contains_eager(IndividualBooking.booking).contains_eager(Booking.stock).load_only(Stock.beginningDatetime)
-        )
-        .options(
             contains_eager(IndividualBooking.booking)
-            .contains_eager(Booking.stock)
-            .contains_eager(Stock.bookings)
             .load_only(Booking.id, Booking.stockId, Booking.quantity, Booking.token)
-        )
-        .options(
-            contains_eager(IndividualBooking.booking)
             .contains_eager(Booking.stock)
+            .load_only(Stock.beginningDatetime)
             .contains_eager(Stock.offer)
             .load_only(
                 Offer.name,
@@ -947,11 +940,6 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Individual
                 Offer.withdrawalType,
                 Offer.withdrawalDetails,
             )
-        )
-        .options(
-            contains_eager(IndividualBooking.booking)
-            .contains_eager(Booking.stock)
-            .contains_eager(Stock.offer)
             .joinedload(Offer.venue, innerjoin=True)
             .load_only(Venue.name, Venue.publicName, Venue.address, Venue.city, Venue.postalCode)
         )

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -2788,3 +2788,15 @@ class GetTomorrowEventOfferTest:
         bookings = booking_repository.find_individual_bookings_event_happening_tomorrow_query()
 
         assert len(bookings) == 0
+
+    def should_select_several_bookings_given_one_stock_with_several_bookings(self):
+        tomorrow = datetime.utcnow() + timedelta(days=1)
+        stock = offers_factories.EventStockFactory(
+            beginningDatetime=tomorrow,
+        )
+        bookings_factories.IndividualBookingFactory(stock=stock)
+        bookings_factories.IndividualBookingFactory(stock=stock)
+
+        bookings = booking_repository.find_individual_bookings_event_happening_tomorrow_query()
+
+        assert len(bookings) == 2


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14131

## But de la pull request

les emails ne s'envoyaient pas via le cron en testing

on suspecte que c'était parce qu'il y avait plusieurs réservations pour une meme offre

avant, on ne sélectionnait que les stocks et s'il y avait plusieurs individuals bookings on ne mailait que le premier

maintenant, on sélectionne les individuals bookings

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires

