### PR TITLE
(PC-15772)[PRO] feat: add to toggle to chose between siret and commen…

### DIFF
--- a/pro/src/components/layout/form/fields/SiretField/SiretField.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/SiretField.tsx
@@ -13,36 +13,36 @@ interface ISiretFieldProps {
   label: string
   readOnly: boolean
   siren?: string
+  required?: boolean
 }
 
 const SiretField = ({
   label = 'SIRET : ',
   readOnly = true,
   siren,
+  required = false,
 }: ISiretFieldProps): JSX.Element => {
   const isEntrepriseApiDisabled: boolean = useActiveFeature(
     'DISABLE_ENTERPRISE_API'
   )
 
   const siretFormField = useField('siret', {})
-  const commentFormField = useField('comment', {})
   const haveInitialValue = ![null, undefined].includes(
     siretFormField.meta.initial
   )
   const siretValue = siretFormField.input.value
-  const commentValue = commentFormField.input.value
   const isValid = !!siretValue && siretValue.length === 14
 
   let validate: ((siret: string) => Promise<string | undefined>) | null = null
 
-  if (!(haveInitialValue || isEntrepriseApiDisabled)) {
+  if (!(haveInitialValue || isEntrepriseApiDisabled) && required) {
     validate = (siret: string) => {
       if (siren && siret && !siret.startsWith(siren)) {
         return Promise.resolve(
           'Le code SIRET doit correspondre à un établissement de votre structure'
         )
       }
-      return siretApiValidate(siret, commentValue)
+      return siretApiValidate(siret)
     }
   }
 
@@ -72,6 +72,7 @@ const SiretField = ({
       name="siret"
       parse={unhumanizeSiret}
       readOnly={readOnly}
+      required={required}
       renderTooltip={() => tooltip}
       type="siret"
       validate={validate}

--- a/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
@@ -21,12 +21,17 @@ describe('components | SiretField', () => {
       <Provider store={store}>
         <Form initialValues={{}} name="venue" onSubmit={() => {}}>
           {() => (
-            <SiretField siren={siren} readOnly={false} label="Siret field" />
+            <SiretField
+              siren={siren}
+              readOnly={false}
+              label="Siret field"
+              required
+            />
           )}
         </Form>
       </Provider>
     )
-    const siretField = screen.getByLabelText('Siret field')
+    const siretField = screen.getByLabelText('Siret field*')
     expect(siretField).toBeInTheDocument()
 
     const wrongSiret = '11111111199999'
@@ -105,7 +110,7 @@ describe('components | SiretField', () => {
       const humanSiret = '123 456 789 01234'
 
       // when
-      await siretApiValidate(humanSiret, '')
+      await siretApiValidate(humanSiret)
 
       // then
       expect(fetch).toHaveBeenCalledTimes(1)
@@ -136,7 +141,7 @@ describe('components | SiretField', () => {
       )
 
       // when
-      const errorMessage = await siretApiValidate(siret, '')
+      const errorMessage = await siretApiValidate(siret)
 
       // then
       expect(errorMessage).toBeUndefined()
@@ -165,7 +170,7 @@ describe('components | SiretField', () => {
       )
 
       // when
-      const errorMessage = await siretApiValidate(siret, '')
+      const errorMessage = await siretApiValidate(siret)
 
       // then
       expect(errorMessage).toBeUndefined()
@@ -195,7 +200,7 @@ describe('components | SiretField', () => {
       )
 
       // when
-      const errorMessage = await siretApiValidate(siret, '')
+      const errorMessage = await siretApiValidate(siret)
 
       // then
       expect(errorMessage).toBeUndefined()
@@ -208,7 +213,7 @@ describe('components | SiretField', () => {
       })
 
       // when
-      const errorMessage = await siretApiValidate(siret, '')
+      const errorMessage = await siretApiValidate(siret)
 
       // then
       expect(errorMessage).toBe(
@@ -227,7 +232,7 @@ describe('components | SiretField', () => {
       )
 
       // when
-      const errorMessage = await siretApiValidate(siret, '')
+      const errorMessage = await siretApiValidate(siret)
 
       // then
       expect(errorMessage).toBe(
@@ -242,7 +247,7 @@ describe('components | SiretField', () => {
       })
 
       // when
-      const errorMessage = await siretApiValidate(siret, '')
+      const errorMessage = await siretApiValidate(siret)
 
       // then
       expect(errorMessage).toBe("Ce SIRET n'est pas reconnu")
@@ -255,8 +260,8 @@ describe('components | SiretField', () => {
       })
 
       // when
-      await siretApiValidate(siret, '')
-      await siretApiValidate(siret, '')
+      await siretApiValidate(siret)
+      await siretApiValidate(siret)
 
       // then
       expect(fetch).toHaveBeenCalledTimes(1)

--- a/pro/src/components/layout/form/fields/SiretField/validators/siretApiValidate.ts
+++ b/pro/src/components/layout/form/fields/SiretField/validators/siretApiValidate.ts
@@ -1,11 +1,8 @@
 import { getSiretDataAdapter } from 'core/Venue'
 
-const siretApiValidate = async (
-  siret: string,
-  comment: string
-): Promise<string | undefined> => {
+const siretApiValidate = async (siret: string): Promise<string | undefined> => {
   if (!siret) {
-    return comment ? undefined : 'Ce champs est obligatoire'
+    return 'Ce champ est obligatoire'
   }
 
   const entrepriseData = await getSiretDataAdapter(siret)

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
@@ -47,6 +47,7 @@ const VenueCreation = () => {
 
   const [venueTypes, setVenueTypes] = useState(null)
   const [venueLabels, setVenueLabels] = useState(null)
+  const [isSiretValued, setIsSiretValued] = useState(true)
   const isBankInformationWithSiretActive = useActiveFeature(
     'ENFORCE_BANK_INFORMATION_WITH_SIRET'
   )
@@ -97,7 +98,7 @@ const VenueCreation = () => {
     handleFail,
     handleSuccess,
   }) => {
-    const body = formatVenuePayload(formValues, true)
+    const body = formatVenuePayload(formValues, true, isSiretValued)
     try {
       const response = await createVenue(body)
       handleSuccess(response)
@@ -159,7 +160,7 @@ const VenueCreation = () => {
     } = values
 
     const siretValidOnCreation =
-      !!formSiret && unhumanizeSiret(formSiret).length === 14
+      !!formSiret && unhumanizeSiret(formSiret).length === 14 && isSiretValued
     return (
       <form name="venue" onSubmit={handleSubmit}>
         <IdentifierFields
@@ -168,6 +169,7 @@ const VenueCreation = () => {
           isCreatedEntity
           readOnly={readOnly}
           siren={offerer.siren}
+          updateIsSiretValued={setIsSiretValued}
           venueLabels={venueLabels}
           venueTypes={venueTypes}
         />

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreation.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreation.spec.jsx
@@ -97,6 +97,10 @@ describe('venue form', () => {
       // FIXME: make cacheSelector reset on each test.
       testId += 1
       await renderVenueCreation({ props, storeOverrides })
+      const toggle = await screen.getByRole('button', {
+        name: 'Je veux créer un lieu avec SIRET',
+      })
+      await userEvent.click(toggle)
 
       formValues = {
         name: 'Librairie de test',

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/helpers.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/helpers.js
@@ -7,7 +7,7 @@ export const fieldLabels = {
   siret: {
     labelCreation: 'SIRET du lieu qui accueille vos offres (si applicable) :',
     label: 'SIRET :',
-    exact: true,
+    exact: false,
     type: 'text',
   },
   name: { label: 'Nom du lieu', exact: false, type: 'text' },

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
@@ -261,6 +261,7 @@ const VenueEdition = () => {
             formSiret={formSiret}
             initialSiret={initialSiret}
             isDirtyFieldBookingEmail={isDirtyFieldBookingEmail}
+            isToggleDisabled
             readOnly={readOnly || initialIsVirtual}
             venueIsVirtual={initialIsVirtual}
             venueLabelId={venueLabelId}

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/IdentifierFields.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/IdentifierFields.jsx
@@ -6,7 +6,8 @@ import HiddenField from 'components/layout/form/fields/HiddenField'
 import Icon from 'components/layout/Icon'
 import PropTypes from 'prop-types'
 import ReactTooltip from 'react-tooltip'
-import { SiretField } from 'components/layout/form/fields/SiretField'
+
+import SiretOrCommentFields from '../SiretOrCommentFields'
 import TextField from 'components/layout/form/fields/TextField'
 import TextareaField from 'components/layout/form/fields/TextareaField'
 import VenueLabel from 'components/pages/Offerers/Offerer/VenueV1/ValueObjects/VenueLabel'
@@ -14,7 +15,6 @@ import VenueType from 'components/pages/Offerers/Offerer/VenueV1/ValueObjects/Ve
 /*eslint no-undef: 0*/
 import classnames from 'classnames'
 import getLabelFromList from './utils/getLabelFromList'
-import { removeWhitespaces } from 'react-final-form-utils'
 
 class IdentifierFields extends PureComponent {
   componentDidUpdate() {
@@ -33,22 +33,6 @@ class IdentifierFields extends PureComponent {
       </span>
     )
 
-  commentValidate = comment => {
-    const { formSiret } = this.props
-
-    const formatedSiret = removeWhitespaces(formSiret)
-
-    if (formatedSiret && formatedSiret.length === 14) {
-      return ''
-    }
-
-    if (comment === undefined || comment === '') {
-      return 'Ce champ est obligatoire'
-    }
-
-    return ''
-  }
-
   venueTypeValidate = venueType => {
     if (venueType === undefined || venueType === '') {
       return 'Ce champ est obligatoire'
@@ -62,8 +46,10 @@ class IdentifierFields extends PureComponent {
       initialSiret,
       isCreatedEntity,
       isDirtyFieldBookingEmail,
+      isToggleDisabled,
       readOnly,
       siren,
+      updateIsSiretValued,
       venueIsVirtual,
       venueLabels,
       venueLabelId,
@@ -94,23 +80,17 @@ class IdentifierFields extends PureComponent {
           )}
         </h2>
         <div className="field-group">
-          {isCreatedEntity && <HiddenField name="managingOffererId" />}
           {!venueIsVirtual && (
-            <>
-              <SiretField
-                label={siretLabel}
-                readOnly={readOnly || initialSiret !== null}
-                siren={siren}
-              />
-              <TextareaField
-                label="Commentaire (si pas de SIRET) : "
-                name="comment"
-                readOnly={readOnly}
-                rows={1}
-                validate={this.commentValidate}
-              />
-            </>
+            <SiretOrCommentFields
+              siretLabel={siretLabel}
+              readOnly={readOnly || initialSiret !== null}
+              siren={siren}
+              isToggleDisabled={isToggleDisabled}
+              initialSiret={initialSiret}
+              updateIsSiretValued={updateIsSiretValued}
+            />
           )}
+          {isCreatedEntity && <HiddenField name="managingOffererId" />}
           <TextField
             label="Nom du lieu : "
             name="name"
@@ -248,6 +228,7 @@ IdentifierFields.defaultProps = {
   initialSiret: null,
   isCreatedEntity: false,
   isDirtyFieldBookingEmail: false,
+  isToggleDisabled: false,
   readOnly: true,
   siren: null,
   venueIsVirtual: false,
@@ -261,8 +242,10 @@ IdentifierFields.propTypes = {
   initialSiret: PropTypes.string,
   isCreatedEntity: PropTypes.bool,
   isDirtyFieldBookingEmail: PropTypes.bool,
+  isToggleDisabled: PropTypes.bool,
   readOnly: PropTypes.bool,
   siren: PropTypes.string,
+  updateIsSiretValued: PropTypes.func,
   venueIsVirtual: PropTypes.bool,
   venueLabelId: PropTypes.string,
   venueLabels: PropTypes.arrayOf(PropTypes.instanceOf(VenueLabel)).isRequired,

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/__specs__/IdentifierFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/IdentifierFields/__specs__/IdentifierFields.spec.jsx
@@ -86,7 +86,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
         name: 'Venue name',
         publicName: 'Venue publicName',
         bookingEmail: 'booking@email.app',
-        comment: 'Venue comment',
         venueTypeCode: 'OTHER_TYPE_ID',
         venueLabelId: 'OTHER_LABEL_ID',
         description: 'Venue description',
@@ -116,7 +115,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       const bookingEmailField = await screen.findByLabelText('Mail', {
         exact: false,
       })
-      const commentField = await helpers.findVenueInputForField('comment')
       const venueTypeCodeField = await helpers.queryVenueInputForField(
         'venueTypeCode'
       )
@@ -129,7 +127,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       expect(nameField).toBeDisabled()
       expect(publicNameField).toBeDisabled()
       expect(bookingEmailField).toBeDisabled()
-      expect(commentField).toBeDisabled()
       expect(descriptionField).toBeDisabled()
 
       // select elements are replace with spans
@@ -144,7 +141,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
         name: formValues['name'],
         publicName: formValues['publicName'],
         bookingEmail: formValues['bookingEmail'],
-        comment: formValues['comment'],
         venueTypeCode: getLabelFromList(
           props.venueTypes,
           formValues['venueTypeCode']
@@ -166,9 +162,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       ).toBeInTheDocument()
       expect(
         screen.getByDisplayValue(displayedValues['bookingEmail'])
-      ).toBeInTheDocument()
-      expect(
-        screen.getByDisplayValue(displayedValues['comment'])
       ).toBeInTheDocument()
       expect(
         screen.getByDisplayValue(displayedValues['description'])
@@ -212,7 +205,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       const bookingEmailField = await helpers.findVenueInputForField(
         'bookingEmail'
       )
-      const commentField = await helpers.findVenueInputForField('comment')
       const venueTypeCodeField = await helpers.findVenueInputForField(
         'venueTypeCode'
       )
@@ -227,7 +219,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       expect(nameField).toBeEnabled()
       expect(publicNameField).toBeEnabled()
       expect(bookingEmailField).toBeEnabled()
-      expect(commentField).toBeEnabled()
       expect(descriptionField).toBeEnabled()
       expect(venueTypeCodeField).toBeEnabled()
       expect(venueLabelIdField).toBeEnabled()
@@ -235,9 +226,8 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       expect(nameField).toBeRequired()
       expect(venueTypeCodeField).toBeRequired()
       expect(bookingEmailField).toBeRequired()
-      expect(siretField).not.toBeRequired()
+      expect(siretField).toBeRequired()
       expect(publicNameField).not.toBeRequired()
-      expect(commentField).not.toBeRequired()
       expect(descriptionField).not.toBeRequired()
       expect(venueLabelIdField).not.toBeRequired()
 
@@ -245,7 +235,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       expect(nameField).toHaveValue('')
       expect(publicNameField).toHaveValue('')
       expect(bookingEmailField).toHaveValue('')
-      expect(commentField).toHaveValue('')
       expect(descriptionField).toHaveValue('')
       expect(venueTypeCodeField).toHaveValue('')
       expect(venueLabelIdField).toHaveValue('')
@@ -259,7 +248,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
         name: 'Venue name',
         publicName: 'Venue publicName',
         bookingEmail: 'booking@email.app',
-        comment: 'Venue comment',
         venueTypeCode: 'OTHER_TYPE_ID',
         venueLabelId: 'OTHER_LABEL_ID',
         description: 'Venue description',
@@ -291,7 +279,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       const bookingEmailField = await helpers.findVenueInputForField(
         'bookingEmail'
       )
-      const commentField = await helpers.findVenueInputForField('comment')
       const venueTypeCodeField = await helpers.findVenueInputForField(
         'venueTypeCode'
       )
@@ -308,7 +295,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
 
       expect(publicNameField).toBeEnabled()
       expect(bookingEmailField).toBeEnabled()
-      expect(commentField).toBeEnabled()
       expect(descriptionField).toBeEnabled()
       expect(venueTypeCodeField).toBeEnabled()
       expect(venueLabelIdField).toBeEnabled()
@@ -316,9 +302,8 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       expect(nameField).toBeRequired()
       expect(venueTypeCodeField).toBeRequired()
       expect(bookingEmailField).toBeRequired()
-      expect(siretField).not.toBeRequired()
+      expect(siretField).toBeRequired()
       expect(publicNameField).not.toBeRequired()
-      expect(commentField).not.toBeRequired()
       expect(descriptionField).not.toBeRequired()
       expect(venueLabelIdField).not.toBeRequired()
 
@@ -326,7 +311,6 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
       expect(nameField).toHaveValue(formValues.name)
       expect(publicNameField).toHaveValue(formValues.publicName)
       expect(bookingEmailField).toHaveValue(formValues.bookingEmail)
-      expect(commentField).toHaveValue(formValues.comment)
       expect(descriptionField).toHaveValue(formValues.description)
       expect(venueTypeCodeField).toHaveValue(formValues.venueTypeCode)
       expect(venueLabelIdField).toHaveValue(formValues.venueLabelId)

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+
+import { SiretField } from 'components/layout/form/fields/SiretField'
+import TextareaField from 'components/layout/form/fields/TextareaField'
+import Toggle from 'ui-kit/Toggle'
+import { useState } from 'react'
+
+export interface SiretOrCommentInterface {
+  isToggleDisabled?: boolean
+  initialSiret?: string
+  readOnly: boolean
+  siren: string
+  siretLabel: string
+  updateIsSiretValued: (isSiretValued: boolean) => void
+}
+
+const SiretOrCommentFields = ({
+  initialSiret,
+  isToggleDisabled = false,
+  readOnly,
+  siretLabel,
+  siren,
+  updateIsSiretValued,
+}: SiretOrCommentInterface): JSX.Element => {
+  const [isSiretSelected, setIsSiretSelected] = useState(
+    !isToggleDisabled || initialSiret !== null
+  )
+  const handleChange = () => {
+    updateIsSiretValued(!isSiretSelected)
+    setIsSiretSelected(!isSiretSelected)
+  }
+  const commentValidate = (comment: string) => {
+    if (comment === undefined || (comment === '' && !isSiretSelected)) {
+      return 'Ce champ est obligatoire'
+    }
+
+    return ''
+  }
+
+  return (
+    <>
+      <Toggle
+        label="Je veux créer un lieu avec SIRET"
+        isActiveByDefault={isSiretSelected}
+        isDisabled={readOnly || isToggleDisabled}
+        handleClick={handleChange}
+      ></Toggle>
+      {isSiretSelected ? (
+        <SiretField
+          label={siretLabel}
+          readOnly={readOnly}
+          siren={siren}
+          required={isSiretSelected}
+        />
+      ) : (
+        <TextareaField
+          label="Commentaire : "
+          name="comment"
+          placeholder="Je suis un équipement culturel (ou autre) donc je n’ai pas de SIRET ou je n’ai pas la gestion de ce lieu, il accueille simplement une proposition...
+          "
+          readOnly={readOnly}
+          required={!isSiretSelected}
+          rows={2}
+          validate={commentValidate}
+        />
+      )}
+    </>
+  )
+}
+
+export default SiretOrCommentFields

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/SiretOrCommentFields/__specs__/SiretOrCommentFields.spec.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/SiretOrCommentFields/__specs__/SiretOrCommentFields.spec.tsx
@@ -1,0 +1,85 @@
+import '@testing-library/jest-dom'
+
+import SiretOrCommentFields, {
+  SiretOrCommentInterface,
+} from '../SiretOrCommentFields'
+import { render, screen } from '@testing-library/react'
+
+import { Form } from 'react-final-form'
+import { Provider } from 'react-redux'
+import React from 'react'
+
+import { configureTestStore } from 'store/testUtils'
+import userEvent from '@testing-library/user-event'
+
+describe('components | SiretOrCommentFields', () => {
+  let props: SiretOrCommentInterface
+
+  beforeEach(() => {
+    const siren = '000000000'
+    const siretLabel = 'Siret field'
+    const updateIsSiretValued = jest.fn()
+
+    props = {
+      siren: siren,
+      siretLabel: siretLabel,
+      readOnly: false,
+      updateIsSiretValued: updateIsSiretValued,
+    }
+  })
+
+  it('should display siret field by default', async () => {
+    const store = configureTestStore()
+    render(
+      <Provider store={store}>
+        <Form initialValues={{}} name="venue" onSubmit={() => {}}>
+          {() => <SiretOrCommentFields {...props} />}
+        </Form>
+      </Provider>
+    )
+    const siretField = screen.getByLabelText('Siret field*')
+    expect(siretField).toBeInTheDocument()
+    expect(siretField).toBeRequired()
+    const commentField = screen.queryByText('Commentaire :')
+    expect(commentField).not.toBeInTheDocument()
+  })
+
+  it('should display comment field when toggle is clicked', async () => {
+    const store = configureTestStore()
+    render(
+      <Provider store={store}>
+        <Form initialValues={{}} name="venue" onSubmit={() => {}}>
+          {() => <SiretOrCommentFields {...props} />}
+        </Form>
+      </Provider>
+    )
+
+    const toggle = await screen.getByRole('button', {
+      name: 'Je veux créer un lieu avec SIRET',
+    })
+    await userEvent.click(toggle)
+    const siretField = screen.queryByText('Siret field')
+    expect(siretField).not.toBeInTheDocument()
+    const commentField = screen.getByLabelText('Commentaire :', {
+      exact: false,
+    })
+    expect(commentField).toBeInTheDocument()
+    expect(commentField).toBeRequired()
+  })
+
+  it('should display toggle disabled', async () => {
+    const store = configureTestStore()
+    render(
+      <Provider store={store}>
+        <Form initialValues={{}} name="venue" onSubmit={() => {}}>
+          {() => <SiretOrCommentFields {...props} isToggleDisabled />}
+        </Form>
+      </Provider>
+    )
+
+    const toggle = await screen.getByRole('button', {
+      name: 'Je veux créer un lieu avec SIRET',
+    })
+    expect(toggle).toBeDisabled()
+  })
+})

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/SiretOrCommentFields/index.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/SiretOrCommentFields/index.js
@@ -1,0 +1,1 @@
+export { default } from './SiretOrCommentFields'

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/__specs__/formatPatch.spec.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/__specs__/formatPatch.spec.js
@@ -86,7 +86,7 @@ describe('formatPatch', () => {
       expect(result).toStrictEqual({
         address: 'RUE DIDEROT',
         bookingEmail: 'R6465373fake674654673sub@example.com',
-        comment: 'comment',
+        comment: '',
         description: 'description',
         city: 'Aulnay-sous-Bois',
         latitude: 48.92071,

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
@@ -52,7 +52,11 @@ const edition_authorized_input_field = [
   'contact',
 ]
 
-export const formatVenuePayload = (payload, isCreatedEntity) => {
+export const formatVenuePayload = (
+  payload,
+  isCreatedEntity,
+  isSiretValued = true
+) => {
   const requestPayload = {}
 
   const authorizedFields = isCreatedEntity
@@ -65,7 +69,14 @@ export const formatVenuePayload = (payload, isCreatedEntity) => {
       payload[inputName] = ''
     }
 
-    if (inputName === 'comment' && payload[inputName] === undefined) {
+    if (inputName === 'siret' && !isSiretValued) {
+      delete payload[inputName]
+    }
+
+    if (
+      inputName === 'comment' &&
+      (payload[inputName] === undefined || isSiretValued)
+    ) {
       payload[inputName] = ''
     }
 

--- a/pro/testcafe/05_venue.js
+++ b/pro/testcafe/05_venue.js
@@ -81,11 +81,15 @@ test('je peux créer un lieu sans SIRET avec une description', async t => {
     'get_existing_pro_validated_user_with_validated_offerer_validated_user_offerer_no_physical_venue'
   )
   const newVenueButton = Selector(`a`).withText('Créer un lieu')
+  const toggleSiretOrComment = Selector(`button`).withText(
+    'Je veux créer un lieu avec SIRET'
+  )
 
   await navigateToOffererAs(user, offerer)(t)
 
   await t
     .click(newVenueButton)
+    .click(toggleSiretOrComment)
     .typeText(nameInput, 'Le lieu sympa de type sans siret')
     .typeText(commentInput, 'Test sans SIRET')
     .click(venueType)


### PR DESCRIPTION
…t in venue creation/edition

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15772

## But de la pull request

Ajout d'un toggle pour sélectionner si le siret ou le commentaire va être valorisé dans la création/édition d'un lieu

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
