### PR TITLE
(PC-16012)[BO-FRONT] Fix: birthday label overlap placeholder

### DIFF
--- a/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
@@ -257,11 +257,10 @@ export const UserDetailsCard = ({ user, firstIdCheckHistory }: Props) => {
                   label={'Date de naissance'}
                   defaultValue={
                     user.dateOfBirth
-                      ? moment(user.dateOfBirth).format('YYYY-MM-D')
+                      ? moment(user.dateOfBirth).format('YYYY-MM-DD')
                       : ''
                   }
                   disabled={!editable}
-                  style={{ width: '100%' }}
                   variant={'standard'}
                   type={'date'}
                 />


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16102

## But de la pull request

Correction d'affichage du label "date de naissance" qui recouvre la valeur ou le placeholder.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
