### PR TITLE
(PC-16308)[PRO] fix: wording no siret pop-in  when selecting reimburs…

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
@@ -121,8 +121,8 @@ const ReimbursementPoint = ({
               <InfoDialog
                 buttonText="J'ai compris"
                 iconName="ico-info-wrong"
-                title="Vous devez sélectionner un SIRET pour ajouter de nouvelles coordonnées bancaires"
-                subTitle="Sélectionner un SIRET parmi la liste puis valider votre sélection."
+                title="Vous devez sélectionner un lieu avec SIRET pour ajouter de nouvelles coordonnées bancaires"
+                subTitle="Sélectionner un lieu avec SIRET parmi la liste puis valider votre sélection."
                 closeDialog={() => setIsNoSiretDialogOpen(false)}
               ></InfoDialog>
             )}


### PR DESCRIPTION
…ement point

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Modifier le wording de la pop-in affiché quand l'utilisateur n'a pas selectionné de siret de valorisation et essaie d'ajouter un point de remboursement : 

Actuel : Sélectionner un SIRET parmi la liste puis valider votre sélection.

New → Sélectionner un lieu avec SIRET parmi la liste puis valider votre sélection.

## Screnshot 

![Capture d’écran 2022-07-21 à 15 15 46](https://user-images.githubusercontent.com/71768799/180222698-dee17d39-9126-436b-9363-5000fb7d0692.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
