### PR TITLE
(PC-14225)[PRO] fix: OfferV3 categories sub-types select display

### DIFF
--- a/pro/src/new_components/OfferIndividualForm/Categories/MusicTypes/MusicTypes.tsx
+++ b/pro/src/new_components/OfferIndividualForm/Categories/MusicTypes/MusicTypes.tsx
@@ -63,7 +63,7 @@ const MusicTypes = (): JSX.Element => {
         />
       </FormLayout.Row>
 
-      {musicType && (
+      {musicTypesOptions.musicSubType.length > 0 && (
         <FormLayout.Row smSpaceAfter={true}>
           <Select
             label="Choisir un sous-genre"

--- a/pro/src/new_components/OfferIndividualForm/Categories/ShowTypes/ShowTypes.tsx
+++ b/pro/src/new_components/OfferIndividualForm/Categories/ShowTypes/ShowTypes.tsx
@@ -28,12 +28,12 @@ const ShowTypes = (): JSX.Element => {
     setFieldValue('showSubType', FORM_DEFAULT_VALUES.showSubType)
     let newShowSubTypeOptions: SelectOptions = []
     if (showType !== FORM_DEFAULT_VALUES.showType) {
-      const selectedMusicTypeChildren = showOptionsTree.find(
-        musicTypeOption => musicTypeOption.code === parseInt(showType)
+      const selectedShowTypeChildren = showOptionsTree.find(
+        showTypeOption => showTypeOption.code === parseInt(showType)
       )?.children
 
-      if (selectedMusicTypeChildren) {
-        newShowSubTypeOptions = selectedMusicTypeChildren.map(data => ({
+      if (selectedShowTypeChildren) {
+        newShowSubTypeOptions = selectedShowTypeChildren.map(data => ({
           value: data.code.toString(),
           label: data.label,
         }))
@@ -43,7 +43,7 @@ const ShowTypes = (): JSX.Element => {
     setShowTypesOptions(prevOptions => {
       return {
         ...prevOptions,
-        musicSubType: newShowSubTypeOptions,
+        showSubType: newShowSubTypeOptions,
       }
     })
   }, [showType])
@@ -59,7 +59,7 @@ const ShowTypes = (): JSX.Element => {
           value: FORM_DEFAULT_VALUES.showType,
         }}
       />
-      {showType && (
+      {showTypesOptions.showSubType.length > 0 && (
         <Select
           label="Choisir un sous type"
           name="showSubType"

--- a/pro/src/new_components/OfferIndividualForm/Categories/validationSchema.ts
+++ b/pro/src/new_components/OfferIndividualForm/Categories/validationSchema.ts
@@ -24,7 +24,7 @@ const validationSchema = {
   }),
   showType: yup.string().when('subCategoryFields', {
     is: (subCategoryFields: string[]) => subCategoryFields.includes('showType'),
-    then: yup.string().required('Veuillez séléctionner un type de spéctacle'),
+    then: yup.string().required('Veuillez séléctionner un type de spectacle'),
     otherwise: yup.string(),
   }),
   showSubType: yup.string().when(['subCategoryFields', 'showType'], {
@@ -33,7 +33,7 @@ const validationSchema = {
       showType !== CATEGORIES_DEFAULT_VALUES.showType,
     then: yup
       .string()
-      .required('Veuillez séléctionner un sous-type de spéctacle'),
+      .required('Veuillez séléctionner un sous-type de spectacle'),
     otherwise: yup.string(),
   }),
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14225

Retour po lors de la review : 
* Il me manque les sous-types pour la catégorie spectacle vivant 
*  enlever l’accent à "spéctacle" du message d’erreur
* si je choisie une offre numérique, un lieu numérique n’est pas créé s’il n’existe pas 

Pour le 3em points, nous n'avons jamais créer de lieu numérique à ce moment.
Une structure à et doit toujours avoir un lieu numérique, celui ci est créer lors de la création de la structure dans le parcours utilisateur classique.
Nous devons avoir en testing des cas de structure (peut etre créer via la sandbox) sans lieu numérique, ce qui n'est pas normal.