### PR TITLE
(BSR)[API] ci: Bump Helm chart to 0.11.9

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -16,16 +16,16 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.11.8
+      - chartVersion: 0.11.9
   staging:
     values:
-      - chartVersion: 0.11.8
+      - chartVersion: 0.11.9
   integration:
     values:
-      - chartVersion: 0.11.8
+      - chartVersion: 0.11.9
   production:
     values:
-      - chartVersion: 0.11.8
+      - chartVersion: 0.11.9
   ops:
     values:
       - chartVersion: 0.9.0


### PR DESCRIPTION
Version 0.11.9 forbids concurrent cronjobs by default. See pass-culture/pcapi-chart@e539f358ffc36fe49dc1a368748252825a5912d9.