### PR TITLE
PC 10707 refactor accessibility

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -24,7 +24,7 @@ from pcapi.core.categories import subcategories
 from pcapi.core.educational import exceptions
 from pcapi.core.offers.models import Offer
 from pcapi.models import Model
-from pcapi.models.offer_mixin import AccessibilityMixin
+from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import StatusMixin
 from pcapi.models.offer_mixin import ValidationMixin

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -38,6 +38,7 @@ from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.domain.ts_vector import create_ts_vector_and_table_args
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.bank_information import BankInformationStatus
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.has_address_mixin import HasAddressMixin
@@ -124,7 +125,7 @@ VenueTypeCodeKey = enum.Enum(  # type: ignore [misc]
 )
 
 
-class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixin):  # type: ignore [valid-type, misc]
+class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixin, AccessibilityMixin):  # type: ignore [valid-type, misc]
     __tablename__ = "venue"
 
     id = Column(BigInteger, primary_key=True)
@@ -194,14 +195,6 @@ class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixi
     dateCreated = Column(DateTime, nullable=False, default=datetime.utcnow)
 
     withdrawalDetails = Column(Text, nullable=True)
-
-    audioDisabilityCompliant = Column(Boolean, nullable=True)
-
-    mentalDisabilityCompliant = Column(Boolean, nullable=True)
-
-    motorDisabilityCompliant = Column(Boolean, nullable=True)
-
-    visualDisabilityCompliant = Column(Boolean, nullable=True)
 
     description = Column(Text, nullable=True)
 

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -12,10 +12,10 @@ import pcapi.core.bookings.constants as bookings_constants
 from pcapi.core.categories import subcategories
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.extra_data_mixin import ExtraDataMixin
 from pcapi.models.has_thumb_mixin import HasThumbMixin
-from pcapi.models.offer_mixin import AccessibilityMixin
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import StatusMixin
 from pcapi.models.offer_mixin import ValidationMixin

--- a/api/src/pcapi/models/accessibility_mixin.py
+++ b/api/src/pcapi/models/accessibility_mixin.py
@@ -1,0 +1,11 @@
+import sqlalchemy as sa
+
+
+class AccessibilityMixin:
+    audioDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
+
+    mentalDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
+
+    motorDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
+
+    visualDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)

--- a/api/src/pcapi/models/offer_mixin.py
+++ b/api/src/pcapi/models/offer_mixin.py
@@ -30,16 +30,6 @@ class OfferValidationType(enum.Enum):
     MANUAL = "MANUAL"
 
 
-class AccessibilityMixin:
-    audioDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
-
-    mentalDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
-
-    motorDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
-
-    visualDisabilityCompliant = sa.Column(sa.Boolean, nullable=True)
-
-
 class StatusMixin:
     @sa.ext.hybrid.hybrid_property
     def status(self) -> OfferStatus:

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -12,6 +12,7 @@ from pcapi.core.educational.models import CollectiveOfferTemplate
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offers.models import Offer
 from pcapi.routes.native.utils import convert_to_cent
+from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceStrictMixin
 from pcapi.routes.native.v1.serialization.common_models import Coordinates
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import to_camel
@@ -66,7 +67,7 @@ class OfferVenueResponse(BaseModel):
         allow_population_by_field_name = True
 
 
-class OfferResponse(BaseModel):
+class OfferResponse(BaseModel, AccessibilityComplianceStrictMixin):
     @classmethod
     def from_orm(cls: Any, offer: Offer):  # type: ignore
         offer.subcategoryLabel = offer.subcategory.app_label
@@ -86,10 +87,6 @@ class OfferResponse(BaseModel):
     venue: OfferVenueResponse
     extraData: Any
     durationMinutes: Optional[int]
-    motorDisabilityCompliant: bool
-    visualDisabilityCompliant: bool
-    audioDisabilityCompliant: bool
-    mentalDisabilityCompliant: bool
 
     class Config:
         orm_mode = True
