### PR TITLE
(BSR)[API] feat: Tweak IPython configuration

### DIFF
--- a/api/.flaskenv
+++ b/api/.flaskenv
@@ -1,1 +1,2 @@
 FLASK_APP=pcapi.flask_app:app
+IPYTHONDIR=.ipython

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -72,6 +72,8 @@ target/
 
 # IPython Notebook
 .ipynb_checkpoints
+.ipython
+!.ipython/profile_default/ipython_config.py
 
 # pyenv
 .python-version

--- a/api/.ipython/profile_default/ipython_config.py
+++ b/api/.ipython/profile_default/ipython_config.py
@@ -1,0 +1,30 @@
+import pygments.token
+
+from pcapi import settings
+
+
+def get_prompt_color():
+    # Colors come from https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/windowsterminal/Ubuntu.json
+    if settings.ENV in "production":
+        return "#cc0000"  # red
+    if settings.ENV == "staging":
+        return "#ad7fa8"  # purple
+    if settings.ENV == "testing":
+        return "#06989a"  # cyan
+    return None  # do not customize locally
+
+
+prompt_color = get_prompt_color()
+
+
+c = get_config()
+
+c.TerminalInteractiveShell.autoformatter = None
+if prompt_color:
+    c.TerminalInteractiveShell.highlighting_style_overrides = {
+        pygments.token.Token.Prompt: f"{prompt_color} bold",
+        pygments.token.Token.PromptNum: f"{prompt_color} bold",
+        pygments.token.Token.OutPrompt: f"{prompt_color} bold",
+        pygments.token.Token.OutPromptNum: f"{prompt_color} bold",
+    }
+c.TerminalInteractiveShell.term_title = False

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -18,6 +18,7 @@ Flask-Cors==3.0.10
 Flask-JWT-Extended==4.3.1
 Flask-Limiter==1.4
 Flask-Login==0.5.0
+flask-shell-ipython
 Flask-SQLAlchemy==2.5.*
 freezegun==0.3.12
 google-auth==2.6.2


### PR DESCRIPTION
1. Do not change the title of the terminal. "IPython: src/app" is not
   particularly helpful (especially for those of us who customize
   their terminal title with the environment they are on).

2. Do not reformat code with Black. It fails with an error on staging
   and production.

3. Tweak color of the prompt as we used to do with the default Python
   prompt.