### PR TITLE
(POC) Infra as Python code

### DIFF
--- a/api/src/pcapi/infratest/components/__init__.py
+++ b/api/src/pcapi/infratest/components/__init__.py
@@ -1,0 +1,1 @@
+from .crons import cron

--- a/api/src/pcapi/infratest/components/crons.py
+++ b/api/src/pcapi/infratest/components/crons.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from pcapi.models.feature import FeatureToggle
+from pcapi.scheduled_tasks import decorators
+
+class InfraCronProfiles(Enum):
+    LOW = "low"
+    HIGH = "high"
+
+@dataclass
+class Cron:
+    command: str
+    schedule: str
+    profile: InfraCronProfiles
+    backoff_limit: Optional[int] = None
+
+crons_list = []
+
+def cron(blueprint, schedule, feature_toggle: Optional[FeatureToggle] = None):
+    def decorator(func):
+        command_name = func.__name__
+        crons_list.append(
+            Cron(
+                command = command_name,
+                schedule = schedule,
+                profile = InfraCronProfiles.LOW,
+            )
+        )
+
+        func = decorators.log_cron_with_transaction(func)
+
+        if feature_toggle:
+            func = decorators.cron_require_feature(feature_toggle)(func)
+
+        return blueprint.cli.command(command_name)(func)
+
+    return decorator

--- a/api/src/pcapi/infratest/exports/for_helm.py
+++ b/api/src/pcapi/infratest/exports/for_helm.py
@@ -1,0 +1,16 @@
+
+import pcapi.scheduled_tasks.commands
+from pcapi.infratest.components import crons
+import yaml
+from pcapi.infratest.components.crons import Cron
+
+def format_cron(cron: Cron):
+    return {
+        "command": cron.command,
+        "schedule": cron.schedule,
+        "profile": cron.profile.value,
+        "backoffLimit": cron.backoff_limit,
+    }
+
+if __name__ == "__main__":
+    print(yaml.dump([format_cron(cron) for cron in crons.crons_list]))

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -47,7 +47,7 @@ from pcapi.scripts.booking import notify_soon_to_be_expired_bookings
 from pcapi.scripts.payment import user_recredit
 from pcapi.scripts.subscription.handle_deleted_dms_applications import handle_deleted_dms_applications
 from pcapi.utils.blueprint import Blueprint
-
+from pcapi.infratest import components
 
 DMS_OLD_PROCEDURE_ID = 44623
 
@@ -55,10 +55,7 @@ DMS_OLD_PROCEDURE_ID = 44623
 blueprint = Blueprint(__name__, __name__)
 logger = logging.getLogger(__name__)
 
-
-@blueprint.cli.command("update_booking_used")
-@log_cron_with_transaction
-@cron_require_feature(FeatureToggle.UPDATE_BOOKING_USED)
+@components.cron(blueprint, "0 1 * * *", feature_toggle=FeatureToggle.UPDATE_BOOKING_USED)
 def update_booking_used() -> None:
     """Automatically mark as used bookings that correspond to events that
     have happened (with a delay).
@@ -66,17 +63,14 @@ def update_booking_used() -> None:
     bookings_api.auto_mark_as_used_after_event()
 
 
-@blueprint.cli.command("synchronize_allocine_stocks")
-@log_cron_with_transaction
-@cron_require_feature(FeatureToggle.SYNCHRONIZE_ALLOCINE)
+@components.cron(blueprint, "0 * * * *", feature_toggle=FeatureToggle.SYNCHRONIZE_ALLOCINE)
 def synchronize_allocine_stocks() -> None:
     """Launch AlloCine synchronization."""
     allocine_stocks_provider_id = get_provider_by_local_class("AllocineStocks").id
     synchronize_venue_providers_for_provider(allocine_stocks_provider_id)
 
 
-@blueprint.cli.command("synchronize_provider_api")
-@log_cron_with_transaction
+@components.cron(blueprint, "0 3 * * *")
 def synchronize_provider_api() -> None:
     """Launch Providers (excepts AlloCine) synchronization."""
     provider_api_stocks.synchronize_stocks()


### PR DESCRIPTION
// Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

L'objectif serait de générer une partie de la configuration de l'infra via le code python, notamment celle qui dépend beaucoup de ce code et/ou qui est particulièrement modifiée par les devs.
Ce POC essait sur un premier exemple : la configuration des crons, l'objectif est ainsi de générer cette liste https://github.com/pass-culture/pass-culture-deployment/blob/e43566fd92e1750582307d9c0da98cb16cbd9080/helm/pcapi/values.production.yaml#L395 via le code python, selon un format cohérent par rapport à comment les devs travaillent avec les crons.

L'objectif du POC et donc de la PR est de : 
- vérifier la faisabilité avec l'équipe ops (format du fichier, génération pendant le process de déploiement)
- discuter de ce que ça donne dans le code (positionnement des différentes briques) 

## Implémentation

- création d'un nouveau dossier infrastructure (infratest pour l'instant, infrastructure était pris par du code legacy)
- création d'un decorateur "cron" qui applique les décorateurs existants (un peu bonus) et permet de configurer ce qui se retrouve dans le yaml (surtout ce que veulent configurer les devs eux même)
- utilisation pour quelques crons

## Informations supplémentaires

Commandes à lancer `python src/pcapi/infratest/exports/for_helm.py`
Résultat : 
```
- backoffLimit: null
  command: update_booking_used
  profile: low
  schedule: 0 1 * * *
- backoffLimit: null
  command: synchronize_allocine_stocks
  profile: low
  schedule: 0 * * * *
- backoffLimit: null
  command: synchronize_provider_api
  profile: low
  schedule: 0 3 * * *
```

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
