### PR TITLE
(PC-14214)[PRO] feat: add infobox column into..

### DIFF
--- a/pro/src/new_components/FormLayout/FormLayout.module.scss
+++ b/pro/src/new_components/FormLayout/FormLayout.module.scss
@@ -1,4 +1,5 @@
 @use 'styles/mixins/_rem.scss' as rem;
+@use 'styles/variables/_colors.scss' as colors;
 
 .form-layout {
   &.small {
@@ -62,6 +63,22 @@
 
     &:first-child {
       margin-left: 0;
+    }
+  }
+
+  &-row-info {
+    display: flex;
+    &-field {
+      flex: 1 1 100%;
+    }
+    &-info {
+      flex: 1 0 rem.torem(316px);
+      margin-left: rem.torem(24px);
+      position: relative;
+      &-inner {
+        background: colors.$white;
+        position: absolute;
+      }
     }
   }
 }

--- a/pro/src/new_components/FormLayout/FormLayout.stories.tsx
+++ b/pro/src/new_components/FormLayout/FormLayout.stories.tsx
@@ -1,4 +1,8 @@
+import { Formik } from 'formik'
 import React from 'react'
+
+import { Button, TextInput } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
 
 import FormLayout from './FormLayout'
 
@@ -53,3 +57,105 @@ const Template = () => (
 )
 
 export const Default = Template.bind({})
+
+const DemoInformationBox = () => (
+  <div>
+    <h4>Information sur champs</h4>
+    <p>
+      Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor
+      sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet sit amet
+      Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet sit amet
+    </p>
+  </div>
+)
+
+const TemplateDesigned = () => (
+  <div style={{ width: 850 }}>
+    <Formik initialValues={{}} onSubmit={() => alert('Form submit !')}>
+      <FormLayout>
+        <FormLayout.Section
+          description="Lorem ipsum dolor sit amet"
+          title="Lorem ipsum dolor sit amet"
+        >
+          <FormLayout.Row sideComponent={<DemoInformationBox />}>
+            <TextInput label="Nom" name="lastname" />
+          </FormLayout.Row>
+        </FormLayout.Section>
+        <FormLayout.Section
+          description="Lorem ipsum dolor sit amet"
+          title="Lorem ipsum dolor sit amet"
+        >
+          <FormLayout.Row sideComponent={null}>
+            <TextInput label="Prénom" name="firstname" />
+          </FormLayout.Row>
+          <FormLayout.SubSection title="Sub section title">
+            <FormLayout.Row inline sideComponent={<DemoInformationBox />}>
+              <>
+                <TextInput label="Prénom" name="firstname" />
+                <TextInput label="Nom" name="lastname" />
+              </>
+            </FormLayout.Row>
+          </FormLayout.SubSection>
+        </FormLayout.Section>
+        <FormLayout.Actions>
+          <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
+          <Button>Envoyer</Button>
+        </FormLayout.Actions>
+      </FormLayout>
+    </Formik>
+  </div>
+)
+
+export const Designed = TemplateDesigned.bind({})
+
+const TemplateWithInfo = () => (
+  <div style={{ width: 780 }}>
+    <FormLayout>
+      <FormLayout.Section
+        description="Lorem ipsum dolor sit amet"
+        title="Lorem ipsum dolor sit amet"
+      >
+        <FormLayout.Row>
+          <label>
+            Hello
+            <input type="text" />
+          </label>
+          <div>Information box</div>
+        </FormLayout.Row>
+      </FormLayout.Section>
+      <FormLayout.Section
+        description="Lorem ipsum dolor sit amet"
+        title="Lorem ipsum dolor sit amet"
+      >
+        <FormLayout.Row>
+          <label>
+            Hello
+            <input type="text" />
+          </label>
+          <div>Information box</div>
+        </FormLayout.Row>
+        <FormLayout.SubSection title="Sub section title">
+          <FormLayout.Row inline>
+            <>
+              <label>
+                Hello
+                <input type="text" />
+              </label>
+              <label>
+                Hello
+                <input type="text" />
+              </label>
+            </>
+            <div>Information box</div>
+          </FormLayout.Row>
+        </FormLayout.SubSection>
+      </FormLayout.Section>
+      <FormLayout.Actions>
+        <button type="button">Annuler</button>
+        <button type="button">Envoyer</button>
+      </FormLayout.Actions>
+    </FormLayout>
+  </div>
+)
+
+export const WithInfo = TemplateWithInfo.bind({})

