### PR TITLE
Pc 16555 pc 16556 pc 16559 collective offers api

### DIFF
--- a/api/src/pcapi/routes/pro/public_api/collective_offers.py
+++ b/api/src/pcapi/routes/pro/public_api/collective_offers.py
@@ -1,6 +1,7 @@
 import logging
 
 from pcapi.core.categories import categories
+from pcapi.core.educational import repository as educational_repository
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.routes.pro import blueprint
 from pcapi.routes.serialization import public_api_collective_offers_serialize
@@ -55,5 +56,26 @@ def list_categories() -> public_api_collective_offers_serialize.CollectiveOffers
             )
             for category in categories.ALL_CATEGORIES
             if category.is_selectable
+        ]
+    )
+
+
+@blueprint.pro_public_api_v2.route("/collective-offers/educational-domains", methods=["GET"])
+@api_key_required
+@spectree_serialize(
+    on_success_status=200,
+    on_error_statuses=[401],
+    response_model=public_api_collective_offers_serialize.CollectiveOffersListDomainsResponseModel,
+    api=blueprint.pro_public_schema_v2,
+)
+def list_educational_domains() -> public_api_collective_offers_serialize.CollectiveOffersListDomainsResponseModel:
+    # in French, to be used by Swagger for the API documentation
+    """Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives."""
+    educational_domains = educational_repository.get_all_educational_domains_ordered_by_name()
+
+    return public_api_collective_offers_serialize.CollectiveOffersListDomainsResponseModel(
+        __root__=[
+            public_api_collective_offers_serialize.CollectiveOffersDomainResponseModel.from_orm(educational_domain)
+            for educational_domain in educational_domains
         ]
     )

--- a/api/src/pcapi/routes/pro/public_api/collective_offers.py
+++ b/api/src/pcapi/routes/pro/public_api/collective_offers.py
@@ -1,6 +1,7 @@
 import logging
 
 from pcapi.core.categories import categories
+from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.routes.pro import blueprint
@@ -77,5 +78,26 @@ def list_educational_domains() -> public_api_collective_offers_serialize.Collect
         __root__=[
             public_api_collective_offers_serialize.CollectiveOffersDomainResponseModel.from_orm(educational_domain)
             for educational_domain in educational_domains
+        ]
+    )
+
+
+@blueprint.pro_public_api_v2.route("/collective-offers/student-levels", methods=["GET"])
+@api_key_required
+@spectree_serialize(
+    on_success_status=200,
+    on_error_statuses=[401],
+    response_model=public_api_collective_offers_serialize.CollectiveOffersListStudentLevelsResponseModel,
+    api=blueprint.pro_public_schema_v2,
+)
+def list_students_levels() -> public_api_collective_offers_serialize.CollectiveOffersListStudentLevelsResponseModel:
+    # in French, to be used by Swagger for the API documentation
+    """Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées."""
+    return public_api_collective_offers_serialize.CollectiveOffersListStudentLevelsResponseModel(
+        __root__=[
+            public_api_collective_offers_serialize.CollectiveOffersStudentLevelResponseModel(
+                id=student_level.name, name=student_level.value
+            )
+            for student_level in educational_models.StudentLevels
         ]
     )

--- a/api/src/pcapi/routes/pro/public_api/collective_offers.py
+++ b/api/src/pcapi/routes/pro/public_api/collective_offers.py
@@ -1,5 +1,6 @@
 import logging
 
+from pcapi.core.categories import categories
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.routes.pro import blueprint
 from pcapi.routes.serialization import public_api_collective_offers_serialize
@@ -32,5 +33,27 @@ def list_venues() -> public_api_collective_offers_serialize.CollectiveOffersList
         __root__=[
             public_api_collective_offers_serialize.CollectiveOffersVenueResponseModel.from_orm(venue)
             for venue in venues
+        ]
+    )
+
+
+@blueprint.pro_public_api_v2.route("/collective-offers/categories", methods=["GET"])
+@api_key_required
+@spectree_serialize(
+    on_success_status=200,
+    on_error_statuses=[401],
+    response_model=public_api_collective_offers_serialize.CollectiveOffersListCategoriesResponseModel,
+    api=blueprint.pro_public_schema_v2,
+)
+def list_categories() -> public_api_collective_offers_serialize.CollectiveOffersListCategoriesResponseModel:
+    # in French, to be used by Swagger for the API documentation
+    """Récupération de la liste des catégories d'offres proposées."""
+    return public_api_collective_offers_serialize.CollectiveOffersListCategoriesResponseModel(
+        __root__=[
+            public_api_collective_offers_serialize.CollectiveOffersCategoryResponseModel(
+                id=category.id, name=category.pro_label
+            )
+            for category in categories.ALL_CATEGORIES
+            if category.is_selectable
         ]
     )

