### PR TITLE
(PC-17206)[PRO] feat: add input text autocomplete component

### DIFF
--- a/pro/src/ui-kit/form/TextInputAutocomplete/TextInputAutocomplete.module.scss
+++ b/pro/src/ui-kit/form/TextInputAutocomplete/TextInputAutocomplete.module.scss
@@ -1,0 +1,19 @@
+.input-autocomplete-container {
+  box-sizing: border-box;
+  position: relative;
+  width: 100%;
+
+  .option {
+    input[type='checkbox'] {
+      opacity: 0;
+    }
+
+    &-disabled:hover {
+      background-color: white;
+    }
+
+    span {
+      position: absolute;
+    }
+  }
+}

--- a/pro/src/ui-kit/form/TextInputAutocomplete/TextInputAutocomplete.stories.tsx
+++ b/pro/src/ui-kit/form/TextInputAutocomplete/TextInputAutocomplete.stories.tsx
@@ -1,0 +1,42 @@
+import { action } from '@storybook/addon-actions'
+import type { Story } from '@storybook/react'
+import { Formik } from 'formik'
+import React from 'react'
+import * as yup from 'yup'
+
+import TextInputAutocomplete from './TextInputAutocomplete'
+
+export default {
+  title: 'ui-kit/forms/TextInputAutocomplete',
+  component: TextInputAutocomplete,
+}
+const getSuggestions = () => {
+  return [
+    { value: '1', label: '12 rue des étoiles - 75000 - Paris' },
+    { value: '2', label: '19 rue de la république - 69000 - Lyon' },
+    { value: '3', label: '43 rue des fleurs - 13000 - Marseille' },
+  ]
+}
+
+const validationSchema = yup.object().shape({
+  adress: yup.string().required('Veuillez renseigner une adresse'),
+})
+
+const Template: Story<{ label: string }> = ({ label }) => (
+  <Formik
+    initialValues={{ adress: '', 'search-adress': '' }}
+    onSubmit={action('onSubmit')}
+    validationSchema={validationSchema}
+  >
+    <TextInputAutocomplete
+      getSuggestions={getSuggestions}
+      label={label}
+      fieldName="adress"
+      placeholder="input placeholder"
+    />
+  </Formik>
+)
+
+export const WithoutLabel = Template.bind({})
+export const WithLabel = Template.bind({})
+WithLabel.args = { label: 'Adresse' }

