### PR TITLE
(BSR) ci: update api client in adage-front

### DIFF
--- a/.github/workflows/update-api-client-template.yml
+++ b/.github/workflows/update-api-client-template.yml
@@ -37,7 +37,7 @@ jobs:
         id: check-dependency-change
         run: |
           for changed_file in ${{ steps.files.outputs.all }}; do
-            if [[ "$changed_file" == "pro/yarn.lock" || "$changed_file" == "api/requirements.txt" ]];
+            if [[ "$changed_file" == "pro/yarn.lock" || "$changed_file" == "adage-front/yarn.lock" || "$changed_file" == "api/requirements.txt" ]];
               then
                 echo ::set-output name=dependency-change::'true'
             fi
@@ -79,7 +79,7 @@ jobs:
           sudo chown -R 1000:1000 .
           ./pc start-backend &
 
-      - name: Update permission
+      - name: Update permission PRO
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         run: cd pro && sudo chown -R $USER .
 
@@ -92,10 +92,30 @@ jobs:
             ${{ runner.os }}-node-14-yarn-${{ hashFiles('pro/yarn.lock') }}
             ${{ runner.os }}-node-14-yarn-
 
-      - name: Install dependencies
+      - name: Update permission ADAGE FRONT
+        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
+        run: cd adage-front && sudo chown -R $USER .
+
+      - uses: actions/cache@v2
+        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
+        with:
+          path: adage-front/node_modules
+          key: ${{ runner.os }}-adage-node-14-yarn-${{ hashFiles('adage-front/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-adage-node-14-yarn-${{ hashFiles('adage-front/yarn.lock') }}
+            ${{ runner.os }}-adage-node-14-yarn-
+
+      - name: Install dependencies PRO
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         run: |
           cd pro
+          sudo chown -R $USER .
+          yarn install
+
+      - name: Install dependencies ADAGE FRONT
+        if: steps.evaluate-variables.outputs.should-run-cache == 'true'
+        run: |
+          cd adage-front
           sudo chown -R $USER .
           yarn install
 
@@ -107,6 +127,8 @@ jobs:
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         run: |
           cd pro
+          yarn generate:api:client:local
+          cd ../adage-front
           yarn generate:api:client:local
 
       - name: Check if there are changes

--- a/adage-front/scripts/generate_api_client_local.sh
+++ b/adage-front/scripts/generate_api_client_local.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-openapi --input http://localhost:5001/adage-iframe/openapi.json --output src/apiClient/v1 --indent='2' --name AppClient 
+openapi --input http://localhost:5001/adage-iframe/openapi.json --output src/apiClient --indent='2' --name AppClient


### PR DESCRIPTION
Comme sur PRO, pouvoir commit les changements API dans adage-front automatiquement