### PR TITLE
(PC-16208)[PRO] fix: force calendar to always open at input bottom

### DIFF
--- a/pro/src/components/layout/inputs/PeriodSelector/PeriodSelector.jsx
+++ b/pro/src/components/layout/inputs/PeriodSelector/PeriodSelector.jsx
@@ -52,6 +52,13 @@ const PeriodSelector = ({
               openToDate={periodBeginningDate ? periodBeginningDate : todayDate}
               placeholderText="JJ/MM/AAAA"
               selected={periodBeginningDate}
+              popperPlacement="bottom-start"
+              popperModifiers={[
+                {
+                  name: 'flip',
+                  enabled: false,
+                },
+              ]}
             />
           </div>
           <span className="vertical-bar" />
@@ -80,6 +87,13 @@ const PeriodSelector = ({
               placeholderText="JJ/MM/AAAA"
               ref={endDateInput}
               selected={periodEndingDate}
+              popperPlacement="bottom-start"
+              popperModifiers={[
+                {
+                  name: 'flip',
+                  enabled: false,
+                },
+              ]}
             />
           </div>
         </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16208

## But de la pull request

Empêcher le flip du composant date-picker pour faire en sorte que le calendrier s'ouvre toujours en bas du champs de saisie. 
(voir l'exemple du comportement posant problème dans le ticket)

[Documentation du composant](https://popper.js.org/docs/v2/modifiers/flip/) `Popper` utiliser par `react-datetpicker`
