### PR TITLE
(PC-17433)[API] fix: NoResultFound exception when requesting venue_for_offerer with wrong id

### DIFF
--- a/api/src/pcapi/admin/custom_views/offer_view.py
+++ b/api/src/pcapi/admin/custom_views/offer_view.py
@@ -359,7 +359,7 @@ class OfferForVenueSubview(OfferView):
         if venue_id is None:
             abort(400, "Venue id required")
 
-        venue = Venue.query.filter(Venue.id == venue_id).one()
+        venue = Venue.query.filter(Venue.id == venue_id).one_or_none()
         if not venue:
             abort(404, "Ce lieu n'existe pas ou plus")
 

--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -463,7 +463,7 @@ class VenueForOffererSubview(VenueView):
         if offerer_id is None:
             abort(400, "Offerer id required")
 
-        offerer = Offerer.query.filter(Offerer.id == offerer_id).one()
+        offerer = Offerer.query.filter(Offerer.id == offerer_id).one_or_none()
         if not offerer:
             abort(404, "Cette structure n'existe pas ou plus")
 

--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -1402,3 +1402,15 @@ class OfferViewTest:
         assert response.status_code == 302
         mocked_reindex_offer_ids.assert_called_once_with([offer.id])
         assert offer.lastValidationType == OfferValidationType.AUTO  # unchanged
+
+
+class OfferForVenueSubviewTest:
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
+        admin = users_factories.AdminFactory(email="user@example.com")
+        client = client.with_session_auth(admin.email)
+
+        response = client.get(url_for("offer_for_venue.index", id=42))
+
+        assert response.status_code == 404


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17433

## But de la pull request

Corriger une erreur serveur (500) reportée par Sentry :
Unexpected error on method=GET url=https://backend.passculture.pro/pc/back-office/venue_for_offerer/?id=286: NoResultFound('No row was found when one was required')

https://sentry.passculture.team/organizations/sentry/issues/395668/?project=5&referrer=slack

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
