### PR TITLE
PC-16263 build annotation on one line

### DIFF
--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -232,12 +232,13 @@ def _compute_new_annotation(
 ) -> str:
     annotation = ""
     if birth_date_error:
-        annotation += f"{FIELD_ERROR_LABELS.get(birth_date_error.key)} ({birth_date_error.value}) indique que le demandeur n'est pas éligible au pass Culture (doit avoir entre 15 et 18 ans)\n"
+        annotation += f"{FIELD_ERROR_LABELS.get(birth_date_error.key)} ({birth_date_error.value}) indique que le demandeur n'est pas éligible au pass Culture (doit avoir entre 15 et 18 ans). "
 
     if field_errors:
-        annotation += "Champs invalides :\n"
-        for field_error in field_errors:
-            annotation += f"- {FIELD_ERROR_LABELS.get(field_error.key)}: {field_error.value}\n"
+        annotation += "Champs invalides: "
+        annotation += ", ".join(
+            f"{FIELD_ERROR_LABELS.get(field_error.key)} ({field_error.value})" for field_error in field_errors
+        )
 
     if not annotation:
         annotation = "Aucune erreur détectée. Le dossier peut être passé en instruction."

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -472,14 +472,14 @@ class HandleDmsAnnotationsTest:
             (
                 [],
                 fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.birth_date, value="2000-01-01"),
-                "La date de naissance (2000-01-01) indique que le demandeur n'est pas éligible au pass Culture (doit avoir entre 15 et 18 ans)\n",
+                "La date de naissance (2000-01-01) indique que le demandeur n'est pas éligible au pass Culture (doit avoir entre 15 et 18 ans). ",
             ),
             (
                 [fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.first_name, value="/taylor")],
                 fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.birth_date, value="2000-01-01"),
                 (
-                    "La date de naissance (2000-01-01) indique que le demandeur n'est pas éligible au pass Culture (doit avoir entre 15 et 18 ans)\n"
-                    "Champs invalides :\n- Le prénom: /taylor\n"
+                    "La date de naissance (2000-01-01) indique que le demandeur n'est pas éligible au pass Culture (doit avoir entre 15 et 18 ans). "
+                    "Champs invalides: Le prénom (/taylor)"
                 ),
             ),
             (
@@ -492,9 +492,7 @@ class HandleDmsAnnotationsTest:
                     ),
                 ],
                 None,
-                (
-                    "Champs invalides :\n- Le prénom: /taylor\n- La date de naissance: trente juillet deux mille quatre\n"
-                ),
+                ("Champs invalides: Le prénom (/taylor), La date de naissance (trente juillet deux mille quatre)"),
             ),
         ],
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16263

## But de la pull request

Construire les annotations sur une ligne, car DMS ne les présente pas en multi lignes

## Implémentation

- RAS

## Informations supplémentaires

- J'en profite pour mettre à jour le fraud check au moment où on change l'annotation, comme ça on est à jour

## Modifications du schéma de la base de données

- None

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
