### PR TITLE
(PC-16753)[API] fix: reset error messages in fraud check when receiving an update

### DIFF
--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -77,6 +77,8 @@ def _is_fraud_check_up_to_date(
 def _update_fraud_check_with_new_content(
     fraud_check: fraud_models.BeneficiaryFraudCheck, new_content: fraud_models.DMSContent
 ) -> None:
+    fraud_check.reason = None
+    fraud_check.reasonCodes = []
     fraud_check.resultContent = new_content.dict()
     new_eligibility = fraud_api.decide_eligibility(
         fraud_check.user, new_content.get_birth_date(), new_content.get_registration_datetime()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16753

## But de la pull request

Aussi nmettre à jour les éventuels messages d'erreurs du fraud check quand on reçoit une update

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
