### PR TITLE
(PC-17018)[API] fix: delete stocks when delete draft offers

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -577,6 +577,7 @@ def delete_past_draft_offers() -> None:
         criteria_models.OfferCriterion.offerId == Offer.id,
         *filters,
     ).delete(synchronize_session=False)
+    Stock.query.filter(Stock.offerId == Offer.id).filter(*filters).delete(synchronize_session=False)
     Offer.query.filter(*filters).delete()
     db.session.commit()
 

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1217,6 +1217,7 @@ class DeletePastDraftOfferTest:
             dateCreated=two_days_ago, validation=offer_mixin.OfferValidationStatus.DRAFT, criteria=[criterion]
         )
         factories.MediationFactory(offer=offer)
+        factories.StockFactory(offer=offer)
         past_offer = factories.OfferFactory(
             dateCreated=two_days_ago, validation=offer_mixin.OfferValidationStatus.PENDING
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17018

## But de la pull request
Supprimer les stocks des offres draft par le cron `clean_past_draft_offers`

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
