### PR TITLE
(BSR) Fix typo and remove unnecessary query

### DIFF
--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -231,7 +231,7 @@ class GetVenueResponseModel(base.BaseVenueResponse, AccessibilityComplianceMixin
             if reimbursement_link.timespan.lower > now:
                 continue
             if not reimbursement_link.timespan.upper or reimbursement_link.timespan.upper > now:
-                venue.reimbursementPointId = reimbursement_link.reimbursementPoint.id
+                venue.reimbursementPointId = reimbursement_link.reimbursementPointId
         return super().from_orm(venue)
 
 

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -223,7 +223,7 @@ class GetVenueResponseModel(base.BaseVenueResponse, AccessibilityComplianceMixin
         for pricing_link in venue.pricing_point_links:
             if pricing_link.timespan.lower > now:
                 continue
-            if not pricing_link.timespan.upper or pricing_link.timespan.upper < now:
+            if not pricing_link.timespan.upper or pricing_link.timespan.upper > now:
                 venue.pricingPoint = pricing_link.pricingPoint
 
         venue.reimbursementPointId = None


### PR DESCRIPTION
## But de la pull request

Corriger et améliorer la sérialisation pour `get_venue()`

## Implémentation

- Corrige une typo
- Récupère l'attribut `reimbursementPointId` directement au niveau de `VenueReimbursementPointLink`, au lieu d'appeler la relation
- Ajoute des tests

## Informations supplémentaires

N/A

## Modifications du schéma de la base de données

N/A