### PR TITLE
(PC-16578)[PRO] fix: Hide business unit banner on venue edition page if new FF is on

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueEdition.jsx
@@ -486,18 +486,20 @@ const VenueEdition = () => {
           nonHumanizedId={venue.nonHumanizedId}
         />
       )}
-      {venue.businessUnit && !venue.businessUnit.siret && (
-        <Banner
-          className="banner-invalid-bu"
-          href={`/structures/${offererId}/point-de-remboursement/`}
-          icon="ico-right-circle-arrow"
-          linkTitle="Rattacher votre lieu à un point de remboursement valide"
-        >
-          Ce lieu n’est pas rattaché à un point de remboursement valide. Pour
-          continuer à percevoir vos remboursements, veuillez renseigner un SIRET
-          de référence pour votre point de remboursement.
-        </Banner>
-      )}
+      {!isNewBankInformationCreation &&
+        venue.businessUnit &&
+        !venue.businessUnit.siret && (
+          <Banner
+            className="banner-invalid-bu"
+            href={`/structures/${offererId}/point-de-remboursement/`}
+            icon="ico-right-circle-arrow"
+            linkTitle="Rattacher votre lieu à un point de remboursement valide"
+          >
+            Ce lieu n’est pas rattaché à un point de remboursement valide. Pour
+            continuer à percevoir vos remboursements, veuillez renseigner un
+            SIRET de référence pour votre point de remboursement.
+          </Banner>
+        )}
       <PageTitle title={pageTitle} />
       <Titles
         action={actionLink || undefined}


### PR DESCRIPTION
If the new `ENABLE_NEW_BANK_INFORMATIONS_CREATION` feature flag is on,
we should not display the old business unit-related banner.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16578