### PR TITLE
(BSR) ci: remove cache in update-api-client workflow

### DIFF
--- a/.github/workflows/update-api-client.yml
+++ b/.github/workflows/update-api-client.yml
@@ -21,22 +21,6 @@ jobs:
             src:
               - 'api/**'
 
-      - name: Cache
-        if: steps.changesApi.outputs.src == 'true'
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        with:
-<<<<<<< Updated upstream
-          key: docker-cache-${{ hashFiles('api/requirements.txt') }}
-          restore-keys: |
-            docker-cache-${{ hashFiles('api/requirements.txt') }}
-            docker-cache
-=======
-          key: docker-cache-{hash}
-          restore-keys: |
-            docker-cache-
-            docker-cache-
->>>>>>> Stashed changes
-
       - uses: actions/setup-node@v2
         if: steps.changesApi.outputs.src == 'true'
         with:


### PR DESCRIPTION
Le cache n'est pas restauré entre les run du workflow de 2 PRs différentes, donc on perd du temps à éxécuter le post-cache à chaque workflow. En attendant de trouver une solution qui marche, je préfère retirer ce cache