### PR TITLE
(PC-15298)[PRO] fix: siren bug in some weird cases

### DIFF
--- a/pro/src/ui-kit/form/SirenInput/SirenInput.tsx
+++ b/pro/src/ui-kit/form/SirenInput/SirenInput.tsx
@@ -4,13 +4,14 @@ import TextInput from '../TextInput'
 import { humanizeSiren } from 'core/Offerers/utils'
 import { useField } from 'formik'
 
-const formatSiren = (value: string) => {
-  // remove character when when it's not a number
+const formatSiren = (siren: string) => {
+  const lastChar = siren.charAt(siren.length - 1)
+  // remove character when it's not a number
   // this way we're sure that this field only accept number
-  if (value && isNaN(Number(value))) {
-    return value.slice(0, -1)
+  if (lastChar && isNaN(Number(lastChar))) {
+    return siren.slice(0, -1)
   }
-  return humanizeSiren(value)
+  return humanizeSiren(siren)
 }
 
 interface ISirenInputProps {
@@ -29,12 +30,11 @@ const SirenInput = ({
   const [field, meta, helpers] = useField({ name })
   const { setValue } = helpers
   useEffect(() => {
-    if (!meta.touched) return
-    if (!meta.error) {
-      setValue(formatSiren(field.value))
+    setValue(formatSiren(field.value))
+    if (!meta.error && meta.touched) {
       onValidSiren(field.value)
     }
-  }, [meta.touched, meta.error])
+  }, [meta.touched, meta.error, field.value])
 
   return (
     <TextInput


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15298

## But de la pull request

Pour reproduire le bug : 
Remplir le champ siren avec 123456789. Blur le champ
Blur n'importe quel autre champ, la dernière entrée du champ siren devrait se vider. 
La regex retire tous caractères n'étant pas un chiffre ou un espace.

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
