### PR TITLE
(PC-16089)[API] fix: allow empty siret field in bank info  V4 procedure

### DIFF
--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -51,10 +51,17 @@ class SaveVenueBankInformations:
         )
 
         api_errors = CannotRegisterBankInformation()
-        siret = application_details.siret
-        siren = application_details.siren
-        offerer = Offerer.query.filter_by(siren=siren).one_or_none()
-        check_offerer_presence(offerer, api_errors)
+
+        if procedure_id in (
+            settings.DMS_VENUE_PROCEDURE_ID,
+            settings.DMS_VENUE_PROCEDURE_ID_V2,
+            settings.DMS_VENUE_PROCEDURE_ID_V3,
+        ):
+            siret = application_details.siret
+            siren = application_details.siren
+            offerer = Offerer.query.filter_by(siren=siren).one_or_none()
+            check_offerer_presence(offerer, api_errors)
+
         venue = self.get_referent_venue(application_details, offerer, api_errors)
 
         if api_errors.errors:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16089

## But de la pull request

check_offerer() ne doit pas être appelé pour un dossier de procédure V4 puisque le champ siret est facultatif.