@@ -162,7 +159,7 @@ class EducationalInstitutionResponseModel(BaseModel):
         extra = "forbid"
 
 
-class CollectiveOfferResponseModel(BaseModel):
+class CollectiveOfferResponseModel(BaseModel, AccessibilityComplianceStrictMixin):
     id: int
     subcategoryLabel: str
     description: Optional[str]
@@ -176,10 +173,6 @@ class CollectiveOfferResponseModel(BaseModel):
     contactEmail: str
     contactPhone: str
     durationMinutes: Optional[int]
-    motorDisabilityCompliant: bool
-    visualDisabilityCompliant: bool
-    audioDisabilityCompliant: bool
-    mentalDisabilityCompliant: bool
     offerId: Optional[str]
     educationalPriceDetail: Optional[str]
     domains: list[OfferDomain]
@@ -206,7 +199,7 @@ class CollectiveOfferResponseModel(BaseModel):
         extra = "forbid"
 
 
-class CollectiveOfferTemplateResponseModel(BaseModel):
+class CollectiveOfferTemplateResponseModel(BaseModel, AccessibilityComplianceStrictMixin):
     id: int
     subcategoryLabel: str
     description: Optional[str]
@@ -219,10 +212,6 @@ class CollectiveOfferTemplateResponseModel(BaseModel):
     contactEmail: str
     contactPhone: str
     durationMinutes: Optional[int]
-    motorDisabilityCompliant: bool
-    visualDisabilityCompliant: bool
-    audioDisabilityCompliant: bool
-    mentalDisabilityCompliant: bool
     educationalPriceDetail: Optional[str]
     offerId: Optional[str]
     domains: list[OfferDomain]

--- a/api/src/pcapi/routes/native/v1/serialization/common_models.py
+++ b/api/src/pcapi/routes/native/v1/serialization/common_models.py
@@ -1,9 +1,30 @@
 from decimal import Decimal
-from typing import Optional
+import typing
+
+
+# fmt: off
+# isort: off
+from pydantic import BaseModel as PydanticBaseModel  # pylint: disable=wrong-pydantic-base-model-import
+# isort: on
+# fmt: on
 
 from pcapi.routes.serialization import BaseModel
 
 
 class Coordinates(BaseModel):
-    latitude: Optional[Decimal]
-    longitude: Optional[Decimal]
+    latitude: typing.Optional[Decimal]
+    longitude: typing.Optional[Decimal]
+
+
+class AccessibilityComplianceMixin(PydanticBaseModel):
+    audioDisabilityCompliant: typing.Optional[bool]
+    mentalDisabilityCompliant: typing.Optional[bool]
+    motorDisabilityCompliant: typing.Optional[bool]
+    visualDisabilityCompliant: typing.Optional[bool]
+
+
+class AccessibilityComplianceStrictMixin(PydanticBaseModel):
+    audioDisabilityCompliant: bool
+    mentalDisabilityCompliant: bool
+    motorDisabilityCompliant: bool
+    visualDisabilityCompliant: bool

--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -7,15 +7,15 @@ from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import base
 
 
+class BannerMetaModel(TypedDict, total=False):
+    image_credit: typing.Optional[base.VenueImageCredit]  # type: ignore [valid-type]
+
+
 class VenueAccessibilityModel(BaseModel):
     audioDisability: typing.Optional[bool]
     mentalDisability: typing.Optional[bool]
     motorDisability: typing.Optional[bool]
     visualDisability: typing.Optional[bool]
-
-
-class BannerMetaModel(TypedDict, total=False):
-    image_credit: typing.Optional[base.VenueImageCredit]  # type: ignore [valid-type]
 
 
 class VenueResponse(base.BaseVenueResponse):

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -13,6 +13,7 @@ from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers.models import Venue
 from pcapi.models.offer_mixin import OfferStatus
+from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization.educational_institutions import EducationalInstitutionResponseModel
 from pcapi.routes.serialization.offers_serialize import ListOffersVenueResponseModel
