### PR TITLE
(BSR)[API] tests: silence specific DeprecationWarning for urllib3

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -148,6 +148,10 @@ filterwarnings = [
     # FIXME (askorski, 2022-05-02): algoliasearch uses deprecated @coroutine decorator
     # Remove this when alogliasearch no more uses @coroutine
     'ignore:"@coroutine" decorator is deprecated since Python 3.8, use \"async def\" instead:DeprecationWarning',
+    # FIXME (francois-seguin, 2022-08-23): requests-toolbelt uses deprecated urllib3.contrib.pyopenssl
+    # see https://github.com/requests/toolbelt/issues/331
+    # Remove this when requests-toolbelt fixes its use
+    "ignore:'urllib3.contrib.pyopenssl' module is deprecated*:DeprecationWarning",
 ]
 testpaths = ["tests"]
 norecursedirs = [".git", "venv", ".pytest_cache"]


### PR DESCRIPTION
## But de la pull request

Ignorer un `Warning` (transformé en erreur) d'obsolescence introduit dans `urllib3==1.26.12`, en attendant que la lib tierce `requests-toolbelt` soit mise à jour.


## Implémentation

Edition de `pyproject.toml`

## Informations supplémentaires

- Une issue GH est ouverte dans le repo concerné: https://github.com/requests/toolbelt/issues/331

## Modifications du schéma de la base de données

N/A
