### PR TITLE
(PC-16633)[API] perf: Optimize `_generate_cashflows()` pricings query

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-4b549301f9f7 (pre) (head)
-4054f720ac9f (post) (head)
+46ab023fbf0f (pre) (head)
+934d0e50595f (post) (head)

--- a/api/src/pcapi/alembic/versions/20220803T153235_46ab023fbf0f_add_pricing_venue_id.py
+++ b/api/src/pcapi/alembic/versions/20220803T153235_46ab023fbf0f_add_pricing_venue_id.py
@@ -1,0 +1,19 @@
+"""Add pricing.venueId."""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "46ab023fbf0f"
+down_revision = "4b549301f9f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("pricing", sa.Column("venueId", sa.BigInteger(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("pricing", "venueId")

--- a/api/src/pcapi/alembic/versions/20220803T153725_934d0e50595f_add_fk_and_index_on_pricing_venue_id.py
+++ b/api/src/pcapi/alembic/versions/20220803T153725_934d0e50595f_add_fk_and_index_on_pricing_venue_id.py
@@ -1,0 +1,31 @@
+"""Add index and foreign key constraint on pricing.venueId
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "934d0e50595f"
+down_revision = "4054f720ac9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute('CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_pricing_venueId" ON pricing ("venueId")')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+    # The ALTER TABLE query would lock prod and staging for too long.
+    # We probably need to disable the "price_bookings" prod and add
+    # the index/foreign key during the off-hours.
+    if not (settings.IS_PROD or settings.IS_STAGING):
+        op.create_foreign_key("pricing_venueId_fkey", "pricing", "venue", ["venueId"], ["id"])
+
+
+def downgrade():
+    op.execute('ALTER TABLE pricing DROP CONSTRAINT IF EXISTS "pricing_venueId_fkey"')
+    op.execute('DROP INDEX IF EXISTS "ix_pricing_venueId"')

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1012,8 +1012,8 @@ def _generate_cashflows(batch: models.CashflowBatch) -> None:
                 models.BankInformation.id,
                 sqla.func.array_remove(
                     sqla.func.array_cat(
-                        sqla_func.array_agg(bookings_models.Booking.venueId),
-                        sqla_func.array_agg(educational_models.CollectiveBooking.venueId),
+                        sqla_func.array_agg(bookings_models.Booking.venueId.distinct()),
+                        sqla_func.array_agg(educational_models.CollectiveBooking.venueId.distinct()),
                     ),
                     None,
                 ),

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -671,6 +671,7 @@ def _price_booking(
         "lines": lines,
         "bookingId": booking.id if not is_booking_collective else None,
         "collectiveBookingId": booking.id if is_booking_collective else None,
+        "venueId": booking.venueId,  # denormalized for performance in `_generate_cashflows()`
     }
 
     return models.Pricing(**pricing_data)  # type: ignore [arg-type]
@@ -1069,10 +1070,7 @@ def _generate_cashflows(batch: models.CashflowBatch) -> None:
                         )
                         .outerjoin(models.CashflowPricing)
                         .filter(
-                            sqla_func.coalesce(
-                                bookings_models.Booking.venueId,
-                                educational_models.CollectiveBooking.venueId,
-                            ).in_(venue_ids),
+                            models.Pricing.venueId.in_(venue_ids),
                             *filters,
                         )
                     )

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -57,6 +57,7 @@ class PricingFactory(BaseFactory):
 
     status = models.PricingStatus.VALIDATED
     booking = factory.SubFactory(bookings_factories.UsedIndividualBookingFactory)
+    venue = factory.SelfAttribute("booking.venue")
     businessUnit = factory.SelfAttribute("booking.venue.businessUnit")
     siret = factory.LazyAttribute(
         lambda pricing: pricing.booking.venue.siret or pricing.booking.venue.businessUnit.siret
@@ -74,6 +75,7 @@ class CollectivePricingFactory(BaseFactory):
 
     status = models.PricingStatus.VALIDATED
     collectiveBooking = factory.SubFactory(UsedCollectiveBookingFactory)
+    venue = factory.SelfAttribute("collectiveBooking.venue")
     businessUnit = factory.SelfAttribute("collectiveBooking.venue.businessUnit")
     siret = factory.SelfAttribute("collectiveBooking.venue.siret")
     valueDate = factory.SelfAttribute("collectiveBooking.dateUsed")

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -136,13 +136,15 @@ class Pricing(Base, Model):  # type: ignore [valid-type, misc]
 
     bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
     booking = sqla_orm.relationship("Booking", foreign_keys=[bookingId], backref="pricings")  # type: ignore [misc]
-
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
     )
     collectiveBooking = sqla_orm.relationship(  # type: ignore [misc]
         "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
     )
+    # FIXME (dbaty 2022-08-03): make NOT NULLable once we have populated all rows.
+    venueId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("venue.id"), index=True, nullable=True)
+    venue = sqla_orm.relationship("Venue", foreign_keys=[venueId])  # type: ignore [misc]
 
     # FIXME (dbaty, 2022-06-20): remove `businessUnitId` and `siret`
     # columns once we have fully switched to `pricingPointId`

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -139,6 +139,7 @@ class PriceBookingTest:
         pricing = api.price_booking(booking, self.use_pricing_point)
         assert models.Pricing.query.count() == 1
         assert pricing.booking == booking
+        assert pricing.venue == booking.venue
         if self.use_pricing_point:
             assert pricing.pricingPointId == booking.venue.id
         else:
@@ -290,6 +291,7 @@ class PriceCollectiveBookingTest:
         pricing = api.price_booking(collective_booking, self.use_pricing_point)
         assert models.Pricing.query.count() == 1
         assert pricing.collectiveBooking == collective_booking
+        assert pricing.venue == collective_booking.venue
         if self.use_pricing_point:
             assert pricing.pricingPointId == collective_booking.venue.id
         else:


### PR DESCRIPTION
Commits à relire séparément, j'ai fait une mini-modification au
passage (qui n'affecte pas les performances).

---

The business unit-based SQL query in `_generate_cashflows()` was fast
because we filtered on `pricing.businessUnitId`, which has an index.

With reimbursement points, we did not use any index, so we JOINed a
lot of pricings with a lot of bookings. This took several seconds
for each reimbursement point to process.

This commit adds a `pricing.venueId` column with an index, on which
we can now quickly filter.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16633