--- a/pro/src/ui-kit/form/TextInputAutocomplete/TextInputAutocomplete.tsx
+++ b/pro/src/ui-kit/form/TextInputAutocomplete/TextInputAutocomplete.tsx
@@ -1,0 +1,169 @@
+import cn from 'classnames'
+import { useField, useFormikContext } from 'formik'
+import React, { useEffect, useRef, useState } from 'react'
+
+import { SelectOption } from 'custom_types/form'
+
+import {
+  AutocompleteList,
+  BaseCheckbox,
+  BaseInput,
+  FieldLayout,
+} from '../shared'
+import { IAutocompleteItemProps } from '../shared/AutocompleteList/type'
+
+import styles from './TextInputAutocomplete.module.scss'
+
+export interface ITextInputAutocompleteProps {
+  className?: string
+  disabled?: boolean
+  fieldName: string
+  filterLabel?: string
+  getSuggestions: (search: string) => IAutocompleteItemProps[]
+  hideFooter?: boolean
+  isOptional?: boolean
+  label: string
+  maxDisplayOptions?: number
+  maxDisplayOptionsLabel?: string
+  maxHeight?: number
+  onSelectCustom?: (selectedItem: IAutocompleteItemProps) => void
+  onSearchChange?: () => void
+  smallLabel?: boolean
+  placeholder?: string
+  hideArrow?: boolean
+}
+
+const AutocompleteTextInput = ({
+  className,
+  disabled = false,
+  fieldName,
+  getSuggestions,
+  hideFooter = false,
+  isOptional = false,
+  label,
+  maxHeight = 100,
+  onSelectCustom,
+  smallLabel = false,
+  placeholder,
+}: ITextInputAutocompleteProps): JSX.Element => {
+  const [suggestions, setSuggestions] = useState<SelectOption[]>([])
+  const [isOpen, setIsOpen] = useState(false)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const [field, meta, helpers] = useField(fieldName)
+  const [searchField] = useField({
+    name: `search-${fieldName}`,
+  })
+  const [lastSelectedValue, setLastSelectedValue] =
+    useState<IAutocompleteItemProps>()
+
+  const { setFieldValue } = useFormikContext()
+
+  const updateSuggestions = (search: string) => {
+    const suggestions = getSuggestions(search)
+    if (suggestions.length > 0) {
+      setSuggestions(suggestions)
+      setIsOpen(true)
+    } else {
+      setIsOpen(false)
+    }
+  }
+
+  useEffect(() => {
+    updateSuggestions(searchField.value)
+    if (!searchField.value) {
+      setIsOpen(false)
+    }
+  }, [searchField.value])
+
+  const updateFieldWithSelectedItem = (
+    selectedItem?: IAutocompleteItemProps
+  ) => {
+    if (onSelectCustom && selectedItem) {
+      onSelectCustom(selectedItem)
+    }
+    helpers.setValue(selectedItem?.label || '')
+    setFieldValue(`search-${fieldName}`, selectedItem?.label || '', false)
+    //We need a timeout here cause setFieldValue seems to take some time until it triggers the useEffect on searchField.value
+    setTimeout(() => setIsOpen(false), 100)
+  }
+  const handleSelect = (selectedItem: IAutocompleteItemProps) => {
+    setLastSelectedValue(selectedItem)
+    updateFieldWithSelectedItem(selectedItem)
+  }
+
+  const renderSuggestion = (item: SelectOption, disabled?: boolean) => (
+    <BaseCheckbox
+      label={item.label}
+      key={`${fieldName}-${item.value}`}
+      className={cn(styles['option'], {
+        [styles['option-disabled']]: disabled,
+      })}
+      value={item.label}
+      id={`${fieldName}-${item.value}`}
+      name={`${fieldName}-${item.value}`}
+      role="option"
+      aria-selected={field.value === item.label}
+      disabled={disabled}
+      checked={field.value === item.value}
+      onClick={() => handleSelect(item)}
+      readOnly
+    />
+  )
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent): void => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        if (isOpen || !searchField.value) {
+          updateFieldWithSelectedItem(lastSelectedValue)
+          setIsOpen(false)
+        }
+      }
+    }
+    if (containerRef.current) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [containerRef, isOpen, lastSelectedValue, updateFieldWithSelectedItem])
+
+  return (
+    <FieldLayout
+      label={label}
+      name={`search-${fieldName}`}
+      error={meta.error}
+      showError={meta.touched && !!meta.error}
+      smallLabel={smallLabel}
+      isOptional={isOptional}
+      hideFooter={hideFooter}
+      className={className}
+    >
+      <div
+        className={cn(styles['input-autocomplete-container'], className)}
+        ref={containerRef}
+      >
+        <BaseInput
+          placeholder={placeholder ?? label}
+          hasError={meta.touched && !!meta.error}
+          type="text"
+          disabled={disabled}
+          className={styles['select-autocomplete-input']}
+          autoComplete="off"
+          {...searchField}
+        />
+        <AutocompleteList
+          className={styles['menu']}
+          filteredOptions={suggestions}
+          hideArrow={true}
+          isOpen={isOpen}
+          maxHeight={maxHeight}
+          onButtonClick={() => {}}
+          renderOption={renderSuggestion}
+        />
+      </div>
+    </FieldLayout>
+  )
+}
+
+export default AutocompleteTextInput

