### PR TITLE
(BSR)[API] fix: Remove SQLAlchemy warning about CashflowPricing relationships

### DIFF
--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -10,7 +10,7 @@ filterwarnings=
     # -------------- Temporary ignored warnings due to SLQAlchemy bump to 1.4 -------------- #
     # FIXME (lixxday, 2022/06/09)
     # Warning on relationships. Fix with backrefs: https://docs.sqlalchemy.org/en/14/errors.html#error-qzyx
-    ignore:relationship '(User.UserOfferers|User.offerers|Offerer.UserOfferers|UserOfferer.*|OffererTagMapping.*|VenueCriterion.*|OfferCriterion.*|CashflowPricing.*)' will copy column .* to column .*, which conflicts with relationship:sqlalchemy.exc.SAWarning
+    ignore:relationship '(User.UserOfferers|User.offerers|Offerer.UserOfferers|UserOfferer.*|OffererTagMapping.*|VenueCriterion.*|OfferCriterion.*)' will copy column .* to column .*, which conflicts with relationship:sqlalchemy.exc.SAWarning
     # Warning on deprecated sqla function as_scalar()
     ignore:The Query.as_scalar\(\) method is deprecated and will be removed in a future release:sqlalchemy.exc.SADeprecationWarning
     # Warning cartesian product in SELECT statement. Apply join conditions between each element to resolve.

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -285,9 +285,7 @@ class CashflowPricing(Model):  # type: ignore [valid-type, misc]
     """
 
     cashflowId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("cashflow.id"), index=True, primary_key=True)
-    cashflow = sqla_orm.relationship("Cashflow", foreign_keys=[cashflowId])
     pricingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("pricing.id"), index=True, primary_key=True)
-    pricing = sqla_orm.relationship("Pricing", foreign_keys=[pricingId])
 
     __table_args__ = (
         sqla.UniqueConstraint(


### PR DESCRIPTION
We had the following warning:

   sqlalchemy.exc.SAWarning: relationship 'CashflowPricing.cashflow'
   will copy column cashflow.id to column cashflow_pricing.cashflowId,
   which conflicts with relationship(s): 'Cashflow.pricings' (copies
   cashflow.id to cashflow_pricing.cashflowId), 'Pricing.cashflows'
   (copies cashflow.id to cashflow_pricing.cashflowId).

We don't need the relationships in `CashflowPricing`.