### PR TITLE
(PC-16002)[API] feat: New backoffice: offerer details: get attached users

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -24,6 +24,7 @@ class Permissions(enum.Enum):
     REVIEW_PUBLIC_ACCOUNT = "faire une revue manuelle d'un compte bénéficiaire/grand public"
     MANAGE_PUBLIC_ACCOUNT = "gérer un compte bénéficiaire/grand public"
     SEARCH_PRO_ACCOUNT = "rechercher un acteur culturel"
+    READ_OFFERER = "Visualiser une structure"
 
 
 def sync_enum_with_db_field(session: sa.orm.Session, py_enum: Type[enum.Enum], db_field: sa.Column) -> None:

--- a/api/src/pcapi/routes/backoffice/__init__.py
+++ b/api/src/pcapi/routes/backoffice/__init__.py
@@ -5,5 +5,6 @@ def install_routes(app: Flask) -> None:
     # pylint: disable=unused-import
     from . import accounts
     from . import auth
+    from . import offerers
     from . import permissions
     from . import pro

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -1,0 +1,29 @@
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.permissions import utils as perm_utils
+from pcapi.serialization.decorator import spectree_serialize
+
+from . import blueprint
+from . import serialization
+
+
+@blueprint.backoffice_blueprint.route("offerers/<int:offerer_id>/users", methods=["GET"])
+@spectree_serialize(
+    response_model=serialization.OffererAttachedUsersResponseModel,
+    on_success_status=200,
+    api=blueprint.api,
+)
+@perm_utils.permission_required(perm_models.Permissions.READ_OFFERER)
+def get_offerer_users(offerer_id: int) -> serialization.OffererAttachedUsersResponseModel:
+    """Get the list of all (pro) users attached to the offerer"""
+    users_offerer: list[offerers_models.UserOfferer] = (
+        offerers_models.UserOfferer.query.filter(
+            offerers_models.UserOfferer.offererId == offerer_id, offerers_models.UserOfferer.isValidated
+        )
+        .order_by(offerers_models.UserOfferer.id)
+        .all()
+    )
+
+    return serialization.OffererAttachedUsersResponseModel(
+        data=[serialization.OffererAttachedUser.from_orm(user_offerer.user) for user_offerer in users_offerer]
+    )

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -237,3 +237,17 @@ class ProResult(BaseModel):
 
 class SearchProResponseModel(PaginatedResponse):
     data: list[ProResult]
+
+
+class OffererAttachedUser(BaseModel):
+    class Config:
+        orm_mode = True
+
+    id: int
+    firstName: str | None
+    lastName: str | None
+    email: str
+
+
+class OffererAttachedUsersResponseModel(BaseModel):
+    data: list[OffererAttachedUser]

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1,0 +1,93 @@
+from flask import url_for
+import pytest
+
+from pcapi.core.auth.api import generate_token
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.permissions.models import Permissions
+from pcapi.core.testing import override_features
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class GetOffererUsersTest:
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_get_offerer_users_returns_list(self, client):
+        # given
+        offerer1 = offerers_factories.OffererFactory()
+        uo1 = offerers_factories.UserOffererFactory(
+            offerer=offerer1, user=users_factories.ProFactory(firstName=None, lastName=None)
+        )
+        uo2 = offerers_factories.UserOffererFactory(
+            offerer=offerer1, user=users_factories.ProFactory(firstName="Jean", lastName="Bon")
+        )
+        offerers_factories.UserOffererFactory(
+            offerer=offerer1, user=users_factories.ProFactory(), validationToken="not-validated"
+        )
+
+        offerer2 = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(offerer=offerer2, user=users_factories.ProFactory())
+
+        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_OFFERER])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.get_offerer_users", offerer_id=offerer1.id)
+        )
+
+        # then
+        assert response.status_code == 200
+        assert response.json["data"] == [
+            {
+                "id": uo1.user.id,
+                "firstName": None,
+                "lastName": None,
+                "email": uo1.user.email,
+            },
+            {
+                "id": uo2.user.id,
+                "firstName": "Jean",
+                "lastName": "Bon",
+                "email": uo2.user.email,
+            },
+        ]
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_get_offerer_users_returns_empty_if_offerer_is_not_found(self, client):
+        # given
+        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_OFFERER])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.get_offerer_users", offerer_id=42)
+        )
+
+        # then
+        assert response.status_code == 200
+        assert response.json["data"] == []
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_get_offerer_users_without_permission(self, client):
+        # given
+        offerer1 = offerers_factories.OffererFactory()
+        auth_token = generate_token(users_factories.UserFactory(), [])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.get_offerer_users", offerer_id=offerer1.id)
+        )
+
+        # then
+        assert response.status_code == 403
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_cannot_get_offerer_users_as_anonymous(self, client):
+        # given
+        offerer1 = offerers_factories.OffererFactory()
+
+        # when
+        response = client.get(url_for("backoffice_blueprint.get_offerer_users", offerer_id=offerer1.id))
+
+        # then
+        assert response.status_code == 403


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16002

## But de la pull request

Ajout d'un endpoint permettant d'afficher le contenu de l'onglet « Comptes rattachés » dans le détail d'une structure dans le nouveau backoffice. Il s'agit donc ici de récupérer les utilisateurs reliés à la structure (prénom, nom, email).

## Informations supplémentaires

Les mêmes fichiers et permission que la PR https://github.com/pass-culture/pass-culture-main/pull/3517 (actuellement en revue) sont ajoutés dans cette PR, car il s'agit du même écran.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