--- a/pro/src/ui-kit/form/TextInputAutocomplete/__specs__/TextInputAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/TextInputAutocomplete/__specs__/TextInputAutocomplete.spec.tsx
@@ -1,0 +1,126 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Formik } from 'formik'
+import React from 'react'
+
+import TextInputAutocomplete from '..'
+import { ITextInputAutocompleteProps } from '../TextInputAutocomplete'
+
+const renderTextInputAutocomplete = async (
+  initialValues: any,
+  props: ITextInputAutocompleteProps
+) => {
+  await render(
+    <Formik initialValues={initialValues} onSubmit={() => {}}>
+      <TextInputAutocomplete {...props} />
+    </Formik>
+  )
+}
+
+describe('src | ui-kit | form | TextInputAutocomplete', () => {
+  let initialValues = {}
+  let props: ITextInputAutocompleteProps
+  const onSelectCustom = jest.fn()
+  const getSuggestions = (search: string) => {
+    if (search == 'testNoSuggestions') {
+      return []
+    }
+    return [
+      {
+        value: '1',
+        label: `${search} - 1`,
+        extraData: { postalCode: '75001' },
+      },
+      {
+        value: '2',
+        label: `${search} - 2`,
+        extraData: { postalCode: '75002' },
+      },
+      {
+        value: '3',
+        label: `${search} - 3`,
+        extraData: { postalCode: '75003' },
+      },
+      {
+        value: '4',
+        label: 'Option par défaut',
+      },
+    ]
+  }
+  beforeEach(() => {
+    initialValues = { adresse: '', 'search-adresse': '' }
+    props = {
+      fieldName: 'adresse',
+      label: 'Adresse',
+      getSuggestions: getSuggestions,
+      onSelectCustom: onSelectCustom,
+    }
+  })
+  describe('render', () => {
+    it('should display field', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      expect(screen.getByLabelText('Adresse')).toBeInTheDocument()
+    })
+    it('should not display any suggestions with empty search', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      expect(
+        screen.queryByLabelText('Option par défaut')
+      ).not.toBeInTheDocument()
+    })
+    it('should not display any suggestions when search not match any suggestions', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      const searchField = screen.getByLabelText('Adresse')
+      await userEvent.type(searchField, 'testNoSuggestions')
+      expect(
+        screen.queryByLabelText('Option par défaut')
+      ).not.toBeInTheDocument()
+    })
+    it('should display suggestions when search match suggestions', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      const searchField = screen.getByLabelText('Adresse')
+      await userEvent.type(searchField, 'test')
+      expect(await screen.findByText('Option par défaut')).toBeInTheDocument()
+      expect(await screen.findByText('test - 1')).toBeInTheDocument()
+    })
+  })
+  describe('select value', () => {
+    it('should not set any default value for search input', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      const searchField = screen.getByLabelText('Adresse')
+      expect(searchField).toHaveValue('')
+    })
+    it('should set input value corresponding to selected option and call custom function', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      const searchField = screen.getByLabelText('Adresse')
+      await userEvent.type(searchField, 'test')
+      const secondSuggestion = await screen.findByText('test - 1')
+      await userEvent.click(secondSuggestion)
+      expect(searchField).toHaveValue('test - 1')
+      expect(onSelectCustom).toHaveBeenCalledWith({
+        value: '1',
+        label: 'test - 1',
+        extraData: { postalCode: '75001' },
+      })
+    })
+  })
+  describe('handle on click outside', () => {
+    it('set field value to last selected value on click outside', async () => {
+      await renderTextInputAutocomplete(initialValues, props)
+      const searchField = screen.getByLabelText('Adresse')
+      await userEvent.type(searchField, 'test')
+      const secondSuggestion = await screen.findByText('test - 1')
+      await userEvent.click(secondSuggestion)
+      expect(searchField).toHaveValue('test - 1')
+      await userEvent.type(searchField, ' - not selected')
+      expect(searchField).toHaveValue('test - 1 - not selected')
+      await userEvent.click(document.body)
+      expect(searchField).toHaveValue('test - 1')
+      expect(onSelectCustom).toHaveBeenCalledWith({
+        value: '1',
+        label: 'test - 1',
+        extraData: { postalCode: '75001' },
+      })
+    })
+  })
+})

--- a/pro/src/ui-kit/form/TextInputAutocomplete/index.ts
+++ b/pro/src/ui-kit/form/TextInputAutocomplete/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TextInputAutocomplete'

--- a/pro/src/ui-kit/form/shared/AutocompleteList/AutocompleteList.tsx
+++ b/pro/src/ui-kit/form/shared/AutocompleteList/AutocompleteList.tsx
@@ -2,23 +2,21 @@ import cx from 'classnames'
 import React from 'react'
 
 import Icon from 'components/layout/Icon'
-import { SelectOption } from 'custom_types/form'
 
 import styles from './AutocompleteList.module.scss'
+import { IAutocompleteItemProps } from './type'
 
 // FIXME (MathildeDuboille - 15-06-22): improve accessibility and refactor if needed.
 // This component is used in SelectAutocomplete and MultiselectAutocomplete
 type AutocompleteListProps = {
   className?: string
   displayNumberOfSelectedValues?: boolean
-  filteredOptions: (SelectOption & { disabled?: boolean })[]
+  filteredOptions: IAutocompleteItemProps[]
   isOpen: boolean
   maxHeight?: number
   numberOfSelectedOptions?: number
   onButtonClick: () => void
-  renderOption: (
-    option: SelectOption & { disabled?: boolean }
-  ) => React.ReactNode
+  renderOption: (option: IAutocompleteItemProps) => React.ReactNode
   disabled?: boolean
   hideArrow?: boolean
 }

--- a/pro/src/ui-kit/form/shared/AutocompleteList/type.ts
+++ b/pro/src/ui-kit/form/shared/AutocompleteList/type.ts
@@ -1,0 +1,6 @@
+export interface IAutocompleteItemProps {
+  value: string | number
+  label: string
+  disabled?: boolean
+  extraData?: any
+}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17206

## But de la pull request

Ajouter un composant TextInput permettant d'utiliser l'autocomplete avec source personnalisée.

## Implémentation

Ce nouveau composant est basé sur l'implémentation de `SelectAutocomplete`, mais avec des fonctionnalités différentes

- Ajout d'un type `IAutocompleteItemProps` pour passer des data autres que le `label` et la `value` d'une option
- Ajout d'un `onSelectCustom` permettant d'ajouter une action à réaliser lorsque l'utilisateur choisi une donnée dans la liste déroulante
- Ajout du comportement qui fait que l'utilisateur ne peut pas entrer une valeur qui n'est pas issue de la liste des suggestions (voir `lastSelectedValue`)


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
