### PR TITLE
(PC-16096)[BO-FRONT] fix: Afficher la liste des étapes à faire par l'…

### DIFF
--- a/backoffice/.eslintrc.json
+++ b/backoffice/.eslintrc.json
@@ -20,7 +20,6 @@
   },
   "plugins": ["@typescript-eslint", "import"],
   "rules": {
-    "react/react-in-jsx-scope": "off",
     "indent": "off",
     "import/order": [
       "warn",
@@ -45,6 +44,7 @@
         "allowTemplateLiterals": true
       }
     ],
+    "react/react-in-jsx-scope": "off",
     "semi": ["error", "never"]
   }
 }

--- a/backoffice/src/resources/PublicUsers/Components/CheckHistoryCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/CheckHistoryCard.tsx
@@ -11,16 +11,16 @@ import moment from 'moment'
 import React, { useState } from 'react'
 
 import { snakeCaseToTitleCase } from '../../../tools/textTools'
-import { EligibilityFraudCheck, FraudCheck } from '../types'
+import { EligibilityFraudCheck } from '../types'
 
-import { StatusAvatar } from './StatusAvatar'
 import { BeneficiaryBadge } from './BeneficiaryBadge'
+import { StatusAvatar } from './StatusAvatar'
 
 type Props = {
-  fraudCheck: EligibilityFraudCheck
+  eligibilityFraudCheck: EligibilityFraudCheck
 }
 
