### PR TITLE
PC-16031 get gender from educonnect

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -127,10 +127,10 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
             ine_hash=educonnect_identity[_get_field_oid("64")][0],
             last_name=educonnect_identity["sn"][0],
             logout_url=logout_url,
-            user_type=user_type,
             saml_request_id=saml_request_id,
             school_uai=educonnect_identity.get(_get_field_oid("72"), [None])[0],
             student_level=educonnect_identity.get(_get_field_oid("73"), [None])[0],
+            user_type=user_type,
         )
 
     except Exception:

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -121,6 +121,7 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
     try:
         return models.EduconnectUser(
             birth_date=datetime.strptime(educonnect_identity[_get_field_oid("67")][0], "%Y-%m-%d").date(),
+            civility=_get_civility(educonnect_identity),
             connection_datetime=_get_connexion_datetime(educonnect_identity),
             educonnect_id=educonnect_identity[_get_field_oid("57")][0],
             first_name=educonnect_identity["givenName"][0],
@@ -168,3 +169,12 @@ def _get_connexion_datetime(educonnect_identity: dict) -> datetime | None:
         if _get_field_oid("6") in educonnect_identity
         else None
     )
+
+
+def _get_civility(educonnect_identity: dict) -> users_models.GenderEnum | None:
+    oid = _get_field_oid("76")
+    if oid not in educonnect_identity:
+        logger.error("No civility in educonnect identity", extra={"educonnect_identity": educonnect_identity})
+        return None
+    educonnect_civility = educonnect_identity[_get_field_oid("76")][0]
+    return users_models.GenderEnum(educonnect_civility)

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/models.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/models.py
@@ -1,10 +1,13 @@
 from dataclasses import dataclass
 import datetime
 
+from pcapi.core.users import models as users_models
+
 
 @dataclass
 class EduconnectUser:
     birth_date: datetime.date
+    civility: users_models.GenderEnum | None
     connection_datetime: datetime.datetime | None
     educonnect_id: str
     first_name: str

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/models.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/models.py
@@ -11,7 +11,7 @@ class EduconnectUser:
     ine_hash: str
     last_name: str
     logout_url: str
-    user_type: str | None
     saml_request_id: str
     school_uai: str | None
     student_level: str | None
+    user_type: str | None

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -111,6 +111,7 @@ class EduconnectContentFactory(factory.Factory):
     ine_hash = factory.Sequence(lambda _: "".join(random.choices(string.ascii_lowercase + string.digits, k=32)))
     last_name = factory.Faker("last_name")
     registration_datetime = factory.LazyFunction(datetime.utcnow)
+    civility = users_models.GenderEnum.F
 
 
 class ProfileCompletionContentFactory(factory.Factory):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -99,6 +99,7 @@ class EduconnectContent(common_models.IdentityCheckContent):
     birth_date: datetime.date
     educonnect_id: str
     first_name: str
+    civility: users_models.GenderEnum | None
     ine_hash: str
     last_name: str
     registration_datetime: datetime.datetime
@@ -110,6 +111,9 @@ class EduconnectContent(common_models.IdentityCheckContent):
 
     def get_first_name(self) -> str:
         return self.first_name
+
+    def get_civility(self) -> str | None:
+        return self.civility.value if self.civility else None
 
     def get_last_name(self) -> str:
         return self.last_name

