### PR TITLE
(PC-16260) edit venue DMS applications handling

### DIFF
--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -156,6 +156,10 @@ def check_venue_can_be_linked_to_reimbursement_point(venue: models.Venue, reimbu
         .options(sqla_orm.joinedload(models.Venue.bankInformation))
         .one_or_none()
     )
+    if not venue.current_pricing_point_id:
+        raise ApiErrors(
+            errors={"pricingPoint": ["Vous devez d'abord choisir un lieu pour le calcul du barème de remboursement."]}
+        )
     if not reimbursement_point:
         raise ApiErrors(errors={"reimbursementPointId": ["Ce lieu n'existe pas."]})
     if (

--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -162,8 +162,8 @@ def check_venue_can_be_linked_to_reimbursement_point(venue: models.Venue, reimbu
         not reimbursement_point.bankInformation
         or reimbursement_point.bankInformation.status != finance_models.BankInformationStatus.ACCEPTED
     ):
-        error = f"Le SIRET {reimbursement_point.siret} ne peut pas être utilisé pour les remboursements car il n'a pas de coordonnées bancaires validées."
+        error = f"Le lieu {reimbursement_point.name} ne peut pas être utilisé pour les remboursements car il n'a pas de coordonnées bancaires validées."
         raise ApiErrors(errors={"reimbursementPointId": [error]})
     if reimbursement_point.managingOffererId != venue.managingOffererId:
-        error = f"Le SIRET {reimbursement_point.siret} ne peut pas être utilisé pour les remboursements car il n'appartient pas à la même structure."
+        error = f"Le lieu {reimbursement_point.name} ne peut pas être utilisé pour les remboursements car il n'appartient pas à la même structure."
         raise ApiErrors(errors={"reimbursementPointId": [error]})

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -238,9 +238,7 @@ class GetOffererListQueryModel(BaseModel):
 class ReimbursementPointResponseModel(BaseModel):
     venueId: int
     venueName: str
-    siret: str
     iban: str
-    bic: str
 
 
 class ReimbursementPointListResponseModel(BaseModel):

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -939,7 +939,7 @@ class LinkVenueToReimbursementPointTest:
 
         with pytest.raises(api_errors.ApiErrors) as error:
             offerers_api.link_venue_to_reimbursement_point(venue, reimbursement_point.id)
-        msg = f"Le SIRET {reimbursement_point.siret} ne peut pas être utilisé pour les remboursements car il n'a pas de coordonnées bancaires validées."
+        msg = f"Le lieu {reimbursement_point.name} ne peut pas être utilisé pour les remboursements car il n'a pas de coordonnées bancaires validées."
         assert error.value.errors == {"reimbursementPointId": [msg]}
 
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -873,7 +873,7 @@ class LinkVenueToPricingPointTest:
 
 class LinkVenueToReimbursementPointTest:
     def test_no_pre_existing_link(self):
-        venue = offerers_factories.VenueFactory()
+        venue = offerers_factories.VenueFactory(pricing_point="self")
         reimbursement_point = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
         finance_factories.BankInformationFactory(venue=reimbursement_point)
         assert offerers_models.VenueReimbursementPointLink.query.count() == 0
@@ -888,7 +888,7 @@ class LinkVenueToReimbursementPointTest:
     @freeze_time()
     def test_end_pre_existing_link(self):
         now = datetime.datetime.utcnow()
-        venue = offerers_factories.VenueFactory(reimbursement_point="self")
+        venue = offerers_factories.VenueFactory(reimbursement_point="self", pricing_point="self")
         offerers_api.link_venue_to_reimbursement_point(venue, None)
 
         former_link = offerers_models.VenueReimbursementPointLink.query.one()
@@ -898,7 +898,7 @@ class LinkVenueToReimbursementPointTest:
 
     def test_pre_existing_links(self):
         now = datetime.datetime.utcnow()
-        venue = offerers_factories.VenueFactory()
+        venue = offerers_factories.VenueFactory(pricing_point="self")
         reimbursement_point_1 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
         finance_factories.BankInformationFactory(venue=reimbursement_point_1)
         offerers_factories.VenueReimbursementPointLinkFactory(
@@ -935,7 +935,7 @@ class LinkVenueToReimbursementPointTest:
     def test_fails_if_reimbursement_point_has_no_bank_information(self):
         reimbursement_point = offerers_factories.VenueFactory()
         offerer = reimbursement_point.managingOfferer
-        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
 
         with pytest.raises(api_errors.ApiErrors) as error:
             offerers_api.link_venue_to_reimbursement_point(venue, reimbursement_point.id)

--- a/api/tests/routes/pro/get_available_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_available_reimbursement_points_test.py
@@ -16,12 +16,16 @@ class Returns200Test:
         )
         offerer = user_offerer.offerer
         offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
-        venue_1 = offerers_factories.VenueFactory(managingOfferer=offerer, name="Chez Toto")
-        finance_factories.BankInformationFactory(venue=venue_1, status=BankInformationStatus.ACCEPTED)
-        venue_2 = offerers_factories.VenueFactory(
-            managingOfferer=offerer, name="Dans l'antre de la folie", publicName="Association des démons"
+        venue_with_siret = offerers_factories.VenueFactory(managingOfferer=offerer, name="Chez Toto")
+        finance_factories.BankInformationFactory(venue=venue_with_siret, status=BankInformationStatus.ACCEPTED)
+        venue_without_siret = offerers_factories.VenueFactory(
+            siret=None,
+            comment="Ceci est une collectivité locale",
+            managingOfferer=offerer,
+            name="Dans l'antre de la folie",
+            publicName="Association des démons",
         )
-        finance_factories.BankInformationFactory(venue=venue_2, status=BankInformationStatus.ACCEPTED)
+        finance_factories.BankInformationFactory(venue=venue_without_siret, status=BankInformationStatus.ACCEPTED)
         _venue_without_bank_info_nor_siret = offerers_factories.VenueFactory(
             siret=None, comment="Pas de SIRET", managingOfferer=offerer
         )
@@ -38,18 +42,14 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json == [
             {
-                "venueId": venue_2.id,
+                "venueId": venue_without_siret.id,
                 "venueName": "Association des démons",
-                "siret": venue_2.siret,
-                "iban": venue_2.iban,
-                "bic": venue_2.bic,
+                "iban": venue_without_siret.iban,
             },
             {
-                "venueId": venue_1.id,
+                "venueId": venue_with_siret.id,
                 "venueName": "Chez Toto",
-                "siret": venue_1.siret,
-                "iban": venue_1.iban,
-                "bic": venue_1.bic,
+                "iban": venue_with_siret.iban,
             },
         ]
 

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -249,9 +249,7 @@ class Returns200Test:
     @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_add_reimbursement_point(self, client) -> None:
         user_offerer = offerers_factories.UserOffererFactory()
-        venue = offerers_factories.VenueFactory(
-            managingOfferer=user_offerer.offerer,
-        )
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, pricing_point="self")
 
         new_reimbursement_point = offerers_factories.VenueFactory(
             managingOfferer=user_offerer.offerer,
@@ -272,9 +270,7 @@ class Returns200Test:
     @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_remove_reimbursement_point_id(self, client) -> None:
         user_offerer = offerers_factories.UserOffererFactory()
-        venue = offerers_factories.VenueFactory(
-            managingOfferer=user_offerer.offerer,
-        )
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, pricing_point="self")
         current_reimbursement_point = offerers_factories.VenueFactory()
         offerers_factories.VenueReimbursementPointLinkFactory(
             venue=venue, reimbursementPoint=current_reimbursement_point
@@ -329,9 +325,7 @@ class Returns400Test:
     @override_features(ENABLE_NEW_BANK_INFORMATIONS_CREATION=True)
     def test_raises_if_different_offerer(self, client) -> None:
         user_offerer = offerers_factories.UserOffererFactory()
-        venue = offerers_factories.VenueFactory(
-            managingOfferer=user_offerer.offerer,
-        )
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, pricing_point="self")
         another_offerer = offerers_factories.OffererFactory()
         new_reimbursement_point = offerers_factories.VenueFactory(managingOfferer=another_offerer)
         finance_factories.BankInformationFactory(venue=new_reimbursement_point)

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -346,5 +346,5 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json["reimbursementPointId"] == [
-            f"Le SIRET {new_reimbursement_point.siret} ne peut pas être utilisé pour les remboursements car il n'appartient pas à la même structure."
+            f"Le lieu {new_reimbursement_point.name} ne peut pas être utilisé pour les remboursements car il n'appartient pas à la même structure."
         ]

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -686,7 +686,7 @@ class SaveVenueBankInformationsTest:
             )
 
         def test_draft_application(self, mock_dms_graphql_client, app):
