### PR TITLE
Revert "[PC-17032] Copy sources in the right place directly"

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,6 +18,18 @@ COPY ./requirements.txt ./
 RUN pip install --user \
 	--requirement ./requirements.txt
 
+########## SOURCES ##########
+
+FROM python:3.10-slim AS sources
+
+RUN mkdir -p /tmp/src
+
+WORKDIR /tmp/src
+
+COPY . .
+
+RUN rm -rf tests/ pyproject.toml
+
 ######### LIB ##########
 
 FROM python:3.10-slim AS lib
@@ -39,8 +51,7 @@ COPY --from=builder /home/pcapi/.local /home/pcapi/.local
 
 WORKDIR /usr/src/app
 
-COPY src/ src/
-COPY [^tests]* .
+COPY --from=sources /tmp/src .
 
 RUN chown -R pcapi:pcapi .
 


### PR DESCRIPTION
Reverts pass-culture/pass-culture-main#3336

L'instruction `COPY [^tests]* .`  ne marche pas du tout comme on le pensait.