### PR TITLE
(PC-16642)[PRO] fix: venue name should be readonly in venue edition

### DIFF
--- a/pro/src/new_components/VenueForm/Informations/Informations.tsx
+++ b/pro/src/new_components/VenueForm/Informations/Informations.tsx
@@ -48,7 +48,7 @@ const Informations = ({
           <TextInput
             name="name"
             label="Nom du lieu"
-            readOnly={isFieldNameFrozen}
+            readOnly={readOnly || isFieldNameFrozen}
           />
         </FormLayout.Row>
         <FormLayout.Row>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16642

## But de la pull request

Rendre le champ `Nom du lieu` non editable dans le formulaire édition du lieu

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
