### PR TITLE
Pc 16001 misc back fixes for backoffice

### DIFF
--- a/api/src/pcapi/core/permissions/api.py
+++ b/api/src/pcapi/core/permissions/api.py
@@ -41,10 +41,11 @@ def update_role(id_: int, name: str, permission_ids: typing.Iterable[int]) -> Ro
     return role
 
 
-def delete_role(id_: int) -> None:
+def delete_role(id_: int) -> Role:
     role = Role.query.get(id_)
     if role.name == "admin":
         raise ValueError("Cannot delete admin role")
     role.permissions = []
-    repository.save()
+    repository.save(role)
     db.session.delete(role)
+    return role

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -62,7 +62,7 @@ def get_public_account(user_id: int) -> serialization.PublicAccount:
     return serialization.PublicAccount.from_orm(user)
 
 
-@blueprint.backoffice_blueprint.route("public_accounts/<int:user_id>", methods=["POST"])
+@blueprint.backoffice_blueprint.route("public_accounts/<int:user_id>", methods=["PUT"])
 @perm_utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
 @spectree_serialize(
     response_model=serialization.PublicAccount,

--- a/api/src/pcapi/routes/backoffice/auth.py
+++ b/api/src/pcapi/routes/backoffice/auth.py
@@ -1,17 +1,21 @@
-from pcapi.core.auth.api import authenticate_with_permissions
+from pcapi.core.auth import api as auth_api
+from pcapi.models.api_errors import ApiErrors
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
-from .serialization import AuthTokenQuery
-from .serialization import AuthTokenResponseModel
+from . import serialization
 
 
 @blueprint.backoffice_blueprint.route("auth/token", methods=["GET"])
 @spectree_serialize(
-    response_model=AuthTokenResponseModel,
+    response_model=serialization.AuthTokenResponseModel,
     on_success_status=200,
     api=blueprint.api,
 )
-def get_auth_token(query: AuthTokenQuery) -> AuthTokenResponseModel:
-    token = authenticate_with_permissions(query.token)
-    return AuthTokenResponseModel(token=token)
+def get_auth_token(query: serialization.AuthTokenQuery) -> serialization.AuthTokenResponseModel:
+    try:
+        token = auth_api.authenticate_with_permissions(query.token)
+    except auth_api.NotAPassCultureTeamAccountError:
+        raise ApiErrors({"global": "not a passsCulture team account"})
+
+    return serialization.AuthTokenResponseModel(token=token)

--- a/api/src/pcapi/routes/backoffice/permissions.py
+++ b/api/src/pcapi/routes/backoffice/permissions.py
@@ -73,11 +73,14 @@ def update_role(id_: int, body: RoleRequestModel) -> Role:
 @blueprint.backoffice_blueprint.route("roles/<int:id_>", methods=["DELETE"])
 @perm_utils.permission_required(perm_models.Permissions.MANAGE_PERMISSIONS)
 @spectree_serialize(
-    on_success_status=204,
+    response_model=Role,
+    on_success_status=200,
     api=blueprint.api,
 )
-def delete_role(id_: int) -> None:
+def delete_role(id_: int) -> Role:
     try:
-        perm_api.delete_role(id_=id_)
+        deleted = perm_api.delete_role(id_=id_)
     except ValueError as err:
         raise ApiErrors(errors={"id": str(err)})
+
+    return Role.from_orm(deleted)

--- a/api/src/pcapi/routes/backoffice/permissions.py
+++ b/api/src/pcapi/routes/backoffice/permissions.py
@@ -38,7 +38,12 @@ def list_roles() -> ListRoleResponseModel:
 )
 def list_permissions() -> ListPermissionResponseModel:
     permissions = perm_api.list_permissions()
-    return ListPermissionResponseModel(permissions=[Permission.from_orm(perm) for perm in permissions])
+    return ListPermissionResponseModel(
+        permissions=[
+            Permission(id=perm.id, name=perm_models.Permissions[perm.name].value, category=perm.category)
+            for perm in permissions
+        ]
+    )
 
 
 @blueprint.backoffice_blueprint.route("roles", methods=["POST"])

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -275,7 +275,7 @@ class UpdatePublicAccountTest:
         auth_token = generate_token(admin, [Permissions.MANAGE_PUBLIC_ACCOUNT])
 
         # when
