### PR TITLE
(BSR)[fix]ci: notify of deployment success when all deployments are OK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1285,6 +1285,8 @@ workflows:
           requires:
             - restart-pcapi
             - deploy-pro
+            - deploy-adage-front
+            - deploy-backoffice-front
       - restart-pcapi:
           requires:
             - deploy-pcapi
@@ -1325,6 +1327,8 @@ workflows:
           requires:
             - restart-pcapi
             - deploy-pro
+            - deploy-adage-front
+            - deploy-backoffice-front
       - restart-pcapi:
           requires:
             - deploy-pcapi


### PR DESCRIPTION
## But de la pull request

Envoyer une notification Slack de succès seulement après le succès du déploiement de chaque composant

## Implémentation

Modification de la config CircleCI afin que le step `release-synthesis` requiert les précédents.


exemple de faux-positif:
![notify of deployment success when all deployments are OK](https://user-images.githubusercontent.com/33030007/182160452-d4295fcf-37b8-478a-9552-122f8934250d.png)

