### PR TITLE
Pc 16127 category id to category

### DIFF
--- a/api/src/pcapi/admin/custom_views/category_view.py
+++ b/api/src/pcapi/admin/custom_views/category_view.py
@@ -34,7 +34,7 @@ class SubcategoryView(BaseCustomAdminView):
         column_names += [field.name for field in fields(Subcategory) if field.name not in ("pro_label", "app_label")]
         column_labels = {
             "id": "Nom tech de la sous-catégorie",
-            "category_id": "Nom tech de la catégorie",
+            "category": "Nom tech de la catégorie",
             "is_bookable_by_underage_when_free": "Réservable par les 15-17 si gratuite",
             "is_bookable_by_underage_when_not_free": "Réservable par les 15-17 si payante",
         }

--- a/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -37,7 +37,7 @@ def _get_subcategory_choices() -> list[tuple[str, list[tuple[str, str]]]]:
     choices = collections.defaultdict(list)
     for subcategory in ALL_SUBCATEGORIES:
         if subcategory.is_selectable:
-            choices[ALL_CATEGORIES_DICT[subcategory.category_id].pro_label].append(
+            choices[ALL_CATEGORIES_DICT[subcategory.category.id].pro_label].append(
                 (subcategory.id, subcategory.pro_label)
             )
 

--- a/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
+++ b/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
@@ -87,9 +87,9 @@ def _get_products_compatible_status(products: list[offers_models.Product]) -> di
 
 
 def _get_product_type(product: offers_models.Product) -> str:
-    if product.subcategory.category_id == categories.FILM.id:
+    if product.subcategory.category == categories.FILM:
         return "cinema"
-    if product.subcategory.category_id == categories.LIVRE.id:
+    if product.subcategory.category == categories.LIVRE:
         return "book"
 
     return "unknown"

--- a/api/src/pcapi/admin/custom_views/offer_view.py
+++ b/api/src/pcapi/admin/custom_views/offer_view.py
@@ -72,7 +72,7 @@ logger = logging.getLogger(__name__)
 def offer_category_formatter(view: BaseAdminView, context: Context, model: Offer, name: str) -> str:
     if model.subcategoryId is None:
         return ""
-    return subcategories.ALL_SUBCATEGORIES_DICT[model.subcategoryId].category_id
+    return subcategories.ALL_SUBCATEGORIES_DICT[model.subcategoryId].category.id
 
 
 def offer_name_formatter(view: BaseAdminView, context: Context, model: Offer, name: str) -> Markup:
@@ -100,7 +100,7 @@ class CategoryFilterEqual(FilterEqual):
         searched_subcategories = [
             subcategory.id
             for subcategory in subcategories.ALL_SUBCATEGORIES
-            if subcategory.category_id.upper() == value.upper()
+            if subcategory.category.id.upper() == value.upper()
         ]
         return filter_query.filter(self.get_column(alias).in_(searched_subcategories))
 

--- a/api/src/pcapi/core/categories/subcategories_v2.py
+++ b/api/src/pcapi/core/categories/subcategories_v2.py
@@ -59,7 +59,7 @@ class ReimbursementRuleChoices(Enum):
 @dataclass(frozen=True)
 class Subcategory:
     id: str
-    category_id: str
+    category: categories.Category
     pro_label: str
     app_label: str
     search_group_name: str
@@ -91,12 +91,16 @@ class Subcategory:
         if self.reimbursement_rule not in [r.value for r in ReimbursementRuleChoices]:
             raise ValueError("online_offline_platform can only be one of ReimbursementRuleChoices")
 
+    @property
+    def category_id(self) -> str:
+        return self.category.id
+
 
 # region Subcategories declarations
 # region FILM
 SUPPORT_PHYSIQUE_FILM = Subcategory(
     id="SUPPORT_PHYSIQUE_FILM",
-    category_id=categories.FILM.id,
+    category=categories.FILM,
     pro_label="Support physique (DVD, Blu-ray...)",
     app_label="Support physique (DVD, Blu-ray...)",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -113,7 +117,7 @@ SUPPORT_PHYSIQUE_FILM = Subcategory(
 )
 ABO_MEDIATHEQUE = Subcategory(
     id="ABO_MEDIATHEQUE",
-    category_id=categories.FILM.id,
+    category=categories.FILM,
     pro_label="Abonnement médiathèque",
     app_label="Abonnement médiathèque",
     search_group_name=SearchGroups.BIBLIOTHEQUES_MEDIATHEQUE.name,
@@ -130,7 +134,7 @@ ABO_MEDIATHEQUE = Subcategory(
 )
 VOD = Subcategory(
     id="VOD",
-    category_id=categories.FILM.id,
+    category=categories.FILM,
     pro_label="Vidéo à la demande",
     app_label="Vidéo à la demande",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -148,7 +152,7 @@ VOD = Subcategory(
 )
 ABO_PLATEFORME_VIDEO = Subcategory(
     id="ABO_PLATEFORME_VIDEO",
-    category_id=categories.FILM.id,
+    category=categories.FILM,
     pro_label="Abonnement plateforme streaming",
     app_label="Abonnement plateforme streaming",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -166,7 +170,7 @@ ABO_PLATEFORME_VIDEO = Subcategory(
 )
 AUTRE_SUPPORT_NUMERIQUE = Subcategory(
     id="AUTRE_SUPPORT_NUMERIQUE",
-    category_id=categories.FILM.id,
+    category=categories.FILM,
     pro_label="Autre support numérique",
     app_label="Autre support numérique",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -186,7 +190,7 @@ AUTRE_SUPPORT_NUMERIQUE = Subcategory(
 # region CINEMA
 CARTE_CINE_MULTISEANCES = Subcategory(
     id="CARTE_CINE_MULTISEANCES",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Carte cinéma multi-séances",
     app_label="Carte cinéma multi-séances",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -203,7 +207,7 @@ CARTE_CINE_MULTISEANCES = Subcategory(
 )
 CARTE_CINE_ILLIMITE = Subcategory(
     id="CARTE_CINE_ILLIMITE",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Carte cinéma illimité",
     app_label="Carte cinéma illimité",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -220,7 +224,7 @@ CARTE_CINE_ILLIMITE = Subcategory(
 )
 SEANCE_CINE = Subcategory(
     id="SEANCE_CINE",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Séance de cinéma",
     app_label="Séance de cinéma",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -237,7 +241,7 @@ SEANCE_CINE = Subcategory(
 )
 EVENEMENT_CINE = Subcategory(
     id="EVENEMENT_CINE",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Événement cinématographique",
     app_label="Événement cinéma",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -254,7 +258,7 @@ EVENEMENT_CINE = Subcategory(
 )
 FESTIVAL_CINE = Subcategory(
     id="FESTIVAL_CINE",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Festival de cinéma",
     app_label="Festival de cinéma",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -271,7 +275,7 @@ FESTIVAL_CINE = Subcategory(
 )
 CINE_VENTE_DISTANCE = Subcategory(
     id="CINE_VENTE_DISTANCE",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Cinéma vente à distance",
     app_label="Cinéma",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -290,7 +294,7 @@ CINE_VENTE_DISTANCE = Subcategory(
 
 CINE_PLEIN_AIR = Subcategory(
     id="CINE_PLEIN_AIR",
-    category_id=categories.CINEMA.id,
+    category=categories.CINEMA,
     pro_label="Cinéma plein air",
     app_label="Cinéma plein air",
     search_group_name=SearchGroups.FILMS_SERIES_CINEMA.name,
@@ -311,7 +315,7 @@ CINE_PLEIN_AIR = Subcategory(
 
 CONFERENCE = Subcategory(
     id="CONFERENCE",
-    category_id=categories.CONFERENCE_RENCONTRE.id,
+    category=categories.CONFERENCE_RENCONTRE,
     pro_label="Conférence",
     app_label="Conférence",
     search_group_name=SearchGroups.RENCONTRES_CONFERENCES.name,
@@ -328,7 +332,7 @@ CONFERENCE = Subcategory(
 )
 RENCONTRE = Subcategory(
     id="RENCONTRE",
-    category_id=categories.CONFERENCE_RENCONTRE.id,
+    category=categories.CONFERENCE_RENCONTRE,
     pro_label="Rencontre",
     app_label="Rencontre",
     search_group_name=SearchGroups.RENCONTRES_CONFERENCES.name,
@@ -345,7 +349,7 @@ RENCONTRE = Subcategory(
 )
 DECOUVERTE_METIERS = Subcategory(
     id="DECOUVERTE_METIERS",
-    category_id=categories.CONFERENCE_RENCONTRE.id,
+    category=categories.CONFERENCE_RENCONTRE,
     pro_label="Découverte des métiers",
     app_label="Découverte des métiers",
     search_group_name=SearchGroups.RENCONTRES_CONFERENCES.name,
@@ -363,7 +367,7 @@ DECOUVERTE_METIERS = Subcategory(
 )
 SALON = Subcategory(
     id="SALON",
-    category_id=categories.CONFERENCE_RENCONTRE.id,
+    category=categories.CONFERENCE_RENCONTRE,
     pro_label="Salon, Convention",
     app_label="Salon, Convention",
     search_group_name=SearchGroups.RENCONTRES_CONFERENCES.name,
@@ -380,7 +384,7 @@ SALON = Subcategory(
 )
 RENCONTRE_EN_LIGNE = Subcategory(
     id="RENCONTRE_EN_LIGNE",
-    category_id=categories.CONFERENCE_RENCONTRE.id,
+    category=categories.CONFERENCE_RENCONTRE,
     pro_label="Rencontre en ligne",
     app_label="Rencontre en ligne",
     search_group_name=SearchGroups.RENCONTRES_CONFERENCES.name,
@@ -400,7 +404,7 @@ RENCONTRE_EN_LIGNE = Subcategory(
 # region JEU
 CONCOURS = Subcategory(
     id="CONCOURS",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Concours - jeux",
     app_label="Concours - jeux",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -417,7 +421,7 @@ CONCOURS = Subcategory(
 )
 RENCONTRE_JEU = Subcategory(
     id="RENCONTRE_JEU",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Rencontres - jeux",
     app_label="Rencontres - jeux",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -434,7 +438,7 @@ RENCONTRE_JEU = Subcategory(
 )
 ESCAPE_GAME = Subcategory(
     id="ESCAPE_GAME",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Escape game",
     app_label="Escape game",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -451,7 +455,7 @@ ESCAPE_GAME = Subcategory(
 )
 EVENEMENT_JEU = Subcategory(
     id="EVENEMENT_JEU",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Événements - jeux",
     app_label="Événements - jeux",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -468,7 +472,7 @@ EVENEMENT_JEU = Subcategory(
 )
 JEU_EN_LIGNE = Subcategory(
     id="JEU_EN_LIGNE",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Jeux en ligne",
     app_label="Jeux en ligne",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -487,7 +491,7 @@ JEU_EN_LIGNE = Subcategory(
 )
 ABO_JEU_VIDEO = Subcategory(
     id="ABO_JEU_VIDEO",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Abonnement jeux vidéos",
     app_label="Abonnement jeux vidéos",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -506,7 +510,7 @@ ABO_JEU_VIDEO = Subcategory(
 )
 ABO_LUDOTHEQUE = Subcategory(
     id="ABO_LUDOTHEQUE",
-    category_id=categories.JEU.id,
+    category=categories.JEU,
     pro_label="Abonnement ludothèque",
     app_label="Abonnement ludothèque",
     search_group_name=SearchGroups.JEUX_JEUX_VIDEOS.name,
@@ -529,7 +533,7 @@ ABO_LUDOTHEQUE = Subcategory(
 
 LIVRE_PAPIER = Subcategory(
     id="LIVRE_PAPIER",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Livre papier",
     app_label="Livre",
     search_group_name=SearchGroups.LIVRES.name,
@@ -546,7 +550,7 @@ LIVRE_PAPIER = Subcategory(
 )
 LIVRE_NUMERIQUE = Subcategory(
     id="LIVRE_NUMERIQUE",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Livre numérique, e-book",
     app_label="Livre numérique, e-book",
     search_group_name=SearchGroups.LIVRES.name,
@@ -564,7 +568,7 @@ LIVRE_NUMERIQUE = Subcategory(
 )
 TELECHARGEMENT_LIVRE_AUDIO = Subcategory(
     id="TELECHARGEMENT_LIVRE_AUDIO",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Livre audio à télécharger",
     app_label="Livre audio à télécharger",
     search_group_name=SearchGroups.PLATEFORMES_EN_LIGNE.name,
@@ -582,7 +586,7 @@ TELECHARGEMENT_LIVRE_AUDIO = Subcategory(
 )
 LIVRE_AUDIO_PHYSIQUE = Subcategory(
     id="LIVRE_AUDIO_PHYSIQUE",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Livre audio sur support physique",
     app_label="Livre audio sur support physique",
     search_group_name=SearchGroups.LIVRES.name,
@@ -600,7 +604,7 @@ LIVRE_AUDIO_PHYSIQUE = Subcategory(
 )
 ABO_BIBLIOTHEQUE = Subcategory(
     id="ABO_BIBLIOTHEQUE",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Abonnement (bibliothèques, médiathèques...)",
     app_label="Abonnement (bibliothèques, médiathèques...)",
     search_group_name=SearchGroups.BIBLIOTHEQUES_MEDIATHEQUE.name,
@@ -617,7 +621,7 @@ ABO_BIBLIOTHEQUE = Subcategory(
 )
 ABO_LIVRE_NUMERIQUE = Subcategory(
     id="ABO_LIVRE_NUMERIQUE",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Abonnement livres numériques",
     app_label="Abonnement livres numériques",
     search_group_name=SearchGroups.LIVRES.name,
@@ -635,7 +639,7 @@ ABO_LIVRE_NUMERIQUE = Subcategory(
 )
 FESTIVAL_LIVRE = Subcategory(
     id="FESTIVAL_LIVRE",
-    category_id=categories.LIVRE.id,
+    category=categories.LIVRE,
     pro_label="Festival et salon du livre",
     app_label="Festival et salon du livre",
     search_group_name=SearchGroups.LIVRES.name,
@@ -652,7 +656,7 @@ FESTIVAL_LIVRE = Subcategory(
 )
 CARTE_JEUNES = Subcategory(
     id="CARTE_JEUNES",
-    category_id=categories.CARTE_JEUNES.id,
+    category=categories.CARTE_JEUNES,
     pro_label="Carte jeunes",
     app_label="Carte jeunes",
     search_group_name=SearchGroups.CARTES_JEUNES.name,
@@ -673,7 +677,7 @@ CARTE_JEUNES = Subcategory(
 
 CARTE_MUSEE = Subcategory(
     id="CARTE_MUSEE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Cartes musées, patrimoine, architecture, arts visuels",
     app_label="Cartes musées, patrimoine...",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -690,7 +694,7 @@ CARTE_MUSEE = Subcategory(
 )
 ABO_MUSEE = Subcategory(
     id="ABO_MUSEE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Entrée libre ou abonnement musée, patrimoine…",
     app_label="Entrée libre ou abonnement musée",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -707,7 +711,7 @@ ABO_MUSEE = Subcategory(
 )
 VISITE = Subcategory(
     id="VISITE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Visite",
     app_label="Visite",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -724,7 +728,7 @@ VISITE = Subcategory(
 )
 VISITE_GUIDEE = Subcategory(
     id="VISITE_GUIDEE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Visite guidée",
     app_label="Visite guidée",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -741,7 +745,7 @@ VISITE_GUIDEE = Subcategory(
 )
 EVENEMENT_PATRIMOINE = Subcategory(
     id="EVENEMENT_PATRIMOINE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Événement et atelier patrimoine",
     app_label="Événement et atelier patrimoine",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -758,7 +762,7 @@ EVENEMENT_PATRIMOINE = Subcategory(
 )
 VISITE_VIRTUELLE = Subcategory(
     id="VISITE_VIRTUELLE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Visite virtuelle",
     app_label="Visite virtuelle",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -776,7 +780,7 @@ VISITE_VIRTUELLE = Subcategory(
 )
 MUSEE_VENTE_DISTANCE = Subcategory(
     id="MUSEE_VENTE_DISTANCE",
-    category_id=categories.MUSEE.id,
+    category=categories.MUSEE,
     pro_label="Musée vente à distance",
     app_label="Musée vente à distance",
     search_group_name=SearchGroups.MUSEES_VISITES_CULTURELLES.name,
@@ -797,7 +801,7 @@ MUSEE_VENTE_DISTANCE = Subcategory(
 
 CONCERT = Subcategory(
     id="CONCERT",
-    category_id=categories.MUSIQUE_LIVE.id,
+    category=categories.MUSIQUE_LIVE,
     pro_label="Concert",
     app_label="Concert",
     search_group_name=SearchGroups.CONCERTS_FESTIVALS.name,
@@ -815,7 +819,7 @@ CONCERT = Subcategory(
 )
 EVENEMENT_MUSIQUE = Subcategory(
     id="EVENEMENT_MUSIQUE",
-    category_id=categories.MUSIQUE_LIVE.id,
+    category=categories.MUSIQUE_LIVE,
     pro_label="Autre type d'événement musical",
     app_label="Autre type d'événement musical",
     search_group_name=SearchGroups.CONCERTS_FESTIVALS.name,
@@ -833,7 +837,7 @@ EVENEMENT_MUSIQUE = Subcategory(
 )
 LIVESTREAM_MUSIQUE = Subcategory(
     id="LIVESTREAM_MUSIQUE",
-    category_id=categories.MUSIQUE_LIVE.id,
+    category=categories.MUSIQUE_LIVE,
     pro_label="Livestream musical",
     app_label="Livestream musical",
     search_group_name=SearchGroups.EVENEMENTS_EN_LIGNE.name,
@@ -851,7 +855,7 @@ LIVESTREAM_MUSIQUE = Subcategory(
 )
 ABO_CONCERT = Subcategory(
     id="ABO_CONCERT",
-    category_id=categories.MUSIQUE_LIVE.id,
+    category=categories.MUSIQUE_LIVE,
     pro_label="Abonnement concert",
     app_label="Abonnement concert",
     search_group_name=SearchGroups.CONCERTS_FESTIVALS.name,
@@ -868,7 +872,7 @@ ABO_CONCERT = Subcategory(
 )
 FESTIVAL_MUSIQUE = Subcategory(
     id="FESTIVAL_MUSIQUE",
-    category_id=categories.MUSIQUE_LIVE.id,
+    category=categories.MUSIQUE_LIVE,
     pro_label="Festival de musique",
     app_label="Festival de musique",
     search_group_name=SearchGroups.CONCERTS_FESTIVALS.name,
@@ -888,7 +892,7 @@ FESTIVAL_MUSIQUE = Subcategory(
 # region MUSIQUE_ENREGISTREE
 SUPPORT_PHYSIQUE_MUSIQUE = Subcategory(
     id="SUPPORT_PHYSIQUE_MUSIQUE",
-    category_id=categories.MUSIQUE_ENREGISTREE.id,
+    category=categories.MUSIQUE_ENREGISTREE,
     pro_label="Support physique (CD, vinyle...)",
     app_label="Support physique (CD, vinyle...)",
     search_group_name=SearchGroups.CD_VINYLE_MUSIQUE_EN_LIGNE.name,
@@ -905,7 +909,7 @@ SUPPORT_PHYSIQUE_MUSIQUE = Subcategory(
 )
 TELECHARGEMENT_MUSIQUE = Subcategory(
     id="TELECHARGEMENT_MUSIQUE",
-    category_id=categories.MUSIQUE_ENREGISTREE.id,
+    category=categories.MUSIQUE_ENREGISTREE,
     pro_label="Téléchargement de musique",
     app_label="Téléchargement de musique",
     search_group_name=SearchGroups.CD_VINYLE_MUSIQUE_EN_LIGNE.name,
@@ -923,7 +927,7 @@ TELECHARGEMENT_MUSIQUE = Subcategory(
 )
 ABO_PLATEFORME_MUSIQUE = Subcategory(
     id="ABO_PLATEFORME_MUSIQUE",
-    category_id=categories.MUSIQUE_ENREGISTREE.id,
+    category=categories.MUSIQUE_ENREGISTREE,
     pro_label="Abonnement plateforme musicale",
     app_label="Abonnement plateforme musicale",
     search_group_name=SearchGroups.CD_VINYLE_MUSIQUE_EN_LIGNE.name,
@@ -941,7 +945,7 @@ ABO_PLATEFORME_MUSIQUE = Subcategory(
 )
 CAPTATION_MUSIQUE = Subcategory(
     id="CAPTATION_MUSIQUE",
-    category_id=categories.MUSIQUE_ENREGISTREE.id,
+    category=categories.MUSIQUE_ENREGISTREE,
     pro_label="Captation musicale",
     app_label="Captation musicale",
     search_group_name=SearchGroups.CD_VINYLE_MUSIQUE_EN_LIGNE.name,
@@ -962,7 +966,7 @@ CAPTATION_MUSIQUE = Subcategory(
 # region PRATIQUE
 SEANCE_ESSAI_PRATIQUE_ART = Subcategory(
     id="SEANCE_ESSAI_PRATIQUE_ART",
-    category_id=categories.PRATIQUE_ART.id,
+    category=categories.PRATIQUE_ART,
     pro_label="Séance d'essai",
     app_label="Séance d'essai",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
@@ -979,7 +983,7 @@ SEANCE_ESSAI_PRATIQUE_ART = Subcategory(
 )
 ATELIER_PRATIQUE_ART = Subcategory(
     id="ATELIER_PRATIQUE_ART",
-    category_id=categories.PRATIQUE_ART.id,
+    category=categories.PRATIQUE_ART,
     pro_label="Atelier, stage de pratique artistique",
     app_label="Atelier, stage de pratique artistique",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
@@ -996,7 +1000,7 @@ ATELIER_PRATIQUE_ART = Subcategory(
 )
 ABO_PRATIQUE_ART = Subcategory(
     id="ABO_PRATIQUE_ART",
-    category_id=categories.PRATIQUE_ART.id,
+    category=categories.PRATIQUE_ART,
     pro_label="Abonnement pratique artistique",
     app_label="Abonnement pratique artistique",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
@@ -1013,7 +1017,7 @@ ABO_PRATIQUE_ART = Subcategory(
 )
 PRATIQUE_ART_VENTE_DISTANCE = Subcategory(
     id="PRATIQUE_ART_VENTE_DISTANCE",
-    category_id=categories.PRATIQUE_ART.id,
+    category=categories.PRATIQUE_ART,
     pro_label="Pratique artistique - vente à distance",
     app_label="Pratique artistique - vente à distance",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
@@ -1030,7 +1034,7 @@ PRATIQUE_ART_VENTE_DISTANCE = Subcategory(
 )
 PLATEFORME_PRATIQUE_ARTISTIQUE = Subcategory(
     id="PLATEFORME_PRATIQUE_ARTISTIQUE",
-    category_id=categories.PRATIQUE_ART.id,
+    category=categories.PRATIQUE_ART,
     pro_label="Pratique artistique - plateforme en ligne",
     app_label="Plateforme de pratique artistique",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
@@ -1048,7 +1052,7 @@ PLATEFORME_PRATIQUE_ARTISTIQUE = Subcategory(
 )
 LIVESTREAM_PRATIQUE_ARTISTIQUE = Subcategory(
     id="LIVESTREAM_PRATIQUE_ARTISTIQUE",
-    category_id=categories.PRATIQUE_ART.id,
+    category=categories.PRATIQUE_ART,
     pro_label="Pratique artistique - livestream",
     app_label="Pratique artistique - livestream",
     search_group_name=SearchGroups.EVENEMENTS_EN_LIGNE.name,
@@ -1068,7 +1072,7 @@ LIVESTREAM_PRATIQUE_ARTISTIQUE = Subcategory(
 # region MEDIAS
 ABO_PRESSE_EN_LIGNE = Subcategory(
     id="ABO_PRESSE_EN_LIGNE",
-    category_id=categories.MEDIA.id,
+    category=categories.MEDIA,
     pro_label="Abonnement presse en ligne",
     app_label="Abonnement presse en ligne",
     search_group_name=SearchGroups.MEDIA_PRESSE.name,
@@ -1086,7 +1090,7 @@ ABO_PRESSE_EN_LIGNE = Subcategory(
 )
 PODCAST = Subcategory(
     id="PODCAST",
-    category_id=categories.MEDIA.id,
+    category=categories.MEDIA,
     pro_label="Podcast",
     app_label="Podcast",
     search_group_name=SearchGroups.MEDIA_PRESSE.name,
@@ -1104,7 +1108,7 @@ PODCAST = Subcategory(
 )
 APP_CULTURELLE = Subcategory(
     id="APP_CULTURELLE",
-    category_id=categories.MEDIA.id,
+    category=categories.MEDIA,
     pro_label="Application culturelle",
     app_label="Application culturelle",
     search_group_name=SearchGroups.MEDIA_PRESSE.name,
@@ -1124,7 +1128,7 @@ APP_CULTURELLE = Subcategory(
 # region SPECTACLE
 SPECTACLE_REPRESENTATION = Subcategory(
     id="SPECTACLE_REPRESENTATION",
-    category_id=categories.SPECTACLE.id,
+    category=categories.SPECTACLE,
     pro_label="Spectacle, représentation",
     app_label="Spectacle, représentation",
     search_group_name=SearchGroups.SPECTACLES.name,
@@ -1142,7 +1146,7 @@ SPECTACLE_REPRESENTATION = Subcategory(
 )
 SPECTACLE_ENREGISTRE = Subcategory(
     id="SPECTACLE_ENREGISTRE",
-    category_id=categories.SPECTACLE.id,
+    category=categories.SPECTACLE,
     pro_label="Spectacle enregistré",
     app_label="Spectacle enregistré",
     search_group_name=SearchGroups.SPECTACLES.name,
@@ -1160,7 +1164,7 @@ SPECTACLE_ENREGISTRE = Subcategory(
 )
 LIVESTREAM_EVENEMENT = Subcategory(
     id="LIVESTREAM_EVENEMENT",
-    category_id=categories.SPECTACLE.id,
+    category=categories.SPECTACLE,
     pro_label="Livestream d'événement",
     app_label="Livestream d'événement",
     search_group_name=SearchGroups.EVENEMENTS_EN_LIGNE.name,
@@ -1178,7 +1182,7 @@ LIVESTREAM_EVENEMENT = Subcategory(
 )
 FESTIVAL_SPECTACLE = Subcategory(
     id="FESTIVAL_SPECTACLE",
-    category_id=categories.SPECTACLE.id,
+    category=categories.SPECTACLE,
     pro_label="Festival",
     app_label="Festival",
     search_group_name=SearchGroups.SPECTACLES.name,
@@ -1196,7 +1200,7 @@ FESTIVAL_SPECTACLE = Subcategory(
 )
 ABO_SPECTACLE = Subcategory(
     id="ABO_SPECTACLE",
-    category_id=categories.SPECTACLE.id,
+    category=categories.SPECTACLE,
     pro_label="Abonnement spectacle",
     app_label="Abonnement spectacle",
     search_group_name=SearchGroups.SPECTACLES.name,
@@ -1213,7 +1217,7 @@ ABO_SPECTACLE = Subcategory(
 )
 SPECTACLE_VENTE_DISTANCE = Subcategory(
     id="SPECTACLE_VENTE_DISTANCE",
-    category_id=categories.SPECTACLE.id,
+    category=categories.SPECTACLE,
     pro_label="Spectacle vivant - vente à distance",
     app_label="Spectacle vivant - vente à distance",
     search_group_name=SearchGroups.SPECTACLES.name,
@@ -1232,7 +1236,7 @@ SPECTACLE_VENTE_DISTANCE = Subcategory(
 # region INSTRUMENT
 ACHAT_INSTRUMENT = Subcategory(
     id="ACHAT_INSTRUMENT",
-    category_id=categories.INSTRUMENT.id,
+    category=categories.INSTRUMENT,
     pro_label="Achat instrument",
     app_label="Achat instrument",
     search_group_name=SearchGroups.INSTRUMENTS.name,
@@ -1249,7 +1253,7 @@ ACHAT_INSTRUMENT = Subcategory(
 )
 BON_ACHAT_INSTRUMENT = Subcategory(
     id="BON_ACHAT_INSTRUMENT",
-    category_id=categories.INSTRUMENT.id,
+    category=categories.INSTRUMENT,
     pro_label="Bon d'achat instrument",
     app_label="Bon d'achat instrument",
     search_group_name=SearchGroups.INSTRUMENTS.name,
@@ -1266,7 +1270,7 @@ BON_ACHAT_INSTRUMENT = Subcategory(
 )
 LOCATION_INSTRUMENT = Subcategory(
     id="LOCATION_INSTRUMENT",
-    category_id=categories.INSTRUMENT.id,
+    category=categories.INSTRUMENT,
     pro_label="Location instrument",
     app_label="Location instrument",
     search_group_name=SearchGroups.INSTRUMENTS.name,
@@ -1283,7 +1287,7 @@ LOCATION_INSTRUMENT = Subcategory(
 )
 PARTITION = Subcategory(
     id="PARTITION",
-    category_id=categories.INSTRUMENT.id,
+    category=categories.INSTRUMENT,
     pro_label="Partition",
     app_label="Partition",
     search_group_name=SearchGroups.INSTRUMENTS.name,
@@ -1302,7 +1306,7 @@ PARTITION = Subcategory(
 # region BEAUX_ARTS
 MATERIEL_ART_CREATIF = Subcategory(
     id="MATERIEL_ART_CREATIF",
-    category_id=categories.BEAUX_ARTS.id,
+    category=categories.BEAUX_ARTS,
     pro_label="Matériel arts créatifs",
     app_label="Matériel arts créatifs",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
@@ -1321,7 +1325,7 @@ MATERIEL_ART_CREATIF = Subcategory(
 # region TECHNICAL
 ACTIVATION_EVENT = Subcategory(
     id="ACTIVATION_EVENT",
-    category_id=categories.TECHNIQUE.id,
+    category=categories.TECHNIQUE,
     pro_label="Catégorie technique d'événement d'activation ",
     app_label="Catégorie technique d'événement d'activation ",
     search_group_name=SearchGroups.NONE.name,
@@ -1340,7 +1344,7 @@ ACTIVATION_EVENT = Subcategory(
 )
 ACTIVATION_THING = Subcategory(
     id="ACTIVATION_THING",
-    category_id=categories.TECHNIQUE.id,
+    category=categories.TECHNIQUE,
     pro_label="Catégorie technique de thing d'activation",
     app_label="Catégorie technique de thing d'activation",
     search_group_name=SearchGroups.NONE.name,
@@ -1359,7 +1363,7 @@ ACTIVATION_THING = Subcategory(
 )
 JEU_SUPPORT_PHYSIQUE = Subcategory(
     id="JEU_SUPPORT_PHYSIQUE",
-    category_id=categories.TECHNIQUE.id,
+    category=categories.TECHNIQUE,
     pro_label="Catégorie technique Jeu support physique",
     app_label="Catégorie technique Jeu support physique",
     search_group_name=SearchGroups.NONE.name,
@@ -1379,7 +1383,7 @@ JEU_SUPPORT_PHYSIQUE = Subcategory(
 )
 OEUVRE_ART = Subcategory(
     id="OEUVRE_ART",
-    category_id=categories.TECHNIQUE.id,
+    category=categories.TECHNIQUE,
     pro_label="Catégorie technique d'oeuvre d'art",
     app_label="Catégorie technique d'oeuvre d'art",
     search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -373,7 +373,7 @@ def get_educational_categories() -> dict:
     educational_subcategories = [
         subcategory for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.can_be_educational == True
     ]
-    educational_categories_ids = list(set(subcategory.category_id for subcategory in educational_subcategories))
+    educational_categories_ids = list(set(subcategory.category.id for subcategory in educational_subcategories))
     educational_categories = [
         category for category in categories.ALL_CATEGORIES if category.id in educational_categories_ids
     ]

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -577,12 +577,7 @@ class Offer(PcObject, Base, Model, ExtraDataMixin, DeactivableMixin, ValidationM
 
     @property
     def category(self) -> categories.Category:
-        category_id = self.subcategory.category_id
-
-        try:
-            return categories.ALL_CATEGORIES_DICT[category_id]
-        except KeyError:
-            raise ValueError(f"Unexpected category_id '{category_id}' for offer {self.id}")
+        return self.subcategory.category
 
     @property
     def image(self) -> OfferImage | None:

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -150,7 +150,7 @@ def get_offers_by_filters(
         query = _filter_by_creation_mode(query, creation_mode)
     if category_id is not None:
         requested_subcategories = [
-            subcategory.id for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.category_id == category_id
+            subcategory.id for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.category.id == category_id
         ]
         query = query.filter(Offer.subcategoryId.in_(requested_subcategories))
     if name_keywords_or_isbn is not None:
@@ -230,7 +230,7 @@ def get_collective_offers_by_filters(
         query = query.filter(CollectiveOffer.venueId == venue_id)
     if category_id is not None:
         requested_subcategories = [
-            subcategory.id for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.category_id == category_id
+            subcategory.id for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.category.id == category_id
         ]
         query = query.filter(CollectiveOffer.subcategoryId.in_(requested_subcategories))
     if name_keywords is not None:
@@ -310,7 +310,7 @@ def get_collective_offers_template_by_filters(
         query = query.filter(CollectiveOfferTemplate.venueId == venue_id)
     if category_id is not None:
         requested_subcategories = [
-            subcategory.id for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.category_id == category_id
+            subcategory.id for subcategory in subcategories.ALL_SUBCATEGORIES if subcategory.category.id == category_id
         ]
         query = query.filter(CollectiveOfferTemplate.subcategoryId.in_(requested_subcategories))
     if name_keywords is not None:

--- a/api/src/pcapi/core/users/external/__init__.py
+++ b/api/src/pcapi/core/users/external/__init__.py
@@ -245,7 +245,7 @@ def _get_bookings_categories_and_subcategories(user_bookings: list[Booking]) -> 
     bookings_by_subcategories = defaultdict(list)
     for booking in user_bookings:
         if booking.status != BookingStatus.CANCELLED:
-            booking_categories.add(booking.stock.offer.subcategory.category_id)
+            booking_categories.add(booking.stock.offer.subcategory.category.id)
             bookings_by_subcategories[booking.stock.offer.subcategoryId].append(booking)
 
     sorted_subcategories_items = sorted(

--- a/api/tests/routes/adage_iframe/get_categories_test.py
+++ b/api/tests/routes/adage_iframe/get_categories_test.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.core.categories.categories import Category
+from pcapi.core.categories import categories
 from pcapi.core.categories.subcategories import Subcategory
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
     (
         Subcategory(
             id="ABO_BIBLIOTHEQUE",
-            category_id="LIVRE",
+            category=categories.LIVRE,
             pro_label="Abonnement (bibliothèques, médiathèques...)",
             app_label="Abonnement (bibliothèques, médiathèques...)",
             search_group_name="LIVRE",
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
         ),
         Subcategory(
             id="CINE_PLEIN_AIR",
-            category_id="CINEMA",
+            category=categories.CINEMA,
             pro_label="Cinéma plein air",
             app_label="Cinéma plein air",
             search_group_name="CINEMA",
@@ -53,11 +53,11 @@ pytestmark = pytest.mark.usefixtures("db_session")
 @patch(
     "pcapi.core.categories.categories.ALL_CATEGORIES",
     (
-        Category(
+        categories.Category(
             id="LIVRE",
             pro_label="Livre",
         ),
-        Category(
+        categories.Category(
             id="CINEMA",
             pro_label="Cinéma",
         ),

--- a/api/tests/routes/pro/get_categories_test.py
+++ b/api/tests/routes/pro/get_categories_test.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.core.categories.categories import Category
+from pcapi.core.categories import categories
 from pcapi.core.categories.subcategories import Subcategory
 import pcapi.core.users.factories as users_factories
 
@@ -12,7 +12,7 @@ import pcapi.core.users.factories as users_factories
     (
         Subcategory(
             id="ABO_BIBLIOTHEQUE",
-            category_id="LIVRE",
+            category=categories.LIVRE,
             pro_label="Abonnement (bibliothèques, médiathèques...)",
             app_label="Abonnement (bibliothèques, médiathèques...)",
             search_group_name="LIVRE",
@@ -29,7 +29,7 @@ import pcapi.core.users.factories as users_factories
         ),
         Subcategory(
             id="CINE_PLEIN_AIR",
-            category_id="CINEMA",
+            category=categories.CINEMA,
             pro_label="Cinéma plein air",
             app_label="Cinéma plein air",
             search_group_name="CINEMA",
@@ -49,11 +49,11 @@ import pcapi.core.users.factories as users_factories
 @patch(
     "pcapi.core.categories.categories.ALL_CATEGORIES",
     (
-        Category(
+        categories.Category(
             id="LIVRE",
             pro_label="Livre",
         ),
-        Category(
+        categories.Category(
             id="CINEMA",
             pro_label="Cinéma",
         ),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16127

## But de la pull request

Ne plus utiliser l'id de la catégorie lors de la définition d'une sous-catégorie, mais directement la catégorie : cela évite d'avoir à vérifier que l'id correspond bien à une catégorie existante.