### PR TITLE
(PC-15953) Add route to get available reimbursement points

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -367,3 +367,19 @@ def dms_token_exists(dms_token: str) -> bool:
 
 def get_venues_educational_statuses() -> list[models.VenueEducationalStatus]:
     return db.session.query(models.VenueEducationalStatus).order_by(models.VenueEducationalStatus.name).all()
+
+
+def find_available_reimbursement_points_for_offerer(offerer_id: int) -> list[models.Venue]:
+    """
+    Returns a list of Venues whose SIRETs can be used to reimburse bookings, and their bank info,
+    ordered by `publicName` or name if `publicName` is null
+    """
+    return (
+        models.Venue.query.join(BankInformation)
+        .filter(
+            BankInformation.status == BankInformationStatus.ACCEPTED,
+            models.Venue.managingOffererId == offerer_id,
+        )
+        .order_by(sqla.func.coalesce(models.Venue.publicName, models.Venue.name))
+        .all()
+    )

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -223,3 +223,15 @@ class GetOffererListQueryModel(BaseModel):
     keywords: Optional[str]
     page: Optional[int] = 1
     paginate: Optional[int] = 10
+
+
+class ReimbursementPointResponseModel(BaseModel):
+    venueId: int
+    venueName: str
+    siret: str
+    iban: str
+    bic: str
+
+
+class ReimbursementPointListResponseModel(BaseModel):
+    __root__: list[ReimbursementPointResponseModel]

--- a/api/tests/routes/pro/get_available_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_available_reimbursement_points_test.py
@@ -1,0 +1,65 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+from pcapi.models.bank_information import BankInformationStatus
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class Returns200Test:
+    def test_available_reimbursement_points(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(
+            user__email="user.pro@example.com",
+        )
+        offerer = user_offerer.offerer
+        offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
+        venue_1 = offerers_factories.VenueFactory(managingOfferer=offerer, name="Chez Toto")
+        offers_factories.BankInformationFactory(venue=venue_1, status=BankInformationStatus.ACCEPTED)
+        venue_2 = offerers_factories.VenueFactory(
+            managingOfferer=offerer, name="Dans l'antre de la folie", publicName="Association des démons"
+        )
+        offers_factories.BankInformationFactory(venue=venue_2, status=BankInformationStatus.ACCEPTED)
+        _venue_without_bank_info_nor_siret = offerers_factories.VenueFactory(
+            siret=None, comment="Pas de SIRET", managingOfferer=offerer
+        )
+
+        client = client.with_session_auth("user.pro@example.com")
+        response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
+
+        assert response.status_code == 200
+        assert response.json == [
+            {
+                "venueId": venue_2.id,
+                "venueName": "Association des démons",
+                "siret": venue_2.siret,
+                "iban": venue_2.iban,
+                "bic": venue_2.bic,
+            },
+            {
+                "venueId": venue_1.id,
+                "venueName": "Chez Toto",
+                "siret": venue_1.siret,
+                "iban": venue_1.iban,
+                "bic": venue_1.bic,
+            },
+        ]
+
+    def test_no_available_reimbursement_point(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(
+            user__email="user.pro@example.com",
+        )
+        offerer = user_offerer.offerer
+        offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
+        _venue_without_siret_nor_bank_info = offerers_factories.VenueFactory(
+            siret=None, comment="Pas de SIRET", managingOfferer=offerer
+        )
+        venue_with_pending_bank_info = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offers_factories.BankInformationFactory(venue=venue_with_pending_bank_info, status=BankInformationStatus.DRAFT)
+
+        client = client.with_session_auth("user.pro@example.com")
+        response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
+
+        assert response.status_code == 200
+        assert response.json == []


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15953

## But de la pull request

Ajout d'une route get_available_reimbursement_points() permettant de lister les lieux pouvant servir de point de remboursement à un lieu spécifique.

## Implémentation

- Ajout de modèles Pydantic et sérialization
- La liste des lieux en retour est **triée** par `publicName` (ou `name` si `publicName` est absent)

## Modifications du schéma de la base de données

N/A

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
