### PR TITLE
(PC-15810)[API]fix : add conditon to show siret in pdf with feature flip

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1845,6 +1845,7 @@ def _prepare_invoice_context(invoice: models.Invoice) -> dict:
         period_start=period_start,
         period_end=period_end,
         reimbursements_by_venue=reimbursements_by_venue,
+        is_new_bank_information_enabled=FeatureToggle.ENABLE_NEW_BANK_INFORMATIONS_CREATION.is_active(),
     )
 
 

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -196,7 +196,9 @@
 {% if venue is not none %}
     <p><b>Adresse :</b> {{ venue.address }} - {{ venue.postalCode}} {{ venue.city }}</p>
 {% endif %}
+{% if not is_new_bank_information_enabled %}
     <p><b>SIRET :</b> {{ invoice.businessUnit.siret }}</p>
+{% endif %}
 </div>
 <h3 class="coloredTitle">
     Remboursement des réservations validées entre le {{ period_start.strftime("%d/%m/%y") }} et le {{ period_end.strftime("%d/%m/%y") }}, sauf cas exceptionnels

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -197,6 +197,7 @@
     <p><b>Adresse :</b> 1 boulevard Poissonnière - 75000 Paris</p>
 
     <p><b>SIRET :</b> 85331845900023</p>
+
 </div>
 <h3 class="coloredTitle">
     Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15810

## But de la pull request

ajoute de la condition du feature flip ENABLE_NEW_BANK_INFORMATIONS_CREATION pour ne pas afficher le siret dans le pdf justificatif de remboursement 