### PR TITLE
(PC-17361)[PRO] fix: Fix validate venue edition error when venue doesn't have reimbursementPoint

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/ReimbursementPoint/ReimbursementPoint.jsx
@@ -175,7 +175,7 @@ const ReimbursementPoint = ({
                   initialValue={
                     venueReimbursementPoint
                       ? venueReimbursementPoint.venueId
-                      : ''
+                      : null
                   }
                 >
                   <option disabled value="">


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17361

## But de la pull request
La valeur de de l'attribut`reimbursementPointId` dans le body de la requête d'édition de lieu doit être `null` quand aucun point de remboursement est sélectionné.

