### PR TITLE
(PC-16235)[API] fix: fix allocine sync for venue without siret

### DIFF
--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -332,7 +332,8 @@ def _is_original_version_offer(id_at_provider: str) -> bool:
 
 
 def _build_movie_uuid(movie_information: dict, venue: Venue) -> str:
-    return f"{movie_information['id']}%{venue.siret}"
+    venue_id = venue.id if not venue.siret else venue.siret
+    return f"{movie_information['id']}%{venue_id}"
 
 
 def _build_french_movie_uuid(movie_information: dict, venue: Venue) -> str:

--- a/api/tests/local_providers/allocine_stocks_functions_test.py
+++ b/api/tests/local_providers/allocine_stocks_functions_test.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 import pytest
 
+from pcapi.core.offerers.models import Venue
+from pcapi.local_providers.allocine.allocine_stocks import _build_movie_uuid
 from pcapi.local_providers.allocine.allocine_stocks import _filter_only_digital_and_non_experience_showtimes
 from pcapi.local_providers.allocine.allocine_stocks import _find_showtime_by_showtime_uuid
 from pcapi.local_providers.allocine.allocine_stocks import _format_poster_url
@@ -353,3 +355,35 @@ class FindShowtimesByShowtimeUUIDTest:
 
         # Then
         assert showtime is None
+
+
+class BuildMovieUuidTest:
+    def test_should_construct_uuid_with_siret(self):
+        # Given
+        venue = Venue(name="Cinéma Allociné", siret="77567146400110")
+
+        # When
+        movie_uuid = _build_movie_uuid(movie_information=MOVIE_INFO["node"]["movie"], venue=venue)
+
+        # Then
+        assert movie_uuid == "TW92aWU6MjY4Njgw%77567146400110"
+
+    def test_should_construct_uuid_with_venue_id_when_siret_is_none(self):
+        # Given
+        venue = Venue(name="Cinéma Allociné", id=333, siret=None)
+
+        # When
+        movie_uuid = _build_movie_uuid(movie_information=MOVIE_INFO["node"]["movie"], venue=venue)
+
+        # Then
+        assert movie_uuid == "TW92aWU6MjY4Njgw%333"
+
+    def test_should_construct_uuid_with_venue_id_when_siret_is_empty(self):
+        # Given
+        venue = Venue(name="Cinéma Allociné", id=333, siret="")
+
+        # When
+        movie_uuid = _build_movie_uuid(movie_information=MOVIE_INFO["node"]["movie"], venue=venue)
+
+        # Then
+        assert movie_uuid == "TW92aWU6MjY4Njgw%333"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16235

## But de la pull request

Corriger la création d'un identifiant unique d'offer côté AlloCiné quand l'acteur culturel (le cinéma) n'a pas de Siret


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
- [x] J'ai écrit les tests nécessaires
