### PR TITLE
(PC-15654)[PRO] feat: use bool return by backend to set if venue has …

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
@@ -23,8 +23,10 @@ const ReimbursementPoint = ({
   const [venueReimbursementPoint, setVenueReimbursementPoint] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isNoSiretDialogOpen, setIsNoSiretDialogOpen] = useState(false)
-  const [hasPendingDmsApplication, setHasPendingDmsApplication] =
-    useState(false)
+  const [
+    hasPendingBankInformationApplication,
+    setHasPendingBankInformationApplication,
+  ] = useState(false)
   const [hasAlreadyAddReimbursementPoint, setHasAlreadyAddReimbursementPoint] =
     useState(false)
 
@@ -79,12 +81,8 @@ const ReimbursementPoint = ({
           id: reimbursementPoint.venueId,
         }))
       )
-      setHasPendingDmsApplication(
-        venue.id &&
-          !venue.iban &&
-          !venue.bic &&
-          venue.demarchesSimplifieesApplicationId &&
-          !venue.isVirtual
+      setHasPendingBankInformationApplication(
+        venue.hasPendingBankInformationApplication
       )
       setIsLoading(false)
     }
@@ -111,7 +109,7 @@ const ReimbursementPoint = ({
             Coordonnées bancaires
           </Title>
         </div>
-        {hasPendingDmsApplication ? (
+        {hasPendingBankInformationApplication ? (
           <ApplicationBanner
             applicationId={venue.demarchesSimplifieesApplicationId}
           />

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/__specs__/ReimbursementPoint.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/__specs__/ReimbursementPoint.spec.jsx
@@ -146,9 +146,7 @@ describe('src | Venue | ReimbursementPoint', () => {
     const venueWithPendingApplication = {
       id: 'AA',
       name: 'fake venue name',
-      bic: null,
-      iban: null,
-      demarchesSimplifieesApplicationId: '2',
+      hasPendingBankInformationApplication: true,
     }
 
     props.venue = venueWithPendingApplication


### PR DESCRIPTION
…pending bank information application

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15654

## But de la pull request

Mettre à jour la condition d'affichage de la bannière 'En cours de validation" sur les coordonnées bancaires' en utilisant le booléen renvoyé par le back : `hasPendingBankInformationApplication`


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
