### PR TITLE
(PC-16425)[API] feat: prevent Virtual Venue edition of most attributes

### DIFF
--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -80,6 +80,15 @@ def check_venue_edition(modifications, venue):  # type: ignore [no-untyped-def]
         modifications.get("visualDisabilityCompliant"),
     ]
 
+    allowed_virtual_venue_modifications = {
+        "reimbursementPointId",
+        "businessUnitId",  # FUTURE-NEW-BANK-DETAILS: remove when new bank details journey is complete
+    }
+    if venue.isVirtual and modifications.keys() - allowed_virtual_venue_modifications:
+        raise ApiErrors(
+            errors={"venue": ["Vous ne pouvez modifier que le point de remboursement du lieu Offre Numérique."]}
+        )
+
     if managing_offerer_id:
         raise ApiErrors(errors={"managingOffererId": ["Vous ne pouvez pas changer la structure d'un lieu"]})
     if siret and venue.siret and siret != venue.siret:

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -343,6 +343,17 @@ class EditVenueTest:
         assert link.businessUnit == business_unit
         assert link.timespan.upper is None
 
+    def test_cannot_update_virtual_venue_name(self):
+        offerer = offerers_factories.OffererFactory(siren="000000000")
+        virtual_venue = offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
+
+        venue_data = {"name": "Toto"}
+        with pytest.raises(api_errors.ApiErrors) as error:
+            offerers_api.update_venue(virtual_venue, **venue_data)
+
+        msg = "Vous ne pouvez modifier que le point de remboursement du lieu Offre Numérique."
+        assert error.value.errors == {"venue": [msg]}
+
     def test_edit_venue_with_pending_bank_info(self):
         venue = offerers_factories.VenueFactory(
             pricing_point="self", reimbursement_point="self", publicName="Nom actuel"


### PR DESCRIPTION
Only reimbursementPointId should be editable

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16425

## But de la pull request

Limiter, côté back, les attributs qui sont modifiables pour un lieu numérique; à ce jour, seulement le `reimbursementPointId`.

## Implémentation

- Modification de la fonction de validation `check_venue_edition()`

## Informations supplémentaires

- On a temporairement laissé businessUnitId dans la liste des attributs modifiables, même si on ne s'en sert plus. Le nettoyage sera fait dans un autre ticket.
