### PR TITLE
(PC-15062)[API] feat: stop synchronise xxx named offers

### DIFF
--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -15,6 +15,7 @@ from pcapi.local_providers.local_provider import LocalProvider
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models.product import BookFormat
 from pcapi.models.product import Product
+from pcapi.models.product import UNRELEASED_OR_UNAVAILABLE_BOOK_MARKER
 from pcapi.repository import local_provider_event_queries
 from pcapi.repository import product_queries
 from pcapi.repository.product_queries import ProductWithBookingsException
@@ -29,7 +30,6 @@ THINGS_FOLDER_NAME_TITELIVE = "livre3_11"
 NUMBER_OF_ELEMENTS_PER_LINE = 46  # (45 elements from line + \n)
 PAPER_PRESS_TVA = "2,10"
 PAPER_PRESS_SUPPORT_CODE = "R"
-UNRELEASED_BOOK_MARKER = "xxx"
 SCHOOL_RELATED_CSR_CODE = [
     "2700",
     "2701",
@@ -346,4 +346,4 @@ def get_extra_data_from_infos(infos: dict) -> dict:
 def is_unreleased_book(product_info: dict) -> bool:
     title = product_info.get("titre", "").lower()
     authors = product_info.get("auteurs", "").lower()
-    return title == authors == UNRELEASED_BOOK_MARKER
+    return title == authors == UNRELEASED_OR_UNAVAILABLE_BOOK_MARKER

--- a/api/src/pcapi/models/product.py
+++ b/api/src/pcapi/models/product.py
@@ -32,6 +32,9 @@ class BookFormat(enum.Enum):
     MOYEN_FORMAT = "MOYEN FORMAT"
 
 
+UNRELEASED_OR_UNAVAILABLE_BOOK_MARKER = "xxx"
+
+
 class Product(PcObject, Model, ExtraDataMixin, HasThumbMixin, ProvidableMixin):  # type: ignore [valid-type, misc]
 
     name = Column(String(140), nullable=False)
@@ -72,17 +75,21 @@ class Product(PcObject, Model, ExtraDataMixin, HasThumbMixin, ProvidableMixin): 
         return subcategories.ALL_SUBCATEGORIES_DICT[self.subcategoryId]
 
     @property
-    def isDigital(self):  # type: ignore [no-untyped-def]
+    def isDigital(self) -> bool:
         return self.url is not None and self.url != ""
 
     @property
-    def is_offline_only(self):  # type: ignore [no-untyped-def]
+    def is_offline_only(self) -> bool:
         return self.subcategory.online_offline_platform == subcategories.OnlineOfflinePlatformChoices.OFFLINE.value
 
     @property
-    def is_online_only(self):  # type: ignore [no-untyped-def]
+    def is_online_only(self) -> bool:
         return self.subcategory.online_offline_platform == subcategories.OnlineOfflinePlatformChoices.ONLINE.value
 
     @hybrid_property
-    def can_be_synchronized(self):  # type: ignore [no-untyped-def]
-        return self.isGcuCompatible & self.isSynchronizationCompatible
+    def can_be_synchronized(self) -> bool:
+        return (
+            self.isGcuCompatible
+            & self.isSynchronizationCompatible
+            & (self.name != UNRELEASED_OR_UNAVAILABLE_BOOK_MARKER)
+        )

--- a/api/src/pcapi/repository/product_queries.py
+++ b/api/src/pcapi/repository/product_queries.py
@@ -17,7 +17,7 @@ class ProductWithBookingsException(Exception):
     pass
 
 
-def delete_unwanted_existing_product(isbn: str):  # type: ignore [no-untyped-def]
+def delete_unwanted_existing_product(isbn: str) -> None:
     product_has_at_least_one_booking = (
         Product.query.filter_by(idAtProviders=isbn).join(Offer).join(Stock).join(Booking).count() > 0
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15062

## But de la pull request

Ne pas synchroniser les offres quand le produit correspondant a un nom en "xxx" (le libre est pas encore disponible ou ne l'est plus).

## Implémentation

- Lors de la synchro, on exclu les produits dont le nom est xxx, du coup les offres correspondantes sont rejetées

## Informations supplémentaires

- Un peu de BSR en typant les fonctions de Product

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
