### PR TITLE
(PC-14916)[PRO] fix: ui-kit: Select: fix vertical align

### DIFF
--- a/pro/src/ui-kit/form/Select/Select.module.scss
+++ b/pro/src/ui-kit/form/Select/Select.module.scss
@@ -6,6 +6,7 @@
 
 .select-input {
   @include formsM.input-theme();
+  line-height: rem.torem(36px);
   padding-right: rem.torem(forms.$input-right-icon-padding);
 
   &.has-error {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14916

`$ yarn storybook`
storybook locale: http://localhost:6006/?path=/story/ui-kit-forms-select--formik-field


## But de la pull request

Le champs est mal aligné sur firefox: 

![form_select_vertical_align_wrong](https://user-images.githubusercontent.com/139848/175324740-2cb06c9b-e6a5-441f-881f-d4174401a5d8.png)


## Implémentation

fix: 

![form_select_vertical_align](https://user-images.githubusercontent.com/139848/175324770-f08df04c-f6a0-4946-aef5-d25766ecdcde.png)
