### PR TITLE
(PC-17271)[API] feat:  new delete offer thumbnail route.

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -743,6 +743,24 @@ def create_mediation(
         return mediation
 
 
+def delete_mediation(offer: Offer) -> None:
+    mediations = Mediation.query.filter(Mediation.offerId == offer.id).all()
+    for mediation in mediations:
+        try:
+            for thumb_index in range(0, mediation.thumbCount):
+                remove_thumb(mediation, image_index=thumb_index)
+        except Exception as exception:  # pylint: disable=broad-except
+            logger.exception(
+                "An unexpected error was encountered during the thumbnails deletion for %s: %s",
+                mediation,
+                exception,
+            )
+        else:
+            repository.delete(mediation)
+
+    search.async_index_offer_ids([offer.id])
+
+
 def update_stock_id_at_providers(venue: Venue, old_siret: str) -> None:
     current_siret = venue.siret
 

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -196,6 +196,27 @@ def create_thumbnail(form: CreateThumbnailBodyModel) -> CreateThumbnailResponseM
     return CreateThumbnailResponseModel(id=thumbnail.id)
 
 
+@private_api.route("/offers/thumbnails/<offer_id>", methods=["DELETE"])
+@login_required
+@spectree_serialize(
+    on_success_status=204,
+    api=blueprint.pro_private_schema,
+)
+def delete_thumbnail(offer_id: int) -> None:
+    try:
+        offer = offers_repository.get_offer_by_id(offer_id)
+    except exceptions.OfferNotFound:
+        raise ApiErrors(
+            errors={
+                "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],
+            },
+            status_code=404,
+        )
+    check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
+
+    offers_api.delete_mediation(offer=offer)
+
+
 @private_api.route("/offers/categories", methods=["GET"])
 @login_required
 @spectree_serialize(

--- a/api/tests/routes/pro/delete_thumbnail_test.py
+++ b/api/tests/routes/pro/delete_thumbnail_test.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.offers.models import Mediation
+from pcapi.utils.human_ids import humanize
+
+
+@pytest.mark.usefixtures("db_session")
+class OfferMediationTest:
+    @patch("pcapi.core.object_storage.backends.local.LocalBackend.delete_public_object")
+    @patch("pcapi.core.search.async_index_offer_ids")
+    def test_delete_mediation(self, mock_search_async_index_offer_ids, mock_delete_public_object, client):
+        offer = offers_factories.OfferFactory()
+        mediation = offers_factories.MediationFactory(offer=offer, thumbCount=1)
+        offerers_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+        client = client.with_session_auth(email="user@example.com")
+        response = client.delete(f"/offers/thumbnails/{offer.id}")
+
+        expected_thumb_path = f"{mediation.thumb_path_component}/{humanize(mediation.id)}"
+        assert Mediation.query.all() == []
+        assert response.status_code == 204
+        assert mock_delete_public_object.call_args_list == [
+            (("thumbs", expected_thumb_path),),
+        ]
+        mock_search_async_index_offer_ids.assert_called_once_with([offer.id])
+
+    @patch("pcapi.core.object_storage.backends.local.LocalBackend.delete_public_object")
+    def test_delete_no_mediation(self, mock_delete_public_object, client):
+        offer = offers_factories.OfferFactory()
+        offerers_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+        client = client.with_session_auth(email="user@example.com")
+        response = client.delete(f"/offers/thumbnails/{offer.id}")
+
+        assert response.status_code == 204
+        mock_delete_public_object.assert_not_called()
+
+    def test_user_cannot_delete_mediation(self, client):
+        offer = offers_factories.OfferFactory()
+        offerers_factories.UserOffererFactory(user__email="user@example.com")
+
+        client = client.with_session_auth(email="user@example.com")
+        response = client.delete(f"/offers/thumbnails/{offer.id}")
+
+        assert response.status_code == 403
+
+    def test_unkown_offer(self, client):
+        offerers_factories.UserOffererFactory(user__email="user@example.com")
+
+        client = client.with_session_auth(email="user@example.com")
+        response = client.delete("/offers/thumbnails/123445678")
+
+        assert response.status_code == 404
+        expected_error = ["Aucun objet ne correspond à cet identifiant dans notre base de données"]
+        assert response.json["global"] == expected_error

--- a/api/tests/routes/pro/post_thumbnail_test.py
+++ b/api/tests/routes/pro/post_thumbnail_test.py
@@ -138,3 +138,17 @@ class CreateThumbnailFromFileTest:
         assert response.status_code == 400
         assert response.json["code"] == "BAD_IMAGE_RATIO"
         assert response.json["extra"] == "Bad image ratio: expected 0.6666666666666666, found 1.4989293361884368"
+
+    def test_wrong_offer_id(self, client, offer, offerer):
+        client = client.with_session_auth(email="user@example.com")
+        thumb = (IMAGES_DIR / "mouette_landscape_bigger.jpg").read_bytes()
+        data = {
+            "offerId": humanize(offer.id + 1),
+            "thumb": (BytesIO(thumb), "image.jpg"),
+        }
+
+        response = client.post("/offers/thumbnails", form=data)
+
+        # then
+        assert response.status_code == 404
+        assert response.json["global"] == ["Aucun objet ne correspond à cet identifiant dans notre base de données"]

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1127,6 +1127,28 @@ export class DefaultService {
   }
 
   /**
+   * delete_thumbnail <DELETE>
+   * @param offerId
+   * @returns void
+   * @throws ApiError
+   */
+  public deleteThumbnail(
+    offerId: string,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'DELETE',
+      url: '/offers/thumbnails/{offer_id}',
+      path: {
+        'offer_id': offerId,
+      },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
    * get_offer <GET>
    * @param offerId
    * @returns GetIndividualOfferResponseModel OK


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17271

## But de la pull request

Ajout de la suppression de thumbnail pour les offres. Reproduction de ce qui est fait pour les lieux

## Informations supplémentaires
Pour avoir un peu d'historique, il était possible d'avoir plusieurs mediations, aujourd'hui uniquement la plus récente [est utilisée](https://github.com/pass-culture/pass-culture-main/blob/fef61af9f1d1a583d78cc64d16caf53eb0263f39/api/src/pcapi/core/offers/models.py#L589). 
[Un script](https://github.com/pass-culture/pass-culture-api/blob/master/api/src/pcapi/scripts/delete_unused_mediations_and_assets.py) était passé pour nettoyer les mediations supperflues, il en reste. 
On pourrait faire un nettoyage en modifiant la synchro titelive pour n'enregistrer que la thumb intéressante, supprimer les mediations non utilisées et en adaptant les endpoints. Est-ce qu'on modifie le modèle en imaginant qu'on aura pas, à court terme, plusieurs thumb/offres?


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
