### PR TITLE
(PC-16137)[PRO] feat: Home display yellow banner when missing reimbusement points

### DIFF
--- a/pro/src/components/pages/Home/Offerers/MissingReimbursementPoints/MissingReimbursementPoints.tsx
+++ b/pro/src/components/pages/Home/Offerers/MissingReimbursementPoints/MissingReimbursementPoints.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import Icon from 'components/layout/Icon'
+import { Banner } from 'ui-kit'
+
+const MissingReimbursementPoints = () => {
+  return (
+    <>
+      <h3 className="h-card-secondary-title">
+        Coordonnées bancaires
+        <Icon
+          alt="Coordonnées bancaires manquantes"
+          className="ico-bank-warning"
+          svg="ico-alert-filled"
+        />
+      </h3>
+
+      <div className="h-card-content">
+        <Banner
+          icon="ico-outer-pen"
+          linkTitle="Renseigner des coordonnées bancaires"
+        >
+          Certains de vos lieux ne sont pas rattachés à des coordonnées
+          bancaires. Pour percevoir les remboursements liés aux offres de ces
+          lieux, veuillez renseigner des coordonnées bancaires.
+        </Banner>
+      </div>
+    </>
+  )
+}
+
+export default MissingReimbursementPoints

--- a/pro/src/components/pages/Home/Venues/VenueLegacy.jsx
+++ b/pro/src/components/pages/Home/Venues/VenueLegacy.jsx
@@ -134,10 +134,8 @@ const Venue = ({
               </span>
             </h3>
             <div className="button-group">
-              {(isNewBankInformationActive ||
-                isBankInformationWithSiretActive) &&
-                !hasReimbursementPoint &&
-                !hasBusinessUnit &&
+              {((isNewBankInformationActive && !hasReimbursementPoint) ||
+                (isBankInformationWithSiretActive && !hasBusinessUnit)) &&
                 !isVirtual && (
                   <>
                     <Link

--- a/pro/src/components/pages/Home/Venues/__specs__/VenueLegacy.spec.jsx
+++ b/pro/src/components/pages/Home/Venues/__specs__/VenueLegacy.spec.jsx
@@ -206,5 +206,28 @@ describe('venues', () => {
         'http://localhost/structures/OFFERER01/lieux/VENUE01?modification'
       )
     })
+
+    it('should display add bank information when venue does not have a reimbursement point', async () => {
+      // Given
+      props.hasReimbursementPoint = false
+      const storeOverrides = configureTestStore({
+        features: {
+          list: [
+            {
+              isActive: true,
+              nameKey: 'ENABLE_NEW_BANK_INFORMATIONS_CREATION',
+            },
+          ],
+        },
+      })
+
+      // When
+      await renderVenue(props, storeOverrides)
+
+      // Then
+      expect(screen.getByRole('link', { name: 'Ajouter un RIB' }).href).toBe(
+        'http://localhost/structures/OFFERER01/lieux/VENUE01?modification'
+      )
+    })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16137

## But de la pull request

Affichage bannière jaune (ajouter votre coordonnées bancaires...) :
- Si au moins un lieu n'a pas de de point de remboursement 

CTA “Ajouter un RIB” (sur les lieux de la page d’accueil) 
-Affichage pour tous les lieux qui n’ont pas sélectionner ou ajouter de point de remboursement 
-Sauf les lieux numériques 

![image](https://user-images.githubusercontent.com/77629406/183035949-905dc2db-192e-4157-b273-38f2f3ce39b8.png)

![image](https://user-images.githubusercontent.com/77629406/182660980-42456d92-f230-40c1-8205-60b5d8681314.png)

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
