### PR TITLE
PC-16175 subscription messages wordings update

### DIFF
--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -80,7 +80,7 @@ def _handle_validation_errors(
     if fraud_models.FraudReasonCode.DUPLICATE_USER in fraud_check.reasonCodes:  # type: ignore [operator]
         subscription_messages.add_error_message(
             user,
-            "Ton compte ÉduConnect est déjà rattaché à un autre compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse mail.",
+            "Ton compte ÉduConnect est déjà rattaché à un compte pass Culture. Vérifie que tu n'as pas déjà créé un compte avec une autre adresse e-mail.",
         )
         duplicate_beneficiary.send_duplicate_beneficiary_email(user, fraud_check.source_data())  # type: ignore [arg-type]
 

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -99,7 +99,7 @@ def on_ubble_journey_cannot_continue(user: users_models.User) -> None:
 def on_fraud_review_ko(user: users_models.User) -> None:
     message = models.SubscriptionMessage(
         user=user,
-        userMessage="Ton dossier a été rejeté. Tu n'es malheureusement pas éligible au pass culture.",
+        userMessage="Ton dossier a été refusé : tu n’es malheureusement pas éligible au pass Culture.",
         popOverIcon=models.PopOverIcon.ERROR,
     )
     repository.save(message)
@@ -216,7 +216,7 @@ def on_dms_application_received(user: users_models.User) -> None:
 def on_dms_application_refused(user: users_models.User) -> None:
     message = models.SubscriptionMessage(
         user=user,
-        userMessage="Ton dossier déposé sur le site Démarches-Simplifiées a été rejeté. Tu n’es malheureusement pas éligible au pass culture.",
+        userMessage="Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : tu n’es malheureusement pas éligible au pass Culture.",
         popOverIcon=models.PopOverIcon.ERROR,
     )
     repository.save(message)
@@ -297,8 +297,8 @@ def on_dms_application_field_errors(
         )
     else:
         user_message = _generate_form_field_error(
-            "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé car le champ ‘{formatted_error_fields}’ n’est pas valide.",
-            "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé car les champs ‘{formatted_error_fields}’ ne sont pas valides.",
+            "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : le champ ‘{formatted_error_fields}’ n’est pas valide.",
+            "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : les champs ‘{formatted_error_fields}’ ne sont pas valides.",
             error_fields,
         )
     message = models.SubscriptionMessage(

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -323,12 +323,12 @@ def on_user_subscription_journey_stopped(user: users_models.User) -> None:
 
 ### Educonnect specific messages ###
 def on_educonnect_age_not_valid(user: users_models.User, educonnect_user: educonnect_models.EduconnectUser) -> None:
-    message = f"Ton dossier a été refusé. La date de naissance enregistrée sur ton compte Educonnect ({educonnect_user.birth_date.strftime('%d/%m/%Y')}) indique que tu n'as pas entre {users_constants.ELIGIBILITY_UNDERAGE_RANGE[0]} et {users_constants.ELIGIBILITY_UNDERAGE_RANGE[-1]} ans."
+    message = f"Ton dossier a été refusé. La date de naissance enregistrée sur ton compte ÉduConnect ({educonnect_user.birth_date.strftime('%d/%m/%Y')}) indique que tu n'as pas entre {users_constants.ELIGIBILITY_UNDERAGE_RANGE[0]} et {users_constants.ELIGIBILITY_UNDERAGE_RANGE[-1]} ans."
     _add_error_message(user, message)
 
 
 def on_educonnect_not_eligible(user: users_models.User, educonnect_user: educonnect_models.EduconnectUser) -> None:
-    message = f"La date de naissance de ton dossier Educonnect ({educonnect_user.birth_date.strftime('%d/%m/%Y')}) indique que tu n'es pas éligible."
+    message = f"La date de naissance de ton dossier ÉduConnect ({educonnect_user.birth_date.strftime('%d/%m/%Y')}) indique que tu n'es pas éligible."
     eligibity_start = users_api.get_eligibility_start_datetime(educonnect_user.birth_date)
     if datetime.datetime.utcnow() < eligibity_start:  # type: ignore [operator]
         message += f" Tu seras éligible le {eligibity_start.strftime('%d/%m/%Y')}."  # type: ignore [union-attr]

--- a/api/tests/admin/custom_views/support_view_test.py
+++ b/api/tests/admin/custom_views/support_view_test.py
@@ -343,7 +343,7 @@ class BeneficiaryValidationViewTest:
         assert subscription_models.SubscriptionMessage.query.count() == 1
         message = subscription_models.SubscriptionMessage.query.first()
         assert message.popOverIcon == subscription_models.PopOverIcon.ERROR
-        assert message.userMessage == "Ton dossier a été rejeté. Tu n'es malheureusement pas éligible au pass culture."
+        assert message.userMessage == "Ton dossier a été refusé : tu n’es malheureusement pas éligible au pass Culture."
 
     @override_features(BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS=True)
     def test_validation_view_validate_user_with_non_default_eligibility(self, client):

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -268,7 +268,7 @@ class HandleDmsApplicationTest:
         subscription_message = subscription_models.SubscriptionMessage.query.filter_by(userId=user.id).one()
         assert (
             subscription_message.userMessage
-            == "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé car le champ ‘ta pièce d'identité’ n’est pas valide."
+            == "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : le champ ‘ta pièce d'identité’ n’est pas valide."
         )
 
         send_dms_message_mock.assert_not_called()
@@ -301,7 +301,7 @@ class HandleDmsApplicationTest:
         subscription_message = subscription_models.SubscriptionMessage.query.filter_by(userId=user.id).one()
         assert (
             subscription_message.userMessage
-            == "Ton dossier déposé sur le site Démarches-Simplifiées a été rejeté. Tu n’es malheureusement pas éligible au pass culture."
+            == "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : tu n’es malheureusement pas éligible au pass Culture."
         )
 
         send_dms_message_mock.assert_not_called()

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1104,7 +1104,7 @@ class PostManualReviewTest:
         assert subscription_models.SubscriptionMessage.query.count() == 1
         message = subscription_models.SubscriptionMessage.query.first()
         assert message.popOverIcon == subscription_models.PopOverIcon.ERROR
-        assert message.userMessage == "Ton dossier a été rejeté. Tu n'es malheureusement pas éligible au pass culture."
+        assert message.userMessage == "Ton dossier a été refusé : tu n’es malheureusement pas éligible au pass Culture."
 
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_cannot_review_with_unknown_data(self, client):

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -388,7 +388,7 @@ class DmsWebhookApplicationTest:
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.ERROR
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Ton dossier déposé sur le site Démarches-Simplifiées a été rejeté. Tu n’es malheureusement pas éligible au pass culture."
+            == "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : tu n’es malheureusement pas éligible au pass Culture."
         )
         assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.REFUSED_BY_OPERATOR]
 

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -349,7 +349,7 @@ class EduconnectTest:
         assert len(user.subscriptionMessages) == 1
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Ton dossier a été refusé. La date de naissance enregistrée sur ton compte Educonnect (21/11/2007) indique que tu n'as pas entre 15 et 17 ans."
+            == "Ton dossier a été refusé. La date de naissance enregistrée sur ton compte ÉduConnect (21/11/2007) indique que tu n'as pas entre 15 et 17 ans."
         )
 
     @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_educonnect_user")
