### PR TITLE
(PC-15229)[API] feat: rename eligible for strict search

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -478,12 +478,7 @@ def get_offerer_by_collective_offer_template_id(collective_offer_id: int) -> Off
     return get_by_collective_offer_template_id(collective_offer_id)
 
 
-def is_venue_eligible_for_strict_search(venue: offerers_models.Venue) -> bool:
-    """
-    A venue is considered eligible for strict search if
-      1. it is eligible for search and validated/active;
-      2. at least one if its offers is eligible for search
-    """
+def has_venue_at_least_one_bookable_offer(venue: offerers_models.Venue) -> bool:
     if not FeatureToggle.ENABLE_VENUE_STRICT_SEARCH.is_active():
         return True
 

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -443,6 +443,8 @@ class AlgoliaBackend(base.SearchBackend):
     @classmethod
     def serialize_venue(cls, venue: offerers_models.Venue) -> dict:
         social_medias = getattr(venue.contact, "social_medias", {})
+        has_at_least_one_bookable_offer = offerers_api.has_venue_at_least_one_bookable_offer(venue)
+
         return {
             "objectID": venue.id,
             "city": venue.city,
@@ -464,7 +466,9 @@ class AlgoliaBackend(base.SearchBackend):
             "tags": [criterion.name for criterion in venue.criteria],
             "banner_url": venue.bannerUrl,
             "_geoloc": position(venue),
-            "is_eligible_for_strict_search": offerers_api.is_venue_eligible_for_strict_search(venue),
+            # TODO: remove "is_eligible_for_strict_search" key when the app does not use it anymore
+            "is_eligible_for_strict_search": has_at_least_one_bookable_offer,
+            "has_at_least_one_bookable_offer": has_at_least_one_bookable_offer,
         }
 
     @classmethod

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -738,39 +738,39 @@ def test_delete_business_unit():
     assert other_link.timespan.upper is None  # unchanged
 
 
-class IsVenueEligibleForStrictSearchTest:
+class HasVenueAtLeastOneBookableOfferTest:
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_eligible(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
         offers_factories.EventStockFactory(offer__venue=venue)
 
-        assert offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert offerers_api.has_venue_at_least_one_bookable_offer(venue)
 
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_venue_not_validated(self):
         venue = offerers_factories.VenueFactory(isPermanent=True, validationToken="not_validated_yet")
         offers_factories.EventStockFactory(offer__venue=venue)
 
-        assert not offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert not offerers_api.has_venue_at_least_one_bookable_offer(venue)
 
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_no_offers(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
-        assert not offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert not offerers_api.has_venue_at_least_one_bookable_offer(venue)
 
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_managing_offerer_not_validated(self):
         venue = offerers_factories.VenueFactory(isPermanent=True, managingOfferer__validationToken="not_validated_yet")
         offers_factories.EventStockFactory(offer__venue=venue)
 
-        assert not offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert not offerers_api.has_venue_at_least_one_bookable_offer(venue)
 
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_offer_without_stock(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
         offers_factories.OfferFactory(venue=venue)
 
-        assert not offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert not offerers_api.has_venue_at_least_one_bookable_offer(venue)
 
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_expired_event(self):
@@ -779,7 +779,7 @@ class IsVenueEligibleForStrictSearchTest:
         one_week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
         offers_factories.EventStockFactory(beginningDatetime=one_week_ago, offer__venue=venue)
 
-        assert not offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert not offerers_api.has_venue_at_least_one_bookable_offer(venue)
 
     @override_features(ENABLE_VENUE_STRICT_SEARCH=True)
     def test_only_one_bookable_offer(self):
@@ -792,4 +792,4 @@ class IsVenueEligibleForStrictSearchTest:
         one_week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
         offers_factories.EventStockFactory(beginningDatetime=one_week_ago, offer__venue=venue)
 
-        assert offerers_api.is_venue_eligible_for_strict_search(venue)
+        assert offerers_api.has_venue_at_least_one_bookable_offer(venue)

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -164,15 +164,17 @@ def test_serialize_venue():
         "banner_url": venue.bannerUrl,
         "_geoloc": {"lng": float(venue.longitude), "lat": float(venue.latitude)},
         "is_eligible_for_strict_search": False,
+        "has_at_least_one_bookable_offer": False,
     }
 
 
-def test_serialize_eligible_for_strict_search_venue():
+def test_serialize_venue_with_one_bookable_offer():
     venue = offerers_factories.VenueFactory(isPermanent=True)
     offers_factories.EventStockFactory(offer__venue=venue)
 
     serialized = algolia.AlgoliaBackend().serialize_venue(venue)
     assert serialized["is_eligible_for_strict_search"]
+    assert serialized["has_at_least_one_bookable_offer"]
 
 
 def test_serialize_collective_offer():


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15229

## But de la pull request

Lors de l'indexation d'un lieu, on a récemment ajouté un champ nommé `is_eligible_for_strict_search`. Celui-ci était trop flou et cette PR vient donc procéder à quelques renommages : ce champ ainsi que la fonction associée.

Le FF reste tel quel parce que c'est moins important.