### PR TITLE
(PC-16288)[API]: add cds account id column

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-5311cec32519 (pre) (head)
+aed2f6174add (pre) (head)
 090834b497b7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220726T101204_aed2f6174add_add_account_id_column_to_cds_cinema_details_table.py
+++ b/api/src/pcapi/alembic/versions/20220726T101204_aed2f6174add_add_account_id_column_to_cds_cinema_details_table.py
@@ -11,7 +11,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("cds_cinema_details", sa.Column("accountId", sa.Text()))
+    op.add_column("cds_cinema_details", sa.Column("accountId", sa.Text(), nullable=False))
 
 
 def downgrade() -> None:

--- a/api/src/pcapi/alembic/versions/20220726T101204_aed2f6174add_add_account_id_column_to_cds_cinema_details_table.py
+++ b/api/src/pcapi/alembic/versions/20220726T101204_aed2f6174add_add_account_id_column_to_cds_cinema_details_table.py
@@ -1,0 +1,18 @@
+"""add_account_id_column_to_cds_cinema_details_table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "aed2f6174add"
+down_revision = "5311cec32519"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("cds_cinema_details", sa.Column("accountId", sa.Text()))
+
+
+def downgrade() -> None:
+    op.drop_column("cds_cinema_details", "accountId")

--- a/api/src/pcapi/connectors/cine_digital_service.py
+++ b/api/src/pcapi/connectors/cine_digital_service.py
@@ -42,7 +42,7 @@ MOCKS: dict[ResourceCDS, dict | list[dict] | list] = {
 
 def get_resource(
     api_url: str,
-    cinema_id: str,
+    account_id: str,
     cinema_api_token: str | None,
     resource: ResourceCDS,
     path_params: dict[str, Any] | None = None,
@@ -52,7 +52,7 @@ def get_resource(
         return MOCKS[resource]
 
     try:
-        url = _build_url(api_url, cinema_id, cinema_api_token, resource, path_params)
+        url = _build_url(api_url, account_id, cinema_api_token, resource, path_params)
         response = requests.get(url)
         response.raise_for_status()
 
@@ -66,13 +66,13 @@ def get_resource(
 
 
 def put_resource(
-    api_url: str, cinema_id: str, cinema_api_token: str | None, resource: ResourceCDS, body: BaseModel
+    api_url: str, account_id: str, cinema_api_token: str | None, resource: ResourceCDS, body: BaseModel
 ) -> dict | list[dict] | list | None:
     if settings.IS_DEV:
         return MOCKS[resource]
 
     try:
-        url = _build_url(api_url, cinema_id, cinema_api_token, resource)
+        url = _build_url(api_url, account_id, cinema_api_token, resource)
         headers = {"Content-Type": "application/json"}
         response = requests.put(url, headers=headers, data=body.json(by_alias=True))
         response.raise_for_status()
@@ -90,10 +90,10 @@ def put_resource(
 
 
 def post_resource(
-    api_url: str, cinema_id: str, cinema_api_token: str | None, resource: ResourceCDS, body: BaseModel
+    api_url: str, account_id: str, cinema_api_token: str | None, resource: ResourceCDS, body: BaseModel
 ) -> dict:
     try:
-        url = _build_url(api_url, cinema_id, cinema_api_token, resource)
+        url = _build_url(api_url, account_id, cinema_api_token, resource)
         headers = {"Content-Type": "application/json"}
         response = requests.post(url, headers=headers, data=body.json(by_alias=True))
         response.raise_for_status()
@@ -120,7 +120,7 @@ def get_movie_poster_from_api(image_url: str) -> bytes:
 
 def _build_url(
     api_url: str,
-    cinema_id: str,
+    account_id: str,
     cinema_api_token: str | None,
     resource: ResourceCDS,
     path_params: dict[str, Any] | None = None,
@@ -129,7 +129,7 @@ def _build_url(
     if path_params:
         for key, value in path_params.items():
             resource_url = resource_url.replace(":" + key, str(value))
-    return f"https://{cinema_id}.{api_url}{resource_url}?api_token={cinema_api_token}"
+    return f"https://{account_id}.{api_url}{resource_url}?api_token={cinema_api_token}"
 
 
 def _filter_token(error_message: str, token: str | None) -> str:

--- a/api/src/pcapi/core/booking_providers/api.py
+++ b/api/src/pcapi/core/booking_providers/api.py
@@ -2,7 +2,7 @@ import sqlalchemy.orm as sqla_orm
 
 from pcapi.core.booking_providers.cds.client import CineDigitalServiceAPI
 import pcapi.core.booking_providers.models as booking_providers_models
-from pcapi.core.providers.repository import get_cds_cinema_api_token
+from pcapi.core.providers.repository import get_cds_cinema_details
 
 
 def get_show_stock(venue_id: int, show_id: int) -> int:
@@ -40,8 +40,10 @@ def _get_booking_provider_client_api(venue_id: int) -> booking_providers_models.
     cinema_id = venue_booking_provider.idAtProvider
     api_url = venue_booking_provider.bookingProvider.apiUrl
     if venue_booking_provider.bookingProvider.name == booking_providers_models.BookingProviderName.CINE_DIGITAL_SERVICE:
-        cinema_api_token = get_cds_cinema_api_token(cinema_id)
-        return CineDigitalServiceAPI(cinema_id, api_url, cinema_api_token)
+        cds_cinema_details = get_cds_cinema_details(cinema_id)
+        cinema_api_token = cds_cinema_details.cinemaApiToken
+        account_id = cds_cinema_details.accountId
+        return CineDigitalServiceAPI(cinema_id, account_id, api_url, cinema_api_token)
     raise Exception(f"No booking provider named : {venue_booking_provider.bookingProvider.name}")
 
 

--- a/api/src/pcapi/core/booking_providers/models.py
+++ b/api/src/pcapi/core/booking_providers/models.py
@@ -76,10 +76,11 @@ class Ticket:
 
 
 class BookingProviderClientAPI:
-    def __init__(self, cinema_id: str, api_url: str, token: str | None):
+    def __init__(self, cinema_id: str, account_id: str, api_url: str, token: str | None):
         self.token = token
         self.api_url = api_url
         self.cinema_id = cinema_id
+        self.account_id = account_id
 
     def get_show_remaining_places(self, show_id: int) -> int:
         raise NotImplementedError("Should be implemented in subclass (abstract method)")

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -79,6 +79,7 @@ class CDSCinemaDetailsFactory(BaseFactory):
 
     cinemaProviderPivot = factory.SubFactory(CinemaProviderPivotFactory)
     cinemaApiToken = factory.LazyFunction(secrets.token_urlsafe)
+    accountId = factory.Sequence("account{}".format)
 
 
 class AllocineProviderFactory(BaseFactory):

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -171,7 +171,7 @@ class CDSCinemaDetails(PcObject, Model):  # type: ignore [valid-type, misc]
 
     cinemaApiToken = Column(Text, nullable=False)
 
-    accountId = Column(Text)
+    accountId = Column(Text, nullable=False)
 
 
 class AllocineVenueProvider(VenueProvider):

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -171,6 +171,8 @@ class CDSCinemaDetails(PcObject, Model):  # type: ignore [valid-type, misc]
 
     cinemaApiToken = Column(Text, nullable=False)
 
+    accountId = Column(Text)
+
 
 class AllocineVenueProvider(VenueProvider):
     __tablename__ = "allocine_venue_provider"

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -90,15 +90,11 @@ def get_providers_to_exclude(venue: Venue) -> list[str]:
     return providers_to_exclude
 
 
-def get_cds_cinema_api_token(cinema_id: str) -> str | None:
+def get_cds_cinema_details(cinema_id: str) -> CDSCinemaDetails:
     cinema_details = (
-        CDSCinemaDetails.query.join(CinemaProviderPivot)
-        .filter(CinemaProviderPivot.idAtProvider == cinema_id)
-        .one_or_none()
+        CDSCinemaDetails.query.join(CinemaProviderPivot).filter(CinemaProviderPivot.idAtProvider == cinema_id).one()
     )
-    if cinema_details:
-        return cinema_details.cinemaApiToken
-    return None
+    return cinema_details
 
 
 # Each venue is known to allocine by its siret (AllocineTheater) or by its id (AllocinePivot).

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -14,7 +14,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import Stock
 from pcapi.core.providers.models import VenueProvider
-from pcapi.core.providers.repository import get_cds_cinema_api_token
+from pcapi.core.providers.repository import get_cds_cinema_details
 from pcapi.local_providers.local_provider import LocalProvider
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models import Model
@@ -31,6 +31,9 @@ class CDSStocks(LocalProvider):
         self.apiUrl = settings.CDS_API_URL
         self.venue = venue_provider.venue
         self.cinema_id = venue_provider.venueIdAtOfferProvider
+        cinema_details = get_cds_cinema_details(venue_provider.venueIdAtOfferProvider)
+        self.apiToken = cinema_details.cinemaApiToken
+        self.accountId = cinema_details.accountId
         self.isDuo = venue_provider.isDuoOffers if venue_provider.isDuoOffers else False
         self.movies: Iterator[Movie] = iter(self._get_cds_movies())
         self.shows = self._get_cds_shows()
@@ -172,8 +175,9 @@ class CDSStocks(LocalProvider):
             raise Exception("CDS API URL not configured in this env")
         client_cds = CineDigitalServiceAPI(
             cinema_id=self.venue_provider.venueIdAtOfferProvider,
+            account_id=self.accountId,
             api_url=self.apiUrl,
-            cinema_api_token=get_cds_cinema_api_token(self.venue_provider.venueIdAtOfferProvider),
+            cinema_api_token=self.apiToken,
         )
         return client_cds.get_internet_sale_gauge_active()
 
@@ -182,8 +186,9 @@ class CDSStocks(LocalProvider):
             raise Exception("CDS API URL not configured in this env")
         client_cds = CineDigitalServiceAPI(
             cinema_id=self.venue_provider.venueIdAtOfferProvider,
+            account_id=self.accountId,
             api_url=self.apiUrl,
-            cinema_api_token=get_cds_cinema_api_token(self.venue_provider.venueIdAtOfferProvider),
+            cinema_api_token=self.apiToken,
         )
         return client_cds.get_venue_movies()
 
@@ -192,8 +197,9 @@ class CDSStocks(LocalProvider):
             raise Exception("CDS API URL not configured in this env")
         client_cds = CineDigitalServiceAPI(
             cinema_id=self.venue_provider.venueIdAtOfferProvider,
+            account_id=self.accountId,
             api_url=self.apiUrl,
-            cinema_api_token=get_cds_cinema_api_token(self.venue_provider.venueIdAtOfferProvider),
+            cinema_api_token=self.apiToken,
         )
         return client_cds.get_movie_poster(image_url)
 
@@ -202,8 +208,9 @@ class CDSStocks(LocalProvider):
             raise Exception("CDS API URL not configured in this env")
         client_cds = CineDigitalServiceAPI(
             cinema_id=self.venue_provider.venueIdAtOfferProvider,
+            account_id=self.accountId,
             api_url=self.apiUrl,
-            cinema_api_token=get_cds_cinema_api_token(self.venue_provider.venueIdAtOfferProvider),
+            cinema_api_token=self.apiToken,
         )
 
         shows = client_cds.get_shows()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
@@ -171,7 +171,7 @@ def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType
     cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
         venue=venue_synchronized_with_cds, provider=cds_provider, idAtProvider="cdsdemorc1"
     )
-    providers_factories.CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
+    providers_factories.CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot, accountId="cdsdemorc1")
     providers_factories.VenueProviderFactory(venue=venue_synchronized_with_cds, provider=cds_provider)
 
     venue_by_name[venue_synchronized_with_cds.name] = venue_synchronized_with_cds

--- a/api/tests/core/booking_providers/cds/test_client.py
+++ b/api/tests/core/booking_providers/cds/test_client.py
@@ -60,9 +60,9 @@ class CineDigitalServiceGetShowTest:
     @patch("pcapi.core.booking_providers.cds.client.get_resource")
     def test_should_return_show_corresponding_to_show_id(self, mocked_get_resource):
         # Given
-        cinema_id = "cinemaid_test"
         token = "token_test"
         api_url = "apiUrl_test/"
+        account_id = "accountid_test"
         resource = ResourceCDS.SHOWS
 
         json_shows = [
@@ -113,12 +113,15 @@ class CineDigitalServiceGetShowTest:
 
         # when
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinemaid_test", cinema_api_token="token_test", api_url="apiUrl_test/"
+            cinema_id="cinemaid_test",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="apiUrl_test/",
         )
         show = cine_digital_service.get_show(2)
 
         # then
-        mocked_get_resource.assert_called_once_with(api_url, cinema_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
 
         assert show.id == 2
 
@@ -140,7 +143,7 @@ class CineDigitalServiceGetShowTest:
         ]
         mocked_get_resource.return_value = json_shows
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="account_test", cinema_api_token="token_test", api_url="test_url"
         )
         with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as cds_exception:
             cine_digital_service.get_show(4)
@@ -160,9 +163,9 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
         self, mocked_internet_sale_gauge_active, mocked_get_resource
     ):
         # Given
-        cinema_id = "cinemaid_test"
         token = "token_test"
         api_url = "apiUrl_test/"
+        account_id = "accountid_test"
         resource = ResourceCDS.SHOWS
 
         json_shows = [
@@ -213,12 +216,15 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
 
         # when
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinemaid_test", cinema_api_token="token_test", api_url="apiUrl_test/"
+            cinema_id="cinemaid_test",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="apiUrl_test/",
         )
         shows_remaining_places = cine_digital_service.get_shows_remaining_places([2, 3])
 
         # then
-        mocked_get_resource.assert_called_once_with(api_url, cinema_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
 
         assert shows_remaining_places == {2: 30, 3: 100}
 
@@ -231,7 +237,7 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
         self, mocked_internet_sale_gauge_active, mocked_get_resource
     ):
         # Given
-        cinema_id = "cinemaid_test"
+        account_id = "accountid_test"
         token = "token_test"
         api_url = "apiUrl_test/"
         resource = ResourceCDS.SHOWS
@@ -284,12 +290,15 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
 
         # when
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinemaid_test", cinema_api_token="token_test", api_url="apiUrl_test/"
+            cinema_id="cinemaid_test",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="apiUrl_test/",
         )
         shows_remaining_places = cine_digital_service.get_shows_remaining_places([2, 3])
 
         # then
-        mocked_get_resource.assert_called_once_with(api_url, cinema_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
 
         assert shows_remaining_places == {2: 88, 3: 88}
 
@@ -312,7 +321,7 @@ class CineDigitalServiceGetPaymentTypeTest:
 
         mocked_get_resource.return_value = json_payment_types
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinemaid_test", cinema_api_token="token_test", api_url="apiUrl_test"
+            cinema_id="cinemaid_test", account_id="accountid_test", cinema_api_token="token_test", api_url="apiUrl_test"
         )
 
         payment_type = cine_digital_service.get_voucher_payment_type()
@@ -336,7 +345,7 @@ class CineDigitalServiceGetPaymentTypeTest:
         ]
         mocked_get_resource.return_value = json_payment_types
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as cds_exception:
             cine_digital_service.get_voucher_payment_type()
@@ -358,7 +367,10 @@ class CineDigitalServiceGetPCVoucherTypesTest:
 
         mocked_get_resource.return_value = json_voucher_types
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinema_id_test", cinema_api_token="token_test", api_url="apiUrl_test"
+            cinema_id="cinema_id_test",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="apiUrl_test",
         )
         pc_voucher_types = cine_digital_service.get_pc_voucher_types()
 
@@ -390,7 +402,10 @@ class CineDigitalServiceGetTariffTest:
         ]
         mocked_get_resource.return_value = json_tariffs
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinema_id_test", cinema_api_token="token_test", api_url="apiUrl_test"
+            cinema_id="cinema_id_test",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="apiUrl_test",
         )
         tariff = cine_digital_service.get_tariff()
 
@@ -414,7 +429,7 @@ class CineDigitalServiceGetTariffTest:
         ]
         mocked_get_resource.return_value = json_tariffs
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as cds_exception:
             cine_digital_service.get_tariff()
@@ -449,7 +464,7 @@ class CineDigitalServiceGetScreenTest:
         ]
         mocked_get_resource.return_value = json_screens
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         show = cine_digital_service.get_screen(2)
 
@@ -479,7 +494,7 @@ class CineDigitalServiceGetScreenTest:
         ]
         mocked_get_resource.return_value = json_screens
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as cds_exception:
             cine_digital_service.get_screen(4)
@@ -513,7 +528,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
         mocked_get_resource.return_value = seatmap_json
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         best_seat = cine_digital_service.get_available_seat(1, screen)
         assert len(best_seat) == 1
@@ -540,7 +555,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
         mocked_get_resource.return_value = seatmap_json
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         best_seat = cine_digital_service.get_available_seat(1, screen)
         assert len(best_seat) == 1
@@ -567,7 +582,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
         mocked_get_resource.return_value = seatmap_json
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         best_seat = cine_digital_service.get_available_seat(1, screen)
         assert not best_seat
@@ -593,7 +608,7 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
 
         mocked_get_resource.return_value = seatmap_json
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(1, screen)
         assert len(duo_seats) == 2
@@ -619,7 +634,7 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
 
         mocked_get_resource.return_value = seatmap_json
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(1, screen)
         assert len(duo_seats) == 0
@@ -643,7 +658,7 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
 
         mocked_get_resource.return_value = seatmap_json
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(1, screen)
         assert len(duo_seats) == 2
@@ -658,7 +673,7 @@ class CineDigitalServiceCancelBookingTest:
         json_response = {}
         mocked_put_resource.return_value = json_response
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         # When
@@ -679,7 +694,7 @@ class CineDigitalServiceCancelBookingTest:
         }
         mocked_put_resource.return_value = json_response
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         # When
@@ -717,7 +732,7 @@ class CineDigitalServiceGetVoucherForShowTest:
         mocked_get_resource.return_value = json_voucher_types
 
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         voucher_type = cine_digital_service.get_voucher_type_for_show(show)
@@ -749,7 +764,7 @@ class CineDigitalServiceGetVoucherForShowTest:
         mocked_get_resource.return_value = json_voucher_types
 
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         voucher_type = cine_digital_service.get_voucher_type_for_show(show)
@@ -814,7 +829,7 @@ class CineDigitalServiceBookTicketTest:
         mocked_post_resource.return_value = json_create_transaction
 
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         tickets = cine_digital_service.book_ticket(show_id=14, quantity=1)
@@ -899,7 +914,7 @@ class CineDigitalServiceBookTicketTest:
         mocked_post_resource.return_value = json_create_transaction
 
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         tickets = cine_digital_service.book_ticket(show_id=14, quantity=2)
@@ -971,7 +986,7 @@ class CineDigitalServiceBookTicketTest:
         mocked_post_resource.return_value = json_create_transaction
 
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
         )
 
         tickets = cine_digital_service.book_ticket(show_id=14, quantity=1)
@@ -995,9 +1010,9 @@ class CineDigitalServiceGetMoviesTest:
     def test_should_return_movies_information(self, mocked_get_resource):
 
         # Given
-        cinema_id = "cinemaid_test"
         token = "token_test"
         api_url = "apiUrl_test/"
+        account_id = "accountid_test"
         resource = ResourceCDS.MEDIA
 
         json_movies = [
@@ -1021,10 +1036,13 @@ class CineDigitalServiceGetMoviesTest:
 
         # when
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinemaid_test", cinema_api_token="token_test", api_url="apiUrl_test/"
+            cinema_id="cinemaid_test",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="apiUrl_test/",
         )
         movies = cine_digital_service.get_venue_movies()
 
         # then
-        mocked_get_resource.assert_called_once_with(api_url, cinema_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
         assert len(movies) == 2

--- a/api/tests/core/booking_providers/test_api.py
+++ b/api/tests/core/booking_providers/test_api.py
@@ -52,7 +52,9 @@ class GetBookingProviderClientApiTest:
         cinema_provider_pivot = CinemaProviderPivotFactory(
             venue=venue_booking_provider.venue, idAtProvider=venue_booking_provider.idAtProvider
         )
-        CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot, cinemaApiToken="test_token")
+        CDSCinemaDetailsFactory(
+            cinemaProviderPivot=cinema_provider_pivot, cinemaApiToken="test_token", accountId="test_account"
+        )
 
         # When
         venue_id = venue_booking_provider.venueId
@@ -64,12 +66,13 @@ class GetBookingProviderClientApiTest:
         assert client_api.token == "test_token"
         assert client_api.api_url == "test_api_url"
 
-    def test_should_raise_an_exception_if_no_token_provided_when_required(self) -> None:
+    def test_should_raise_an_exception_if_no_cds_details_provided_when_required(self) -> None:
         # Given
         booking_provider = BookingProviderFactory(name=BookingProviderName.CINE_DIGITAL_SERVICE, apiUrl="test_api_url")
         venue_booking_provider = VenueBookingProviderFactory(
             idAtProvider="test_id", bookingProvider=booking_provider, token=None
         )
+        CinemaProviderPivotFactory(venue=venue_booking_provider.venue, idAtProvider=venue_booking_provider.idAtProvider)
         venue_id = venue_booking_provider.venueId
 
         # When
@@ -77,7 +80,7 @@ class GetBookingProviderClientApiTest:
             _get_booking_provider_client_api(venue_id)
 
         # Then
-        assert str(e.value) == f"Missing token for {venue_booking_provider.idAtProvider}"
+        assert str(e.value) == "No row was found when one was required"
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16288

## But de la pull request

Ajout d'une colonne accountId dans la table cds_cinema_details, pour stock l'identifiant du compte des cinémas cds.


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