@@ -370,7 +370,7 @@ class EduconnectTest:
         assert len(user.subscriptionMessages) == 1
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Ton dossier a été refusé. La date de naissance enregistrée sur ton compte Educonnect (21/11/2003) indique que tu n'as pas entre 15 et 17 ans."
+            == "Ton dossier a été refusé. La date de naissance enregistrée sur ton compte ÉduConnect (21/11/2003) indique que tu n'as pas entre 15 et 17 ans."
         )
 
     @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_educonnect_user")
@@ -391,7 +391,7 @@ class EduconnectTest:
         assert len(user.subscriptionMessages) == 1
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Ton dossier a été refusé. La date de naissance enregistrée sur ton compte Educonnect (21/11/2001) indique que tu n'as pas entre 15 et 17 ans."
+            == "Ton dossier a été refusé. La date de naissance enregistrée sur ton compte ÉduConnect (21/11/2001) indique que tu n'as pas entre 15 et 17 ans."
         )
 
     @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_educonnect_user")

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -864,7 +864,7 @@ class GraphQLSourceProcessApplicationTest:
         assert user.subscriptionMessages[0]
         assert (
             user.subscriptionMessages[0].userMessage
-            == "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé car les champs ‘ta pièce d'identité, ton code postal’ ne sont pas valides."
+            == "Ton dossier déposé sur le site Démarches-Simplifiées a été refusé : les champs ‘ta pièce d'identité, ton code postal’ ne sont pas valides."
         )
         assert user.subscriptionMessages[0].popOverIcon == subscription_models.PopOverIcon.WARNING
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16175

## But de la pull request

Mettre à jour les formulations des messages d'activation de compte in-app 

## Implémentation

- RAS

## Informations supplémentaires

- RAS

## Modifications du schéma de la base de données

- N/A


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
