### PR TITLE
[PC-16952] Fix deploy rollout restart command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -997,7 +997,7 @@ jobs:
       - run:
           name: Get GKE cluster credentials
           command: gcloud container clusters get-credentials --region ${GCP_REGION} ${GKE_CLUSTER_NAME}
-      - run: kubectl get deploy -n <<parameters.helm_environment>> -o name | xargs  -L 1 kubectl rollout restart -n <<parameters.helm_environment>>
+      - run: kubectl -n <<parameters.helm_environment>> rollout restart deploy
 
   measure_workflow_execution_time:
     docker:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16952

## But de la pull request

L'ancienne commande dépendait de `xargs` dont les paramètres varient selon les images, cette commande plus récente n'en dépend pas.
