### PR TITLE
(bsr)[PRO] rtl await in test

### DIFF
--- a/pro/src/components/layout/Tutorial/__specs__/TutorialDialog.spec.jsx
+++ b/pro/src/components/layout/Tutorial/__specs__/TutorialDialog.spec.jsx
@@ -54,7 +54,7 @@ describe('tutorial modal', () => {
       app: { logEvent: mockLogEvent },
     })
     renderTutorialDialog(store, {})
-    const closeButton = await screen.getByTitle('Fermer la modale')
+    const closeButton = screen.getByTitle('Fermer la modale')
     await userEvent.click(closeButton)
     expect(mockLogEvent).toHaveBeenNthCalledWith(1, Events.TUTO_PAGE_VIEW, {
       page_number: '1',

--- a/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
+++ b/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
@@ -314,9 +314,7 @@ describe('homepage', () => {
           })
 
           // when
-          fireEvent.click(
-            await screen.getByRole('button', { name: 'Enregistrer' })
-          )
+          fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
 
           // then
           expect(pcapi.updateUserInformations).toHaveBeenCalledWith({

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BusinessUnitField.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BusinessUnitField.spec.jsx
@@ -14,7 +14,7 @@ jest.mock('repository/pcapi/pcapi', () => ({
 const renderBusinessUnitField = async props => {
   const rtlReturn = await render(<BusinessUnitFields {...props} />)
 
-  const loadingMessage = await screen.queryByText('Chargement en cours ...')
+  const loadingMessage = screen.queryByText('Chargement en cours ...')
   await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
 
   return rtlReturn

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -2679,7 +2679,7 @@ describe('stocks page', () => {
         )
 
         // Then
-        const successMessage = await screen.queryByText(
+        const successMessage = screen.queryByText(
           'Votre offre a bien été créée et vos stocks sauvegardés.'
         )
         expect(successMessage).toBeInTheDocument()

--- a/pro/src/new_components/RouteLeavingGuardOfferCreation/__specs__/RouteLeavingGuardOfferCreation.spec.tsx
+++ b/pro/src/new_components/RouteLeavingGuardOfferCreation/__specs__/RouteLeavingGuardOfferCreation.spec.tsx
@@ -55,7 +55,7 @@ describe('new_components | RouteLeavingGuardOfferCreation', () => {
     renderRouteLeavingGuardOfferCreation(props, history)
     await userEvent.click(screen.getByText('Stocks'))
     expect(
-      await screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
+      screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
     ).not.toBeInTheDocument()
     expect(spyHistory).toHaveBeenLastCalledWith({ pathname: '/offres' })
   })
@@ -88,7 +88,7 @@ describe('new_components | RouteLeavingGuardOfferCreation', () => {
     renderRouteLeavingGuardOfferCreation(props, history)
     await userEvent.click(screen.getByText('Stocks'))
     expect(
-      await screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
+      screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
     ).not.toBeInTheDocument()
   })
 
@@ -97,7 +97,7 @@ describe('new_components | RouteLeavingGuardOfferCreation', () => {
     await renderRouteLeavingGuardOfferCreation(props, history)
     await userEvent.click(screen.getByText('Récapitulatif'))
     expect(
-      await screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
+      screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
     ).not.toBeInTheDocument()
   })
 
@@ -106,7 +106,7 @@ describe('new_components | RouteLeavingGuardOfferCreation', () => {
     await renderRouteLeavingGuardOfferCreation(props, history)
     await userEvent.click(screen.getByText('Confirmation'))
     expect(
-      await screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
+      screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
     ).not.toBeInTheDocument()
   })
 
@@ -125,7 +125,7 @@ describe('new_components | RouteLeavingGuardOfferCreation', () => {
       )
       await userEvent.click(screen.getByText('Visibilité'))
       expect(
-        await screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
+        screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
       ).not.toBeInTheDocument()
     })
   })

--- a/pro/src/routes/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/routes/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -93,7 +93,7 @@ const renderBookingsRecap = async (
     if (hasBoookings) {
       await waitFor(() => expect(displayBookingsButton).not.toBeDisabled())
     } else {
-      const loadingMessage = await screen.queryByText('Chargement en cours ...')
+      const loadingMessage = screen.queryByText('Chargement en cours ...')
       await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
     }
   }

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOfferTypeStep.spec.tsx
@@ -46,7 +46,7 @@ describe('screens | OfferEducational : creation offer type step', () => {
       '0/1000'
     )
 
-    const durationInput = await screen.getByLabelText(/Durée/)
+    const durationInput = screen.getByLabelText(/Durée/)
     expect(durationInput).toBeInTheDocument()
     expect(durationInput).toBeEnabled()
     expect(durationInput).toHaveValue('')

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
@@ -134,17 +134,13 @@ describe('screens | OfferEducational : creation offerer step', () => {
       expect(offererSelect.children).toHaveLength(1)
       expect(offererSelect).toBeDisabled()
 
-      expect(
-        await screen.queryByTestId('error-offererId')
-      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId('error-offererId')).not.toBeInTheDocument()
 
       expect(venueSelect).toBeInTheDocument()
       expect(venueSelect).toHaveValue('VENUE_ID')
       expect(venueSelect.children).toHaveLength(1)
       expect(venueSelect).toBeDisabled()
-      expect(
-        await screen.queryByTestId('error-venueId')
-      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId('error-venueId')).not.toBeInTheDocument()
 
       expect(offerTypeTitle).toBeInTheDocument()
     })
@@ -172,9 +168,7 @@ describe('screens | OfferEducational : creation offerer step', () => {
       expect(offererSelect).toHaveValue('')
       expect(offererSelect.children).toHaveLength(3)
       expect(offererSelect).toBeEnabled()
-      expect(
-        await screen.queryByTestId('error-offererId')
-      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId('error-offererId')).not.toBeInTheDocument()
 
       await userEvent.click(offererSelect)
       await userEvent.tab()
@@ -236,9 +230,7 @@ describe('screens | OfferEducational : creation offerer step', () => {
       expect(venueSelect).toHaveDisplayValue('Sélectionner un lieu')
       expect(venueSelect.children).toHaveLength(3)
       expect(venueSelect).toBeEnabled()
-      expect(
-        await screen.queryByTestId('error-venueId')
-      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId('error-venueId')).not.toBeInTheDocument()
 
       expect(
         screen.queryByRole('heading', {


### PR DESCRIPTION
Retrait des `await` sur les methods rtl `getBy*` et `queryBy*` car celle-ci sont synchrones.
