### PR TITLE
(PC-15343) Ensure fraud check idempotency

### DIFF
--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -110,7 +110,7 @@ def parse_beneficiary_information_graphql(
         application_number=application_number,
         birth_date=birth_date,
         city=city,
-        civility=civility,
+        civility=_parse_dms_civility(civility),
         department=department,
         email=email,
         first_name=first_name,
@@ -127,3 +127,11 @@ def parse_beneficiary_information_graphql(
     if parsing_errors:
         raise subscription_exceptions.DMSParsingError(email, parsing_errors, result_content, "Error validating")
     return result_content
+
+
+def _parse_dms_civility(civility: dms_models.Civility) -> Optional[users_models.GenderEnum]:
+    if civility == dms_models.Civility.M:
+        return users_models.GenderEnum.M
+    if civility == dms_models.Civility.MME:
+        return users_models.GenderEnum.F
+    return None

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -9,7 +9,6 @@ from factory.declarations import LazyAttribute
 import factory.fuzzy
 import pytz
 
-from pcapi.connectors.dms import models as dms_models
 from pcapi.core import testing
 import pcapi.core.fraud.ubble.models as ubble_fraud_models
 from pcapi.core.users import models as users_models
@@ -62,7 +61,7 @@ class DMSContentFactory(factory.Factory):
 
     last_name = factory.Faker("last_name")
     first_name = factory.Faker("first_name")
-    civility = random.choice([civility.value for civility in dms_models.Civility])
+    civility = users_models.GenderEnum.F
     email = factory.Faker("ascii_safe_email")
     application_number = factory.Faker("pyint")
     procedure_id = factory.Faker("pyint")

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -175,14 +175,6 @@ class JouveContent(common_models.IdentityCheckContent):
         return self.bodyPieceNumber
 
 
-def _parse_dms_civility(civility: dms_models.Civility) -> typing.Optional[users_models.GenderEnum]:
-    if civility == dms_models.Civility.M:
-        return users_models.GenderEnum.M
-    if civility == dms_models.Civility.MME:
-        return users_models.GenderEnum.F
-    return None
-
-
 class DMSContent(common_models.IdentityCheckContent):
     activity: typing.Optional[str]
     address: typing.Optional[str]
@@ -202,8 +194,6 @@ class DMSContent(common_models.IdentityCheckContent):
     processed_datetime: typing.Optional[datetime.datetime]
     registration_datetime: typing.Optional[datetime.datetime]
     state: typing.Optional[str]
-
-    _parse_civility = pydantic.validator("civility", pre=True, allow_reuse=True)(_parse_dms_civility)
 
     class Config:
         allow_population_by_field_name = True

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -98,6 +98,10 @@ def handle_dms_application(
 
     fraud_check = fraud_dms_api.get_or_create_fraud_check(user, application_number, application_content)
 
+    if fraud_check.status == fraud_models.FraudCheckStatus.OK:
+        logger.warning("[DMS] Skipping because FraudCheck already has OK status", extra=log_extra_data)
+        return fraud_check
+
     fraud_check.resultContent = application_content.dict()
     fraud_check.eligibilityType = fraud_api.decide_eligibility(  # type: ignore [assignment]
         user, application_content.get_birth_date(), application_content.get_registration_datetime()

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -310,8 +310,6 @@ class FindDuplicateUserTest:
         assert fraud_api.find_duplicate_id_piece_number_user(new_id_piece_number, new_user.id) == existing_user
 
 
-
-
 @pytest.mark.usefixtures("db_session")
 class EduconnectFraudTest:
     def test_on_educonnect_result(self):

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -310,34 +310,6 @@ class FindDuplicateUserTest:
         assert fraud_api.find_duplicate_id_piece_number_user(new_id_piece_number, new_user.id) == existing_user
 
 
-@pytest.mark.usefixtures("db_session")
-class DMSFraudCheckTest:
-    def test_dms_fraud_check(self):
-        user = users_factories.UserFactory()
-        content = fraud_factories.DMSContentFactory()
-        fraud_check = fraud_api.on_dms_fraud_result(user, content)
-        assert fraud_check.eligibilityType == users_models.EligibilityType.AGE18
-
-        expected_content = fraud_check.source_data()
-        assert content == expected_content
-
-    def test_dms_update_eligibility(self):
-        birth_date = datetime.datetime.utcnow() - relativedelta(years=17, months=1)
-        user = users_factories.UserFactory(dateOfBirth=birth_date)
-        assert user.eligibility == users_models.EligibilityType.UNDERAGE
-        content = fraud_factories.DMSContentFactory(
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=18, months=1)
-        )
-
-        fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
-            user=user,
-            type=fraud_models.FraudCheckType.DMS,
-            eligibilityType=user.eligibility,
-            thirdPartyId=str(content.application_number),
-        )
-        fraud_api.on_dms_fraud_result(user, content)
-
-        assert fraud_check.eligibilityType == users_models.EligibilityType.AGE18
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -10,7 +10,6 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi import settings
-from pcapi.connectors.dms import models as dms_models
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
 import pcapi.core.mails.testing as mails_testing
@@ -641,7 +640,7 @@ class OnSuccessfulDMSApplicationTest:
             address="11 Rue du Test",
             application_number=123,
             procedure_id=123456,
-            civility=dms_models.Civility.MME,
+            civility=users_models.GenderEnum.F,
             activity="Étudiant",
             registration_datetime=datetime.today(),
         )
@@ -677,7 +676,7 @@ class OnSuccessfulDMSApplicationTest:
             address="11 Rue du Test",
             application_number=123,
             procedure_id=123456,
-            civility=dms_models.Civility.MME,
+            civility=users_models.GenderEnum.F,
             activity="Étudiant",
             registration_datetime=datetime.today(),
         )

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 import pytest
 import requests_mock
 
