### PR TITLE
(BSR)[API] Optimisation dans `price_bookings()`

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -986,7 +986,7 @@ class PriceBookingsTest:
         assert len(collective_booking.pricings) == 1
 
     @auto_override_features
-    @mock.patch("pcapi.core.finance.api.price_booking", lambda booking: None)
+    @mock.patch("pcapi.core.finance.api.price_booking", lambda booking, use_pricing_point: None)
     def test_num_queries(self):
         bookings_factories.UsedBookingFactory(
             dateUsed=self.few_minutes_ago,


### PR DESCRIPTION
When there was a lot of bookings to price (which sometimes happens
during the day or just after we enable back the cronjob after having
stopped it for a few hours), `price_bookings()` took a lot of time on
the call to `db.session.commit()`. This is because SQLAlchemy had to
somehow update the session with a large number of objects. Calling
`price_booking()` (that includes the commit) could take up 1 or 2
seconds.

This commit is a quick, minimally changing hack that price bookings by
batches of 100, clearing the session after each batch.