### PR TITLE
(BSR)[API] feat: Do not compress "payment_details.csv" finance file

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1423,11 +1423,6 @@ def _generate_payments_file(batch_id: int) -> pathlib.Path:
             payments_models.Deposit.type.label("deposit_type"),
             sqla_func.sum(models.Pricing.amount).label("pricing_amount"),
         )
-    # FIXME (dbaty, 2021-11-30): other functions use `yield_per()`
-    # but I am not sure it helps here. We have used
-    # `pcapi.utils.db.get_batches` in the old-style payment code
-    # and that may be what's best here.
-    bookings_query = bookings_query.yield_per(1000)
 
     collective_bookings_query = (
         models.Pricing.query.filter_by(status=models.PricingStatus.PROCESSED)
@@ -1495,18 +1490,12 @@ def _generate_payments_file(batch_id: int) -> pathlib.Path:
             educational_models.EducationalDeposit.ministry.label("ministry"),
             sqla_func.sum(models.Pricing.amount).label("pricing_amount"),
         )
-    # FIXME (dbaty, 2021-11-30): other functions use `yield_per()`
-    # but I am not sure it helps here. We have used
-    # `pcapi.utils.db.get_batches` in the old-style payment code
-    # and that may be what's best here.
-    collective_bookings_query = collective_bookings_query.yield_per(1000)
 
     return _write_csv(
         "payment_details",
         header,
         rows=itertools.chain(bookings_query, collective_bookings_query),
         row_formatter=_payment_details_row_formatter,
-        compress=True,  # it's a large CSV file (> 100 Mb), we should compress it
     )
 
 

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1519,7 +1519,7 @@ def test_generate_payment_files(mocked_gdrive_create_file):
     gdrive_file_names = {call.args[1] for call in mocked_gdrive_create_file.call_args_list}
     assert gdrive_file_names == {
         "business_units.csv",
-        "payment_details.csv.zip",
+        "payment_details.csv",
         "soldes_des_utilisateurs.csv.zip",
     }
 
@@ -1720,11 +1720,9 @@ def test_generate_payments_file():
     with assert_num_queries(n_queries):
         path = api._generate_payments_file(batch_id)
 
-    with zipfile.ZipFile(path) as zfile:
-        with zfile.open("payment_details.csv") as csv_bytefile:
-            csv_textfile = io.TextIOWrapper(csv_bytefile)
-            reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
-            rows = list(reader)
+    with open(path, encoding="utf-8") as fp:
+        reader = csv.DictReader(fp, quoting=csv.QUOTE_NONNUMERIC)
+        rows = list(reader)
 
     assert len(rows) == 4
     assert rows[0] == {
@@ -1891,11 +1889,9 @@ def test_generate_payments_file_legacy_with_business_units():
     with assert_num_queries(n_queries):
         path = api._generate_payments_file(batch_id)
 
-    with zipfile.ZipFile(path) as zfile:
-        with zfile.open("payment_details.csv") as csv_bytefile:
-            csv_textfile = io.TextIOWrapper(csv_bytefile)
-            reader = csv.DictReader(csv_textfile, quoting=csv.QUOTE_NONNUMERIC)
-            rows = list(reader)
+    with open(path, encoding="utf-8") as fp:
+        reader = csv.DictReader(fp, quoting=csv.QUOTE_NONNUMERIC)
+        rows = list(reader)
 
     assert len(rows) == 5
     assert rows[0] == {


### PR DESCRIPTION
It used to include all pricing lines and was thus quite large. Now it
only contains one line per reimbursement point and is thus much
smaller (< 1Mb). We don't need to compress the file anymore.

Also, we don't need `yield_per()` because only a few thousands rows
are returned.