### PR TITLE
Create github action for mypy leaderboard

### DIFF
--- a/.github/workflows/mypy-leaderboard.yml
+++ b/.github/workflows/mypy-leaderboard.yml
@@ -1,0 +1,61 @@
+name: Mypy leaderboard
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [closed]
+
+jobs:
+  get_mypy_score_on_merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      mypy_score: ${{ steps.mypy-score-calculator.outputs.mypy_score }}
+      author: ${{ steps.mypy-score-calculator.outputs.author }}
+      hash: ${{ steps.mypy-score-calculator.outputs.hash }}
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
+      - name: Check changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'api/**'
+      - name: Calculate mypy diff
+        id: mypy-score-calculator
+        if: steps.changes.outputs.src == 'true'
+        run: |
+          cd api
+          this_branch_ignore_count="$(grep "type: ignore" -r src | wc -l)"
+          author_line="$(git log -n 1 --pretty=short | grep Author)"
+          author="$(echo "$author_line" | cut -d ':' -f 2 | xargs)"
+          hash="$(git log -n 1 --pretty=format:'%H')"
+          git fetch origin master:master --quiet
+          git checkout master --quiet
+          master_ignore_count="$(grep "type: ignore" -r src | wc -l)"
+          git checkout - --quiet
+          diff=$(($master_ignore_count - $this_branch_ignore_count))
+          echo "::set-output name=mypy_score::$diff"
+          echo "::set-output name=author::$author"
+          echo "::set-output name=hash::$hash"
+
+  send_info:
+    runs-on: ubuntu-latest
+    needs: get_mypy_score_on_merge
+    steps:
+      - name: Call cloud function
+        id: call-cloud-function
+        run: |
+          curl --location --request POST 'https://us-central1-maposaic-99785.cloudfunctions.net/mypy-leaderboard' \
+          --header 'Authorization: ${{ secrets.MYPY_LEADERBOARD_FUNCTION_AUTHORIZATION }}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "commitHash": "${{ needs.get_mypy_score_on_merge.outputs.hash }}",
+              "author": "${{ needs.get_mypy_score_on_merge.outputs.author }}",
+              "mypyDiff": ${{ needs.get_mypy_score_on_merge.outputs.mypy_score }}
+          }'


### PR DESCRIPTION
~Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX~

## But de la pull request

Créer unleaderboard des résolveurs de mypy :partying_face: 

## Implémentation

- Une github action récupère les infos au merge d'une PR dans master
- Puis envoie ça à une cloud task qui écris dans une google sheet

## Informations supplémentaires

Exemple OK: https://github.com/pass-culture/pass-culture-main/runs/7914860417?check_suite_focus=true

## Modifications du schéma de la base de données

- None

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
