### PR TITLE
[API] PC 16548 ff default to true

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -152,7 +152,6 @@ class Feature(PcObject, Base, Model, DeactivableMixin):  # type: ignore [valid-t
 
 
 FEATURES_DISABLED_BY_DEFAULT = (
-    FeatureToggle.ALLOW_ACCOUNT_UNSUSPENSION,
     FeatureToggle.ALLOW_IDCHECK_REGISTRATION_FOR_EDUCONNECT_ELIGIBLE,
     FeatureToggle.APP_ENABLE_CATEGORY_FILTER_PAGE,
     FeatureToggle.APP_ENABLE_SEARCH_HOMEPAGE_REWORK,

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1995,7 +1995,8 @@ class UnsuspendAccountTest:
         user = users_factories.BeneficiaryGrant18Factory(isActive=False)
         users_factories.SuspendedUponUserRequestFactory(user=user)
 
-        self.assert_code_and_not_active(client, user, "ACCOUNT_UNSUSPENSION_NOT_ENABLED")
+        with override_features(ALLOW_ACCOUNT_UNSUSPENSION=False):
+            self.assert_code_and_not_active(client, user, "ACCOUNT_UNSUSPENSION_NOT_ENABLED")
 
     def test_error_when_not_suspended(self, client):
         user = users_factories.BeneficiaryGrant18Factory(isActive=True)

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1976,20 +1976,19 @@ class UnsuspendAccountTest:
         user = users_factories.BeneficiaryGrant18Factory(isActive=False)
         users_factories.SuspendedUponUserRequestFactory(user=user)
 
-        with override_features(ALLOW_ACCOUNT_UNSUSPENSION=True):
-            client.with_token(email=user.email)
-            response = client.post("/native/v1/account/unsuspend")
+        client.with_token(email=user.email)
+        response = client.post("/native/v1/account/unsuspend")
 
-            assert response.status_code == 204
+        assert response.status_code == 204
 
-            db.session.refresh(user)
-            assert user.isActive
+        db.session.refresh(user)
+        assert user.isActive
 
-            assert len(mails_testing.outbox) == 1
+        assert len(mails_testing.outbox) == 1
 
-            mail = mails_testing.outbox[0]
-            assert mail.sent_data["template"] == dataclasses.asdict(TransactionalEmail.ACCOUNT_UNSUSPENDED.value)
-            assert mail.sent_data["To"] == user.email
+        mail = mails_testing.outbox[0]
+        assert mail.sent_data["template"] == dataclasses.asdict(TransactionalEmail.ACCOUNT_UNSUSPENDED.value)
+        assert mail.sent_data["To"] == user.email
 
     def test_error_when_ff_not_enabled(self, client):
         user = users_factories.BeneficiaryGrant18Factory(isActive=False)

--- a/api/tests/routes/native/v1/settings_test.py
+++ b/api/tests/routes/native/v1/settings_test.py
@@ -45,7 +45,7 @@ class SettingsTest:
             "isWebappV2Enabled": True,
             "objectStorageUrl": "http://localhost/storage",
             "proDisableEventsQrcode": False,
-            "allowAccountUnsuspension": False,
+            "allowAccountUnsuspension": True,
             "accountUnsuspensionLimit": 60,
         }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16548 

## But de la pull request

Passer le _FF_ `ALLOW_ACCOUNT_UNSUSPENSION` à `True` par défaut.

## Informations supplémentaires

**Au passage**

Refacto : dans certains tests, les appels à l'API sont sont explicitement dans la fonction de test, pas cachés dans une méthode-outil. C'est plus clair comme ça.