### PR TITLE
(BSR)[API] feat: add retry on ubble GET requests

### DIFF
--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -8,6 +8,8 @@ from requests import Response
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from pcapi import settings
+
 
 # fmt: off
 # isort: off
@@ -98,4 +100,5 @@ class Session(_SessionMixin, requests.Session):  # type: ignore [misc]
         safe_adapter = HTTPAdapter(max_retries=safe_retry_strategy)
         unsafe_adapter = HTTPAdapter(max_retries=unsafe_retry_strategy)
         self.mount("https://www.demarches-simplifiees.fr", safe_adapter)
+        self.mount(settings.UBBLE_API_URL, safe_adapter)
         self.mount("https://api.batch.com", unsafe_adapter)


### PR DESCRIPTION
to reduce errors on ubble webhook ; the POST requests (called when starting ubble identification) are not impacted


## But de la pull request

Réduire le bruit sur sentry ["Could not update ubble workflow"](https://sentry.internal-passculture.app/organizations/sentry/issues/?environment=production&project=5&query=is%3Aunresolved+Could+not+update+Ubble+workflow&statsPeriod=14d), principalement dû à l'heure actuelle à des erreurs de connexion à l'api d'ubble. 

Il faut savoir qu'[ubble retente jusqu'à 2 fois](https://ubbleai.github.io/developer-documentation/#webhook) quand notre api [renvoie une erreur](https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/external/users_subscription.py#L54), donc a priori il n'y avait pas de souci fonctionnel.