### PR TITLE
(PC-14328)[API] feat: click: use nargs instead of option

### DIFF
--- a/api/src/pcapi/core/bookings/external/booking_notifications.py
+++ b/api/src/pcapi/core/bookings/external/booking_notifications.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 import logging
+import typing
 
 from pcapi import settings
 from pcapi.core.bookings.exceptions import BookingIsExpired
@@ -39,7 +40,7 @@ def send_today_events_notifications_metropolitan_france() -> None:
             logger.exception("Could not send today stock notification", extra={"stock": stock_id})
 
 
-def send_today_events_notifications_overseas(utc_mean_offset: int, departments: list[str]) -> None:
+def send_today_events_notifications_overseas(utc_mean_offset: int, departments: typing.Iterable[str]) -> None:
     """
     Find bookings (grouped by stocks) that occur today in overseas
     french departments but not the morning (11h UTC), and send

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import typing
 
 import click
 import sqlalchemy.orm as sqla_orm
@@ -186,9 +187,9 @@ def send_today_events_notifications_metropolitan_france_command() -> None:
 
 @blueprint.cli.command("send_today_events_notifications_overseas_france")
 @log_cron_with_transaction
-@click.option("--utc-mean-offset", help="UTC offset to use (can be negative)", type=int)
-@click.option("--departments", help="target departments (list of str)", type=list)
-def send_today_events_notifications_overseas_france(utc_mean_offset: int, departments: list[str]) -> None:
+@click.option("--utc-mean-offset", help="UTC offset to use (can be negative)", type=int, required=True)
+@click.argument("departments", nargs=-1)
+def send_today_events_notifications_overseas_france(utc_mean_offset: int, departments: typing.Iterable[str]) -> None:
     """
     Find bookings (grouped by stocks) that occur today in overseas
     France departments and send notifications to remind the users


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14328

## But de la pull request

Utiliser `argument`/`nargs`, parce que `option` avec `type=list` ne fonctionne pas comme prévu : `--departments=123` va renvoyer `("1", "2", "3")`.

Il faudra ensuite modifier la manière dont est utilisée la commande.