--- a/pro/src/new_components/FormLayout/FormLayout.tsx
+++ b/pro/src/new_components/FormLayout/FormLayout.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import style from './FormLayout.module.scss'
 import Actions from './FormLayoutActions'
 import Row from './FormLayoutRow'
+import RowWithInfo from './FormLayoutRowWithInfo'
 import Section from './FormLayoutSection'
 import SubSection from './FormLayoutSubSection'
 
@@ -25,6 +26,7 @@ const FormLayout = ({
   </div>
 )
 
+FormLayout.RowWithInfo = RowWithInfo
 FormLayout.Row = Row
 FormLayout.SubSection = SubSection
 FormLayout.Section = Section

--- a/pro/src/new_components/FormLayout/FormLayoutRow.tsx
+++ b/pro/src/new_components/FormLayout/FormLayoutRow.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames'
 import React from 'react'
 
 import style from './FormLayout.module.scss'
+import RowWithInfo from './FormLayoutRowWithInfo'
 
 interface IFormLayoutRowProps {
   children: React.ReactNode | React.ReactNode[]
@@ -9,6 +10,7 @@ interface IFormLayoutRowProps {
   inline?: boolean
   lgSpaceAfter?: boolean
   smSpaceAfter?: boolean
+  sideComponent?: JSX.Element | null
 }
 
 const Row = ({
@@ -17,16 +19,29 @@ const Row = ({
   inline,
   lgSpaceAfter,
   smSpaceAfter,
-}: IFormLayoutRowProps): JSX.Element => (
-  <div
-    className={cn(style['form-layout-row'], className, {
-      [style['inline-group']]: inline,
-      [style['large-space-after']]: lgSpaceAfter,
-      [style['small-space-after']]: smSpaceAfter,
-    })}
-  >
-    {children}
-  </div>
-)
+  sideComponent,
+}: IFormLayoutRowProps): JSX.Element => {
+  return sideComponent !== undefined ? (
+    <RowWithInfo
+      className={className}
+      inline={inline}
+      lgSpaceAfter={lgSpaceAfter}
+      smSpaceAfter={smSpaceAfter}
+      sideComponent={sideComponent}
+    >
+      {children}
+    </RowWithInfo>
+  ) : (
+    <div
+      className={cn(style['form-layout-row'], className, {
+        [style['inline-group']]: inline,
+        [style['large-space-after']]: lgSpaceAfter,
+        [style['small-space-after']]: smSpaceAfter,
+      })}
+    >
+      {children}
+    </div>
+  )
+}
 
 export default Row

--- a/pro/src/new_components/FormLayout/FormLayoutRowWithInfo.tsx
+++ b/pro/src/new_components/FormLayout/FormLayoutRowWithInfo.tsx
@@ -1,0 +1,42 @@
+import cn from 'classnames'
+import React from 'react'
+
+import style from './FormLayout.module.scss'
+import Row from './FormLayoutRow'
+
+interface IFormLayoutRowWithInfoProps {
+  children: React.ReactNode | React.ReactNode[]
+  className?: string
+  inline?: boolean
+  lgSpaceAfter?: boolean
+  smSpaceAfter?: boolean
+  sideComponent: JSX.Element | null
+}
+
+const RowWithInfo = ({
+  children,
+  className,
+  inline,
+  lgSpaceAfter,
+  smSpaceAfter,
+  sideComponent,
+}: IFormLayoutRowWithInfoProps): JSX.Element => {
+  return (
+    <Row
+      className={cn(className, style['form-layout-row-info'])}
+      lgSpaceAfter={lgSpaceAfter}
+      smSpaceAfter={smSpaceAfter}
+    >
+      <Row className={style['form-layout-row-info-field']} inline={inline}>
+        {children}
+      </Row>
+      <div className={style['form-layout-row-info-info']}>
+        <div className={style['form-layout-row-info-info-inner']}>
+          {sideComponent && sideComponent}
+        </div>
+      </div>
+    </Row>
+  )
+}
+
+export default RowWithInfo


### PR DESCRIPTION
  ..new_components/FormLayout

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14214

## But de la pull request

Ajout de la possibiliter d'avoir une colonnes à droite des champs dans le layout de nos formulaire.
Cette colonne doit etre utiliser pour placer les bulles d'aides: 
![help_box](https://user-images.githubusercontent.com/139848/183385543-c559ef0e-d15d-40a5-abfb-da59d41402b3.png)


## Implémentation

![infobox_position](https://user-images.githubusercontent.com/139848/183385577-11f07e49-5676-4796-8c11-60d19a34f04c.png)
