### PR TITLE
(PC-17062)[API] fix: update booking.offer.url only after serialization

### DIFF
--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -159,9 +159,21 @@ def get_bookings(user: User) -> BookingsResponse:
             )
         ],
     )
-    # TODO: remove this once the booking.stock.offer.url = booking.completedUrl hack in serialization is removed
+    _update_booking_offer_url(result.ended_bookings)
+    _update_booking_offer_url(result.ongoing_bookings)
+
+    # TODO: some objects seem to be updated. remove rollback when this is fixed
     db.session.rollback()
     return result
+
+
+def _update_booking_offer_url(booking_response_list: list[BookingReponse]) -> None:
+    # Native application should use `booking.completedUrl` but actually
+    # it uses booking.stock.offer.url in some places.
+    # So we need to update the response object not to override the database object
+    # Remove when native app stops using booking.stock.offer.url
+    for booking in booking_response_list:
+        booking.stock.offer.url = booking.completedUrl
 
 
 def is_ended_booking(booking: Booking) -> bool:

--- a/api/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -114,13 +114,6 @@ class BookingReponse(BaseModel):
 
     @classmethod
     def from_orm(cls: Any, booking: Booking):  # type: ignore
-        # Native application should use `booking.completedUrl` but actually
-        # up to version 135, it uses booking.stock.offer.url instead.
-        # Therefore the API will override `booking.stock.offer.url` with
-        # `booking.completedUrl`.
-        # Unfortunate side-effect, the offer object has its url modified and
-        # needs to be rolledback.
-        booking.stock.offer.url = booking.completedUrl
         booking.confirmationDate = booking.cancellationLimitDate
         return super().from_orm(booking)
 

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -235,6 +235,37 @@ class GetBookingsTest:
         for booking in response.json["ongoing_bookings"]:
             assert booking["qrCodeData"] is not None
 
+    def test_offer_url_is_not_overrided_by_cancelled_booking_url(self, app, client):
+        OFFER_URL = "https://demo.pass/some/path?token={token}&email={email}&offerId={offerId}"
+        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
+        stock = StockFactory(offer__url=OFFER_URL)
+
+        cancelled_booking = booking_factories.CancelledIndividualBookingFactory(
+            individualBooking__user=user, displayAsEnded=True, stock=stock
+        )
+        ongoing_booking = booking_factories.IndividualBookingFactory(
+            individualBooking__user=user,
+            stock=stock,
+        )
+
+        test_client = client.with_token(user.email)
+
+        response = test_client.get("/native/v1/bookings")
+
+        assert response.status_code == 200
+
+        assert ongoing_booking.token in response.json["ongoing_bookings"][0]["stock"]["offer"]["url"]
+        assert (
+            response.json["ongoing_bookings"][0]["completedUrl"]
+            == response.json["ongoing_bookings"][0]["stock"]["offer"]["url"]
+        )
+
+        assert cancelled_booking.token in response.json["ended_bookings"][0]["stock"]["offer"]["url"]
+        assert (
+            response.json["ended_bookings"][0]["completedUrl"]
+            == response.json["ended_bookings"][0]["stock"]["offer"]["url"]
+        )
+
     @freeze_time("2021-03-12")
     def test_get_bookings_withdrawal_informations(self, client):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)


### PR DESCRIPTION
booking.stock.offer.url was updated with booking.completedUrl. But booking.completedUrl is computed from offer.url. So we must not update the database object before all the objects have been serialized. Update the seralized object instead

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17062
