### PR TITLE
(BSR)[API] feat: Update id for non-prod INVOICE_AVAILABLE_TO_PRO SendinBlue template

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -101,7 +101,7 @@ class TransactionalEmail(Enum):
     )
     FIRST_VENUE_APPROVED_OFFER_TO_PRO = TemplatePro(id_prod=569, id_not_prod=75, tags=["pro_premiere_offre"])
     FIRST_VENUE_BOOKING_TO_PRO = TemplatePro(id_prod=568, id_not_prod=78, tags=["pro_premiere_reservation"])
-    INVOICE_AVAILABLE_TO_PRO = TemplatePro(id_prod=405, id_not_prod=61, tags=["remboursement_justificatif"])
+    INVOICE_AVAILABLE_TO_PRO = TemplatePro(id_prod=405, id_not_prod=95, tags=["remboursement_justificatif"])
     NEW_BOOKING_TO_PRO = TemplatePro(id_prod=608, id_not_prod=59, tags=["pro_nouvelle_reservation"])
     NEW_OFFERER_VALIDATION = TemplatePro(id_prod=489, id_not_prod=58, tags=["pro_validation_structure"])
     OFFER_APPROVAL_TO_PRO = TemplatePro(


### PR DESCRIPTION
The previous non-prod template (61) had errors that the prod template
did not have (a space was missing and there were too many decimals for
the reimbursement amount). The production template has thus been
copied over a new template (id 95) for the non-prod environments.