### PR TITLE
PC-16429 create model for new intervention area in eac context

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-aed2f6174add (pre) (head)
+4b549301f9f7 (pre) (head)
 090834b497b7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220729T080301_4b549301f9f7_add_column_for_intervention_area.py
+++ b/api/src/pcapi/alembic/versions/20220729T080301_4b549301f9f7_add_column_for_intervention_area.py
@@ -1,0 +1,29 @@
+"""add_column_for_intervention_area
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "4b549301f9f7"
+down_revision = "aed2f6174add"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "collective_offer",
+        sa.Column("interventionArea", postgresql.ARRAY(sa.Text()), server_default="{}", nullable=False),
+    )
+    op.add_column(
+        "collective_offer_template",
+        sa.Column("interventionArea", postgresql.ARRAY(sa.Text()), server_default="{}", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("collective_offer_template", "interventionArea")
+    op.drop_column("collective_offer", "interventionArea")

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -43,6 +43,7 @@ class CollectiveOfferFactory(BaseFactory):
         "otherAddress": "1 rue des polissons, Paris 75017",
         "venueId": "",
     }
+    interventionArea = ["93", "94", "95"]
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):  # type: ignore [no-untyped-def]
@@ -92,6 +93,7 @@ class CollectiveOfferTemplateFactory(BaseFactory):
         "otherAddress": "1 rue des polissons, Paris 75017",
         "venueId": "",
     }
+    interventionArea = ["2A", "2B"]
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -134,6 +134,8 @@ class CollectiveOffer(PcObject, offer_mixin.ValidationMixin, AccessibilityMixin,
 
     offerVenue = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=False)  # type: ignore [misc]
 
+    interventionArea = sa.Column(MutableList.as_mutable(postgresql.ARRAY(sa.Text())), nullable=False, server_default="{}")  # type: ignore [misc]
+
     domains: RelationshipProperty[list["EducationalDomain"]] = relationship(
         "EducationalDomain", secondary="collective_offer_domain", back_populates="collectiveOffers"
     )
@@ -315,6 +317,8 @@ class CollectiveOfferTemplate(PcObject, offer_mixin.ValidationMixin, Accessibili
     contactPhone = sa.Column(sa.Text, nullable=False)
 
     offerVenue = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=False)  # type: ignore [misc]
+
+    interventionArea = sa.Column(MutableList.as_mutable(postgresql.ARRAY(sa.Text())), nullable=False, server_default="{}")  # type: ignore [misc]
 
     domains: RelationshipProperty[list["EducationalDomain"]] = relationship(
         "EducationalDomain", secondary="collective_offer_template_domain", back_populates="collectiveOfferTemplates"


### PR DESCRIPTION

## Modifications du schéma de la base de données

- Ajout d'une colonne `interventionArea` dans les tables `collective_offer` et `collective_offer_template` contenant une liste de département (par leur numero/code) décrivant la liste des départements ou les intervenant de cette offre peuvent se déplacer.