-            venue = offerers_factories.VenueFactory(businessUnit=None)
+            venue = offerers_factories.VenueFactory(businessUnit=None, pricing_point="self")
             application_id = "9"
             mock_dms_graphql_client.return_value.get_bic.return_value = (
                 dms_creators.venue_application_detail_response_procedure_v4(
@@ -703,7 +703,7 @@ class SaveVenueBankInformationsTest:
             assert bank_information.status == BankInformationStatus.DRAFT
 
         def test_on_going_application(self, mock_dms_graphql_client, app):
-            venue = offerers_factories.VenueFactory(businessUnit=None)
+            venue = offerers_factories.VenueFactory(businessUnit=None, pricing_point="self")
             application_id = "9"
             mock_dms_graphql_client.return_value.get_bic.return_value = (
                 dms_creators.venue_application_detail_response_procedure_v4(
@@ -720,7 +720,7 @@ class SaveVenueBankInformationsTest:
             assert bank_information.status == BankInformationStatus.DRAFT
 
         def test_accepted_application(self, mock_dms_graphql_client, app):
-            venue = offerers_factories.VenueFactory(businessUnit=None)
+            venue = offerers_factories.VenueFactory(businessUnit=None, pricing_point="self")
             application_id = "9"
             mock_dms_graphql_client.return_value.get_bic.return_value = (
                 dms_creators.venue_application_detail_response_procedure_v4(
@@ -737,7 +737,7 @@ class SaveVenueBankInformationsTest:
             assert bank_information.status == BankInformationStatus.ACCEPTED
 
         def test_refused_application(self, mock_dms_graphql_client, app):
-            venue = offerers_factories.VenueFactory(businessUnit=None)
+            venue = offerers_factories.VenueFactory(businessUnit=None, pricing_point="self")
             application_id = "9"
             mock_dms_graphql_client.return_value.get_bic.return_value = (
                 dms_creators.venue_application_detail_response_procedure_v4(
@@ -754,7 +754,7 @@ class SaveVenueBankInformationsTest:
             assert bank_information.status == BankInformationStatus.REJECTED
 
         def test_without_continuation_application(self, mock_dms_graphql_client, app):
-            venue = offerers_factories.VenueFactory(businessUnit=None)
+            venue = offerers_factories.VenueFactory(businessUnit=None, pricing_point="self")
             application_id = "9"
             mock_dms_graphql_client.return_value.get_bic.return_value = (
                 dms_creators.venue_application_detail_response_procedure_v4(

--- a/pro/src/apiClient/v1/models/ReimbursementPointResponseModel.ts
+++ b/pro/src/apiClient/v1/models/ReimbursementPointResponseModel.ts
@@ -3,9 +3,7 @@
 /* eslint-disable */
 
 export type ReimbursementPointResponseModel = {
-  bic: string;
   iban: string;
-  siret: string;
   venueId: number;
   venueName: string;
 };


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16260

## But de la pull request

- Créer immédiatement un `VenueReimbursementPointLink` lorsqu'un dossier de CB est validé
- Vérifier que le lieu a bien a `pricingPoint` avant de le lier à un `reimbursementPoint`

## Implémentation

- Edition de `SaveVenueBankInformations`
- Edition de `check_venue_can_be_linked_to_reimbursement_point()`

## Informations supplémentaires

- Edition de `ReimbursementPointResponseModel` (supprimer des attributs superflus pour le front)
- Corriger la formulation d'erreurs remontées par la validation `check_venue_can_be_linked_to_reimbursement_point()`
