### PR TITLE
[PC-14745][PRO] - Add reimbursment details by venue

### DIFF
--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -163,6 +163,9 @@
             background: #F1F1F4;
             font-weight: bold;
         }
+        .minimizedHead {
+            font-weight: 500;
+        }
     </style>
 
     <meta name="description" content="Etat justifiant du montant du remboursement">
@@ -282,5 +285,30 @@
     </tr>
     </tbody>
 </table>
+<h3>Montant des remboursements par lieu et détail de la part individuelle et collective</h3>
+<table class="reimbursmentByVenueTable">
+    <thead>
+        <tr>
+            <th>Lieux</th>
+            <th>Montant des réservations validées (TTC)</th>
+            <th>Montant de la contribution offreur (TTC)</th>
+            <th class="coloredSection">Montant remboursé (TTC)</th>
+            <th class="minimizedCell">Dont offres individuelles (TTC)</th>
+            <th class="minimizedCell">Dont offres collectives (TTC)</th>
+        </tr>
+    </thead>
+    <tbody>
+{% for venue in reimbursements_by_venue %}
+        <tr>
+            <td>{{ venue.venue_name }}</td>
+            <td>{{ venue.validated_booking_amount }} €</td>
+            <td>{{ venue.validated_booking_amount - venue.reimbursed_amount }} €</td>
+            <td class="coloredSection">{{ venue.reimbursed_amount }} €</td>
+            <td>{{ venue.individual_amount }} €</td>
+            <td>{{ venue.reimbursed_amount - venue.individual_amount }} €</td>
+        </tr>
+{% endfor %}
+    </tbody>
+  </table>
 </body>
 </html>

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -155,6 +155,10 @@
             font-weight: 800;
         }
 
+        .coloredTitle {
+            color: #870087;
+        }
+
         .coloredSection {
             background: #F1F1F4;
             font-weight: bold;
@@ -191,6 +195,9 @@
 {% endif %}
     <p><b>SIRET :</b> {{ invoice.businessUnit.siret }}</p>
 </div>
+<h3 class="coloredTitle">
+    Remboursement des réservations validées entre le {{ period_start.strftime("%d/%m/%y") }} et le {{ period_end.strftime("%d/%m/%y") }}, sauf cas exceptionnels
+</h3>
 <h3>
     Détail des offres remboursées incluant la contribution offreur,
     appliquée selon le barème défini dans nos conditions générales de vente

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1971,6 +1971,16 @@ class PrepareInvoiceContextTest:
         assert context["total_contribution_amount"] == 6626
         assert context["total_reimbursed_amount"] == -2015604
 
+    def test_get_invoice_period_second_half(self):
+        start_period, end_period = api.get_invoice_period(datetime.datetime(2020, 3, 4))
+        assert start_period == datetime.datetime(2020, 2, 16)
+        assert end_period == datetime.datetime(2020, 2, 29)
+
+    def test_get_invoice_period_first_half(self):
+        start_period, end_period = api.get_invoice_period(datetime.datetime(2020, 3, 27))
+        assert start_period == datetime.datetime(2020, 3, 1)
+        assert end_period == datetime.datetime(2020, 3, 15)
+
 
 class GenerateInvoiceHtmlTest:
     TEST_FILES_PATH = pathlib.Path(tests.__path__[0]) / "files"
@@ -2019,6 +2029,11 @@ class GenerateInvoiceHtmlTest:
         expected_invoice_html = expected_invoice_html.replace(
             'content: "Relevé n°F220000001 du 30/01/2022";',
             f'content: "Relevé n°F220000001 du {invoice.date.strftime("%d/%m/%Y")}";',
+        )
+        start_period, end_period = api.get_invoice_period(invoice.date)
+        expected_invoice_html = expected_invoice_html.replace(
+            "Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels",
+            f'Remboursement des réservations validées entre le {start_period.strftime("%d/%m/%y")} et le {end_period.strftime("%d/%m/%y")}, sauf cas exceptionnels',
         )
         assert expected_invoice_html == invoice_html
 

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -163,6 +163,9 @@
             background: #F1F1F4;
             font-weight: bold;
         }
