### PR TITLE
PC 16118 update booking confirmation email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -95,6 +95,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "EVENT_HOUR": formatted_event_beginning_time,
             "OFFER_PRICE": stock_price,
             "OFFER_TOKEN": booking_token,
+            "OFFER_CATEGORY": offer.category,
             "IS_DIGITAL_BOOKING_WITH_ACTIVATION_CODE_AND_NO_EXPIRATION_DATE": bool(
                 is_digital_booking_with_activation_code_and_no_expiration_date
             ),

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -18,7 +18,7 @@ class TransactionalEmail(Enum):
         id_prod=225, id_not_prod=37, tags=["jeunes_offre_annulee_pros"]
     )
     BOOKING_CONFIRMATION_BY_BENEFICIARY = Template(
-        id_prod=725, id_not_prod=91, tags=["jeunes_reservation_confirmee_v2"]
+        id_prod=725, id_not_prod=92, tags=["jeunes_reservation_confirmee_v3"]
     )
     BOOKING_EVENT_REMINDER_TO_BENEFICIARY = Template(id_prod=665, id_not_prod=82, tags=["jeunes_rappel_evenement_j-1"])
     BOOKING_POSTPONED_BY_PRO_TO_BENEFICIARY = Template(id_prod=224, id_not_prod=36, tags=["jeunes_offre_reportee_pro"])

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy import and_
 
 import pcapi.core.bookings.constants as bookings_constants
+from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories
 from pcapi.models import Model
 from pcapi.models import db
@@ -501,6 +502,15 @@ class Offer(PcObject, Model, ExtraDataMixin, DeactivableMixin, ValidationMixin, 
         if self.subcategoryId not in subcategories.ALL_SUBCATEGORIES_DICT:
             raise ValueError(f"Unexpected subcategoryId '{self.subcategoryId}' for offer {self.id}")
         return subcategories.ALL_SUBCATEGORIES_DICT[self.subcategoryId]
+
+    @property
+    def category(self) -> categories.Category:
+        category_id = self.subcategory.category_id
+
+        try:
+            return categories.ALL_CATEGORIES_DICT[category_id]
+        except KeyError:
+            raise ValueError(f"Unexpected category_id '{category_id}' for offer {self.id}")
 
     @property
     def image(self) -> Optional[OfferImage]:

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -52,6 +52,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "EVENT_HOUR": "14h48",
             "OFFER_PRICE": f"{booking.total_amount} €" if booking.stock.price > 0 else "Gratuit",
             "OFFER_TOKEN": booking.token,
+            "OFFER_CATEGORY": booking.stock.offer.category,
             "VENUE_NAME": booking.stock.offer.venue.name,
             "VENUE_ADDRESS": booking.stock.offer.venue.address,
             "VENUE_POSTAL_CODE": booking.stock.offer.venue.postalCode,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16118

## But de la pull request

Objectif : donner accès à la catégorie de l'offre au _template_ de confirmation de réservation d'une offre.

1. Ajouter une méthode pour récupérer facilement la catégorie d'une offre.
2. Ajouter cette catégorie dans les paramètres d'un _template_ SiB.
3. Mettre à jour l'id du template hors-prod et dans la foulée le suffixe du tag.
