### PR TITLE
PC-15015 send eligibility msg with parsing errors

### DIFF
--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -61,12 +61,12 @@ def build_field_errors_user_message(field_errors: list[dms_models.DmsFieldErrorD
     )
 
 
-def build_dms_error_message_user_not_eligible(birth_date: datetime.date, application_scalar_id: str) -> str:
+def build_dms_error_message_user_not_eligible(birth_date: datetime.date, application_id: int) -> str:
     return (
         "Bonjour,\n"
         "\n"
         f"Nous avons bien reçu ton dossier, mais la date de naissance que tu as renseignée ({birth_date.isoformat()}) indique que tu n’as pas l’âge requis pour profiter du pass Culture (tu dois avoir entre 15 et 18 ans).\n"
-        f'S’il s’agit d’une erreur, tu peux corriger ton dossier depuis démarches-simplifiées: <a target="_blank" rel="noopener" href="https://www.demarches-simplifiees.fr/dossiers/{application_scalar_id}">https://www.demarches-simplifiees.fr/dossiers/{application_scalar_id}</a>\n'
+        f'S’il s’agit d’une erreur, tu peux corriger ton dossier depuis démarches-simplifiées: <a target="_blank" rel="noopener" href="https://www.demarches-simplifiees.fr/dossiers/{application_id}">https://www.demarches-simplifiees.fr/dossiers/{application_id}</a>\n'
         "\n"
         'Tu trouveras de l’aide dans cet article : <a href="https://aide.passculture.app/hc/fr/articles/4411999116433--Jeunes-Où-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-Démarches-Simplifiées-">Où puis-je trouver de l’aide concernant mon dossier d’inscription sur Démarches Simplifiées ?</a>'
         "\n"

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -61,6 +61,21 @@ def build_field_errors_user_message(field_errors: list[dms_models.DmsFieldErrorD
     )
 
 
+def build_dms_error_message_user_not_eligible(birth_date: datetime.date, application_scalar_id: str) -> str:
+    return (
+        "Bonjour,\n"
+        "\n"
+        f"Nous avons bien reçu ton dossier, mais la date de naissance que tu as renseignée ({birth_date.isoformat()}) indique que tu n’as pas l’âge requis pour profiter du pass Culture (tu dois avoir entre 15 et 18 ans).\n"
+        f'S’il s’agit d’une erreur, tu peux corriger ton dossier depuis démarches-simplifiées: <a target="_blank" rel="noopener" href="https://www.demarches-simplifiees.fr/dossiers/{application_scalar_id}">https://www.demarches-simplifiees.fr/dossiers/{application_scalar_id}</a>\n'
+        "\n"
+        'Tu trouveras de l’aide dans cet article : <a href="https://aide.passculture.app/hc/fr/articles/4411999116433--Jeunes-Où-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-Démarches-Simplifiées-">Où puis-je trouver de l’aide concernant mon dossier d’inscription sur Démarches Simplifiées ?</a>'
+        "\n"
+        "Bonne journée,\n"
+        "\n"
+        "L’équipe du pass Culture"
+    )
+
+
 def on_review_pending(user: users_models.User) -> None:
     message = models.SubscriptionMessage(
         user=user,

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -730,7 +730,7 @@ class DmsWebhookApplicationTest:
     def test_dms_birth_date_error(self, send_user_message, execute_query, client, birthday_date):
         user = users_factories.UserFactory()
         execute_query.return_value = make_single_application(
-            12, state=dms_models.GraphQLApplicationStates.draft.value, email=user.email, birth_date=birthday_date
+            6044787, state=dms_models.GraphQLApplicationStates.draft.value, email=user.email, birth_date=birthday_date
         )
 
         form_data = {
@@ -751,12 +751,12 @@ class DmsWebhookApplicationTest:
         assert send_user_message.call_args[0][2] == (
             "Bonjour,\n"
             "\n"
-            "Nous avons bien reçu ton dossier, mais il y a une erreur dans le champ contenant ta date de naissance, inscrit sur le formulaire en ligne:\n"
-            "Merci de corriger ton dossier.\n"
+            f"Nous avons bien reçu ton dossier, mais la date de naissance que tu as renseignée ({birthday_date}) indique que tu n’as pas l’âge requis pour profiter du pass Culture (tu dois avoir entre 15 et 18 ans).\n"
+            f'S’il s’agit d’une erreur, tu peux corriger ton dossier depuis démarches-simplifiées: <a target="_blank" rel="noopener" href="https://www.demarches-simplifiees.fr/dossiers/6044787">https://www.demarches-simplifiees.fr/dossiers/6044787</a>\n'
             "\n"
-            'Tu trouveras de l’aide dans cet article : <a href="https://aide.passculture.app/hc/fr/articles/4411999116433--Jeunes-Où-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-Démarches-Simplifiées-">Où puis-je trouver de l’aide concernant mon dossier d’inscription sur Démarches Simplifiées ?</a>\n'
+            'Tu trouveras de l’aide dans cet article : <a href="https://aide.passculture.app/hc/fr/articles/4411999116433--Jeunes-Où-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-Démarches-Simplifiées-">Où puis-je trouver de l’aide concernant mon dossier d’inscription sur Démarches Simplifiées ?</a>'
             "\n"
-            "Nous te souhaitons une belle journée.\n"
+            "Bonne journée,\n"
             "\n"
             "L’équipe du pass Culture"
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15015

## But de la pull request

Update après retour de validation: envoyer les messages concernant l'éligibilité ET les erreurs de dans les champs de formulaires via la messagerie DMS

## Modifications du schéma de la base de données

None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
