### PR TITLE
(PC-15639)[PRO] fix: dont display popin if venue has siret

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
@@ -46,7 +46,7 @@ const ReimbursementPoint = ({
   }, [])
 
   const openDMSApplication = useCallback(() => {
-    if (venueHasPricingPoint) {
+    if (venueHasPricingPoint || venue.siret) {
       window.open(
         DEMARCHES_SIMPLIFIEES_BUSINESS_UNIT_RIB_UPLOAD_PROCEDURE_URL,
         '_blank'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15639

## But de la pull request

Ne pas afficher de pop-in lors de l'ajout de coordonnées bancaires si le lieu possède un siret

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
