### PR TITLE
(BSR)[API] ci: Do not add mypy cop report comment if ignore count does not change

### DIFF
--- a/.github/workflows/mypy-cop.yml
+++ b/.github/workflows/mypy-cop.yml
@@ -10,19 +10,32 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           persist-credentials: false
-      - name: check changes
+      - name: Check changes
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             src:
               - 'api/**'
-      - name: Run mypy cop 🔧
-        id: mypy-cop
+      - name: Count mypy ignore's on this branch and master
+        id: mypy-ignore-counter
         if: steps.changes.outputs.src == 'true'
         run: |
           cd api
-          body="$(./mypy_cop.sh)"
+          this_branch_ignore_count="$(grep "type: ignore" -r src | wc -l | xargs)"
+          git fetch origin master:master --quiet
+          git checkout master --quiet
+          master_ignore_count="$(grep "type: ignore" -r src | wc -l | xargs)"
+          git checkout - --quiet
+          echo "::set-output name=this_branch_ignore_count::$this_branch_ignore_count"
+          echo "::set-output name=master_ignore_count::$master_ignore_count"
+      - name: Create mypy cop report
+        id: mypy-cop
+        run: |
+          cd api
+          body="$(./mypy_cop.sh ${{ steps.mypy-ignore-counter.outputs.master_ignore_count }} ${{ steps.mypy-ignore-counter.outputs.this_branch_ignore_count }} )"
+          # Escape output, otherwise only its first line will be stored by `set-ouput` below.
+          # See https://github.community/t/set-output-truncates-multiline-strings/16852
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
@@ -36,7 +49,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Mypy cop report
       - name: Create comment
-        if: ${{ steps.changes.outputs.src == 'true' && steps.fc.outputs.comment-id == '' }}
+        if: ${{ steps.changes.outputs.src == 'true' && steps.fc.outputs.comment-id == '' && steps.mypy-ignore-counter.outputs.this_branch_ignore_count != steps.mypy-ignore-counter.outputs.master_ignore_count }}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/api/mypy_cop.sh
+++ b/api/mypy_cop.sh
@@ -1,29 +1,33 @@
 #!/bin/bash
+#
+# Display an HTML report about the evolution of mypy ignore count
+# between the master branch and the current branch.
+#
+# Usage:
+#
+#   mypy_cop.sh <master_count> <this_branch_count>
+#
 
-type_ignore_counter=$(grep "type: ignore" -r src | wc -l | xargs)
-git fetch origin master:master --quiet
-git checkout master --quiet
-master_type_ignore_counter=$(grep "type: ignore" -r src | wc -l | xargs)
-git checkout - --quiet
+master_count=$1
+this_branch_count=$2
 
 echo "<h2>🚓 Mypy cop report:</h2>"
 
-if [ $type_ignore_counter -lt $master_type_ignore_counter ]; then
+if [ ${this_branch_count} -eq ${master_count} ]
+then
+    echo "<p>Number of type ignore equal to master:</p>"
+elif [ ${this_branch_count} -lt ${master_count} ]
+then
     echo '<p>🎉 Number of type ignore inferior to master, good job !</p>'
     echo "<p>Have yourself a merry little break and learn a few facts about the year <a href='https://fr.wikipedia.org/wiki/$type_ignore_counter' target='_blank'>$type_ignore_counter</a> </p>"
-fi
-
-if [ $type_ignore_counter -gt $master_type_ignore_counter ]; then
-    diff=$(($type_ignore_counter - $master_type_ignore_counter))
+elif [ ${this_branch_count} -gt ${master_count} ]
+then
+    diff=$((${this_branch_count} - ${master_count}))
     echo '<p>😿 Number of type ignore superior to master</p>'
     echo "<p>At least $diff <i>#type:ignore</i> comments need to be resolved before merging</p>"
 fi
 
-if [ $type_ignore_counter -eq $master_type_ignore_counter ]; then
-    echo "<p>Number of type ignore equal to master:</p>"
-fi
-
 echo "<table>"
 echo "<tr><th>Master</th><th>Current branch</th></tr>"
-echo "<tr><td>$master_type_ignore_counter</td><td>$type_ignore_counter</td></tr>"
+echo "<tr><td>$master_count</td><td>$this_branch_count</td></tr>"
 echo "</table>"


### PR DESCRIPTION
Before this commit, we would get a comment about "mypy ignore count"
being stable on each pull request. This was noisy and not very useful.

Now we get a comment in a pull request only if there are more or less
ignore's than master or, if so, when a further commit makes the count
equal to what we have on master (i.e. when we got from 10 to 8
ignore's, and then back to 10, or the other way around).