### PR TITLE
(PC-17317)[PRO] feat: add offerer stats section on homepage

### DIFF
--- a/pro/src/components/pages/Home/Homepage.tsx
+++ b/pro/src/components/pages/Home/Homepage.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react'
 
+import useActiveFeature from 'components/hooks/useActiveFeature'
 import useCurrentUser from 'components/hooks/useCurrentUser'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import { BannerRGS } from 'new_components/Banner'
@@ -8,6 +9,7 @@ import { setHasSeenRGSBanner } from 'repository/pcapi/pcapi'
 
 import HomepageBreadcrumb, { STEP_ID_OFFERERS } from './HomepageBreadcrumb'
 import Offerers from './Offerers/Offerers'
+import { OffererStats } from './OffererStats'
 import { ProfileAndSupport } from './ProfileAndSupport'
 
 const Homepage = (): JSX.Element => {
@@ -18,6 +20,7 @@ const Homepage = (): JSX.Element => {
   const [hasClosedRGSBanner, setHasClosedRGSBanner] = useState<boolean>(
     Boolean(hasSeenProRgs)
   )
+  const isOffererStatsActive = useActiveFeature('ENABLE_OFFERER_STATS')
   const handleCloseRGSBanner = () => {
     setHasSeenRGSBanner().finally(() => {
       setHasClosedRGSBanner(true)
@@ -39,6 +42,11 @@ const Homepage = (): JSX.Element => {
       <section className="h-section">
         <Offerers />
       </section>
+      {isOffererStatsActive && (
+        <section className="h-section">
+          <OffererStats />
+        </section>
+      )}
 
       <section className="h-section" ref={profileRef}>
         <ProfileAndSupport />

--- a/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
+++ b/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const OffererStats = () => {
+  return (
+    <>
+      <h2 className="h-section-title">Statistiques</h2>
+      <p>A venir, section statistiques</p>
+    </>
+  )
+}
+
+export default OffererStats

--- a/pro/src/components/pages/Home/OffererStats/index.ts
+++ b/pro/src/components/pages/Home/OffererStats/index.ts
@@ -1,0 +1,1 @@
+export { default as OffererStats } from './OffererStats'

--- a/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
+++ b/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
@@ -358,5 +358,31 @@ describe('homepage', () => {
         })
       })
     })
+
+    describe('offererStats', () => {
+      beforeEach(() => {
+        store = configureTestStore({
+          user: {
+            currentUser: {
+              id: 'fake_id',
+              firstName: 'John',
+              lastName: 'Do',
+              email: 'john.do@dummy.xyz',
+              phoneNumber: '01 00 00 00 00',
+            },
+            initialized: true,
+          },
+          features: {
+            list: [{ isActive: true, nameKey: 'ENABLE_OFFERER_STATS' }],
+          },
+        })
+      })
+      it('should display section when ff is active', async () => {
+        await renderHomePage(store)
+        expect(
+          screen.getByText('Statistiques', { selector: 'h2' })
+        ).toBeInTheDocument()
+      })
+    })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17317

## But de la pull request

Ajout de la section Statistiques sur la homepage conditionné par l'activation du FF `ENABLE_OFFERER_STATS`

#