### PR TITLE
(PC-17199)[PRO] fix: display correct error message when booking canno…

### DIFF
--- a/pro/src/routes/Desk/adapters/getBooking.ts
+++ b/pro/src/routes/Desk/adapters/getBooking.ts
@@ -54,11 +54,21 @@ const getBookingFailure = (
   }
   if (apiResponseError.status === HTTP_STATUS.FORBIDDEN) {
     const apiReimbursedErrorMessage = apiResponseError.body['payment']
+    const apiCantBeValidatedErrorMessage = apiResponseError.body['booking']
     if (apiReimbursedErrorMessage) {
       return {
         error: {
           isTokenValidated: false,
           message: apiReimbursedErrorMessage,
+          variant: MESSAGE_VARIANT.ERROR,
+        },
+      }
+    }
+    if (apiCantBeValidatedErrorMessage) {
+      return {
+        error: {
+          isTokenValidated: false,
+          message: apiCantBeValidatedErrorMessage,
           variant: MESSAGE_VARIANT.ERROR,
         },
       }


### PR DESCRIPTION
…t be validated yet

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17199

## But de la pull request

Afficher le bon message d'erreur quand il est encore trop tôt pour valider une contremarque

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
