### PR TITLE
(PC-14717)[API] feat: connect to flask admin without google sso in development env

### DIFF
--- a/api/src/pcapi/admin/base_configuration.py
+++ b/api/src/pcapi/admin/base_configuration.py
@@ -1,5 +1,7 @@
+import datetime
 import logging
 import secrets
+from typing import Optional
 
 from flask import session
 from flask import url_for
@@ -12,14 +14,13 @@ from flask_admin.helpers import get_form_data
 from flask_login import current_user
 from flask_login import login_user
 from flask_login import logout_user
-from werkzeug.exceptions import Forbidden
-from werkzeug.utils import redirect
+import werkzeug
 
 from pcapi import settings
 from pcapi.core.users import models as users_models
 from pcapi.core.users import repository as users_repository
+import pcapi.core.users.api as users_api
 from pcapi.flask_app import oauth
-from pcapi.models import db
 
 
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ class BaseAdminView(BaseAdminMixin, ModelView):
     form_base_class = SecureForm
 
     def inaccessible_callback(self, name, **kwargs):  # type: ignore [no-untyped-def]
-        return redirect(url_for("admin.index"))
+        return werkzeug.utils.redirect(url_for("admin.index"))
 
     def after_model_change(self, form, model, is_created):  # type: ignore [no-untyped-def]
         action = "Création" if is_created else "Modification"
@@ -101,14 +102,41 @@ class BaseCustomSuperAdminView(BaseSuperAdminMixin, BaseView):
 
 
 class AdminIndexView(AdminIndexBaseView):
+    def _create_local_admin_user(
+        self, email: str, first_name: str, last_name: str, given_name: Optional[str] = None
+    ) -> users_models.User:
+        local_admin = users_api.create_account(
+            email=email, password="not-so-secret-password", birthdate=datetime.date(1990, 1, 1), is_email_validated=True
+        )
+        local_admin.roles = [users_models.UserRole.ADMIN]
+        local_admin.firstName = first_name
+        local_admin.lastName = last_name
+        local_admin.publicName = given_name if given_name is not None else f"{first_name} {last_name}"
+        # generate a random password as the user won't login to anything else.
+        local_admin.setPassword(secrets.token_urlsafe(20))
+        return local_admin
+
     @expose("/")
     def index(self):  # type: ignore [no-untyped-def]
         if not current_user.is_authenticated:
-            return redirect(url_for(".login_view"))
+            return werkzeug.utils.redirect(url_for(".login_view"))
         return super().index()
 
     @expose("/login/", methods=("GET", "POST"))
-    def login_view(self):  # type: ignore [no-untyped-def]
+    def login_view(self) -> werkzeug.Response:
+        if settings.IS_DEV:
+            from pcapi.utils import login_manager
+
+            local_admin_email = "admin@passculture.local"
+            local_admin = users_repository.find_user_by_email(local_admin_email)
+
+            if not local_admin:
+                local_admin = self._create_local_admin_user(local_admin_email, "Local", "Admin")
+
+            login_user(local_admin, remember=True)
+            login_manager.stamp_session(local_admin)
+            return werkzeug.utils.redirect(url_for(".index"))
+
         redirect_uri = url_for(".authorize", _external=True)
         return oauth.google.authorize_redirect(redirect_uri)
 
@@ -118,7 +146,7 @@ class AdminIndexView(AdminIndexBaseView):
 
         logout_user()
         login_manager.discard_session()
-        return redirect(url_for(".index"))
+        return werkzeug.utils.redirect(url_for(".index"))
 
     @expose("/authorize/")
     def authorize(self):  # type: ignore [no-untyped-def]
@@ -129,40 +157,34 @@ class AdminIndexView(AdminIndexBaseView):
         google_email = google_user["email"]
         db_user = users_repository.find_user_by_email(google_email)
         if db_user and not db_user.isActive:
-            return Forbidden()
+            return werkzeug.exceptions.Forbidden()
 
         if not db_user:
-            if settings.IS_TESTING or settings.IS_DEV:
-                db_user = users_models.User(
-                    firstName=google_user["given_name"],
-                    lastName=google_user["family_name"],
+            if settings.IS_TESTING:
+                db_user = self._create_local_admin_user(
                     email=google_user["email"],
-                    publicName=google_user["name"],
-                    isEmailValidated=True,
-                    isActive=True,
-                    roles=[users_models.UserRole.ADMIN],
+                    first_name=google_user["name"],
+                    last_name=google_user["family_name"],
+                    given_name=google_user["given_name"],
                 )
-                # generate a random password as the user won't login to anything else.
-                db_user.setPassword(secrets.token_urlsafe(20))
-                db.session.add(db_user)
-                db.session.commit()
+
             else:
                 session["google_email"] = google_email
-                return redirect(url_for(".no_user_found_view"))
+                return werkzeug.utils.redirect(url_for(".no_user_found_view"))
 
         login_user(db_user, remember=True)
         login_manager.stamp_session(db_user)
-        return redirect(url_for(".index"))
+        return werkzeug.utils.redirect(url_for(".index"))
 
     @expose("/no-user-found/")
     def no_user_found_view(self):  # type: ignore [no-untyped-def]
         from pcapi.utils import login_manager
 
         if current_user.is_authenticated:
-            return redirect(url_for(".index"))
+            return werkzeug.utils.redirect(url_for(".index"))
 
         if session.get("google_email") is None:
-            return redirect(url_for(".index"))
+            return werkzeug.utils.redirect(url_for(".index"))
 
         rendered_view = self.render("admin/no_user_found.html", email=session["google_email"])
         login_manager.discard_session()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14717

## But de la pull request

Pouvoir se connecter à Flask Admin sans passer par le SSO Google sur la machine de dev locale.

## Implémentation

- création automatique d'un utilisateur admin en local à la première connexion à Flask Admin

## Informations supplémentaires

- Un peu de refacto pour utiliser une fonction de création d'utilisateur de l'api users, plutôt que le faire en local.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