--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -22,6 +22,7 @@ def handle_educonnect_authentication(
 ) -> list[fraud_models.FraudReasonCode]:
     educonnect_content = fraud_models.EduconnectContent(
         birth_date=educonnect_user.birth_date,
+        civility=educonnect_user.civility if educonnect_user.civility else None,
         educonnect_id=educonnect_user.educonnect_id,
         first_name=educonnect_user.first_name,
         ine_hash=educonnect_user.ine_hash,

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -355,6 +355,7 @@ class EduconnectUserFactory(factory.Factory):
     educonnect_id = "e6759833fb379e0340322889f2a367a5a5150f1533f80dfe963d21e43e33f7164b76cc802766cdd33c6645e1abfd1875"
     last_name = factory.Faker("last_name")
     first_name = factory.Faker("first_name")
+    civility = models.GenderEnum.F
     logout_url = "https://educonnect.education.gouv.fr/Logout"
     user_type = None
     saml_request_id = factory.Faker("lexify", text="id-?????????????????")

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -107,6 +107,7 @@ def on_educonnect_authentication_response() -> Response:
             "educonnect_id": educonnect_user.educonnect_id,
             "ine_hash": educonnect_user.ine_hash,
             "first_name": educonnect_user.first_name,
+            "civility": educonnect_user.civility.value if educonnect_user.civility else None,
             "last_name": educonnect_user.last_name,
             "logout_url": educonnect_user.logout_url,
             "user_type": educonnect_user.user_type,

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -320,6 +320,7 @@ class EduconnectFraudTest:
             user,
             fraud_models.EduconnectContent(
                 birth_date=birth_date,
+                civility=users_models.GenderEnum.F,
                 educonnect_id="id-1",
                 first_name="Lucy",
                 ine_hash="5ba682c0fc6a05edf07cd8ed0219258f",
@@ -340,6 +341,7 @@ class EduconnectFraudTest:
         assert fraud_check.eligibilityType == users_models.EligibilityType.UNDERAGE
         assert fraud_check.status == fraud_models.FraudCheckStatus.OK
         assert fraud_check.source_data().__dict__ == {
+            "civility": users_models.GenderEnum.F,
             "educonnect_id": "id-1",
             "first_name": "Lucy",
             "ine_hash": "5ba682c0fc6a05edf07cd8ed0219258f",
@@ -355,6 +357,7 @@ class EduconnectFraudTest:
             user,
             fraud_models.EduconnectContent(
                 birth_date=birth_date,
+                civility=users_models.GenderEnum.M,
                 educonnect_id="id-1",
                 first_name="Lucille",
                 ine_hash="0000",
@@ -377,6 +380,7 @@ class EduconnectFraudTest:
         assert fraud_check.type == fraud_models.FraudCheckType.EDUCONNECT
         assert fraud_check.eligibilityType == users_models.EligibilityType.UNDERAGE
         assert fraud_check.source_data().__dict__ == {
+            "civility": users_models.GenderEnum.M,
             "educonnect_id": "id-1",
             "first_name": "Lucille",
             "ine_hash": "0000",

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -84,6 +84,7 @@ class EduconnectFlowTest:
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.64": [ine_hash],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.7": ["eleve1d"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.72": ["school_uai"],
+            "urn:oid:1.3.6.1.4.1.20326.10.999.1.76": ["Mme"],
         }
         mock_saml_response.in_response_to = request_id
 
@@ -99,6 +100,7 @@ class EduconnectFlowTest:
         assert user.lastName == "Wrong Lastname"
         assert user.dateOfBirth == datetime(2006, 8, 18, 0, 0)
         assert user.ineHash is None
+        assert user.civility is None
 
         assert not user.is_beneficiary
         assert subscription_api.get_next_subscription_step(user) == subscription_models.SubscriptionStep.HONOR_STATEMENT
@@ -113,6 +115,7 @@ class EduconnectFlowTest:
         assert user.lastName == "SENS"
         assert user.ineHash == ine_hash
         assert user.dateOfBirth == datetime(2006, 8, 18, 0, 0)
+        assert user.civility == "Mme"
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -107,6 +107,7 @@ class EduconnectTest:
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.72": ["school_uai"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.73": ["2212"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.64": [ine_hash],
+            "urn:oid:1.3.6.1.4.1.20326.10.999.1.76": ["Mme"],
         }
         mock_saml_response.in_response_to = self.request_id
 
@@ -121,6 +122,7 @@ class EduconnectTest:
         )
 
         assert caplog.records[0].extra == {
+            "civility": "Mme",
             "date_of_birth": "2006-08-18",
             "educonnect_connection_date": "2021-10-08T11:51:33.437000",
             "educonnect_id": "e6759833fb379e0340322889f2a367a5a5150f1533f80dfe963d21e43e33f7164b76cc802766cdd33c6645e1abfd1875",
@@ -144,6 +146,7 @@ class EduconnectTest:
 
         assert fraud_check.resultContent == {
             "birth_date": "2006-08-18",
+            "civility": "Mme",
             "educonnect_id": "e6759833fb379e0340322889f2a367a5a5150f1533f80dfe963d21e43e33f7164b76cc802766cdd33c6645e1abfd1875",
             "first_name": "Max",
             "ine_hash": ine_hash,
@@ -183,6 +186,7 @@ class EduconnectTest:
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.72": ["school_uai"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.73": ["2212"],
             "urn:oid:1.3.6.1.4.1.20326.10.999.1.64": ["ine_hash"],
+            "urn:oid:1.3.6.1.4.1.20326.10.999.1.76": ["Mme"],
         }
         mock_saml_response.in_response_to = self.request_id
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16031

## But de la pull request

Educonnect a un nouveau champ `civility` dans son vecteur identité. On l'enregistre donc aussi chez nous

## Implémentation

- RAS

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
