### PR TITLE
(BSR)[API] chore: Specify type of Token.value

### DIFF
--- a/api/src/pcapi/admin/custom_views/admin_user_view.py
+++ b/api/src/pcapi/admin/custom_views/admin_user_view.py
@@ -105,6 +105,7 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
                 expiration=datetime.datetime.utcnow() + RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED,
             )
             transactional_mails.send_email_validation_to_admin_email(model, token)
-            flash(f"Lien de réinitialisation du mot de passe : {build_pc_webapp_reset_password_link(token.value)}")  # type: ignore [arg-type]
+            link = build_pc_webapp_reset_password_link(token.value)
+            flash(f"Lien de réinitialisation du mot de passe : {link}")
 
         super().after_model_change(form, model, is_created)

--- a/api/src/pcapi/admin/custom_views/partner_user_view.py
+++ b/api/src/pcapi/admin/custom_views/partner_user_view.py
@@ -121,7 +121,7 @@ class PartnerUserView(ResendValidationEmailMixin, SuspensionMixin, BaseAdminView
                 expiration=datetime.datetime.utcnow() + RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED,
             )
             flash(
-                f"Lien de réinitialisation du mot de passe : {build_pc_webapp_reset_password_link(resetPasswordToken.value)}"  # type: ignore [arg-type]
+                f"Lien de réinitialisation du mot de passe : {build_pc_webapp_reset_password_link(resetPasswordToken.value)}"
             )
 
     def get_query(self) -> BaseQuery:

--- a/api/src/pcapi/admin/custom_views/pro_user_view.py
+++ b/api/src/pcapi/admin/custom_views/pro_user_view.py
@@ -185,7 +185,7 @@ class ProUserView(SuspensionMixin, BaseAdminView):
                 model,
                 expiration=datetime.datetime.utcnow() + RESET_PASSWORD_TOKEN_LIFE_TIME_EXTENDED,
             )
-            reset_password_link = build_pc_pro_create_password_link(resetPasswordToken.value)  # type: ignore [arg-type]
+            reset_password_link = build_pc_pro_create_password_link(resetPasswordToken.value)
             flash(f"Lien de création de mot de passe : {reset_password_link}")
             if current_user:
                 transactional_mails.send_reset_password_link_to_admin_email(

--- a/api/src/pcapi/core/mails/transactional/pro/email_validation.py
+++ b/api/src/pcapi/core/mails/transactional/pro/email_validation.py
@@ -30,5 +30,5 @@ def get_email_validation_to_admin_email_data(token: str) -> models.Transactional
 
 
 def send_email_validation_to_admin_email(user: User, token: Token) -> bool:
-    data = get_email_validation_to_admin_email_data(token.value)  # type: ignore [arg-type]
+    data = get_email_validation_to_admin_email_data(token.value)
     return mails.send(recipients=[user.email], data=data)

--- a/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
@@ -13,7 +13,7 @@ from pcapi.utils.mailing import build_pc_pro_reset_password_link
 def get_reset_password_to_pro_email_data(
     user: users_models.User, token: users_models.Token
 ) -> models.TransactionalEmailData:
-    reinit_password_url = build_pc_pro_reset_password_link(token.value)  # type: ignore [arg-type]
+    reinit_password_url = build_pc_pro_reset_password_link(token.value)
     return models.TransactionalEmailData(
         template=TransactionalEmail.RESET_PASSWORD_TO_PRO.value,
         params={

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -67,7 +67,7 @@ class Token(PcObject, Base, Model):  # type: ignore [valid-type, misc]
 
     user = orm.relationship("User", foreign_keys=[userId], backref=orm.backref("tokens", passive_deletes=True))  # type: ignore [misc]
 
-    value = sa.Column(sa.String, index=True, unique=True, nullable=False)
+    value: str = sa.Column(sa.String, index=True, unique=True, nullable=False)
 
     type = sa.Column(sa.Enum(TokenType, create_constraint=False), nullable=False)
 


### PR DESCRIPTION
Non-nullable constraints are not taken in account (*), so mypy thought
that `Token.value` was optional. Let's make its type explicit.

(*) https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html#introspection-of-columns-based-on-typeengine