### PR TITLE
(PC-16943)[PRO] fix: display reimbursement point name for invoice whe…

### DIFF
--- a/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableBody/ReimbursementsTableBody.tsx
+++ b/pro/src/components/pages/Reimbursements/ReimbursementsTable/TableBody/ReimbursementsTableBody.tsx
@@ -17,7 +17,7 @@ const ReimbursementsTableBody = ({ invoices }: ITableBody): JSX.Element => {
           <tr key={invoice.reference}>
             <td className={styles['date']}>{invoice.date}</td>
             <td className={styles['business-unit']}>
-              {invoice.businessUnitName}
+              {invoice.reimbursementPointName || invoice.businessUnitName}
             </td>
             <td className={styles['reference']}>{invoice.reference}</td>
             {/* For now only one label is possible by invoice. */}


### PR DESCRIPTION
…n it is valued

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16943

## But de la pull request

Fix l'affichage du nom du point de remboursement d'un lieu dans la section Justificatif de remboursement pour prendre en compte le nouveau modèle