--- a/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
@@ -14,3 +14,12 @@ class CollectiveOffersVenueResponseModel(BaseModel):
 
 class CollectiveOffersListVenuesResponseModel(BaseModel):
     __root__: list[CollectiveOffersVenueResponseModel]
+
+
+class CollectiveOffersCategoryResponseModel(BaseModel):
+    id: str
+    name: str
+
+
+class CollectiveOffersListCategoriesResponseModel(BaseModel):
+    __root__: list[CollectiveOffersCategoryResponseModel]

--- a/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
@@ -35,3 +35,12 @@ class CollectiveOffersDomainResponseModel(BaseModel):
 
 class CollectiveOffersListDomainsResponseModel(BaseModel):
     __root__: list[CollectiveOffersDomainResponseModel]
+
+
+class CollectiveOffersStudentLevelResponseModel(BaseModel):
+    id: str
+    name: str
+
+
+class CollectiveOffersListStudentLevelsResponseModel(BaseModel):
+    __root__: list[CollectiveOffersStudentLevelResponseModel]

--- a/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
@@ -23,3 +23,15 @@ class CollectiveOffersCategoryResponseModel(BaseModel):
 
 class CollectiveOffersListCategoriesResponseModel(BaseModel):
     __root__: list[CollectiveOffersCategoryResponseModel]
+
+
+class CollectiveOffersDomainResponseModel(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
+class CollectiveOffersListDomainsResponseModel(BaseModel):
+    __root__: list[CollectiveOffersDomainResponseModel]

--- a/api/tests/routes/pro/openapi_test.py
+++ b/api/tests/routes/pro/openapi_test.py
@@ -23,9 +23,23 @@ def test_public_api(client, app):
                     "title": "CollectiveOffersCategoryResponseModel",
                     "type": "object",
                 },
+                "CollectiveOffersDomainResponseModel": {
+                    "properties": {
+                        "id": {"title": "Id", "type": "integer"},
+                        "name": {"title": "Name", "type": "string"},
+                    },
+                    "required": ["id", "name"],
+                    "title": "CollectiveOffersDomainResponseModel",
+                    "type": "object",
+                },
                 "CollectiveOffersListCategoriesResponseModel": {
                     "items": {"$ref": "#/components/schemas/CollectiveOffersCategoryResponseModel"},
                     "title": "CollectiveOffersListCategoriesResponseModel",
+                    "type": "array",
+                },
+                "CollectiveOffersListDomainsResponseModel": {
+                    "items": {"$ref": "#/components/schemas/CollectiveOffersDomainResponseModel"},
+                    "title": "CollectiveOffersListDomainsResponseModel",
                     "type": "array",
                 },
                 "CollectiveOffersListVenuesResponseModel": {
@@ -307,6 +321,33 @@ def test_public_api(client, app):
                         },
                     },
                     "summary": "Récupération de la liste des catégories d'offres proposées.",
+                    "tags": [],
+                }
+            },
+            "/v2/collective-offers/educational-domains": {
+                "get": {
+                    "description": "",
+                    "operationId": "ListEducationalDomains",
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/CollectiveOffersListDomainsResponseModel"}
+                                }
+                            },
+                            "description": "OK",
+                        },
+                        "401": {"description": "Unauthorized"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "summary": "Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.",
                     "tags": [],
                 }
             },

--- a/api/tests/routes/pro/openapi_test.py
+++ b/api/tests/routes/pro/openapi_test.py
@@ -42,10 +42,24 @@ def test_public_api(client, app):
                     "title": "CollectiveOffersListDomainsResponseModel",
                     "type": "array",
                 },
+                "CollectiveOffersListStudentLevelsResponseModel": {
+                    "items": {"$ref": "#/components/schemas/CollectiveOffersStudentLevelResponseModel"},
+                    "title": "CollectiveOffersListStudentLevelsResponseModel",
+                    "type": "array",
+                },
                 "CollectiveOffersListVenuesResponseModel": {
                     "items": {"$ref": "#/components/schemas/CollectiveOffersVenueResponseModel"},
                     "title": "CollectiveOffersListVenuesResponseModel",
                     "type": "array",
+                },
+                "CollectiveOffersStudentLevelResponseModel": {
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "name": {"title": "Name", "type": "string"},
+                    },
+                    "required": ["id", "name"],
+                    "title": "CollectiveOffersStudentLevelResponseModel",
+                    "type": "object",
                 },
                 "CollectiveOffersVenueResponseModel": {
                     "properties": {
@@ -348,6 +362,35 @@ def test_public_api(client, app):
                         },
                     },
                     "summary": "Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.",
