### PR TITLE
(PC-16708)[API] feat: Batch/Sendinblue: New rule for is_former_beneficiary attribute

### DIFF
--- a/api/src/pcapi/core/users/external/models.py
+++ b/api/src/pcapi/core/users/external/models.py
@@ -25,7 +25,7 @@ class UserAttributes:
     is_active: bool  # Added for Zendesk
     is_beneficiary: bool
     is_current_beneficiary: bool  # Beneficiary with a non-expired remaining credit
-    is_former_beneficiary: bool  # Beneficiary which credit is expired or spent
+    is_former_beneficiary: bool  # Beneficiary whose last possible credit is definitely expired or spent
     is_eligible: bool
     is_email_validated: bool
     is_phone_validated: bool  # Added for Zendesk

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -475,15 +475,12 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
         )
 
     @hybrid_property
-    def is_ex_beneficiary(self) -> bool:
+    def has_remaining_credit(self) -> bool:
         today = datetime.combine(date.today(), datetime.min.time())
         return (
-            self.is_beneficiary
-            and self.deposit is not None
-            and self.deposit.expirationDate is not None
-            and (
-                self.deposit.expirationDate <= today or self.deposit.expirationDate > today and self.wallet_balance == 0
-            )
+            self.deposit is not None
+            and (self.deposit.expirationDate is None or self.deposit.expirationDate > today)
+            and self.wallet_balance > 0
         )
 
     @hybrid_property

--- a/api/tests/core/users/external/user_automations_test.py
+++ b/api/tests/core/users/external/user_automations_test.py
@@ -423,3 +423,48 @@ class UserAutomationsTest:
 
         assert mock_update_batch.call_args.args[0] == users[2].id
         assert mock_update_batch.call_args.args[1].is_former_beneficiary is True
+
+    def test_get_ex_underage_beneficiaries_who_can_no_longer_recredit(self):
+        with freeze_time("2021-09-10 15:00:00"):
+            user = users_factories.UnderageBeneficiaryFactory(
+                email="underage+test@example.net",
+                dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=17, months=1),
+            )
+            assert user.deposit.expirationDate == datetime(2022, 8, 10)  # at birthday
+
+        with freeze_time("2022-08-10 05:00:00"):
+            results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
+            assert not results
+
+        with freeze_time("2023-08-10 05:00:00"):
+            results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
+            assert not results
+
+        with freeze_time("2023-08-11 05:00:00"):
+            results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
+            assert results == [user]
+
+        with freeze_time("2023-08-12 05:00:00"):
+            results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
+            assert not results
+
+    @patch("pcapi.core.users.external.update_batch_user")
+    @patch("pcapi.core.users.external.update_sendinblue_user")
+    def test_users_whose_credit_expired_today_automation_underage(self, mock_update_sendinblue, mock_update_batch):
+        with freeze_time("2021-09-10 15:00:00"):
+            user = users_factories.UnderageBeneficiaryFactory(
+                email="underage+test@example.net",
+                dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=17, months=1),
+            )
+
+        with freeze_time("2023-08-11 05:00:00"):
+            user_automations.users_whose_credit_expired_today_automation()
+
+        mock_update_sendinblue.assert_called_once()
+        mock_update_batch.assert_called_once()
+
+        assert mock_update_sendinblue.call_args.args[0] == user.email
+        assert mock_update_sendinblue.call_args.args[1].is_former_beneficiary is True
+
+        assert mock_update_batch.call_args.args[0] == user.id
+        assert mock_update_batch.call_args.args[1].is_former_beneficiary is True


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16708

## But de la pull request

Suite à une demande du marketing, on change la règle de l'attribut `is_former_beneficiary` envoyé à Batch et Sendinblue, pour que seuls les utilisateurs qui n'ont plus et n'auront plus de possibilité de recharge soient considérés comme ex-bénéficiaires.
Cela exclut donc tous les _underage beneficiaries_ qui ont encore la possibilité de demander un crédit 18 ans.

Plus de détails dans le ticket

## Implémentation

## Informations supplémentaires

Les ex-_underage_ qui n'ont pas demandé un crédit 18 ans à leur dix-neuvième anniversaire deviennent donc `is_former_beneficiary = True` à cet anniversaire, qui n'est pas sur une action. On enrichit donc l'automation de crédit expiré pour mettre à jour ces utilisateurs au bon moment.

Une fois déployé en production, un rattrappage devra être fait en réenvoyant les attributs des utilisateurs jeunes qui ont à la fois le rôle `UNDERAGE_BENEFICIARY` et dont le crédit est expiré ; filtrage permettant de cibler ceux qui ont `is_former_beneficiary` à `True` pouvant potentiellement passer à `False`

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
