### PR TITLE
(PC-16095)[API] fix: add user profiling item to history

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -27,6 +27,7 @@ from . import utils
 SUBSCRIPTION_ITEM_METHODS = [
     subscription_api.get_email_validation_subscription_item,
     subscription_api.get_phone_validation_subscription_item,
+    subscription_api.get_user_profiling_subscription_item,
     subscription_api.get_profile_completion_subscription_item,
     subscription_api.get_identity_check_subscription_item,
     subscription_api.get_honor_statement_subscription_item,

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -716,6 +716,7 @@ class GetUserHistoryTest:
                 "subscriptionItems": [
                     {"status": "ok", "type": "email-validation"},
                     {"status": "not-applicable", "type": "phone-validation"},
+                    {"status": "not-applicable", "type": "user-profiling"},
                     {"status": "todo", "type": "profile-completion"},
                     {"status": "todo", "type": "identity-check"},
                     {"status": "todo", "type": "honor-statement"},
@@ -726,6 +727,7 @@ class GetUserHistoryTest:
                 "subscriptionItems": [
                     {"status": "ok", "type": "email-validation"},
                     {"status": "void", "type": "phone-validation"},
+                    {"status": "not-enabled", "type": "user-profiling"},
                     {"status": "void", "type": "profile-completion"},
                     {"status": "void", "type": "identity-check"},
                     {"status": "void", "type": "honor-statement"},
@@ -748,6 +750,7 @@ class GetUserHistoryTest:
                 "subscriptionItems": [
                     {"status": "ok", "type": "email-validation"},
                     {"status": "not-applicable", "type": "phone-validation"},
+                    {"status": "not-applicable", "type": "user-profiling"},
                     {"status": "void", "type": "profile-completion"},
                     {"status": "void", "type": "identity-check"},
                     {"status": "void", "type": "honor-statement"},
@@ -758,6 +761,7 @@ class GetUserHistoryTest:
                 "subscriptionItems": [
                     {"status": "ok", "type": "email-validation"},
                     {"status": "todo", "type": "phone-validation"},
+                    {"status": "not-enabled", "type": "user-profiling"},
                     {"status": "todo", "type": "profile-completion"},
                     {"status": "todo", "type": "identity-check"},
                     {"status": "todo", "type": "honor-statement"},
@@ -797,6 +801,7 @@ class GetUserHistoryTest:
             "subscriptionItems": [
                 {"status": "ok", "type": "email-validation"},
                 {"status": "not-applicable", "type": "phone-validation"},
+                {"status": "not-applicable", "type": "user-profiling"},
                 {"status": "void", "type": "profile-completion"},
                 {"status": "void", "type": "identity-check"},
                 {"status": "void", "type": "honor-statement"},
@@ -806,6 +811,7 @@ class GetUserHistoryTest:
         assert data["AGE18"]["subscriptionItems"] == [
             {"status": "ok", "type": "email-validation"},
             {"status": "ok", "type": "phone-validation"},
+            {"status": "not-enabled", "type": "user-profiling"},
             {"status": "ok", "type": "profile-completion"},
             {"status": "todo", "type": "identity-check"},
             {"status": "ok", "type": "honor-statement"},
@@ -885,6 +891,7 @@ class GetUserHistoryTest:
             "subscriptionItems": [
                 {"status": "ok", "type": "email-validation"},
                 {"status": "void", "type": "phone-validation"},
+                {"status": "not-enabled", "type": "user-profiling"},
                 {"status": "void", "type": "profile-completion"},
                 {"status": "void", "type": "identity-check"},
                 {"status": "void", "type": "honor-statement"},
@@ -894,6 +901,7 @@ class GetUserHistoryTest:
         assert data["UNDERAGE"]["subscriptionItems"] == [
             {"status": "ok", "type": "email-validation"},
             {"status": "not-applicable", "type": "phone-validation"},
+            {"status": "not-applicable", "type": "user-profiling"},
             {"status": "ok", "type": "profile-completion"},
             {"status": "ok", "type": "identity-check"},
             {"status": "ok", "type": "honor-statement"},


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16095

## But de la pull request

ajout du status du user profiling dans l'historique d'inscription des utilisateurs

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données
RAS technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai relu attentivement les migrations, en particulier pour éviter les _locks_~~
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
