### PR TITLE
(PC-16942) fix update venue

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -81,7 +81,10 @@ def update_venue(
     if "businessUnitId" in modifications:
         set_business_unit_to_venue_id(modifications["businessUnitId"], venue.id)
 
-    if feature.FeatureToggle.ENABLE_NEW_BANK_INFORMATIONS_CREATION.is_active():
+    if (
+        feature.FeatureToggle.ENABLE_NEW_BANK_INFORMATIONS_CREATION.is_active()
+        and reimbursement_point_id != venue.current_reimbursement_point_id
+    ):
         link_venue_to_reimbursement_point(venue, reimbursement_point_id)
 
     old_booking_email = venue.bookingEmail if modifications.get("bookingEmail") else None

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -343,6 +343,20 @@ class EditVenueTest:
         assert link.businessUnit == business_unit
         assert link.timespan.upper is None
 
+    def test_edit_venue_with_pending_bank_info(self):
+        venue = offerers_factories.VenueFactory(
+            pricing_point="self", reimbursement_point="self", publicName="Nom actuel"
+        )
+        finance_factories.BankInformationFactory(venue=venue, status=finance_models.BankInformationStatus.DRAFT)
+        venue_data = {
+            "publicName": "Nouveau nom",
+            "reimbursementPointId": venue.current_reimbursement_point_id,
+            # all the other venue attributes should be in this dict
+        }
+        offerers_api.update_venue(venue, **venue_data)
+
+        assert venue.publicName == "Nouveau nom"
+
 
 class EditVenueContactTest:
     def test_create_venue_contact(self, app):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16942

## But de la pull request

Permettre l'édition de lieu sans vérifier les CB de point de remboursement systématiquement

## Implémentation

Correction de `update_venue()`

## Modifications du schéma de la base de données

N/A