### PR TITLE
[PC-16944] Use tag to generate helm secrets value file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ executors:
 
   pcapi:
     docker:
-      - image: ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi:${CIRCLE_SHA1}
+      - image: ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi:${CIRCLE_TAG:-${CIRCLE_SHA1}}
         auth:
           username: _json_key # default username when using a JSON key file to authenticate
           password: $GCP_INFRA_KEY


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16944

## But de la pull request

Utiliser l'image docker dont le tag est le tag git actuel s'il est disponible (pour les déploiements en staging/intégration/production)