### PR TITLE
(PC-15576)[API] Bug: fix allocine provider missing for venue without siret

### DIFF
--- a/api/src/pcapi/core/providers/exceptions.py
+++ b/api/src/pcapi/core/providers/exceptions.py
@@ -18,6 +18,14 @@ class NoAllocineTheater(VenueProviderException):
     pass
 
 
+class NoAllocinePivot(VenueProviderException):
+    pass
+
+
+class UnknownVenueToAlloCine(VenueProviderException):
+    pass
+
+
 class NoCinemaProviderPivot(VenueProviderException):
     pass
 

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -102,9 +102,12 @@ def get_cds_cinema_api_token(cinema_id: str) -> Optional[str]:
     return None
 
 
+# Each venue is known to allocine by its siret (AllocineTheater) or by its id (AllocinePivot).
+# This class is used to handle this logic when a venue wants to sync with Allocine.
 @dataclass
 class AllocineVenue:
     def __init__(self, venue: Venue):
+        self.venue = venue
         self.allocine_pivot = get_allocine_pivot(venue)
         if not self.has_pivot():
             self.allocine_theater = get_allocine_theater(venue)
@@ -127,6 +130,8 @@ class AllocineVenue:
         return cast(AllocinePivot, self.allocine_pivot)
 
     def get_theater(self) -> AllocineTheater:
+        if self.has_pivot():
+            self.allocine_theater = get_allocine_theater(self.venue)
         if not self.has_theater():
             raise providers_exceptions.NoAllocineTheater
         return cast(AllocineTheater, self.allocine_theater)

--- a/api/src/pcapi/local_providers/CONTRIBUTING.md
+++ b/api/src/pcapi/local_providers/CONTRIBUTING.md
@@ -14,7 +14,7 @@ C'est un iterator, appelle le __next__ dans local_provider.py
 Providable n'est pas utilse lorsqu'on a récupéré toujours les informations d'un objet:
 méta données 
 - id
-- date de mofification
+- date de modification
 - type
 
 Est-ce que je connais cet objet ? Est-ce que j'ai besoin de le mettre à jour

--- a/api/src/pcapi/routes/pro/venue_providers.py
+++ b/api/src/pcapi/routes/pro/venue_providers.py
@@ -76,7 +76,7 @@ def create_venue_provider(body: PostVenueProviderBody) -> VenueProviderResponse:
         raise ApiErrors(
             {"provider": ["Le fournisseur choisi n'est pas correctement implémenté, veuillez contacter le support."]}
         )
