### PR TITLE
(BSR) ci: create workflow to prepare cache on schedule

### DIFF
--- a/.github/workflows/prepare-cache.yml
+++ b/.github/workflows/prepare-cache.yml
@@ -1,0 +1,55 @@
+on:
+  schedule:
+    - cron: "*/10 * * * *" # every 10min to test
+
+jobs:
+  prepare-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Install dockerize
+        run: |
+          sudo chown -R $USER .
+          ./scripts/install_dockerize.sh $DOCKERIZE_VERSION
+
+      - name: Cache
+        uses: satackey/action-docker-layer-caching@v0.0.11
+        with:
+          key: docker-cache-${{ hashFiles('api/requirements.txt') }}
+          restore-keys: |
+            docker-cache-${{ hashFiles('api/requirements.txt') }}
+            docker-cache
+
+      - name: Run API
+        run: |
+          sudo chown -R 1000:1000 .
+          ./pc start-backend &
+
+      - name: Update permission
+        run: cd pro && sudo chown -R $USER .
+
+      - uses: actions/cache@v2
+        with:
+          path: pro/node_modules
+          key: ${{ runner.os }}-node-14-yarn-${{ hashFiles('pro/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-14-yarn-${{ hashFiles('pro/yarn.lock') }}
+            ${{ runner.os }}-node-14-yarn-
+
+      - name: Install dependencies
+        run: |
+          cd pro
+          sudo chown -R $USER .
+          yarn install
+
+      - name: Wait for backend
+        run: dockerize -wait http://localhost:5001/health/api -timeout 10m -wait-retry-interval 5s


### PR DESCRIPTION
[La doc](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) de github-action stipule que pour des raisons de sécurité, le cache n'est pas partagé entre plusieurs PRs
On peut contourner le problème en cachant sur la branche main pour qu'il soit partagé avec les PRs

Ce workflow a pour but de tourner une fois par jour afin de set le cache pour les PRs de la journée. En cas d'invalidation du cache sur une PR à cause d'un changement de dépendances, alors le cache sera partiellement restauré 