### PR TITLE
(PC-15595) add dms_token to Venue

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-9ba6bfeeab21 (pre) (head)
+cb1d904c149d (pre) (head)
 01e4e1b7f714 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220620T174806_cb1d904c149d_add_dms_token_column_to_venue_table.py
+++ b/api/src/pcapi/alembic/versions/20220620T174806_cb1d904c149d_add_dms_token_column_to_venue_table.py
@@ -1,0 +1,19 @@
+"""add dms_token column to venue table (PRE-deploy)"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "cb1d904c149d"
+down_revision = "9ba6bfeeab21"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("venue", sa.Column("dms_token", sa.Text(), nullable=True))
+    op.create_unique_constraint(None, "venue", ["dms_token"])
+
+
+def downgrade():
+    op.drop_column("venue", "dms_token")

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -4,6 +4,7 @@ from pcapi.core.testing import BaseFactory
 import pcapi.core.users.factories as users_factories
 from pcapi.utils import crypto
 
+from . import api
 from . import models
 
 
@@ -53,6 +54,7 @@ class VenueFactory(BaseFactory):
     )
     contact = factory.RelatedFactory("pcapi.core.offerers.factories.VenueContactFactory", factory_related_name="venue")
     bookingEmail = factory.Sequence("venue{}@example.net".format)
+    dms_token = factory.LazyFunction(api.generate_dms_token)
 
     @factory.post_generation
     def venue_link(venue, create, extracted, **kwargs):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -218,6 +218,9 @@ class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixi
         "Criterion", backref=db.backref("venue_criteria", lazy="dynamic"), secondary="venue_criterion"
     )
 
+    # TODO(fseguin,2022-06-20): Make column non-nullable when column is populated on all envs
+    dms_token = Column(Text, nullable=True, unique=True)
+
     @property
     def is_eligible_for_search(self) -> bool:
         not_administrative = self.venueTypeCode != VenueTypeCode.ADMINISTRATIVE  # type: ignore [attr-defined]

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -347,3 +347,7 @@ def offerer_has_venue_with_adage_id(offerer_id: int) -> bool:
         models.Offerer.id == offerer_id,
     )
     return bool(query.count())
+
+
+def dms_token_exists(dms_token: str) -> bool:
+    return db.session.query(models.Venue.query.filter_by(dms_token=dms_token).exists()).scalar()

--- a/api/src/pcapi/scripts/venue/add_dms_token_to_each_venue.py
+++ b/api/src/pcapi/scripts/venue/add_dms_token_to_each_venue.py
@@ -1,0 +1,24 @@
+# FIXME(fseguin,2022-06-20): remove after it has been successfully executed on all envs
+import pcapi.core.offerers.api as offerers_api
+import pcapi.core.offerers.models as offerers_models
+from pcapi.models import db
+
+
+def add_dms_token_to_each_venue(batch_size: int = 100) -> None:
+    print(f"[add_dms_token_to_each_venue] {batch_size=} START")
+
+    batch_nr = 1
+
+    query = offerers_models.Venue.query.filter(offerers_models.Venue.dms_token.is_(None))
+    venues_to_update = query.limit(batch_size).all()
+
+    while len(venues_to_update) > 0:
+        print(f"[add_dms_token_to_each_venue] Batch {batch_nr}")
+        for venue in venues_to_update:
+            venue.dms_token = offerers_api.generate_dms_token()
+            db.session.add(venue)
+        db.session.commit()
+        batch_nr += 1
+        venues_to_update = query.limit(batch_size).all()
+
+    print("[add_dms_token_to_each_venue] END")

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -64,6 +64,7 @@ class CreateVenueTest:
         assert venue.managingOfferer == offerer
         assert venue.name == "La Venue"
         assert venue.bookingEmail == "venue@example.com"
+        assert venue.dms_token
 
     def test_with_business_unit(self):
         offerer = offerers_factories.OffererFactory()

--- a/api/tests/scripts/venue/test_add_dms_token_to_each_venue.py
+++ b/api/tests/scripts/venue/test_add_dms_token_to_each_venue.py
@@ -1,0 +1,18 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
+from pcapi.scripts.venue.add_dms_token_to_each_venue import add_dms_token_to_each_venue
+
+
+class AddDmsTokenToEachVenueTest:
+    @pytest.mark.usefixtures("db_session")
+    def test_add_dms_token_to_each_venue(self):
+        offerers_factories.VenueFactory.create_batch(size=3)
+        offerers_models.Venue.query.update({"dms_token": None}, synchronize_session=False)
+        offerers_factories.VenueFactory()
+        assert offerers_models.Venue.query.filter(offerers_models.Venue.dms_token.is_(None)).count() == 3
+
+        add_dms_token_to_each_venue(batch_size=2)
+
+        assert offerers_models.Venue.query.filter(offerers_models.Venue.dms_token.is_(None)).count() == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15595

## But de la pull request

Ajouter un identifiant unique servant à identifier les démarches DMS concernant un lieu.

## Implémentation

- Ajout de colonne
- Modification de factory
- Génération de ce `dms_token` lors d'une création de lieu
- Ajout d'un script de rattrapage

## Informations supplémentaires

12 caractères hexadécimaux soit 48 bits semblent être suffisants pour éviter les conflits. On tentera néanmoins 10 générations avant de lever une erreur.

## Modifications du schéma de la base de données

- Ajout d'une colonne de type `TEXT` `dms_token` à la table `venue`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
