### PR TITLE
(PC-16932)[API] fix: use formatted phone number to send sms

### DIFF
--- a/api/src/pcapi/core/subscription/phone_validation/api.py
+++ b/api/src/pcapi/core/subscription/phone_validation/api.py
@@ -149,17 +149,17 @@ def send_phone_validation_code(
         _check_sms_sending_is_allowed(user)
     _ensure_phone_number_unicity(user, phone_data.phone_number, change_owner=False)
 
-    user.phoneNumber = phone_number  # type: ignore [assignment]
+    user.phoneNumber = phone_data.phone_number  # type: ignore [assignment]
     repository.save(user)
 
     phone_validation_token = users_api.create_phone_validation_token(
         user,
-        phone_number,
+        phone_data.phone_number,
         expiration=expiration,
     )
     content = f"{phone_validation_token.value} est ton code de confirmation pass Culture"  # type: ignore [union-attr]
 
-    _send_sms_with_retry(phone_number, content)
+    _send_sms_with_retry(phone_data.phone_number, content)
 
     sending_limit.update_sent_SMS_counter(app.redis_client, user)  # type: ignore [attr-defined]
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16932

## But de la pull request

Avant : 
body.phoneNumber = "+33 6 82 10 10 10" => sms recipient = "33 6 82 10 10 10" => [Bad Request](https://sentry.internal-passculture.app/organizations/sentry/issues/392816/?environment=production&project=5&query=&statsPeriod=14d)

Maintenant : 
body.phoneNumber = "+33 6 82 10 10 10" => sms recipient = "33682101010" => Good Request

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
