### PR TITLE
(PC-15387)[PRO] fix: crop venue name when

### DIFF
--- a/pro/src/components/pages/Home/Venues/Venue.scss
+++ b/pro/src/components/pages/Home/Venues/Venue.scss
@@ -38,6 +38,7 @@
   }
 
   .h-card-title {
+    overflow: hidden;
     .tertiary-button {
       .h-card-title-ico {
         margin-left: 0;
@@ -54,6 +55,8 @@
     .title-text {
       display: block;
       margin-right: rem.torem(16px);
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }


### PR DESCRIPTION
it have more than 90char without whitespace

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15387

![bug_home_nom_du_lieu_no_whitespace](https://user-images.githubusercontent.com/139848/176133156-1e52d51e-f0c2-48de-8eaa-cf4bda07bce2.png)
![bug_home_nom_du_lieu](https://user-images.githubusercontent.com/139848/176133159-99c0c5b7-ac11-475a-bb0f-af0fcdbec17c.png)

