### PR TITLE
(BSR)[API] feat: Make `User.isActive` non nullable

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 363db8d498a7 (pre) (head)
-b9deaf12993c (post) (head)
+090834b497b7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220622T143904_d6082bf14ca2_user_isactive_non_nullable_step1.py
+++ b/api/src/pcapi/alembic/versions/20220622T143904_d6082bf14ca2_user_isactive_non_nullable_step1.py
@@ -1,0 +1,25 @@
+"""Make user.isActive not nullable (step 1 of 4)."""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d6082bf14ca2"
+down_revision = "b9deaf12993c"
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT = "user_isactive_not_null_constraint"
+
+
+def upgrade():
+    op.execute(
+        f"""
+        ALTER TABLE "user" DROP CONSTRAINT IF EXISTS "{CONSTRAINT}";
+        ALTER TABLE "user" ADD CONSTRAINT "{CONSTRAINT}" CHECK ("isActive" IS NOT NULL) NOT VALID;
+        """
+    )
+
+
+def downgrade():
+    op.drop_constraint(CONSTRAINT, table_name="user")

--- a/api/src/pcapi/alembic/versions/20220622T143905_090834b497b7_user_isactive_non_nullable_step4.py
+++ b/api/src/pcapi/alembic/versions/20220622T143905_090834b497b7_user_isactive_non_nullable_step4.py
@@ -1,0 +1,20 @@
+"""Make user.isActive not nullable (step 4 of 4)."""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "090834b497b7"
+down_revision = "905c3b79223a"
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT = "user_isactive_not_null_constraint"
+
+
+def upgrade():
+    op.drop_constraint(CONSTRAINT, table_name="user")
+
+
+def downgrade():
+    op.execute(f"""ALTER TABLE "user" ADD CONSTRAINT "{CONSTRAINT}" CHECK ("isActive" IS NOT NULL) NOT VALID""")

--- a/api/src/pcapi/alembic/versions/20220622T143905_905c3b79223a_user_isactive_non_nullable_step3.py
+++ b/api/src/pcapi/alembic/versions/20220622T143905_905c3b79223a_user_isactive_non_nullable_step3.py
@@ -1,0 +1,17 @@
+"""Make user.isActive not nullable (step 3 of 4)."""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "905c3b79223a"
+down_revision = "d12acf29a74d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("user", "isActive", nullable=False)
+
+
+def downgrade():
+    op.alter_column("user", "isActive", nullable=True)

--- a/api/src/pcapi/alembic/versions/20220622T143905_d12acf29a74d_user_isactive_non_nullable_step2.py
+++ b/api/src/pcapi/alembic/versions/20220622T143905_d12acf29a74d_user_isactive_non_nullable_step2.py
@@ -1,0 +1,25 @@
+"""Make user.isActive not nullable (step 2 of 4)."""
+from alembic import op
+
+from pcapi import settings
+
+
+# revision identifiers, used by Alembic.
+revision = "d12acf29a74d"
+down_revision = "d6082bf14ca2"
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT = "user_isactive_not_null_constraint"
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout = '900s'")
+    op.execute(f'ALTER TABLE "user" VALIDATE CONSTRAINT "{CONSTRAINT}"')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade():
+    pass

--- a/api/src/pcapi/core/users/external/__init__.py
+++ b/api/src/pcapi/core/users/external/__init__.py
@@ -192,7 +192,7 @@ def get_user_attributes(user: User) -> UserAttributes:
         first_name=user.firstName,
         has_completed_id_check=fraud_api.has_user_performed_identity_check(user),
         user_id=user.id,
-        is_active=user.isActive,  # type: ignore [arg-type]
+        is_active=user.isActive,
         is_beneficiary=user.is_beneficiary,  # type: ignore [arg-type]
         is_current_beneficiary=user.is_beneficiary and not is_ex_beneficiary,
         is_former_beneficiary=is_ex_beneficiary,

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -26,6 +26,7 @@ from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.exceptions import InvalidUserRoleException
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.needs_validation_mixin import NeedsValidationMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.utils import crypto
@@ -184,7 +185,7 @@ class AccountState(enum.Enum):
         return self == AccountState.DELETED
 
 
-class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, misc]
+class User(PcObject, Model, NeedsValidationMixin, DeactivableMixin):  # type: ignore [valid-type, misc]
     __tablename__ = "user"
 
     activity = sa.Column(sa.String(128), nullable=True)
@@ -206,12 +207,6 @@ class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, 
     hasSeenProRgs = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     idPieceNumber = sa.Column(sa.String, nullable=True, unique=True)
     ineHash = sa.Column(sa.Text, nullable=True, unique=True)
-
-    # FIXME (dbaty, 2020-12-14): once v114 has been deployed, populate
-    # existing rows, remove this field and let the User model
-    # use DeactivableMixin. We'll need to add a migration that adds a
-    # NOT NULL constraint.
-    isActive = sa.Column(sa.Boolean, nullable=True, server_default=expression.true(), default=True)
     isEmailValidated = sa.Column(sa.Boolean, nullable=True, server_default=expression.false())
     lastConnectionDate = sa.Column(sa.DateTime, nullable=True)
     lastName = sa.Column(sa.String(128), nullable=True)
@@ -304,7 +299,7 @@ class User(PcObject, Model, NeedsValidationMixin):  # type: ignore [valid-type, 
 
     @property
     def is_active(self) -> bool:  # required by flask-login
-        return self.isActive  # type: ignore [return-value]
+        return self.isActive
 
     @property
     def is_anonymous(self) -> bool:  # required by flask-login


### PR DESCRIPTION
The column is now inherited from `DeactivableMixin`, which defines the
column as non nullable. All rows of the "user" table already validates
this new constraint.