### PR TITLE
(BSR)[API] bsr: turn subcategory mandatory for offer creation

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -145,14 +145,14 @@ def create_offer(
     user: User,
     save_as_active: bool = True,
 ) -> Offer:
-    subcategory = subcategories.ALL_SUBCATEGORIES_DICT.get(offer_data.subcategory_id)  # type: ignore [arg-type]
     venue = load_or_raise_error(Venue, offer_data.venue_id)
     check_user_has_access_to_offerer(user, offerer_id=venue.managingOffererId)  # type: ignore [attr-defined]
     _check_offer_data_is_valid(offer_data, offer_data.is_educational)  # type: ignore [arg-type]
-    if _is_able_to_create_book_offer_from_isbn(subcategory):  # type: ignore [arg-type]
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[offer_data.subcategory_id]
+    if _is_able_to_create_book_offer_from_isbn(subcategory):
         offer = _initialize_book_offer_from_template(offer_data)
     else:
-        offer = _initialize_offer_with_new_data(offer_data, subcategory, venue)  # type: ignore [arg-type]
+        offer = _initialize_offer_with_new_data(offer_data, subcategory, venue)
 
     _complete_common_offer_fields(offer, offer_data, venue)
     offer.isActive = save_as_active
@@ -211,7 +211,7 @@ def _initialize_offer_with_new_data(
     offer = Offer()
     offer.populate_from_dict(data)
     offer.product = product
-    offer.subcategoryId = subcategory.id if subcategory else None  # type: ignore [assignment]
+    offer.subcategoryId = subcategory.id
     offer.product.owningOfferer = venue.managingOfferer
     return offer
 
@@ -237,7 +237,7 @@ def _check_offer_data_is_valid(
     offer_is_educational: bool,
 ) -> None:
     check_offer_subcategory_is_valid(offer_data.subcategory_id)
-    check_offer_is_eligible_for_educational(offer_data.subcategory_id, offer_is_educational)  # type: ignore [arg-type]
+    check_offer_is_eligible_for_educational(offer_data.subcategory_id, offer_is_educational)
     if not offer_is_educational:
         validation.check_offer_extra_data(None, offer_data.subcategory_id, offer_data.extra_data)  # type: ignore [arg-type]
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -324,7 +324,7 @@ def check_offer_is_eligible_for_educational(subcategory_id: str, is_educational:
 
 
 def check_offer_withdrawal(
-    withdrawal_type: Optional[WithdrawalTypeEnum], withdrawal_delay: Optional[int], subcategory_id: Optional[str]
+    withdrawal_type: Optional[WithdrawalTypeEnum], withdrawal_delay: Optional[int], subcategory_id: str
 ) -> None:
     if subcategory_id not in WITHDRAWABLE_SUBCATEGORIES and withdrawal_type is not None:
         raise exceptions.NonWithdrawableEventOfferCantHaveWithdrawal()
@@ -343,7 +343,7 @@ def check_offer_withdrawal(
         raise exceptions.EventWithTicketMustHaveDelay()
 
 
-def check_offer_subcategory_is_valid(offer_subcategory_id):  # type: ignore [no-untyped-def]
+def check_offer_subcategory_is_valid(offer_subcategory_id: str) -> None:
     if offer_subcategory_id not in ALL_SUBCATEGORIES_DICT:
         raise exceptions.UnknownOfferSubCategory()
     if not ALL_SUBCATEGORIES_DICT[offer_subcategory_id].is_selectable:

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -66,7 +66,7 @@ class CategoryResponseModel(BaseModel):
 class PostOfferBodyModel(BaseModel):
     venue_id: str
     product_id: Optional[str]
-    subcategory_id: Optional[str]
+    subcategory_id: str
     name: Optional[str]
     booking_email: Optional[str]
     external_ticket_office_url: Optional[HttpUrl]

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1044,7 +1044,6 @@ class CreateOfferTest:
         assert offer.isEducational
 
     def test_cannot_create_educational_offer_when_not_eligible_subcategory(self):
-
         # Given
         unauthorized_subcategory_id = "BON_ACHAT_INSTRUMENT"
         venue = offerers_factories.VenueFactory()
@@ -1091,6 +1090,7 @@ class CreateOfferTest:
         user = users_factories.ProFactory()
         data = offers_serialize.PostOfferBodyModel(
             venueId=humanize(venue.id),
+            subcategoryId=subcategories.CONCERT.id,
             audioDisabilityCompliant=True,
             mentalDisabilityCompliant=True,
             motorDisabilityCompliant=True,

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -151,7 +151,7 @@ class Returns400Test:
 
 
 class Returns403Test:
-    def when_user_is_not_attached_to_offerer(self, app, client):
+    def test_when_user_is_not_attached_to_offerer(self, app, client):
         # Given
         offer = CollectiveOfferTemplateFactory(name="Old name")
         offerers_factories.UserOffererFactory(user__email="user@example.com")

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -388,7 +388,7 @@ class Returns400Test:
 
 @pytest.mark.usefixtures("db_session")
 class Returns403Test:
-    def when_user_is_not_attached_to_offerer(self, client):
+    def test_when_user_is_not_attached_to_offerer(self, client):
         # Given
         users_factories.ProFactory(email="user@example.com")
         venue = offerers_factories.VirtualVenueFactory()
@@ -396,6 +396,7 @@ class Returns403Test:
         # When
         data = {
             "venueId": humanize(venue.id),
+            "subcategoryId": subcategories.JEU_EN_LIGNE.id,
             "audioDisabilityCompliant": True,
             "mentalDisabilityCompliant": False,
             "motorDisabilityCompliant": False,


### PR DESCRIPTION
## But de la pull request

Rendre la propriété `subcategory_id` obligatoire dans le endpoint de création d'offre.
Ajout de typage.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
