### PR TITLE
(PC-16824) feat: add new identification flow flag

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -70,6 +70,7 @@ class FeatureToggle(enum.Enum):
     ENABLE_NEW_BANK_INFORMATIONS_CREATION = (
         "Active le nouveau parcours d'ajout de coordonnées bancaires sur la page lieu"
     )
+    ENABLE_NEW_IDENTIFICATION_FLOW = "Activer le nouveau flux d'inscription jeune pré-Ubble"
     ENABLE_NEW_VENUE_PAGES = "Utiliser la nouvelle version des pages d'edition et de creation de lieux"
     ENABLE_PHONE_VALIDATION = "Active la validation du numéro de téléphone"
     ENABLE_PHONE_VALIDATION_IN_STEPPER = (
@@ -164,6 +165,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.ENABLE_IOS_OFFERS_LINK_WITH_REDIRECTION,
     FeatureToggle.ENABLE_ISBN_REQUIRED_IN_LIVRE_EDITION_OFFER_CREATION,
     FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,
+    FeatureToggle.ENABLE_NEW_IDENTIFICATION_FLOW,
     FeatureToggle.ENABLE_NEW_VENUE_PAGES,
     FeatureToggle.ENABLE_PRO_BOOKINGS_V2,
     FeatureToggle.ENABLE_UBBLE_SUBSCRIPTION_LIMITATION,

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -27,6 +27,7 @@ def get_settings() -> serializers.SettingsResponse:
         FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA,
         FeatureToggle.ENABLE_NATIVE_CULTURAL_SURVEY,
         FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING,
+        FeatureToggle.ENABLE_NEW_IDENTIFICATION_FLOW,
         FeatureToggle.ENABLE_PHONE_VALIDATION,
         FeatureToggle.ENABLE_USER_PROFILING,
         FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
@@ -50,6 +51,8 @@ def get_settings() -> serializers.SettingsResponse:
         enable_native_eac_individual=True,
         enable_native_cultural_survey=features[FeatureToggle.ENABLE_NATIVE_CULTURAL_SURVEY],
         enable_native_id_check_verbose_debugging=features[FeatureToggle.ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING],
+        # TODO(anoukhello): remove enable_new_identification_flow when the flow is adopted by all users (PC-17223)
+        enable_new_identification_flow=features[FeatureToggle.ENABLE_NEW_IDENTIFICATION_FLOW],
         enable_phone_validation=features[FeatureToggle.ENABLE_PHONE_VALIDATION],
         # TODO: lixxday: remove after the next forced app release (forced release > 1.176.0)
         enable_underage_generalisation=True,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16824

## But de la pull request

Ajout du FF ENABLE_NEW_IDENTIFICATION_FLOW permettant l'activation d'un nouveau parcours d'inscription sur l'application Jeunes.

## Informations supplémentaires

Création du ticket visant à le supprimer lorsque le parcours sera adopté par tous. 

https://passculture.atlassian.net/browse/PC-17223


## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
