### PR TITLE
(PC-FIX)[API] fix: local provider thumbs: keep ratio by default

### DIFF
--- a/api/src/pcapi/local_providers/local_provider.py
+++ b/api/src/pcapi/local_providers/local_provider.py
@@ -68,7 +68,7 @@ class LocalProvider(Iterator):
         return 0
 
     def get_keep_poster_ratio(self) -> bool:
-        return False
+        return True
 
     @property
     @abstractmethod


### PR DESCRIPTION
## But de la pull request

Modifier la valeur par défaut d'un booléen : de `False` à `True`.

Dans ce contexte (`local_provider`), on veut que les images envoyées soient enregistrées sans vérification sur le ratio, juste le strict minimum (transformation en jpeg pour commencer).

La valeur de cette méthode est utilisée par `_save_same_thumb_from_thumb_count_to_index` qui appelle `create_thumb` à son tour et s'en sert pour le paramètre `keep_ratio` (qu'on veut donc à `True` pour ne pas avoir de vérification poussée). 