### PR TITLE
PC-15325 use keywords for dms label matching

### DIFF
--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -60,27 +60,19 @@ class DmsField(pydantic.BaseModel):
     value: typing.Optional[str] = pydantic.Field(None, alias="stringValue")
 
 
-class FieldLabel(enum.Enum):
+class FieldLabelKeyword(enum.Enum):
     """
     Ces champs sont tirés des labels des questions des démarches DMS
     """
 
-    ACTIVITY_ET = "Merci d' indiquer ton statut"
-    ACTIVITY_FR = "Merci d'indiquer ton statut"
-    ADDRESS_ET = "Quelle est ton adresse de résidence ?"
-    ADDRESS_FR = "Quelle est ton adresse de résidence"
-    BIRTH_DATE_ET = "Quelle est ta date de naissance ?"
-    BIRTH_DATE_FR = "Quelle est votre date de naissance"
-    CITY_FR = "Quelle est ta ville de résidence ?"
-    CITY_ET = "Quelle est ta ville de résidence ?"
-    ID_PIECE_NUMBER_ET = "Quel est le numéro de la pièce que tu viens de saisir ?"
-    ID_PIECE_NUMBER_FR = "Quel est le numéro de la pièce que tu viens de saisir ?"
-    ID_PIECE_NUMBER_PROCEDURE_4765 = "Quel est le numéro de la pièce que vous venez de saisir ?"
-    POSTAL_CODE_ET = "Quel est le code postal de ta commune de résidence ?"
-    POSTAL_CODE_FR = "Quel est le code postal de ta commune de résidence ? (ex : 25370)"
-    POSTAL_CODE_OLD = "Quel est le code postal de votre commune de résidence ?"
-    TELEPHONE_ET = "Quel est ton numéro de téléphone ?"
-    TELEPHONE_FR = "Quel est ton numéro de téléphone ?"
+    ACTIVITY = "statut"
+    ADDRESS = "adresse de résidence"
+    BIRTH_DATE = "date de naissance"
+    CITY_1 = "ville de résidence"
+    CITY_2 = "commune de résidence"
+    ID_PIECE_NUMBER = "numéro de la pièce"
+    POSTAL_CODE = "code postal"
+    TELEPHONE = "numéro de téléphone"
 
 
 class ApplicationPageInfo(pydantic.BaseModel):

--- a/api/tests/connectors/dms/serializer_test.py
+++ b/api/tests/connectors/dms/serializer_test.py
@@ -119,3 +119,28 @@ class ParseBeneficiaryInformationTest:
         content, _ = dms_serializer.parse_beneficiary_information_graphql(dms_models.DmsApplicationResponse(**raw_data))
         assert content.activity == None
         mocked_logger.assert_called_once_with("Unknown activity value for application %s: %s", 1, "invalid")
+
+    def test_serializer_is_resilient_to_minor_label_updates(self):
+        base_raw_data = fixture.make_graphql_application(1, "accepte")
+        labels_edited_raw_data = fixture.make_graphql_application(
+            1,
+            "accepte",
+            labels={
+                "status": "statut ?",
+                "address": "adresse de résidence ?",
+                "birth_date": "date de naissance ?",
+                "city": "commune de résidence ?",
+                "id_piece_number": "numéro de la pièce ?",
+                "postal_code": "code postal ?",
+                "phone_number": "numéro de téléphone ?",
+            },
+        )
+
+        base_content, _ = dms_serializer.parse_beneficiary_information_graphql(
+            dms_models.DmsApplicationResponse(**base_raw_data)
+        )
+        labels_edited_content, _ = dms_serializer.parse_beneficiary_information_graphql(
+            dms_models.DmsApplicationResponse(**labels_edited_raw_data)
+        )
+
+        assert base_content == labels_edited_content

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -17,7 +17,7 @@ DEFAULT_MESSAGES = [
 ]
 
 
-def make_graphql_application(
+def make_graphql_application(  # pylint: disable=dangerous-default-value
     application_number: int,
     state: str,
     activity: str = "Étudiant",
@@ -37,6 +37,7 @@ def make_graphql_application(
     messages: Optional[list] = None,
     application_techid: Optional[str] = None,
     procedure_number: Optional[int] = 8888,
+    labels: Optional[dict] = {},
 ) -> dict:
     if messages is None:
         messages = DEFAULT_MESSAGES
@@ -69,7 +70,7 @@ def make_graphql_application(
             },
             {
                 "id": "Q2hhbXAtNTgyMjIw",
-                "label": "Quelle est votre date de naissance",
+                "label": labels.get("birth_date") or "Quelle est votre date de naissance",
                 "stringValue": babel.dates.format_date(birth_date, format="long", locale="fr"),
             },
             {"id": "Q2hhbXAtNzE4MjIy", "label": "Pièces justificatives acceptées", "stringValue": ""},
@@ -84,21 +85,30 @@ def make_graphql_application(
             },
             {
                 "id": "Q2hhbXAtMTg3Mzc0Mw==",
-                "label": "Quel est le numéro de la pièce que tu viens de saisir ?",
+                "label": labels.get("id_piece_number") or "Quel est le numéro de la pièce que tu viens de saisir ?",
                 "stringValue": id_piece_number,
             },
-            {"id": "Q2hhbXAtNTgyMjE5", "label": "Quel est ton numéro de téléphone ?", "stringValue": "01 23 45 67 89"},
+            {
+                "id": "Q2hhbXAtNTgyMjE5",
+                "label": labels.get("phone_number") or "Quel est ton numéro de téléphone ?",
+                "stringValue": "01 23 45 67 89",
+            },
             {
                 "id": "Q2hhbXAtNTgyMjIx",
-                "label": "Quel est le code postal de ta commune de résidence ? (ex : 25370)",
+                "label": labels.get("postal_code")
+                or "Quel est le code postal de ta commune de résidence ? (ex : 25370)",
                 "stringValue": postal_code,
             },
             {
                 "id": "Q2hhbXAtNTgyMjIz",
-                "label": "Quelle est ton adresse de résidence",
+                "label": labels.get("address") or "Quelle est ton adresse de résidence",
                 "stringValue": "3 La Bigotais 22800 Saint-Donan",
             },
-            {"id": "Q2hhbXAtNzE4MDk0", "label": "Merci d'indiquer ton statut", "stringValue": activity},
+            {
+                "id": "Q2hhbXAtNzE4MDk0",
+                "label": labels.get("status") or "Merci d'indiquer ton statut",
+                "stringValue": activity,
+            },
             {"id": "Q2hhbXAtNDUxMjg0", "label": "Déclaration de résidence", "stringValue": ""},
             {"id": "Q2hhbXAtNTgyMzI4", "label": "Certification sur l'honneur", "stringValue": ""},
             {
@@ -145,7 +155,11 @@ def make_graphql_application(
     }
     if city is not None:
         data["champs"].append(
-            {"id": "Q2hhbXAtNTgyMjIy", "label": "Quelle est ta ville de résidence ?", "stringValue": city}
+            {
+                "id": "Q2hhbXAtNTgyMjIy",
+                "label": labels.get("city") or "Quelle est ta ville de résidence ?",
+                "stringValue": city,
+            }
         )
     if full_graphql_response:
         enveloppe = {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15325

## But de la pull request

Etre résilient aux changements des formulations des questions du formulaire DMS

## Implémentation

- Au lieu de matcher sur toute la question, on cherche des mots clefs 

## Modifications du schéma de la base de données

None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
