### PR TITLE
(BSR)[API] chore: Add typing annotation on UUID model columns

### DIFF
--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -9,6 +9,7 @@ import dataclasses
 import datetime
 import enum
 import typing
+import uuid
 
 import sqlalchemy as sqla
 import sqlalchemy.dialects.postgresql as sqla_psql
@@ -268,7 +269,7 @@ class Cashflow(Base, Model):  # type: ignore [valid-type, misc]
 
     # The transaction id is a UUID that will be included in the wire
     # transfer file that is sent to the bank.
-    transactionId = sqla.Column(
+    transactionId: uuid.UUID = sqla.Column(
         sqla_psql.UUID(as_uuid=True), nullable=False, unique=True, server_default=sqla.func.gen_random_uuid()
     )
 
@@ -454,7 +455,7 @@ class Payment(Base, Model):  # type: ignore [valid-type, misc]
     )
     comment = sqla.Column(sqla.Text, nullable=True)
     author = sqla.Column(sqla.String(27), nullable=False)
-    transactionEndToEndId = sqla.Column(sqla_psql.UUID(as_uuid=True), nullable=True)
+    transactionEndToEndId: uuid.UUID = sqla.Column(sqla_psql.UUID(as_uuid=True), nullable=True)
     transactionLabel = sqla.Column(sqla.String(140), nullable=True)
     paymentMessageId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("payment_message.id"), nullable=True)
     paymentMessage = sqla_orm.relationship(  # type: ignore [misc]

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 import enum
 from operator import attrgetter
 import typing
+import uuid
 
 import sqlalchemy as sa
 from sqlalchemy import orm
@@ -177,7 +178,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
     clearTextPassword = None
     comment = sa.Column(sa.Text(), nullable=True)
     culturalSurveyFilledDate = sa.Column(sa.DateTime, nullable=True)
-    culturalSurveyId = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)
+    culturalSurveyId: uuid.UUID = sa.Column(postgresql.UUID(as_uuid=True), nullable=True)
     dateCreated = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
     dateOfBirth = sa.Column(sa.DateTime, nullable=True)
     departementCode = sa.Column(sa.String(3), nullable=True)

--- a/api/src/pcapi/models/user_session.py
+++ b/api/src/pcapi/models/user_session.py
@@ -1,8 +1,7 @@
-""" user offerer """
+from uuid import UUID
 
-from sqlalchemy import BigInteger
-from sqlalchemy import Column
-from sqlalchemy.dialects.postgresql import UUID
+import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as sa_psql
 
 from pcapi.models import Base
 from pcapi.models import Model
@@ -10,6 +9,6 @@ from pcapi.models.pc_object import PcObject
 
 
 class UserSession(PcObject, Base, Model):  # type: ignore [valid-type, misc]
-    userId = Column(BigInteger, nullable=False)
+    userId = sa.Column(sa.BigInteger, nullable=False)
 
-    uuid = Column(UUID(as_uuid=True), unique=True, nullable=False)
+    uuid: UUID = sa.Column(sa_psql.UUID(as_uuid=True), unique=True, nullable=False)


### PR DESCRIPTION
Otherwise mypy gets confused:

    [SQLAlchemy Mypy plugin] Can't infer type from ORM mapped
    expression assigned to attribute 'uuid'; please specify a Python
    type or Mapped[<python type>] on the left hand side. [misc]