### PR TITLE
(BSR)[API] fix: Keep last booking in session for each loop of `price_bookings()`

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -249,7 +249,11 @@ def price_bookings(
                     },
                 )
         loops -= 1
-        db.session.expunge_all()
+        # Keep last booking in the session, we'll need it when calling
+        # `_get_loop_query()` for the next loop.
+        for booking in bookings:
+            if booking not in (last_booking, last_collective_booking):
+                db.session.expunge(booking)
 
 
 def _get_pricing_point_link(


### PR DESCRIPTION
This fixes an SQLAlchemy DetachedInstanceError in `_get_loop_query()`:

    Instance <Booking at 0x7f38da3ef730> is not bound to a Session;
    attribute refresh operation cannot proceed (Background on this
    error at: https://sqlalche.me/e/14/bhk3)