### PR TITLE
(PC-15812)[API] feat: backoffice - add pagination to public account search

### DIFF
--- a/api/src/pcapi/models/__init__.py
+++ b/api/src/pcapi/models/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import typing
 
 from flask_sqlalchemy import SQLAlchemy
 import pydantic.json

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -1,3 +1,5 @@
+import typing
+
 from pcapi.core.auth.utils import get_current_user
 from pcapi.core.fraud import api as fraud_api
 from pcapi.core.fraud import models as fraud_models
@@ -34,13 +36,13 @@ SUBSCRIPTION_ITEM_METHODS = [
 @blueprint.backoffice_blueprint.route("public_accounts/search", methods=["GET"])
 @perm_utils.permission_required(perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT)
 @spectree_serialize(
-    response_model=serialization.PaginatedResponse,
+    response_model=serialization.ListPublicAccountsResponseModel,
     on_success_status=200,
     api=blueprint.api,
 )
 def search_public_account(
     query: serialization.PublicAccountSearchQuery,
-) -> serialization.PaginatedResponse:
+) -> serialization.ListPublicAccountsResponseModel:
     terms = query.q.split()
     sorts = query.sort.split(",") if query.sort else ["id"]
 
@@ -49,13 +51,18 @@ def search_public_account(
         per_page=query.perPage,
     )
 
-    return utils.build_paginated_response(
-        pages=paginated.pages,
-        total=paginated.total,
-        page=paginated.page,
-        sort=query.sort,
-        data=[serialization.PublicAccount.from_orm(account) for account in paginated.items],
+    response = typing.cast(
+        serialization.ListPublicAccountsResponseModel,
+        utils.build_paginated_response(
+            response_model=serialization.ListPublicAccountsResponseModel,
+            pages=paginated.pages,
+            total=paginated.total,
+            page=paginated.page,
+            sort=query.sort,
+            data=[serialization.PublicAccount.from_orm(account) for account in paginated.items],
+        ),
     )
+    return response
 
 
 @blueprint.backoffice_blueprint.route("public_accounts/<int:user_id>", methods=["GET"])

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -67,15 +67,27 @@ class PublicAccount(BaseModel):
     city: typing.Optional[str]
 
 
-class PublicAccountSearchQuery(BaseModel):
+class PaginableQuery(BaseModel):
+    page: typing.Optional[int] = 1
+    perPage: typing.Optional[int] = 20
+    sort: typing.Optional[str] = None
+
+
+class PublicAccountSearchQuery(PaginableQuery):
     q: str
 
 
-class ListPublicAccountsResponseModel(BaseModel):
-    class Config:
-        orm_mode = True
+class PaginatedResponse(BaseModel):
+    pages: int
+    total: int
+    page: int
+    size: int
+    sort: typing.Optional[str]
+    data: typing.Any
 
-    accounts: list[PublicAccount]
+
+class ListPublicAccountsResponseModel(PaginatedResponse):
+    data: list[PublicAccount]
 
 
 class PublicAccountUpdateRequest(BaseModel):

--- a/api/src/pcapi/routes/backoffice/utils.py
+++ b/api/src/pcapi/routes/backoffice/utils.py
@@ -16,6 +16,12 @@ def get_user_or_error(user_id: int, error_code: int = 400) -> users_models.User:
 
 
 def build_paginated_response(
-    page: int, pages: int, total: int, sort: typing.Optional[str], data: list[BaseModel]
+    page: int,
+    pages: int,
+    total: int,
+    sort: typing.Optional[str],
+    data: list[BaseModel],
+    response_model: typing.Type[PaginatedResponse] = PaginatedResponse,
 ) -> PaginatedResponse:
-    return PaginatedResponse(pages=pages, total=total, page=page, size=len(data), sort=sort, data=data)
+    response = response_model(pages=pages, total=total, page=page, size=len(data), sort=sort, data=data)
+    return response

--- a/api/src/pcapi/routes/backoffice/utils.py
+++ b/api/src/pcapi/routes/backoffice/utils.py
@@ -1,6 +1,10 @@
+import typing
+
 from pcapi.core.users import models as users_models
 from pcapi.core.users import repository as users_repository
 from pcapi.models.api_errors import ApiErrors
+from pcapi.routes.backoffice.serialization import PaginatedResponse
+from pcapi.routes.serialization import BaseModel
 
 
 def get_user_or_error(user_id: int, error_code: int = 400) -> users_models.User:
@@ -9,3 +13,9 @@ def get_user_or_error(user_id: int, error_code: int = 400) -> users_models.User:
         raise ApiErrors(errors={"user_id": "L'utilisateur n'existe pas"}, status_code=error_code)
 
     return user
+
+
+def build_paginated_response(
+    page: int, pages: int, total: int, sort: typing.Optional[str], data: list[BaseModel]
+) -> PaginatedResponse:
+    return PaginatedResponse(pages=pages, total=total, page=page, size=len(data), sort=sort, data=data)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15812

## But de la pull request

Ajouter un mécanisme de pagination au endpoint de recherche de compte jeune/grand-public qui puisse servir de modèle pour la pagination des autres endpoints qui retournent des listes.

## Implémentation

- Ajout d'un modèle pydantic `PaginableQuery` qui sert de base pour les paramètre attendus par le endpoint:
  - `page` est le numéro de la page demandée
  -  `perPage` est le nombre d'éléments par page
  - `sort` est une chaine qui contient, séparés par des virgules,  les noms des champs selon lesquels trier, éventuellement préfixés par un `-` pour trier dans le sens décroissant.
- `PublicAccountSearchQuery` hérite de `PaginableQuery`
- ajout d'une fonction `get_ordering_clauses` pour créer une liste de paramètres à donner à la méthode `order_by` d'une query SqlAlchemy à partir du contenu du paramètre `PaginableQuery.sort`
- `pcapi.core.users.api.search_public_account` utilise la fonction `get_ordering_clauses` pour appliquer un tri à la query SqlAlchemy
- Ajout d'un modèle pydantic `PaginatedResponse` pour servir d'enveloppe aux données à renvoyer:
  - `pages: int` le nombre total de pages
  - `total: int` le nombre total d'éléments
  - `page: int` le numéro de la page retournée
  - `size: int` le nombre d'élement dans la page retournée
  - `sort: typing.Optional[str]` un rappel du tri
  - `data: typing.Any` les données à retourner
- le endpoint `backoffice/public_accounts/search` renvoie maintenant une `PaginatedResponse`

## Informations supplémentaires

les requêtes au endpoint de recherche acceptent maintenant le paramètres suivants en querystring:
- `page`: le numéro de la page souhaitée, optionnel, **1** par défaut
- `perPage`: le nombre d'éléments par page, optionnel, **20** par défaut
- `sort`: des consignes de tri, optionnel, trié par **id** par défaut
la consigne de tri est une chaine qui fourni une liste de champs sur lesquels trier, séparés par des virgules. le prefix `-` devant un nom de champ indique ce tri par ce champs doit être dans l'ordre décroissant.

les réponses contiennent les données suivantes:
- `pages`: le nombre total de pages
- `total`: le nombre total d'éléments
- `page`: le numéro de la page
- `size`: le nombre d'élements sur la page
- `sort`: un rappel des critères de tri
- `data`: les données

Ajout de 2 commentaire `# type: ignore []` dans la fonction `pcapi.utils.db.get_ordering_clauses` concernant le model de base `pcapi.models.Model` qui ne semble pas être considéré comme une classe par Mypy.

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai relu attentivement les migrations, en particulier pour éviter les _locks_~~
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
