### PR TITLE
[PC-16952] Use cloud-sdk alpine image only for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,13 @@ parameters:
 executors:
   gcp-sdk:
     docker:
+      - image: google/cloud-sdk:316.0.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+
+  gcp-sdk-alpine:
+    docker:
       - image: google/cloud-sdk:316.0.0-alpine
         auth:
           username: $DOCKERHUB_USER
@@ -725,7 +732,7 @@ jobs:
                 channel: shérif
 
   build-and-push-image:
-    executor: gcp-sdk
+    executor: gcp-sdk-alpine
     environment:
       DOCKER_BUILDKIT: 1
     parameters:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16952

## But de la pull request

L'image alpine du sdk Google Cloud est 80% moins lourde que l'image full et permet de gagner 40 secondes par build. Par contre elle ne contient pas kubectl donc on continue d'utiliser l'image full pour le rollout restart.