### PR TITLE
(PC-16802)[BO-FRONT] fix: always show user details

### DIFF
--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -898,17 +898,6 @@ class GetUserHistoryTest:
                     {"status": "todo", "type": "honor-statement"},
                 ],
             },
-            "AGE18": {
-                "idCheckHistory": [],
-                "subscriptionItems": [
-                    {"status": "ok", "type": "email-validation"},
-                    {"status": "void", "type": "phone-validation"},
-                    {"status": "not-enabled", "type": "user-profiling"},
-                    {"status": "void", "type": "profile-completion"},
-                    {"status": "void", "type": "identity-check"},
-                    {"status": "void", "type": "honor-statement"},
-                ],
-            },
         }
 
     @override_features(ENABLE_BACKOFFICE_API=True)
@@ -921,17 +910,6 @@ class GetUserHistoryTest:
         data = self._test_user_history(client, user)
 
         assert data == {
-            "UNDERAGE": {
-                "idCheckHistory": [],
-                "subscriptionItems": [
-                    {"status": "ok", "type": "email-validation"},
-                    {"status": "not-applicable", "type": "phone-validation"},
-                    {"status": "not-applicable", "type": "user-profiling"},
-                    {"status": "void", "type": "profile-completion"},
-                    {"status": "void", "type": "identity-check"},
-                    {"status": "void", "type": "honor-statement"},
-                ],
-            },
             "AGE18": {
                 "idCheckHistory": [],
                 "subscriptionItems": [
@@ -971,18 +949,6 @@ class GetUserHistoryTest:
         )
 
         data = self._test_user_history(client, user)
-
-        assert data["UNDERAGE"] == {
-            "idCheckHistory": [],
-            "subscriptionItems": [
-                {"status": "ok", "type": "email-validation"},
-                {"status": "not-applicable", "type": "phone-validation"},
-                {"status": "not-applicable", "type": "user-profiling"},
-                {"status": "void", "type": "profile-completion"},
-                {"status": "void", "type": "identity-check"},
-                {"status": "void", "type": "honor-statement"},
-            ],
-        }
 
         assert data["AGE18"]["subscriptionItems"] == [
             {"status": "ok", "type": "email-validation"},
@@ -1061,18 +1027,6 @@ class GetUserHistoryTest:
         )
 
         data = self._test_user_history(client, user)
-
-        assert data["AGE18"] == {
-            "idCheckHistory": [],
-            "subscriptionItems": [
-                {"status": "ok", "type": "email-validation"},
-                {"status": "void", "type": "phone-validation"},
-                {"status": "not-enabled", "type": "user-profiling"},
-                {"status": "void", "type": "profile-completion"},
-                {"status": "void", "type": "identity-check"},
-                {"status": "void", "type": "honor-statement"},
-            ],
-        }
 
         assert data["UNDERAGE"]["subscriptionItems"] == [
             {"status": "ok", "type": "email-validation"},

--- a/backoffice/src/resources/PublicUsers/UserDetail.tsx
+++ b/backoffice/src/resources/PublicUsers/UserDetail.tsx
@@ -153,57 +153,32 @@ export const UserDetail = () => {
 
   const digitalCreditProgression = (remainingCredit / initialCredit) * 100
 
-  let subscriptionItems: EligibilitySubscriptionItem[] = []
-  let idsCheckHistory: EligibilityFraudCheck[] = []
+  const subscriptionItems: EligibilitySubscriptionItem[] = []
+  const idsCheckHistory: EligibilityFraudCheck[] = []
 
-  const idCheckHistoryLengthAge18 = AGE18?.idCheckHistory?.length
-  const idCheckHistoryLengthUnderage = UNDERAGE?.idCheckHistory?.length
-
-  if (idCheckHistoryLengthAge18 > 0 && idCheckHistoryLengthUnderage === 0) {
+  if (AGE18?.idCheckHistory?.length > 0) {
     idsCheckHistory.push({
       role: PublicUserRolesEnum.beneficiary,
       items: AGE18.idCheckHistory,
     })
+  }
+  if (AGE18?.subscriptionItems?.length > 0) {
     subscriptionItems.push({
       role: PublicUserRolesEnum.beneficiary,
       items: AGE18.subscriptionItems,
     })
-  } else if (
-    idCheckHistoryLengthUnderage > 0 &&
-    idCheckHistoryLengthAge18 === 0
-  ) {
+  }
+  if (UNDERAGE?.idCheckHistory?.length > 0) {
     idsCheckHistory.push({
       role: PublicUserRolesEnum.underageBeneficiary,
       items: UNDERAGE.idCheckHistory,
     })
+  }
+  if (UNDERAGE?.subscriptionItems?.length > 0) {
     subscriptionItems.push({
       role: PublicUserRolesEnum.underageBeneficiary,
       items: UNDERAGE.subscriptionItems,
     })
-  } else if (
-    idCheckHistoryLengthAge18 > 0 &&
-    idCheckHistoryLengthUnderage > 0
-  ) {
-    idsCheckHistory.push(
-      {
-        role: PublicUserRolesEnum.beneficiary,
-        items: AGE18.idCheckHistory,
-      },
-      {
-        role: PublicUserRolesEnum.underageBeneficiary,
-        items: UNDERAGE.idCheckHistory,
-      }
-    )
-    subscriptionItems.push(
-      { role: PublicUserRolesEnum.beneficiary, items: AGE18.subscriptionItems },
-      {
-        role: PublicUserRolesEnum.underageBeneficiary,
-        items: UNDERAGE.subscriptionItems,
-      }
-    )
-  } else {
-    idsCheckHistory = []
-    subscriptionItems = []
   }
 
   return (
@@ -451,13 +426,10 @@ export const UserDetail = () => {
                 </Grid>
               </Card>
               <div id="details-user">
-                {idsCheckHistory.length > 0 &&
-                  idsCheckHistory[0].items.length > 0 && (
-                    <UserDetailsCard
-                      user={userBaseInfo}
-                      firstFraudCheck={idsCheckHistory[0].items[0]}
-                    />
-                  )}
+                <UserDetailsCard
+                  user={userBaseInfo}
+                  firstFraudCheck={idsCheckHistory[0]?.items[0]}
+                />
               </div>
               <div id="parcours-register">
                 {subscriptionItems.map(subscriptionItem => (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16802

## But de la pull request

Afficher toutes les informations du parcours d’inscription, même si le compte est suspendu ou si rien n’est enregistré en base. Pour que le support puisse savoir quoi faire/répondre.

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
