### PR TITLE
(PC-16171)[API] fix: Correctly cache files for weasyprint

### DIFF
--- a/api/src/pcapi/utils/pdf.py
+++ b/api/src/pcapi/utils/pdf.py
@@ -27,9 +27,9 @@ class CachingUrlFetcher:
         self.tmp_dir.mkdir()
 
     def __del__(self) -> None:
-        self.clean_cache()
+        self.delete_cache()
 
-    def clean_cache(self) -> None:
+    def delete_cache(self) -> None:
         try:
             shutil.rmtree(self.tmp_dir)
         except Exception:  # pylint: disable=broad-except
@@ -51,9 +51,11 @@ class CachingUrlFetcher:
             # File objects cannot be serialized, we serialize their
             # content instead.
             result["string"] = result.pop("file_obj").read()  # type: ignore[attr-defined]
-        content_path.write_bytes(result["string"])  # despite the name, it's bytes
+        with content_path.open("bx") as fp:
+            fp.write(result["string"])  # despite the name, it's bytes
         metadata = {key: value for key, value in result.items() if key != "string"}
-        metadata_path.write_text(json.dumps(metadata))
+        with metadata_path.open("tx", encoding="utf-8") as fp:
+            fp.write(json.dumps(metadata))
         return result
 
 

--- a/api/tests/utils/pdf_creation_test.py
+++ b/api/tests/utils/pdf_creation_test.py
@@ -35,9 +35,9 @@ class GeneratePdfFromHtmlTest:
             assert False, "Output PDF is not as expected"
         assert duration < ACCEPTABLE_GENERATION_DURATION
 
-    @pytest.mark.xfail(reason="Flaky test")
     def test_cache(self, example_html):
-        pdf.url_cache.clean_cache()
+        pdf.url_cache.delete_cache()
+        pdf.url_cache.tmp_dir.mkdir()
         start = time.perf_counter()
         out1 = pdf.generate_pdf_from_html(html_content=example_html)
         duration1 = time.perf_counter() - start


### PR DESCRIPTION
`write_bytes()` and `write_text()` expect that the files exist.
Obviously, it's not the case.

The 'x' opening mode means "open for exclusive creation, failing if
the file already exists". See https://docs.python.org/3/library/functions.html#open.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16171