### PR TITLE
(BSR)[API] feat: validate email update: fix: user does not exist

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -125,7 +125,7 @@ def validate_user_email(body: serializers.ChangeBeneficiaryEmailBody) -> None:
             {"code": "INVALID_TOKEN", "message": "Token invalide"},
             status_code=400,
         )
-    except exceptions.EmailExistsError:
+    except (exceptions.EmailExistsError, exceptions.UserDoesNotExist):
         # Returning an error message might help the end client find
         # existing email addresses.
         pass


### PR DESCRIPTION
## But de la pull request

Modifier le comportement de la route native `/profile/validate_email` qui permet de valider une modification d'email : si l'utilisateur n'existe pas, alors on renvoie une 204 sans rien modifier. Ceci correspond au comportement pour le cas où l'email existe déjà.

Le cas d'erreur (l'utilisateur n'existe pas) semble arriver lorsque l'utilisateur clique deux fois sur le lien de validation : au second clic, l'email a bien été modifié et on ne retrouve donc plus l'utilisateur avec son ancienne adresse.

Ceci pose deux problèmes (le second est discutable) : 

1. cela créé des erreurs Sentry qui n'en sont pas, il y a bien une erreur mais elle est due au client, pas à l'API.
2. cela permet d'identifier des adresses qui n'existent pas en base.

EDIT : on parle de JWT, donc dans ce contexte, le cas 2. n'est pas envisageable.