### PR TITLE
(PC-15823)[PRO] fix: fix banner text when offerer has no venue with s…

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields.tsx
@@ -49,7 +49,7 @@ const ReimbursementFields = ({
             linkTitle="Créer un lieu avec SIRET"
           >
             Afin de pouvoir ajouter de nouvelles coordonnées bancaires, vous
-            devez avoir minimum un lieu rattaché à un SIRET.
+            devez avoir, au minimum, un lieu rattaché à un SIRET.
           </InternalBanner>
         ) : (
           <>


### PR DESCRIPTION
…iret

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15823

## But de la pull request

Mettre à jour le label de la bannière affichée quand une structure n'a pas de lieu avec SIRET. 

Afin de pouvoir ajouter de nouvelles coordonnées bancaires, vous devez avoir minimum un lieu rattaché à un SIRET
→  **Afin de pouvoir ajouter de nouvelles coordonnées bancaires, vous devez avoir, au minimum, un lieu rattaché à un SIRET.**

