### PR TITLE
(PC-16108)[PRO] fix: date type use in components

### DIFF
--- a/pro/src/core/Offers/adapters/__specs__/useGetOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/__specs__/useGetOffer.spec.ts
@@ -10,7 +10,7 @@ import { api } from 'apiClient/api'
 import { renderHook } from '@testing-library/react-hooks'
 import { useGetOffer } from '..'
 
-describe('useOffererNames', () => {
+describe('useGetOffer', () => {
   it('should return loading payload then success payload', async () => {
     const apiOffer: GetIndividualOfferResponseModel = {
       activeMediation: null,
@@ -192,8 +192,8 @@ describe('useOffererNames', () => {
       withdrawalDelay: null,
       stocks: [
         {
-          beginningDatetime: new Date('2022-05-23T08:25:31.009799Z'),
-          bookingLimitDatetime: new Date('2022-05-23T07:25:31.009799Z'),
+          beginningDatetime: '2022-05-23T08:25:31.009799Z',
+          bookingLimitDatetime: '2022-05-23T07:25:31.009799Z',
           bookingsQuantity: 2,
           dateCreated: new Date('2022-05-18T08:25:31.015652Z'),
           hasActivationCode: false,

--- a/pro/src/core/Offers/adapters/serializers.ts
+++ b/pro/src/core/Offers/adapters/serializers.ts
@@ -37,12 +37,8 @@ export const serializeStockApi = (
   apiStock: GetOfferStockResponseModel
 ): IOfferIndividualStock => {
   return {
-    beginningDatetime: apiStock.beginningDatetime
-      ? new Date(apiStock.beginningDatetime)
-      : null,
-    bookingLimitDatetime: apiStock.bookingLimitDatetime
-      ? new Date(apiStock.bookingLimitDatetime)
-      : null,
+    beginningDatetime: apiStock.beginningDatetime ?? null,
+    bookingLimitDatetime: apiStock.bookingLimitDatetime ?? null,
     bookingsQuantity: apiStock.bookingsQuantity,
     dateCreated: new Date(apiStock.dateCreated),
     hasActivationCode: apiStock.hasActivationCode,

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -82,8 +82,8 @@ export interface IOfferSubCategory {
 }
 
 export interface IOfferIndividualStock {
-  beginningDatetime: Date | null
-  bookingLimitDatetime: Date | null
+  beginningDatetime: string | null
+  bookingLimitDatetime: string | null
   bookingsQuantity: number
   dateCreated: Date
   hasActivationCode: boolean

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventItem/StockEventItem.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventItem/StockEventItem.tsx
@@ -11,10 +11,10 @@ import { format } from 'date-fns-tz'
 
 export interface IStockEventItemProps {
   className?: string
-  beginningDateTime: Date | null
+  beginningDateTime: string | null
   price: number
   quantity?: number | null
-  bookingLimitDatetime: Date | null
+  bookingLimitDatetime: string | null
 }
 
 const StockEventItem = ({

--- a/pro/src/screens/OfferIndividual/Summary/StockThingSection/StockThingSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockThingSection/StockThingSection.tsx
@@ -7,7 +7,7 @@ import { format } from 'date-fns-tz'
 export interface IStockThingSectionProps {
   quantity?: number | null
   price: number
-  bookingLimitDatetime: Date | null
+  bookingLimitDatetime: string | null
 }
 
 interface IStockThingSummarySection extends IStockThingSectionProps {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16108

Les types qui avaient été définis dans le front pour beginningDatetime et bookingLimitDatetime n'étaient pas les bons (typés en Date). Dans la PR de suppression de l'ancien générateur api, il y a eu une refacto pour transformer les string recues par le back en Date. Or une des fonction qui utilise ces date ne fonctionne qu'avec une string et non une date, ce qui causait le bug. On ne s'en est pas rendu compte au moment de la refacto car le fichier étant écrit en javascript, il n'y a pas d'erreur relevées au moment de l'analyse statique faite par typescript