### PR TITLE
(PC-17158) indexing add joinedload

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -382,9 +382,15 @@ def reindex_offer_ids(offer_ids: Iterable[int]) -> None:
 
     to_add = []
     to_delete = []
-    # FIXME (dbaty, 2021-07-05): join-load Stock, Venue, Offerer,
-    # etc. to avoid N+1 queries on each offer.
-    offers = Offer.query.filter(Offer.id.in_(offer_ids))
+    offers = (
+        Offer.query.options(joinedload(Offer.venue).joinedload(Venue.managingOfferer))
+        .options(joinedload(Offer.criteria))
+        .options(joinedload(Offer.mediations))
+        .options(joinedload(Offer.product))
+        .options(joinedload(Offer.stocks))
+        .filter(Offer.id.in_(offer_ids))
+    )
+
     for offer in offers:
         if offer and offer.is_eligible_for_search:
             to_add.append(offer)

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -7,6 +7,7 @@ from pcapi.core.offerers import models as offerers_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.search.testing as search_testing
+from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 
@@ -93,6 +94,15 @@ class ReindexOfferIdsTest:
         assert search_testing.search_store["offers"] == {}
         search.reindex_offer_ids([offer.id])
         assert offer.id in search_testing.search_store["offers"]
+
+    def test_no_unexpected_query_made(self):
+        offer_ids = [make_bookable_offer().id for _ in range(3)]
+
+        # 1: get offers
+        # 2. get FF
+        # 3. get the offers's venue id
+        with assert_num_queries(3):
+            search.reindex_offer_ids(offer_ids)
 
     def test_unindex_unbookable_offer(self, app):
         offer = make_unbookable_offer()

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -150,6 +150,18 @@ class ReindexVenueIdsTest:
         search.reindex_venue_ids([venue.id])
         assert venue.id in search_testing.search_store["venues"]
 
+    def test_no_unexpected_query_made(self):
+        venues = offerers_factories.VenueFactory.create_batch(3, isPermanent=True)
+        venue_ids = [venue.id for venue in venues]
+
+        assert search_testing.search_store["venues"] == {}
+
+        # load venues (1 query)
+        # load FF (1 query)
+        # find whether venue has at least one bookable offer (1 query per venue)
+        with assert_num_queries(5):
+            search.reindex_venue_ids(venue_ids)
+
     def test_unindex_ineligible_venues(self):
         indexable_venue = offerers_factories.VenueFactory(
             isPermanent=True, managingOfferer__isActive=True, venueTypeCode=offerers_models.VenueTypeCode.BOOKSTORE


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17158

## But de la pull request

Éviter des N+1 lors de la réindexation des offres et des lieux.

## Implémentation

Pour ce qui est des lieux, lors de la sérialisation on regarde si le lieu a au moins une offre indexable et ce calcul génère une requête. Je n'ai pas cherché à améliorer cet aspect parce que cela m'a l'air d'être plus compliqué qu'ajouter de simples `joinedload`.

## Notes

Cette PR a pour but d'avoir une base de code à tester en situation réelle. Il faut d'abord vérifier que cette amélioration en est vraiment une : si la requête est trop lourde on évite les N+1 mais on pourrait y perdre (beaucoup).