### PR TITLE
(BSR)[PRO] refactor: smaller space after FormLayout.Row

### DIFF
--- a/pro/src/new_components/FormLayout/FormLayout.module.scss
+++ b/pro/src/new_components/FormLayout/FormLayout.module.scss
@@ -27,7 +27,7 @@
   }
 
   &-row {
-    margin-bottom: rem.torem(16px);
+    margin-bottom: rem.torem(8px);
     max-width: 100%;
 
     &.small-space-after {


### PR DESCRIPTION
Demandé et valider avec UX: De 16px vers 8px entre chaque ligne de formulaire.

![small_space_form_layout](https://user-images.githubusercontent.com/139848/173088675-53d73eb2-690f-4ba6-87a3-62b438eb4400.png)