-export const CheckHistoryCard = ({ fraudCheck }: Props) => {
+export const CheckHistoryCard = ({ eligibilityFraudCheck }: Props) => {
   const cardStyle = {
     width: '100%',
     marginTop: '20px',
@@ -34,8 +34,10 @@ export const CheckHistoryCard = ({ fraudCheck }: Props) => {
     setChecked(event.target.checked)
   }
 
-  const beneficiaryBadge = <BeneficiaryBadge role={fraudCheck.role} />
-  const fraudCheckItem = fraudCheck.items[0]
+  const beneficiaryBadge = (
+    <BeneficiaryBadge role={eligibilityFraudCheck.role} />
+  )
+  const fraudCheckItem = eligibilityFraudCheck.items[0]
   return (
     <Card style={cardStyle}>
       <Grid container spacing={1}>

--- a/backoffice/src/resources/PublicUsers/Components/ManualReviewModal.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/ManualReviewModal.tsx
@@ -22,13 +22,13 @@ import { UserBaseInfo, UserManualReview, EligibilityFraudCheck } from '../types'
 
 export const ManualReviewModal = ({
   user,
-  fraudChecks,
+  eligibilityFraudChecks,
 }: {
   user: UserBaseInfo
-  fraudChecks: EligibilityFraudCheck[]
+  eligibilityFraudChecks: EligibilityFraudCheck[]
 }) => {
   const [openModal, setOpenModal] = useState(false)
-  const noFraudCheck = fraudChecks.length <= 0
+  const noFraudCheck = eligibilityFraudChecks.length <= 0
   const notify = useNotify()
 
   const styleModal = {

--- a/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
@@ -1,5 +1,4 @@
-import { Card } from '@material-ui/core'
-import { Button, Grid, Stack, Tooltip, Typography } from '@mui/material'
+import { Card, Button, Grid, Stack, Tooltip, Typography } from '@mui/material'
 import { captureException } from '@sentry/react'
 import moment from 'moment'
 import React, { useState } from 'react'
@@ -21,9 +20,9 @@ import { FraudCheck, UserBaseInfo } from '../types'
 
 type Props = {
   user: UserBaseInfo
-  firstIdCheckHistory: FraudCheck
+  firstFraudCheck: FraudCheck
 }
-export const UserDetailsCard = ({ user, firstIdCheckHistory }: Props) => {
+export const UserDetailsCard = ({ user, firstFraudCheck }: Props) => {
   const notify = useNotify()
 
   const [editable, setEditable] = useState(false)
@@ -271,8 +270,8 @@ export const UserDetailsCard = ({ user, firstIdCheckHistory }: Props) => {
                 </Typography>
 
                 <Typography variant={'body1'}>
-                  {firstIdCheckHistory && firstIdCheckHistory.dateCreated
-                    ? moment(firstIdCheckHistory.dateCreated).format(
+                  {firstFraudCheck && firstFraudCheck.dateCreated
+                    ? moment(firstFraudCheck.dateCreated).format(
                         'D/MM/YYYY à HH:mm'
                       )
                     : 'N/A'}
@@ -292,10 +291,10 @@ export const UserDetailsCard = ({ user, firstIdCheckHistory }: Props) => {
                   label={'N° pièce d’identité'}
                   variant={'standard'}
                   defaultValue={
-                    firstIdCheckHistory &&
-                    firstIdCheckHistory.technicalDetails &&
-                    firstIdCheckHistory.technicalDetails.identificationId
-                      ? firstIdCheckHistory.technicalDetails.identificationId
+                    firstFraudCheck &&
+                    firstFraudCheck.technicalDetails &&
+                    firstFraudCheck.technicalDetails.identificationId
+                      ? firstFraudCheck.technicalDetails.identificationId
                       : ''
                   }
                   source={'idPieceNumber'}

--- a/backoffice/src/resources/PublicUsers/Components/UserHistoryCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/UserHistoryCard.tsx
@@ -1,8 +1,3 @@
-import {
-  EligibilitySubscriptionItem,
-  SubscriptionItemStatus,
-  SubscriptionItemType,
-} from '../types'
 import { Card } from '@material-ui/core'
 import {
   Grid,
@@ -12,9 +7,16 @@ import {
   ListItemText,
   Typography,
 } from '@mui/material'
-import { StatusAvatar } from './StatusAvatar'
 import React from 'react'
+
+import {
+  EligibilitySubscriptionItem,
+  SubscriptionItemStatus,
+  SubscriptionItemType,
+} from '../types'
+
 import { BeneficiaryBadge } from './BeneficiaryBadge'
+import { StatusAvatar } from './StatusAvatar'
 
 type Props = {
   subscriptionItem: EligibilitySubscriptionItem
@@ -36,7 +38,7 @@ export const UserHistoryCard = ({ subscriptionItem }: Props) => {
         <span style={{ marginLeft: '3rem' }}>{beneficiaryBadge}</span>
       </Typography>
       {subscriptionItem.items.length > 0 && (
-        <Grid container spacing={5} sx={{ mt: 4 }}>
+        <Grid container spacing={5} sx={{ mt: 4 }} style={gridStyle}>
           <Grid item xs={6}>
             <List sx={{ width: '100%' }}>
               <ListItem>

--- a/backoffice/src/resources/PublicUsers/UserDetail.tsx
+++ b/backoffice/src/resources/PublicUsers/UserDetail.tsx
@@ -1,7 +1,7 @@
-import { Card } from '@material-ui/core'
 import {
   Box,
   Button,
+  Card,
   CircularProgress,
   Grid,
   LinearProgress,
@@ -29,13 +29,13 @@ import { CheckHistoryCard } from './Components/CheckHistoryCard'
 import { ManualReviewModal } from './Components/ManualReviewModal'
 import { StatusBadge } from './Components/StatusBadge'
 import { UserDetailsCard } from './Components/UserDetailsCard'
+import { UserHistoryCard } from './Components/UserHistoryCard'
 import {
   EligibilityFraudCheck,
   PublicUserRolesEnum,
   EligibilitySubscriptionItem,
   UserBaseInfo,
 } from './types'
-import { UserHistoryCard } from './Components/UserHistoryCard'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -224,7 +224,7 @@ export const UserDetail = () => {
 
                 <ManualReviewModal
                   user={userBaseInfo}
-                  fraudChecks={idsCheckHistory}
+                  eligibilityFraudChecks={idsCheckHistory}
                 />
               </Stack>
             </div>
@@ -377,7 +377,7 @@ export const UserDetail = () => {
             <div id="details-user">
               <UserDetailsCard
                 user={userBaseInfo}
-                firstIdCheckHistory={idsCheckHistory[0].items[0]}
+                firstFraudCheck={idsCheckHistory[0].items[0]}
               />
             </div>
             <div id="parcours-register">
@@ -395,7 +395,7 @@ export const UserDetail = () => {
                     key={fraudCheck.thirdPartyId}
                   >
                     <CheckHistoryCard
-                      fraudCheck={{
+                      eligibilityFraudCheck={{
                         role: idCheckHistory.role,
                         items: [fraudCheck],
                       }}

--- a/backoffice/src/resources/PublicUsers/types.tsx
+++ b/backoffice/src/resources/PublicUsers/types.tsx
@@ -67,6 +67,7 @@ export interface EligibilityFraudCheck {
   role: PublicUserRolesEnum
   items: FraudCheck[]
 }
+
 export interface FraudCheckTechnicalDetails {
   score?: string
   gender?: string


### PR DESCRIPTION
…user remontée par le back

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16096

## But de la pull request

En tant que équipe support 
J'aimerais voir la liste des étapes à faire par l’utilisateur avec les statuts associés
Afin de comprendre ou est l’utilisateur dans son parcours d’inscription

## Implémentation

Afficher la ou les listes remotée(s) par le back avec les statuts associés

Afficher tous les fraudChecks avec l’eligibilité associé (ex: si l’user a fait les deux parcours pass 15-17 et pass 18 il faudrait qu’on puisse distinguer les fraudChecks fait pour les différentes offres).

## Informations supplémentaires

- Reformulation des variables concernant les fraudchecks

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
