### PR TITLE
(BSR)[API] fix: remove useless logger in validator

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_stock_serialize.py
@@ -61,9 +61,6 @@ def validate_booking_limit_datetime(
 def validate_beginning_datetime(beginning_datetime: datetime, values: Dict[str, Any], field: ModelField) -> datetime:
     # we need a datetime with timezone information which is not provided by datetime.utcnow.
     if beginning_datetime < datetime.now(timezone.utc):  # pylint: disable=datetime-now
-        logger.error(
-            "L'utilisateur a essayé de créer un stock pour la date %s qui est dans le passé", str(beginning_datetime)
-        )
         raise ValueError("L'évènement ne peut commencer dans le passé.")
     return beginning_datetime
 


### PR DESCRIPTION
Je ne sais pas pourquoi ce logger existe mais il n'est pas correcte:

- en français 
- pas de raison de le faire en error
- innutile

cette pr le retire.