### PR TITLE
(PC-15236)[API] fix: exception when creating pro user with empty postal code

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -624,7 +624,7 @@ def _generate_offerer(data: dict) -> offerers_models.Offerer:
 
 
 def _set_offerer_departement_code(new_user: User, offerer: offerers_models.Offerer) -> User:
-    if offerer.postalCode is not None:
+    if offerer.postalCode:  # not None, not ""
         new_user.departementCode = PostalCode(offerer.postalCode).get_departement_code()
     else:
         new_user.departementCode = None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15236

## But de la pull request

éviter l'exception remontée par Sentry avec un code postal vide (chaîne vide) : 
https://sentry.internal-passculture.app/organizations/sentry/issues/380646/?project=5

## Implémentation

## Informations supplémentaires

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
