### PR TITLE
Pc 16103 add fraud check textual status

### DIFF
--- a/backoffice/src/resources/PublicUsers/Components/FraudCheckCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/FraudCheckCard.tsx
@@ -14,13 +14,13 @@ import { snakeCaseToTitleCase } from '../../../tools/textTools'
 import { EligibilityFraudCheck } from '../types'
 
 import { BeneficiaryBadge } from './BeneficiaryBadge'
-import { StatusAvatar } from './StatusAvatar'
+import { FraudCheckStatusBadge } from './FraudCheckStatusBadge'
 
 type Props = {
   eligibilityFraudCheck: EligibilityFraudCheck
 }
 
-export const CheckHistoryCard = ({ eligibilityFraudCheck }: Props) => {
+export const FraudCheckCard = ({ eligibilityFraudCheck }: Props) => {
   const cardStyle = {
     width: '100%',
     marginTop: '20px',
@@ -34,9 +34,6 @@ export const CheckHistoryCard = ({ eligibilityFraudCheck }: Props) => {
     setChecked(event.target.checked)
   }
 
-  const beneficiaryBadge = (
-    <BeneficiaryBadge role={eligibilityFraudCheck.role} />
-  )
   const fraudCheckItem = eligibilityFraudCheck.items[0]
   return (
     <Card style={cardStyle}>
@@ -44,7 +41,9 @@ export const CheckHistoryCard = ({ eligibilityFraudCheck }: Props) => {
         <Typography variant={'h5'}>
           {fraudCheckItem.type &&
             snakeCaseToTitleCase(fraudCheckItem.type as string)}
-          <span style={{ marginLeft: '3rem' }}>{beneficiaryBadge}</span>
+          <span style={{ marginLeft: '3rem' }}>
+            <BeneficiaryBadge role={eligibilityFraudCheck.role} />
+          </span>
         </Typography>
         <Grid container spacing={1} sx={{ mt: 4 }}>
           <Stack spacing={2} direction={'row'} style={{ width: '100%' }}>
@@ -71,9 +70,11 @@ export const CheckHistoryCard = ({ eligibilityFraudCheck }: Props) => {
             <Grid item xs={6}>
               <p>Statut</p>
             </Grid>
-            <Grid item xs={6}>
+            <Grid>
               <p>
-                <StatusAvatar item={fraudCheckItem} />
+                <FraudCheckStatusBadge
+                  fraudCheckStatus={fraudCheckItem.status}
+                />
               </p>
             </Grid>
           </Stack>
@@ -114,7 +115,7 @@ export const CheckHistoryCard = ({ eligibilityFraudCheck }: Props) => {
                 <Grid item style={gridStyle}>
                   <Collapse in={checked}>
                     <pre>
-                      <code>
+                      <code data-testid="fraudCheckTechnicalDetails">
                         {fraudCheckItem.technicalDetails &&
                           JSON.stringify(
                             fraudCheckItem.technicalDetails,

--- a/backoffice/src/resources/PublicUsers/Components/FraudCheckStatusBadge.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/FraudCheckStatusBadge.tsx
@@ -1,0 +1,53 @@
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import { Chip } from '@mui/material'
+
+import { FraudCheckStatus } from '../types'
+
+type Props = {
+  active?: boolean
+  fraudCheckStatus: FraudCheckStatus
+}
+
+export const FraudCheckStatusBadge = ({
+  fraudCheckStatus: checkHistoryStatus,
+}: Props) => {
+  const chipLabel = checkHistoryStatus.toUpperCase()
+  const fontSize = '1rem'
+
+  switch (checkHistoryStatus) {
+    case FraudCheckStatus.OK:
+      return (
+        <Chip
+          color={'success'}
+          label={chipLabel}
+          icon={<CheckCircleOutlineIcon />}
+          style={{
+            fontSize: fontSize,
+          }}
+        />
+      )
+    case FraudCheckStatus.KO:
+      return (
+        <Chip
+          color={'error'}
+          label={chipLabel}
+          icon={<ErrorOutlineIcon />}
+          style={{
+            fontSize: fontSize,
+          }}
+        />
+      )
+    default:
+      return (
+        <Chip
+          color={'warning'}
+          label={chipLabel}
+          icon={<ErrorOutlineIcon />}
+          style={{
+            fontSize: fontSize,
+          }}
+        />
+      )
+  }
+}

--- a/backoffice/src/resources/PublicUsers/Components/ManualReviewModal.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/ManualReviewModal.tsx
@@ -28,7 +28,12 @@ export const ManualReviewModal = ({
   eligibilityFraudChecks: EligibilityFraudCheck[]
 }) => {
   const [openModal, setOpenModal] = useState(false)
-  const noFraudCheck = eligibilityFraudChecks.length <= 0
+
+  const fraudChecks = eligibilityFraudChecks.flatMap(
+    eligibilityFraudCheck => eligibilityFraudCheck.items
+  )
+  const noFraudCheck = fraudChecks.length <= 0
+
   const notify = useNotify()
 
   const styleModal = {

--- a/backoffice/src/resources/PublicUsers/UserDetail.tsx
+++ b/backoffice/src/resources/PublicUsers/UserDetail.tsx
@@ -33,7 +33,7 @@ import {
 import { dataProvider } from '../../providers/dataProvider'
 
 import { BeneficiaryBadge } from './Components/BeneficiaryBadge'
-import { CheckHistoryCard } from './Components/CheckHistoryCard'
+import { FraudCheckCard } from './Components/FraudCheckCard'
 import { ManualReviewModal } from './Components/ManualReviewModal'
 import { StatusBadge } from './Components/StatusBadge'
 import { UserDetailsCard } from './Components/UserDetailsCard'
@@ -44,12 +44,6 @@ import {
   EligibilitySubscriptionItem,
   UserBaseInfo,
 } from './types'
-import { dataProvider } from '../../providers/dataProvider'
-import {
-  getHttpApiErrorMessage,
-  PcApiHttpError,
-} from '../../providers/apiHelpers'
-import { captureException } from '@sentry/react'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -467,7 +461,7 @@ export const UserDetail = () => {
                           id={fraudCheck.thirdPartyId}
                           key={fraudCheck.thirdPartyId}
                         >
-                          <CheckHistoryCard
+                          <FraudCheckCard
                             eligibilityFraudCheck={{
                               role: idCheckHistory.role,
                               items: [fraudCheck],

--- a/backoffice/src/resources/PublicUsers/__specs__/BeneficiaryBadge.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/BeneficiaryBadge.spec.jsx
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import { BeneficiaryBadge } from '../Components/BeneficiaryBadge'
+import { PublicUserRolesEnum } from '../types'
+
+const renderBeneficiaryBadge = props => render(<BeneficiaryBadge {...props} />)
+
+describe('beneficiary Badge', () => {
+  it('should display badge related to role', () => {
+    // Given
+    const props = {
+      role: PublicUserRolesEnum.beneficiary,
+    }
+    const expectedLabel = 'Pass 18'
+
+    // When
+    renderBeneficiaryBadge(props)
+
+    // Then
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument()
+  })
+})

--- a/backoffice/src/resources/PublicUsers/__specs__/FraudCheckCard.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/FraudCheckCard.spec.jsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom'
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { FraudCheckCard } from '../Components/FraudCheckCard'
+import { PublicUserRolesEnum } from '../types'
+
+const renderFraudCheckCard = props => render(<FraudCheckCard {...props} />)
+const someFraudCheck = {
+  type: 'UBBLE',
+  thirdPartyId: 'some-third-party-id',
+  dateCreated: Date(),
+  status: 'ok',
+}
+
+const fraudCheckTechnicalDetailsId = 'fraudCheckTechnicalDetails'
+
+describe('fraud check card', () => {
+  it('should display fraud check information', () => {
+    // Given
+    const props = {
+      eligibilityFraudCheck: {
+        role: PublicUserRolesEnum.underageBeneficiary,
+        items: [someFraudCheck],
+      },
+    }
+    const expectedLabel = 'UBBLE'
+    const expectedBadgeText = 'Pass 15-17'
+    const statusIconTestId = 'CheckCircleOutlineIcon'
+
+    // When
+    renderFraudCheckCard(props)
+
+    // Then
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument()
+    expect(screen.getByText(expectedBadgeText)).toBeInTheDocument()
+    expect(screen.getByText(someFraudCheck.thirdPartyId)).toBeInTheDocument()
+    expect(screen.getByTestId(statusIconTestId)).toBeInTheDocument()
+    expect(screen.getByTestId(fraudCheckTechnicalDetailsId)).not.toBeVisible()
+  })
+
+  it('should reveal technical details when dedicated switch is on', () => {
+    // Given
+    const technicalDetails = 'some-technical-detail'
+    const props = {
+      eligibilityFraudCheck: {
+        role: PublicUserRolesEnum.underageBeneficiary,
+        items: [
+          {
+            ...someFraudCheck,
+            technicalDetails: technicalDetails,
+          },
+        ],
+      },
+    }
+
+    // When
+    renderFraudCheckCard(props)
+    fireEvent.click(screen.getByRole('checkbox'))
+
+    // Then
+    expect(screen.getByTestId(fraudCheckTechnicalDetailsId)).toBeVisible()
+    expect(screen.getByText(`"${technicalDetails}"`)).toBeInTheDocument()
+  })
+})

--- a/backoffice/src/resources/PublicUsers/__specs__/FraudCheckStatusBadge.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/FraudCheckStatusBadge.spec.jsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { FraudCheckStatusBadge } from '../Components/FraudCheckStatusBadge'
+import { FraudCheckStatus } from '../types'
+
+const renderFraudCheckStatusBadge = props =>
+  render(<FraudCheckStatusBadge {...props} />)
+
+describe('fraud check status badge', () => {
+  it('should display success chip when status is OK', () => {
+    // Given
+    const props = { active: true, fraudCheckStatus: FraudCheckStatus.OK }
+
+    // When
+    renderFraudCheckStatusBadge(props)
+
+    // Then
+    expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument()
+    expect(screen.getByText('OK')).toBeInTheDocument()
+  })
+
+  it('should display error chip when status is KO', () => {
+    // Given
+    const props = { active: false, fraudCheckStatus: FraudCheckStatus.KO }
+
+    // When
+    renderFraudCheckStatusBadge(props)
+
+    // Then
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument()
+    expect(screen.getByText('KO')).toBeInTheDocument()
+  })
+
+  it('should display warning chip when status is other than OK or KO', () => {
+    // Given
+    const props = { status: false, fraudCheckStatus: FraudCheckStatus.STARTED }
+
+    // When
+    renderFraudCheckStatusBadge(props)
+
+    // Then
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument()
+    expect(screen.getByText('STARTED')).toBeInTheDocument()
+  })
+})

--- a/backoffice/src/resources/PublicUsers/__specs__/ManualReviewModal.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/ManualReviewModal.spec.jsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 
 import { ManualReviewModal } from '../Components/ManualReviewModal'
+import { PublicUserRolesEnum } from '../types'
 
 const renderManualReviewModal = props =>
   render(<ManualReviewModal {...props} />)
@@ -15,11 +16,15 @@ const someUser = {
 }
 
 describe('manual review modal button', () => {
-  it('should be disabled when beneficiary has no idCheck', () => {
+  it('should be disabled when beneficiary has no fraud check', () => {
     // Given
+    const eligibilityFraudCheck = {
+      role: PublicUserRolesEnum.beneficiary,
+      items: [],
+    }
     const props = {
       user: someUser,
-      checkHistory: [],
+      eligibilityFraudChecks: [eligibilityFraudCheck],
     }
     const expectedLabel =
       'Revue manuelle non disponible (aucun fraud check avec nom, prénom, date de naissance)'
@@ -32,18 +37,21 @@ describe('manual review modal button', () => {
     expect(screen.getByRole('button')).toBeDisabled()
   })
 
-  it('should be active when user has idCheck', () => {
+  it('should be active when user has fraud check', () => {
     // Given
+    const fraudCheck = {
+      type: 'ubble',
+      thirdPartyId: 'some-id',
+      dateCreated: new Date(2022, 7, 11),
+      status: 'ok',
+    }
+    const eligibilityFraudCheck = {
+      role: PublicUserRolesEnum.beneficiary,
+      items: [fraudCheck],
+    }
     const props = {
       user: someUser,
-      checkHistory: [
-        {
-          type: 'ubble',
-          thirdPartyId: 'some-id',
-          dateCreated: new Date(2022, 7, 11),
-          status: 'ok',
-        },
-      ],
+      eligibilityFraudChecks: [eligibilityFraudCheck],
     }
     const expectedLabel = 'Revue manuelle'
 

--- a/backoffice/src/resources/PublicUsers/__specs__/StatusAvatar.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/StatusAvatar.spec.jsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { StatusAvatar } from '../Components/StatusAvatar'
+
+const renderStatusAvatar = props => render(<StatusAvatar {...props} />)
+
+describe('status avatar', () => {
+  it('should display success avatar when status is OK', () => {
+    // Given
+    const props = { item: { type: 'honor-statement', status: 'ok' } }
+
+    // When
+    renderStatusAvatar(props)
+
+    // Then
+    expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument()
+  })
+  it('should display error avatar when status is KO', () => {
+    // Given
+    const props = { item: { type: 'honor-statement', status: 'ko' } }
+
+    // When
+    renderStatusAvatar(props)
+
+    // Then
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument()
+  })
+
+  it('should display warning avatar when status is other than ok or ko', () => {
+    // Given
+    const suspiciousStatus = 'suspicious'
+    const props = {
+      item: { type: 'honor-statement', status: suspiciousStatus },
+    }
+
+    // When
+    renderStatusAvatar(props)
+
+    // Then
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(suspiciousStatus.toUpperCase())
+    ).toBeInTheDocument()
+  })
+
+  it('should display warning avatar when status is undefined', () => {
+    // Given
+    const props = { item: undefined }
+
+    // When
+    renderStatusAvatar(props)
+
+    // Then
+    expect(screen.getByTestId('ErrorOutlineIcon')).toBeInTheDocument()
+    expect(screen.getByLabelText('Statut inconnu')).toBeInTheDocument()
+  })
+})

--- a/backoffice/src/resources/PublicUsers/__specs__/StatusBadge.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/StatusBadge.spec.jsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+
+import { StatusBadge } from '../Components/StatusBadge'
+
+const renderStatusBadge = props => render(<StatusBadge {...props} />)
+
+describe('status badge', () => {
+  it('should display success when active is OK', () => {
+    // Given
+    const props = { active: true }
+
+    // When
+    renderStatusBadge(props)
+
+    // Then
+    expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument()
+    expect(screen.getByText('Actif')).toBeInTheDocument()
+  })
+
+  it('should display error badge by default', () => {
+    // Given
+    const props = {}
+
+    // When
+    renderStatusBadge(props)
+
+    // Then
+    expect(screen.getByTestId('HighlightOffIcon')).toBeInTheDocument()
+    expect(screen.getByText('Suspendu')).toBeInTheDocument()
+  })
+})

--- a/backoffice/src/resources/PublicUsers/types.tsx
+++ b/backoffice/src/resources/PublicUsers/types.tsx
@@ -86,11 +86,21 @@ export interface FraudCheckTechnicalDetails {
   registrationDateTime: Date
 }
 
+export enum FraudCheckStatus {
+  OK = 'ok',
+  KO = 'ko',
+  STARTED = 'started',
+  SUSPISCIOUS = 'suspiscious',
+  PENDING = 'pending',
+  CANCELED = 'canceled',
+  ERROR = 'error',
+}
+
 export interface FraudCheck {
   type: string
   thirdPartyId: string
   dateCreated: Date
-  status: 'ok' | 'void' | 'not-applicable' | 'ko' | 'not-enabled'
+  status: FraudCheckStatus
   reason?: string
   reasonCodes?: string
   technicalDetails?: FraudCheckTechnicalDetails


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16103

## But de la pull request

Ajout du libellé du statut du fraud check.

## Implémentation

- Remplacement du StatusAvatar par un nouveau composant IdCheckStatusBadge qui porte le picto et le label

## Informations supplémentaires

- ajout d'un commit spécifique pour refactor  le nom `CheckHistory` par `IdCheck` qui colle mieux au métier.
- ajout d'un commit pour le "Nice to have" du ticket : affichage du json en <pre>
- ajout de tests sur certains composants qui n'en avaient pas encore

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
