### PR TITLE
Correction de la détection des commentaires dans mycop

### DIFF
--- a/.github/workflows/mypy-cop.yml
+++ b/.github/workflows/mypy-cop.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Mypy cop report
+          body-includes: 'mypy cop report'
       - name: Create comment
         if: ${{ steps.changes.outputs.src == 'true' && steps.fc.outputs.comment-id == '' && steps.mypy-ignore-counter.outputs.this_branch_ignore_count != steps.mypy-ignore-counter.outputs.master_ignore_count }}
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/mypy-cop.yml
+++ b/.github/workflows/mypy-cop.yml
@@ -22,10 +22,10 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         run: |
           cd api
-          this_branch_ignore_count="$(grep "type: ignore" -r src | wc -l | xargs)"
+          this_branch_ignore_count="$(grep "type: ignore" -r src | wc -l)"
           git fetch origin master:master --quiet
           git checkout master --quiet
-          master_ignore_count="$(grep "type: ignore" -r src | wc -l | xargs)"
+          master_ignore_count="$(grep "type: ignore" -r src | wc -l)"
           git checkout - --quiet
           echo "::set-output name=this_branch_ignore_count::$this_branch_ignore_count"
           echo "::set-output name=master_ignore_count::$master_ignore_count"


### PR DESCRIPTION
On détectait mal les commentaires, et donc on ajoutait toujours un commentaire (au lieu de mettre à jour le commentaire existant).