### PR TITLE
(PC-15237)[API] fix: do not block sync for stock without price before 1st of june

### DIFF
--- a/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 
 from requests.exceptions import RequestException
@@ -78,12 +79,16 @@ class ProviderAPI:
                 continue
 
             if "price" not in stock_response:
-                logger.exception(
-                    "[%s SYNC] missing price key in response with ref %s",
-                    self.name,
-                    stock_response_ref,
-                )
-                continue
+                # FIXME (jsdupuis, 2022-05-24) : to be removed after the start_blocking_date
+                start_blocking_date = datetime.strptime("2022-06-01 00:00:00", "%Y-%m-%d %H:%M:%S")
+
+                if datetime.utcnow() > start_blocking_date:
+                    logger.exception(
+                        "[%s SYNC] missing price key in response with ref %s",
+                        self.name,
+                        stock_response_ref,
+                    )
+                    continue
 
             validated_stock_responses.append(stock_response)
 

--- a/api/tests/local_providers/provider_manager_test.py
+++ b/api/tests/local_providers/provider_manager_test.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 import requests_mock
 
@@ -28,6 +29,8 @@ def mock_init_provider(*arg):
 
 class SynchronizeVenueProviderTest:
     @pytest.mark.usefixtures("db_session")
+    # FIXME (jsdupuis, 2022-05-24) : freeze_time to be removed after the 1st of june
+    @freeze_time("2022-06-01 09:00:00")
     def test_synchronize_venue_provider(self, app):
         api_url = "https://example.com/provider/api"
         old_provider = providers_factories.APIProviderFactory(id=1)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15237

## But de la pull request

- Ne pas bloquer la synchro des stocks sans prix avant la date d'échéance du 1er juin 2022

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
