### PR TITLE
(PC-15943)[API] fix: Zendesk Sell cloud tasks

### DIFF
--- a/api/src/pcapi/core/users/external/zendesk_sell.py
+++ b/api/src/pcapi/core/users/external/zendesk_sell.py
@@ -492,7 +492,7 @@ def create_venue(venue: offerers_models.Venue) -> None:
         return
 
     # API calls to Zendesk Sell are delayed in a GCP task to return quickly
-    zendesk_sell_tasks.create_venue_task.delay(venue.id)
+    zendesk_sell_tasks.create_venue_task.delay(zendesk_sell_tasks.VenuePayload(venue_id=venue.id))
 
 
 def do_create_venue(venue_id: int) -> None:
@@ -513,7 +513,7 @@ def update_venue(venue: offerers_models.Venue) -> None:
         return
 
     # API calls to Zendesk Sell are delayed in a GCP task to return quickly
-    zendesk_sell_tasks.update_venue_task.delay(venue.id)
+    zendesk_sell_tasks.update_venue_task.delay(zendesk_sell_tasks.VenuePayload(venue_id=venue.id))
 
 
 def do_update_venue(venue_id: int) -> None:
@@ -546,7 +546,7 @@ def create_offerer(offerer: offerers_models.Offerer) -> None:
         return
 
     # API calls to Zendesk Sell are delayed in a GCP task to return quickly
-    zendesk_sell_tasks.create_offerer_task.delay(offerer.id)
+    zendesk_sell_tasks.create_offerer_task.delay(zendesk_sell_tasks.OffererPayload(offerer_id=offerer.id))
 
 
 def do_create_offerer(offerer_id: int) -> None:
@@ -567,7 +567,7 @@ def update_offerer(offerer: offerers_models.Offerer) -> None:
         return
 
     # API calls to Zendesk Sell are delayed in a GCP task to return quickly
-    zendesk_sell_tasks.update_offerer_task.delay(offerer.id)
+    zendesk_sell_tasks.update_offerer_task.delay(zendesk_sell_tasks.OffererPayload(offerer_id=offerer.id))
 
 
 def do_update_offerer(offerer_id: int) -> None:

--- a/api/src/pcapi/tasks/zendesk_sell_tasks.py
+++ b/api/src/pcapi/tasks/zendesk_sell_tasks.py
@@ -1,5 +1,6 @@
 import logging
 
+from pcapi.routes.serialization import BaseModel
 from pcapi.settings import GCP_ZENDESK_SELL_QUEUE_NAME
 from pcapi.tasks.decorator import task
 
@@ -7,29 +8,37 @@ from pcapi.tasks.decorator import task
 logger = logging.getLogger(__name__)
 
 
+class OffererPayload(BaseModel):
+    offerer_id: int
+
+
+class VenuePayload(BaseModel):
+    venue_id: int
+
+
 @task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/create_offerer")  # type: ignore [arg-type]
-def create_offerer_task(offerer_id: int) -> None:
+def create_offerer_task(payload: OffererPayload) -> None:
     from pcapi.core.users.external import zendesk_sell
 
-    zendesk_sell.do_create_offerer(offerer_id)
+    zendesk_sell.do_create_offerer(payload.offerer_id)
 
 
 @task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/update_offerer")  # type: ignore [arg-type]
-def update_offerer_task(offerer_id: int) -> None:
+def update_offerer_task(payload: OffererPayload) -> None:
     from pcapi.core.users.external import zendesk_sell
 
-    zendesk_sell.do_update_offerer(offerer_id)
+    zendesk_sell.do_update_offerer(payload.offerer_id)
 
 
 @task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/create_venue")  # type: ignore [arg-type]
-def create_venue_task(venue_id: int) -> None:
+def create_venue_task(payload: VenuePayload) -> None:
     from pcapi.core.users.external import zendesk_sell
 
-    zendesk_sell.do_create_venue(venue_id)
+    zendesk_sell.do_create_venue(payload.venue_id)
 
 
 @task(GCP_ZENDESK_SELL_QUEUE_NAME, "/zendesk_sell/update_venue")  # type: ignore [arg-type]
-def update_venue_task(venue_id: int) -> None:
+def update_venue_task(payload: VenuePayload) -> None:
     from pcapi.core.users.external import zendesk_sell
 
-    zendesk_sell.do_update_venue(venue_id)
+    zendesk_sell.do_update_venue(payload.venue_id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15943

## But de la pull request

Les cloud tasks pour Zendesk Sell ne reçoivent pas bien les offerer_id ou venue_id à partir du body (qui contient bien l'id) :
https://sentry.internal-passculture.app/organizations/sentry/issues/394959/?project=5&referrer=slack

Donc je tente de faire la manière la plus répandue dans le code, avec un objet pydantic.

## Implémentation

## Informations supplémentaires

Les cloud tasks ne peuvent pas être testées en environnement de développement

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
