### PR TITLE
(PC-15858)[API|PRO] feat: validate new pro email

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -30,6 +30,7 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.repository import transaction
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.routes.native.security import authenticated_maybe_inactive_user_required
+from pcapi.routes.serialization import users as users_serializers
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
@@ -113,7 +114,7 @@ def update_user_email(user: users_models.User, body: serializers.UserProfileEmai
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 def validate_user_email(body: serializers.ChangeBeneficiaryEmailBody) -> None:
     try:
-        payload = serializers.ChangeEmailTokenContent.from_token(body.token)
+        payload = users_serializers.ChangeEmailTokenContent.from_token(body.token)
         api.change_user_email(current_email=payload.current_email, new_email=payload.new_email)
     except pydantic.ValidationError:
         raise ApiErrors(

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -1,10 +1,16 @@
 from datetime import datetime
 import typing
 
+from jwt import DecodeError
+from jwt import ExpiredSignatureError
+from jwt import InvalidSignatureError
+from jwt import InvalidTokenError
 from pydantic import EmailStr
 from pydantic.class_validators import validator
 
 from pcapi.core.users import models as user_models
+from pcapi.core.users.utils import decode_jwt_token
+from pcapi.core.users.utils import sanitize_email
 from pcapi.domain.password import check_password_strength
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import humanize_field
@@ -230,3 +236,39 @@ class SharedCurrentUserResponseModel(BaseModel):
         user.isAdmin = user.has_admin_role
         result = super().from_orm(user)
         return result
+
+
+class ChangeProEmailBody(BaseModel):
+    token: str
+
+
+class ChangeEmailTokenContent(BaseModel):
+    current_email: EmailStr
+    new_email: EmailStr
+
+    @validator("current_email", "new_email", pre=True)
+    @classmethod
+    def validate_emails(cls, email: str) -> str:
+        try:
+            return sanitize_email(email)
+        except Exception as e:
+            raise ValueError(email) from e
+
+    @classmethod
+    def from_token(cls, token: str) -> "ChangeEmailTokenContent":
+        try:
+            jwt_payload = decode_jwt_token(token)
+        except (
+            ExpiredSignatureError,
+            InvalidSignatureError,
+            DecodeError,
+            InvalidTokenError,
+        ) as error:
+            raise InvalidTokenError() from error
+
+        if not {"new_email", "current_email"} <= set(jwt_payload):
+            raise InvalidTokenError()
+
+        current_email = jwt_payload["current_email"]
+        new_email = jwt_payload["new_email"]
+        return cls(current_email=current_email, new_email=new_email)

--- a/api/tests/routes/pro/patch_validate_email_test.py
+++ b/api/tests/routes/pro/patch_validate_email_test.py
@@ -1,0 +1,71 @@
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from typing import Any
+
+import jwt
+import pytest
+
+from pcapi import settings
+import pcapi.core.users.factories as users_factories
+from pcapi.core.users.utils import ALGORITHM_HS_256
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class PatchValidateEmailTest:
+    origin_email = "email@example.com"
+    new_email = "update_" + origin_email
+
+    def generate_token(self, email: str, expiration_delta: date = None) -> str:
+        if not expiration_delta:
+            expiration_delta = timedelta(hours=1)
+
+        expiration = int((datetime.utcnow() + expiration_delta).timestamp())
+        token_payload = {"exp": expiration, "current_email": email, "new_email": self.new_email}
+        token = jwt.encode(
+            token_payload,
+            settings.JWT_SECRET_KEY,  # type: ignore # known as str in build assertion
+            algorithm=ALGORITHM_HS_256,
+        )
+        return token
+
+    def test_validate_email(self, client: Any) -> None:
+        pro = users_factories.ProFactory(email=self.origin_email)
+        token = self.generate_token(pro.email)
+        response = client.patch("/users/validate_email", json={"token": token})
+
+        assert response.status_code == 204
+        assert pro.email == self.new_email
+
+    def test_expired_token(self, client: Any) -> None:
+        pro = users_factories.ProFactory(email=self.origin_email)
+        token = self.generate_token(pro.email, expiration_delta=-timedelta(hours=1))
+        response = client.patch("/users/validate_email", json={"token": token})
+
+        assert response.status_code == 400
+        assert response.json["global"] == ["Token invalide"]
+        assert pro.email == self.origin_email
+
+    def test_email_invalid(self, client: Any) -> None:
+        token = self.generate_token("not_an_email")
+        response = client.patch("/users/validate_email", json={"token": token})
+
+        assert response.status_code == 400
+        assert response.json["global"] == ["Adresse email invalide"]
+
+    def test_email_exists(self, client: Any) -> None:
+        """
+        Test that if the email already exists, an OK response is sent
+        but nothing is changed (avoid user enumeration).
+        """
+        pro_changing = users_factories.ProFactory(email=self.origin_email)
+        pro = users_factories.ProFactory(email=self.new_email, isEmailValidated=True)
+
+        token = self.generate_token(pro.email)
+        response = client.patch("/users/validate_email", json={"token": token})
+
+        assert response.status_code == 204
+
+        assert pro_changing.email == self.origin_email

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -27,6 +27,7 @@ export type { BusinessUnitListResponseModel } from './models/BusinessUnitListRes
 export type { BusinessUnitResponseModel } from './models/BusinessUnitResponseModel';
 export type { CategoriesResponseModel } from './models/CategoriesResponseModel';
 export type { CategoryResponseModel } from './models/CategoryResponseModel';
+export type { ChangeProEmailBody } from './models/ChangeProEmailBody';
 export type { CollectiveBookingCollectiveStockResponseModel } from './models/CollectiveBookingCollectiveStockResponseModel';
 export type { CollectiveBookingResponseModel } from './models/CollectiveBookingResponseModel';
 export { CollectiveBookingStatusFilter } from './models/CollectiveBookingStatusFilter';

--- a/pro/src/apiClient/v1/models/ChangeProEmailBody.ts
+++ b/pro/src/apiClient/v1/models/ChangeProEmailBody.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ChangeProEmailBody = {
+  token: string;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -8,6 +8,7 @@ import type { BookingStatusFilter } from '../models/BookingStatusFilter';
 import type { BusinessUnitEditionBodyModel } from '../models/BusinessUnitEditionBodyModel';
 import type { BusinessUnitListResponseModel } from '../models/BusinessUnitListResponseModel';
 import type { CategoriesResponseModel } from '../models/CategoriesResponseModel';
+import type { ChangeProEmailBody } from '../models/ChangeProEmailBody';
 import type { CollectiveBookingStatusFilter } from '../models/CollectiveBookingStatusFilter';
 import type { CollectiveOfferFromTemplateResponseModel } from '../models/CollectiveOfferFromTemplateResponseModel';
 import type { CollectiveOfferResponseIdModel } from '../models/CollectiveOfferResponseIdModel';
@@ -1493,6 +1494,27 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'PATCH',
       url: '/users/tuto-seen',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * patch_validate_email <PATCH>
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public patchValidateEmail(
+    requestBody?: ChangeProEmailBody,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'PATCH',
+      url: '/users/validate_email',
+      body: requestBody,
+      mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,

--- a/pro/src/new_components/UserPhoneForm/validationSchema.ts
+++ b/pro/src/new_components/UserPhoneForm/validationSchema.ts
@@ -13,7 +13,12 @@ const validationSchema = yup.object().shape({
       'Votre numéro de téléphone n’est pas valide',
       value => {
         if (!value) return false
-        const phoneNumber = parseAndValidateFrenchPhoneNumber(value)
+        let phoneNumber
+        try {
+          phoneNumber = parseAndValidateFrenchPhoneNumber(value)
+        } catch (e) {
+          return false
+        }
         const isValid = phoneNumber?.isValid()
         if (!isValid) return false
         return true

--- a/pro/src/routes/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/routes/EmailChangeValidation/EmailChangeValidation.tsx
@@ -1,0 +1,36 @@
+// react hooks and usages doc : https://reactjs.org/docs/hooks-intro.html
+import React, { useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { useLocation } from 'react-router'
+
+import { api } from 'apiClient/api'
+import { EmailChangeValidationScreen } from 'screens/EmailChangeValidation'
+import { resetIsInitialized } from 'store/user/actions'
+import { parse } from 'utils/query-string'
+
+const EmailChangeValidation = (): JSX.Element => {
+  const [isSuccess, setIsSuccess] = useState<boolean | undefined>(undefined)
+  const location = useLocation()
+  const dispatch = useDispatch()
+  useEffect(() => {
+    const { expiration_timestamp, token } = parse(location.search)
+    const expiration_date = new Date(expiration_timestamp)
+    const now = new Date(Date.now() / 1000)
+    if (expiration_date > now) {
+      setIsSuccess(false)
+      return
+    }
+    api
+      .patchValidateEmail({ token: token })
+      .then(() => {
+        setIsSuccess(true)
+        dispatch(resetIsInitialized())
+      })
+      .catch(() => setIsSuccess(false))
+  }, [])
+
+  if (isSuccess === undefined) return <></>
+  return <EmailChangeValidationScreen isSuccess={isSuccess} />
+}
+
+export default EmailChangeValidation

--- a/pro/src/routes/EmailChangeValidation/index.ts
+++ b/pro/src/routes/EmailChangeValidation/index.ts
@@ -1,0 +1,1 @@
+export { default as EmailChangeValidation } from './EmailChangeValidation'

--- a/pro/src/routes/routes_map.tsx
+++ b/pro/src/routes/routes_map.tsx
@@ -25,6 +25,7 @@ import CollectiveOfferCreationVisibility from 'routes/CollectiveOfferVisibility/
 import CollectiveOfferEditionVisibility from 'routes/CollectiveOfferVisibility/CollectiveOfferEditionVisibility'
 import CsvDetailViewContainer from 'routes/CsvTable'
 import Desk from 'routes/Desk'
+import { EmailChangeValidation } from 'routes/EmailChangeValidation'
 import OfferEducationalCreation from 'routes/OfferEducationalCreation'
 import OfferEducationalEdition from 'routes/OfferEducationalEdition'
 import OfferEducationalStockCreation from 'routes/OfferEducationalStockCreation'
@@ -172,6 +173,18 @@ const routes: IRoute[] = [
       layoutConfig: {
         fullscreen: true,
         pageName: 'sign-in',
+      },
+    },
+  },
+  {
+    component: EmailChangeValidation,
+    path: '/email_validation',
+    title: 'Validation changement adresse e-mail',
+    meta: {
+      public: true,
+      layoutConfig: {
+        fullscreen: true,
+        pageName: 'email-validation',
       },
     },
   },

--- a/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/screens/EmailChangeValidation/EmailChangeValidation.tsx
@@ -1,0 +1,62 @@
+// react hooks and usages doc : https://reactjs.org/docs/hooks-intro.html
+import React from 'react'
+
+import Logo from 'components/layout/Logo'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+interface IEmailChangeValidationProps {
+  isSuccess: boolean
+}
+
+const EmailChangeValidation = ({
+  isSuccess,
+}: IEmailChangeValidationProps): JSX.Element => {
+  return (
+    <>
+      <div className="logo-side">
+        <Logo noLink signPage />
+      </div>
+      <div className="scrollable-content-side">
+        <div className="content" id="override-content-width">
+          {isSuccess && (
+            <section className="password-set-request-form">
+              <div>
+                <h1>Et voilà !</h1>
+                <h2>
+                  Merci d’avoir confirmé votre changement d’adresse e-mail.
+                </h2>
+                <ButtonLink
+                  variant={ButtonVariant.PRIMARY}
+                  link={{ to: '/', isExternal: false }}
+                >
+                  Se connecter
+                </ButtonLink>
+              </div>
+            </section>
+          )}
+          {!isSuccess && (
+            <section className="password-set-request-form">
+              <div>
+                <h1>Votre lien a expiré !</h1>
+                <h2>
+                  Votre adresse e-mail n’a pas été modifiée car le lien reçu par
+                  mail expire 24 heures après sa récéption.
+                </h2>
+                <h2>Connectez-vous avec votre ancienne adresse e-mail.</h2>
+                <ButtonLink
+                  variant={ButtonVariant.PRIMARY}
+                  link={{ to: '/', isExternal: false }}
+                >
+                  Se connecter
+                </ButtonLink>
+              </div>
+            </section>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default EmailChangeValidation

--- a/pro/src/screens/EmailChangeValidation/README.md
+++ b/pro/src/screens/EmailChangeValidation/README.md
@@ -1,0 +1,4 @@
+## EmailChangeValidation
+
+Vous pouvrez retrouver les example d'utilisations de [EmailChangeValidation dans notre storybook](https://pass-culture.github.io/pass-culture-main/?path=/story/screens-emailchangevalidation--c-1)
+

--- a/pro/src/screens/EmailChangeValidation/__specs__/EmailChangeValidation.spec.tsx
+++ b/pro/src/screens/EmailChangeValidation/__specs__/EmailChangeValidation.spec.tsx
@@ -1,0 +1,35 @@
+// react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router'
+
+import { EmailChangeValidationScreen } from '../'
+
+describe('screens:EmailChangeValidation', () => {
+  it('renders component successfully when success', async () => {
+    render(
+      <MemoryRouter>
+        <EmailChangeValidationScreen isSuccess={true} />
+      </MemoryRouter>
+    )
+
+    expect(
+      screen.getByText('Et voilà !', {
+        selector: 'h1',
+      })
+    ).toBeInTheDocument()
+  })
+  it('renders component successfully when not success', () => {
+    render(
+      <MemoryRouter>
+        <EmailChangeValidationScreen isSuccess={false} />
+      </MemoryRouter>
+    )
+    expect(
+      screen.getByText('Votre lien a expiré !', {
+        selector: 'h1',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/screens/EmailChangeValidation/index.ts
+++ b/pro/src/screens/EmailChangeValidation/index.ts
@@ -1,0 +1,1 @@
+export { default as EmailChangeValidationScreen } from './EmailChangeValidation'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15858

## But de la pull request

Nous pouvons aujourd'hui modifier l'adresse email d'un pro à la validation d'un formulaire. On cherche à modifier ça et avoir le même porcess que pour les jeunes :

- envoi de 2 emails, un à l'ancienne et un avec un lien à la nouvelle adresse (PR précedente)
- validation de la nouvelle adresse au clic sur le lien dans le mail precedent. (ça se passe ici)

2 commits back : 
- Partage du model des routes de validation d'email entre jeune et pro (est-ce une bonne idée de partager ou je duplique?)
-  Ajout d'une route de validation de l'email

Commits front : 
- Ajout de la page de validation / refus du jeton

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
