### PR TITLE
[PC-15794] fix: Invoice shows wrong booked amount when isDuo offers exists

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1631,6 +1631,7 @@ def get_reimbursements_by_venue(invoice: models.Invoice) -> typing.List[typing.D
             *common_columns,
             models.Pricing.amount.label("pricing_amount"),
             bookings_models.Booking.amount.label("booking_amount"),
+            bookings_models.Booking.quantity.label("booking_quantity"),
             bookings_models.Booking.individualBookingId,
         )
         .join(models.Pricing.booking)
@@ -1666,7 +1667,7 @@ def get_reimbursements_by_venue(invoice: models.Invoice) -> typing.List[typing.D
         individual_amount = 0
         for booking in bookings:
             reimbursed_amount += booking.pricing_amount
-            validated_booking_amount += decimal.Decimal(booking.booking_amount)
+            validated_booking_amount += decimal.Decimal(booking.booking_amount) * booking.booking_quantity
             if booking.individualBookingId:
                 individual_amount += booking.pricing_amount
         if FeatureToggle.ENABLE_NEW_COLLECTIVE_MODEL.is_active() and venue_id in collective_reimbursement_by_venue:

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1677,9 +1677,9 @@ def get_reimbursements_by_venue(invoice: models.Invoice) -> typing.List[typing.D
         reimbursements_by_venue.append(
             {
                 "venue_name": venue_name,
-                "reimbursed_amount": -finance_utils.to_euros(reimbursed_amount),
-                "validated_booking_amount": validated_booking_amount,
-                "individual_amount": -finance_utils.to_euros(individual_amount),
+                "reimbursed_amount": reimbursed_amount,
+                "validated_booking_amount": -utils.to_eurocents(validated_booking_amount),
+                "individual_amount": individual_amount,
             }
         )
     return reimbursements_by_venue

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -301,11 +301,11 @@
 {% for venue in reimbursements_by_venue %}
         <tr>
             <td>{{ venue.venue_name }}</td>
-            <td>{{ venue.validated_booking_amount }} €</td>
-            <td>{{ venue.validated_booking_amount - venue.reimbursed_amount }} €</td>
-            <td class="coloredSection">{{ venue.reimbursed_amount }} €</td>
-            <td>{{ venue.individual_amount }} €</td>
-            <td>{{ venue.reimbursed_amount - venue.individual_amount }} €</td>
+            <td>{{ venue.validated_booking_amount|fr_currency }} €</td>
+            <td>{{ (venue.validated_booking_amount - venue.reimbursed_amount)|fr_currency }} €</td>
+            <td class="coloredSection">{{ venue.reimbursed_amount|fr_currency }} €</td>
+            <td>{{ venue.individual_amount|fr_currency }} €</td>
+            <td>{{ (venue.reimbursed_amount - venue.individual_amount)|fr_currency }} €</td>
         </tr>
 {% endfor %}
     </tbody>

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1988,7 +1988,7 @@ class PrepareInvoiceContextTest:
 class GenerateInvoiceHtmlTest:
     TEST_FILES_PATH = pathlib.Path(tests.__path__[0]) / "files"
 
-    def generate_and_compare_invoice(self, stocks, business_unit):
+    def generate_and_compare_invoice(self, stocks, business_unit, venue):
         bookings = []
         user = create_rich_user()
         for stock in stocks:
@@ -2002,6 +2002,10 @@ class GenerateInvoiceHtmlTest:
         api.generate_cashflows(cutoff=datetime.datetime.utcnow())
         for booking in bookings[3:]:
             api.price_booking(booking)
+        duo_offer = offers_factories.OfferFactory(venue=venue, isDuo=True)
+        duo_stock = offers_factories.StockFactory(offer=duo_offer, price=1)
+        duo_booking = bookings_factories.UsedIndividualBookingFactory(stock=duo_stock, quantity=2)
+        api.price_booking(duo_booking)
         api.generate_cashflows(cutoff=datetime.datetime.utcnow())
         cashflows = (
             models.Cashflow.query.join(models.Cashflow.pricings)
@@ -2054,7 +2058,7 @@ class GenerateInvoiceHtmlTest:
         api.price_booking(educational_booking1)
         api.price_booking(educational_booking2)
 
-        self.generate_and_compare_invoice(stocks, business_unit)
+        self.generate_and_compare_invoice(stocks, business_unit, venue)
 
     @override_features(ENABLE_NEW_COLLECTIVE_MODEL=True)
     def test_basics_with_new_collective_model(self, invoice_data):
@@ -2072,7 +2076,7 @@ class GenerateInvoiceHtmlTest:
         api.price_booking(collective_booking)
         api.price_booking(collective_booking2)
 
-        self.generate_and_compare_invoice(stocks, business_unit)
+        self.generate_and_compare_invoice(stocks, business_unit, venue)
 
 
 class StoreInvoicePdfTest:

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -402,11 +402,11 @@
 
         <tr>
             <td>Coiffeur justificaTIF</td>
-            <td>25474.30 €</td>
-            <td>66.36 €</td>
-            <td class="coloredSection">25407.94 €</td>
-            <td>20157.94 €</td>
-            <td>5250.00 €</td>
+            <td>25 474,30 €</td>
+            <td>66,36 €</td>
+            <td class="coloredSection">25 407,94 €</td>
+            <td>20 157,94 €</td>
+            <td>5 250,00 €</td>
         </tr>
 
     </tbody>

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -234,19 +234,19 @@
     <tr>
         <td class="headRow">Montant remboursé</td>
         <td>95 %</td>
-        <td>81,30 €</td>
+        <td>83,30 €</td>
         <td>5 %</td>
-        <td>4,06 €</td>
-        <td>77,24 €</td>
+        <td>4,16 €</td>
+        <td>79,14 €</td>
     </tr>
 
     <tr style="color: dimgrey">
         <td class="headRow">SOUS-TOTAL</td>
         <td></td>
-        <td>25 311,30 €</td>
+        <td>25 313,30 €</td>
         <td></td>
-        <td>4,06 €</td>
-        <td>25 307,24 €</td>
+        <td>4,16 €</td>
+        <td>25 309,14 €</td>
     </tr>
 
     <tr class="coloredSection">
@@ -336,10 +336,10 @@
     <tr class="bottomTableText">
         <td class="headRow">TOTAL</td>
         <td></td>
-        <td>25 472,30 €</td>
+        <td>25 474,30 €</td>
         <td></td>
-        <td>66,26 €</td>
-        <td>25 406,04 €</td>
+        <td>66,36 €</td>
+        <td>25 407,94 €</td>
     </tr>
     </tbody>
 </table>
@@ -376,13 +376,13 @@
         <td>Virement FR2710010000000000000000064</td>
         <td class="cashflow_batch_label">2</td>
         <td class="cashflow_creation_date">21/12/2021</td>
-        <td>156,04 €</td>
+        <td>157,94 €</td>
         <td>SARL LIBRAIRIE BOOKING</td>
     </tr>
 
     <tr class="coloredSection bottomTableText">
         <td class="headRow" colspan="3">TOTAL RÈGLEMENT PASS CULTURE</td>
-        <td>25 406,04 €</td>
+        <td>25 407,94 €</td>
     </tr>
     </tbody>
 </table>
@@ -402,10 +402,10 @@
 
         <tr>
             <td>Coiffeur justificaTIF</td>
-            <td>25472.30 €</td>
-            <td>66.26 €</td>
-            <td class="coloredSection">25406.04 €</td>
-            <td>20156.04 €</td>
+            <td>25474.30 €</td>
+            <td>66.36 €</td>
+            <td class="coloredSection">25407.94 €</td>
+            <td>20157.94 €</td>
             <td>5250.00 €</td>
         </tr>
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15794

Les offres duo n'étaient comptées qu'une seule fois. Le design des sommes n'était pas de norme française

## But de la pull request

[Exemple de justif](https://storage.googleapis.com/passculture-metier-ehp-staging-assets/invoices/IhDFngSDUKntBEj26VCW_lRb6oEXLb94D-GtMVO91Ps/17062022-F220041150-Justificatif-de-remboursement-pass-Culture.pdf)

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai vérifié les migrations (upgrade / downgrade ; locks ; édition de `alembic_version_conflict_detection.txt`)
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
