### PR TITLE
(PC-17110) edit venue siret in FA

### DIFF
--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -287,7 +287,10 @@ class VenueView(BaseAdminView):
                 new_adage_id,
             )
 
-        result = super().update_model(new_venue_form, venue)
+        # A failed update (invalid DB constraint for example) does not raise but returns False
+        update_success = super().update_model(new_venue_form, venue)
+        if not update_success:
+            return False
 
         # Immediately index venue if tags (criteria) are involved:
         # tags are used by other tools (eg. building playlists for the
@@ -314,8 +317,7 @@ class VenueView(BaseAdminView):
         for email in offerers_repository.get_emails_by_venue(venue):
             update_external_pro(email)
 
-        if result:
-            zendesk_sell.update_venue(venue)
+        zendesk_sell.update_venue(venue)
 
         return True
 

--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -271,7 +271,9 @@ class VenueView(BaseAdminView):
             if hasattr(new_venue_form, field) and getattr(new_venue_form, field).data != getattr(venue, field)
         }
 
-        if str(new_venue_form.adageId.data) != venue.adageId:
+        if (new_venue_form.adageId.data and str(new_venue_form.adageId.data) != venue.adageId) or (
+            new_venue_form.adageId.data is None and venue.adageId
+        ):
             emails = offerers_repository.get_emails_by_venue(venue)
             for email in emails:
                 update_external_pro(email)

--- a/api/src/pcapi/core/finance/exceptions.py
+++ b/api/src/pcapi/core/finance/exceptions.py
@@ -8,3 +8,11 @@ class NonCancellablePricingError(FinanceError):
 
 class InvalidSiret(Exception):
     pass
+
+
+class WrongLengthSiret(InvalidSiret):
+    pass
+
+
+class NotAllDigitSiret(InvalidSiret):
+    pass

--- a/api/src/pcapi/core/finance/validation.py
+++ b/api/src/pcapi/core/finance/validation.py
@@ -9,17 +9,22 @@ from . import models
 # function is used temporarily in business unit initialization. It
 # will be removed soon.
 def check_business_unit_siret(business_unit: models.BusinessUnit, siret: str) -> None:
+    validate_siret_format(siret)
+
     if db.session.query(models.BusinessUnit.query.filter_by(siret=siret).exists()).scalar():
         raise exceptions.InvalidSiret()
 
     venue = business_unit.venues[0]
     offerer = venue.managingOfferer
 
-    if len(siret) != 14:
-        raise exceptions.InvalidSiret()
-    if not siret.isdigit():
-        raise exceptions.InvalidSiret()
     if not offerer.siren:  # FIXME: while Offerer.siren is nullable
         raise exceptions.InvalidSiret()
     if siret[:9] != offerer.siren:
         raise exceptions.InvalidSiret()
+
+
+def validate_siret_format(siret: str) -> None:
+    if len(siret) != 14:
+        raise exceptions.WrongLengthSiret()
+    if not siret.isdigit():
+        raise exceptions.NotAllDigitSiret()

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -766,11 +766,12 @@ def update_stock_id_at_providers(venue: Venue, old_siret: str) -> None:
         stock.idAtProviders = new_id_at_providers
         stocks_to_update.append(stock)
 
-    logger.warning(
-        "The following stocks are already migrated from old siret to new siret: [%s]",
-        stock_ids_already_migrated,
-        extra={"venueId": venue.id, "current_siret": venue.siret, "old_siret": old_siret},
-    )
+    if stock_ids_already_migrated:
+        logger.warning(
+            "The following stocks are already migrated from old siret to new siret: [%s]",
+            stock_ids_already_migrated,
+            extra={"venueId": venue.id, "current_siret": venue.siret, "old_siret": old_siret},
+        )
 
     repository.save(*stocks_to_update)
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -348,29 +348,60 @@ class TestClient:
         form: dict = None,
         files: dict = None,
         headers: dict = None,
+        follow_redirects: bool = False,
     ):
         headers = headers or {}
         if raw_json:
             result = self.client.post(
-                route, data=raw_json, content_type="application/json", headers={**self.auth_header, **headers}
+                route,
+                data=raw_json,
+                content_type="application/json",
+                headers={**self.auth_header, **headers},
+                follow_redirects=follow_redirects,
             )
         elif form or files:
-            result = self.client.post(route, data=form if form else files, headers={**self.auth_header, **headers})
+            result = self.client.post(
+                route,
+                data=form if form else files,
+                headers={**self.auth_header, **headers},
+                follow_redirects=follow_redirects,
+            )
         else:
-            result = self.client.post(route, json=json, headers={**self.auth_header, **headers})
+            result = self.client.post(
+                route, json=json, headers={**self.auth_header, **headers}, follow_redirects=follow_redirects
+            )
 
         self._print_spec("POST", route, json, result)
         return result
 
-    def patch(self, route: str, json: dict = None, headers: dict = None):
+    def patch(
+        self,
+        route: str,
+        json: dict = None,
+        headers: dict = None,
+        follow_redirects: bool = False,
+    ):
         headers = headers or {}
-        result = self.client.patch(route, json=json, headers={**self.auth_header, **headers})
+        result = self.client.patch(
+            route,
+            json=json,
+            headers={**self.auth_header, **headers},
+            follow_redirects=follow_redirects,
+        )
         self._print_spec("PATCH", route, json, result)
         return result
 
-    def put(self, route: str, json: dict = None, headers: dict = None):
+    def put(
+        self,
+        route: str,
+        json: dict = None,
+        headers: dict = None,
+        follow_redirects: bool = False,
+    ):
         headers = headers or {}
-        result = self.client.put(route, json=json, headers={**self.auth_header, **headers})
+        result = self.client.put(
+            route, json=json, headers={**self.auth_header, **headers}, follow_redirects=follow_redirects
+        )
         self._print_spec("PUT", route, json, result)
         return result
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17110

## But de la pull request

Pouvoir modifier le SIRET d'un lieu, en tenant compte de la nouvelle modélisation

## Implémentation

- Edition de la vue FA

## Informations supplémentaires

- traiter correctement les échecs d'updates de DB
- extraire la validation du format de SIRET
- ne pas logger des avertissements superflus
- ajouter un kwarg `follow_redirects` au client de test afin de pouvoir tester la réponse finale