### PR TITLE
(PC-16218)[PRO] fix: display right timezone time depending on departement

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Offer.scss
+++ b/pro/src/components/pages/Offers/Offer/Offer.scss
@@ -91,7 +91,6 @@
     display: flex;
     justify-content: center;
     margin-top: rem.torem(64px);
-    width: rem.torem(600px);
     button,
     a {
       flex: 1;
@@ -103,4 +102,7 @@
       }
     }
   }
+  .edit-buttons {
+    width: rem.torem(600px);
+}
 }

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -1146,7 +1146,11 @@ const OfferForm = ({
           </Fragment>
         )}
 
-      <section className="actions-section">
+      <section
+        className={
+          isEdition ? 'actions-section edit-buttons' : 'actions-section'
+        }
+      >
         <Link className="secondary-link" to={backUrl} onClick={onCancelClick}>
           {isEdition ? `Voir le récapitulatif` : 'Annuler et quitter'}
         </Link>

--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/domain.js
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/domain.js
@@ -220,13 +220,14 @@ export const formatStock = (stock, departementCode) => {
     key: stock.id,
   }
   if (stock.beginningDatetime) {
-    formattedStock.beginningDatetime = getLocalDepartementDateTimeFromUtc(
+    formattedStock['beginningDatetime'] = getLocalDepartementDateTimeFromUtc(
       stock.beginningDatetime,
       departementCode
     )
   }
+
   if (stock.activationCodesExpirationDatetime) {
-    formattedStock.activationCodesExpirationDatetime =
+    formattedStock['activationCodesExpirationDatetime'] =
       getLocalDepartementDateTimeFromUtc(
         stock.activationCodesExpirationDatetime,
         departementCode

--- a/pro/src/core/Offers/adapters/__specs__/useGetOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/__specs__/useGetOffer.spec.ts
@@ -219,6 +219,7 @@ describe('useGetOffer', () => {
         },
         postalCode: '75000',
         publicName: 'Cinéma synchro avec booking provider',
+        departmentCode: '75',
       },
     }
 

--- a/pro/src/core/Offers/adapters/serializers.ts
+++ b/pro/src/core/Offers/adapters/serializers.ts
@@ -28,6 +28,7 @@ export const serializeVenueApi = (
     isVirtual: apiOffer.venue.isVirtual,
     address: apiOffer.venue.address || '',
     postalCode: apiOffer.venue.postalCode || '',
+    departmentCode: apiOffer.venue.departementCode || '',
     city: apiOffer.venue.city || '',
     offerer: serializeOffererApi(apiOffer),
   }

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -111,6 +111,7 @@ export interface IOfferIndividualVenue {
   postalCode: string
   city: string
   offerer: IOfferIndividualOfferer
+  departmentCode: string
 }
 
 export interface IOfferIndividual {

--- a/pro/src/routes/OfferIndividualSummary/serializer.ts
+++ b/pro/src/routes/OfferIndividualSummary/serializer.ts
@@ -95,6 +95,7 @@ const serializerOfferSectionProps = (
 
     venueName: offer.venue.name,
     venuePublicName: offer.venue.publicName,
+    venueDepartmentCode: offer.venue.departmentCode,
     isVenueVirtual: offer.venue.isVirtual,
     offererName: offer.venue.offerer.name,
     bookingEmail: offer.bookingEmail,
@@ -146,7 +147,8 @@ const serializerStockEventSectionProps = (
     quantity: stock.quantity,
     price: stock.price,
     bookingLimitDatetime: stock.bookingLimitDatetime,
-    beginningDateTime: stock.beginningDatetime,
+    beginningDatetime: stock.beginningDatetime,
+    departmentCode: offer.venue.departmentCode,
   }))
 }
 

--- a/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
@@ -46,6 +46,7 @@ export interface IOfferSectionProps {
 
   venueName: string
   venuePublicName: string
+  venueDepartmentCode: string
   isVenueVirtual: boolean
   offererName: string
   bookingEmail: string

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventItem/StockEventItem.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventItem/StockEventItem.tsx
@@ -1,8 +1,4 @@
-import {
-  FORMAT_DD_MM_YYYY,
-  FORMAT_HH_mm,
-  toDateStrippedOfTimezone,
-} from 'utils/date'
+import { FORMAT_DD_MM_YYYY, FORMAT_HH_mm } from 'utils/date'
 
 import React from 'react'
 import { SummaryLayout } from 'new_components/SummaryLayout'
@@ -10,42 +6,38 @@ import { format } from 'date-fns-tz'
 
 export interface IStockEventItemProps {
   className?: string
-  beginningDateTime: string | null
+  beginningDatetime: string | Date | null
   price: number
   quantity?: number | null
-  bookingLimitDatetime: string | null
+  bookingLimitDatetime: string | Date | null
 }
 
 const StockEventItem = ({
   className,
-  beginningDateTime,
+  beginningDatetime,
   price,
   quantity,
   bookingLimitDatetime,
 }: IStockEventItemProps): JSX.Element => {
-  const eventLocalDateTime = toDateStrippedOfTimezone(beginningDateTime)
   return (
     <div className={className}>
-      {beginningDateTime && (
+      {beginningDatetime && (
         <SummaryLayout.Row
           title="Date"
-          description={format(eventLocalDateTime, FORMAT_DD_MM_YYYY)}
+          description={format(beginningDatetime, FORMAT_DD_MM_YYYY)}
         />
       )}
-      {beginningDateTime && (
+      {beginningDatetime && (
         <SummaryLayout.Row
           title="Horaire"
-          description={format(eventLocalDateTime, FORMAT_HH_mm)}
+          description={format(beginningDatetime, FORMAT_HH_mm)}
         />
       )}
       <SummaryLayout.Row title="Prix" description={`${price} €`} />
       {bookingLimitDatetime !== null && (
         <SummaryLayout.Row
           title="Date limite de réservation"
-          description={format(
-            toDateStrippedOfTimezone(bookingLimitDatetime),
-            FORMAT_DD_MM_YYYY
-          )}
+          description={format(bookingLimitDatetime, FORMAT_DD_MM_YYYY)}
         />
       )}
       <SummaryLayout.Row

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
@@ -12,6 +12,7 @@ import { ROOT_PATH } from 'utils/config'
 import { RootState } from 'store/reducers'
 import { StockEventItem } from './StockEventItem'
 import { SummaryLayout } from 'new_components/SummaryLayout'
+import { formatAndSortStocks } from 'components/pages/Offers/Offer/Stocks/StockItem/domain'
 import styles from './StockEventSection.module.scss'
 import { useSelector } from 'react-redux'
 
@@ -21,23 +22,30 @@ export interface IStockEventSectionProps {
   stocks: IStockEventItemProps[]
   isCreation: boolean
   offerId: string
+  departmentCode: string
 }
 
 const StockEventSection = ({
   stocks,
   isCreation,
   offerId,
+  departmentCode,
 }: IStockEventSectionProps): JSX.Element => {
-  const [showAllStocks, setShowAllStocks] = useState(false)
-  const [displayedStocks, setDisplayedStocks] = useState(
-    stocks.slice(0, NB_UNFOLDED_STOCK)
+  const [formattedStocks] = useState<IStockEventItemProps[]>(
+    formatAndSortStocks(stocks, departmentCode)
   )
+  const [showAllStocks, setShowAllStocks] = useState(false)
+  const [displayedStocks, setDisplayedStocks] = useState<
+    IStockEventItemProps[]
+  >([])
 
   useEffect(() => {
     setDisplayedStocks(
-      showAllStocks ? [...stocks] : stocks.slice(0, NB_UNFOLDED_STOCK)
+      showAllStocks
+        ? formattedStocks
+        : formattedStocks.slice(0, NB_UNFOLDED_STOCK)
     )
-  }, [showAllStocks, stocks])
+  }, [showAllStocks, formattedStocks])
 
   const iconName = showAllStocks ? 'ico-arrow-up-b' : 'ico-arrow-down-b'
   const editLink = isCreation
@@ -62,7 +70,7 @@ const StockEventSection = ({
         <StockEventItem
           key={`stock-${k}`}
           className={styles['stock-event-item']}
-          beginningDateTime={s.beginningDateTime}
+          beginningDatetime={s.beginningDatetime}
           price={s.price}
           quantity={s.quantity}
           bookingLimitDatetime={s.bookingLimitDatetime}

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -143,6 +143,7 @@ const Summary = ({
               stocks={stockEventList}
               isCreation={isCreation}
               offerId={offerId}
+              departmentCode={offer.venueDepartmentCode}
             />
           )}
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16218

## But de la pull request

Affichage des stocks par date décroissante sur la page de récap + Affichage de l'heure de l'évènement en fonction du département du lieu ayant créé l'offre.

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
