### PR TITLE
(PC-16681)[PRO] feat: fix desk error message when booking is already …

### DIFF
--- a/pro/src/routes/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/routes/Desk/__specs__/Desk.spec.tsx
@@ -191,6 +191,37 @@ describe('src | routes | Desk', () => {
     expect(response.error.variant).toBe(MESSAGE_VARIANT.ERROR)
   })
 
+  it('test getBooking failure, booking reimbursed', async () => {
+    const cancelledErrorMessage = 'Cette réservation a été remboursée'
+    jest.spyOn(apiContremarque, 'getBookingByTokenV2').mockRejectedValue(
+      new ApiError(
+        {} as ApiRequestOptions,
+        {
+          status: HTTP_STATUS.FORBIDDEN,
+          body: { payment: 'Cette réservation a été remboursée' },
+        } as ApiResult,
+        cancelledErrorMessage
+      )
+    )
+
+    const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
+
+    userEvent.click(buttonGetBooking)
+    await waitFor(() => {
+      expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
+        testToken
+      )
+    })
+    // to fix - no-conditional-in-test
+    const response = JSON.parse(responseDataContainer.textContent || '')
+
+    expect(Object.keys(response)).toHaveLength(1)
+    expect(response.error).toBeDefined()
+    expect(response.error.isTokenValidated).toBe(false)
+    expect(response.error.message).toBe(cancelledErrorMessage)
+    expect(response.error.variant).toBe(MESSAGE_VARIANT.ERROR)
+  })
+
   it('test getBooking failure, api error', async () => {
     const globalErrorMessage = 'Server error'
     jest

--- a/pro/src/routes/Desk/adapters/getBooking.ts
+++ b/pro/src/routes/Desk/adapters/getBooking.ts
@@ -52,6 +52,18 @@ const getBookingFailure = (
       },
     }
   }
+  if (apiResponseError.status === HTTP_STATUS.FORBIDDEN) {
+    const apiReimbursedErrorMessage = apiResponseError.body['payment']
+    if (apiReimbursedErrorMessage) {
+      return {
+        error: {
+          isTokenValidated: false,
+          message: apiReimbursedErrorMessage,
+          variant: MESSAGE_VARIANT.ERROR,
+        },
+      }
+    }
+  }
   return {
     error: {
       isTokenValidated: false,


### PR DESCRIPTION
…reimbursed

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16681

## But de la pull request

Afficher le bon message d'erreur lors de la consultation d'une contremarque déja remboursée