### PR TITLE
(pc-16993)[API] feat: add achive ubble pictures command

### DIFF
--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+
+from pcapi.core.fraud import models
+from pcapi.core.fraud.models import BeneficiaryFraudCheck
+from pcapi.core.fraud.models import FraudCheckStatus
+from pcapi.core.fraud.models import FraudCheckType
+import pcapi.core.subscription.ubble.api as ubble_api
+from pcapi.core.subscription.ubble.exceptions import UbbleDownloadedFileEmpty
+from pcapi.utils.requests import ExternalAPIException
+
+
+DEFAULT_LIMIT = 1000
+DEFAULT_ID_PICTURE_STORE_STATUS = None
+
+
+class UbbleIdentificationPicturesArchiveResult:
+    def __init__(self, pictures_archived: int = 0, pictures_not_archived: int = 0):
+        self.pictures_archived: int = pictures_archived
+        self.pictures_not_archived: int = pictures_not_archived
+        self.errors = 0
+        self.total = 0
+
+    def add_result(self, result: bool | None = None) -> int:
+        if result is True:
+            self.pictures_archived += 1
+        elif result is False:
+            self.pictures_not_archived += 1
+        else:
+            self.errors += 1
+        self.total += 1
+        return self.total
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, UbbleIdentificationPicturesArchiveResult):
+            return False
+
+        return (
+            self.pictures_archived == other.pictures_archived
+            and self.pictures_not_archived == other.pictures_not_archived
+            and self.errors == other.errors
+        )
+
+
+def archive_past_identification_pictures(
+    start_date: datetime,
+    end_date: datetime,
+    status: bool | None = DEFAULT_ID_PICTURE_STORE_STATUS,
+    limit: int = DEFAULT_LIMIT,
+) -> UbbleIdentificationPicturesArchiveResult:
+    if start_date > end_date:
+        raise ValueError('"start date" must be before "end date"')
+
+    result = UbbleIdentificationPicturesArchiveResult()
+    offset = 0
+
+    while True:
+        fraud_checks = get_fraud_check_to_archive(start_date, end_date, status, limit, offset)
+
+        if not fraud_checks:
+            break
+
+        for fraud_check in fraud_checks:
+            try:
+                ubble_api.archive_ubble_user_id_pictures(fraud_check.thirdPartyId)  # type: ignore [arg-type]
+                result.add_result(True)
+            except (UbbleDownloadedFileEmpty, ExternalAPIException):
+                result.add_result(False)
+            except Exception:  # pylint: disable=broad-except
+                # Catch all exception. Watch logs to find errors during archive
+                result.add_result()
+
+        # Offset and limit are used to window query result inside loop.
+        # For the first request we use offset 0. Offset is updated at each iteration.
+        offset += limit
+
+    return result
+
+
+def get_fraud_check_to_archive(
+    start_date: datetime, end_date: datetime, status: bool | None, limit: int = DEFAULT_LIMIT, offset: int = 0
+) -> list[BeneficiaryFraudCheck]:
+    query = (
+        models.BeneficiaryFraudCheck.query.filter(
+            BeneficiaryFraudCheck.status == FraudCheckStatus.OK,
+            BeneficiaryFraudCheck.dateCreated.between(start_date, end_date),
+            BeneficiaryFraudCheck.idPicturesStored.is_(status),
+            BeneficiaryFraudCheck.type == FraudCheckType.UBBLE,
+        )
+        .order_by(BeneficiaryFraudCheck.dateCreated.asc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return query.all()

--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -22,6 +22,7 @@ def install_commands(app: flask.Flask) -> None:
         "pcapi.scripts.provider.check_provider_api",
         "pcapi.scripts.sandbox",
         "pcapi.scripts.update_providables",
+        "pcapi.scripts.ubble_archive_past_identifications",
         "pcapi.utils.human_ids",
         "pcapi.utils.secrets",
         "pcapi.workers.worker",

--- a/api/src/pcapi/scripts/ubble_archive_past_identifications.py
+++ b/api/src/pcapi/scripts/ubble_archive_past_identifications.py
@@ -1,0 +1,38 @@
+import datetime
+import logging
+
+import click
+
+from pcapi.core.subscription.ubble.archive_past_identification_pictures import archive_past_identification_pictures
+from pcapi.utils.blueprint import Blueprint
+
+
+logger = logging.getLogger(__name__)
+blueprint = Blueprint(__name__, __name__)
+
+
+@blueprint.cli.command("archive_past_identifications")
+@click.argument("start_date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.argument("end_date", type=click.DateTime(formats=["%Y-%m-%d"]), required=True)
+@click.argument("limit", type=int, required=False)
+@click.argument("status", type=bool, required=False)
+def ubble_archive_past_identifications(
+    start_date: datetime.datetime, end_date: datetime.datetime, limit: int, status: bool | None
+) -> None:
+    result = archive_past_identification_pictures(start_date, end_date, status, limit)
+    print("Done :")
+    print(f"Total records : ....................... {result.total}")
+    print(f"archive successful : .................. {result.pictures_archived}")
+    print(f"not archived (see logs for details) : . {result.pictures_not_archived}")
+    print(f"errors (see logs for details) : ....... {result.errors}")
+
+
+@blueprint.cli.command("archive_past_identifications_automation")
+def ubble_archive_past_identifications_automation() -> None:
+    # call the archive function on the last 6 months for the statuses "None"
+    # (the archive process has never been executed)
+    # and "False" (the archive process has executed but failed)
+    end_date = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    start_date = end_date - datetime.timedelta(days=186)
+    archive_past_identification_pictures(start_date, end_date, None)
+    archive_past_identification_pictures(start_date, end_date, False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16993

## But de la pull request

Ajouter une commande qui permette de relancer l'upload des images Ubble à archiver pour rattraper celles qui n'ont pas été archivées en cas d'erreur côté ubble.
La commande sera lancée par un cron qui se déclenchera chaque nuit.

## Implémentation

- ajout d'une commande `archive_past_identifications` qui pourra être lancée manuellement avec des paramètres spécifiques.
- ajout d'une commande `archive_past_identifications_automation` qui sera appelé par le cron.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
