### PR TITLE
(PC-16776)[API] feat: Link reimbursement point when processing a v3 applications

### DIFF
--- a/api/tests/core/logging/tests.py
+++ b/api/tests/core/logging/tests.py
@@ -101,6 +101,7 @@ class JsonFormatterTest:
                 "set": {1},
                 "user": user,
                 "bytes": b"encod\xc3\xa9",
+                "nested_complex_object": [{"foo": ["bar"]}],
             },
         )
         serialized = formatter.format(record)
@@ -115,6 +116,7 @@ class JsonFormatterTest:
             "set": [1],
             "user": 7,
             "bytes": "encodé",
+            "nested_complex_object": [{"foo": ["bar"]}],
         }
 
         # gracefully handle non-serializable objects

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -817,6 +817,7 @@ class SaveVenueBankInformationsTest:
             assert bank_information.bic == "SOGEFRPP"
             assert bank_information.iban == "FR7630007000111234567890144"
             assert bank_information.status == BankInformationStatus.ACCEPTED
+            assert venue.current_reimbursement_point_id == venue.id
 
         def test_refused_application(self, mock_dms_graphql_client, app):
             venue = offerers_factories.VenueFactory(businessUnit=None, pricing_point="self")


### PR DESCRIPTION
There still are ongoing v3 applications. When they are validated, a
BankInformation object will be created (as it should), but we should
also create a new VenueReimbursementPointLink, just like we do when
processing a v4 application.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16776

---

+ 1 commit indépendant. **Donc commits à relire séparément.**