### PR TITLE
(PC-17411)[API] fix: avoid calling ubble with deprecated fraud check ids

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -517,6 +517,9 @@ def activate_beneficiary_if_no_missing_step(user: users_models.User) -> bool:
     return True
 
 
+DEPRECATED_UBBLE_PREFIX = "deprecated-"
+
+
 def _update_fraud_check_eligibility_with_history(
     fraud_check: fraud_models.BeneficiaryFraudCheck, eligibility: users_models.EligibilityType
 ) -> fraud_models.BeneficiaryFraudCheck:
@@ -542,7 +545,7 @@ def _update_fraud_check_eligibility_with_history(
     if fraud_check.reasonCodes is None:
         fraud_check.reasonCodes = []
     fraud_check.reasonCodes.append(fraud_models.FraudReasonCode.ELIGIBILITY_CHANGED)
-    fraud_check.thirdPartyId = f"deprecated-{fraud_check.thirdPartyId}"
+    fraud_check.thirdPartyId = f"{DEPRECATED_UBBLE_PREFIX}{fraud_check.thirdPartyId}"
 
     pcapi_repository.repository.save(fraud_check, new_fraud_check)
 

--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -1,9 +1,6 @@
 from datetime import datetime
 
-from pcapi.core.fraud import models
-from pcapi.core.fraud.models import BeneficiaryFraudCheck
-from pcapi.core.fraud.models import FraudCheckStatus
-from pcapi.core.fraud.models import FraudCheckType
+from pcapi.core.fraud import models as fraud_models
 import pcapi.core.subscription.ubble.api as ubble_api
 from pcapi.core.subscription.ubble.exceptions import UbbleDownloadedFileEmpty
 from pcapi.utils.requests import ExternalAPIException
@@ -78,15 +75,15 @@ def archive_past_identification_pictures(
 
 def get_fraud_check_to_archive(
     start_date: datetime, end_date: datetime, status: bool | None, limit: int = DEFAULT_LIMIT, offset: int = 0
-) -> list[BeneficiaryFraudCheck]:
+) -> list[fraud_models.BeneficiaryFraudCheck]:
     query = (
-        models.BeneficiaryFraudCheck.query.filter(
-            BeneficiaryFraudCheck.status == FraudCheckStatus.OK,
-            BeneficiaryFraudCheck.dateCreated.between(start_date, end_date),
-            BeneficiaryFraudCheck.idPicturesStored.is_(status),
-            BeneficiaryFraudCheck.type == FraudCheckType.UBBLE,
+        fraud_models.BeneficiaryFraudCheck.query.filter(
+            fraud_models.BeneficiaryFraudCheck.status == fraud_models.FraudCheckStatus.OK,
+            fraud_models.BeneficiaryFraudCheck.dateCreated.between(start_date, end_date),
+            fraud_models.BeneficiaryFraudCheck.idPicturesStored.is_(status),
+            fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE,
         )
-        .order_by(BeneficiaryFraudCheck.dateCreated.asc())
+        .order_by(fraud_models.BeneficiaryFraudCheck.dateCreated.asc())
         .limit(limit)
         .offset(offset)
     )

--- a/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
+++ b/api/src/pcapi/core/subscription/ubble/archive_past_identification_pictures.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.subscription import api as subscription_api
 import pcapi.core.subscription.ubble.api as ubble_api
 from pcapi.core.subscription.ubble.exceptions import UbbleDownloadedFileEmpty
 from pcapi.utils.requests import ExternalAPIException
@@ -82,6 +83,7 @@ def get_fraud_check_to_archive(
             fraud_models.BeneficiaryFraudCheck.dateCreated.between(start_date, end_date),
             fraud_models.BeneficiaryFraudCheck.idPicturesStored.is_(status),
             fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.UBBLE,
+            fraud_models.BeneficiaryFraudCheck.thirdPartyId.notlike(f"{subscription_api.DEPRECATED_UBBLE_PREFIX}%"),
         )
         .order_by(fraud_models.BeneficiaryFraudCheck.dateCreated.asc())
         .limit(limit)

--- a/api/tests/core/subscription/ubble/test_archive_past_identification_pictures.py
+++ b/api/tests/core/subscription/ubble/test_archive_past_identification_pictures.py
@@ -1,0 +1,36 @@
+import datetime
+
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.subscription import api as subscription_api
+from pcapi.core.subscription.ubble.archive_past_identification_pictures import get_fraud_check_to_archive
+
+
+class ArchivePastIdentificationPicturesTest:
+    @pytest.mark.usefixtures("db_session")
+    def test_get_fraud_check_to_archive(self):
+        # Given
+        start_date = datetime.datetime(2021, 1, 1)
+        end_date = datetime.datetime(2021, 1, 31)
+
+        fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
+            dateCreated=datetime.datetime(2021, 1, 15),
+            status=fraud_models.FraudCheckStatus.OK,
+            type=fraud_models.FraudCheckType.UBBLE,
+        )
+        deprecated_fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
+            thirdPartyId=f"{subscription_api.DEPRECATED_UBBLE_PREFIX}{fraud_check.thirdPartyId}",
+            dateCreated=datetime.datetime(2021, 1, 15),
+            status=fraud_models.FraudCheckStatus.OK,
+            type=fraud_models.FraudCheckType.UBBLE,
+        )
+
+        # When
+        fraud_checks_to_archive = get_fraud_check_to_archive(start_date, end_date, None)
+
+        # Then
+        assert len(fraud_checks_to_archive) == 1
+        assert fraud_check in fraud_checks_to_archive
+        assert deprecated_fraud_check not in fraud_checks_to_archive


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17411

## But de la pull request

Corriger https://sentry.passculture.team/organizations/sentry/issues/392943/events/latest/?environment=production&project=5&referrer=slack

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