-    except exceptions.NoAllocineTheater:
+    except exceptions.UnknownVenueToAlloCine:
         raise ApiErrors(
             {
                 "allocine": [

--- a/api/tests/models/allocine_theater_queries_test.py
+++ b/api/tests/models/allocine_theater_queries_test.py
@@ -1,56 +1,69 @@
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
-from pcapi.core.providers.factories import AllocineTheaterFactory
+from pcapi.core.providers.exceptions import UnknownVenueToAlloCine
+import pcapi.core.providers.factories as providers_factories
+from pcapi.core.providers.repository import AllocineVenue
 from pcapi.core.providers.repository import get_allocine_theater
-from pcapi.core.providers.repository import is_venue_known_by_allocine
 
 
 class IsVenueKnownByAllocineTest:
     @pytest.mark.usefixtures("db_session")
-    def test_should_return_false(self, app):
+    def test_should_throw(self, app):
         # Given
         venue = offerers_factories.VenueFactory(id=1234)
-        AllocineTheaterFactory()
+        providers_factories.AllocineTheaterFactory()
+        providers_factories.AllocinePivotFactory()
 
-        # When
-        has_allocine_theater = is_venue_known_by_allocine(venue)
-
-        # Then
-        assert not has_allocine_theater
+        # When / Then
+        with pytest.raises(UnknownVenueToAlloCine):
+            AllocineVenue(venue)
 
     @pytest.mark.usefixtures("db_session")
-    def test_should_return_true(self, app):
+    def test_should_return_theater_when_allocine_theater_is_present(self, app):
         # Given
         venue_id = 1234
         venue = offerers_factories.VenueFactory(id=venue_id)
-        AllocineTheaterFactory(siret=venue.siret)
+        allocine_theater = providers_factories.AllocineTheaterFactory(siret=venue.siret)
 
         # When
-        has_allocine_theater = is_venue_known_by_allocine(venue)
+        allocine_venue = AllocineVenue(venue)
 
         # Then
-        assert has_allocine_theater
+        assert allocine_venue.get_theater() == allocine_theater
+
+    @pytest.mark.usefixtures("db_session")
+    def test_should_return_true_when_allocine_pivot_is_present(self, app):
+        # Given
+        venue_id = 1234
+        venue = offerers_factories.VenueFactory(id=venue_id)
+        allocine_pivot = providers_factories.AllocinePivotFactory(venue=venue)
+
+        # When
+        allocine_venue = AllocineVenue(venue)
+
+        # Then
+        assert allocine_venue.get_pivot() == allocine_pivot
 
 
 class GetAllocineTheaterTest:
     @pytest.mark.usefixtures("db_session")
-    def test_should_not_return_value_when_not_matching_in_allocine_theater(self, app):
+    def test_should_return_none_when_not_matching_in_allocine_theater(self, app):
         # Given
         venue = offerers_factories.VenueFactory()
-        AllocineTheaterFactory()
+        providers_factories.AllocineTheaterFactory()
 
         # When
-        allocine_theater = get_allocine_theater(venue)
+        actual = get_allocine_theater(venue)
 
         # Then
-        assert not allocine_theater
+        assert actual is None
 
     @pytest.mark.usefixtures("db_session")
     def test_should_return_allocine_theater_when_venue_is_present_in_allocine_theater(self, app):
         # Given
         venue = offerers_factories.VenueFactory()
-        allocine_theater = AllocineTheaterFactory(siret=venue.siret)
+        allocine_theater = providers_factories.AllocineTheaterFactory(siret=venue.siret)
 
         # When
         allocine_theater_from_db = get_allocine_theater(venue)

--- a/api/tests/use_cases/connect_allocine_to_venue_test.py
+++ b/api/tests/use_cases/connect_allocine_to_venue_test.py
@@ -3,13 +3,14 @@ from decimal import Decimal
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.providers.exceptions import UnknownVenueToAlloCine
 import pcapi.core.providers.factories as providers_factories
 import pcapi.core.providers.models as providers_models
 from pcapi.use_cases.connect_venue_to_allocine import connect_venue_to_allocine
 
 
 @pytest.mark.usefixtures("db_session")
-def test_connect_venue_to_allocine_provider():
+def test_connect_venue_with_siret_to_allocine_provider():
     # Given
     venue = offerers_factories.VenueFactory()
     allocine_provider = providers_factories.AllocineProviderFactory()
@@ -42,3 +43,54 @@ def test_connect_venue_to_allocine_provider():
     assert allocine_venue_provider.venueIdAtOfferProvider == "123VHJ=="
     assert venue_provider_price_rule.price == Decimal("9.99")
     assert allocine_pivot.venueId == venue.id
+
+
+@pytest.mark.usefixtures("db_session")
+def test_connect_venue_without_siret_to_allocine_provider():
+    # Given
+    venue = offerers_factories.VenueFactory()
+    allocine_provider = providers_factories.AllocineProviderFactory()
+    allocine_pivot = providers_factories.AllocinePivotFactory(venue=venue)
+
+    # When
+    connect_venue_to_allocine(
+        venue,
+        allocine_provider.id,
+        providers_models.VenueProviderCreationPayload(
+            price="9.99",
+            isDuo=True,
+            quantity=50,
+        ),
+    )
+
+    # Then
+    allocine_venue_provider = providers_models.AllocineVenueProvider.query.one()
+    venue_provider_price_rule = providers_models.AllocineVenueProviderPriceRule.query.one()
+
+    assert allocine_venue_provider.venue == venue
+    assert allocine_venue_provider.isDuo
+    assert allocine_venue_provider.quantity == 50
+    assert allocine_venue_provider.internalId == allocine_pivot.internalId
+    assert allocine_venue_provider.venueIdAtOfferProvider == allocine_pivot.theaterId
+    assert venue_provider_price_rule.price == Decimal("9.99")
+
+
+@pytest.mark.usefixtures("db_session")
+def test_should_throw_when_venue_is_unknown_by_allocine():
+    # Given
+    venue = offerers_factories.VenueFactory()
+    allocine_provider = providers_factories.AllocineProviderFactory()
+    providers_factories.AllocineTheaterFactory()
+    providers_factories.AllocinePivotFactory()
+
+    # When / Then
+    with pytest.raises(UnknownVenueToAlloCine):
+        connect_venue_to_allocine(
+            venue,
+            allocine_provider.id,
+            providers_models.VenueProviderCreationPayload(
+                price="9.99",
+                isDuo=True,
+                quantity=50,
+            ),
+        )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15576

## But de la pull request

Faire apparaitre le provider AlloCine pour le lieux sans siret lors du choix de synchronisation.

## Implémentation

- Refactor avec une nouvelle classe AlloCineVenue qui porte la logique de savoir si un lieu est connu d'AlloCine.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
