### PR TITLE
(PC-16203)[API] fix: set the educational institution type field to 80 as there are data with length 68

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-a7accb2d29db (pre) (head)
+5311cec32519 (pre) (head)
 090834b497b7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220725T135316_5311cec32519_fix_educational_institution_type_length.py
+++ b/api/src/pcapi/alembic/versions/20220725T135316_5311cec32519_fix_educational_institution_type_length.py
@@ -1,0 +1,32 @@
+"""fix_educational_institution_type_length
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "5311cec32519"
+down_revision = "a7accb2d29db"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "educational_institution",
+        "institutionType",
+        existing_type=sa.String(length=60),
+        type_=sa.String(length=80),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "educational_institution",
+        "institutionType",
+        existing_type=sa.String(length=80),
+        type_=sa.String(length=60),
+        existing_nullable=False,
+    )

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -526,7 +526,7 @@ class EducationalInstitution(PcObject, Model):  # type: ignore[valid-type, misc]
 
     institutionId = sa.Column(sa.String(30), nullable=False, unique=True, index=True)
 
-    institutionType = sa.Column(sa.String(60), nullable=True)
+    institutionType = sa.Column(sa.String(80), nullable=True)
 
     name = sa.Column(sa.Text(), nullable=False)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16203

## Modifications du schéma de la base de données

- passage du champ educational_institution."institutionType" d'un VARCHAR(60) a un VARCHAR(80)
