### PR TITLE
(PC-15596)[API] Utiliser les points de valorisation (à la place des business units) pour la valorisation

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-3a02357e17ba (pre) (head)
+80c915a0b453 (pre) (head)
 090834b497b7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220629T105234_80c915a0b453_pricing_nullable_business_unit_id_and_siret.py
+++ b/api/src/pcapi/alembic/versions/20220629T105234_80c915a0b453_pricing_nullable_business_unit_id_and_siret.py
@@ -1,0 +1,20 @@
+"""[pre] Make `pricing.businessUunitId` and `siret` nullable."""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "80c915a0b453"
+down_revision = "3a02357e17ba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("pricing", "businessUnitId", existing_type=sa.BIGINT(), nullable=True)
+    op.alter_column("pricing", "siret", existing_type=sa.VARCHAR(length=14), nullable=True)
+
+
+def downgrade():
+    op.alter_column("pricing", "siret", existing_type=sa.VARCHAR(length=14), nullable=False)
+    op.alter_column("pricing", "businessUnitId", existing_type=sa.BIGINT(), nullable=False)

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -307,8 +307,13 @@ def price_booking(booking: typing.Union[bookings_models.Booking, CollectiveBooki
             return None
 
         business_unit = booking.venue.businessUnit
-        # FIXME (dbaty, 2021-12-08): we can get rid of this condition
-        # once BusinessUnit.siret is set as NOT NULLable.
+        if not business_unit:
+            return None
+        if business_unit.id != business_unit_id:
+            # The business unit has changed since the beginning of the
+            # function. We should stop now, and let the booking be
+            # priced later (when we can lock the new business unit).
+            return None
         if not business_unit.siret:
             return None
         if business_unit.status != models.BusinessUnitStatus.ACTIVE:

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -50,6 +50,7 @@ class PricingFactory(BaseFactory):
     siret = factory.LazyAttribute(
         lambda pricing: pricing.booking.venue.siret or pricing.booking.venue.businessUnit.siret
     )
+    pricingPointId = factory.SelfAttribute("booking.venue.current_pricing_point_id")
     valueDate = factory.SelfAttribute("booking.dateUsed")
     amount = LazyAttribute(lambda pricing: -int(100 * pricing.booking.total_amount))
     standardRule = "Remboursement total pour les offres physiques"

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -126,12 +126,12 @@ class Pricing(Model):  # type: ignore [valid-type, misc]
 
     # FIXME (dbaty, 2022-06-20): remove `businessUnitId` and `siret`
     # columns once we have fully switched to `pricingPointId`
-    businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=False)
+    businessUnitId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("business_unit.id"), index=True, nullable=True)
     businessUnit = sqla_orm.relationship("BusinessUnit", foreign_keys=[businessUnitId])
     # `siret` is either the SIRET of the venue if it has one, or the
     # SIRET of its business unit (at the time of the creation of the
     # pricing).
-    siret = sqla.Column(sqla.String(14), nullable=False, index=True)
+    siret = sqla.Column(sqla.String(14), nullable=True, index=True)
     # FIXME (dbaty, 2022-06-20): set non-NULLABLE once pricing code
     # has been updated and old data has been migrated.
     pricingPointId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=True)

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -432,7 +432,7 @@ ts_indexes = [
 
 
 class VenuePricingPointLink(Model):  # type: ignore [misc, valid-type]
-    """At any given time, the booking of a venue are priced against a
+    """At any given time, the bookings of a venue are priced against a
     particular venue that we call the "pricing point" of the venue.
     There should only ever be one pricing point for each venue, but
     for flexibility's sake we store the link in a table with the
@@ -441,7 +441,7 @@ class VenuePricingPointLink(Model):  # type: ignore [misc, valid-type]
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
     venueId = Column(BigInteger, ForeignKey("venue.id"), index=True, nullable=False)
-    venue = relationship(Venue, foreign_keys=[venueId])
+    venue = relationship(Venue, foreign_keys=[venueId], backref="pricing_point_links")
     pricingPointId = Column(BigInteger, ForeignKey("venue.id"), index=True, nullable=False)
     pricingPoint = relationship(Venue, foreign_keys=[pricingPointId])
     # The lower bound is inclusive and required. The upper bound is

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -119,6 +119,7 @@ class FeatureToggle(enum.Enum):
     OFFER_DRAFT_ENABLED = "Active la fonctionnalités de création d'offre en brouillon"
     ENABLE_IN_PAGE_PROFILE_FORM = "Active le formulaire d'édition de profile dans une page séparée"
     ENABLE_ADAGE_VENUE_INFORMATION = "Active la page acteur culturel"
+    USE_PRICING_POINT_FOR_PRICING = "Utilise le modèle VenuePricingPointLink pour la valorisation"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -178,6 +179,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.OFFER_FORM_V3,
     FeatureToggle.PRO_DISABLE_EVENTS_QRCODE,
     FeatureToggle.USER_PROFILING_FRAUD_CHECK,
+    FeatureToggle.USE_PRICING_POINT_FOR_PRICING,
 )
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -11,6 +11,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.payments.factories as payments_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
 
 
 logger = logging.getLogger(__name__)
