### PR TITLE
(PC-15625)[API] chore: upgrade PyJWT library

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -44,7 +44,7 @@ pgcli==2.2.0
 phonenumberslite==8.12.23
 Pillow>=8.1.1
 pydantic[email]==1.9.1
-PyJWT[crypto]==2.1.0
+PyJWT[crypto]==2.4.0
 pylint
 pylint-strict-informational
 pysaml2


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15625

## But de la pull request

Le safety check montre une vulnérabilité de la librairie MyJWT.
Montée de version de la librairie en version 2.4.0

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
