### PR TITLE
(PC-16708)[API] fix: optimize script which rejects incompatible offers

### DIFF
--- a/api/src/pcapi/scripts/reject_cgu_incompatible_offers.py
+++ b/api/src/pcapi/scripts/reject_cgu_incompatible_offers.py
@@ -33,7 +33,7 @@ def reject_offers(product_id: int, dry_run: bool = True) -> int:
     if dry_run:
         LOGGER.info("%s offers related to product %s would have been rejected", offers_count, product_id)
 
-    else:
+    elif offers_count > 0:
         offers.update(
             values={
                 "validation": OfferValidationStatus.REJECTED,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16708

## But de la pull request

Juste une petite condition pour que le script de rejet d'offres incompatibles ne soit pas interminable.

## Informations supplémentaires

A été lancé en production avec cette modification ce matin.
Ne prend plus que 8 minutes quand il n'y a presque plus rien à rejeter.

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
