### PR TITLE
(PC-17357)[API] fix: use accountId instead of cinemaId in get_interne…

### DIFF
--- a/api/src/pcapi/core/booking_providers/cds/client.py
+++ b/api/src/pcapi/core/booking_providers/cds/client.py
@@ -25,7 +25,7 @@ class CineDigitalServiceAPI(booking_providers_models.BookingProviderClientAPI):
         super().__init__(cinema_id, account_id, api_url, cinema_api_token)
 
     def get_internet_sale_gauge_active(self) -> bool:
-        data = get_resource(self.api_url, self.cinema_id, self.token, ResourceCDS.CINEMAS)
+        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.CINEMAS)
         cinemas = parse_obj_as(list[cds_serializers.CinemasCDS], data)
         for cinema in cinemas:
             if cinema.id == self.cinema_id:


### PR DESCRIPTION
…t_sale_gauge_active

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17357

## But de la pull request

Fix l’appel à get_internet_sale_gauge_active pour utiliser l'`accountId` du cinéma et non son `cinemaId`
