### PR TITLE
(PC-17027)[API] fix: fix DOM phone numbers formating

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -37,7 +37,7 @@ mypy==0.941
 notion-client==0.9.0
 openpyxl
 pgcli # a tool not used in code. There is no point in pinning its version
-phonenumberslite==8.12.23
+phonenumberslite==8.12.*
 Pillow>=8.1.1
 pydantic[email]==1.9.1
 PyJWT[crypto]==2.4.0

--- a/api/src/pcapi/admin/validators.py
+++ b/api/src/pcapi/admin/validators.py
@@ -11,6 +11,6 @@ class PhoneNumberValidator:
         value = field.data
         if value:
             try:
-                phone_number.parse_phone_number(value, "FR")
+                phone_number.parse_phone_number(value)
             except phone_validation_exceptions.InvalidPhoneNumber:
                 raise ValidationError("Numéro de téléphone invalide")

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -268,7 +268,7 @@ class Cashflow(Base, Model):  # type: ignore [valid-type, misc]
 
     # The transaction id is a UUID that will be included in the wire
     # transfer file that is sent to the bank.
-    transactionId = sqla.Column(  # type: ignore [misc]
+    transactionId = sqla.Column(
         sqla_psql.UUID(as_uuid=True), nullable=False, unique=True, server_default=sqla.func.gen_random_uuid()
     )
 
@@ -454,7 +454,7 @@ class Payment(Base, Model):  # type: ignore [valid-type, misc]
     )
     comment = sqla.Column(sqla.Text, nullable=True)
     author = sqla.Column(sqla.String(27), nullable=False)
