### PR TITLE
(PC-15592)[API] feat: Prepare moving away from business units

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-cb1d904c149d (pre) (head)
+363db8d498a7 (pre) (head)
 01e4e1b7f714 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220621T111911_363db8d498a7_add_venue_links.py
+++ b/api/src/pcapi/alembic/versions/20220621T111911_363db8d498a7_add_venue_links.py
@@ -1,0 +1,82 @@
+"""Add venue_pricing_point_link, venue_reimbursement_point_link and new columns in pricing, cashflow and invoice."""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "363db8d498a7"
+down_revision = "cb1d904c149d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "venue_pricing_point_link",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("venueId", sa.BigInteger(), nullable=False),
+        sa.Column("pricingPointId", sa.BigInteger(), nullable=False),
+        sa.Column("timespan", postgresql.TSRANGE(), nullable=False),
+        postgresql.ExcludeConstraint((sa.column("venueId"), "="), (sa.column("timespan"), "&&"), using="gist"),
+        sa.ForeignKeyConstraint(
+            ["pricingPointId"],
+            ["venue.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["venueId"],
+            ["venue.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_venue_pricing_point_link_pricingPointId"), "venue_pricing_point_link", ["pricingPointId"], unique=False
+    )
+    op.create_index(op.f("ix_venue_pricing_point_link_venueId"), "venue_pricing_point_link", ["venueId"], unique=False)
+
+    op.create_table(
+        "venue_reimbursement_point_link",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("venueId", sa.BigInteger(), nullable=False),
+        sa.Column("reimbursementPointId", sa.BigInteger(), nullable=False),
+        sa.Column("timespan", postgresql.TSRANGE(), nullable=False),
+        postgresql.ExcludeConstraint((sa.column("venueId"), "="), (sa.column("timespan"), "&&"), using="gist"),
+        sa.ForeignKeyConstraint(
+            ["reimbursementPointId"],
+            ["venue.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["venueId"],
+            ["venue.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_venue_reimbursement_point_link_reimbursementPointId"),
+        "venue_reimbursement_point_link",
+        ["reimbursementPointId"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_venue_reimbursement_point_link_venueId"), "venue_reimbursement_point_link", ["venueId"], unique=False
+    )
+
+    op.add_column("pricing", sa.Column("pricingPointId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_pricing_pricingPointId"), "pricing", ["pricingPointId"], unique=False)
+    op.create_foreign_key(None, "pricing", "venue", ["pricingPointId"], ["id"])
+
+    op.add_column("cashflow", sa.Column("reimbursementPointId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_cashflow_reimbursementPointId"), "cashflow", ["reimbursementPointId"], unique=False)
+    op.create_foreign_key(None, "cashflow", "venue", ["reimbursementPointId"], ["id"])
+
+    op.add_column("invoice", sa.Column("reimbursementPointId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_invoice_reimbursementPointId"), "invoice", ["reimbursementPointId"], unique=False)
+    op.create_foreign_key(None, "invoice", "venue", ["reimbursementPointId"], ["id"])
+
+
+def downgrade():
+    op.drop_column("pricing", "pricingPointId")
+    op.drop_column("invoice", "reimbursementPointId")
+    op.drop_column("cashflow", "reimbursementPointId")
+    op.drop_table("venue_reimbursement_point_link")
+    op.drop_table("venue_pricing_point_link")

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -132,12 +132,18 @@ class Pricing(Model):  # type: ignore [valid-type, misc]
         "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
     )
 
+    # FIXME (dbaty, 2022-06-20): remove `businessUnitId` and `siret`
+    # columns once we have fully switched to `pricingPointId`
     businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=False)
     businessUnit = sqla_orm.relationship("BusinessUnit", foreign_keys=[businessUnitId])
     # `siret` is either the SIRET of the venue if it has one, or the
     # SIRET of its business unit (at the time of the creation of the
     # pricing).
     siret = sqla.Column(sqla.String(14), nullable=False, index=True)
+    # FIXME (dbaty, 2022-06-20): set non-NULLABLE once pricing code
+    # has been updated and old data has been migrated.
+    pricingPointId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=True)
+    pricingPoint = sqla_orm.relationship("Venue", foreign_keys=[pricingPointId])  # type: ignore [misc]
 
     creationDate = sqla.Column(sqla.DateTime, nullable=False, server_default=sqla.func.now())
     # `valueDate` is `Booking.dateUsed` but it's useful to denormalize
@@ -222,8 +228,8 @@ class Cashflow(Model):  # type: ignore [valid-type, misc]
     creationDate = sqla.Column(sqla.DateTime, nullable=False, server_default=sqla.func.now())
     status = sqla.Column(db_utils.MagicEnum(CashflowStatus), index=True, nullable=False)
 
-    # FIXME (dbaty, 2022-01-26): set NOT NULL constraint once the
-    # table has been populated.
+    # FIXME (dbaty, 2022-06-20): remove `businessUnitId` once we have
+    # fully switched to `reimbursementPointId`
     businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=True)
     businessUnit = sqla_orm.relationship("BusinessUnit", foreign_keys=[businessUnitId])
     # We denormalize `BusinessUnit.bankAccountId` here because it may
