### PR TITLE
(PC-15969)[API] fix: remove link to dms in dms message (user is already on dms)

### DIFF
--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -139,7 +139,6 @@ def _notify_field_error(field_errors: list[dms_types.DmsFieldErrorDetails], appl
 def _notify_eligibility_error(
     birth_date: typing.Optional[date],
     application_scalar_id: str,
-    application_number: int,
     extra_data: typing.Optional[dict] = None,
 ) -> None:
     if not birth_date:
@@ -152,7 +151,7 @@ def _notify_eligibility_error(
     client.send_user_message(
         application_scalar_id,
         settings.DMS_INSTRUCTOR_ID,
-        subscription_messages.build_dms_error_message_user_not_eligible(birth_date, application_number),
+        subscription_messages.build_dms_error_message_user_not_eligible(birth_date),
     )
 
 
@@ -199,9 +198,7 @@ def _process_draft_application(
         return
 
     if current_fraud_check.eligibilityType is None:
-        _notify_eligibility_error(
-            birth_date, application_scalar_id, fraud_check_content.application_number, extra_data=log_extra_data
-        )
+        _notify_eligibility_error(birth_date, application_scalar_id, extra_data=log_extra_data)
         _on_dms_eligibility_error(user, current_fraud_check, birth_date, extra_data=log_extra_data)
     if field_errors:
         _notify_field_error(field_errors, application_scalar_id)

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -61,12 +61,12 @@ def build_field_errors_user_message(field_errors: list[dms_models.DmsFieldErrorD
     )
 
 
-def build_dms_error_message_user_not_eligible(birth_date: datetime.date, application_id: int) -> str:
+def build_dms_error_message_user_not_eligible(birth_date: datetime.date) -> str:
     return (
         "Bonjour,\n"
         "\n"
         f"Nous avons bien reçu ton dossier, mais la date de naissance que tu as renseignée ({birth_date.isoformat()}) indique que tu n’as pas l’âge requis pour profiter du pass Culture (tu dois avoir entre 15 et 18 ans).\n"
-        f'S’il s’agit d’une erreur, tu peux corriger ton dossier depuis démarches-simplifiées: <a target="_blank" rel="noopener" href="https://www.demarches-simplifiees.fr/dossiers/{application_id}">https://www.demarches-simplifiees.fr/dossiers/{application_id}</a>\n'
+        f"S’il s’agit d’une erreur, tu peux modifier ton dossier.\n"
         "\n"
         'Tu trouveras de l’aide dans cet article : <a href="https://aide.passculture.app/hc/fr/articles/4411999116433--Jeunes-Où-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-Démarches-Simplifiées-">Où puis-je trouver de l’aide concernant mon dossier d’inscription sur Démarches Simplifiées ?</a>'
         "\n"

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -752,7 +752,7 @@ class DmsWebhookApplicationTest:
             "Bonjour,\n"
             "\n"
             f"Nous avons bien reçu ton dossier, mais la date de naissance que tu as renseignée ({birthday_date}) indique que tu n’as pas l’âge requis pour profiter du pass Culture (tu dois avoir entre 15 et 18 ans).\n"
-            f'S’il s’agit d’une erreur, tu peux corriger ton dossier depuis démarches-simplifiées: <a target="_blank" rel="noopener" href="https://www.demarches-simplifiees.fr/dossiers/6044787">https://www.demarches-simplifiees.fr/dossiers/6044787</a>\n'
+            f"S’il s’agit d’une erreur, tu peux modifier ton dossier.\n"
             "\n"
             'Tu trouveras de l’aide dans cet article : <a href="https://aide.passculture.app/hc/fr/articles/4411999116433--Jeunes-Où-puis-je-trouver-de-l-aide-concernant-mon-dossier-d-inscription-sur-Démarches-Simplifiées-">Où puis-je trouver de l’aide concernant mon dossier d’inscription sur Démarches Simplifiées ?</a>'
             "\n"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15969

## But de la pull request

Reformuler le message à l'utilisateur en cas de date de naissance non éligible. 

## Modifications du schéma de la base de données

- None 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
