### PR TITLE
(BSR)[API] chore: Clean up "extension-pkg-whitelist" pylint option

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -59,14 +59,7 @@ exclude = """
 
 [tool.pylint.MASTER]
 extension-pkg-whitelist = [
-    "binascii",
-    "lxml",
-    "math",
-    "netifaces",
-    "posix_ipc",
     "pydantic",
-    "spidev",
-    "unicodedata",
 ]
 load-plugins = [
     "pcapi.utils.pylint",


### PR DESCRIPTION
Some modules are unnecessarily listed here. Some modules are not used
anymore and/or have never been used (e.g. lxml and spidev).
