### PR TITLE
(PC-15595)[API] refactor: change dms_token column name to camelcase

### DIFF
--- a/api/src/pcapi/alembic/versions/20220620T174806_cb1d904c149d_add_dms_token_column_to_venue_table.py
+++ b/api/src/pcapi/alembic/versions/20220620T174806_cb1d904c149d_add_dms_token_column_to_venue_table.py
@@ -1,4 +1,4 @@
-"""add dms_token column to venue table (PRE-deploy)"""
+"""add dmsToken column to venue table (PRE-deploy)"""
 
 from alembic import op
 import sqlalchemy as sa
@@ -11,9 +11,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("venue", sa.Column("dms_token", sa.Text(), nullable=True))
-    op.create_unique_constraint(None, "venue", ["dms_token"])
+    op.add_column("venue", sa.Column("dmsToken", sa.Text(), nullable=True))
+    op.create_unique_constraint(None, "venue", ["dmsToken"])
 
 
 def downgrade():
-    op.drop_column("venue", "dms_token")
+    op.drop_column("venue", "dmsToken")

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -69,7 +69,7 @@ def create_digital_venue(offerer: Offerer) -> Venue:
     digital_venue.name = "Offre numérique"
     digital_venue.venueTypeCode = offerers_models.VenueTypeCode.DIGITAL  # type: ignore [attr-defined]
     digital_venue.managingOfferer = offerer
-    digital_venue.dms_token = generate_dms_token()
+    digital_venue.dmsToken = generate_dms_token()
     return digital_venue
 
 
@@ -176,7 +176,7 @@ def create_venue(venue_data: PostVenueBodyModel) -> Venue:
 
     if venue_data.contact:
         upsert_venue_contact(venue, venue_data.contact)
-    venue.dms_token = generate_dms_token()
+    venue.dmsToken = generate_dms_token()
     repository.save(venue)
 
     if venue_data.businessUnitId:
@@ -511,4 +511,4 @@ def generate_dms_token() -> str:
         dms_token = secrets.token_hex(6)
         if not dms_token_exists(dms_token):
             return dms_token
-    raise ValueError("Could not generate new dms_token for Venue")
+    raise ValueError("Could not generate new dmsToken for Venue")

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -56,7 +56,7 @@ class VenueFactory(BaseFactory):
     )
     contact = factory.RelatedFactory("pcapi.core.offerers.factories.VenueContactFactory", factory_related_name="venue")
     bookingEmail = factory.Sequence("venue{}@example.net".format)
-    dms_token = factory.LazyFunction(api.generate_dms_token)
+    dmsToken = factory.LazyFunction(api.generate_dms_token)
 
     @factory.post_generation
     def business_unit_venue_link(venue, create, extracted, **kwargs):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -222,7 +222,7 @@ class Venue(PcObject, Model, HasThumbMixin, ProvidableMixin, NeedsValidationMixi
     )
 
     # TODO(fseguin,2022-06-20): Make column non-nullable when column is populated on all envs
-    dms_token = Column(Text, nullable=True, unique=True)
+    dmsToken = Column(Text, nullable=True, unique=True)
 
     @property
     def is_eligible_for_search(self) -> bool:

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -362,4 +362,4 @@ def offerer_has_venue_with_adage_id(offerer_id: int) -> bool:
 
 
 def dms_token_exists(dms_token: str) -> bool:
-    return db.session.query(models.Venue.query.filter_by(dms_token=dms_token).exists()).scalar()
+    return db.session.query(models.Venue.query.filter_by(dmsToken=dms_token).exists()).scalar()

--- a/api/src/pcapi/scripts/venue/add_dms_token_to_each_venue.py
+++ b/api/src/pcapi/scripts/venue/add_dms_token_to_each_venue.py
@@ -4,21 +4,21 @@ import pcapi.core.offerers.models as offerers_models
 from pcapi.models import db
 
 
-def add_dms_token_to_each_venue(batch_size: int = 100) -> None:
-    print(f"[add_dms_token_to_each_venue] {batch_size=} START")
+def add_dmsToken_to_each_venue(batch_size: int = 100) -> None:
+    print(f"[add_dmsToken_to_each_venue] {batch_size=} START")
 
     batch_nr = 1
 
-    query = offerers_models.Venue.query.filter(offerers_models.Venue.dms_token.is_(None))
+    query = offerers_models.Venue.query.filter(offerers_models.Venue.dmsToken.is_(None))
     venues_to_update = query.limit(batch_size).all()
 
     while len(venues_to_update) > 0:
-        print(f"[add_dms_token_to_each_venue] Batch {batch_nr}")
+        print(f"[add_dmsToken_to_each_venue] Batch {batch_nr}")
         for venue in venues_to_update:
-            venue.dms_token = offerers_api.generate_dms_token()
+            venue.dmsToken = offerers_api.generate_dms_token()
             db.session.add(venue)
         db.session.commit()
         batch_nr += 1
         venues_to_update = query.limit(batch_size).all()
 
-    print("[add_dms_token_to_each_venue] END")
+    print("[add_dmsToken_to_each_venue] END")

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -64,7 +64,7 @@ class CreateVenueTest:
         assert venue.managingOfferer == offerer
         assert venue.name == "La Venue"
         assert venue.bookingEmail == "venue@example.com"
-        assert venue.dms_token
+        assert venue.dmsToken
 
     def test_with_business_unit(self):
         offerer = offerers_factories.OffererFactory()

--- a/api/tests/scripts/venue/test_add_dms_token_to_each_venue.py
+++ b/api/tests/scripts/venue/test_add_dms_token_to_each_venue.py
@@ -2,17 +2,17 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
-from pcapi.scripts.venue.add_dms_token_to_each_venue import add_dms_token_to_each_venue
+from pcapi.scripts.venue.add_dms_token_to_each_venue import add_dmsToken_to_each_venue
 
 
 class AddDmsTokenToEachVenueTest:
     @pytest.mark.usefixtures("db_session")
-    def test_add_dms_token_to_each_venue(self):
+    def test_add_dmsToken_to_each_venue(self):
         offerers_factories.VenueFactory.create_batch(size=3)
-        offerers_models.Venue.query.update({"dms_token": None}, synchronize_session=False)
+        offerers_models.Venue.query.update({"dmsToken": None}, synchronize_session=False)
         offerers_factories.VenueFactory()
-        assert offerers_models.Venue.query.filter(offerers_models.Venue.dms_token.is_(None)).count() == 3
+        assert offerers_models.Venue.query.filter(offerers_models.Venue.dmsToken.is_(None)).count() == 3
 
-        add_dms_token_to_each_venue(batch_size=2)
+        add_dmsToken_to_each_venue(batch_size=2)
 
-        assert offerers_models.Venue.query.filter(offerers_models.Venue.dms_token.is_(None)).count() == 0
+        assert offerers_models.Venue.query.filter(offerers_models.Venue.dmsToken.is_(None)).count() == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15595

## But de la pull request

Passer la nom de la colonne `venue.dms_token` en camelcase: `dmsToken`

## Implémentation

Edition de la migration (seulement jouée en testing) et du code

## Modifications du schéma de la base de données

- la colonne `venue.dms_token `sera finalement nommée `venue.dmsToken`

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
