### PR TITLE
Pc 14982 public user history

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -24,6 +24,9 @@ from pcapi.core.subscription.phone_validation import exceptions as phone_validat
 from pcapi.core.users import external as users_external
 from pcapi.core.users import repository as users_repository
 from pcapi.core.users import utils as users_utils
+from pcapi.core.users.external import update_external_pro
+from pcapi.core.users.external import update_external_user
+from pcapi.core.users.repository import find_user_by_email
 from pcapi.domain.password import random_hashed_password
 from pcapi.domain.postal_code.postal_code import PostalCode
 from pcapi.models import db

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -232,3 +232,18 @@ def skip_phone_validation(user_id: int) -> None:
         users_api.skip_phone_validation_step(user)
     except phone_validation_exceptions.UserPhoneNumberAlreadyValidated:
         raise ApiErrors({"user_id": "Le numéro de téléphone est déjà validé"})
+
+
+@blueprint.backoffice_blueprint.route("public_accounts/<int:user_id>/logs", methods=["GET"])
+@perm_utils.permission_required(perm_models.Permissions.READ_PUBLIC_ACCOUNT)
+@spectree_serialize(
+    response_model=s11n.PublicHistoryResponseModel,
+    on_success_status=200,
+    api=blueprint.api,
+)
+def get_public_history(user_id: int) -> s11n.PublicHistoryResponseModel:
+    user = get_user_or_error(user_id)
+
+    history = users_api.public_account_history(user)
+
+    return s11n.PublicHistoryResponseModel(history=[s11n.PublicHistoryItem(**item) for item in history])

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -177,3 +177,16 @@ class BeneficiaryReviewRequestModel(BaseModel):
 class BeneficiaryReviewResponseModel(BeneficiaryReviewRequestModel):
     userId: int
     authorId: int
+
+
+class PublicHistoryItem(BaseModel):
+    class config:
+        extra = pydantic.Extra.forbid
+
+    action: str
+    datetime: datetime.datetime
+    message: str
+
+
+class PublicHistoryResponseModel(BaseModel):
+    history: list[PublicHistoryItem]

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1,7 +1,4 @@
-from datetime import date
-from datetime import datetime
-from datetime import time
-from datetime import timedelta
+import datetime
 import re
 from unittest import mock
 
@@ -529,7 +526,8 @@ class GetUserHistoryTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_get_user_history_16y_no_subscription(self, client):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=16, days=5)
+            dateOfBirth=datetime.datetime.combine(datetime.date.today(), datetime.time(0, 0))
+            - relativedelta(years=16, days=5)
         )
 
         data = self._test_user_history(client, user)
@@ -560,7 +558,8 @@ class GetUserHistoryTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_get_user_history_18y_no_subscription(self, client):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=18, days=5)
+            dateOfBirth=datetime.datetime.combine(datetime.date.today(), datetime.time(0, 0))
+            - relativedelta(years=18, days=5)
         )
 
         data = self._test_user_history(client, user)
@@ -591,7 +590,8 @@ class GetUserHistoryTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_get_user_subscription_history_ubble(self, client):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=18, days=5),
+            dateOfBirth=datetime.datetime.combine(datetime.date.today(), datetime.time(0, 0))
+            - relativedelta(years=18, days=5),
             activity=users_models.ActivityEnum.STUDENT.value,
         )
         user.phoneValidationStatus = users_models.PhoneValidationStatusType.VALIDATED
@@ -659,7 +659,8 @@ class GetUserHistoryTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_get_user_subscription_history_dms(self, client):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.combine(date.today(), time(0, 0)) - relativedelta(years=15, days=5),
+            dateOfBirth=datetime.datetime.combine(datetime.date.today(), datetime.time(0, 0))
+            - relativedelta(years=15, days=5),
             activity=users_models.ActivityEnum.HIGH_SCHOOL_STUDENT.value,
         )
 
@@ -770,7 +771,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_review_ko_application(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.KO
         )
@@ -802,7 +803,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_review_dms_application(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         reviewer = users_factories.UserFactory()
         auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
@@ -830,7 +831,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_review_educonnect_application(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=15, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=15, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=fraud_models.FraudCheckType.EDUCONNECT,
@@ -862,7 +863,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_review_ubble_application(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
         auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
@@ -917,7 +918,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_with_unknown_data(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
         auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
@@ -934,7 +935,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_with_missing_data(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
         auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
@@ -951,7 +952,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_without_permission(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
         auth_token = generate_token(reviewer, [])
@@ -968,7 +969,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_as_anonymous(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         auth_token = generate_token(users_factories.UserFactory.build(), [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
@@ -984,7 +985,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_when_no_age_is_found(self, client):
         # given
-        birth_date_15_yo = datetime.utcnow() - relativedelta(years=15, months=2)
+        birth_date_15_yo = datetime.datetime.utcnow() - relativedelta(years=15, months=2)
         user = users_factories.UserFactory(dateOfBirth=birth_date_15_yo)
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -1023,7 +1024,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_ok_already_beneficiary_account(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         DepositGrantFactory(user=user)
         reviewer = users_factories.UserFactory()
@@ -1041,7 +1042,7 @@ class PostManualReviewTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_review_with_non_default_eligibility(self, client):
         # given
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2))
+        user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         reviewer = users_factories.UserFactory()
         auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
@@ -1303,12 +1304,12 @@ class GetPublicAccountHistoryTest:
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=fraud_models.FraudCheckType.USER_PROFILING,
-            dateCreated=datetime.utcnow() - timedelta(minutes=50),
+            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(minutes=50),
         )
         review = fraud_factories.BeneficiaryFraudReviewFactory(
             user=user,
             author=users_factories.UserFactory(),
-            dateReviewed=datetime.utcnow() - timedelta(minutes=5),
+            dateReviewed=datetime.datetime.utcnow() - datetime.timedelta(minutes=5),
             review=fraud_models.FraudReviewStatus.OK,
         )
         auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PUBLIC_ACCOUNT])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14982

## But de la pull request

Ajouter un endpoint qui permet de récupérer l'historique des opérations réalisées sur un compte jeune/grand-public

## Implémentation

- ajout de la fonction `pcapi.core.users.api.public_account_history`
- ajout de la route `GET public_accounts/<int:user_id>/logs` dans `pcapi.routes.backoffice.accounts`

## Informations supplémentaires

- pas mal de nettoyages (surtout sur les imports)

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
