### PR TITLE
(PC-17053)[API] feat: send educonnect UserTypeNotParent error code wh…

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -112,11 +112,8 @@ def get_educonnect_user(saml_response: str) -> models.EduconnectUser:
     user_type = educonnect_identity.get(_get_field_oid("7"), [None])[0]
     logout_url = educonnect_identity[_get_field_oid("5")][0]
 
-    if user_type in ["resp1d", "resp2d"]:
-        raise exceptions.UserTypeNotStudent(saml_request_id, user_type, logout_url)
-
     if user_type not in ["eleve1d", "eleve2d"]:
-        logger.error("Unknown user type %s", user_type, extra={"saml_request_id": saml_request_id})
+        raise exceptions.UserTypeNotStudent(saml_request_id, user_type, logout_url)
 
     try:
         return models.EduconnectUser(


### PR DESCRIPTION
…en not defined

when the attribute is not defined, it means the user is a 'responsable non attaché à un élève'

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17053
