### PR TITLE
(PC-16043)[PRO] fix: new offer creation from confirmation

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Confirmation/Confirmation.jsx
+++ b/pro/src/components/pages/Offers/Offer/Confirmation/Confirmation.jsx
@@ -1,31 +1,20 @@
-import { Link, useLocation } from 'react-router-dom'
 import React, { useCallback } from 'react'
 
 import { DisplayOfferInAppLink } from 'components/pages/Offers/Offer/DisplayOfferInAppLink'
+import { Link } from 'react-router-dom'
 import { OFFER_STATUS_PENDING } from 'core/Offers/constants'
 import { ReactComponent as PendingIcon } from 'components/pages/Offers/Offer/Confirmation/assets/pending.svg'
 import PropTypes from 'prop-types'
 import { ReactComponent as ValidateIcon } from 'components/pages/Offers/Offer/Confirmation/assets/validate.svg'
-import { queryParamsFromOfferer } from 'components/pages/Offers/utils/queryParamsFromOfferer'
 
 const Confirmation = ({ offer, setOffer }) => {
-  const location = useLocation()
-
   const resetOffer = useCallback(() => {
     setOffer(null)
   }, [setOffer])
 
   const isPendingOffer = offer.status === OFFER_STATUS_PENDING
 
-  let queryString = ''
-  const queryParams = queryParamsFromOfferer(location)
-  if (queryParams.structure !== '') {
-    queryString = `?structure=${queryParams.structure}`
-  }
-
-  if (queryParams.lieu !== '') {
-    queryString += `&lieu=${queryParams.lieu}`
-  }
+  let queryString = `?structure=${offer.venue.managingOfferer.id}&lieu=${offer.venueId}`
 
   return (
     <div className="offer-confirmation">

--- a/pro/src/components/pages/Offers/Offer/Confirmation/__specs__/Confirmation.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Confirmation/__specs__/Confirmation.spec.jsx
@@ -14,7 +14,11 @@ jest.mock('utils/config', () => {
 describe('confirmation page', () => {
   it('should display the rights information when offer is draft', async () => {
     // Given
-    const offer = offerFactory({ name: 'mon offre', status: 'DRAFT' })
+    const offer = offerFactory({
+      name: 'mon offre',
+      status: 'DRAFT',
+      venueId: 'VENUEID',
+    })
     jest.spyOn(apiV1, 'getOffersGetOffer').mockResolvedValue(offer)
 
     // When
@@ -38,12 +42,19 @@ describe('confirmation page', () => {
     ).toHaveAttribute('href', `http://localhost/offre/${offer.nonHumanizedId}`)
     expect(
       screen.getByText('Créer une nouvelle offre', { selector: 'a' })
-    ).toHaveAttribute('href', '/offre/creation/individuel')
+    ).toHaveAttribute(
+      'href',
+      `/offre/creation/individuel?structure=${offer.venue.managingOffererId}&lieu=${offer.venueId}`
+    )
   })
 
   it('should display the rights information when offer is pending', async () => {
     // Given
-    const offer = offerFactory({ name: 'mon offre', status: 'PENDING' })
+    const offer = offerFactory({
+      name: 'mon offre',
+      status: 'PENDING',
+      venueId: 'VENUEID',
+    })
     jest.spyOn(apiV1, 'getOffersGetOffer').mockResolvedValue(offer)
 
     // When
@@ -68,6 +79,9 @@ describe('confirmation page', () => {
     ).toHaveAttribute('href', `http://localhost/offre/${offer.nonHumanizedId}`)
     expect(
       screen.getByText('Créer une nouvelle offre', { selector: 'a' })
-    ).toHaveAttribute('href', '/offre/creation/individuel')
+    ).toHaveAttribute(
+      'href',
+      `/offre/creation/individuel?structure=${offer.venue.managingOffererId}&lieu=${offer.venueId}`
+    )
   })
 })

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -2209,11 +2209,11 @@ describe('stocks page', () => {
 
     it('should display a specific success notification when the user has finished the offer creation process', async () => {
       // Given
-      const draftOffer = {
-        ...defaultOffer,
+      const draftOffer = offerFactory({
         name: 'mon offre',
+        id: 'AG3A',
         status: 'DRAFT',
-      }
+      })
 
       jest.spyOn(apiV1, 'getOffersGetOffer').mockResolvedValue(draftOffer)
       pcapi.bulkCreateOrEditStock.mockResolvedValue({})

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
@@ -30,7 +30,7 @@ const StockEventSection = ({
     setDisplayedStocks(
       showAllStocks ? [...stocks] : stocks.slice(0, NB_UNFOLDED_STOCK)
     )
-  }, [showAllStocks])
+  }, [showAllStocks, stocks])
 
   const iconName = showAllStocks ? 'ico-arrow-up-r' : 'ico-arrow-down-r'
   const editLink = isCreation


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16043

## But de la pull request

1er commit : Correction "spinner infini" quand on clique sur "Créer une nouvelle offre" sur la page de confirmation après en avoir créée une. Petite regression : Si on arrive sur le formulaire en ayant juste un offerId en queryString, quand on cliquera sur "Créer une nouvelle offre", on aura l'offererId et la venueId par défaut. Ces infos ne passent plus dans le formulaire des stocks et n'est plus récupéré dans la page de confirmation. Quick & dirty mais pas trop le temps

2e commit : les stocks pouvaient être modifiés mais le prix n'était pas à jour

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