-from pcapi.connectors.dms import models as dms_models
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
@@ -705,7 +704,7 @@ class BeneficiaryInformationUpdateTest:
             last_name="Doe",
             first_name="Jane",
             activity="Lycéen",
-            civility=dms_models.Civility.MME,
+            civility=users_models.GenderEnum.F,
             birth_date=datetime.date(2000, 5, 1),
             email="jane.doe@test.com",
             phone="0612345678",

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -268,7 +268,7 @@ class DmsWebhookApplicationTest:
         assert content.application_number == 7654321
         assert content.birth_date == datetime.date(2003, 5, 5)
         assert content.city == None
-        assert content.civility == None
+        assert content.civility == users_models.GenderEnum.F
         assert content.department == None
         assert content.email == "young@example.com"
         assert content.first_name == "Young"

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -26,7 +26,6 @@ def make_graphql_application(
     city: Optional[str] = None,
     construction_datetime: str = "2020-05-13T09:09:46+02:00",
     last_modification_date: str = "2020-05-13T10:41:23+02:00",
-    department_code: str = "67 - Bas-Rhin",
     email: Optional[str] = "young.individual@example.com",
     first_name: str = "John",
     full_graphql_response: bool = False,

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -19,7 +19,6 @@ from pcapi.core.mails.transactional.sendinblue_template_ids import Transactional
 from pcapi.core.payments.models import Deposit
 from pcapi.core.payments.models import DepositType
 import pcapi.core.subscription.api as subscription_api
-from pcapi.core.subscription.dms import api as dms_api
 import pcapi.core.subscription.models as subscription_models
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
@@ -142,7 +141,7 @@ class RunTest:
             source_data=fraud_models.DMSContent(
                 last_name="Doe",
                 first_name="John",
-                civility=dms_models.Civility.MME,
+                civility=users_models.GenderEnum.F,
                 email="john.doe@test.com",
                 application_number=123,
                 procedure_id=6712558,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15343

## But de la pull request

Empêcher le downgrade de FraudCheck de OK à KO pour Ubble et DMS.

Ceci est causé par l'appel des webhooks à peu de temps d'intervalle. Lorsque le deuxième appel d'un statut "accepté" arrive, le FraudCheck peut avoir un code d'erreur "ALREADY_BENEFICIARY".

Dans le cas de DMS, on met en place la règle suivante : si le FraudCheck et déjà OK, on arrête le workflow. Si le FraudCheck est KO, on continue quand même car il se peut que l'instructeur revienne sur son choix.

Pour Ubble, les status OK, KO, CANCELLED, SUSPICIOUS sont considérés comme statuts finaux.

Pour Educonnect, on crée un nouveau fraudCheck à chaque fois qu'il y a un nouvel appel, donc on va garder ce processus.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
