### PR TITLE
PC-16920 make dms handling idempotent

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-6cd0e66502d1 (pre) (head)
+4df590d6ffb3 (pre) (head)
 1f778fcd4019 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220819T120622_4df590d6ffb3_.py
+++ b/api/src/pcapi/alembic/versions/20220819T120622_4df590d6ffb3_.py
@@ -1,0 +1,20 @@
+"""Create orphan dms application latest modification datetime column
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "4df590d6ffb3"
+down_revision = "6cd0e66502d1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("orphan_dms_application", sa.Column("latest_modification_datetime", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("orphan_dms_application", "latest_modification_datetime")

--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -110,7 +110,7 @@ class DmsApplicationResponse(pydantic.BaseModel):
     fields: list[DmsField] = pydantic.Field(alias="champs")
     filing_date: datetime.datetime = pydantic.Field(alias="dateDepot")
     id: str
-    latest_modification_date: datetime.datetime = pydantic.Field(alias="dateDerniereModification")
+    latest_modification_datetime: datetime.datetime = pydantic.Field(alias="dateDerniereModification")
     messages: list[DMSMessage]
     number: int
     on_going_date: datetime.datetime | None = pydantic.Field(None, alias="datePassageEnInstruction")
@@ -120,7 +120,7 @@ class DmsApplicationResponse(pydantic.BaseModel):
 
     _format_processed_datetime = pydantic.validator("processed_datetime", allow_reuse=True)(parse_dms_datetime)
     _format_filing_date = pydantic.validator("filing_date", allow_reuse=True)(parse_dms_datetime)
-    _format_latest_modification_date = pydantic.validator("latest_modification_date", allow_reuse=True)(
+    _format_latest_modification_datetime = pydantic.validator("latest_modification_datetime", allow_reuse=True)(
         parse_dms_datetime
     )
     _format_on_going_date = pydantic.validator("on_going_date", allow_reuse=True)(parse_dms_datetime)

--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -124,6 +124,7 @@ def parse_beneficiary_information_graphql(
         first_name=first_name,
         id_piece_number=id_piece_number,
         last_name=last_name,
+        latest_modification_datetime=application_detail.latest_modification_datetime,
         phone=phone,
         postal_code=postal_code,
         procedure_number=application_detail.procedure.number,

--- a/api/src/pcapi/core/fraud/common/models.py
+++ b/api/src/pcapi/core/fraud/common/models.py
@@ -33,6 +33,9 @@ class IdentityCheckContent(pydantic.BaseModel):
     def get_ine_hash(self) -> str | None:
         return None
 
+    def get_latest_modification_datetime(self) -> datetime.datetime | None:
+        return None
+
     def get_married_name(self) -> str | None:
         return None
 

--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -41,12 +41,3 @@ def create_fraud_check(
     )
     repository.save(fraud_check)
     return fraud_check
-
-
-def get_or_create_fraud_check(
-    user: users_models.User, application_number: int, result_content: fraud_models.DMSContent | None = None
-) -> fraud_models.BeneficiaryFraudCheck:
-    fraud_check = get_fraud_check(user, application_number)
-    if fraud_check is None:
-        return create_fraud_check(user, application_number, result_content)
-    return fraud_check

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -189,6 +189,7 @@ class DMSContent(common_models.IdentityCheckContent):
     first_name: str
     id_piece_number: str | None
     last_name: str
+    latest_modification_datetime: datetime.datetime | None
     phone: str | None
     postal_code: str | None
     procedure_number: int = pydantic.Field(..., alias="procedure_id")  # keep alias for old data
@@ -231,6 +232,9 @@ class DMSContent(common_models.IdentityCheckContent):
 
     def get_registration_datetime(self) -> datetime.datetime | None:
         return dms_models.parse_dms_datetime(self.registration_datetime) if self.registration_datetime else None
+
+    def get_latest_modification_datetime(self) -> datetime.datetime | None:
+        return self.latest_modification_datetime
 
 
 class UserProfilingRiskRating(enum.Enum):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -442,6 +442,9 @@ class OrphanDmsApplication(PcObject, Base, Model):  # type: ignore [valid-type, 
     dateCreated = sa.Column(
         sa.DateTime, nullable=True, default=datetime.datetime.utcnow
     )  # no sql default because the column was added after table creation
+    latest_modification_datetime = sa.Column(
+        sa.DateTime, nullable=True
+    )  # This field copies the value provided in the DMS application
     email = sa.Column(sa.Text, nullable=True, index=True)
     application_id = sa.Column(sa.BigInteger, primary_key=True)  # refers to DMS application "number"
     process_id = sa.Column(sa.BigInteger)

--- a/api/src/pcapi/core/subscription/dms/repository.py
+++ b/api/src/pcapi/core/subscription/dms/repository.py
@@ -1,3 +1,5 @@
+import datetime
+
 from sqlalchemy import Integer
 from sqlalchemy import or_
 
@@ -5,16 +7,21 @@ from pcapi.core.fraud import models as fraud_models
 from pcapi.models import db
 
 
-def create_orphan_dms_application_if_not_exists(
-    application_number: int, procedure_number: int, email: str | None = None
-) -> None:
-    if db.session.query(
-        fraud_models.OrphanDmsApplication.query.filter_by(application_id=application_number, email=email).exists()
-    ).scalar():
-        return
+def get_orphan_dms_application_by_application_id(application_id: int) -> fraud_models.OrphanDmsApplication | None:
+    return fraud_models.OrphanDmsApplication.query.filter_by(application_id=application_id).first()
 
+
+def create_orphan_dms_application(
+    application_number: int,
+    procedure_number: int,
+    latest_modification_datetime: datetime.datetime,
+    email: str | None = None,
+) -> None:
     orphan_dms_application = fraud_models.OrphanDmsApplication(
-        application_id=application_number, process_id=procedure_number, email=email
+        application_id=application_number,
+        process_id=procedure_number,
+        email=email,
+        latest_modification_datetime=latest_modification_datetime,
     )
     db.session.add(orphan_dms_application)
     db.session.commit()

--- a/api/src/pcapi/scripts/subscription/dms/handle_inactive_dms_applications.py
+++ b/api/src/pcapi/scripts/subscription/dms/handle_inactive_dms_applications.py
@@ -50,7 +50,7 @@ def handle_inactive_dms_applications(procedure_number: int, with_never_eligible_
 def _has_inactivity_delay_expired(dms_application: dms_models.DmsApplicationResponse) -> bool:
     date_with_delay = datetime.datetime.utcnow() - relativedelta(days=settings.DMS_INACTIVITY_TOLERANCE_DELAY)
 
-    if dms_application.latest_modification_date >= date_with_delay:
+    if dms_application.latest_modification_datetime >= date_with_delay:
         return False
 
     if not dms_application.messages:

--- a/api/tests/core/fraud/dms/test_api.py
+++ b/api/tests/core/fraud/dms/test_api.py
@@ -2,19 +2,19 @@ import pytest
 
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
-from pcapi.core.fraud.dms.api import get_or_create_fraud_check
+from pcapi.core.fraud.dms import api as dms_api
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 
 
 @pytest.mark.usefixtures("db_session")
 class DmsApiTest:
-    def test_get_or_create_fraud_check_creates(self):
+    def test_create_fraud_check(self):
         user = users_factories.UserFactory()
         application_number = 1
         result_content = None
 
-        fraud_check = get_or_create_fraud_check(user, application_number, result_content)
+        fraud_check = dms_api.create_fraud_check(user, application_number, result_content)
 
         user_fraud_checks = user.beneficiaryFraudChecks
         assert len(user_fraud_checks) == 1
@@ -22,12 +22,12 @@ class DmsApiTest:
         assert user_fraud_checks[0].thirdPartyId == str(application_number)
         assert user_fraud_checks[0].resultContent == None
 
-    def test_get_or_create_fraud_check_gets(self):
+    def test_get_fraud_check(self):
         user = users_factories.UserFactory()
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS, thirdPartyId=1)
         application_number = 1
 
-        fraud_check = get_or_create_fraud_check(user, application_number)
+        fraud_check = dms_api.get_fraud_check(user, application_number)
 
         user_fraud_checks = user.beneficiaryFraudChecks
         assert len(user_fraud_checks) == 1

--- a/api/tests/core/subscription/dms/test_repository.py
+++ b/api/tests/core/subscription/dms/test_repository.py
@@ -1,0 +1,23 @@
+import datetime
+
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.subscription.dms import repository
+
+
+@pytest.mark.usefixtures("db_session")
+class RepositoryUnitTest:
+    def test_get_orphan_dms_application_by_application_id(self):
+        fraud_factories.OrphanDmsApplicationFactory(application_id=88)
+        assert repository.get_orphan_dms_application_by_application_id(88) is not None
+        assert repository.get_orphan_dms_application_by_application_id(99) is None
+
+    def test_create_orphan_dms_application(self):
+        repository.create_orphan_dms_application(
+            application_number=88,
+            procedure_number=99,
+            latest_modification_datetime=datetime.datetime.utcnow(),
+            email="john.stiles@example.com",
+        )
+        assert repository.get_orphan_dms_application_by_application_id(88) is not None

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -807,6 +807,7 @@ class DmsWebhookApplicationTest:
             state=dms_models.GraphQLApplicationStates.draft.value,
             email=user.email,
             id_piece_number="error_identity_piece_number",
+            last_modification_date=datetime.datetime(2021, 9, 30, 17, 55, 58),
         )
         form_data = {
             "procedure_id": 48860,
@@ -832,7 +833,10 @@ class DmsWebhookApplicationTest:
         # Second DMS webhook call: on_going with no value errors
         execute_query.reset_mock()
         execute_query.return_value = make_single_application(
-            12, state=dms_models.GraphQLApplicationStates.on_going.value, email=user.email
+            12,
+            state=dms_models.GraphQLApplicationStates.on_going.value,
+            email=user.email,
+            last_modification_date=datetime.datetime(2021, 9, 30, 18, 00, 00),
         )
         response = client.post(
             f"/webhooks/dms/application_status?token={settings.DMS_WEBHOOK_TOKEN}",

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -128,7 +128,6 @@ class RunTest:
     def test_beneficiary_is_created_with_procedure_number(
         self, on_successful_application, get_applications_with_details
     ):
-        # given
         applicant = users_factories.UserFactory(firstName="Doe", lastName="John", email="john.doe@test.com")
         get_applications_with_details.return_value = [
             fixture.make_parsed_graphql_application(
@@ -160,6 +159,7 @@ class RunTest:
                 postal_code="67200",
                 processed_datetime=datetime(2020, 5, 13, 8, 41, 21),
                 registration_datetime=datetime(2020, 5, 13, 9, 9, 46, tzinfo=timezone(timedelta(seconds=7200))),
+                latest_modification_datetime=datetime(2020, 5, 13, 8, 41, 23),
                 id_piece_number="123123121",
                 state="accepte",
             ),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16920

## But de la pull request

Rendre la gestion de dossiers DMS idemptotente pour pouvoir garder en parallèle le webhook et le cron

## Implémentation

- Early return basés sur la datetime de dernière modification d'un dossier dans DMS

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
