### PR TITLE
(PC-16131)[BO FRONT] feat: Phone confirmation button not when phone already confirmed

### DIFF
--- a/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/UserDetailsCard.tsx
@@ -1,13 +1,13 @@
-import { Card, Button, Grid, Stack, Tooltip, Typography } from '@mui/material'
+import { Button, Card, Grid, Stack, Tooltip, Typography } from '@mui/material'
 import { captureException } from '@sentry/react'
 import moment from 'moment'
 import React, { useState } from 'react'
 import {
   Form,
-  useNotify,
-  TextInput,
   SaveButton,
+  TextInput,
   UpdateParams,
+  useNotify,
 } from 'react-admin'
 import { FieldValues } from 'react-hook-form'
 
@@ -17,14 +17,40 @@ import {
   PcApiHttpError,
 } from '../../../providers/apiHelpers'
 import { dataProvider } from '../../../providers/dataProvider'
-import { FraudCheck, UserBaseInfo } from '../types'
+import {
+  FraudCheck,
+  SubscriptionItem,
+  SubscriptionItemStatus,
+  SubscriptionItemType,
+  UserBaseInfo,
+} from '../types'
 
 type Props = {
   user: UserBaseInfo
   firstFraudCheck: FraudCheck
+  firstSubcriptionItems: SubscriptionItem[]
 }
-export const UserDetailsCard = ({ user, firstFraudCheck }: Props) => {
+export const UserDetailsCard = ({
+  user,
+  firstFraudCheck,
+  firstSubcriptionItems,
+}: Props) => {
   const notify = useNotify()
+
+  const isPhoneValidated = () => {
+    if (firstSubcriptionItems.length > 0) {
+      const item: SubscriptionItem | undefined = firstSubcriptionItems.find(
+        ({
+          type,
+        }: {
+          type: SubscriptionItemType
+          status: SubscriptionItemStatus
+        }) => type === SubscriptionItemType.PHONE_VALIDATION
+      )
+      return item ? item.status === SubscriptionItemStatus.OK : false
+    }
+    return false
+  }
 
   const [editable, setEditable] = useState(false)
 
@@ -196,7 +222,9 @@ export const UserDetailsCard = ({ user, firstFraudCheck }: Props) => {
                   >
                     <div>
                       <Button
-                        disabled={!user.phoneNumber}
+                        disabled={
+                          !user.phoneNumber || isPhoneValidated() === true
+                        }
                         variant="outlined"
                         onClick={sendPhoneValidationCode}
                       >

--- a/backoffice/src/resources/PublicUsers/UserDetail.tsx
+++ b/backoffice/src/resources/PublicUsers/UserDetail.tsx
@@ -451,6 +451,7 @@ export const UserDetail = () => {
                     <UserDetailsCard
                       user={userBaseInfo}
                       firstFraudCheck={idsCheckHistory[0].items[0]}
+                      firstSubcriptionItems={subscriptionItems[0].items}
                     />
                   )}
               </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16131

## But de la pull request

Le bouton “confirmer manuellement” est cliquable même quand le numéro de téléphone est déjà validé. Au clique sur le bouton on a une erreur 500 “une erreur est survenue”.


## Implémentation

Ajout des subscription item pour la souscription la plus récente afin de détecter le statut de validation du numéro de téléphone. 


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`