### PR TITLE
(BSR)[API] test: Simplify collective booking-related tests of cashflow generation

### DIFF
--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -57,20 +57,6 @@ class PricingFactory(BaseFactory):
     revenue = LazyAttribute(lambda pricing: int(100 * pricing.booking.total_amount))
 
 
-class EducationalPricingFactory(BaseFactory):
-    class Meta:
-        model = models.Pricing
-
-    status = models.PricingStatus.VALIDATED
-    booking = factory.SubFactory(bookings_factories.UsedEducationalBookingFactory)
-    businessUnit = factory.SelfAttribute("booking.venue.businessUnit")
-    siret = factory.SelfAttribute("booking.venue.siret")
-    valueDate = factory.SelfAttribute("booking.dateUsed")
-    amount = LazyAttribute(lambda pricing: -int(100 * pricing.booking.total_amount))
-    revenue = LazyAttribute(lambda pricing: int(100 * pricing.booking.total_amount))
-    standardRule = "Remboursement total"
-
-
 class CollectivePricingFactory(BaseFactory):
     class Meta:
         model = models.Pricing


### PR DESCRIPTION
There is no Pricing that is related to an "educational booking" (a
Booking linked to an EducationalBooking):

    => select count(pricing.id) from pricing
       join booking on booking.id=pricing."bookingId"
       where booking."educationalBookingId" is not null;
    0

They have been migrated as Pricings that are linked to a
CollectiveBooking.

We can thus get rid of EducationalPricingFactory. Also, we can merge
tests and just include a few CollectiveBooking in the general-purpose
test method.