@@ -183,7 +184,7 @@ class GetCollectiveOfferManagingOffererResponseModel(BaseModel):
         orm_mode = True
 
 
-class GetCollectiveOfferVenueResponseModel(BaseModel):
+class GetCollectiveOfferVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     address: Optional[str]
     bookingEmail: Optional[str]
     city: Optional[str]
@@ -207,10 +208,6 @@ class GetCollectiveOfferVenueResponseModel(BaseModel):
     siret: Optional[str]
     thumbCount: int
     venueLabelId: Optional[str]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
 
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
@@ -246,7 +243,7 @@ class GetCollectiveOfferCollectiveStockResponseModel(BaseModel):
         json_encoders = {datetime: format_into_utc_date}
 
 
-class GetCollectiveOfferBaseResponseModel(BaseModel):
+class GetCollectiveOfferBaseResponseModel(BaseModel, AccessibilityComplianceMixin):
     id: str
     bookingEmail: Optional[str]
     dateCreated: datetime
@@ -259,10 +256,6 @@ class GetCollectiveOfferBaseResponseModel(BaseModel):
     hasBookingLimitDatetimesPassed: bool
     offerId: Optional[str]
     isActive: bool
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     nonHumanizedId: int
     name: str
     subcategoryId: SubcategoryIdEnum
@@ -384,7 +377,7 @@ class CollectiveOfferTemplateResponseIdModel(BaseModel):
         arbitrary_types_allowed = True
 
 
-class PatchCollectiveOfferBodyModel(BaseModel):
+class PatchCollectiveOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     bookingEmail: Optional[str]
     description: Optional[str]
     name: Optional[str]
@@ -393,10 +386,6 @@ class PatchCollectiveOfferBodyModel(BaseModel):
     contactEmail: Optional[str]
     contactPhone: Optional[str]
     durationMinutes: Optional[int]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     subcategoryId: Optional[SubcategoryIdEnum]
     domains: Optional[list[int]]
 

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -8,13 +8,14 @@ from pcapi.core.offerers.repository import get_api_key_prefixes
 from pcapi.core.offerers.repository import has_digital_venue_with_at_least_one_offer
 from pcapi.core.offerers.repository import has_physical_venue_without_draft_or_accepted_bank_information
 import pcapi.core.users.models as users_models
+from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization.venues_serialize import VenueStatsResponseModel
 from pcapi.serialization.utils import humanize_field
 from pcapi.utils.date import format_into_utc_date
 
 
-class GetOffererVenueResponseModel(BaseModel):
+class GetOffererVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     address: Optional[str]
     bookingEmail: Optional[str]
     businessUnitId: Optional[int]
@@ -30,10 +31,6 @@ class GetOffererVenueResponseModel(BaseModel):
     publicName: Optional[str]
     venueLabelId: Optional[str]
     withdrawalDetails: Optional[str]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
     _humanize_venue_label_id = humanize_field("venueLabelId")
@@ -121,7 +118,7 @@ class GetOfferersNamesQueryModel(BaseModel):
         extra = "forbid"
 
 
-class GetEducationalOffererVenueResponseModel(BaseModel):
+class GetEducationalOffererVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     address: Optional[str]
     city: Optional[str]
     id: str
@@ -129,10 +126,6 @@ class GetEducationalOffererVenueResponseModel(BaseModel):
     publicName: Optional[str]
     name: str
     postalCode: Optional[str]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     _humanize_id = humanize_field("id")
 
     class Config:

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -17,6 +17,7 @@ from pcapi.core.offers.models import Stock
 from pcapi.core.offers.models import WithdrawalTypeEnum
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferStatus
+from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import dehumanize_field
 from pcapi.serialization.utils import dehumanize_list_field
@@ -182,7 +183,7 @@ class CompletedEducationalOfferModel(EducationalOfferBodyModel):
     external_ticket_office_url: Optional[str] = None
 
 
