### PR TITLE
(BSR)[API] Mentionner "pre" ou "post" dans le fichier de migration Alembic

### DIFF
--- a/api/src/pcapi/alembic/script.py.mako
+++ b/api/src/pcapi/alembic/script.py.mako
@@ -4,6 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 ${imports if imports else ""}
 
+# pre/post deployment: ${config.cmd_opts.head.split("@")[0]}
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}


### PR DESCRIPTION
That way, the generated migration file clearly mentions the branch:

    """Add blob.frobul
    """
    [...]
    # pre/post deployment: ${config.cmd_opts.head.split("@")[0]}
    # revision identifiers, used by Alembic.
    revision = 'abcdef123'
    [...]

... which helps when (re)viewing code. The branch was not included in
the doctring because `alembic history` already shows it and it would
then appear twice:

    363db8d498a7 -> 3a02357e17ba (pre) (head), create_venue_educational_status
    cb1d904c149d -> 363db8d498a7 (pre), Add venue_pricing_point_link

Getting the name of the branch is a bit convoluted. I could not find a
better way, given what's provided to the template.

Suggested by François.