-        response = client.with_explicit_token(auth_token).post(
+        response = client.with_explicit_token(auth_token).put(
             url_for("backoffice_blueprint.update_public_account", user_id=user.id),
             json={
                 "firstName": "Upda",
@@ -321,7 +321,7 @@ class UpdatePublicAccountTest:
         auth_token = generate_token(admin, [Permissions.MANAGE_PUBLIC_ACCOUNT])
 
         # when
-        response = client.with_explicit_token(auth_token).post(
+        response = client.with_explicit_token(auth_token).put(
             url_for("backoffice_blueprint.update_public_account", user_id=user.id),
             json={"email": "Updated@example.com"},
         )
@@ -387,7 +387,7 @@ class UpdatePublicAccountTest:
         auth_token = generate_token(admin, [Permissions.MANAGE_PUBLIC_ACCOUNT])
 
         # when
-        response = client.with_explicit_token(auth_token).post(
+        response = client.with_explicit_token(auth_token).put(
             url_for("backoffice_blueprint.update_public_account", user_id=user.id),
             json={"email": "updated.example.com"},
         )
@@ -404,7 +404,7 @@ class UpdatePublicAccountTest:
         auth_token = generate_token(admin, [Permissions.MANAGE_PUBLIC_ACCOUNT])
 
         # when
-        response = client.with_explicit_token(auth_token).post(
+        response = client.with_explicit_token(auth_token).put(
             url_for("backoffice_blueprint.update_public_account", user_id=user1.id),
             json={"email": user2.email},
         )
@@ -421,7 +421,7 @@ class UpdatePublicAccountTest:
         auth_token = generate_token(admin, [Permissions.MANAGE_PUBLIC_ACCOUNT])
 
         # when
-        response = client.with_explicit_token(auth_token).post(
+        response = client.with_explicit_token(auth_token).put(
             url_for("backoffice_blueprint.update_public_account", user_id=user.id),
             json={"phoneNumber": "0987654321"},
         )
@@ -441,7 +441,7 @@ class UpdatePublicAccountTest:
         auth_token = generate_token(user, [])
 
         # when
-        response = client.with_explicit_token(auth_token).post(
+        response = client.with_explicit_token(auth_token).put(
             url_for("backoffice_blueprint.update_public_account", user_id=user.id),
             json={"email": "updated@example.com"},
         )

--- a/api/tests/routes/backoffice/auth_test.py
+++ b/api/tests/routes/backoffice/auth_test.py
@@ -1,0 +1,62 @@
+from unittest import mock
+
+from flask import url_for
+import pytest
+
+from pcapi.core.testing import override_features
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class AuthenticationTest:
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_authenticate(self, client):
+        # given
+        user = users_factories.UserFactory(email="toto@passculture.app")
+        with mock.patch("pcapi.core.auth.api.get_google_token_id_info") as token_info_mock, mock.patch(
+            "pcapi.core.auth.api.get_groups_from_google_workspace"
+        ) as google_groups_mock:
+            token_info_mock.return_value = {"email": user.email}
+            google_groups_mock.return_value = {"groups": []}
+
+            # when
+            response = client.get(
+                url_for("backoffice_blueprint.get_auth_token", token="example token"),
+            )
+
+        # then
+        assert response.status_code == 200
+        assert len(response.json["token"].split(".")) == 3
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_authenticate_with_a_non_passculture_email(self, client):
+        # given
+        user = users_factories.UserFactory(email="toto@example.com")
+
+        with mock.patch("pcapi.core.auth.api.get_user_from_google_id") as user_from_google_mock:
+            user_from_google_mock.return_value = user
+
+            # when
+            response = client.get(
+                url_for("backoffice_blueprint.get_auth_token", token="example token"),
+            )
+
+        # then
+        assert response.status_code == 400
+        assert response.json["global"] == "not a passsCulture team account"
+
+    def test_cannot_authenticate_with_an_unknown_email(self, client):
+        # given
+        with mock.patch("pcapi.core.auth.api.get_google_token_id_info") as token_info_mock:
+            token_info_mock.return_value = {"email": "toto@passculture.app"}
+
+            # when
+            response = client.get(
+                url_for("backoffice_blueprint.get_auth_token", token="example token"),
+            )
+
+        # then
+        assert response.status_code == 400
+        assert response.json["global"] == "not a passsCulture team account"

--- a/api/tests/routes/backoffice/permissions_test.py
+++ b/api/tests/routes/backoffice/permissions_test.py
@@ -334,8 +334,11 @@ class DeleteRoleTest:
         )
 
         # then
-        assert response.status_code == 204
+        assert response.status_code == 200
         assert Role.query.filter_by(id=role.id).count() == 0
+        deleted_role = response.json
+        assert deleted_role["id"] == role.id
+        assert deleted_role["name"] == role.name
 
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_delete_role_with_empty_permissions(self, client):
@@ -350,8 +353,11 @@ class DeleteRoleTest:
         )
 
         # then
-        assert response.status_code == 204
+        assert response.status_code == 200
         assert Role.query.filter_by(id=role.id).count() == 0
+        deleted_role = response.json
+        assert deleted_role["id"] == role.id
+        assert deleted_role["name"] == role.name
 
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_delete_admin_role(self, client):

--- a/api/tests/routes/backoffice/permissions_test.py
+++ b/api/tests/routes/backoffice/permissions_test.py
@@ -79,8 +79,6 @@ class PermissionListTest:
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_list_permissions(self, client):
         # given
-        PermissionFactory(name="test_permission_1")
-        PermissionFactory(name="test_permission_2")
         user = UserFactory()
         auth_token = generate_token(user, [Permissions.MANAGE_PERMISSIONS])
 
@@ -92,17 +90,11 @@ class PermissionListTest:
         # then
         assert response.status_code == 200
         permissions = response.json["permissions"]
-        assert set(perm["name"] for perm in permissions) == {
-            *[p.name for p in Permissions],
-            "test_permission_1",
-            "test_permission_2",
-        }
+        assert set(perm["name"] for perm in permissions) == {p.value for p in Permissions}
 
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_list_permissions_without_permission(self, client):
         # given
-        PermissionFactory(name="test_permission_1")
-        PermissionFactory(name="test_permission_2")
         user = UserFactory()
         auth_token = generate_token(user, [])
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16001

## But de la pull request

lot de 4 corrections (en 4 commits):
- le endpoint de liste des permissions renvoi le descriptif de chaque permission plutôt que des noms d'Enum
- un problème d’authentification au backoffice renvoie maintenant une 400 avec un message d’erreur au lieu d’une 500
- le endpoint de suppression de rôle renvoi le rôle supprimé.
- le endpoint de mise à jour d’un compte public utilise maintenant la méthode PUT (au lieu de POST)

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai relu attentivement les migrations, en particulier pour éviter les _locks_~~
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
