### PR TITLE
(PC-17129) Drop and bypass recredit.recreditType constraints

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 3c4183de2005 (pre) (head)
-43d6625d1e4f (post) (head)
+992529bd24e5 (post) (head)

--- a/api/src/pcapi/alembic/versions/20220909T094309_992529bd24e5_drop_recredit_constraint.py
+++ b/api/src/pcapi/alembic/versions/20220909T094309_992529bd24e5_drop_recredit_constraint.py
@@ -1,0 +1,25 @@
+"""drop_recredit_constraint
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "992529bd24e5"
+down_revision = "43d6625d1e4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE recredit DROP CONSTRAINT IF EXISTS recredittype")
+    op.execute(
+        """
+        ALTER TABLE recredit ALTER COLUMN "recreditType" type text
+        """
+    )
+
+
+def downgrade() -> None:
+    # do not execute otherwise it could fail if some rows have other types than RECREDIT_16 or RECREDIT_17
+    pass


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17129
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/22373097/189323644-9f391af9-e3f2-46ce-9733-71ddd3a8b82b.png">

2 problèmes : 
- il y a une check constraint qui nous empeche de mettre une autre valeur dans recreditType
- il y a une limite du nombre de caractères fixée à 11