### PR TITLE
(PC-15323)[API] fix: add dms activity choices

### DIFF
--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 DMS_ACTIVITY_ENUM_MAPPING = {
+    "Collégien": users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
     "Lycéen": users_models.ActivityEnum.HIGH_SCHOOL_STUDENT.value,
     "Étudiant": users_models.ActivityEnum.STUDENT.value,
     "Etudiant": users_models.ActivityEnum.STUDENT.value,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15323

Erreur sentry : https://sentry.internal-passculture.app/organizations/sentry/issues/382141/events/aa17c015cdd54046afcd2590af6c722b/?project=5

Le type "Apprenti, Alternant, Volontaire en service civique rémunéré" vient d'être enlevé des choix du formulaire.

En revanche il faut bien ajouter collégien dans le code.

### Procédure ETRANGER
<img width="621" alt="image" src="https://user-images.githubusercontent.com/22373097/181181047-582dcdfd-5d93-4e04-b781-bd2f82c0bb00.png">

### Procédure FR
<img width="756" alt="image" src="https://user-images.githubusercontent.com/22373097/181181159-6abab114-09bd-4c5b-ad1f-5dd0fafbb10b.png">

Labels dans le code : 
```
DMS_ACTIVITY_ENUM_MAPPING = {
    "Collégien": users_models.ActivityEnum.MIDDLE_SCHOOL_STUDENT.value,
    "Lycéen": users_models.ActivityEnum.HIGH_SCHOOL_STUDENT.value,
    "Étudiant": users_models.ActivityEnum.STUDENT.value,
    "Etudiant": users_models.ActivityEnum.STUDENT.value, # celui là est sûrement inutile mais je le laisse, dans le doute
    "Employé": users_models.ActivityEnum.EMPLOYEE.value,
    "En recherche d'emploi ou chômeur": users_models.ActivityEnum.UNEMPLOYED.value,
    "Inactif (ni en emploi ni au chômage), En incapacité de travailler": users_models.ActivityEnum.INACTIVE.value,
    "Apprenti": users_models.ActivityEnum.APPRENTICE.value,
    "Alternant": users_models.ActivityEnum.APPRENTICE_STUDENT.value,
    "Volontaire en service civique rémunéré": users_models.ActivityEnum.VOLUNTEER.value,
}
```