### PR TITLE
(PC-17146)[API] fix: CDS transaction amount when booking ticket

### DIFF
--- a/api/tests/core/booking_providers/cds/test_client.py
+++ b/api/tests/core/booking_providers/cds/test_client.py
@@ -999,10 +999,13 @@ class CineDigitalServiceBookTicketTest:
         assert create_transaction_body_arg_call.ticket_sale_collection[0].seat_number == "A_1"
         assert create_transaction_body_arg_call.ticket_sale_collection[1].id == -2
         assert create_transaction_body_arg_call.ticket_sale_collection[1].seat_number == "A_2"
-        assert len(create_transaction_body_arg_call.payement_collection) == 1
+        assert len(create_transaction_body_arg_call.payement_collection) == 2
         assert create_transaction_body_arg_call.payement_collection[0].id == -1
-        assert create_transaction_body_arg_call.payement_collection[0].amount == 0
+        assert create_transaction_body_arg_call.payement_collection[0].amount == 5.0
         assert create_transaction_body_arg_call.payement_collection[0].payement_type.id == 12
+        assert create_transaction_body_arg_call.payement_collection[1].id == -2
+        assert create_transaction_body_arg_call.payement_collection[1].amount == 5.0
+        assert create_transaction_body_arg_call.payement_collection[1].payement_type.id == 12
 
         assert len(tickets) == 2
         assert tickets[0].barcode == "141414141414"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17146

## But de la pull request

Problème résolu : lors du booking des tickets de cinéma, nous n'envoyons pas le montant des différentes réservations dans le dictionnaire payementCollection. N.B: Il faut envoyer autant d'éléments de payment dans payementCollection que de ticket à réserver.

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
