### PR TITLE
(BSR)[API] feat: Retry requests on Insee Sirene API upon error

### DIFF
--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -106,6 +106,7 @@ class Session(requests.Session):
         self.mount("https://www.demarches-simplifiees.fr", safe_adapter)
         self.mount(settings.UBBLE_API_URL, safe_adapter)
         self.mount(settings.BATCH_API_URL, unsafe_adapter)
+        self.mount("https://api.insee.fr/entreprises/sirene/V3", safe_adapter)
 
     def request(self, method: str | bytes, url: str | bytes, *args: Any, **kwargs: Any) -> Response:
         return _wrapper(super().request, method, url, *args, **kwargs)


### PR DESCRIPTION
We have a non-zero (though not unacceptable) error rate on this API.
Since it's safe and easy to retry requests, let's do that.