### PR TITLE
(PC-17336)[API] fix: Rework Sendinblue automation process to help cron return quickly

### DIFF
--- a/api/src/pcapi/routes/external/__init__.py
+++ b/api/src/pcapi/routes/external/__init__.py
@@ -4,6 +4,6 @@ from flask import Flask
 def install_routes(app: Flask) -> None:
     # pylint: disable=unused-import
     from . import bank_informations
-    from . import unsubscribe_users
+    from . import sendinblue
     from . import users_subscription
     from . import zendesk

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -78,7 +78,7 @@ else:
 
 
 # API config
-API_URL = os.environ.get("API_URL")
+API_URL = os.environ.get("API_URL", "")
 
 
 # Applications urls

--- a/api/src/pcapi/tasks/cloud_task.py
+++ b/api/src/pcapi/tasks/cloud_task.py
@@ -91,7 +91,7 @@ def enqueue_task(
 
 
 def enqueue_internal_task(queue, path, payload, deduplicate: bool = False, delayed_seconds: int = 0):  # type: ignore [no-untyped-def]
-    url = settings.API_URL + CLOUD_TASK_SUBPATH + path  # type: ignore [operator]
+    url = settings.API_URL + CLOUD_TASK_SUBPATH + path
 
     if settings.IS_DEV:
         _call_internal_api_endpoint(queue, url, payload)

--- a/api/tests/routes/external/sendinblue_test.py
+++ b/api/tests/routes/external/sendinblue_test.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from pcapi.core.testing import override_settings
@@ -69,3 +71,22 @@ class UnsubscribeUserTest:
 
         # Then
         assert response.status_code == 400
+
+
+@pytest.mark.usefixtures("db_session")
+class NotifyImportContactsTest:
+    def test_notify_importcontacts(self, app, caplog):
+        # Given
+        headers = {"X-Forwarded-For": "1.179.112.9"}
+
+        # When
+        with caplog.at_level(logging.INFO):
+            response = TestClient(app.test_client()).post("/webhooks/sendinblue/importcontacts/18/1", headers=headers)
+
+        # Then
+        assert response.status_code == 204
+        assert caplog.records[0].message == "ContactsApi->import_contacts finished"
+        assert caplog.records[0].extra == {
+            "list_id": 18,
+            "iteration": 1,
+        }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17336

## But de la pull request

Raccourcir fortement la durée d'exécution des cron d'automatisation Sendinblue.

## Implémentation

- ne plus vider les listes avant d'envoyer les contacts
- recevoir la notification de fin d'ingestion des contacts dans un webhook

Voir le ticket pour la description complète des idées évoquées.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
