### PR TITLE
(PC-15624)[PRO] feat: add pop in when user cancel venue creation

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/VenueCreation.jsx
@@ -10,7 +10,7 @@ import LocationFields, {
   bindGetSuggestionsToLongitude,
 } from '../fields/LocationFields'
 import { NavLink, useHistory, useParams } from 'react-router-dom'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import {
   createVenue,
@@ -22,10 +22,10 @@ import { getCanSubmit, parseSubmitErrors } from 'react-final-form-utils'
 
 import BankInformation from '../fields/BankInformationFields'
 import BusinessUnitFields from '../fields/BankInformationFields/BusinessUnitFields'
+import ConfirmDialog from 'new_components/ConfirmDialog'
 import ContactInfosFields from '../fields/ContactInfosFields'
 import { Form } from 'react-final-form'
 import Icon from 'components/layout/Icon'
-import ModifyOrCancelControl from '../controls/ModifyOrCancelControl/ModifyOrCancelControl'
 import NotificationMessage from '../Notification'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 /*eslint no-undef: 0*/
@@ -47,6 +47,7 @@ const VenueCreation = () => {
 
   const [venueTypes, setVenueTypes] = useState(null)
   const [venueLabels, setVenueLabels] = useState(null)
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false)
   const [isSiretValued, setIsSiretValued] = useState(true)
   const isBankInformationWithSiretActive = useActiveFeature(
     'ENFORCE_BANK_INFORMATION_WITH_SIRET'
@@ -147,6 +148,16 @@ const VenueCreation = () => {
       })
     })
   }
+  const openCancelDialog = useCallback(() => {
+    setIsCancelDialogOpen(true)
+  }, [])
+
+  const closeCancelDialog = useCallback(() => {
+    setIsCancelDialogOpen(false)
+  }, [])
+  const handleCancelConfirm = () => {
+    history.replace(`/accueil?structure=${offererId}`)
+  }
 
   const onHandleRender = formProps => {
     const readOnly = false
@@ -200,13 +211,13 @@ const VenueCreation = () => {
           className="field is-grouped is-grouped-centered"
           style={{ justifyContent: 'space-between' }}
         >
-          <ModifyOrCancelControl
-            form={form}
-            history={history}
-            isCreatedEntity
-            offererId={offererId}
-            readOnly={readOnly}
-          />
+          <button
+            className="secondary-button"
+            onClick={openCancelDialog}
+            type="reset"
+          >
+            Quitter
+          </button>
 
           <ReturnOrSubmitControl
             canSubmit={canSubmit}
@@ -244,6 +255,20 @@ const VenueCreation = () => {
       <p className="advice">Ajoutez un lieu où accéder à vos offres.</p>
 
       {!isReady && <Spinner />}
+      {isCancelDialogOpen && (
+        <ConfirmDialog
+          cancelText="Annuler"
+          confirmText="Quitter sans enregister"
+          onCancel={closeCancelDialog}
+          onConfirm={handleCancelConfirm}
+          title="Voulez-vous quitter la création de lieu ?"
+        >
+          <p>
+            Votre lieu ne sera pas sauvegardé et toutes les informations seront
+            perdues.
+          </p>
+        </ConfirmDialog>
+      )}
 
       {isReady && (
         <Form

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreation.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueCreation/__specs__/VenueCreation.spec.jsx
@@ -225,6 +225,45 @@ describe('venue form', () => {
       expect(contactMail).toHaveValue('test@test.com')
     })
   })
+  it('should display popin when quit button is clicked', async () => {
+    await renderVenueCreation({ props, storeOverrides })
+    const quitButton = screen.getByRole('button', { name: 'Quitter' })
+
+    await userEvent.click(quitButton)
+
+    expect(
+      screen.queryByText('Voulez-vous quitter la création de lieu ?')
+    ).toBeInTheDocument()
+  })
+  it('should display homepage when cancel popin is confirm', async () => {
+    await renderVenueCreation({ props, storeOverrides })
+    const quitButton = screen.getByRole('button', { name: 'Quitter' })
+
+    await userEvent.click(quitButton)
+
+    const quitDialogButton = screen.getByRole('button', {
+      name: 'Quitter sans enregister',
+    })
+    await userEvent.click(quitDialogButton)
+
+    expect(screen.queryByText("Bienvenue sur l'accueil")).toBeInTheDocument()
+  })
+
+  it('should close dialog when cancel button in popin is clicked', async () => {
+    await renderVenueCreation({ props, storeOverrides })
+    const quitButton = screen.getByRole('button', { name: 'Quitter' })
+
+    await userEvent.click(quitButton)
+
+    const cancelDialogButton = screen.getByRole('button', {
+      name: 'Annuler',
+    })
+    await userEvent.click(cancelDialogButton)
+
+    expect(
+      screen.queryByText('Voulez-vous quitter la création de lieu ?')
+    ).not.toBeInTheDocument()
+  })
 
   describe('business unit fileds', () => {
     storeOverrides = {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15624

## But de la pull request

Afficher une pop-in lors du click sur le bouton `Quitter` de la page création de lieu

## Screenshot

![Capture d’écran 2022-07-11 à 15 39 03](https://user-images.githubusercontent.com/71768799/178277396-6dcedb93-778e-4318-b076-3e6ca884b8fd.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