@@ -231,6 +237,10 @@ class Cashflow(Model):  # type: ignore [valid-type, misc]
     # the time the cashflow was created.
     bankAccountId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("bank_information.id"), index=True, nullable=False)
     bankAccount = sqla_orm.relationship("BankInformation", foreign_keys=[bankAccountId])  # type: ignore [misc]
+    # FIXME (dbaty, 2022-06-20): set non-NULLABLE once cashflow code
+    # has been updated and old data has been migrated.
+    reimbursementPointId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=True)
+    reimbursementPoint = sqla_orm.relationship("Venue", foreign_keys=[reimbursementPointId])  # type: ignore [misc]
 
     batchId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("cashflow_batch.id"), index=True, nullable=False)
     batch = sqla_orm.relationship("CashflowBatch", foreign_keys=[batchId])
@@ -350,8 +360,14 @@ class Invoice(Model):  # type: ignore [valid-type, misc]
     id = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
     date = sqla.Column(sqla.DateTime, nullable=False, server_default=sqla.func.now())
     reference = sqla.Column(sqla.Text, nullable=False, unique=True)
+    # FIXME (dbaty, 2022-06-20): remove `businessUnitId` once we have
+    # fully switched to `reimbursementPointId`
     businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=False)
     businessUnit = sqla_orm.relationship("BusinessUnit", back_populates="invoices")
+    # FIXME (dbaty, 2022-06-20): set non-NULLABLE once invoice code
+    # has been updated and old data has been migrated.
+    reimbursementPointId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=True)
+    reimbursementPoint = sqla_orm.relationship("Venue", foreign_keys=[reimbursementPointId])  # type: ignore [misc]
     # See the note about `amount` at the beginning of this module.
     amount = sqla.Column(sqla.Integer, nullable=False)
     token = sqla.Column(sqla.Text, unique=True, nullable=False)

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -75,6 +75,8 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     providers_models.AllocineTheater.query.delete()
     booking_providers_models.VenueBookingProvider.query.delete()
     booking_providers_models.BookingProvider.query.delete()
+    offerers_models.VenuePricingPointLink.query.delete()
+    offerers_models.VenueReimbursementPointLink.query.delete()
     offerers_models.Venue.query.delete()
     offerers_models.UserOfferer.query.delete()
     offerers_models.ApiKey.query.delete()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -44,7 +44,12 @@ def create_specific_invoice():  # type: ignore [no-untyped-def]
         siret=business_unit.siret,
         businessUnit=business_unit,
         managingOfferer=offerer,
+        pricing_point="self",
+        reimbursement_point="self",
     )
+    bank_info.venue = venue
+    db.session.add(bank_info)
+    db.session.commit()
     thing_offer1 = offers_factories.ThingOfferFactory(venue=venue)
     thing_offer2 = offers_factories.ThingOfferFactory(venue=venue)
     book_offer1 = offers_factories.OfferFactory(venue=venue, subcategoryId=subcategories.LIVRE_PAPIER.id)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
@@ -105,6 +105,8 @@ def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType
                 venueTypeCode=venue_type_code,
                 isPermanent=True,
                 businessUnit__name=offerer.name,
+                pricing_point="self" if siret else None,
+                reimbursement_point="self" if siret else None,
             )
             providers_factories.VenueProviderFactory(venue=venue)
 


### PR DESCRIPTION
The BusinessUnit model will be replaced by two separate notions:

- the pricing point: the venue against which we price a booking. It
  may be the venue itself or another venue. The pricing point of a
  venue MUST have a SIRET. Once a pricing point has been selected,
  it should not change.

- the reimbursement point: the venue that holds the bank account
  information (through the `bank_information` relationship table)
  that should be used when reimbursing bookings of a venue. The
  reimbursement point of a venue may change with time.

We store the links between a venue and its pricing and reimbursement
points in two specific tables: `VenuePricingPointLink`,
`VenueReimbursementPointLink` (as we did with `BusinessUnitVenueLink`).
Contrary to what we did with `Venue.businessUnitId`, we do not store
the pricing and reimbursement points on the `Venue` model to avoid
inconsistencies (which we have had with links to business units).

In further commits, we'll populate and use these new models in
pricing, cashflow and invoice-related code.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15592