### PR TITLE
(BSR)[API] feat: Make CashflowBatch.label not nullable

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 363db8d498a7 (pre) (head)
-01e4e1b7f714 (post) (head)
+b9deaf12993c (post) (head)

--- a/api/src/pcapi/alembic/versions/20220622T140243_b9deaf12993c_set_cashflowbatch_label_not_nullable.py
+++ b/api/src/pcapi/alembic/versions/20220622T140243_b9deaf12993c_set_cashflowbatch_label_not_nullable.py
@@ -1,0 +1,18 @@
+"""Make cashflow_batch_label not nullable."""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b9deaf12993c"
+down_revision = "01e4e1b7f714"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("cashflow_batch", "label", existing_type=sa.TEXT(), nullable=False)
+
+
+def downgrade():
+    op.alter_column("cashflow_batch", "label", existing_type=sa.TEXT(), nullable=True)

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -118,6 +118,7 @@ class CashflowBatchFactory(BaseFactory):
         model = models.CashflowBatch
 
     cutoff = factory.LazyFunction(datetime.datetime.utcnow)
+    label = factory.Sequence("VIR{}".format)
 
 
 class CashflowFactory(BaseFactory):

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -314,8 +314,7 @@ class CashflowBatch(Model):  # type: ignore [valid-type, misc]
     id = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
     creationDate = sqla.Column(sqla.DateTime, nullable=False, server_default=sqla.func.now())
     cutoff = sqla.Column(sqla.DateTime, nullable=False, unique=True)
-    # FIXME (dbaty, 2022-05-04): set NOT NULL once the column has been populated
-    label = sqla.Column(sqla.Text, nullable=True, unique=True)
+    label = sqla.Column(sqla.Text, nullable=False, unique=True)
 
 
 class InvoiceLine(Model):  # type: ignore [valid-type, misc]


### PR DESCRIPTION
Existing rows have been populated a few weeks ago.