### PR TITLE
(BSR) ci: do not run mypy if MYPY_FILES is empty

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -147,9 +147,11 @@ then
   if [[ ! ",${DISABLED_API_PRE_COMMIT_CHECKS}," =~ ",mypy," ]]
   then
       echo -e "\033[0;96mRunning mypy for type checking...\033[0m"
-      mypy $MYPY_FILES --pretty --show-error-codes
-      if [[ "$?" != 0 ]]; then
-          counter=$((counter + 1))
+      if [[ ! $MYPY_FILES == "" ]]; then
+        mypy $MYPY_FILES --pretty --show-error-codes
+        if [[ "$?" != 0 ]]; then
+            counter=$((counter + 1))
+        fi
       fi
   fi
 


### PR DESCRIPTION
This happens if we only commit test files

Lien vers le ticket Jira : N/A

## But de la pull request

Eviter l'erreur suivante en cas de commit contenant uniquement des test:
```bash
Running mypy for type checking...
usage: mypy [-h] [-v] [-V] [more options; see below]
            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
mypy: error: Missing target module, package, files, or command.
```

## Implémentation

- Ajout d'un IF

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- N/A


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
