### PR TITLE
(PC-16701)[API] feat: New backoffice: search pro accounts

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -23,6 +23,7 @@ class Permissions(enum.Enum):
     READ_PUBLIC_ACCOUNT = "visualiser un compte bénéficiaire/grand public"
     REVIEW_PUBLIC_ACCOUNT = "faire une revue manuelle d'un compte bénéficiaire/grand public"
     MANAGE_PUBLIC_ACCOUNT = "gérer un compte bénéficiaire/grand public"
+    SEARCH_PRO_ACCOUNT = "rechercher un acteur culturel"
 
 
 def sync_enum_with_db_field(session: sa.orm.Session, py_enum: Type[enum.Enum], db_field: sa.Column) -> None:

--- a/api/src/pcapi/routes/backoffice/__init__.py
+++ b/api/src/pcapi/routes/backoffice/__init__.py
@@ -6,3 +6,4 @@ def install_routes(app: Flask) -> None:
     from . import accounts
     from . import auth
     from . import permissions
+    from . import pro

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -42,7 +42,7 @@ SUBSCRIPTION_ITEM_METHODS = [
 )
 @perm_utils.permission_required(perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT)
 def search_public_account(
-    query: serialization.PublicAccountSearchQuery,
+    query: serialization.SearchQuery,
 ) -> serialization.ListPublicAccountsResponseModel:
     terms = query.q.split()
     sorts = query.sort.split(",") if query.sort else None

--- a/api/src/pcapi/routes/backoffice/pro.py
+++ b/api/src/pcapi/routes/backoffice/pro.py
@@ -1,0 +1,47 @@
+import typing
+
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.permissions import utils as perm_utils
+from pcapi.core.users import api as users_api
+from pcapi.serialization.decorator import spectree_serialize
+
+from . import blueprint
+from . import serialization
+from . import utils
+
+
+@blueprint.backoffice_blueprint.route("pro/search", methods=["GET"])
+@spectree_serialize(
+    response_model=serialization.SearchProResponseModel,
+    on_success_status=200,
+    api=blueprint.api,
+)
+@perm_utils.permission_required(perm_models.Permissions.SEARCH_PRO_ACCOUNT)
+def search_pro(
+    query: serialization.SearchQuery,
+) -> serialization.SearchProResponseModel:
+    terms = query.q.split()
+    sorts = query.sort.split(",") if query.sort else None
+
+    paginated = users_api.search_pro_account(terms, order_by=sorts).paginate(
+        page=query.page,
+        per_page=query.perPage,
+    )
+
+    response = typing.cast(
+        serialization.SearchProResponseModel,
+        utils.build_paginated_response(
+            response_model=serialization.SearchProResponseModel,
+            pages=paginated.pages,
+            total=paginated.total,
+            page=paginated.page,
+            sort=query.sort,
+            data=[
+                serialization.ProResult(
+                    resourceType="proUser", id=account.id, payload=serialization.ProUserPayload.from_orm(account)
+                )
+                for account in paginated.items
+            ],
+        ),
+    )
+    return response

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -73,7 +73,7 @@ class PaginableQuery(BaseModel):
     sort: str | None = None
 
 
-class PublicAccountSearchQuery(PaginableQuery):
+class SearchQuery(PaginableQuery):
     q: str
 
 
@@ -202,3 +202,24 @@ class PublicHistoryItem(BaseModel):
 
 class PublicHistoryResponseModel(BaseModel):
     history: list[PublicHistoryItem]
+
+
+class ProUserPayload(BaseModel):
+    class Config:
+        orm_mode = True
+        use_enum_values = True
+
+    firstName: str | None
+    lastName: str | None
+    email: str
+    phoneNumber: str | None
+
+
+class ProResult(BaseModel):
+    resourceType: str  # "proUser" or "venue" or "offerer"
+    id: int
+    payload: ProUserPayload
+
+
+class SearchProResponseModel(PaginatedResponse):
+    data: list[ProResult]

