### PR TITLE
(BSR)[PRO] fix: testcafe/01_signup.js

### DIFF
--- a/pro/testcafe/01_signup.js
+++ b/pro/testcafe/01_signup.js
@@ -73,9 +73,9 @@ test('lorsque je clique sur le lien de validation de création du compte reçu p
 })
 
 test('la balise script pour le tracking HubSpot est présente sur la page', async t => {
-  const trackingScript = Selector(
-    'script[src="//js.hs-scripts.com/5119289.js"]'
+  const trackingScript = Selector('script').withAttribute(
+    'src',
+    /.*\/\/js\.hs-scripts.com\/5119289\.js/
   )
-
   await t.expect(trackingScript.exists).ok()
 })


### PR DESCRIPTION
```sh
 ✖ la balise script pour le tracking HubSpot est présente sur la page
 (screenshots:
 /home/circleci/pass-culture/pro/testcafe_screenshots/2022-07-21_10-16-47/test-4/Chrome_103.0.5060.134_Linux_0.0/errors/1.png)

   1) AssertionError: expected false to be truthy

      Browser: Chrome 103.0.5060.134 / Linux 0.0
      Screenshot:

   /home/circleci/pass-culture/pro/testcafe_screenshots/2022-07-21_10-16-47/test-4/Chrome_103.0.5060.134_Linux_0.0/errors/1.png

         75 |test('la balise script pour le tracking HubSpot est présente
      sur la page', async t => {
         76 |  const trackingScript = Selector(
         77 |    'script[src="//js.hs-scripts.com/5119289.js"]'
         78 |  )
         79 |
       > 80 |  await t.expect(trackingScript.exists).ok()
         81 |})
         82 |

         at <anonymous>
      (/home/circleci/pass-culture/pro/testcafe/01_signup.js:80:41)
         at asyncGeneratorStep
      (/home/circleci/pass-culture/pro/testcafe/01_signup.js:5:145)
         at _next
      (/home/circleci/pass-culture/pro/testcafe/01_signup.js:5:483)
         at <anonymous>
      (/home/circleci/pass-culture/pro/testcafe/01_signup.js:5:648)
         at <anonymous>
      (/home/circleci/pass-culture/pro/testcafe/01_signup.js:5:389)
         at <anonymous>
      (/home/circleci/pass-culture/pro/testcafe/01_signup.js:75:5)
```

Le probleme vients d'un préfix d'url ajouté au build dans les testcafé.

Sur testing nous avons : 
```html
src="//js.hs-scripts.com/5119289.js"
```
Sur le navigateur testcafé nous avons: 
```html
src="http://192.168.0.19:34723/oAGqhCYGa*QUbirEN0U!s!utf-8/http://js.hs-scripts.com/5119289.js"
```