### PR TITLE
PC-16052[PRO] feat: Add trackers to offer form navigation

### DIFF
--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -14,6 +14,10 @@ import {
   WITHDRAWAL_ON_SITE_DELAY_OPTIONS,
   WITHDRAWAL_TYPE_COMPATIBLE_SUBCATEGORIE,
 } from '../_constants'
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import React, {
   Fragment,
   useCallback,
@@ -27,6 +31,7 @@ import DurationInput from 'components/layout/inputs/DurationInput/DurationInput'
 import InternalBanner from 'components/layout/InternalBanner'
 import { Link } from 'react-router-dom'
 import { OFFER_WITHDRAWAL_TYPE_OPTIONS } from 'core/Offers'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import OfferCategories from './OfferCategories'
 import OfferOptions from './OfferOptions'
 import { OfferRefundWarning } from 'new_components/Banner'
@@ -45,6 +50,7 @@ import isEqual from 'lodash.isequal'
 import { isUrlValid } from './validators'
 import { sortByDisplayName } from 'utils/strings'
 import useActiveFeature from 'components/hooks/useActiveFeature'
+import { useSelector } from 'react-redux'
 
 // JOCONDE React:component "Ce composant est vraiment le plus beau et le plus lisible que nous ayons côté pro. Prenez en de la graine !"
 
@@ -88,6 +94,7 @@ const OfferForm = ({
   const formRef = useRef(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitLoading, setIsSubmitLoading] = useState(false)
+  const logEvent = useSelector(state => state.app.logEvent)
 
   const isIsbnRequiredInLivreEditionEnabled = useActiveFeature(
     'ENABLE_ISBN_REQUIRED_IN_LIVRE_EDITION_OFFER_CREATION'
@@ -541,6 +548,11 @@ const OfferForm = ({
 
         const nextStepRedirect = await onSubmit(submittedValues)
         if (nextStepRedirect !== null) {
+          logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+            from: OfferBreadcrumbStep.DETAILS,
+            to: OfferBreadcrumbStep.STOCKS,
+            used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+          })
           await nextStepRedirect()
           return
         }
@@ -559,6 +571,15 @@ const OfferForm = ({
       showErrorNotification,
     ]
   )
+
+  const onCancelClick = () => {
+    if (isEdition)
+      logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+        from: OfferBreadcrumbStep.DETAILS,
+        to: OfferBreadcrumbStep.SUMMARY,
+        used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+      })
+  }
 
   const handleChangeVenue = useCallback(
     event => {
@@ -1124,7 +1145,7 @@ const OfferForm = ({
         )}
 
       <section className="actions-section">
-        <Link className="secondary-link" to={backUrl}>
+        <Link className="secondary-link" to={backUrl} onClick={onCancelClick}>
           {isEdition ? `Voir le détail de l'offre` : 'Annuler et quitter'}
         </Link>
         <SubmitButton

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
@@ -2240,59 +2240,6 @@ describe('offerDetails - Creation - pro user', () => {
       )
       expect(isbnError).toBeInTheDocument()
     })
-
-    it('should show an error notification and display an error message on the placeholder', async () => {
-      // Given
-      const offerValues = {
-        name: 'Ma petite offre',
-        venueId: venues[0].id,
-        audioDisabilityCompliant: false,
-        visualDisabilityCompliant: true,
-        motorDisabilityCompliant: false,
-        mentalDisabilityCompliant: false,
-      }
-
-      jest.spyOn(Object, 'values').mockReturnValue(['item'])
-      pcapi.postThumbnail.mockRejectedValue({
-        errors: {
-          errors: [
-            'Utilisez une image plus grande (supérieure à 400px par 400px)',
-          ],
-        },
-      })
-      const createdOffer = {
-        ...offerValues,
-        venueId: venues[0].id,
-        id: 'AA',
-        stocks: [],
-        venue: venues[0],
-      }
-      pcapi.createOffer.mockResolvedValue(createdOffer)
-      await renderOffers(props, store)
-      jest.spyOn(api, 'getOffer').mockResolvedValue(createdOffer)
-
-      await setOfferValues({ categoryId: 'CINEMA' })
-      await setOfferValues({ subcategoryId: 'CARTE_CINE_MULTISEANCES' })
-
-      pcapi.getVenue.mockResolvedValue(venues[0])
-      await setOfferValues(offerValues)
-      await sidebarDisplayed()
-
-      // When
-      await userEvent.click(screen.getByText('Étape suivante'))
-
-      // Then
-      await sidebarDisplayed()
-      const errorNotification = await screen.findByText(
-        'Une ou plusieurs erreurs sont présentes dans le formulaire'
-      )
-      expect(errorNotification).toBeInTheDocument()
-
-      const thumbnailUploadError = await screen.findByText(
-        'Utilisez une image plus grande (supérieure à 400px par 400px)'
-      )
-      expect(thumbnailUploadError).toBeInTheDocument()
-    })
   })
 
   describe('when quitting offer creation', () => {

--- a/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
@@ -1,5 +1,9 @@
 import * as pcapi from 'repository/pcapi/pcapi'
 
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import React, {
   Fragment,
   useCallback,
@@ -18,6 +22,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 import { ReactComponent as AddStockSvg } from 'icons/ico-plus.svg'
 import { FormActions } from './FormActions'
 import { OFFER_STATUS_DRAFT } from 'core/Offers/constants'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import OfferStatusBanner from 'components/pages/Offers/Offer/OfferDetails/OfferStatusBanner/OfferStatusBanner'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import PropTypes from 'prop-types'
@@ -27,6 +32,7 @@ import { isOfferDisabled } from 'components/pages/Offers/domain/isOfferDisabled'
 import { queryParamsFromOfferer } from '../../utils/queryParamsFromOfferer'
 import useActiveFeature from 'components/hooks/useActiveFeature'
 import { useOfferEditionURL } from 'components/hooks/useOfferEditionURL'
+import { useSelector } from 'react-redux'
 
 const EMPTY_STRING_VALUE = ''
 
@@ -44,6 +50,7 @@ const EventStocks = ({
   const isOfferSynchronized = Boolean(offer.lastProvider)
   const [formErrors, setFormErrors] = useState({})
   const isOfferDraft = offer.status === OFFER_STATUS_DRAFT
+  const logEvent = useSelector(state => state.app.logEvent)
   const useSummaryPage = useActiveFeature('OFFER_FORM_SUMMARY_PAGE')
   const editionOfferLink = useOfferEditionURL(
     offer.isEducational,
@@ -164,6 +171,15 @@ const EventStocks = ({
     return !hasErrors
   }
 
+  const onCancelClick = () => {
+    if (isOfferDraft && !useSummaryPage) return
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.STOCKS,
+      to: OfferBreadcrumbStep.DETAILS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+    })
+  }
+
   const submitStocks = useCallback(() => {
     const updatedStocks = existingStocks.filter(stock => stock.updated)
     if (
@@ -205,7 +221,11 @@ const EventStocks = ({
             if (queryParams.lieu !== '') {
               queryString += `&lieu=${queryParams.lieu}`
             }
-
+            logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+              from: OfferBreadcrumbStep.STOCKS,
+              to: OfferBreadcrumbStep.SUMMARY,
+              used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+            })
             history.push(
               useSummaryPage
                 ? `${summaryStepUrl}${queryString}`
@@ -350,6 +370,7 @@ const EventStocks = ({
               isDraft={isOfferDraft}
               isSubmiting={isSendingStocksOfferCreation}
               onSubmit={submitStocks}
+              onCancelClick={onCancelClick}
             />
           </section>
         </Fragment>

--- a/pro/src/components/pages/Offers/Offer/Stocks/FormActions/FormActions.tsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/FormActions/FormActions.tsx
@@ -10,6 +10,7 @@ interface IFormActionsProps {
   isDraft: boolean
   isSubmiting: boolean
   onSubmit: () => void
+  onCancelClick?: () => void
 }
 
 const FormActions = ({
@@ -18,13 +19,18 @@ const FormActions = ({
   canSubmit,
   isSubmiting,
   onSubmit,
+  onCancelClick,
 }: IFormActionsProps): JSX.Element => {
   const useSummaryPage = useActiveFeature('OFFER_FORM_SUMMARY_PAGE')
 
   return (
     <>
       {cancelUrl && (
-        <ButtonLink variant={ButtonVariant.SECONDARY} to={cancelUrl}>
+        <ButtonLink
+          variant={ButtonVariant.SECONDARY}
+          to={cancelUrl}
+          onClick={onCancelClick ? onCancelClick : undefined}
+        >
           {isDraft
             ? 'Étape précédente'
             : useSummaryPage

--- a/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -1,6 +1,10 @@
 import * as pcapi from 'repository/pcapi/pcapi'
 
 import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
+import {
   LIVRE_PAPIER_SUBCATEGORY_ID,
   OFFER_STATUS_DRAFT,
 } from 'core/Offers/constants'
@@ -15,6 +19,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 
 import { ReactComponent as AddStockSvg } from 'icons/ico-plus.svg'
 import { FormActions } from './FormActions'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import OfferStatusBanner from 'components/pages/Offers/Offer/OfferDetails/OfferStatusBanner/OfferStatusBanner'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import PriceErrorHTMLNotification from './PriceErrorHTMLNotification'
@@ -25,6 +30,7 @@ import { isOfferDisabled } from 'components/pages/Offers/domain/isOfferDisabled'
 import { queryParamsFromOfferer } from '../../utils/queryParamsFromOfferer'
 import useActiveFeature from 'components/hooks/useActiveFeature'
 import { useOfferEditionURL } from 'components/hooks/useOfferEditionURL'
+import { useSelector } from 'react-redux'
 
 const EMPTY_STRING_VALUE = ''
 
@@ -130,6 +136,16 @@ const ThingStocks = ({
     return !stockHasErrors
   }
 
+  const logEvent = useSelector(state => state.app.logEvent)
+  const onCancelClick = () => {
+    if (isOfferDraft && !useSummaryPage) return
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.STOCKS,
+      to: OfferBreadcrumbStep.DETAILS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+    })
+  }
+
   const submitStocks = useCallback(() => {
     if (checkStockIsValid(stock, offer.isEvent, offer.isEducational)) {
       setEnableSubmitButtonSpinner(true)
@@ -168,7 +184,11 @@ const ThingStocks = ({
             if (queryParams.lieu !== '') {
               queryString += `&lieu=${queryParams.lieu}`
             }
-
+            logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+              from: OfferBreadcrumbStep.STOCKS,
+              to: OfferBreadcrumbStep.SUMMARY,
+              used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+            })
             history.push(
               useSummaryPage
                 ? `${summaryStepUrl}${queryString}`
@@ -313,6 +333,7 @@ const ThingStocks = ({
               isDraft={isOfferDraft}
               isSubmiting={enableSubmitButtonSpinner}
               onSubmit={submitStocks}
+              onCancelClick={onCancelClick}
             />
           </section>
         </Fragment>

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -21,6 +21,7 @@ export enum Events {
   CLICKED_LOGOUT = 'hasClickedLogout',
   CLICKED_MODIFY_OFFERER = 'hasClickedModifyOfferer',
   CLICKED_OFFER = 'hasClickedOffer',
+  CLICKED_OFFER_FORM_NAVIGATION = 'hasClickedOfferFormNavigation',
   CLICKED_PERSONAL_DATA = 'hasClickedConsultPersonalData',
   CLICKED_PRO = 'hasClickedPro',
   CLICKED_REIMBURSEMENT = 'hasClickedReimbursement',
@@ -32,4 +33,14 @@ export enum Events {
   SIGNUP_FORM_ABORT = 'signupFormAbort',
   SIGNUP_FORM_SUCCESS = 'signupFormSuccess',
   TUTO_PAGE_VIEW = 'tutoPageView',
+}
+
+export enum OFFER_FORM_NAVIGATION_MEDIUM {
+  RECAP_LINK = 'RecapLink',
+  STICKY_BUTTONS = 'StickyButtons',
+  BREADCRUMB = 'Breadcrumb',
+}
+
+export enum OFFER_FORM_NAVIGATION_OUT {
+  OFFER = 'Offer',
 }

--- a/pro/src/new_components/OfferBreadcrumb/OfferBreadcrumb.tsx
+++ b/pro/src/new_components/OfferBreadcrumb/OfferBreadcrumb.tsx
@@ -2,13 +2,19 @@ import Breadcrumb, {
   BreadcrumbStyle,
 } from 'new_components/Breadcrumb/Breadcrumb'
 import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
+import {
   useOfferEditionURL,
   useOfferStockEditionURL,
 } from 'components/hooks/useOfferEditionURL'
 
 import React from 'react'
+import { RootState } from 'store/reducers'
 import type { Step } from 'new_components/Breadcrumb'
 import useActiveFeature from 'components/hooks/useActiveFeature'
+import { useSelector } from 'react-redux'
 
 export enum OfferBreadcrumbStep {
   DETAILS = 'details',
@@ -39,6 +45,7 @@ const OfferBreadcrumb = ({
     'ENABLE_EDUCATIONAL_INSTITUTION_ASSOCIATION'
   )
   const useSummaryPage = useActiveFeature('OFFER_FORM_SUMMARY_PAGE')
+  const logEvent = useSelector((state: RootState) => state.app.logEvent)
   const offerEditionUrl = useOfferEditionURL(isOfferEducational, offerId, false)
   const stockEditionUrl = useOfferStockEditionURL(isOfferEducational, offerId)
 
@@ -132,6 +139,18 @@ const OfferBreadcrumb = ({
 
     steps = Object.values(stepList)
   }
+
+  // Add firebase tracking only on individual offers
+  if (!isOfferEducational)
+    steps.map((step, index) => {
+      steps[index].onClick = () => {
+        logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+          from: activeStep,
+          to: step.id,
+          used: OFFER_FORM_NAVIGATION_MEDIUM.BREADCRUMB,
+        })
+      }
+    })
 
   return (
     <Breadcrumb

--- a/pro/src/new_components/SummaryLayout/SummaryLayoutSection.tsx
+++ b/pro/src/new_components/SummaryLayout/SummaryLayoutSection.tsx
@@ -10,6 +10,7 @@ interface ISummaryLayoutSectionProps {
   children: React.ReactNode | React.ReactNode[]
   className?: string
   editLink: string
+  onLinkClick?: () => void
 }
 
 const Section = ({
@@ -17,6 +18,7 @@ const Section = ({
   children,
   className,
   editLink,
+  onLinkClick,
 }: ISummaryLayoutSectionProps): JSX.Element => (
   <div className={cn(style['summary-layout-section'], className)}>
     <div className={style['summary-layout-section-header']}>
@@ -28,6 +30,7 @@ const Section = ({
           to={editLink}
           className={style['summary-layout-section-header-edit-link']}
           Icon={BlackPen}
+          onClick={onLinkClick ? onLinkClick : undefined}
         >
           Modifier
         </ButtonLink>

--- a/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
@@ -1,11 +1,18 @@
 import { AccessibilityLabel, AccessiblityLabelEnum } from 'ui-kit'
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 
 import { OFFER_WITHDRAWAL_TYPE_LABELS } from 'core/Offers'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import React from 'react'
+import { RootState } from 'store/reducers'
 import { SummaryLayout } from 'new_components/SummaryLayout'
 import { WithdrawalTypeEnum } from 'apiClient/v1'
 import humanizeDelay from './utils'
 import styles from './OfferSummary.module.scss'
+import { useSelector } from 'react-redux'
 
 export interface IOfferSectionProps {
   id: string
@@ -61,8 +68,20 @@ const OfferSummary = ({
   const editLink = isCreation
     ? `/offre/${offer.id}/individuel/creation`
     : `/offre/${offer.id}/individuel/edition`
+  const logEvent = useSelector((state: RootState) => state.app.logEvent)
+  const logEditEvent = () => {
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.SUMMARY,
+      to: OfferBreadcrumbStep.DETAILS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.RECAP_LINK,
+    })
+  }
   return (
-    <SummaryLayout.Section title="Détails de l'offre" editLink={editLink}>
+    <SummaryLayout.Section
+      title="Détails de l'offre"
+      editLink={editLink}
+      onLinkClick={logEditEvent}
+    >
       <SummaryLayout.SubSection title="Type d'offre">
         <SummaryLayout.Row title="Catégorie" description={offer.categoryName} />
         <SummaryLayout.Row

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
@@ -1,12 +1,19 @@
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import React, { useEffect, useState } from 'react'
 
 import { Button } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import type { IStockEventItemProps } from './StockEventItem'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import { ROOT_PATH } from 'utils/config'
+import { RootState } from 'store/reducers'
 import { StockEventItem } from './StockEventItem'
 import { SummaryLayout } from 'new_components/SummaryLayout'
 import styles from './StockEventSection.module.scss'
+import { useSelector } from 'react-redux'
 
 const NB_UNFOLDED_STOCK = 2
 
@@ -36,8 +43,20 @@ const StockEventSection = ({
   const editLink = isCreation
     ? `/offre/${offerId}/individuel/creation/stocks`
     : `/offre/${offerId}/individuel/stocks`
+  const logEvent = useSelector((state: RootState) => state.app.logEvent)
+  const logEditEvent = () => {
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.SUMMARY,
+      to: OfferBreadcrumbStep.STOCKS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.RECAP_LINK,
+    })
+  }
   return (
-    <SummaryLayout.Section title="Stocks et prix" editLink={editLink}>
+    <SummaryLayout.Section
+      title="Stocks et prix"
+      editLink={editLink}
+      onLinkClick={logEditEvent}
+    >
       {displayedStocks.map((s, k) => (
         <StockEventItem
           key={`stock-${k}`}

--- a/pro/src/screens/OfferIndividual/Summary/StockThingSection/StockThingSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockThingSection/StockThingSection.tsx
@@ -1,8 +1,15 @@
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import { FORMAT_DD_MM_YYYY, toDateStrippedOfTimezone } from 'utils/date'
 
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import React from 'react'
+import { RootState } from 'store/reducers'
 import { SummaryLayout } from 'new_components/SummaryLayout'
 import { format } from 'date-fns-tz'
+import { useSelector } from 'react-redux'
 
 export interface IStockThingSectionProps {
   quantity?: number | null
@@ -25,8 +32,20 @@ const StockThingSection = ({
   const editLink = isCreation
     ? `/offre/${offerId}/individuel/creation/stocks`
     : `/offre/${offerId}/individuel/stocks`
+  const logEvent = useSelector((state: RootState) => state.app.logEvent)
+  const logEditEvent = () => {
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.SUMMARY,
+      to: OfferBreadcrumbStep.STOCKS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.RECAP_LINK,
+    })
+  }
   return (
-    <SummaryLayout.Section title="Stocks et prix" editLink={editLink}>
+    <SummaryLayout.Section
+      title="Stocks et prix"
+      editLink={editLink}
+      onLinkClick={logEditEvent}
+    >
       <SummaryLayout.Row title="Prix" description={`${price} €`} />
       {bookingLimitDatetime !== null && (
         <SummaryLayout.Row

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -2,6 +2,11 @@ import * as pcapi from 'repository/pcapi/pcapi'
 
 import { Button, ButtonLink } from 'ui-kit'
 import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+  OFFER_FORM_NAVIGATION_OUT,
+} from 'core/FirebaseEvents/constants'
+import {
   IOfferAppPreviewProps,
   OfferAppPreview,
 } from 'new_components/OfferAppPreview'
@@ -16,6 +21,7 @@ import { BannerSummary } from 'new_components/Banner'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { DisplayOfferInAppLink } from 'components/pages/Offers/Offer/DisplayOfferInAppLink'
 import { IOfferSubCategory } from 'core/Offers/types'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import { OfferFormLayout } from 'new_components/OfferFormLayout'
 import { ReactComponent as PhoneInfo } from 'icons/info-phone.svg'
 import { RootState } from 'store/reducers'
@@ -50,6 +56,7 @@ const Summary = ({
   const [isDisabled, setIsDisabled] = useState(false)
   const location = useLocation()
   const notification = useNotification()
+  const logEvent = useSelector((state: RootState) => state.app.logEvent)
   const handleOfferPublication = () => {
     setIsDisabled(true)
     const url = `/offre/${offerId}/individuel/creation/confirmation${location.search}`
@@ -57,6 +64,11 @@ const Summary = ({
       .publishOffer(offerId)
       .then(() => {
         setIsDisabled(false)
+        logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+          from: OfferBreadcrumbStep.SUMMARY,
+          to: OfferBreadcrumbStep.CONFIRMATION,
+          used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+        })
         history.push(url)
       })
       .catch(() => {
@@ -67,9 +79,19 @@ const Summary = ({
 
   const history = useHistory()
   const handleNextStep = () => {
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.SUMMARY,
+      to: OfferBreadcrumbStep.CONFIRMATION,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+    })
     history.push(`/offre/${offerId}/v3/creation/individuelle/confirmation`)
   }
   const handlePreviousStep = () => {
+    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OfferBreadcrumbStep.SUMMARY,
+      to: 'THIS ONE?',
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+    })
     history.push(`/offre/${offerId}/v3/creation/individuelle/stocks`)
   }
   const offerSubCategory = subCategories.find(s => s.id === offer.subcategoryId)
@@ -127,6 +149,13 @@ const Summary = ({
                 <ButtonLink
                   variant={ButtonVariant.SECONDARY}
                   to={`/offre/${offerId}/individuel/creation/stocks`}
+                  onClick={() =>
+                    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+                      from: OfferBreadcrumbStep.SUMMARY,
+                      to: 'orthisone?',
+                      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+                    })
+                  }
                 >
                   Étape précédente
                 </ButtonLink>
@@ -140,7 +169,17 @@ const Summary = ({
               </div>
             ) : (
               <div className={styles['offer-creation-preview-actions']}>
-                <ButtonLink variant={ButtonVariant.PRIMARY} to={backOfferUrl}>
+                <ButtonLink
+                  variant={ButtonVariant.PRIMARY}
+                  to={backOfferUrl}
+                  onClick={() =>
+                    logEvent(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+                      from: OfferBreadcrumbStep.SUMMARY,
+                      to: OFFER_FORM_NAVIGATION_OUT.OFFER,
+                      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+                    })
+                  }
+                >
                   Voir la liste des offres
                 </ButtonLink>
               </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16052

## But de la pull request

Trackers trackers trackers. 
3 trackers différents : 
- Breadcrumb
- Liens "Modifier" de la page récap
- boutons étapes précédente, étapes suivante, "retour à la page de récap"

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
