### PR TITLE
(PC-15637)[PRO] feat: display reimbursement point with venue name

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/__specs__/ReimbursementPoint.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/__specs__/ReimbursementPoint.spec.jsx
@@ -1,15 +1,17 @@
 import '@testing-library/jest-dom'
 
-import * as pcapi from 'repository/pcapi/pcapi'
-
 import { render, screen, waitFor } from '@testing-library/react'
+
 import { Form } from 'react-final-form'
 
 import React from 'react'
 import ReimbursementPoint from '../ReimbursementPoint'
+import { api } from 'apiClient/api'
 
-jest.mock('repository/pcapi/pcapi', () => ({
-  getBusinessUnits: jest.fn(),
+jest.mock('apiClient/api', () => ({
+  api: {
+    getAvailableReimbursementPoints: jest.fn(),
+  },
 }))
 
 const renderReimbursementPoint = async props => {
@@ -26,10 +28,12 @@ const renderReimbursementPoint = async props => {
 describe('src | Venue | ReimbursementPoint', () => {
   const venue = {
     id: 'AA',
+    nonHumanizedId: 1,
     name: 'fake venue name',
   }
   const offerer = {
     id: 'BB',
+    nonHumanizedId: 2,
     name: 'fake offerer name',
   }
   let props
@@ -39,11 +43,11 @@ describe('src | Venue | ReimbursementPoint', () => {
 
   it('should display reimbursement point secion  when offerer has at least one', async () => {
     // Given
-    pcapi.getBusinessUnits.mockResolvedValue([
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([
       {
-        name: 'Reimbursement Point #1',
+        venueName: 'Venue #1',
         siret: '111222333',
-        id: 1,
+        venueId: 1,
         bic: 'BDFEFRPP',
         iban: 'FR9410010000000000000000022',
       },
@@ -60,11 +64,11 @@ describe('src | Venue | ReimbursementPoint', () => {
 
   it('should display reimbursement point with the correct name ', async () => {
     // Given
-    pcapi.getBusinessUnits.mockResolvedValue([
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([
       {
-        name: 'Reimbursement Point #1',
+        venueName: 'Venue #1',
         siret: '111222333',
-        id: 1,
+        venueId: 1,
         bic: 'BDFEFRPP',
         iban: 'FR9410010000000000000000022',
       },
@@ -75,13 +79,13 @@ describe('src | Venue | ReimbursementPoint', () => {
 
     // Then
     expect(
-      screen.queryByText('111 222 333 - FR9410010000000000000000022')
+      screen.queryByText('Venue #1 - FR9410010000000000000000022')
     ).toBeInTheDocument()
   })
 
   it('should not display reimbursement point selection  when offerer has not one', async () => {
     // Given
-    pcapi.getBusinessUnits.mockResolvedValue([])
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([])
 
     // When
     await renderReimbursementPoint(props)
@@ -94,7 +98,7 @@ describe('src | Venue | ReimbursementPoint', () => {
 
   it('should display add cb button when venue does not have reimbursement point', async () => {
     // Given
-    pcapi.getBusinessUnits.mockResolvedValue([])
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([])
 
     // When
     await renderReimbursementPoint(props)
@@ -109,22 +113,22 @@ describe('src | Venue | ReimbursementPoint', () => {
 
   it('should display modify button when venue has already add dms cb', async () => {
     // Given
-    const venueWithCb = {
+    const venueWithReimbursementPoint = {
       id: 'AA',
+      nonHumanizedId: 1,
+      reimbursementPointId: 1,
       name: 'fake venue name',
-      isBusinessUnitMainVenue: true,
     }
-
-    props.venue = venueWithCb
-    pcapi.getBusinessUnits.mockResolvedValue([
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([
       {
-        name: 'Reimbursement Point #1',
+        venueName: 'fake venue name',
         siret: '111222333',
-        id: 1,
+        venueId: 1,
         bic: 'BDFEFRPP',
         iban: 'FR9410010000000000000000022',
       },
     ])
+    props.venue = venueWithReimbursementPoint
 
     // When
     await renderReimbursementPoint(props)
@@ -142,13 +146,13 @@ describe('src | Venue | ReimbursementPoint', () => {
     const venueWithPendingApplication = {
       id: 'AA',
       name: 'fake venue name',
-      bix: null,
+      bic: null,
       iban: null,
       demarchesSimplifieesApplicationId: '2',
     }
 
     props.venue = venueWithPendingApplication
-    pcapi.getBusinessUnits.mockResolvedValue([])
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([])
 
     // When
     await renderReimbursementPoint(props)

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/utils/formatVenuePayload.js
@@ -50,6 +50,7 @@ const edition_authorized_input_field = [
   'motorDisabilityCompliant',
   'visualDisabilityCompliant',
   'contact',
+  'reimbursementPointId',
 ]
 
 export const formatVenuePayload = (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Affichage des points de remboursements dans la liste déroulante de la section coordonnées bancaire.

## Implémentation

Point notable : modification de la route (on récupère les points de remboursement et non plus les business Unit)
Conséquence : Quand on poste l'édition du lieu on ne poste plus le businessUnitId mais le reimbursementPointId


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
