### PR TITLE
(PC-17000) fix: wrong path in storybook deploy definition

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -30,4 +30,4 @@ jobs:
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: docs # The folder that we serve our Storybook files from
           clean-exclude: |
-            - .circleci
+            .circleci/config.yml


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17000

## But de la pull request

Corriger une typo dans la définition du workflow GH Storybook