### PR TITLE
(PC-16765)[API] fix: Log error when updating DMS annotation fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,9 @@ jobs:
       - skip_unchanged:
           paths: api
       - run:
+          name: Show installed Python packages
+          command: pip freeze
+      - run:
           name: Check imports are well organized with isort
           when: always
           command: isort . --check-only
@@ -370,6 +373,9 @@ jobs:
       - checkout
       - skip_unchanged:
           paths: api
+      - run:
+          name: Show installed Python packages
+          command: pip freeze
       - run:
           name: Check for alembic multiple heads
           command: |

--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -205,7 +205,7 @@ class DMSGraphQLClient:
         variables = {"dossierNumber": dossier_id}
         return self.execute_query(GET_BIC_QUERY_NAME, variables=variables)
 
-    def update_text_annotation(self, dossier_id: str, instructeur_id: str, annotation_id: str, value: str) -> Any:
+    def update_text_annotation(self, dossier_id: str, instructeur_id: str, annotation_id: str, value: str) -> dict:
         variables = {
             "input": {
                 "dossierId": dossier_id,

--- a/api/src/pcapi/domain/demarches_simplifiees.py
+++ b/api/src/pcapi/domain/demarches_simplifiees.py
@@ -176,7 +176,16 @@ def _find_value_in_fields(fields: list[dict], value_name: str) -> str | None:
 
 def update_demarches_simplifiees_text_annotations(dossier_id: str, annotation_id: str, message: str) -> None:
     client = api_dms.DMSGraphQLClient()
-    client.update_text_annotation(dossier_id, settings.DMS_INSTRUCTOR_ID, annotation_id, message)
+    result = client.update_text_annotation(dossier_id, settings.DMS_INSTRUCTOR_ID, annotation_id, message)
+    errors = result["dossierModifierAnnotationText"].get("errors")  # pylint: disable=unsubscriptable-object
+    if errors:
+        logger.error(
+            "Got error when updating DMS annotation",
+            extra={
+                "errors": errors,
+                "dossier": dossier_id,
+            },
+        )
 
 
 def archive_dossier(dossier_id: str) -> None:


### PR DESCRIPTION
Example of response:

    {
      'dossierModifierAnnotationText': {
        'annotation': None,
        'errors': [{'message': 'L’instructeur n’a pas les droits d’accès à ce dossier'}]
      }
    }

That denotes a problem in the configuration of the procedure. We'll be
happy to know that.


---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16765