### PR TITLE
(BSR)[API] feat: Show environment in IPython prompt instead of command number

### DIFF
--- a/api/.ipython/profile_default/ipython_config.py
+++ b/api/.ipython/profile_default/ipython_config.py
@@ -1,3 +1,4 @@
+from IPython.terminal import prompts
 import pygments.token
 
 from pcapi import settings
@@ -17,6 +18,20 @@ def get_prompt_color():
 prompt_color = get_prompt_color()
 
 
+class CustomPrompt(prompts.Prompts):
+    def in_prompt_tokens(self, cli=None):
+        env = settings.ENV or "local"
+        return [
+            (
+                prompts.Token.Prompt,
+                f"{env}❯ ",
+            ),
+        ]
+
+    def out_prompt_tokens(self, cli=None):
+        return []
+
+
 c = get_config()
 
 c.TerminalInteractiveShell.autoformatter = None
@@ -27,4 +42,5 @@ if prompt_color:
         pygments.token.Token.OutPrompt: f"{prompt_color} bold",
         pygments.token.Token.OutPromptNum: f"{prompt_color} bold",
     }
+c.TerminalInteractiveShell.prompts_class = CustomPrompt
 c.TerminalInteractiveShell.term_title = False


### PR DESCRIPTION
By default, the IPython prompt shows a incrementing number:

    In [1]: a = 1

    In [2]: a
    Out[2]: 1

That number does not seem very useful. Showing the environment instead
looks more interesting:

    production❯ a = 1

    production❯ a
    1

--- 

Capture d'écran : 

![flask shell](https://user-images.githubusercontent.com/471321/183619830-97eea034-346e-41d1-a94d-fad994c24144.png)
