### PR TITLE
(PC-16656)[API] feat: add searchGroupId to offer serialization

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import relationship
 import pcapi.core.bookings.constants as bookings_constants
 from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories
+from pcapi.core.categories import subcategories_v2
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models import db
@@ -567,6 +568,12 @@ class Offer(PcObject, Base, Model, ExtraDataMixin, DeactivableMixin, ValidationM
         if self.subcategoryId not in subcategories.ALL_SUBCATEGORIES_DICT:
             raise ValueError(f"Unexpected subcategoryId '{self.subcategoryId}' for offer {self.id}")
         return subcategories.ALL_SUBCATEGORIES_DICT[self.subcategoryId]
+
+    @property
+    def subcategory_v2(self) -> subcategories_v2.Subcategory:
+        if self.subcategoryId not in subcategories_v2.ALL_SUBCATEGORIES_DICT:
+            raise ValueError(f"Unexpected subcategoryId (v2) '{self.subcategoryId}' for offer {self.id}")
+        return subcategories_v2.ALL_SUBCATEGORIES_DICT[self.subcategoryId]
 
     @property
     def category(self) -> categories.Category:

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -418,7 +418,11 @@ class AlgoliaBackend(base.SearchBackend):
                 "isThing": offer.isThing,
                 "name": offer.name,
                 "prices": prices_sorted,
+                # TODO(jeremieb): keep searchGroupNamev2 and remove
+                # remove searchGroupName once the search group name &
+                # home page label migration is over.
                 "searchGroupName": offer.subcategory.search_group_name,
+                "searchGroupNamev2": offer.subcategory_v2.search_group_name,
                 "stocksDateCreated": sorted(stocks_date_created),
                 "students": extra_data.get("students") or [],
                 "subcategoryId": offer.subcategory.id,

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -57,6 +57,7 @@ def test_serialize_offer():
             "name": "Titre formidable",
             "prices": [decimal.Decimal("10.00")],
             "searchGroupName": "LIVRE",
+            "searchGroupNamev2": "LIVRES",
             "stocksDateCreated": [stock.dateCreated.timestamp()],
             "students": [],
             "subcategoryId": offer.subcategory.id,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16656

## But de la pull request

Ajout d'un champ `searchGroupNamev2` à une offre lors de la sérialisation : il s'agit du _search group name_ tiré du module `subcategories_v2`. Pour rappel : le champ `searchGroupName` provient lui du module `subcategories`.

On a besoin de ce nouveau champ parce l'app native utilise le search group name pour construire ses requêtes lors de la recherche notamment. Pour qu'elle soit en mesure d'utiliser la v2 des `sous-categories` (voir [PR précédente](https://github.com/pass-culture/pass-culture-main/pull/3052)), il faut lui donner la possibilité d'utiliser les v2 des search group name.

Avec le champ `searchGroupNamev2`, les dernières versions du front pourront reposer entièrement sur la v2 des sous-catégories, et les versions moins récentes continueront d'utiliser la v1, sans rien casser.