### PR TITLE
(BSR)[API] Création du lien venue-pricing point lors de la création de lieu avec SIRET + déplacement de la vérif de ENABLE_NEW_BANK_INFORMATIONS_CREATION

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -221,8 +221,6 @@ def link_venue_to_pricing_point(
     Creates a VenuePricingPointLink if the venue had not been previously linked to a pricing point.
     If it had, then it will raise an error, unless the force_link parameter is True, in exceptional circumstances.
     """
-    if not feature.FeatureToggle.ENABLE_NEW_BANK_INFORMATIONS_CREATION.is_active():
-        raise feature.DisabledFeatureError("This function is behind a deactivated feature flag.")
     validation.check_venue_can_be_linked_to_pricing_point(venue, pricing_point_id)
     if not timestamp:
         timestamp = datetime.utcnow()
@@ -262,8 +260,6 @@ def link_venue_to_reimbursement_point(
     reimbursement_point_id: int | None,
     timestamp: datetime | None = None,
 ) -> None:
-    if not feature.FeatureToggle.ENABLE_NEW_BANK_INFORMATIONS_CREATION.is_active():
-        raise feature.DisabledFeatureError("This function is behind a deactivated feature flag.")
     if reimbursement_point_id:
         validation.check_venue_can_be_linked_to_reimbursement_point(venue, reimbursement_point_id)
     if not timestamp:

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -174,6 +174,8 @@ def create_venue(venue_data: venues_serialize.PostVenueBodyModel) -> models.Venu
 
     if venue_data.businessUnitId:
         set_business_unit_to_venue_id(venue_data.businessUnitId, venue.id)
+    if venue.siret:
+        link_venue_to_pricing_point(venue, pricing_point_id=venue.id)
 
     search.async_index_venue_ids([venue.id])
 

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -11,6 +11,7 @@ from pcapi.core.offerers import exceptions
 from pcapi.core.offerers import models
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offerers.models import Venue
+from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import as_dict
@@ -160,6 +161,8 @@ def edit_venue(venue_id: str, body: venues_serialize.EditVenueBodyModel) -> venu
 @login_required
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def link_venue_to_pricing_point(venue_id: str, body: venues_serialize.LinkVenueToPricingPointBodyModel) -> None:
+    if not feature.FeatureToggle.ENABLE_NEW_BANK_INFORMATIONS_CREATION.is_active():
+        raise feature.DisabledFeatureError("This function is behind a deactivated feature flag.")
     venue = load_or_404(Venue, venue_id)
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)  # type: ignore [attr-defined]
     try:

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -504,7 +504,6 @@ def auto_override_features(test_method):
         with override_features(
             USE_PRICING_POINT_FOR_PRICING=active,
             USE_REIMBURSEMENT_POINT_FOR_CASHFLOWS=active,
-            ENABLE_NEW_BANK_INFORMATIONS_CREATION=active,
         ):
             return test_method(self_, *args, **kwargs)
 
@@ -610,7 +609,7 @@ class LegacyCancelCollectivePricingTest(CancelCollectivePricingTest):
 
 
 class DeleteDependentPricingsTest:
-    @override_features(USE_PRICING_POINT_FOR_PRICING=True, ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
+    @override_features(USE_PRICING_POINT_FOR_PRICING=True)
     def test_basics(self):
         used_date = datetime.datetime(2022, 1, 15)
         booking = bookings_factories.UsedBookingFactory(
@@ -644,7 +643,7 @@ class DeleteDependentPricingsTest:
         expected_kept = {earlier_pricing_previous_year, earlier_pricing, later_pricing_another_year}
         assert set(models.Pricing.query.all()) == expected_kept
 
-    @override_features(USE_PRICING_POINT_FOR_PRICING=True, ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
+    @override_features(USE_PRICING_POINT_FOR_PRICING=True)
     def test_scenario1(self):
         # 0. V2 is linked to a BU, V1 is not.
         # 1. B1 is marked as used. It cannot be priced yet.
@@ -668,7 +667,7 @@ class DeleteDependentPricingsTest:
         api._delete_dependent_pricings(b2, "dummy", use_pricing_point=True)
         assert not b1.pricings
 
-    @override_features(USE_PRICING_POINT_FOR_PRICING=True, ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
+    @override_features(USE_PRICING_POINT_FOR_PRICING=True)
     def test_scenario2(self):
         # 0. Venue has 2 bookings.
         # 1. B1 is a booking for event/stock S1.
@@ -703,7 +702,7 @@ class DeleteDependentPricingsTest:
         api._delete_dependent_pricings(b1, "dummy", use_pricing_point=True)
         assert not b2.pricings
 
-    @override_features(USE_PRICING_POINT_FOR_PRICING=True, ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
+    @override_features(USE_PRICING_POINT_FOR_PRICING=True)
     def test_scenario3(self):
         # 0. Venue has 2 bookings.
         # 1. B1 is a booking for a thing.
@@ -733,7 +732,7 @@ class DeleteDependentPricingsTest:
         api._delete_dependent_pricings(b1, "dummy", use_pricing_point=True)
         assert not b2.pricings
 
-    @override_features(USE_PRICING_POINT_FOR_PRICING=True, ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
+    @override_features(USE_PRICING_POINT_FOR_PRICING=True)
     def test_scenario4(self):
         # 0. Venue has 2 bookings.
         # 1. B1 is a booking for E1 (that happens on 15/02).
@@ -767,7 +766,7 @@ class DeleteDependentPricingsTest:
         api._delete_dependent_pricings(b1, "dummy", use_pricing_point=True)
         assert not b2.pricings
 
-    @override_features(USE_PRICING_POINT_FOR_PRICING=True, ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
+    @override_features(USE_PRICING_POINT_FOR_PRICING=True)
     def test_raise_if_a_pricing_is_not_deletable(self):
         booking = create_booking_with_undeletable_dependent(stock__offer__venue__pricing_point="self")
         pricing = models.Pricing.query.one()

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -66,6 +66,18 @@ class CreateVenueTest:
         assert venue.name == "La Venue"
         assert venue.bookingEmail == "venue@example.com"
         assert venue.dmsToken
+        assert venue.current_pricing_point_id == venue.id
+
+    def test_venue_with_no_siret_has_no_pricing_point(self):
+        offerer = offerers_factories.OffererFactory()
+        data = self.base_data(offerer) | {"siret": None, "comment": "no siret"}
+        data = venues_serialize.PostVenueBodyModel(**data)
+
+        offerers_api.create_venue(data)
+
+        venue = offerers_models.Venue.query.one()
+        assert venue.siret is None
+        assert venue.current_pricing_point_id is None
 
     def test_with_business_unit(self):
         offerer = offerers_factories.OffererFactory()

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -828,7 +828,6 @@ def test_delete_business_unit():
 
 
 class LinkVenueToPricingPointTest:
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_no_pre_existing_link(self):
         venue = offerers_factories.VenueFactory(siret=None, comment="no siret")
         pricing_point = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
@@ -841,7 +840,6 @@ class LinkVenueToPricingPointTest:
         assert new_link.pricingPoint == pricing_point
         assert new_link.timespan.upper is None
 
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_raises_if_pre_existing_link(self):
         venue = offerers_factories.VenueFactory(siret=None, comment="no siret")
         pricing_point_1 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
@@ -853,7 +851,6 @@ class LinkVenueToPricingPointTest:
             offerers_api.link_venue_to_pricing_point(venue, pricing_point_2.id)
         assert offerers_models.VenuePricingPointLink.query.one() == pre_existing_link
 
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_raises_if_venue_has_siret(self):
         venue = offerers_factories.VenueFactory(siret="1234", pricing_point="self")
         pre_existing_link = offerers_models.VenuePricingPointLink.query.one()
@@ -863,7 +860,6 @@ class LinkVenueToPricingPointTest:
             offerers_api.link_venue_to_pricing_point(venue, pricing_point_2.id)
         assert offerers_models.VenuePricingPointLink.query.one() == pre_existing_link
 
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_fails_if_venue_has_siret(self):
         reimbursement_point = offerers_factories.VenueFactory()
         offerer = reimbursement_point.managingOfferer
@@ -876,7 +872,6 @@ class LinkVenueToPricingPointTest:
 
 
 class LinkVenueToReimbursementPointTest:
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_no_pre_existing_link(self):
         venue = offerers_factories.VenueFactory()
         reimbursement_point = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
@@ -891,7 +886,6 @@ class LinkVenueToReimbursementPointTest:
         assert new_link.timespan.upper is None
 
     @freeze_time()
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_end_pre_existing_link(self):
         now = datetime.datetime.utcnow()
         venue = offerers_factories.VenueFactory(reimbursement_point="self")
@@ -902,7 +896,6 @@ class LinkVenueToReimbursementPointTest:
         assert former_link.reimbursementPoint == venue
         assert former_link.timespan.upper == now
 
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_pre_existing_links(self):
         now = datetime.datetime.utcnow()
         venue = offerers_factories.VenueFactory()
@@ -939,7 +932,6 @@ class LinkVenueToReimbursementPointTest:
         assert new_link.timespan.lower == current_link.timespan.upper
         assert new_link.timespan.upper is None
 
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_fails_if_reimbursement_point_has_no_siret(self):
         reimbursement_point = offerers_factories.VenueFactory(siret=None, comment="no siret")
         finance_factories.BankInformationFactory(venue=reimbursement_point)
@@ -951,7 +943,6 @@ class LinkVenueToReimbursementPointTest:
         msg = f"Le lieu {reimbursement_point.name} ne peut pas être utilisé pour les remboursements."
         assert error.value.errors == {"reimbursementPointId": [msg]}
 
-    @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_fails_if_reimbursement_point_has_no_bank_information(self):
         reimbursement_point = offerers_factories.VenueFactory()
         offerer = reimbursement_point.managingOfferer


### PR DESCRIPTION
Commits à relire séparément