### PR TITLE
(PC-16746)[API] fix: fix backoffice API in case of expired token

### DIFF
--- a/api/src/pcapi/core/permissions/utils.py
+++ b/api/src/pcapi/core/permissions/utils.py
@@ -4,10 +4,10 @@ import typing
 
 from flask import Response
 from flask import request
+from jwt import ExpiredSignatureError
 
 from pcapi import settings
 from pcapi.core.auth.api import BadPCToken
-from pcapi.core.auth.api import ExpiredTokenError
 from pcapi.core.auth.api import NotAPassCultureTeamAccountError
 from pcapi.core.auth.api import authenticate_from_bearer
 from pcapi.core.auth.utils import _set_current_permissions
@@ -39,7 +39,7 @@ def permission_required(permission: Permissions) -> typing.Callable:
                 user, user_permissions = authenticate_from_bearer(authorization)
             except BadPCToken:
                 raise ApiErrors({"global": "bad token"}, status_code=403)
-            except ExpiredTokenError:
+            except ExpiredSignatureError:
                 raise ApiErrors({"global": "authentication expired"}, status_code=403)
             except NotAPassCultureTeamAccountError:
                 raise ApiErrors({"global": "unknown user"}, status_code=403)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16746

## But de la pull request

corriger une erreur Sentry dans le cas ou un appel est fait à l'API backoffice avec un token expiré

## Implémentation

- RAS

## Informations supplémentaires

- RAS

## Modifications du schéma de la base de données

- RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai relu attentivement les migrations, en particulier pour éviter les _locks_~~
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [ ] ~~J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)~~
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