-    transactionEndToEndId = sqla.Column(sqla_psql.UUID(as_uuid=True), nullable=True)  # type: ignore [misc]
+    transactionEndToEndId = sqla.Column(sqla_psql.UUID(as_uuid=True), nullable=True)
     transactionLabel = sqla.Column(sqla.String(140), nullable=True)
     paymentMessageId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("payment_message.id"), nullable=True)
     paymentMessage = sqla_orm.relationship(  # type: ignore [misc]

--- a/api/src/pcapi/core/subscription/phone_validation/api.py
+++ b/api/src/pcapi/core/subscription/phone_validation/api.py
@@ -36,7 +36,7 @@ def _check_phone_number_validation_is_authorized(user: users_models.User) -> Non
         raise exceptions.UserAlreadyBeneficiary
 
 
-def _check_phone_number_is_legit(user: users_models.User, phone_number: str, country_code: str) -> None:
+def _check_phone_number_is_legit(user: users_models.User, phone_number: str, country_code: int | None) -> None:
     if phone_number in settings.BLACKLISTED_SMS_RECIPIENTS:
         fraud_api.handle_blacklisted_sms_recipient(user, phone_number)
         raise exceptions.InvalidPhoneNumber()

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -792,7 +792,7 @@ def _filter_user_accounts(
 
         # phone number
         try:
-            parsed_phone_number = phone_number_utils.parse_phone_number(term, "FR")
+            parsed_phone_number = phone_number_utils.parse_phone_number(term)
             term_as_phone_number = phone_number_utils.get_formatted_phone_number(parsed_phone_number)
         except phone_validation_exceptions.InvalidPhoneNumber:
             pass  # term can't be a phone number

--- a/api/src/pcapi/core/users/external/zendesk.py
+++ b/api/src/pcapi/core/users/external/zendesk.py
@@ -94,10 +94,7 @@ def update_contact_attributes(
 def _format_user_attributes(email: str, attributes: UserAttributes) -> dict:
     # https://developer.zendesk.com/api-reference/ticketing/users/users/#phone-number
     try:
-        parsed_phone_number = phone_number_utils.parse_phone_number(
-            attributes.phone_number,
-            "FR",
-        )
+        parsed_phone_number = phone_number_utils.parse_phone_number(attributes.phone_number)
         phone_number = phone_number_utils.get_formatted_phone_number(parsed_phone_number)
     except phone_validation_exceptions.InvalidPhoneNumber:
         phone_number = None

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -177,7 +177,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
     clearTextPassword = None
     comment = sa.Column(sa.Text(), nullable=True)
     culturalSurveyFilledDate = sa.Column(sa.DateTime, nullable=True)
-    culturalSurveyId = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)  # type: ignore [misc]
+    culturalSurveyId = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)
     dateCreated = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
     dateOfBirth = sa.Column(sa.DateTime, nullable=True)
     departementCode = sa.Column(sa.String(3), nullable=True)
@@ -477,7 +477,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
         if not value:
             self._phoneNumber = None
         else:
-            self._phoneNumber = ParsedPhoneNumber(value, region="FR").phone_number
+            self._phoneNumber = ParsedPhoneNumber(value).phone_number
 
     @phoneNumber.expression  # type: ignore [no-redef]
     def phoneNumber(cls) -> str | None:  # pylint: disable=no-self-argument

--- a/api/src/pcapi/models/user_session.py
+++ b/api/src/pcapi/models/user_session.py
@@ -12,4 +12,4 @@ from pcapi.models.pc_object import PcObject
 class UserSession(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     userId = Column(BigInteger, nullable=False)
 
-    uuid = Column(UUID(as_uuid=True), unique=True, nullable=False)  # type: ignore [misc]
+    uuid = Column(UUID(as_uuid=True), unique=True, nullable=False)

--- a/api/src/pcapi/repository/user_session_queries.py
+++ b/api/src/pcapi/repository/user_session_queries.py
@@ -7,7 +7,7 @@ from pcapi.repository import repository
 def register_user_session(user_id: int, session_uuid: UUID):  # type: ignore [no-untyped-def]
     session = UserSession()
     session.userId = user_id
-    session.uuid = session_uuid  # type: ignore [call-overload]
+    session.uuid = session_uuid
     repository.save(session)
 
 

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -114,7 +114,7 @@ class PublicAccountUpdateRequest(BaseModel):
 
         try:
             # Convert to international format
-            return phone_number_utils.ParsedPhoneNumber(phone_number, "FR").phone_number
+            return phone_number_utils.ParsedPhoneNumber(phone_number).phone_number
         except phone_validation_exceptions.InvalidPhoneNumber:
             raise ValueError(f"Format de numéro de téléphone invalide : {phone_number}")
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -153,7 +153,7 @@ def update_cultural_survey(user: users_models.User, body: serializers.CulturalSu
             user.needsToFillCulturalSurvey = False
         if body.cultural_survey_id:
             logger.info("User %s updated cultural survey", user.id, extra={"actor": user.id})
-            user.culturalSurveyId = body.cultural_survey_id  # type: ignore [call-overload]
+            user.culturalSurveyId = body.cultural_survey_id
             user.culturalSurveyFilledDate = datetime.utcnow()
     return
 

--- a/api/src/pcapi/routes/serialization/base.py
+++ b/api/src/pcapi/routes/serialization/base.py
@@ -32,7 +32,7 @@ class VenueContactModel(BaseModel):
             return phone_number
 
         try:
-            return phone_number_utils.ParsedPhoneNumber(phone_number, "FR").phone_number
+            return phone_number_utils.ParsedPhoneNumber(phone_number).phone_number
         except Exception:
             raise ValueError(f"numéro de téléphone invalide: {phone_number}")
 

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -38,7 +38,7 @@ class PatchProUserBodyModel(BaseModel):
             return phone_number
 
         try:
-            return phone_number_utils.ParsedPhoneNumber(phone_number, "FR").phone_number
+            return phone_number_utils.ParsedPhoneNumber(phone_number).phone_number
         except Exception:
             raise ValueError(f"numéro de téléphone invalide: {phone_number}")
 
@@ -93,7 +93,7 @@ class UserPhoneBodyModel(BaseModel):
             return phone_number
 
         try:
-            return phone_number_utils.ParsedPhoneNumber(phone_number, "FR").phone_number
+            return phone_number_utils.ParsedPhoneNumber(phone_number).phone_number
         except Exception:
             raise ValueError(f"numéro de téléphone invalide: {phone_number}")
 

--- a/api/src/pcapi/utils/phone_number.py
+++ b/api/src/pcapi/utils/phone_number.py
@@ -1,8 +1,25 @@
+import enum
+
 import phonenumbers
 from phonenumbers import PhoneNumber
 from phonenumbers.phonenumberutil import NumberParseException
 
 from pcapi.core.subscription.phone_validation import exceptions as phone_validation_exceptions
+
+
+class EligibleRegions(enum.Enum):
+    GP = "GP"  # Guadeloupe  (+590)
+    MQ = "MQ"  # Martinique (+596)
+    GF = "GF"  # Guyane (+594)
+    RE = "RE"  # Réunion (+262)
+    PM = "PM"  # Saint Pierre et Miquelon (+508)
+    YT = "YT"  # Mayotte (+262)
+    BL = "BL"  # Saint Barthélémy (+590)
+    MF = "MF"  # Saint Martin (+590)
+    WF = "WF"  # Wallis et Futuna (+681)
+    PF = "PF"  # Polynésie française (+689)
+    NC = "NC"  # Nouvelle Calédonie (+687)
+    FR = "FR"  # métropole (+33)
 
 
 class ParsedPhoneNumber:
@@ -20,18 +37,28 @@ def parse_phone_number(phone_number: str | None, region: str | None = None) -> P
     Raises:
         InvalidPhoneNumber
     """
-    try:
-        if region:
-            parsed_phone_number = phonenumbers.parse(phone_number, region)
-        else:
-            parsed_phone_number = phonenumbers.parse(phone_number)
-    except NumberParseException as error:
-        raise phone_validation_exceptions.InvalidPhoneNumber(str(phone_number)) from error
-    except TypeError as error:
-        raise phone_validation_exceptions.InvalidPhoneNumber(str(phone_number)) from error
+    if phone_number is None:
+        raise phone_validation_exceptions.InvalidPhoneNumber
 
-    if not phonenumbers.is_valid_number(parsed_phone_number):
-        raise phone_validation_exceptions.InvalidPhoneNumber(str(phone_number))
+    regions = tuple(EligibleRegions) if region is None else (getattr(EligibleRegions, region),)
+    parsed_phone_number = None
+    for r in regions:
+        try:
+            parsed_phone_number = phonenumbers.parse(phone_number, r.value)
+        except NumberParseException:
+            pass
+        except TypeError as err:
+            raise phone_validation_exceptions.InvalidPhoneNumber(str(phone_number)) from err
+        else:
+            if phonenumbers.is_valid_number(parsed_phone_number):
+                break
+
+            parsed_phone_number = None
+
+    if parsed_phone_number is None:
+        raise phone_validation_exceptions.InvalidPhoneNumber(
+            f"provided phone number ({phone_number}) does not belong to an eligible region {tuple(r.value for r in regions)}"
+        )
 
     return parsed_phone_number
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1061,12 +1061,12 @@ class SendPhoneValidationCodeTest:
             == subscription_models.SubscriptionItemStatus.KO
         )
 
-    def test_send_phone_validation_code_with_malformed_number(self, client):
+    def test_send_phone_validation_code_with_invalid_number(self, client):
         # user's phone number should be in international format (E.164): +33601020304
         user = users_factories.UserFactory(isEmailValidated=True)
         client.with_token(email=user.email)
 
-        response = client.post("/native/v1/send_phone_validation_code", json={"phoneNumber": "0601020304"})
+        response = client.post("/native/v1/send_phone_validation_code", json={"phoneNumber": "060102030405"})
 
         assert response.status_code == 400
         assert response.json["code"] == "INVALID_PHONE_NUMBER"

--- a/api/tests/utils/phone_number_test.py
+++ b/api/tests/utils/phone_number_test.py
@@ -4,42 +4,64 @@ from pcapi.core.subscription.phone_validation import exceptions as phone_validat
 from pcapi.utils import phone_number as phone_number_utils
 
 
-def test_parsed_phone_number():
-    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("+33102030405")
-    assert parsed_phone_number.phone_number == "+33102030405"
-
-    parsed_phone_number = phone_number_utils.ParsedPhoneNumber(" +33102030405 ")
-    assert parsed_phone_number.phone_number == "+33102030405"
-
-    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("+262262161234")
-    assert parsed_phone_number.phone_number == "+262262161234"
-
-
-def test_parsed_phone_number_region():
-    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("0102030405", "FR")
-    assert parsed_phone_number.phone_number == "+33102030405"
-
-    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("0033102030405", "FR")
-    assert parsed_phone_number.phone_number == "+33102030405"
-
-    parsed_phone_number = phone_number_utils.ParsedPhoneNumber("0262161234", "RE")
-    assert parsed_phone_number.phone_number == "+262262161234"
-
-
-def test_parse_phone_number():
-    parsed = phone_number_utils.parse_phone_number("06 07 08 09 10", "FR")
-    assert phone_number_utils.get_formatted_phone_number(parsed) == "+33607080910"
-
-    parsed = phone_number_utils.parse_phone_number("0607080910", "FR")
-    assert phone_number_utils.get_formatted_phone_number(parsed) == "+33607080910"
-
-    parsed = phone_number_utils.parse_phone_number("+39 066 1234567", "FR")
-    assert phone_number_utils.get_formatted_phone_number(parsed) == "+390661234567"
+@pytest.mark.parametrize(
+    "raw, formatted",
+    (
+        ("+33102030405", "+33102030405"),
+        ("+33102030405 ", "+33102030405"),  # un espace en fin de numéro
+        ("+262262161234", "+262262161234"),
+        ("0102030405", "+33102030405"),
+        ("0262418300", "+262262418300"),
+        ("0590860581", "+590590860581"),
+        ("0596800070", "+596596800070"),
+        ("410200", "+508410200"),
+        ("0590278727", "+590590278727"),
+        ("0590875721", "+590590875721"),
+        ("721717", "+681721717"),
+        ("40505700", "+68940505700"),
+        ("272727", "+687272727"),
+        ("0269635000", "+262269635000"),
+        ("0033102030405", "+33102030405"),
+    ),
+)
+def test_parsed_phone_number(raw, formatted):
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber(raw)
+    assert parsed_phone_number.phone_number == formatted
 
 
-def test_parse_invalid_phone_number():
+@pytest.mark.parametrize(
+    "raw, region, formatted",
+    (
+        ("0102030405", "FR", "+33102030405"),
+        ("0033102030405", "FR", "+33102030405"),
+        ("0262161234", "RE", "+262262161234"),
+    ),
+)
+def test_parsed_phone_number_region(raw, region, formatted):
+    parsed_phone_number = phone_number_utils.ParsedPhoneNumber(raw, region)
+    assert parsed_phone_number.phone_number == formatted
+
+
+@pytest.mark.parametrize(
+    "raw, region, formatted",
+    (
+        ("0102030405", "FR", "+33102030405"),
+        ("0033102030405", "FR", "+33102030405"),
+        ("0262161234", "RE", "+262262161234"),
+    ),
+)
+def test_parse_phone_number(raw, region, formatted):
+    parsed = phone_number_utils.parse_phone_number(raw, region)
+    assert phone_number_utils.get_formatted_phone_number(parsed) == formatted
+
+
+@pytest.mark.parametrize(
+    "raw, region",
+    (
+        (None, "FR"),
+        ("+33123", "FR"),
+    ),
+)
+def test_parse_invalid_phone_number(raw, region):
     with pytest.raises(phone_validation_exceptions.InvalidPhoneNumber):
-        phone_number_utils.parse_phone_number(None, "FR")
-
-    with pytest.raises(phone_validation_exceptions.InvalidPhoneNumber):
-        phone_number_utils.parse_phone_number("+33123", "FR")
+        phone_number_utils.parse_phone_number(raw, region)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17027

## But de la pull request

valider et formater les numéros de tel attribués à des DOM

## Implémentation

- chaque numéro de téléphone est maintenant testée avec chacune des régions téléphoniques de France (Guadeloupe, Martinique, Guyane, Réunion, Saint Pierre et Miquelon,  Mayotte et métropole) avant d'être considéré comme invalide.

## Informations supplémentaires

- Plus la peine de spécifier une région quand on enregistre un numéro de tel puisque toutes les régions autorisées seront testées
- Lé numéro de révision du paquet `phonenumberslite` n'est plus fixé pour permettre à d'éventuelles corrections et modification des plans de numérotations d'être prises en compte

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] ~~J'ai relu attentivement les migrations, en particulier pour éviter les _locks_~~
- [ ] ~~J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités~~
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] ~~J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)~~