+                    "tags": [],
+                }
+            },
+            "/v2/collective-offers/student-levels": {
+                "get": {
+                    "description": "",
+                    "operationId": "ListStudentsLevels",
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/CollectiveOffersListStudentLevelsResponseModel"
+                                    }
+                                }
+                            },
+                            "description": "OK",
+                        },
+                        "401": {"description": "Unauthorized"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "summary": "Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées.",
                     "tags": [],
                 }
             },

--- a/api/tests/routes/pro/openapi_test.py
+++ b/api/tests/routes/pro/openapi_test.py
@@ -14,6 +14,20 @@ def test_public_api(client, app):
                     "enum": ["BIEN", "EVENEMENT"],
                     "title": "BookingOfferType",
                 },
+                "CollectiveOffersCategoryResponseModel": {
+                    "properties": {
+                        "id": {"title": "Id", "type": "string"},
+                        "name": {"title": "Name", "type": "string"},
+                    },
+                    "required": ["id", "name"],
+                    "title": "CollectiveOffersCategoryResponseModel",
+                    "type": "object",
+                },
+                "CollectiveOffersListCategoriesResponseModel": {
+                    "items": {"$ref": "#/components/schemas/CollectiveOffersCategoryResponseModel"},
+                    "title": "CollectiveOffersListCategoriesResponseModel",
+                    "type": "array",
+                },
                 "CollectiveOffersListVenuesResponseModel": {
                     "items": {"$ref": "#/components/schemas/CollectiveOffersVenueResponseModel"},
                     "title": "CollectiveOffersListVenuesResponseModel",
@@ -265,6 +279,35 @@ def test_public_api(client, app):
                     "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Validation d'une réservation.",
                     "tags": ["API Contremarque"],
+                }
+            },
+            "/v2/collective-offers/categories": {
+                "get": {
+                    "description": "",
+                    "operationId": "ListCategories",
+                    "parameters": [],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/CollectiveOffersListCategoriesResponseModel"
+                                    }
+                                }
+                            },
+                            "description": "OK",
+                        },
+                        "401": {"description": "Unauthorized"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable " "Entity",
+                        },
+                    },
+                    "summary": "Récupération de la liste des catégories d'offres proposées.",
+                    "tags": [],
                 }
             },
             "/v2/collective-offers/venues": {

--- a/api/tests/routes/pro/public_api/get_collective_offers_categories_test.py
+++ b/api/tests/routes/pro/public_api/get_collective_offers_categories_test.py
@@ -1,0 +1,57 @@
+from flask import url_for
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class CollectiveOffersGetCategoriesTest:
+    def test_list_categories(self, client):
+        # Given
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=offerer)
+
+        # When
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.list_categories")
+        )
+
+        # Then
+        assert response.status_code == 200
+
+        assert response.json == [
+            {"id": "BEAUX_ARTS", "name": "Beaux-arts"},
+            {"id": "CARTE_JEUNES", "name": "Carte jeunes"},
+            {"id": "CINEMA", "name": "Cinéma"},
+            {"id": "CONFERENCE", "name": "Conférences, rencontres"},
+            {"id": "FILM", "name": "Films, vidéos"},
+            {"id": "INSTRUMENT", "name": "Instrument de musique"},
+            {"id": "JEU", "name": "Jeux"},
+            {"id": "LIVRE", "name": "Livre"},
+            {"id": "MEDIA", "name": "Médias"},
+            {"id": "MUSEE", "name": "Musée, patrimoine, architecture, arts visuels"},
+            {"id": "MUSIQUE_ENREGISTREE", "name": "Musique enregistrée"},
+            {"id": "MUSIQUE_LIVE", "name": "Musique live"},
+            {"id": "PRATIQUE_ART", "name": "Pratique artistique"},
+            {"id": "SPECTACLE", "name": "Spectacle vivant"},
+        ]
+
+    def test_list_categories_user_auth_returns_401(self, client):
+        # Given
+        user_offerer = offerers_factories.UserOffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=user_offerer.offerer)
+
+        # When
+        response = client.with_session_auth(user_offerer.user.email).get(url_for("pro_public_api_v2.list_categories"))
+
+        # Then
+        assert response.status_code == 401
+
+    def test_list_categories_anonymous_returns_401(self, client):
+        # Given
+
+        # When
+        response = client.get(url_for("pro_public_api_v2.list_categories"))
+
+        # Then
+        assert response.status_code == 401

