### PR TITLE
(BSR)[API] ci: Fix Python dependency cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 parameters:
   venv_cache_key:
     type: string
-    default: 'deps1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "api/requirements.txt" }}'
+    default: 'python-deps-v1-{{ checksum "/home/circleci/.pyenv/version" }}-{{ checksum "api/requirements.txt" }}'
   pro_cache_key:
     type: string
     default: 'node_modules-14.18-{{ checksum "pro/yarn.lock" }}'


### PR DESCRIPTION
We used to required pylint (without pinning any version) and that
installed pylint 2.13.9 when it was the latest version. The dependency
cache hence had this version. A new 2.14 version has been released and
is now picked up. But the cache key was still the same, so CircleCI
jobs installed the old 2.13.9 version instead.

We hence need to invalidate this cache. But that's not possible, we
must use a new cache key. Hence the version infix ("v1"). And the use
of a clearer prefix while we're at it.