### PR TITLE
(PC-16565)[API] fix: enable many offers deactivation even if product is already set as incompatible

### DIFF
--- a/api/src/pcapi/templates/admin/edit_many_offers_components/gcu_compatible_form.html
+++ b/api/src/pcapi/templates/admin/edit_many_offers_components/gcu_compatible_form.html
@@ -1,5 +1,5 @@
 <div style="margin-top: 40px;">
-    {% if product_compatibility["status"] != 'incompatible_products' %}
+    {% if product_compatibility["status"] != 'incompatible_products' or active_offers_number > 0 %}
     <form
         action="{{ url_for('many_offers_operations.product_gcu_compatibility') }}?isbn={{ isbn }}"
         method="POST"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16565

## But de la pull request

Ne pas griser le bouton « Rendre le produit et les offres incompatibles avec la GCU » si des offres sont actives (nouvelles ?) sur le produit déjà marqué incompatible.

## Implémentation

détails dans les commentaires du ticket.

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
