### PR TITLE
PC-17192 allow ubble activation when process started before 19yo

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -549,6 +549,14 @@ def _update_fraud_check_eligibility_with_history(
     return new_fraud_check
 
 
+def get_id_provider_detected_eligibility(
+    user: users_models.User, identity_content: common_fraud_models.IdentityCheckContent
+) -> users_models.EligibilityType | None:
+    return fraud_api.decide_eligibility(
+        user, identity_content.get_birth_date(), identity_content.get_registration_datetime()
+    )
+
+
 # TODO (Lixxday): use a proper BeneficiaryFraudCheck History model to track these kind of updates
 def handle_eligibility_difference_between_declaration_and_identity_provider(
     user: users_models.User,
@@ -557,9 +565,7 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
     identity_content: common_fraud_models.IdentityCheckContent = fraud_check.source_data()  # type: ignore [assignment]
 
     declared_eligibility = fraud_check.eligibilityType
-    id_provider_detected_eligibility = fraud_api.decide_eligibility(
-        user, identity_content.get_birth_date(), identity_content.get_registration_datetime()
-    )
+    id_provider_detected_eligibility = get_id_provider_detected_eligibility(user, identity_content)
 
     if declared_eligibility == id_provider_detected_eligibility or id_provider_detected_eligibility is None:
         return fraud_check


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17192

## But de la pull request

Harmoniser les règles d'acceptation des dossiers Ubble sur celles de DMS

## Implémentation

- cf. ticket

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
