### PR TITLE
(PC-15300)[API] fix: save dms fraud_check in db

### DIFF
--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -44,6 +44,7 @@ def create_fraud_check(
         status=fraud_models.FraudCheckStatus.STARTED,
         eligibilityType=eligibility_type,
     )
+    repository.save(fraud_check)
     return fraud_check
 
 

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -379,7 +379,7 @@ class BeneficiaryFraudCheck(PcObject, Model):  # type: ignore [valid-type, misc]
 
     id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
 
-    dateCreated = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
+    dateCreated = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now(), default=datetime.datetime.utcnow)
 
     userId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
 


### PR DESCRIPTION
there is an issue in dms cron when the fraud_check is not saved: we try to access fraud_check.dateCreated which is not defined

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15300


[Erreur sentry](https://sentry.internal-passculture.app/organizations/sentry/issues/381657/?project=5&referrer=jira_integration) :
<img width="988" alt="image" src="https://user-images.githubusercontent.com/22373097/171180653-09d0e72b-0a09-4378-b41a-49e8873d952d.png">
 
