### PR TITLE
[PC-16081] Upgrade pcapi helm charts version to 0.12.2

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -16,16 +16,16 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.12.1
+      - chartVersion: 0.12.2
   staging:
     values:
-      - chartVersion: 0.12.1
+      - chartVersion: 0.12.2
   integration:
     values:
-      - chartVersion: 0.12.1
+      - chartVersion: 0.12.2
   production:
     values:
-      - chartVersion: 0.12.1
+      - chartVersion: 0.12.2
   ops:
     values:
       - chartVersion: 0.9.0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16081

## But de la pull request

Upgrade de la version de helm en 0.12.2 pour testin,staging,integration et production