-class PatchOfferBodyModel(BaseModel):
+class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     bookingEmail: Optional[str]
     description: Optional[str]
     isNational: Optional[bool]
@@ -202,10 +203,6 @@ class PatchOfferBodyModel(BaseModel):
     conditions: Optional[str]
     venueId: Optional[str]
     productId: Optional[str]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
 
     @validator("name", pre=True, allow_reuse=True)
     def validate_name(cls, name):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
@@ -229,16 +226,12 @@ class EducationalOfferPartialExtraDataBodyModel(BaseModel):
         extra = "forbid"
 
 
-class PatchEducationalOfferBodyModel(BaseModel):
+class PatchEducationalOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     bookingEmail: Optional[str]
     description: Optional[str]
     name: Optional[str]
     extraData: Optional[EducationalOfferPartialExtraDataBodyModel]
     durationMinutes: Optional[int]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     subcategoryId: Optional[SubcategoryIdEnum]
 
     @validator("name", allow_reuse=True)
@@ -475,7 +468,7 @@ class GetOfferManagingOffererResponseModel(BaseModel):
         orm_mode = True
 
 
-class GetOfferVenueResponseModel(BaseModel):
+class GetOfferVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     address: Optional[str]
     bookingEmail: Optional[str]
     city: Optional[str]
@@ -499,10 +492,6 @@ class GetOfferVenueResponseModel(BaseModel):
     siret: Optional[str]
     thumbCount: int
     venueLabelId: Optional[str]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
 
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
@@ -553,7 +542,7 @@ class GetOfferMediationResponseModel(BaseModel):
         json_encoders = {datetime: format_into_utc_date}
 
 
-class GetOfferResponseModel(BaseModel):
+class GetOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     activeMediation: Optional[GetOfferMediationResponseModel]
     ageMax: Optional[int]
     ageMin: Optional[int]
@@ -577,11 +566,7 @@ class GetOfferResponseModel(BaseModel):
     isEvent: bool
     isNational: bool
     isThing: bool
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
     nonHumanizedId: int
-    visualDisabilityCompliant: Optional[bool]
     lastProvider: Optional[GetOfferLastProviderResponseModel]
     lastProviderId: Optional[str]
     mediaUrls: list[str]

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -14,6 +14,7 @@ from pydantic import validator
 from pcapi.core.offerers import exceptions
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.validation import VENUE_BANNER_MAX_SIZE
+from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import base
 from pcapi.routes.serialization.finance_serialize import BusinessUnitResponseModel
@@ -30,7 +31,7 @@ MAX_LONGITUDE = 180
 MAX_LATITUDE = 90
 
 
-class PostVenueBodyModel(BaseModel):
+class PostVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     # pydantic constrained types do not work well with Mypy, see https://github.com/samuelcolvin/pydantic/issues/156
     address: pydantic.constr(max_length=200)  # type: ignore
     bookingEmail: pydantic.constr(max_length=120)  # type: ignore
@@ -47,10 +48,6 @@ class PostVenueBodyModel(BaseModel):
     venueTypeCode: str
     withdrawalDetails: Optional[str]
     description: Optional[base.VenueDescription]  # type: ignore
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     contact: Optional[base.VenueContactModel]
     businessUnitId: Optional[int]
 
@@ -139,7 +136,7 @@ class BannerMetaModel(BaseModel):
         return raw_crop_params
 
 
-class GetVenueResponseModel(base.BaseVenueResponse):
+class GetVenueResponseModel(base.BaseVenueResponse, AccessibilityComplianceMixin):
     id: str
     dateCreated: datetime
     isValidated: bool
@@ -164,10 +161,6 @@ class GetVenueResponseModel(base.BaseVenueResponse):
     siret: Optional[str]
     venueLabelId: Optional[str]
     venueTypeCode: Optional[offerers_models.VenueTypeCode]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
 
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
@@ -202,7 +195,7 @@ class GetVenueResponseModel(base.BaseVenueResponse):
         return super().from_orm(venue)
 
 
