### PR TITLE
(PC-16760)[API]: add label and description into offerer_tag table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-4df590d6ffb3 (pre) (head)
+0502f0f2f72c (pre) (head)
 1f778fcd4019 (post) (head)

--- a/api/src/pcapi/admin/custom_views/offerer_tag_view.py
+++ b/api/src/pcapi/admin/custom_views/offerer_tag_view.py
@@ -14,8 +14,8 @@ class OffererTagView(BaseAdminView):
     can_create = True
     can_edit = False  # Nothing to edit
     can_delete = True
-    column_list = ["id", "name"]
-    column_labels = {"name": "Nom"}
+    column_list = ["id", "name", "label", "description"]
+    column_labels = {"name": "Nom", "label": "Libellé", "description": "Description"}
     column_searchable_list = ["name"]
     column_filters: list[str] = []
 
@@ -29,4 +29,11 @@ class OffererTagView(BaseAdminView):
                 Length(max=140, message="Le nom ne peut excéder 140 caractères"),
             ],
         )
+        form.label = StringField(
+            "Libellé",
+            [
+                Length(max=140, message="Le libellé ne peut excéder 140 caractères"),
+            ],
+        )
+        form.description = StringField("Description")
         return form

--- a/api/src/pcapi/alembic/versions/20220823T083137_0502f0f2f72c_add_label_and_description_into_offerer_tag_table.py
+++ b/api/src/pcapi/alembic/versions/20220823T083137_0502f0f2f72c_add_label_and_description_into_offerer_tag_table.py
@@ -1,0 +1,20 @@
+"""add_label_and_description_into_offerer_tag_table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0502f0f2f72c"
+down_revision = "4df590d6ffb3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("offerer_tag", sa.Column("label", sa.String(length=140), nullable=True))
+    op.add_column("offerer_tag", sa.Column("description", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("offerer_tag", "description")
+    op.drop_column("offerer_tag", "label")

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -686,6 +686,8 @@ class OffererTag(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "offerer_tag"
 
     name: str = Column(String(140), nullable=False, unique=True)
+    label: str = Column(String(140))
+    description: str = Column(Text)
 
     def __repr__(self):  # type: ignore [no-untyped-def]
         return "%s" % self.name


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16760

## But de la pull request

Ajout de deux colonne (`label` et `description`) dans la table `offerer_tag` pour l'équipe data.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
