### PR TITLE
(PC-16043)[PRO] fix: CollectiveOffer breadcrumb should always be visible

### DIFF
--- a/pro/src/new_components/OfferBreadcrumb/OfferBreadcrumb.tsx
+++ b/pro/src/new_components/OfferBreadcrumb/OfferBreadcrumb.tsx
@@ -45,8 +45,9 @@ const OfferBreadcrumb = ({
   const isTemplateId = offerId.startsWith('T-')
   let steps: Step[] = []
 
-  if (activeStep == OfferBreadcrumbStep.CONFIRMATION) return <></>
-  if (useSummaryPage && !isCreatingOffer) return <></>
+  if (activeStep == OfferBreadcrumbStep.CONFIRMATION && !isOfferEducational)
+    return <></>
+  if (useSummaryPage && !isCreatingOffer && !isOfferEducational) return <></>
 
   if (!isCreatingOffer) {
     steps = [


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16043

## But de la pull request

Nous ne voulons plus de stepper sur notre page d'édition des offres indiv. 
Ce commit rétablit le stepper pour les offres collectives

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