--- a/api/tests/routes/backoffice/pro_search_test.py
+++ b/api/tests/routes/backoffice/pro_search_test.py
@@ -1,0 +1,199 @@
+from flask import url_for
+import pytest
+
+from pcapi.core.auth.api import generate_token
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.permissions.models import Permissions
+from pcapi.core.testing import override_features
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def assert_user_equals(found_user, expected_user):
+    assert found_user["resourceType"] == "proUser"
+    assert found_user["id"] == expected_user.id
+    assert found_user["payload"]["firstName"] == expected_user.firstName
+    assert found_user["payload"]["lastName"] == expected_user.lastName
+    assert found_user["payload"]["email"] == expected_user.email
+    assert found_user["payload"]["phoneNumber"] == expected_user.phoneNumber
+
+
+class ProSearchTest:
+    def _create_accounts(
+        self,
+        number: int = 12,
+        first_names: list[str] = ("Alice", "Bob", "Oscar"),
+        last_names: list[str] = ("Martin", "Bernard", "Durand", "Dubois"),
+    ) -> None:
+        self.pro_accounts = []
+        for i in range(number):
+            first_name = first_names[i % len(first_names)]
+            last_name = last_names[i % len(last_names)]
+            user = users_factories.UserFactory(
+                firstName=first_name, lastName=last_name, email=f"{first_name.lower()}.{last_name.lower()}@example.com"
+            )
+            # Associate with two offerers, this helps to check that account is returned only once
+            offerers_factories.UserOffererFactory(user=user)
+            offerers_factories.UserOffererFactory(user=user)
+            self.pro_accounts.append(user)
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_by_id(self, client):
+        # given
+        self._create_accounts()
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q=self.pro_accounts[5].id),
+        )
+
+        # then
+        assert response.status_code == 200
+        response_list = response.json["data"]
+        assert len(response_list) == 1
+        assert_user_equals(response_list[0], self.pro_accounts[5])
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_by_email(self, client):
+        # given
+        self._create_accounts()
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q=self.pro_accounts[2].email),
+        )
+
+        # then
+        assert response.status_code == 200
+        response_list = response.json["data"]
+        assert len(response_list) == 1
+        assert_user_equals(response_list[0], self.pro_accounts[2])
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_by_last_name(self, client):
+        # given
+        self._create_accounts()
+        user = users_factories.UserFactory(firstName="Admin", lastName="Dubois")
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q="Dubois"),
+        )
+
+        # then
+        assert response.status_code == 200
+        response_list = response.json["data"]
+        assert len(response_list) == 3
+        assert {u["payload"]["lastName"] for u in response_list} == {"Dubois"}
+        assert {u["payload"]["firstName"] for u in response_list} == {"Alice", "Bob", "Oscar"}
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_by_first_and_last_name(self, client):
+        # given
+        self._create_accounts()
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q="Alice Dubois"),
+        )
+
+        # then
+        assert response.status_code == 200
+        response_list = response.json["data"]
+        assert len(response_list) == 1
+        assert_user_equals(response_list[0], self.pro_accounts[3])
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_empty_query(self, client):
+        # given
+        self._create_accounts()
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q=""),
+        )
+
+        # then
+        assert response.status_code == 200
+        assert len(response.json["data"]) == 0
+
+    @pytest.mark.parametrize("query", ["'", '""', "%", "*", "([{#/="])
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_unexpected(self, client, query):
+        # given
+        self._create_accounts()
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q=query),
+        )
+
+        # then
+        assert response.status_code == 200
+        assert len(response.json["data"]) == 0
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_can_search_pro_also_beneficiary(self, client):
+        # given
+        pro_beneficiary = users_factories.BeneficiaryGrant18Factory(
+            firstName="Paul",
+            lastName="Ochon",
+            email="po@example.net",
+            phoneNumber="+33740506070",
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        offerers_factories.UserOffererFactory(user=pro_beneficiary)
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q=pro_beneficiary.id),
+        )
+
+        # then
+        assert response.status_code == 200
+        response_list = response.json["data"]
+        assert len(response_list) == 1
+        assert_user_equals(response_list[0], pro_beneficiary)
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_search_public_account_without_permission(self, client):
+        # given
+        user = users_factories.UserFactory()
+        auth_token = generate_token(user, [])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q="anything"),
+        )
+
+        # then
+        assert response.status_code == 403
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_search_public_account_as_anonymous(self, client):
+        # given
+        auth_token = generate_token(users_factories.UserFactory.build(), [Permissions.SEARCH_PRO_ACCOUNT])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.search_pro", q="anything"),
+        )
+
+        # then
+        assert response.status_code == 403


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16701

## But de la pull request

Première étape de la recherche d'acteurs culturels dans le nouveau backoffice : la recherche de comptes utilisateurs pro.

## Implémentation

Similaire à la recherche des jeunes et grand public, on utilise les mêmes index.

Cadrage sur Notion :
https://www.notion.so/passcultureapp/Pr-sentation-recherches-avanc-es-avec-PostgreSQL-2d4a683e0e204dbbb43c7bcd904c076e
https://www.notion.so/passcultureapp/Strat-gie-tech-recherche-acteurs-culturels-e07b4437706c4d8985128265895e78fb

## Informations supplémentaires

La recherche des jeunes et grand public a été modifiée car elle ne filtrait pas sur jeunes/pro, tout le monde pouvait apparaître dans les résultats.

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
