### PR TITLE
(BSR)[API] refactor: Refactor `generate_cashflows()` for better reusability

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1217,6 +1217,7 @@ class GenerateCashflowsTest:
         n_queries += 1  # compute next CashflowBatch.label
         n_queries += 1  # insert CashflowBatch
         n_queries += 1  # commit
+        n_queries += 1  # select CashflowBatch again after commit
         n_queries += 1  # select business unit and bank account ids to process
         n_queries += 2 * sum(  # 2 business units
             (


### PR DESCRIPTION
When `generate_cashflows()` fails or is interrupted, we want a simple
way to proceed from where we stopped and re-use the last batch. This
can now be done with:

    batch_id = 12345
    batch = CashflowBatch.query.get(batch_id)
    api._generate_cashflows(batch)
    generate_payment_files(batch_id)