### PR TITLE
(PC-17043)[PRO] fix: dont display empty public name in reimbursement …

### DIFF
--- a/pro/src/components/pages/Reimbursements/Reimbursements.jsx
+++ b/pro/src/components/pages/Reimbursements/Reimbursements.jsx
@@ -65,7 +65,7 @@ const Reimbursements = () => {
         sortByDisplayName(
           reimbursementPointsResponse.map(item => ({
             id: item['id'].toString(),
-            displayName: item['publicName'] ?? item['name'],
+            displayName: item['publicName'] || item['name'],
           }))
         )
       )


### PR DESCRIPTION
…point select options

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17043

## But de la pull request

Ne pas afficher le `publicName` dans la liste des points de remboursements si ce dernier est vide. (On affiche alors le nom du lieu => `venue.name`)