### PR TITLE
(PC-16274)[PRO] fix: do not compute time for product stocks

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
@@ -187,6 +187,7 @@ const EventStocks = ({
       )
     ) {
       setIsSendingStocksOfferCreation(true)
+
       const stocksToCreate = stocksInCreation.map(stockInCreation =>
         createEventStockPayload(stockInCreation, offer.venue.departementCode)
       )

--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/domain.js
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/domain.js
@@ -19,7 +19,7 @@ const buildBeginningDatetime = (
   beginningDateIsoString,
   beginningTimeIsoString
 ) => {
-  if (beginningDateIsoString === null || beginningTimeIsoString === null) {
+  if (!beginningDateIsoString === null || beginningTimeIsoString === null) {
     return ''
   }
   return set(beginningDateIsoString, {
@@ -172,10 +172,7 @@ export const validateUpdatedStock = (
 }
 
 const hasBeginningDateTimeBeenUpdated = (originalStock, updatedStock) => {
-  if (
-    updatedStock.beginningDate === null ||
-    updatedStock.beginningTime === null
-  ) {
+  if (!updatedStock.beginningDate || !updatedStock.beginningTime) {
     return true
   }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16274

## But de la pull request

sur cette page: https://pro.testing.passculture.team/offre/BEYQ/individuel/recapitulatif
le click sur le lient "modifier les stock" provoquait une erreur.

## Implémentation

Le stock etant un produit, la propriété "beginningDate" n'etait pas calculé.
A present le code ignore ce calcule lorsque la propriété n'est pas défini
