### PR TITLE
(PC-15227)[API] feat: signin: use account_state instead of isActive

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -167,6 +167,10 @@ class AccountState(enum.Enum):
     SUSPENDED_UPON_USER_REQUEST = "SUSPENDED_UPON_USER_REQUEST"
     DELETED = "DELETED"
 
+    @property
+    def is_deleted(self) -> bool:
+        return self == AccountState.DELETED
+
 
 class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, misc]
     __tablename__ = "user"

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -51,11 +51,14 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
     except users_exceptions.CredentialsException as exc:
         raise ApiErrors({"general": ["Identifiant ou Mot de passe incorrect"]}) from exc
 
+    if user.account_state.is_deleted:
+        raise ApiErrors({"code": "ACCOUNT_DELETED", "general": ["Le compte a été supprimé"]})
+
     users_api.update_last_connection_date(user)
     return authentication.SigninResponse(
         access_token=users_api.create_user_access_token(user),
         refresh_token=create_refresh_token(identity=user.email),
-        is_active=user.isActive,
+        account_state=user.account_state,
     )
 
 

--- a/api/src/pcapi/routes/native/v1/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v1/serialization/authentication.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from pcapi.core.users.models import AccountState
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
 
@@ -12,7 +13,7 @@ class SigninRequest(BaseModel):
 class SigninResponse(BaseModel):
     refresh_token: str
     access_token: str
-    is_active: bool
+    account_state: AccountState
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -825,9 +825,9 @@ def test_public_api(client, app):
                     "properties": {
                         "accessToken": {"title": "Accesstoken", "type": "string"},
                         "refreshToken": {"title": "Refreshtoken", "type": "string"},
-                        "isActive": {"title": "Isactive", "type": "boolean"},
+                        "accountState": {"$ref": "#/components/schemas/AccountState"},
                     },
-                    "required": ["refreshToken", "accessToken", "isActive"],
+                    "required": ["refreshToken", "accessToken", "accountState"],
                     "title": "SigninResponse",
                     "type": "object",
                 },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15227

## But de la pull request

Renvoyer une erreur 400 avec un code spécifique lorsqu'un utilisateur dont le compte est dans l'état supprimé essaie de se connecter.

Au passage, on remplace le `User.isActive` de la réponse à `/signin` par `User.account_state` : puisqu'on va chercher l'historique du compte s'il est inactif, autant s'en servir directement. Cela permettra ensuite de supprimer la route, récemment ajoutée, `/account/suspension_status` et évitera un aller-retour client front - api.
