### PR TITLE
(BSR)[API] fix: Fix looping in `price_bookings()`

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -992,15 +992,11 @@ class PriceBookingsTest:
             dateUsed=self.few_minutes_ago,
             stock=self.individual_stock_factory(),
         )
-        print("individual = %s" % [b.id for b in bookings_models.Booking.query.all()])
         UsedCollectiveBookingFactory.create_batch(
             3,
             dateUsed=self.few_minutes_ago,
             collectiveStock=self.collective_stock_factory(),
         )
-        import pcapi.core.educational.models as educational_models
-
-        print("collective = %s" % [b.id for b in educational_models.CollectiveBooking.query.all()])
         api.price_bookings(min_date=self.few_minutes_ago, batch_size=1)
         assert models.Pricing.query.count() == 2 + 3
 

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -987,8 +987,13 @@ class PriceBookingsTest:
 
     @auto_override_features
     def test_loop(self):
-        bookings_factories.UsedBookingFactory.create_batch(
-            2,
+        bookings_factories.UsedBookingFactory(
+            id=2,
+            dateUsed=self.few_minutes_ago - datetime.timedelta(minutes=1),
+            stock=self.individual_stock_factory(),
+        )
+        bookings_factories.UsedBookingFactory(
+            id=1,
             dateUsed=self.few_minutes_ago,
             stock=self.individual_stock_factory(),
         )
@@ -997,7 +1002,10 @@ class PriceBookingsTest:
             dateUsed=self.few_minutes_ago,
             collectiveStock=self.collective_stock_factory(),
         )
-        api.price_bookings(min_date=self.few_minutes_ago, batch_size=1)
+        api.price_bookings(
+            min_date=self.few_minutes_ago - datetime.timedelta(minutes=1),
+            batch_size=1,
+        )
         assert models.Pricing.query.count() == 2 + 3
 
     @auto_override_features


### PR DESCRIPTION
We used to base loops on the booking id. That was wrong. For example,
suppose that all bookings were sorted like this for pricing:

   1, 4, 2, 3

With a batch size of 2, the first batch would be [1, 4]. The last id
being for, we would add a "id > 4" filter for the second batch. The
second batch would thus be empty.

Now we add a filter that uses the "composite key" with which bookings
are sorted: it's based on the "dateUsed", the date of the pricing
point link, the booking id, etc.