### PR TITLE
(BSR)[API] chore: Remove redundant definition of "id" column from database models

### DIFF
--- a/api/src/pcapi/core/booking_providers/models.py
+++ b/api/src/pcapi/core/booking_providers/models.py
@@ -20,16 +20,12 @@ class BookingProviderName(enum.Enum):
 
 
 class BookingProvider(PcObject, Base, Model):  # type: ignore [valid-type, misc]
-    id: int = Column(BigInteger, primary_key=True)
-
     name: BookingProviderName = Column(Enum(BookingProviderName), nullable=False)
 
     apiUrl: str = Column(String, nullable=False)
 
 
 class VenueBookingProvider(PcObject, Base, Model):  # type: ignore [valid-type, misc]
-    id: int = Column(BigInteger, primary_key=True)
-
     isActive: bool = Column(Boolean, nullable=False, default=True)
 
     venueId: int = Column(BigInteger, ForeignKey("venue.id"), index=True, nullable=False)

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -404,8 +404,6 @@ class FraudCheckStatus(enum.Enum):
 class BeneficiaryFraudCheck(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "beneficiary_fraud_check"
 
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-
     dateCreated: datetime.datetime = sa.Column(
         sa.DateTime, nullable=False, server_default=sa.func.now(), default=datetime.datetime.utcnow
     )

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -420,8 +420,6 @@ class VenueType(PcObject, Base, Model):  # type: ignore [valid-type, misc]
 class VenueContact(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "venue_contact"
 
-    id: int = Column(BigInteger, primary_key=True)
-
     venueId: int = Column(
         BigInteger, ForeignKey("venue.id", ondelete="CASCADE"), nullable=False, index=True, unique=True
     )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -106,8 +106,6 @@ class Product(PcObject, Base, Model, ExtraDataMixin, HasThumbMixin, ProvidableMi
 class Mediation(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, DeactivableMixin):  # type: ignore [valid-type, misc]
     __tablename__ = "mediation"
 
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-
     credit = sa.Column(sa.String(255), nullable=True)
 
     dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
@@ -624,8 +622,6 @@ class Offer(PcObject, Base, Model, ExtraDataMixin, DeactivableMixin, ValidationM
 class ActivationCode(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "activation_code"
 
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-
     code: str = sa.Column(sa.Text, nullable=False)
 
     expirationDate = sa.Column(sa.DateTime, nullable=True, default=None)
@@ -649,8 +645,6 @@ class ActivationCode(PcObject, Base, Model):  # type: ignore [valid-type, misc]
 
 class OfferValidationConfig(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "offer_validation_config"
-
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
 
     dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
 
@@ -727,8 +721,6 @@ class OfferReport(PcObject, Base, Model):  # type: ignore [valid-type, misc]
             name="custom_reason_null_only_if_reason_is_other",
         ),
     )
-
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
 
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
 

--- a/api/src/pcapi/core/payments/models.py
+++ b/api/src/pcapi/core/payments/models.py
@@ -139,8 +139,6 @@ class DepositType(enum.Enum):
 
 
 class Deposit(PcObject, Base, Model):  # type: ignore [valid-type, misc]
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-
     amount: Decimal = sa.Column(sa.Numeric(10, 2), nullable=False)
 
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -36,8 +36,6 @@ from pcapi.models.providable_mixin import ProvidableMixin
 
 
 class Provider(PcObject, Base, Model, DeactivableMixin):  # type: ignore [valid-type, misc]
-    id: int = Column(BigInteger, primary_key=True)
-
     name: str = Column(String(90), index=True, nullable=False)
 
     localClass = Column(

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -63,8 +63,6 @@ class TokenExtraData:
 class Token(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "token"
 
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
 
     user = orm.relationship("User", foreign_keys=[userId], backref=orm.backref("tokens", passive_deletes=True))  # type: ignore [misc]
@@ -604,8 +602,6 @@ class EmailHistoryEventTypeEnum(enum.Enum):
 class UserEmailHistory(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "user_email_history"
 
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
-
     userId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), index=True, nullable=True)
     user = orm.relationship("User", foreign_keys=[userId], backref=orm.backref("email_history", passive_deletes=True))  # type: ignore [misc]
 
@@ -668,8 +664,6 @@ class UserEmailHistory(PcObject, Base, Model):  # type: ignore [valid-type, misc
 
 class UserSuspension(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     __tablename__ = "user_suspension"
-
-    id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
 
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
     user = orm.relationship(  # type: ignore [misc]


### PR DESCRIPTION
The "PcObject" base class defines an "id" primary key column. We can
remove the redefinition of this column from classes that inherit from
"PcObject", when the redefined column is the same.