### PR TITLE
(PC-13624) refactor: save beneficiary information only when activating

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -545,8 +545,10 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
     return new_fraud_check
 
 
-def update_user_birth_date(user: users_models.User, birth_date: datetime.date | None) -> None:
+def update_user_birth_date_if_not_beneficiary(user: users_models.User, birth_date: datetime.date | None) -> None:
     """Updates the user birth date based on data received from the identity provider.
+    Indeed, if the user is not beneficiary (or underage), user.dateOfBirth was manually declared during account creation.
+    We'd better trust the identity provider so that the user is correctly redirected for the rest of the process.
 
     Args:
         user (users_models.User): The user to update.

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -329,9 +329,10 @@ def _process_accepted_application(
         logger.exception("Error on dms fraud check result: %s", exc)
         return
 
+    subscription_api.update_user_birth_date_if_not_beneficiary(user, dms_content.get_birth_date())
+
     if fraud_check.status != fraud_models.FraudCheckStatus.OK:
         _handle_validation_errors(user, fraud_check.reasonCodes, dms_content)  # type: ignore [arg-type]
-        subscription_api.update_user_birth_date(user, dms_content.get_birth_date())
         return
 
     fraud_api.create_honor_statement_fraud_check(

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -342,7 +342,7 @@ def _process_accepted_application(
     )
 
     try:
-        has_completed_all_steps = subscription_api.on_successful_application(user=user, source_data=dms_content)
+        has_completed_all_steps = subscription_api.activate_beneficiary_if_no_missing_step(user=user)
     except Exception:  # pylint: disable=broad-except
         logger.exception(
             "[DMS] Could not save application %s - Procedure %s",

--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -36,6 +36,8 @@ def handle_educonnect_authentication(
         logger.exception("Error on educonnect result", extra={"user_id": user.id})
         raise exceptions.EduconnectSubscriptionException()
 
+    subscription_api.update_user_birth_date_if_not_beneficiary(user, fraud_check.source_data().get_birth_date())  # type: ignore [union-attr]
+
     if fraud_check.status == fraud_models.FraudCheckStatus.OK:
         try:
             subscription_api.activate_beneficiary_if_no_missing_step(user=user)
@@ -44,7 +46,6 @@ def handle_educonnect_authentication(
             raise exceptions.EduconnectSubscriptionException()
     else:
         _handle_validation_errors(user, fraud_check, educonnect_user)
-        subscription_api.update_user_birth_date(user, fraud_check.source_data().get_birth_date())  # type: ignore [union-attr]
         logger.warning(
             "Fraud suspicion after educonnect authentication with codes: %s",
             (", ").join([code.value for code in fraud_check.reasonCodes]),  # type: ignore [union-attr]

--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -38,7 +38,7 @@ def handle_educonnect_authentication(
 
     if fraud_check.status == fraud_models.FraudCheckStatus.OK:
         try:
-            subscription_api.on_successful_application(user=user, source_data=fraud_check.source_data())  # type: ignore [arg-type]
+            subscription_api.activate_beneficiary_if_no_missing_step(user=user)
         except Exception:
             logger.exception("Error while activating user from Educonnect", extra={"user_id": user.id})
             raise exceptions.EduconnectSubscriptionException()

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -71,7 +71,7 @@ def update_ubble_workflow(fraud_check: fraud_models.BeneficiaryFraudCheck) -> No
         ubble_tasks.store_id_pictures_task.delay(payload)
 
         try:
-            subscription_api.on_successful_application(user=user, source_data=content)
+            subscription_api.activate_beneficiary_if_no_missing_step(user=user)
         except Exception:  # pylint: disable=broad-except
             logger.exception("Failure after ubble successful result", extra={"user_id": user.id})
 

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -61,10 +61,11 @@ def update_ubble_workflow(fraud_check: fraud_models.BeneficiaryFraudCheck) -> No
             logger.exception("Error on Ubble fraud check result: %s", extra={"user_id": user.id})
             return
 
+        subscription_api.update_user_birth_date_if_not_beneficiary(user, content.get_birth_date())
+
         if fraud_check.status != fraud_models.FraudCheckStatus.OK:
             can_retry = ubble_fraud_api.is_user_allowed_to_perform_ubble_check(user, fraud_check.eligibilityType)
             handle_validation_errors(user, fraud_check, can_retry=can_retry)
-            subscription_api.update_user_birth_date(user, content.get_birth_date())
             return
 
         payload = ubble_tasks.StoreIdPictureRequest(identification_id=fraud_check.thirdPartyId)

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -105,9 +105,6 @@ class UbbleWorkflowTest:
         ubble_content = fraud_check.resultContent
         assert ubble_content["status"] == status.value
         assert fraud_check.status == fraud_check_status
-        if fraud_check_status == fraud_models.FraudCheckStatus.OK:
-            assert user.married_name is not None
-            assert user.civility in [users_models.GenderEnum.F.value, users_models.GenderEnum.M.value]
 
     def test_ubble_workflow_processing_add_inapp_message(self, ubble_mocker):
         user = users_factories.UserFactory()

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -767,6 +767,13 @@ class BeneficiaryInformationUpdateTest:
         assert new_user.idPieceNumber == "123456789"
         assert new_user.civility == "M."
 
+    def test_update_user_information_from_ubble_with_married_name(self):
+        user = users_factories.UserFactory(civility=None)
+        ubble_data = fraud_factories.UbbleContentFactory(married_name="Flouz")
+        new_user = users_api.update_user_information_from_external_source(user, ubble_data)
+
+        assert new_user.married_name == "Flouz"
+
     def test_update_id_piece_number(self):
         user = users_factories.UserFactory(activity="Etudiant", postalCode="75001", idPieceNumber=None)
         dms_data = fraud_factories.DMSContentFactory(id_piece_number="140767100016")

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -724,8 +724,6 @@ class UpdateProfileTest:
             city=None,
             postalCode=None,
             activity=None,
-            firstName="Alexandra",
-            lastName="Stan",
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             phoneNumber="+33609080706",
             dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
@@ -735,6 +733,9 @@ class UpdateProfileTest:
             user=user,
             status=fraud_models.FraudCheckStatus.OK,
             type=fraud_models.FraudCheckType.DMS,
+            resultContent=fraud_factories.DMSContentFactory(
+                first_name="Alexandra", last_name="Stan", postal_code="75008"
+            ),
             eligibilityType=users_models.EligibilityType.AGE18,
         )
         fraud_factories.BeneficiaryFraudCheckFactory(
@@ -774,7 +775,7 @@ class UpdateProfileTest:
         notification = push_testing.requests[0]
         assert notification["user_id"] == user.id
         assert notification["attribute_values"]["u.is_beneficiary"]
-        assert notification["attribute_values"]["u.postal_code"] == "77000"
+        assert notification["attribute_values"]["u.postal_code"] == "75008"
 
 
 class ProfileOptionsTypeTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-13624

## But de la pull request

Pour un flux plus cohérent : on n'enregistre les infos sur l'utilisateur que quand on va l'activer
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
