### PR TITLE
[PC-16900] Activate wait flag again for helm upgrades

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,3 +1,6 @@
+helmDefaults:
+  wait: true
+
 repositories:
   - name: passCulture
     url: europe-west1-docker.pkg.dev/passculture-infra-prod
@@ -32,5 +35,3 @@ environments:
   perf:
     values:
       - chartVersion: 0.16.0
-
-


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16900

## But de la pull request

Réactivation du flag `--wait` qui a sauté lors du passage à helmfile.
