### PR TITLE
(PC-15725)[API] chore: update pgcli version and unpin it

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,8 +1,3 @@
-# temporary
-# FIXME: remove pygments version restriction when no more needed
-pygments<2.11.2  # because pygments 2.11.2 breaks pgcli, see https://github.com/dbcli/pgcli/issues/1303
-# /temporary
-
 alembic==1.4.3
 algoliasearch==2.4.0
 APScheduler==3.6.3
@@ -39,7 +34,7 @@ MarkupSafe==2.0.1
 mypy==0.941
 notion-client==0.9.0
 openpyxl
-pgcli==2.2.0
+pgcli # a tool not used in code. There is no point in pinning its version
 phonenumberslite==8.12.23
 Pillow>=8.1.1
 pydantic[email]==1.9.1

--- a/api/tests/core/offers/test_exceptions.py
+++ b/api/tests/core/offers/test_exceptions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from pcapi.core.offers.exceptions import FileSizeExceeded
+
+
+class FileSizeExceededTest:
+    def test_file_size_exceeded_exception(self):
+        exp = FileSizeExceeded(300_000)
+        assert str(exp) == "Utilisez une image dont le poids est inférieur à 300.0 kB"
+
+    @pytest.mark.parametrize("data", ((1, "1 Byte"), (3, "3 Bytes"), (2_320_000, "2.3 MB"), (3_992, "4.0 kB")))
+    def test_natural_size(self, data):
+        result = FileSizeExceeded._natural_size(data[0])
+        expected = data[1]
+        assert result == expected


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15725
pgcli est un outils en ligne de commande que nous utilisons a la main. Il n'y a aucune raison de pin sa version (+ sa version était vraiment vieille)