### PR TITLE
[PC-17309] Fix pcapi docker image tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -73,4 +73,4 @@ jobs:
     secrets: inherit
     with:
       ref: v${{ inputs.tag_number }}
-      tag: v${{ inputs.tag_number }}
+      tag: ${{ inputs.tag_number }}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17309

## But de la pull request

Suppression du `v` en trop devant la version dans le tag des images docker de pcapi.