### PR TITLE
(PC-16096)[BO-FRONT] fix: Afficher la liste des étapes à faire par l'…

### DIFF
--- a/backoffice/src/resources/PublicUsers/Components/CheckHistoryCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/CheckHistoryCard.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@material-ui/core'
 import {
+  Collapse,
   FormControlLabel,
   Grid,
   Stack,
@@ -10,15 +11,16 @@ import moment from 'moment'
 import React, { useState } from 'react'
 
 import { snakeCaseToTitleCase } from '../../../tools/textTools'
-import { CheckHistory } from '../types'
+import { EligibilityFraudCheck, FraudCheck } from '../types'
 
 import { StatusAvatar } from './StatusAvatar'
+import { BeneficiaryBadge } from './BeneficiaryBadge'
 
 type Props = {
-  idCheckHistory: CheckHistory
+  fraudCheck: EligibilityFraudCheck
 }
 
-export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
+export const CheckHistoryCard = ({ fraudCheck }: Props) => {
   const cardStyle = {
     width: '100%',
     marginTop: '20px',
@@ -32,11 +34,15 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
     setChecked(event.target.checked)
   }
 
+  const beneficiaryBadge = <BeneficiaryBadge role={fraudCheck.role} />
+  const fraudCheckItem = fraudCheck.items[0]
   return (
     <Card style={cardStyle}>
       <Grid container spacing={1}>
         <Typography variant={'h5'}>
-          {snakeCaseToTitleCase(idCheckHistory.type as string)}
+          {fraudCheckItem.type &&
+            snakeCaseToTitleCase(fraudCheckItem.type as string)}
+          <span style={{ marginLeft: '3rem' }}>{beneficiaryBadge}</span>
         </Typography>
         <Grid container spacing={1} sx={{ mt: 4 }}>
           <Stack spacing={2} direction={'row'} style={{ width: '100%' }}>
@@ -45,7 +51,7 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
             </Grid>
             <Grid item xs={6}>
               <p>
-                {moment(idCheckHistory.dateCreated).format(
+                {moment(fraudCheckItem.dateCreated).format(
                   'D/MM/YYYY à HH:mm:s'
                 )}
               </p>
@@ -56,7 +62,7 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
               <p>ID Technique</p>
             </Grid>
             <Grid item xs={6}>
-              <p>{idCheckHistory.thirdPartyId}</p>
+              <p>{fraudCheckItem.thirdPartyId}</p>
             </Grid>
           </Stack>
           <Stack spacing={3} direction={'row'} style={{ width: '100%' }}>
@@ -65,7 +71,7 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
             </Grid>
             <Grid item xs={6}>
               <p>
-                <StatusAvatar subscriptionItem={idCheckHistory} />
+                <StatusAvatar item={fraudCheckItem} />
               </p>
             </Grid>
           </Stack>
@@ -74,7 +80,7 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
               <p>Explication</p>
             </Grid>
             <Grid item xs={6}>
-              <p>{idCheckHistory.reason && idCheckHistory.reason}</p>
+              <p>{fraudCheckItem.reason}</p>
             </Grid>
           </Stack>
           <Stack spacing={3} direction={'row'} style={{ width: '100%' }}>
@@ -82,7 +88,7 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
               <p>Code d'erreurs</p>
             </Grid>
             <Grid item xs={6}>
-              <p>{idCheckHistory.reasonCodes && idCheckHistory.reasonCodes}</p>
+              <p>{fraudCheckItem.reasonCodes && fraudCheckItem.reasonCodes}</p>
             </Grid>
           </Stack>
 
@@ -95,7 +101,7 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
                     checked={checked}
                     onChange={handleChange}
                     inputProps={{ 'aria-label': 'controlled' }}
-                    name={idCheckHistory.type}
+                    name={fraudCheckItem.type}
                   />
                 }
                 label="Afficher les détails techniques"
@@ -104,14 +110,18 @@ export const CheckHistoryCard = ({ idCheckHistory }: Props) => {
             <Grid item xs={6}>
               <Grid container spacing={0}>
                 <Grid item style={gridStyle}>
-                  <code style={{ visibility: !checked ? 'hidden' : 'visible' }}>
-                    {idCheckHistory.technicalDetails &&
-                      JSON.stringify(
-                        idCheckHistory.technicalDetails,
-                        undefined,
-                        4
-                      )}
-                  </code>
+                  <Collapse in={checked}>
+                    <pre>
+                      <code>
+                        {fraudCheckItem.technicalDetails &&
+                          JSON.stringify(
+                            fraudCheckItem.technicalDetails,
+                            undefined,
+                            4
+                          )}
+                      </code>
+                    </pre>
+                  </Collapse>
                 </Grid>
               </Grid>
             </Grid>

--- a/backoffice/src/resources/PublicUsers/Components/ManualReviewModal.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/ManualReviewModal.tsx
@@ -18,17 +18,17 @@ import {
 } from '../../../providers/apiHelpers'
 import { dataProvider } from '../../../providers/dataProvider'
 import { ExclamationPointIcon } from '../../Icons/ExclamationPointIcon'
-import { UserBaseInfo, UserManualReview, CheckHistory } from '../types'
+import { UserBaseInfo, UserManualReview, EligibilityFraudCheck } from '../types'
 
 export const ManualReviewModal = ({
   user,
-  checkHistory,
+  fraudChecks,
 }: {
   user: UserBaseInfo
-  checkHistory: CheckHistory[]
+  fraudChecks: EligibilityFraudCheck[]
 }) => {
   const [openModal, setOpenModal] = useState(false)
-  const noFraudCheck = checkHistory.length <= 0
+  const noFraudCheck = fraudChecks.length <= 0
   const notify = useNotify()
 
   const styleModal = {

--- a/backoffice/src/resources/PublicUsers/Components/StatusAvatar.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/StatusAvatar.tsx
@@ -4,21 +4,20 @@ import { Avatar, Tooltip } from '@mui/material'
 import { green, red, yellow } from '@mui/material/colors'
 import React from 'react'
 
-import {
-  CheckHistory,
-  SubscriptionItem,
-  SubscriptionItemStatus,
-} from '../types'
+import { FraudCheck, SubscriptionItem, SubscriptionItemStatus } from '../types'
 
 type Props = {
-  subscriptionItem: SubscriptionItem | CheckHistory | undefined
+  item: SubscriptionItem | FraudCheck | undefined
 }
 
-export const StatusAvatar = ({ subscriptionItem }: Props) => {
+export const StatusAvatar = ({ item }: Props) => {
   let color, icon
   icon = <ErrorOutlineIcon />
   color = red['700']
-  switch (subscriptionItem?.status) {
+
+  const itemLabel = item?.status?.toUpperCase()
+
+  switch (item?.status) {
     case SubscriptionItemStatus.OK:
       color = green['700']
       icon = <CheckCircleOutlineIcon />
@@ -28,7 +27,10 @@ export const StatusAvatar = ({ subscriptionItem }: Props) => {
     default:
       color = yellow['700']
       return (
-        <Tooltip title="Non renseigné" placement="right">
+        <Tooltip
+          title={itemLabel ? itemLabel : 'Statut inconnu'}
+          placement="right"
+        >
           <Avatar sx={{ bgcolor: color }}>{icon}</Avatar>
         </Tooltip>
       )

--- a/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
@@ -17,11 +17,11 @@ import {
   PcApiHttpError,
 } from '../../../providers/apiHelpers'
 import { dataProvider } from '../../../providers/dataProvider'
-import { CheckHistory, UserBaseInfo } from '../types'
+import { FraudCheck, UserBaseInfo } from '../types'
 
 type Props = {
   user: UserBaseInfo
-  firstIdCheckHistory: CheckHistory
+  firstIdCheckHistory: FraudCheck
 }
 export const UserDetailsCard = ({ user, firstIdCheckHistory }: Props) => {
   const notify = useNotify()

--- a/backoffice/src/resources/PublicUsers/Components/UserHistoryCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/UserHistoryCard.tsx
@@ -1,0 +1,127 @@
+import {
+  EligibilitySubscriptionItem,
+  SubscriptionItemStatus,
+  SubscriptionItemType,
+} from '../types'
+import { Card } from '@material-ui/core'
+import {
+  Grid,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material'
+import { StatusAvatar } from './StatusAvatar'
+import React from 'react'
+import { BeneficiaryBadge } from './BeneficiaryBadge'
+
+type Props = {
+  subscriptionItem: EligibilitySubscriptionItem
+}
+
+export const UserHistoryCard = ({ subscriptionItem }: Props) => {
+  const cardStyle = {
+    width: '100%',
+    marginTop: '20px',
+    padding: 30,
+  }
+  const gridStyle = { width: '100%', height: '100%', overflow: 'auto' }
+  const beneficiaryBadge = <BeneficiaryBadge role={subscriptionItem.role} />
+
+  return (
+    <Card style={cardStyle}>
+      <Typography variant={'h5'}>
+        Parcours d'inscription
+        <span style={{ marginLeft: '3rem' }}>{beneficiaryBadge}</span>
+      </Typography>
+      {subscriptionItem.items.length > 0 && (
+        <Grid container spacing={5} sx={{ mt: 4 }}>
+          <Grid item xs={6}>
+            <List sx={{ width: '100%' }}>
+              <ListItem>
+                <ListItemText> Validation email</ListItemText>
+                <ListItemAvatar>
+                  <StatusAvatar
+                    item={subscriptionItem.items.find(
+                      subscriptionItem =>
+                        subscriptionItem.type ===
+                        SubscriptionItemType.EMAIL_VALIDATION
+                    )}
+                  />
+                </ListItemAvatar>
+              </ListItem>
+              <ListItem>
+                <ListItemText>Validation Téléphone</ListItemText>
+                <ListItemAvatar>
+                  <StatusAvatar
+                    item={subscriptionItem.items.find(
+                      (item: {
+                        type: string
+                        status: SubscriptionItemStatus
+                      }) => item.type === SubscriptionItemType.PHONE_VALIDATION
+                    )}
+                  />
+                </ListItemAvatar>
+              </ListItem>
+              <ListItem>
+                <ListItemText>Profil Utilisateur</ListItemText>
+                <ListItemAvatar>
+                  {' '}
+                  <StatusAvatar
+                    item={subscriptionItem.items.find(
+                      item =>
+                        item.type === SubscriptionItemType.PROFILE_COMPLETION
+                    )}
+                  />
+                </ListItemAvatar>
+              </ListItem>
+            </List>
+          </Grid>
+
+          <Grid item xs={6}>
+            <List sx={{ width: '100%' }}>
+              <ListItem>
+                <ListItemText>Complétion Profil</ListItemText>
+                <ListItemAvatar>
+                  <StatusAvatar
+                    item={subscriptionItem.items.find(
+                      (item: {
+                        type: string
+                        status: SubscriptionItemStatus
+                      }) =>
+                        item.type === SubscriptionItemType.PROFILE_COMPLETION
+                    )}
+                  />
+                </ListItemAvatar>
+              </ListItem>
+              <ListItem>
+                <ListItemText>ID Check</ListItemText>
+                <ListItemAvatar>
+                  <StatusAvatar
+                    item={subscriptionItem.items.find(
+                      item => item.type === SubscriptionItemType.IDENTITY_CHECK
+                    )}
+                  />
+                </ListItemAvatar>
+              </ListItem>
+              <ListItem>
+                <ListItemText>Honor Statement</ListItemText>
+                <ListItemAvatar>
+                  <StatusAvatar
+                    item={subscriptionItem.items.find(
+                      (item: {
+                        type: string
+                        status: SubscriptionItemStatus
+                      }) => item.type === SubscriptionItemType.HONOR_STATEMENT
+                    )}
+                  />
+                </ListItemAvatar>
+              </ListItem>
+            </List>
+          </Grid>
+        </Grid>
+      )}
+    </Card>
+  )
+}

--- a/backoffice/src/resources/PublicUsers/__specs__/ManualReviewModal.spec.jsx
+++ b/backoffice/src/resources/PublicUsers/__specs__/ManualReviewModal.spec.jsx
@@ -4,13 +4,14 @@ import { render, screen } from '@testing-library/react'
 
 import { ManualReviewModal } from '../Components/ManualReviewModal'
 
-const renderManualReviewModal = props => render(<ManualReviewModal {...props} />)
+const renderManualReviewModal = props =>
+  render(<ManualReviewModal {...props} />)
 const someUser = {
   id: 123,
   lastname: 'Durond',
   firstname: 'Laurent',
   email: 'laurentdurond@example.com',
-  dateOfBirth: new Date(2005, 12, 25)
+  dateOfBirth: new Date(2005, 12, 25),
 }
 
 describe('manual review modal button', () => {
@@ -18,9 +19,10 @@ describe('manual review modal button', () => {
     // Given
     const props = {
       user: someUser,
-      checkHistory: []
+      checkHistory: [],
     }
-    const expectedLabel = 'Revue manuelle non disponible (aucun fraud check avec nom, prénom, date de naissance)'
+    const expectedLabel =
+      'Revue manuelle non disponible (aucun fraud check avec nom, prénom, date de naissance)'
 
     // When
     renderManualReviewModal(props)
@@ -39,9 +41,9 @@ describe('manual review modal button', () => {
           type: 'ubble',
           thirdPartyId: 'some-id',
           dateCreated: new Date(2022, 7, 11),
-          status: 'ok'
-        }
-      ]
+          status: 'ok',
+        },
+      ],
     }
     const expectedLabel = 'Revue manuelle'
 

--- a/backoffice/src/resources/PublicUsers/types.tsx
+++ b/backoffice/src/resources/PublicUsers/types.tsx
@@ -42,6 +42,7 @@ export enum SubscriptionItemStatus {
   KO = 'ko',
   OK = 'ok',
   NOT_APPLICABLE = 'not-applicable',
+  NOT_ENABLED = 'not-enabled',
   VOID = 'void',
 }
 export enum SubscriptionItemType {
@@ -52,12 +53,21 @@ export enum SubscriptionItemType {
   HONOR_STATEMENT = 'honor-statement',
 }
 
+export interface EligibilitySubscriptionItem {
+  role: PublicUserRolesEnum
+  items: SubscriptionItem[]
+}
+
 export interface SubscriptionItem {
   type: SubscriptionItemType
   status: SubscriptionItemStatus
 }
 
-export interface CheckHistoryTechnicalDetails {
+export interface EligibilityFraudCheck {
+  role: PublicUserRolesEnum
+  items: FraudCheck[]
+}
+export interface FraudCheckTechnicalDetails {
   score?: string
   gender?: string
   status?: string
@@ -75,24 +85,13 @@ export interface CheckHistoryTechnicalDetails {
   registrationDateTime: Date
 }
 
-export interface CheckHistory {
+export interface FraudCheck {
   type: string
   thirdPartyId: string
   dateCreated: Date
-  status: 'ok' | 'void' | 'not-applicable' | 'ko'
+  status: 'ok' | 'void' | 'not-applicable' | 'ko' | 'not-enabled'
   reason?: string
   reasonCodes?: string
-  technicalDetails?: CheckHistoryTechnicalDetails
+  technicalDetails?: FraudCheckTechnicalDetails
   sourceId?: string
-}
-
-export interface UserCredit {
-  dateCreated: Date
-  initialCredit: number
-  remainingCredit: number
-  remainingDigitalCredit: number
-}
-
-export interface CheckHistories {
-  histories: CheckHistory[]
 }


### PR DESCRIPTION
…user remontée par le back

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16096

## But de la pull request

En tant que équipe support 
J'aimerais voir la liste des étapes à faire par l’utilisateur avec les statuts associés
Afin de comprendre ou est l’utilisateur dans son parcours d’inscription

## Implémentation

Afficher la ou les listes remotée(s) par le back avec les statuts associés

Afficher tous les fraudChecks avec l’eligibilité associé (ex: si l’user a fait les deux parcours pass 15-17 et pass 18 il faudrait qu’on puisse distinguer les fraudChecks fait pour les différentes offres).

## Informations supplémentaires

- Reformulation des variables concernant les fraudchecks

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
