### PR TITLE
[APi] PC 16405 add offer sub category

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -96,6 +96,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "OFFER_PRICE": stock_price,
             "OFFER_TOKEN": booking_token,
             "OFFER_CATEGORY": offer.category,
+            "OFFER_SUBCATEGORY": offer.subcategoryId,
             "IS_DIGITAL_BOOKING_WITH_ACTIVATION_CODE_AND_NO_EXPIRATION_DATE": bool(
                 is_digital_booking_with_activation_code_and_no_expiration_date
             ),

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -95,7 +95,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "EVENT_HOUR": formatted_event_beginning_time,
             "OFFER_PRICE": stock_price,
             "OFFER_TOKEN": booking_token,
-            "OFFER_CATEGORY": offer.category,
+            "OFFER_CATEGORY": offer.category.id,
             "OFFER_SUBCATEGORY": offer.subcategoryId,
             "IS_DIGITAL_BOOKING_WITH_ACTIVATION_CODE_AND_NO_EXPIRATION_DATE": bool(
                 is_digital_booking_with_activation_code_and_no_expiration_date

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -18,7 +18,7 @@ class TransactionalEmail(Enum):
         id_prod=225, id_not_prod=37, tags=["jeunes_offre_annulee_pros"]
     )
     BOOKING_CONFIRMATION_BY_BENEFICIARY = Template(
-        id_prod=725, id_not_prod=92, tags=["jeunes_reservation_confirmee_v3"]
+        id_prod=725, id_not_prod=96, tags=["jeunes_reservation_confirmee_v3"]
     )
     BOOKING_EVENT_REMINDER_TO_BENEFICIARY = Template(id_prod=665, id_not_prod=82, tags=["jeunes_rappel_evenement_j-1"])
     BOOKING_POSTPONED_BY_PRO_TO_BENEFICIARY = Template(id_prod=224, id_not_prod=36, tags=["jeunes_offre_reportee_pro"])

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -53,6 +53,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "OFFER_PRICE": f"{booking.total_amount} €" if booking.stock.price > 0 else "Gratuit",
             "OFFER_TOKEN": booking.token,
             "OFFER_CATEGORY": booking.stock.offer.category,
+            "OFFER_SUBCATEGORY": booking.stock.offer.subcategoryId,
             "VENUE_NAME": booking.stock.offer.venue.name,
             "VENUE_ADDRESS": booking.stock.offer.venue.address,
             "VENUE_POSTAL_CODE": booking.stock.offer.venue.postalCode,

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -52,7 +52,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "EVENT_HOUR": "14h48",
             "OFFER_PRICE": f"{booking.total_amount} €" if booking.stock.price > 0 else "Gratuit",
             "OFFER_TOKEN": booking.token,
-            "OFFER_CATEGORY": booking.stock.offer.category,
+            "OFFER_CATEGORY": booking.stock.offer.category.id,
             "OFFER_SUBCATEGORY": booking.stock.offer.subcategoryId,
             "VENUE_NAME": booking.stock.offer.venue.name,
             "VENUE_ADDRESS": booking.stock.offer.venue.address,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16405

## But de la pull request

Remonter la sous-catégorie au _template_ d'email de confirmation de réservation.
Et mise à jour de l'identifiant de _template_ (non prod).

## Informations supplémentaires

Au passage : utilisation de l'id de la catégorie. Cela semble plus logique et plus sûr : on se sert uniquement de l'id dans le template, donc inutile de rajouter des informations inutiles (qui risquent de créer des erreurs de syntaxe ou des incompréhensions au moment de corriger le template via l'interface de SiB).
