### PR TITLE
(PC-16777)[PRO] feat: display public name for reimbursement point lis…

### DIFF
--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -58,6 +58,7 @@ class ReimbursementPointResponseModel(BaseModel):
 
     id: int
     name: str
+    publicName: str
 
 
 class ReimbursementPointListResponseModel(BaseModel):

--- a/api/tests/routes/pro/get_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_reimbursement_points_test.py
@@ -35,7 +35,10 @@ def test_get_reimbursement_points_by_admin(client):
 
 def test_get_reimbursement_points_by_pro(client):
     pro_reimbursement_point_1 = offerers_factories.VenueFactory(
-        businessUnit=None, reimbursement_point="self", name="My Reimbursement Point"
+        businessUnit=None,
+        reimbursement_point="self",
+        name="My Reimbursement Point",
+        publicName="My Reimbursement Point Public Name",
     )
     finance_factories.BankInformationFactory(venue=pro_reimbursement_point_1)
 
@@ -56,6 +59,7 @@ def test_get_reimbursement_points_by_pro(client):
     assert reimbursement_points[0] == {
         "id": pro_reimbursement_point_1.id,
         "name": "My Reimbursement Point",
+        "publicName": "My Reimbursement Point Public Name",
     }
 
 

--- a/pro/src/components/pages/Reimbursements/Reimbursements.jsx
+++ b/pro/src/components/pages/Reimbursements/Reimbursements.jsx
@@ -65,7 +65,9 @@ const Reimbursements = () => {
         sortByDisplayName(
           reimbursementPointsResponse.map(item => ({
             id: item['id'].toString(),
-            displayName: item['name'],
+            displayName: Object.keys(item).includes('publicName')
+              ? item['publicName']
+              : item['name'],
           }))
         )
       )


### PR DESCRIPTION
…t in reimbursement page

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16777

## But de la pull request

Dans la liste des points de remboursement de la section remboursement sur le portail PRO, c’est le nom d’usage du lieu qui doit apparaître (actuellement : c’est le nom du lieu qui apparait - c’est incohérent car c’est le nom d’usage du lieu qui apparaît sur le le justificatif de paiement)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
