### PR TITLE
(PC-16622)[PRO] fix: upload image modal css close button and upload link

### DIFF
--- a/pro/src/new_components/DialogBox/DialogBox.module.scss
+++ b/pro/src/new_components/DialogBox/DialogBox.module.scss
@@ -25,4 +25,5 @@
   position: absolute;
   right: rem.torem(32px);
   top: rem.torem(32px);
+  z-index: 1;
 }

--- a/pro/src/new_components/ImportFromComputerInput/ImportFromComputerInput.module.scss
+++ b/pro/src/new_components/ImportFromComputerInput/ImportFromComputerInput.module.scss
@@ -5,7 +5,6 @@
   cursor: pointer;
   margin-bottom: rem.torem(16px);
   padding: 0 rem.torem(32px);
-  width: rem.torem(372px);
   text-align: center;
 
   &:focus-within {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16622

## But de la pull request

Fix la modale permettant d'uploader une image 


## Implémentation

- Suppression de la contrainte obsolète sur la taille du bouton 
- Ajout de la propriété `z-index = 1` pour la croix permettant de fermer la modal pour qu'elle reste tout le temps clicable

## Screenshot

<img width="858" alt="Capture d’écran 2022-08-22 à 16 32 08" src="https://user-images.githubusercontent.com/71768799/185947483-9e4aa008-9dbb-41a7-82c8-4bdefa850baf.png">

