### PR TITLE
(Pc-15441) feat: add isDraft column to offer table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-363db8d498a7 (pre) (head)
+0bedc00d2368 (pre) (head)
 090834b497b7 (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 0bedc00d2368 (pre) (head)
-090834b497b7 (post) (head)
+bfd208fa705b (post) (head)

--- a/api/src/pcapi/alembic/versions/20220624T152443_0bedc00d2368_create_isdraft_on_offer.py
+++ b/api/src/pcapi/alembic/versions/20220624T152443_0bedc00d2368_create_isdraft_on_offer.py
@@ -1,0 +1,19 @@
+"""Add column isDraft on offer table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0bedc00d2368"
+down_revision = "363db8d498a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("offer", sa.Column("isDraft", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("offer", "isDraft")

--- a/api/src/pcapi/alembic/versions/20220624T153140_bfd208fa705b_alter_isdraft_on_offer_set_not_null.py
+++ b/api/src/pcapi/alembic/versions/20220624T153140_bfd208fa705b_alter_isdraft_on_offer_set_not_null.py
@@ -1,0 +1,52 @@
+"""alter_isdraft_on_offer_set_not_null
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi import settings
+
+
+# revision identifiers, used by Alembic.
+revision = "bfd208fa705b"
+down_revision = "090834b497b7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        SET SESSION statement_timeout = '900s'
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+        DO $$
+        DECLARE
+            min_id bigint; max_id bigint;
+            batch_size int := 100000;
+        BEGIN
+            SELECT Max(id),min(id) INTO max_id, min_id FROM "offer";
+            -- This condition is for CirecleCi or empty database initialisation
+            IF max_id is Null THEN max_id:=1; min_id:=1;
+            END IF;
+            FOR j IN min_id..max_id BY batch_size LOOP
+                UPDATE "offer" SET "isDraft" = False
+                WHERE id >= j AND id < j+batch_size AND "isDraft" is Null;
+                COMMIT;
+            END LOOP;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+        )
+    op.alter_column("offer", "isDraft", existing_type=sa.BOOLEAN(), server_default=sa.text("true"), nullable=False)
+    op.execute(
+        f"""
+        SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}
+        """
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("offer", "isDraft", existing_type=sa.BOOLEAN(), server_default=None, nullable=True)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -153,6 +153,7 @@ def create_educational_offer(offer_data: PostEducationalOfferBodyModel, user: Us
     offerers_api.can_offerer_create_educational_offer(dehumanize(offer_data.offerer_id))
     completed_data = CompletedEducationalOfferModel(**offer_data.dict(by_alias=True))
     offer = create_offer(completed_data, user)
+    offer.isDraft = False
     collective_offer = educational_api.create_collective_offer(offer_data, user, offer.id)
     return (offer, collective_offer.id)
 

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -692,6 +692,7 @@ def upsert_stocks(
     repository.save(*stocks, *activation_codes)
     logger.info("Stock has been created or updated", extra={"offer": offer_id})
     if not FeatureToggle.OFFER_FORM_SUMMARY_PAGE.is_active():
+        offer.isDraft = False
         if offer.validation == OfferValidationStatus.DRAFT:
             update_offer_fraud_information(offer, user)
 
@@ -711,6 +712,7 @@ def upsert_stocks(
 def publish_offer(offer_id: int, user: User) -> Offer:
     offer = offers_repository.get_offer_by_id(offer_id)
     offer.isActive = True
+    offer.isDraft = False
     update_offer_fraud_information(offer, user)
     search.async_index_offer_ids([offer.id])
     return offer

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -58,6 +58,7 @@ class OfferFactory(BaseFactory):
     name = factory.SelfAttribute("product.name")
     description = factory.SelfAttribute("product.description")
     url = factory.SelfAttribute("product.url")
+    isDraft = False
     audioDisabilityCompliant = False
     mentalDisabilityCompliant = False
     motorDisabilityCompliant = False

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -335,7 +335,7 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ValidationMixin, 
 
     fieldsUpdated = sa.Column(sa.ARRAY(sa.String(100)), nullable=False, default=[], server_default="{}")
 
-    isDraft = sa.Column(sa.Boolean, nullable=True)
+    isDraft = sa.Column(sa.Boolean, server_default=sa.true(), default=True, nullable=False)
 
     # FIXME: We shoud be able to remove the index on `venueId`, since this composite index
     #  can be used by PostgreSQL when filtering on the `venueId` column only.

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -335,6 +335,8 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ValidationMixin, 
 
     fieldsUpdated = sa.Column(sa.ARRAY(sa.String(100)), nullable=False, default=[], server_default="{}")
 
+    isDraft = sa.Column(sa.Boolean, nullable=True)
+
     # FIXME: We shoud be able to remove the index on `venueId`, since this composite index
     #  can be used by PostgreSQL when filtering on the `venueId` column only.
     sa.Index("venueId_idAtProvider_index", venueId, idAtProvider, unique=True)

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -414,6 +414,7 @@ def _build_new_offer(
         venueId=venue.id,
         subcategoryId=product.subcategoryId,
         withdrawalDetails=venue.withdrawalDetails,
+        isDraft=False,
     )
 
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -616,6 +616,7 @@ class GetOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
 class GetIndividualOfferResponseModel(GetOfferResponseModel):
     withdrawalType: Optional[WithdrawalTypeEnum]
     withdrawalDelay: Optional[int]
+    isDraft: bool
 
 
 class ImageBodyModel(BaseModel):

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -197,6 +197,7 @@ class SynchronizeStocksTest:
         assert created_offer.venueId == venue.id
         assert created_offer.idAtProvider == spec[2]["ref"]
         assert created_offer.lastProviderId == provider.id
+        assert created_offer.isDraft == False
 
         # Test offer reindexation
         mock_async_index_offer_ids.assert_called_with(
@@ -269,6 +270,7 @@ class SynchronizeStocksTest:
         assert new_offer.venueId == venue.id
         assert new_offer.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert new_offer.withdrawalDetails == venue.withdrawalDetails
+        assert new_offer.isDraft == False
 
     def test_get_stocks_to_upsert(self):
         # Given

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -187,6 +187,7 @@ class Returns200Test:
             "isBookable": True,
             "isDigital": False,
             "isDuo": False,
+            "isDraft": False,
             "isEducational": False,
             "isEditable": True,
             "isEvent": True,

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -54,5 +54,6 @@ class Returns204Test:
         assert response.status_code == 204
         offer = offers_models.Offer.query.get(stock.offer.id)
         assert offer.isActive == True
+        assert offer.isDraft == False
         assert offer.validation == OfferValidationStatus.APPROVED
         mock_async_index_offer_ids.assert_called_once()

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -223,6 +223,7 @@ class Returns200Test:
         assert offer.venue == venue
         assert offer.product.name == "La pièce de théâtre"
         assert offer.product.owningOfferer == offerer
+        assert offer.isDraft == False
         assert offer.audioDisabilityCompliant == False
         assert offer.mentalDisabilityCompliant == True
         assert offer.motorDisabilityCompliant == False

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -17,7 +17,7 @@ from pcapi.utils.human_ids import humanize
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
     @override_features(OFFER_FORM_SUMMARY_PAGE=True)
-    def test_created_offer_should_be_inactive(self, client):
+    def test_created_offer_should_be_inactive_and_draft(self, client):
         venue = offerers_factories.VenueFactory()
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
@@ -33,6 +33,7 @@ class Returns200Test:
         offer_id = dehumanize(response.json["id"])
         offer = Offer.query.get(offer_id)
         assert offer.isActive == False
+        assert offer.isDraft == True
 
     def test_create_event_offer(self, client):
         # Given
@@ -73,6 +74,7 @@ class Returns200Test:
         assert offer.audioDisabilityCompliant == False
         assert offer.mentalDisabilityCompliant == True
         assert offer.isActive == True
+        assert offer.isDraft == True
 
     def when_creating_new_thing_offer(self, client):
         # Given

--- a/api/tests/routes/pro/post_stocks_test.py
+++ b/api/tests/routes/pro/post_stocks_test.py
@@ -23,7 +23,7 @@ class Returns201Test:
     @patch("pcapi.core.search.async_index_offer_ids")
     def test_create_one_stock_with_summury(self, mocked_async_index_offer_ids, app):
         # Given
-        offer = offers_factories.ThingOfferFactory(isActive=False, validation=OfferValidationStatus.DRAFT)
+        offer = offers_factories.ThingOfferFactory(isActive=False, isDraft=True, validation=OfferValidationStatus.DRAFT)
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -47,6 +47,7 @@ class Returns201Test:
         assert offer.id == created_stock.offerId
         assert created_stock.price == 20
         assert offer.isActive == False
+        assert offer.isDraft == True
         assert offer.validation == OfferValidationStatus.DRAFT
         assert len(mails_testing.outbox) == 0  # Mail sent during fraud validation
         mocked_async_index_offer_ids.assert_not_called()
@@ -54,7 +55,7 @@ class Returns201Test:
     @patch("pcapi.core.search.async_index_offer_ids")
     def test_create_one_stock(self, mocked_async_index_offer_ids, app):
         # Given
-        offer = offers_factories.ThingOfferFactory(validation=OfferValidationStatus.DRAFT)
+        offer = offers_factories.ThingOfferFactory(isDraft=True, validation=OfferValidationStatus.DRAFT)
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,
@@ -80,6 +81,7 @@ class Returns201Test:
         assert offer.id == created_stock.offerId
         assert created_stock.price == 20
         assert offer.isActive == True
+        assert offer.isDraft == False
         assert offer.validation == OfferValidationStatus.APPROVED
         assert len(mails_testing.outbox) == 2  # Mail for fraud validation and first offer of venue
         mocked_async_index_offer_ids.assert_called_once_with([offer.id])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15441

## But de la pull request

Ajout d'une colonne isDraft non nulle sur la table Offre 

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
