### PR TITLE
(PC-15366)[API] fix: Correctly order booking for pricing (again)

### DIFF
--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -47,7 +47,9 @@ class PricingFactory(BaseFactory):
     status = models.PricingStatus.VALIDATED
     booking = factory.SubFactory(bookings_factories.UsedIndividualBookingFactory)
     businessUnit = factory.SelfAttribute("booking.venue.businessUnit")
-    siret = factory.SelfAttribute("booking.venue.siret")
+    siret = factory.LazyAttribute(
+        lambda pricing: pricing.booking.venue.siret or pricing.booking.venue.businessUnit.siret
+    )
     valueDate = factory.SelfAttribute("booking.dateUsed")
     amount = LazyAttribute(lambda pricing: -int(100 * pricing.booking.total_amount))
     standardRule = "Remboursement total pour les offres physiques"

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -180,20 +180,25 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
     return venue
 
 
-def set_business_unit_to_venue_id(business_unit_id: int, venue_id: int) -> None:
-    now = datetime.utcnow()
+def set_business_unit_to_venue_id(
+    business_unit_id: int,
+    venue_id: int,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    if not timestamp:
+        timestamp = datetime.utcnow()
     current_link = finance_models.BusinessUnitVenueLink.query.filter(
         finance_models.BusinessUnitVenueLink.venueId == venue_id,
-        finance_models.BusinessUnitVenueLink.timespan.contains(now),
+        finance_models.BusinessUnitVenueLink.timespan.contains(timestamp),
     ).one_or_none()
     if current_link:
         current_link.timespan = current_link._make_timespan(
             current_link.timespan.lower,
-            now,
+            timestamp,
         )
         db.session.add(current_link)
     new_link = finance_models.BusinessUnitVenueLink(
-        businessUnitId=business_unit_id, venueId=venue_id, timespan=(now, None)
+        businessUnitId=business_unit_id, venueId=venue_id, timespan=(timestamp, None)
     )
     db.session.add(new_link)
     Venue.query.filter(Venue.id == venue_id).update({"businessUnitId": business_unit_id})


### PR DESCRIPTION
The previous change made us order on the business unit-link date first.
This was wrong for the following (rather obvious) case:

1. Venue V1 is linked to business unit BU on 01/01.
2. Venue V2 is then linked to the same BU on 05/01.
3. Booking B2 (on venue V2) is used on 10/01 and is priced.
4. Booking B1 (on venue V2) is used on 15/01.

The previous implementation would declare that bookings of V1 should
be booked before bookings of V2 (because it was linked to its BU
first). That made no sense. The first "component" of the order should
rather be `max(venue_link_date, used_date)` (in fact, something a
little more complex but that's the idea).

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15366