### PR TITLE
Pc 15823 pro reimbursement display banner if offerer has no venue with siret

### DIFF
--- a/pro/src/components/layout/InternalBanner/InternalBanner.tsx
+++ b/pro/src/components/layout/InternalBanner/InternalBanner.tsx
@@ -4,13 +4,13 @@ import cn from 'classnames'
 import styles from './InternalBanner.module.scss'
 
 interface IInternalBannerProps {
-  children: JSX.Element | null
-  extraClassName: string
+  children?: string | null
+  extraClassName?: string
   href: string
-  icon: string | null
+  icon?: string | null
   linkTitle: string
-  subtitle: string
-  type: 'notification-info' | 'attention'
+  subtitle?: string
+  type?: 'notification-info' | 'attention'
 }
 
 const InternalBanner = ({

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
@@ -6,6 +6,7 @@ import PricingPoint from '../PricingPoint/PricingPoint'
 
 import ReimbursementPoint from '../ReimbursementPoint/ReimbursementPoint'
 import styles from './ReimbursementFields.module.scss'
+import InternalBanner from 'components/layout/InternalBanner'
 
 export interface ReimbursementInterface {
   offerer: IAPIOfferer
@@ -22,6 +23,7 @@ const ReimbursementFields = ({
 }: ReimbursementInterface) => {
   const venueHaveSiret = !!venue.siret
   const offererHaveVenueWithSiret = offerer.hasAvailablePricingPoints
+  const createVenuePath = `/structures/${offerer.id}/lieux/creation`
   const [venueHasPricingPoint, setVenueHasPricingPoint] = useState<boolean>(
     !!venue.pricingPoint
   )
@@ -40,21 +42,36 @@ const ReimbursementFields = ({
             En savoir plus sur les remboursements
           </a>
         </h2>
-        {!venueHaveSiret && offererHaveVenueWithSiret && (
-          <PricingPoint
-            readOnly={readOnly}
-            offerer={offerer}
-            venue={venue}
-            setVenueHasPricingPoint={setVenueHasPricingPoint}
-          />
+        {!venueHaveSiret && !offererHaveVenueWithSiret ? (
+          <InternalBanner
+            href={createVenuePath}
+            icon="ico-external-site-filled"
+            linkTitle="Créer un lieu avec SIRET"
+          >
+            Certains de vos points de remboursement ne sont pas rattachés à un
+            SIRET. Pour continuer à percevoir vos remboursements, veuillez
+            renseigner un SIRET de référence.
+          </InternalBanner>
+        ) : (
+          <>
+            {!venueHaveSiret && (
+              <PricingPoint
+                readOnly={readOnly}
+                offerer={offerer}
+                venue={venue}
+                setVenueHasPricingPoint={setVenueHasPricingPoint}
+              />
+            )}
+
+            <ReimbursementPoint
+              offerer={offerer}
+              readOnly={readOnly}
+              scrollToSection={scrollToSection}
+              venue={venue}
+              venueHasPricingPoint={venueHasPricingPoint}
+            />
+          </>
         )}
-        <ReimbursementPoint
-          offerer={offerer}
-          readOnly={readOnly}
-          scrollToSection={scrollToSection}
-          venue={venue}
-          venueHasPricingPoint={venueHasPricingPoint}
-        />
       </div>
     </>
   )

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react'
 import { IAPIOfferer } from 'core/Offerers/types'
 import { IAPIVenue } from 'core/Venue/types'
 import Icon from 'components/layout/Icon'
+import InternalBanner from 'components/layout/InternalBanner'
 import PricingPoint from '../PricingPoint/PricingPoint'
 
 import ReimbursementPoint from '../ReimbursementPoint/ReimbursementPoint'
 import styles from './ReimbursementFields.module.scss'
-import InternalBanner from 'components/layout/InternalBanner'
 
 export interface ReimbursementInterface {
   offerer: IAPIOfferer
@@ -48,9 +48,8 @@ const ReimbursementFields = ({
             icon="ico-external-site-filled"
             linkTitle="Créer un lieu avec SIRET"
           >
-            Certains de vos points de remboursement ne sont pas rattachés à un
-            SIRET. Pour continuer à percevoir vos remboursements, veuillez
-            renseigner un SIRET de référence.
+            Afin de pouvoir ajouter de nouvelles coordonnées bancaires, vous
+            devez avoir minimum un lieu rattaché à un SIRET.
           </InternalBanner>
         ) : (
           <>

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.jsx
@@ -1,0 +1,97 @@
+import '@testing-library/jest-dom'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { Form } from 'react-final-form'
+import React from 'react'
+import ReimbursementFields from '../ReimbursementFields'
+
+import { api } from 'apiClient/api'
+
+const renderReimbursementFields = async props => {
+  const rtlReturn = await render(
+    <Form onSubmit={() => {}}>{() => <ReimbursementFields {...props} />}</Form>
+  )
+
+  const loadingMessage = screen.queryByText('Chargement en cours ...')
+  await waitFor(() => expect(loadingMessage).not.toBeInTheDocument())
+
+  return rtlReturn
+}
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getAvailableReimbursementPoints: jest.fn(),
+  },
+}))
+
+describe('src | Venue | ReimbursementFields', () => {
+  const venue = {
+    id: 'AA',
+    nonHumanizedId: 1,
+    name: 'fake venue name',
+  }
+  const otherVenue = {
+    id: 'CC',
+    nonHumanizedId: 2,
+    name: 'Offerer Venue',
+  }
+  const offerer = {
+    id: 'BB',
+    nonHumanizedId: 2,
+    name: 'fake offerer name',
+    managedVenues: [otherVenue],
+    hasAvailablePricingPoints: true,
+  }
+  let props
+  beforeEach(() => {
+    props = { venue, offerer }
+    jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([])
+  })
+
+  it('should display banner if offerer has no pricing point and venue has no siret', async () => {
+    // Given
+    const offererWithoutPricingPoint = {
+      ...offerer,
+      hasAvailablePricingPoints: false,
+    }
+    props.offerer = offererWithoutPricingPoint
+
+    // When
+    await renderReimbursementFields(props)
+
+    // Then
+    expect(screen.queryByText('Créer un lieu avec SIRET')).toBeInTheDocument()
+  })
+
+  it('should not display pricing point section venue has siret', async () => {
+    // Given
+    const venueWithSiret = {
+      ...venue,
+      siret: '00000000012345',
+    }
+    props.venue = venueWithSiret
+
+    // When
+    await renderReimbursementFields(props)
+
+    // Then
+    expect(
+      screen.queryByText('Barème de remboursement')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should display pricing point section when venue has no siret', async () => {
+    // Given
+    const venueWithoutSiret = {
+      ...venue,
+      siret: null,
+    }
+    props.venue = venueWithoutSiret
+
+    // When
+    await renderReimbursementFields(props)
+
+    // Then
+    expect(screen.queryByText('Barème de remboursement')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15823

## But de la pull request

Afficher une bannière si la structure ne possède pas de lieu avec SIRET et qu'un lieu sans SIRET essaie d'ajouter des coordonnées bancaires

## Screenshot

![Capture d’écran 2022-07-08 à 17 19 51](https://user-images.githubusercontent.com/71768799/178021872-98527bfe-0444-4524-8f63-df1bbabe6418.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
