### PR TITLE
(PC-16500)[API] feat: add a table to log acceptance or refusal of cookie

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-2967ed08d3e0 (pre) (head)
+12adabc7c5d3 (pre) (head)
 1f778fcd4019 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220822T135857_12adabc7c5d3_add_cookies_history_table.py
+++ b/api/src/pcapi/alembic/versions/20220822T135857_12adabc7c5d3_add_cookies_history_table.py
@@ -1,0 +1,33 @@
+"""add_cookies_history_table
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "12adabc7c5d3"
+down_revision = "76d1434f787d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cookies_history",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("addedDate", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("deviceId", sa.String(), nullable=False),
+        sa.Column("consent", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("actionDate", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("userId", sa.BigInteger(), nullable=True),
+        sa.ForeignKeyConstraint(["userId"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_cookies_history_userId"), "cookies_history", ["userId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_cookies_history_userId"), table_name="cookies_history")
+    op.drop_table("cookies_history")

--- a/api/src/pcapi/core/cookies/models.py
+++ b/api/src/pcapi/core/cookies/models.py
@@ -1,0 +1,55 @@
+from dataclasses import asdict
+from dataclasses import dataclass
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy import orm
+from sqlalchemy.ext import mutable
+from sqlalchemy.orm import Mapped
+
+from pcapi.models import Base
+from pcapi.models import Model
+from pcapi.models.pc_object import PcObject
+
+
+ListOfCookies = list[str]
+
+
+@dataclass
+class OptionalCookie:
+    accepted: ListOfCookies
+    refused: ListOfCookies
+
+
+@dataclass
+class Consent:
+    mandatory: ListOfCookies
+    optional: OptionalCookie
+
+
+class CookiesHistory(PcObject, Base, Model):  # type: ignore [valid-type, misc]
+    __tablename__ = "cookies_history"
+
+    id = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
+    addedDate: datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
+
+    deviceId: str = sa.Column(sa.String(), nullable=False)
+    _consent: Mapped[Consent] = sa.Column(
+        mutable.MutableDict.as_mutable(sa.dialects.postgresql.JSONB), nullable=False, name="consent"
+    )
+    actionDate: datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
+
+    userId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), index=True, nullable=True)
+    user = orm.relationship("User", foreign_keys=[userId], backref=orm.backref("cookies_history", passive_deletes=True))  # type: ignore [misc]
+
+    @sa.ext.hybrid.hybrid_property
+    def consent(self) -> Consent:
+        return Consent(**self._consent)
+
+    @consent.setter  # type: ignore [no-redef]
+    def consent(self, consent: Consent) -> None:
+        self._consent = asdict(consent)
+
+    @consent.expression  # type: ignore [no-redef]
+    def consent(cls):  # pylint: disable=no-self-argument
+        return cls._consent

--- a/api/src/pcapi/models/__init__.py
+++ b/api/src/pcapi/models/__init__.py
@@ -13,6 +13,7 @@ def install_models() -> None:
     # pylint: disable=unused-import
     import pcapi.core.booking_providers.models
     import pcapi.core.bookings.models
+    import pcapi.core.cookies.models
     import pcapi.core.criteria.models
     import pcapi.core.educational.models
     import pcapi.core.finance.models


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16500

## But de la pull request

Ajout d'une table permettant d'historiser le consentement ou non des cookies par les users

La CNIL peut etre ammené à nous demander de prouver qu'un user à accepter ou refuser tel ou tel cookie

## Modifications du schéma de la base de données

- ajout de la table `cookies_history`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] ~~J'ai écrit les tests nécessaires~~, comment écrire un test pour ça ?
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~ cette table sera utilisé pour de l'écriture uniquement (lecture exceptionnelle à la main ; si la CNIL nous le demande), je ne pense pas qu'on ai besoin de pré-remplir des trucs en sandbox

