### PR TITLE
(BSR)[API] sentry: merge provider synchronization exceptions

### DIFF
--- a/api/src/pcapi/connectors/notion.py
+++ b/api/src/pcapi/connectors/notion.py
@@ -4,6 +4,7 @@ from notion_client import APIResponseError
 from notion_client import Client
 
 from pcapi import settings
+from pcapi.core.providers import models as providers_models
 
 
 logger = logging.getLogger(__name__)
@@ -12,15 +13,12 @@ logger = logging.getLogger(__name__)
 PROVIDER_API_ERRORS_DATABASE_ID = "e7bd2f6ddedf43f7a7bc87849caaa3ed"
 
 
-def add_to_synchronization_error_database(
-    exception: Exception,
-    provider_name: str,
-    venue_id: int,
-    venue_id_at_offer_provider: str,
-) -> None:
+def add_to_synchronization_error_database(exception: Exception, venue_provider: providers_models.VenueProvider) -> None:
     if settings.IS_DEV:
         return
-
+    provider_name = venue_provider.provider.name
+    venue_id = venue_provider.venueId
+    venue_id_at_offer_provider = venue_provider.venueIdAtOfferProvider
     try:
         notion = Client(auth=settings.NOTION_TOKEN)
         notion.pages.create(

--- a/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -11,7 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 class ProviderAPIException(Exception):
-    pass
+    status_code: int
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 REQUEST_TIMEOUT_FOR_PROVIDERS_IN_SECOND = 60
@@ -39,7 +43,7 @@ class ProviderAPI:
 
         if response.status_code != 200:
             raise ProviderAPIException(
-                f"Error {response.status_code} when getting {self.name} stocks for SIRET: {siret}"
+                f"Error {response.status_code} when getting {self.name} stocks for SIRET: {siret}", response.status_code
             )
 
         if not response.content:

--- a/api/src/pcapi/local_providers/provider_manager.py
+++ b/api/src/pcapi/local_providers/provider_manager.py
@@ -6,6 +6,7 @@ from urllib3 import exceptions as urllib3_exceptions
 import pcapi.connectors.notion as notion_connector
 from pcapi.core.providers.models import VenueProvider
 import pcapi.core.providers.repository as providers_repository
+from pcapi.infrastructure.repository.stock_provider import provider_api
 import pcapi.local_providers
 from pcapi.local_providers.provider_api import synchronize_provider_api
 from pcapi.repository import transaction
@@ -40,6 +41,12 @@ def synchronize_venue_providers_for_provider(provider_id: int, limit: int | None
         except (urllib3_exceptions.HTTPError, requests.exceptions.RequestException) as exception:
             notion_connector.add_to_synchronization_error_database(exception, venue_provider)
             logger.error("Connexion error while synchronizing venue_provider", extra=log_data | {"exc": exception})
+        except provider_api.ProviderAPIException as exception:
+            notion_connector.add_to_synchronization_error_database(exception, venue_provider)
+            logger.error(  # pylint: disable=logging-fstring-interpolation
+                f"ProviderAPIException with code {exception.status_code} while synchronizing venue_provider",
+                extra=log_data | {"exc": exception},
+            )
         except Exception as exception:  # pylint: disable=broad-except
             notion_connector.add_to_synchronization_error_database(exception, venue_provider)
             logger.exception("Unexpected error while synchronizing venue provider", extra=log_data)

--- a/api/src/pcapi/local_providers/provider_manager.py
+++ b/api/src/pcapi/local_providers/provider_manager.py
@@ -29,20 +29,15 @@ def synchronize_venue_providers_for_provider(provider_id: int, limit: int | None
         try:
             with transaction():
                 synchronize_venue_provider(venue_provider, limit)
-        except Exception as exc:  # pylint: disable=broad-except
-            notion_connector.add_to_synchronization_error_database(
-                exception=exc,
-                provider_name=venue_provider.provider.name,
-                venue_id=venue_provider.venueId,
-                venue_id_at_offer_provider=venue_provider.venueIdAtOfferProvider,
-            )
+        except Exception as exception:  # pylint: disable=broad-except
+            notion_connector.add_to_synchronization_error_database(exception, venue_provider)
             logger.exception(
                 "Could not synchronize venue provider",
                 extra={
                     "venue_provider": venue_provider.id,
                     "venue": venue_provider.venueId,
                     "provider": venue_provider.providerId,
-                    "exc": exc,
+                    "exc": exception,
                 },
             )
 


### PR DESCRIPTION
But : Grouper [les erreurs remontées sur sentry](https://sentry.internal-passculture.app/organizations/sentry/issues/?environment=production&project=5&query=is%3Aunresolved+Could+not+synchronize+venue+provider&statsPeriod=14d) dues au log *"Could not synchronize venue provider"*

Avant cette PR remontent les *issues* : 
- *Issues* liée à des problèmes de connexion
  - `ReadTimeOut`
  - `SSLError`
  - `ConnectTimeout`
  - ...
- Les `ProviderAPIException` -> majoritairement des 404. Si un autre code que 404 se produit, je pense qu'on n'est pas notifié
- Les `CineDigitalServiceAPIException`, qui peuvent être liées à des erreurs de connexion (c'est le cas quand on zoome sur les 2 qui sont présentes) ou alors a des codes de réponses >= 400.
- Toute autre exception

Après cette PR on aura : 
- 1 *issue* correspondant aux problème de connexion : "Connexion error while synchronizing venue_provider"
- 1 *issue* par code d'erreur reçu dans les `ProviderAPIException` : ça permet d'être notifié si jamais un autre code que 404 se produit
- Toute autre exception, notamment les `CineDigitalServiceAPIException` liées à des codes de réponse >= 400.