--- a/api/tests/routes/pro/public_api/get_collective_offers_educational_domains_test.py
+++ b/api/tests/routes/pro/public_api/get_collective_offers_educational_domains_test.py
@@ -1,0 +1,69 @@
+from operator import itemgetter
+
+from flask import url_for
+import pytest
+
+import pcapi.core.educational.factories as educational_factories
+import pcapi.core.offerers.factories as offerers_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class CollectiveOffersGetEducationalDomainsTest:
+    def test_list_educational_domains(self, client):
+        # Given
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=offerer)
+
+        domain1 = educational_factories.EducationalDomainFactory(name="Arts numériques")
+        domain2 = educational_factories.EducationalDomainFactory(name="Cinéma, audiovisuel")
+
+        # When
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.list_educational_domains")
+        )
+
+        # Then
+        assert response.status_code == 200
+
+        response_list = sorted(response.json, key=itemgetter("id"))
+        assert response_list == [
+            {"id": domain1.id, "name": "Arts numériques"},
+            {"id": domain2.id, "name": "Cinéma, audiovisuel"},
+        ]
+
+    def test_list_educational_domains_empty(self, client):
+        # Given
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=offerer)
+
+        # When
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.list_educational_domains")
+        )
+
+        # Then
+        assert response.status_code == 200
+        assert response.json == []
+
+    def test_list_educational_domains_user_auth_returns_401(self, client):
+        # Given
+        user_offerer = offerers_factories.UserOffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=user_offerer.offerer)
+
+        # When
+        response = client.with_session_auth(user_offerer.user.email).get(
+            url_for("pro_public_api_v2.list_educational_domains")
+        )
+
+        # Then
+        assert response.status_code == 401
+
+    def test_list_educational_domains_anonymous_returns_401(self, client):
+        # Given
+        educational_factories.EducationalDomainFactory(name="Musique")
+
+        # When
+        response = client.get(url_for("pro_public_api_v2.list_educational_domains"))
+
+        # Then
+        assert response.status_code == 401

--- a/api/tests/routes/pro/public_api/get_collective_offers_students_levels_test.py
+++ b/api/tests/routes/pro/public_api/get_collective_offers_students_levels_test.py
@@ -1,0 +1,50 @@
+from flask import url_for
+import pytest
+
+import pcapi.core.educational.models as educational_models
+import pcapi.core.offerers.factories as offerers_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class CollectiveOffersGetStudentsLevelsTest:
+    def test_list_students_levels(self, client):
+        # Given
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=offerer)
+
+        # When
+        response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
+            url_for("pro_public_api_v2.list_students_levels")
+        )
+
+        # Then
+        assert response.status_code == 200
+
+        response_list = response.json
+        assert {"id": "GENERAL0", "name": "Lycée - Terminale"} in response_list
+        assert response_list == [
+            {"id": student_level.name, "name": student_level.value}
+            for student_level in educational_models.StudentLevels
+        ]
+
+    def test_list_students_levels_user_auth_returns_401(self, client):
+        # Given
+        user_offerer = offerers_factories.UserOffererFactory()
+        offerers_factories.ApiKeyFactory(offerer=user_offerer.offerer)
+
+        # When
+        response = client.with_session_auth(user_offerer.user.email).get(
+            url_for("pro_public_api_v2.list_students_levels")
+        )
+
+        # Then
+        assert response.status_code == 401
+
+    def test_list_students_levels_anonymous_returns_401(self, client):
+        # Given
+
+        # When
+        response = client.get(url_for("pro_public_api_v2.list_students_levels"))
+
+        # Then
+        assert response.status_code == 401

--- a/pro/src/apiClient/v2/index.ts
+++ b/pro/src/apiClient/v2/index.ts
@@ -11,7 +11,13 @@ export type { OpenAPIConfig } from './core/OpenAPI';
 
 export { BookingFormula } from './models/BookingFormula';
 export { BookingOfferType } from './models/BookingOfferType';
+export type { CollectiveOffersCategoryResponseModel } from './models/CollectiveOffersCategoryResponseModel';
+export type { CollectiveOffersDomainResponseModel } from './models/CollectiveOffersDomainResponseModel';
+export type { CollectiveOffersListCategoriesResponseModel } from './models/CollectiveOffersListCategoriesResponseModel';
+export type { CollectiveOffersListDomainsResponseModel } from './models/CollectiveOffersListDomainsResponseModel';
+export type { CollectiveOffersListStudentLevelsResponseModel } from './models/CollectiveOffersListStudentLevelsResponseModel';
 export type { CollectiveOffersListVenuesResponseModel } from './models/CollectiveOffersListVenuesResponseModel';