+        .minimizedHead {
+            font-weight: 500;
+        }
     </style>
 
     <meta name="description" content="Etat justifiant du montant du remboursement">
@@ -222,10 +225,10 @@
     <tr>
         <td class="headRow">Montant remboursé</td>
         <td>100 %</td>
-        <td>19 980,00 €</td>
+        <td>25 230,00 €</td>
         <td>0 %</td>
         <td>0,00 €</td>
-        <td>19 980,00 €</td>
+        <td>25 230,00 €</td>
     </tr>
 
     <tr>
@@ -240,10 +243,10 @@
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>20 061,30 €</td>
+        <td>25 311,30 €</td>
         <td></td>
         <td>4,06 €</td>
-        <td>20 057,24 €</td>
+        <td>25 307,24 €</td>
     </tr>
 
     <tr class="coloredSection">
@@ -333,10 +336,10 @@
     <tr class="bottomTableText">
         <td class="headRow">TOTAL</td>
         <td></td>
-        <td>20 222,30 €</td>
+        <td>25 472,30 €</td>
         <td></td>
         <td>66,26 €</td>
-        <td>20 156,04 €</td>
+        <td>25 406,04 €</td>
     </tr>
     </tbody>
 </table>
@@ -365,7 +368,7 @@
         <td>Virement FR2710010000000000000000064</td>
         <td class="cashflow_batch_label">1</td>
         <td class="cashflow_creation_date">21/12/2021</td>
-        <td>20 000,00 €</td>
+        <td>25 250,00 €</td>
         <td>SARL LIBRAIRIE BOOKING</td>
     </tr>
 
@@ -379,9 +382,34 @@
 
     <tr class="coloredSection bottomTableText">
         <td class="headRow" colspan="3">TOTAL RÈGLEMENT PASS CULTURE</td>
-        <td>20 156,04 €</td>
+        <td>25 406,04 €</td>
     </tr>
     </tbody>
 </table>
+<h3>Montant des remboursements par lieu et détail de la part individuelle et collective</h3>
+<table class="reimbursmentByVenueTable">
+    <thead>
+        <tr>
+            <th>Lieux</th>
+            <th>Montant des réservations validées (TTC)</th>
+            <th>Montant de la contribution offreur (TTC)</th>
+            <th class="coloredSection">Montant remboursé (TTC)</th>
+            <th class="minimizedCell">Dont offres individuelles (TTC)</th>
+            <th class="minimizedCell">Dont offres collectives (TTC)</th>
+        </tr>
+    </thead>
+    <tbody>
+
+        <tr>
+            <td>Coiffeur justificaTIF</td>
+            <td>25472.30 €</td>
+            <td>66.26 €</td>
+            <td class="coloredSection">25406.04 €</td>
+            <td>20156.04 €</td>
+            <td>5250.00 €</td>
+        </tr>
+
+    </tbody>
+  </table>
 </body>
 </html>

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -155,6 +155,10 @@
             font-weight: 800;
         }
 
+        .coloredTitle {
+            color: #870087;
+        }
+
         .coloredSection {
             background: #F1F1F4;
             font-weight: bold;
@@ -191,6 +195,9 @@
 
     <p><b>SIRET :</b> 85331845900023</p>
 </div>
+<h3 class="coloredTitle">
+    Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels
+</h3>
 <h3>
     Détail des offres remboursées incluant la contribution offreur,
     appliquée selon le barème défini dans nos conditions générales de vente


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14745

## But de la pull request

Ajout d'un tableau dans le justificatif de remboursement avec un detail des remboursement par lieu.

[01062022-F220000245-Justificatif-de-remboursement-pass-Culture.pdf](https://github.com/pass-culture/pass-culture-main/files/8821735/01062022-F220000245-Justificatif-de-remboursement-pass-Culture.pdf)

## Implémentation

- _Exemples: Ajouts de modèles, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
