### PR TITLE
(BSR)[API] fix: De-duplicate pricings in _delete_dependent_pricings

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -683,6 +683,10 @@ def _delete_dependent_pricings(
         )
     pricings = pricings.filter(clause)
 
+    if not use_pricing_point:
+        # De-duplicate if there was multiple venue-business unit links.
+        pricings = pricings.distinct(models.Pricing.id)
+
     pricings = pricings.with_entities(
         models.Pricing.id,
         models.Pricing.bookingId,


### PR DESCRIPTION
Some venues have been linked to the same business unit more than once.
Now we support that.