### PR TITLE
(PC-16048)[API] feat: add deshumanized id for offerer and offerer man…

### DIFF
--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -24,6 +24,7 @@ class GetOffererVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     isVirtual: bool
     managingOffererId: str
     name: str
+    nonHumanizedId: int
     postalCode: Optional[str]
     publicName: Optional[str]
     siret: Optional[str]
@@ -32,6 +33,11 @@ class GetOffererVenueResponseModel(BaseModel, AccessibilityComplianceMixin):
     _humanize_id = humanize_field("id")
     _humanize_managing_offerer_id = humanize_field("managingOffererId")
     _humanize_venue_label_id = humanize_field("venueLabelId")
+
+    @classmethod
+    def from_orm(cls, venue: offerers_models.Venue) -> "GetOffererVenueResponseModel":
+        venue.nonHumanizedId = venue.id
+        return super().from_orm(venue)
 
     class Config:
         orm_mode = True
@@ -63,6 +69,7 @@ class GetOffererResponseModel(BaseModel):
     lastProviderId: Optional[str]
     managedVenues: list[GetOffererVenueResponseModel]
     name: str
+    nonHumanizedId: int
     postalCode: str
     # FIXME (dbaty, 2020-11-09): optional until we populate the database (PC-5693)
     siren: Optional[str]
@@ -87,6 +94,7 @@ class GetOffererResponseModel(BaseModel):
             or offerer.hasDigitalVenueAtLeastOneOffer
         )
         offerer.hasAvailablePricingPoints = any(venue.siret for venue in offerer.managedVenues)
+        offerer.nonHumanizedId = offerer.id
 
         return super().from_orm(offerer)
 

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -86,6 +86,7 @@ class Returns200Test:
                     "mentalDisabilityCompliant": False,
                     "motorDisabilityCompliant": False,
                     "name": offererVenue.name,
+                    "nonHumanizedId": offererVenue.id,
                     "postalCode": offererVenue.postalCode,
                     "publicName": offererVenue.publicName,
                     "siret": offererVenue.siret,
@@ -96,6 +97,7 @@ class Returns200Test:
                 for offererVenue in offerer.managedVenues
             ],
             "name": offerer.name,
+            "nonHumanizedId": offerer.id,
             "postalCode": offerer.postalCode,
             "siren": offerer.siren,
         }


### PR DESCRIPTION
…aged venues

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16048

## But de la pull request

Ajout des champs `nonHumanizedId` dans le retour de la route `getOfferer` pour Offerer et Offerer.managedVenues

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
