### PR TITLE
(PC-17081)[API] fix: Reduce Sendinblue automations cron duration

### DIFF
--- a/api/tests/core/users/external/user_automations_test.py
+++ b/api/tests/core/users/external/user_automations_test.py
@@ -245,7 +245,8 @@ class UserAutomationsTest:
         assert mock_import_contacts.call_args.args[0].update_existing_contacts == True
         assert mock_import_contacts.call_args.args[0].empty_contacts_attributes == False
 
-        mock_get_process.assert_called()
+        # Not called because we do no longer wait for import completed
+        mock_get_process.assert_not_called()
 
         assert result is True
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17081

## But de la pull request

Réduire le temps que prend l'exécution des cron d'automatisation Sendinblue, en particulier "users-inactive-since-30-days-automation" suite à laquelle un timeout de la base de données crée une exception dans sqlalchemy au retour de fonction.

## Implémentation

On n'attend plus que ce soit terminé (voir ticket)

## Informations supplémentaires

Aussi quelques changements dans les logs pour « mettre aux normes ».

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
