### PR TITLE
(PC-15904)[API] feat: add script to delete cancelled bookings

### DIFF
--- a/api/src/pcapi/core/bookings/exceptions.py
+++ b/api/src/pcapi/core/bookings/exceptions.py
@@ -105,6 +105,14 @@ class BookingDoesntExist(ClientError):
         super().__init__("bookingId", "bookingId ne correspond à aucune réservation")
 
 
+class CannotDeleteBookingWithReimbursementException(ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "cannotDeleteBookingWithReimbursementException",
+            "Réservation non supprimable car elle est liée à un remboursement",
+        )
+
+
 class CannotDeleteOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/scripts/booking/commands.py
+++ b/api/src/pcapi/scripts/booking/commands.py
@@ -1,0 +1,14 @@
+import click
+
+from pcapi.scripts.booking.delete_cancelled_booking import delete_cancelled_booking
+from pcapi.utils.blueprint import Blueprint
+
+
+blueprint = Blueprint(__name__, __name__)
+
+
+@blueprint.cli.command("delete_cancelled_booking")
+@click.option("--venue-id", required=True, help="Id of the venue to delete cancelled bookings", type=int)
+@click.option("--stop-on-exception", default=True, type=bool)
+def delete_booking(venue_id: int, stop_on_exception: bool) -> None:
+    delete_cancelled_booking(venue_id, stop_on_exception)

--- a/api/src/pcapi/scripts/booking/delete_cancelled_booking.py
+++ b/api/src/pcapi/scripts/booking/delete_cancelled_booking.py
@@ -1,0 +1,27 @@
+import logging
+
+from pcapi.core.bookings.exceptions import CannotDeleteBookingWithReimbursementException
+import pcapi.core.bookings.models as bookings_models
+from pcapi.core.finance.repository import has_reimbursement
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def delete_cancelled_booking(venue_id: int, stop_on_exception: bool = True) -> None:
+    booking_to_delete = bookings_models.Booking.query.filter(
+        bookings_models.Booking.venueId == venue_id,
+        bookings_models.Booking.status == bookings_models.BookingStatus.CANCELLED,
+    ).all()
+    logger.info("%s bookings to delete", len(booking_to_delete))
+    for booking in booking_to_delete:
+        if has_reimbursement(booking):
+            if stop_on_exception:
+                db.session.rollback()
+                raise CannotDeleteBookingWithReimbursementException()
+            logger.info("Can't delete booking #%s : it has at least one linked reimbursement", booking.id)
+            continue
+        db.session.delete(booking)
+        logger.info("Deleting booking #%s", booking.id)
+    db.session.commit()

--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -14,6 +14,7 @@ def install_commands(app: flask.Flask) -> None:
         "pcapi.scripts.full_index_offers",
         "pcapi.scripts.generate_invoices",
         "pcapi.scripts.install_data",
+        "pcapi.scripts.booking.commands",
         "pcapi.scripts.offerer.commands",
         "pcapi.scripts.payment.add_custom_offer_reimbursement_rule",
         "pcapi.scripts.provider.check_provider_api",

--- a/api/tests/scripts/booking/delete_cancelled_bookings_test.py
+++ b/api/tests/scripts/booking/delete_cancelled_bookings_test.py
@@ -1,0 +1,62 @@
+import datetime
+
+import pytest
+
+from pcapi.core.bookings.exceptions import CannotDeleteBookingWithReimbursementException
+import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.bookings.models as bookings_models
+import pcapi.core.finance.factories as finance_factories
+from pcapi.core.finance.models import PricingStatus
+from pcapi.scripts.booking.delete_cancelled_booking import delete_cancelled_booking
+
+
+@pytest.mark.usefixtures("db_session")
+def test_should_not_delete_booking_with_reimbursement():
+    # Given
+    value_date = datetime.datetime.utcnow()
+    booking = bookings_factories.BookingFactory(status=bookings_models.BookingStatus.CANCELLED)
+    venue = booking.venue
+    finance_factories.PricingFactory(booking=booking, valueDate=value_date, status=PricingStatus.PROCESSED)
+
+    # When
+    with pytest.raises(CannotDeleteBookingWithReimbursementException) as exception:
+        delete_cancelled_booking(venue.id)
+
+    # Then
+    assert exception.value.errors["cannotDeleteBookingWithReimbursementException"] == [
+        "Réservation non supprimable car elle est liée à un remboursement"
+    ]
+    assert bookings_models.Booking.query.count() == 1
+
+
+@pytest.mark.usefixtures("db_session")
+def test_should_delete_booking_without_reimbursement():
+    # Given
+    booking = bookings_factories.BookingFactory(status=bookings_models.BookingStatus.CANCELLED)
+    venue = booking.venue
+
+    # When
+    delete_cancelled_booking(venue.id)
+
+    # Then
+    assert bookings_models.Booking.query.count() == 0
+
+
+@pytest.mark.usefixtures("db_session")
+def test_should_delete_bookings_without_reimbursement_when_stop_on_exception_is_false():
+    # Given
+    value_date = datetime.datetime.utcnow()
+    booking = bookings_factories.BookingFactory(status=bookings_models.BookingStatus.CANCELLED)
+    venue = booking.venue
+    booking_with_reimbursement = bookings_factories.BookingFactory(
+        stock__offer__venue=venue, status=bookings_models.BookingStatus.CANCELLED
+    )
+    finance_factories.PricingFactory(
+        booking=booking_with_reimbursement, valueDate=value_date, status=PricingStatus.PROCESSED
+    )
+
+    # When
+    delete_cancelled_booking(venue.id, False)
+
+    # Then
+    assert bookings_models.Booking.query.count() == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15904

## But de la pull request

Ajout d'un script pour supprimer les réservations annulées sans remboursements liés. (Dans le but de supprimer par la suite la venue associé à ces remboursements)
