### PR TITLE
[API] PC 15982 inactive users

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -263,11 +263,8 @@ def request_email_confirmation(user: models.User) -> None:
     send_email_confirmation_email(user, token=token)
 
 
-def request_password_reset(user: models.User) -> None:
+def request_password_reset(user: models.User | None) -> None:
     if not user:
-        return
-
-    if not user.isActive and not user.is_account_suspended_upon_user_request:
         return
 
     is_email_sent = reset_password.send_reset_password_email_to_user(user)
@@ -278,7 +275,7 @@ def request_password_reset(user: models.User) -> None:
 
 
 def handle_create_account_with_existing_email(user: models.User) -> None:
-    if not user or not user.isActive:
+    if not user:
         return
 
     is_email_sent = reset_password.send_email_already_exists_email(user)

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -85,7 +85,7 @@ def request_password_reset(body: RequestPasswordResetRequest) -> None:
             raise ApiErrors({"token": "The given token is not valid"})
     user = find_user_by_email(body.email)
     try:
-        users_api.request_password_reset(user)  # type: ignore [arg-type]
+        users_api.request_password_reset(user)
     except users_exceptions.EmailNotSent:
         raise ApiErrors(
             {"email": ["L'email n'a pas pu être envoyé"]},


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15982

## But de la pull request

Permettre à un utilisateur dont le compte est suspendu (pour fraude ou à sa propre demande) ou supprimé de :

1. recevoir l'email _On se connaît, non ?_ lors de la création de compte si l'email existe déjà ;
2. modifier son mot de passe.