+export type { CollectiveOffersStudentLevelResponseModel } from './models/CollectiveOffersStudentLevelResponseModel';
 export type { CollectiveOffersVenueResponseModel } from './models/CollectiveOffersVenueResponseModel';
 export type { GetBookingResponse } from './models/GetBookingResponse';
 export type { UpdateVenueStockBodyModel } from './models/UpdateVenueStockBodyModel';

--- a/pro/src/apiClient/v2/models/CollectiveOffersCategoryResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersCategoryResponseModel.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CollectiveOffersCategoryResponseModel = {
+  id: string;
+  name: string;
+};
+

--- a/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersDomainResponseModel.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CollectiveOffersDomainResponseModel = {
+  id: number;
+  name: string;
+};
+

--- a/pro/src/apiClient/v2/models/CollectiveOffersListCategoriesResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListCategoriesResponseModel.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CollectiveOffersCategoryResponseModel } from './CollectiveOffersCategoryResponseModel';
+
+export type CollectiveOffersListCategoriesResponseModel = Array<CollectiveOffersCategoryResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListDomainsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListDomainsResponseModel.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CollectiveOffersDomainResponseModel } from './CollectiveOffersDomainResponseModel';
+
+export type CollectiveOffersListDomainsResponseModel = Array<CollectiveOffersDomainResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersListStudentLevelsResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersListStudentLevelsResponseModel.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CollectiveOffersStudentLevelResponseModel } from './CollectiveOffersStudentLevelResponseModel';
+
+export type CollectiveOffersListStudentLevelsResponseModel = Array<CollectiveOffersStudentLevelResponseModel>;

--- a/pro/src/apiClient/v2/models/CollectiveOffersStudentLevelResponseModel.ts
+++ b/pro/src/apiClient/v2/models/CollectiveOffersStudentLevelResponseModel.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CollectiveOffersStudentLevelResponseModel = {
+  id: string;
+  name: string;
+};
+

--- a/pro/src/apiClient/v2/services/DefaultService.ts
+++ b/pro/src/apiClient/v2/services/DefaultService.ts
@@ -1,6 +1,9 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { CollectiveOffersListCategoriesResponseModel } from '../models/CollectiveOffersListCategoriesResponseModel';
+import type { CollectiveOffersListDomainsResponseModel } from '../models/CollectiveOffersListDomainsResponseModel';
+import type { CollectiveOffersListStudentLevelsResponseModel } from '../models/CollectiveOffersListStudentLevelsResponseModel';
 import type { CollectiveOffersListVenuesResponseModel } from '../models/CollectiveOffersListVenuesResponseModel';
 
 import type { CancelablePromise } from '../core/CancelablePromise';
@@ -9,6 +12,57 @@ import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 export class DefaultService {
 
   constructor(public readonly httpRequest: BaseHttpRequest) {}
+
+  /**
+   * Récupération de la liste des catégories d'offres proposées.
+   * @returns CollectiveOffersListCategoriesResponseModel OK
+   * @throws ApiError
+   */
+  public listCategories(): CancelablePromise<CollectiveOffersListCategoriesResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v2/collective-offers/categories',
+      errors: {
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.
+   * @returns CollectiveOffersListDomainsResponseModel OK
+   * @throws ApiError
+   */
+  public listEducationalDomains(): CancelablePromise<CollectiveOffersListDomainsResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v2/collective-offers/educational-domains',
+      errors: {
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées.
+   * @returns CollectiveOffersListStudentLevelsResponseModel OK
+   * @throws ApiError
+   */
+  public listStudentsLevels(): CancelablePromise<CollectiveOffersListStudentLevelsResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/v2/collective-offers/student-levels',
+      errors: {
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
 
   /**
    * Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.


### PR DESCRIPTION
Lien vers les tickets Jira : 
https://passculture.atlassian.net/browse/PC-16555
https://passculture.atlassian.net/browse/PC-16556
https://passculture.atlassian.net/browse/PC-16559

## But de la pull request

Implémenter les API des offres collectives : 
- liste des catégories (qui sont en dur dans le code)
- liste des domaines d'éducation (db)
- liste des publics cible (en dur dans le code)

## Implémentation

## Informations supplémentaires

Un commit par ticket.
La notion de cache, évoquée dans certains tickets, est le sujet du ticket PC-16561.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
