### PR TITLE
(BSR)[API] test: Fix order of cashflows in PDF invoice

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1904,6 +1904,10 @@ def get_invoice_period(invoice_date: datetime.datetime) -> typing.Tuple[datetime
 
 
 def _prepare_invoice_context(invoice: models.Invoice, use_reimbursement_point: bool) -> dict:
+    # Easier to sort here and not in PostgreSQL, and not much slower
+    # because there are very few cashflows (and usually only 1).
+    cashflows = sorted(invoice.cashflows, key=lambda c: (c.creationDate, c.id))
+
     invoice_lines = sorted(invoice.lines, key=lambda k: (k.group["position"], -k.rate))
     total_used_bookings_amount = 0
     total_contribution_amount = 0
@@ -1943,6 +1947,7 @@ def _prepare_invoice_context(invoice: models.Invoice, use_reimbursement_point: b
     period_start, period_end = get_invoice_period(invoice.date)  # type: ignore [arg-type]
     return dict(
         invoice=invoice,
+        cashflows=cashflows,
         groups=groups,
         venue=venue,
         reimbursement_point=reimbursement_point,

--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -276,7 +276,7 @@
     </tr>
     </thead>
     <tbody>
-{% for cashflow in invoice.cashflows %}
+{% for cashflow in cashflows %}
     <tr>
         <td>Virement {{ cashflow.bankAccount.iban }}</td>
         <td class="cashflow_batch_label">{{ cashflow.batch.label }}</td>


### PR DESCRIPTION
In reality, all invoices show a single cashflow. So this commit does
not fix any bug.

However, one of our test has an invoice with multiple cashflows. It
sometimes failed because the order of `invoice.cashflows` was not
reliable.