### PR TITLE
(PC-16318)[API] chore: adapt payment model to new eac schema

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-801ba453e407 (pre) (head)
+a7accb2d29db (pre) (head)
 090834b497b7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220721T124051_a7accb2d29db_new_eac_schema_payment.py
+++ b/api/src/pcapi/alembic/versions/20220721T124051_a7accb2d29db_new_eac_schema_payment.py
@@ -1,0 +1,28 @@
+"""new_eac_schema_payment
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "a7accb2d29db"
+down_revision = "801ba453e407"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("payment", sa.Column("collectiveBookingId", sa.BigInteger(), nullable=True))
+    op.alter_column("payment", "bookingId", existing_type=sa.BIGINT(), nullable=True)
+    op.create_index(op.f("ix_payment_collectiveBookingId"), "payment", ["collectiveBookingId"], unique=False)
+    op.create_foreign_key(
+        "payment_collective_booking_fk", "payment", "collective_booking", ["collectiveBookingId"], ["id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("payment_collective_booking_fk", "payment", type_="foreignkey")
+    op.drop_index(op.f("ix_payment_collectiveBookingId"), table_name="payment")
+    op.alter_column("payment", "bookingId", existing_type=sa.BIGINT(), nullable=False)
+    op.drop_column("payment", "collectiveBookingId")

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -415,8 +415,12 @@ class InvoiceCashflow(Model):  # type: ignore [valid-type, misc]
 # by `Pricing`, `Cashflow` and other models listed above.
 class Payment(Model):  # type: ignore [valid-type, misc]
     id = sqla.Column(sqla.BigInteger, primary_key=True, autoincrement=True)
-    bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=False)
+    bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking = sqla_orm.relationship("Booking", foreign_keys=[bookingId], backref="payments")  # type: ignore [misc]
+    collectiveBookingId = sqla.Column(
+        sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
+    )
+    collectiveBooking = sqla_orm.relationship("CollectiveBooking", foreign_keys=[collectiveBookingId], backref="payments")  # type: ignore [misc]
     amount = sqla.Column(sqla.Numeric(10, 2), nullable=False)
     reimbursementRule = sqla.Column(sqla.String(200))
     reimbursementRate = sqla.Column(sqla.Numeric(10, 2))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16318

## Modifications du schéma de la base de données

- dans la tapble `payment` la colonne BookingId devien facultative, et la colonne collectiveBookingId apparait. Normalement cette table ne sert que d'archives mais l'ancien schema m'enpeche de faire le ménage dans les offres EAC.