### PR TITLE
(PC-16504)[API] feat: add FF: APP_ENABLE_COOKIES_V2

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -119,6 +119,7 @@ class FeatureToggle(enum.Enum):
         "de l'année"
     )
     USE_INSEE_SIRENE_API = "Utiliser la nouvelle API Sirene de l'Insee"
+    APP_ENABLE_COOKIES_V2 = "Activer la gestion conforme des cookies"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -179,6 +180,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.ENABLE_INTERVENTION_ZONE_COLLECTIVE_OFFER,
     FeatureToggle.ENABLE_EAC_FINANCIAL_PROTECTION,
     FeatureToggle.USE_INSEE_SIRENE_API,
+    FeatureToggle.APP_ENABLE_COOKIES_V2,
 )
 
 

--- a/api/src/pcapi/routes/native/v1/serialization/settings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/settings.py
@@ -32,6 +32,7 @@ class SettingsResponse(BaseModel):
     pro_disable_events_qrcode: bool
     allow_account_unsuspension: bool
     account_unsuspension_limit: int
+    app_enable_cookies_v2: bool
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -34,6 +34,7 @@ def get_settings() -> serializers.SettingsResponse:
         FeatureToggle.ALLOW_ACCOUNT_UNSUSPENSION,
         FeatureToggle.APP_ENABLE_AUTOCOMPLETE,
         FeatureToggle.APP_ENABLE_CATEGORY_FILTER_PAGE,
+        FeatureToggle.APP_ENABLE_COOKIES_V2,
     )
 
     return serializers.SettingsResponse(
@@ -62,4 +63,5 @@ def get_settings() -> serializers.SettingsResponse:
         pro_disable_events_qrcode=features[FeatureToggle.PRO_DISABLE_EVENTS_QRCODE],
         allow_account_unsuspension=features[FeatureToggle.ALLOW_ACCOUNT_UNSUSPENSION],
         account_unsuspension_limit=constants.ACCOUNT_UNSUSPENSION_DELAY,
+        app_enable_cookies_v2=features[FeatureToggle.APP_ENABLE_COOKIES_V2],
     )

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -202,6 +202,7 @@ def test_public_api(client):
                         "proDisableEventsQrcode": {"title": "Prodisableeventsqrcode", "type": "boolean"},
                         "allowAccountUnsuspension": {"title": "Allowaccountunsuspension", "type": "boolean"},
                         "accountUnsuspensionLimit": {"title": "Accountunsuspensionlimit", "type": "integer"},
+                        "appEnableCookiesV2": {"title": "Appenablecookiesv2", "type": "boolean"},
                     },
                     "required": [
                         "accountCreationMinimumAge",
@@ -223,6 +224,7 @@ def test_public_api(client):
                         "proDisableEventsQrcode",
                         "allowAccountUnsuspension",
                         "accountUnsuspensionLimit",
+                        "appEnableCookiesV2",
                     ],
                     "title": "SettingsResponse",
                     "type": "object",

--- a/api/tests/routes/native/v1/settings_test.py
+++ b/api/tests/routes/native/v1/settings_test.py
@@ -45,6 +45,7 @@ class SettingsTest:
             "proDisableEventsQrcode": False,
             "allowAccountUnsuspension": True,
             "accountUnsuspensionLimit": 60,
+            "appEnableCookiesV2": False,
         }
 
     @override_features(
@@ -59,6 +60,7 @@ class SettingsTest:
         ALLOW_ACCOUNT_UNSUSPENSION=True,
         APP_ENABLE_AUTOCOMPLETE=False,
         APP_ENABLE_CATEGORY_FILTER_PAGE=True,
+        APP_ENABLE_COOKIES_V2=True,
     )
     def test_get_settings_feature_combination_2(self, app):
         response = TestClient(app.test_client()).get("/native/v1/settings")
@@ -84,4 +86,5 @@ class SettingsTest:
             "proDisableEventsQrcode": True,
             "allowAccountUnsuspension": True,
             "accountUnsuspensionLimit": 60,
+            "appEnableCookiesV2": True,
         }


### PR DESCRIPTION
Disabled by default.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16504

## But de la pull request

Créer un FF : `APP_ENABLE_COOKIES_V2`.
**Désactivé par défaut**.