@@ -94,11 +95,12 @@ def create_specific_invoice() -> None:
             user__deposit__source="create_specific_invoice() in industrial sandbox",
         )
         bookings.append(booking)
+    use_pricing_point = FeatureToggle.USE_PRICING_POINT_FOR_PRICING.is_active()
     for booking in bookings[:3]:
-        finance_api.price_booking(booking)
+        finance_api.price_booking(booking, use_pricing_point)
     finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
     for booking in bookings[3:]:
-        finance_api.price_booking(booking)
+        finance_api.price_booking(booking, use_pricing_point)
     finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
     cashflows = (
         finance_models.Cashflow.query.join(finance_models.Cashflow.pricings)

--- a/api/tests/core/finance/test_integration.py
+++ b/api/tests/core/finance/test_integration.py
@@ -6,16 +6,19 @@ import pcapi.core.bookings.api as bookings_api
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.finance import api
 from pcapi.core.finance import models
+import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.testing import override_features
 from pcapi.models import db
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-def test_integration():
+@override_features(USE_PRICING_POINT_FOR_PRICING=False)
+def test_integration_legacy_with_business_unit():
     booking = bookings_factories.IndividualBookingFactory()
     bookings_api.mark_as_used(booking)
-    pricing = api.price_booking(booking)
+    pricing = api.price_booking(booking, use_pricing_point=False)
     assert pricing.status == models.PricingStatus.VALIDATED
 
     cutoff = datetime.datetime.utcnow()
@@ -31,3 +34,30 @@ def test_integration():
     assert cashflow.status == models.CashflowStatus.ACCEPTED
     db.session.refresh(pricing)
     assert pricing.status == models.PricingStatus.INVOICED
+
+
+@override_features(USE_PRICING_POINT_FOR_PRICING=True)
+def test_integration():
+    venue = offerers_factories.VenueFactory(pricing_point="self")
+    booking = bookings_factories.IndividualBookingFactory(stock__offer__venue=venue)
+    bookings_api.mark_as_used(booking)
+    pricing = api.price_booking(booking, use_pricing_point=True)
+    assert pricing.status == models.PricingStatus.VALIDATED
+
+    # FIXME (dbaty, 2022-06-29): uncomment below once cashflow
+    # generation can deal with pricing points.
+    # cutoff = datetime.datetime.utcnow()
+    # api.generate_cashflows_and_payment_files(cutoff)
+    # assert len(pricing.cashflows) == 1
+    # cashflow = pricing.cashflows[0]
+    # assert cashflow.status == models.CashflowStatus.UNDER_REVIEW
+    # db.session.refresh(pricing)
+    # assert pricing.status == models.PricingStatus.PROCESSED
+
+    # FIXME (dbaty, 2022-06-29): uncomment below once invoice
+    # generation can deal with pricing points.
+    # api.generate_invoices()
+    # db.session.refresh(cashflow)
+    # assert cashflow.status == models.CashflowStatus.ACCEPTED
+    # db.session.refresh(pricing)
+    # assert pricing.status == models.PricingStatus.INVOICED


### PR DESCRIPTION
Commits à relire séparément. Le gros consiste à ajouter un feature flag `USE_PRICING_POINT_FOR_PRICING`, et à modifier le comportement du code de valorisation selon la valeur.

À vue de nez, je pense qu'on pourrait tester la bascule comme suit : 

1. On remplit la table `PricingPointVenueLink` et on migre les `Pricing` (pour remplir leur `Pricing.pricingPointId`).
2. On coupe le cron `price_bookings` (il y a déjà un feature flag pour ça).
3. On exporte les Pricing à l'état `VALIDATED` (non inclus dans le remboursement, donc).
4. On les supprime.
5. On active le feature flag `USE_PRICING_POINT_FOR_PRICING`.
6. On réactive le cron `price_booking`.
7. On vérifie qu'on a les mêmes valorisations : les mêmes réservations sont valorisées, avec les mêmes valeur (plus d'éventuelles réservations qui ont été faites après l'étape 4, bien sûr).

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15596