-class EditVenueBodyModel(BaseModel):
+class EditVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     name: Optional[pydantic.constr(max_length=140)]  # type: ignore
     address: Optional[pydantic.constr(max_length=200)]  # type: ignore
     siret: Optional[pydantic.constr(min_length=14, max_length=14)]  # type: ignore
@@ -220,17 +213,13 @@ class EditVenueBodyModel(BaseModel):
     isWithdrawalAppliedOnAllOffers: Optional[bool]
     isEmailAppliedOnAllOffers: Optional[bool]
     description: Optional[base.VenueDescription]  # type: ignore
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     contact: Optional[base.VenueContactModel]
     businessUnitId: Optional[int]
 
     _dehumanize_venue_label_id = dehumanize_field("venueLabelId")
 
 
-class VenueListItemResponseModel(BaseModel):
+class VenueListItemResponseModel(BaseModel, AccessibilityComplianceMixin):
     id: str
     managingOffererId: str
     name: str
@@ -239,10 +228,6 @@ class VenueListItemResponseModel(BaseModel):
     isVirtual: bool
     bookingEmail: Optional[str]
     withdrawalDetails: Optional[str]
-    audioDisabilityCompliant: Optional[bool]
-    mentalDisabilityCompliant: Optional[bool]
-    motorDisabilityCompliant: Optional[bool]
-    visualDisabilityCompliant: Optional[bool]
     businessUnitId: Optional[int]
     businessUnit: Optional[BusinessUnitResponseModel]
     siret: Optional[str]

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -78,10 +78,16 @@ class Returns200Test:
 
         expected_payload = EducationalBookingEdition(
             **serialize_collective_booking(booking).dict(),
-            updatedFields=["name", "students", "contactEmail", "mentalDisabilityCompliant", "subcategoryId", "domains"],
+            updatedFields=sorted(
+                ["name", "students", "contactEmail", "mentalDisabilityCompliant", "subcategoryId", "domains"]
+            ),
         )
-        assert adage_api_testing.adage_requests[0]["sent_data"] == expected_payload
-        assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/prereservation-edit"
+
+        adage_request = adage_api_testing.adage_requests[0]
+        adage_request["sent_data"].updatedFields = sorted(adage_request["sent_data"].updatedFields)
+
+        assert adage_request["sent_data"] == expected_payload
+        assert adage_request["url"] == "https://adage_base_url/v1/prereservation-edit"
 
     @override_settings(ADAGE_API_URL="https://adage_base_url")
     def test_patch_collective_offer_do_not_notify_educational_redactor_when_no_active_booking(

--- a/api/tests/routes/pro/patch_educational_offer_test.py
+++ b/api/tests/routes/pro/patch_educational_offer_test.py
@@ -206,10 +206,14 @@ class Returns200Test:
 
         expected_payload = EducationalBookingEdition(
             **serialize_educational_booking(booking.educationalBooking).dict(),
-            updatedFields=["name", "contactEmail", "mentalDisabilityCompliant", "subcategoryId"],
+            updatedFields=sorted(["name", "contactEmail", "mentalDisabilityCompliant", "subcategoryId"]),
         )
-        assert adage_api_testing.adage_requests[0]["sent_data"] == expected_payload
-        assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/prereservation-edit"
+
+        adage_request = adage_api_testing.adage_requests[0]
+        adage_request["sent_data"].updatedFields = sorted(adage_request["sent_data"].updatedFields)
+
+        assert adage_request["sent_data"] == expected_payload
+        assert adage_request["url"] == "https://adage_base_url/v1/prereservation-edit"
 
     @override_settings(ADAGE_API_URL="https://adage_base_url")
     def test_patch_educational_offer_do_not_notify_educational_redactor_when_no_active_booking(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-10707 

## But de la pull request

Factoriser le code d'accessibilité côté modèles SQLA et Pydantic : les lieux et les offres ont toujours les mêmes quatre champs, inutiles de maintenir des copier/coller partout. Cela évitera de se retrouver avec des inconsistances.