### PR TITLE
(PC-15953)[API] fix: improve query

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -380,6 +380,7 @@ def find_available_reimbursement_points_for_offerer(offerer_id: int) -> list[mod
             BankInformation.status == BankInformationStatus.ACCEPTED,
             models.Venue.managingOffererId == offerer_id,
         )
+        .options(sqla_orm.joinedload(models.Venue.bankInformation))
         .order_by(sqla.func.coalesce(models.Venue.publicName, models.Venue.name))
         .all()
     )

--- a/api/tests/routes/pro/get_available_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_available_reimbursement_points_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pcapi.core import testing
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.models.bank_information import BankInformationStatus
@@ -26,7 +27,13 @@ class Returns200Test:
         )
 
         client = client.with_session_auth("user.pro@example.com")
-        response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
+        n_queries = (
+            testing.AUTHENTICATION_QUERIES
+            + 1  # check_user_has_access_to_offerer
+            + 1  # eligible Venues with their eagerly loaded BankInformation
+        )
+        with testing.assert_num_queries(n_queries):
+            response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
 
         assert response.status_code == 200
         assert response.json == [


### PR DESCRIPTION
BankInformation was not eagerly loaded along the Venue in
find_available_reimbursement_points_for_offerer, which caused a N+1 issue

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15953

## But de la pull request
Corriger un souci de requête N+1 sur `find_available_reimbursement_points_for_offerer()`, relevé par @dbaty (merci !)