### PR TITLE
(BSR)[PRO] fix: e2e

### DIFF
--- a/pro/src/new_components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/new_components/SummaryLayout/SummaryLayout.module.scss
@@ -26,7 +26,7 @@
           align-items: center;
       }
       &-edit-link {
-        height: rem.torem(0px);
+        height: unset;
 
         & > svg {
             height: rem.torem(16px);


### PR DESCRIPTION

## But de la pull request

testcafe n'arrivait pas à cliquer sur le lien car sa hauteur était de 0px (par contre je me demande pourquoi ça fonctionnait avant !)