### PR TITLE
(PC-15531)[API] feat: add missing informations on some endpoints

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -550,7 +550,7 @@ def get_domains_credit(user: User, user_bookings: list[bookings_models.Booking] 
             remaining=max(user.deposit.amount - sum(booking.total_amount for booking in deposit_bookings), Decimal("0"))
             if user.has_active_deposit
             else Decimal("0"),
-        )
+        ),
     )
     specific_caps = user.deposit.specific_caps
 

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -114,6 +114,7 @@ def get_beneficiary_credit(user_id: int) -> s11n.GetBeneficiaryCreditResponseMod
         remainingDigitalCredit=float(domains_credit.digital.remaining)
         if domains_credit and domains_credit.digital
         else 0.0,
+        dateCreated=getattr(user.deposit, "dateCreated", None),
     )
 
 

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -62,6 +62,9 @@ class PublicAccount(BaseModel):
     phoneNumber: typing.Optional[str]
     roles: list[users_models.UserRole]
     isActive: bool
+    address: str
+    postalCode: typing.Optional[str]
+    city: str
 
 
 class PublicAccountSearchQuery(BaseModel):
@@ -108,6 +111,7 @@ class GetBeneficiaryCreditResponseModel(BaseModel):
     initialCredit: float
     remainingCredit: float
     remainingDigitalCredit: float
+    dateCreated: typing.Optional[datetime.datetime]
 
 
 class AuthTokenQuery(BaseModel):

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -203,6 +203,8 @@ class GetPublicAccountTest:
         # then
         assert response.status_code == 200
         assert response.json == {
+            "address": user.address,
+            "city": user.city,
             "dateOfBirth": user.dateOfBirth.isoformat() if user.dateOfBirth else None,
             "email": user.email,
             "firstName": user.firstName,
@@ -210,6 +212,7 @@ class GetPublicAccountTest:
             "isActive": True,
             "lastName": user.lastName,
             "phoneNumber": user.phoneNumber,
+            "postalCode": user.postalCode,
             "roles": expected_roles,
         }
 
@@ -265,6 +268,8 @@ class UpdatePublicAccountTest:
         # then
         assert response.status_code == 200
         assert response.json == {
+            "address": user.address,
+            "city": user.city,
             "dateOfBirth": user.dateOfBirth.isoformat() if user.dateOfBirth else None,
             "email": user.email,
             "firstName": "Upda",
@@ -272,6 +277,7 @@ class UpdatePublicAccountTest:
             "isActive": True,
             "lastName": "Ted",
             "phoneNumber": user.phoneNumber,
+            "postalCode": user.postalCode,
             "roles": ["BENEFICIARY"],
         }
 
@@ -301,6 +307,8 @@ class UpdatePublicAccountTest:
         # then
         assert response.status_code == 200
         assert response.json == {
+            "address": user.address,
+            "city": user.city,
             "dateOfBirth": user.dateOfBirth.isoformat() if user.dateOfBirth else None,
             "email": "updated@example.com",
             "firstName": "Gédéon",
@@ -308,6 +316,7 @@ class UpdatePublicAccountTest:
             "isActive": True,
             "lastName": "Groidanlabénoir",
             "phoneNumber": "+33123456789",
+            "postalCode": user.postalCode,
             "roles": ["UNDERAGE_BENEFICIARY"],
         }
 
@@ -441,6 +450,7 @@ class GetBeneficiaryCreditTest:
         # then
         assert response.status_code == 200
         assert response.json == {
+            "dateCreated": grant_18.deposit.dateCreated.isoformat(),
             "initialCredit": 300.0,
             "remainingCredit": 287.5,
             "remainingDigitalCredit": 87.5,
@@ -465,6 +475,7 @@ class GetBeneficiaryCreditTest:
         for response in responses:
             assert response.status_code == 200
             assert response.json == {
+                "dateCreated": None,
                 "initialCredit": 0.0,
                 "remainingCredit": 0.0,
                 "remainingDigitalCredit": 0.0,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15531

## But de la pull request

Ajouter les informations manquantes dans 2 endpoints:

- `backoffice/public_accounts/{user_id}`: adresse, code postal et vile
- `backoffice/public_accounts/{user_id}/credit`: date de création du credit

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)~~
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
