### PR TITLE
[PC-13949] Use helmfile sync instead of apply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -876,7 +876,7 @@ jobs:
           command: |
             PASSCULTURE_PASSWORD=${GCP_INFRA_KEY} \
             PCAPI_VALUES_FILE=~/pass-culture-deployment/helm/pcapi/values.<<parameters.helm_environment>>.yaml \
-            helmfile -e <<parameters.helm_environment>> apply --set image.tag=<<parameters.app_version>>
+            helmfile -e <<parameters.helm_environment>> sync --set image.tag=<<parameters.app_version>>
       - run:
           name: Send failure notification
           command: |


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13949

## But de la pull request

On utilisait `helmfile apply` au lieu de `helmfile sync` pour déployer, or la commande `apply` fait un diff pour savoir s'il y a des changements et ne fait rien s'il n'y en a pas. Cela pose problème lorsqu'un déploiement a échoué et que l'on souhaite le relancer.