### PR TITLE
(PC-16479)[API] fix: Price booking that has been unused and used again

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -309,7 +309,7 @@ def _get_bookings_to_price(
 
     query = query.filter(
         model.dateUsed.between(*window),  # type: ignore [union-attr]
-        models.Pricing.id.is_(None),
+        models.Pricing.id.is_(None) | (models.Pricing.status == models.PricingStatus.CANCELLED),
     )
 
     query = query.join(model.venue)
@@ -505,7 +505,8 @@ def price_booking(
                 return None
 
         # Pricing the same booking twice is not allowed (and would be
-        # rejected by a database constraint, anyway).
+        # rejected by a database constraint, anyway), unless the
+        # existing pricing has been cancelled.
         pricing = get_non_cancelled_pricing_from_booking(booking)
         if pricing:
             return pricing


### PR DESCRIPTION
We used to ignore (and not price) bookings that already had a
cancelled pricing. This was wrong. If a booking is used (and hence
priced), it may be marked as unused (and its pricing is cancelled),
and then used again, in which case we should price it.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16479