### PR TITLE
(BSR)[API] chore: Fix typing of Booking.email and Booking.userName

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -280,7 +280,7 @@ class Booking(PcObject, Base, Model):  # type: ignore [valid-type, misc]
         if self.educationalBooking is not None:
             return self.educationalBooking.educationalRedactor.firstName
 
-        return None
+        raise ValueError(f"Booking {self.id} has no individual nor educational booking.")
 
     @property
     def lastName(self) -> str | None:
@@ -290,27 +290,27 @@ class Booking(PcObject, Base, Model):  # type: ignore [valid-type, misc]
         if self.educationalBooking is not None:
             return self.educationalBooking.educationalRedactor.lastName
 
-        return None
+        raise ValueError(f"Booking {self.id} has no individual nor educational booking.")
 
     @property
-    def userName(self) -> str | None:
+    def userName(self) -> str:
         if self.individualBooking is not None:
             return f"{self.individualBooking.user.firstName} {self.individualBooking.user.lastName}"
 
         if self.educationalBooking is not None:
             return f"{self.educationalBooking.educationalRedactor.firstName} {self.educationalBooking.educationalRedactor.lastName}"
 
-        return None
+        raise ValueError(f"Booking {self.id} has no individual nor educational booking.")
 
     @property
-    def email(self) -> str | None:
+    def email(self) -> str:
         if self.individualBooking is not None:
             return self.individualBooking.user.email
 
         if self.educationalBooking is not None:
             return self.educationalBooking.educationalRedactor.email
 
-        return None
+        raise ValueError(f"Booking {self.id} has no individual nor educational booking.")
 
     @hybrid_property
     def isExternal(self) -> bool:

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
@@ -24,7 +24,10 @@ def get_booking_cancellation_by_beneficiary_to_pro_email_data(
             "USER_NAME": f"{booking.firstName} {booking.lastName}",
             "VENUE_NAME": booking.stock.offer.venue.name,
         },
-        reply_to=models.EmailInfo(email=booking.email, name=f"{booking.firstName} {booking.lastName}"),  # type: ignore [arg-type]
+        reply_to=models.EmailInfo(
+            email=booking.email,
+            name=f"{booking.firstName} {booking.lastName}",
+        ),
     )
 
 

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
@@ -45,4 +45,4 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
 
 def send_booking_cancellation_by_pro_to_beneficiary_email(booking: Booking) -> bool:
     data = get_booking_cancellation_by_pro_to_beneficiary_email_data(booking)
-    return mails.send(recipients=[booking.email], data=data)  # type: ignore [list-item]
+    return mails.send(recipients=[booking.email], data=data)

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary.py
@@ -18,7 +18,7 @@ def send_batch_booking_postponement_email_to_users(bookings: list[Booking]) -> b
 
 def send_booking_postponement_email_to_users(booking: Booking) -> bool:
     data = get_booking_postponed_by_pro_to_beneficiary_email_data(booking)
-    return mails.send(recipients=[booking.email], data=data)  # type: ignore [list-item]
+    return mails.send(recipients=[booking.email], data=data)
 
 
 def get_booking_postponed_by_pro_to_beneficiary_email_data(

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_test.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class SendOffererDrivenCancellationEmailToOffererTest:
     def test_should_send_cancellation_by_offerer_email_to_offerer(self):
         # Given
-        booking = bookings_factories.BookingFactory(
+        booking = bookings_factories.IndividualBookingFactory(
             stock__offer__bookingEmail="offer@example.com",
         )
 

--- a/api/tests/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary_test.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from pcapi.core.bookings.factories import BookingFactory
+import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.mails.transactional.bookings.booking_postponed_by_pro_to_beneficiary import (
     get_booking_postponed_by_pro_to_beneficiary_email_data,
 )
@@ -16,7 +16,7 @@ class GetBookingPostponedByProToBeneficiaryTest:
     def test_should_get_sendinblue_email_data_when_stock_date_have_been_changed(self):
         # Given
         stock = EventStockFactory(beginningDatetime=datetime(2019, 8, 20, 12, 0, 0))
-        booking = BookingFactory(stock=stock)
+        booking = bookings_factories.IndividualBookingFactory(stock=stock)
 
         # When
         booking_info_for_sendinblue = get_booking_postponed_by_pro_to_beneficiary_email_data(booking)


### PR DESCRIPTION
Also, raise an exception if a booking has no individual nor
educational booking. (We should probably have a database constraint
for this, but since these relationships will be removed, I don't see
much point in doing it now.)

`Booking.firstName` and `lastName` may still return None because
`EducationalRedactor` columns of the same name are nullable.