### PR TITLE
(PC-16955) Add user validated birth date

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d19b9f8cf4d0 (pre) (head)
+685f32d7cb22 (pre) (head)
 6858182908fe (post) (head)

--- a/api/src/pcapi/alembic/versions/20220926T082205_685f32d7cb22_user_validated_birth_date.py
+++ b/api/src/pcapi/alembic/versions/20220926T082205_685f32d7cb22_user_validated_birth_date.py
@@ -1,0 +1,19 @@
+"""Add user.validatedBirthDate column
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "685f32d7cb22"
+down_revision = "d19b9f8cf4d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "validatedBirthDate" DATE;""")
+
+
+def downgrade() -> None:
+    op.drop_column("user", "validatedBirthDate")

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -566,7 +566,7 @@ def has_performed_honor_statement(user: users_models.User, eligibility_type: use
 
 def decide_eligibility(
     user: users_models.User,
-    birth_date: datetime.date | datetime.datetime | None,
+    birth_date: datetime.date | None,
     registration_datetime: datetime.datetime | None,
 ) -> users_models.EligibilityType | None:
     """Returns the applicable eligibility of the user.

--- a/api/src/pcapi/core/payments/api.py
+++ b/api/src/pcapi/core/payments/api.py
@@ -14,7 +14,9 @@ from . import exceptions
 from . import repository as payments_repository
 
 
-def _compute_eighteenth_birthday(birth_date: datetime.datetime) -> datetime.datetime:
+def _compute_eighteenth_birthday(birth_date: datetime.date | None) -> datetime.datetime:
+    if not birth_date:
+        raise exceptions.UserNotGrantable("User has no birth date")
     return datetime.datetime.combine(birth_date, datetime.time(0, 0)) + relativedelta(years=18)
 
 
@@ -29,7 +31,7 @@ def get_granted_deposit(
 
         return GrantedDeposit(
             amount=deposit_conf.GRANTED_DEPOSIT_AMOUNTS_FOR_UNDERAGE_BY_AGE[age_at_registration],
-            expiration_date=_compute_eighteenth_birthday(beneficiary.dateOfBirth),  # type: ignore [arg-type]
+            expiration_date=_compute_eighteenth_birthday(beneficiary.birth_date),
             type=DepositType.GRANT_15_17,
             version=1,
         )

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -35,8 +35,8 @@ USER_PROFILING_BLOCKING_STATUS = fraud_models.FraudCheckStatus.KO
 
 
 def _get_age_at_first_registration(user: users_models.User, eligibility: users_models.EligibilityType) -> int | None:
-    first_registration_date = get_first_registration_date(user, user.dateOfBirth, eligibility)
-    if not first_registration_date or not user.dateOfBirth:
+    first_registration_date = get_first_registration_date(user, user.birth_date, eligibility)
+    if not first_registration_date or not user.birth_date:
         return None
     return users_utils.get_age_at_date(user.dateOfBirth, first_registration_date)
 
@@ -636,7 +636,7 @@ def _get_jouve_subscription_item_status(
 
 def get_first_registration_date(
     user: users_models.User,
-    birth_date: datetime.date | datetime.datetime | None,
+    birth_date: datetime.date | None,
     eligibility: users_models.EligibilityType,
 ) -> datetime.datetime | None:
     fraud_checks = user.beneficiaryFraudChecks

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -38,7 +38,7 @@ def _get_age_at_first_registration(user: users_models.User, eligibility: users_m
     first_registration_date = get_first_registration_date(user, user.birth_date, eligibility)
     if not first_registration_date or not user.birth_date:
         return None
-    return users_utils.get_age_at_date(user.dateOfBirth, first_registration_date)
+    return users_utils.get_age_at_date(user.birth_date, first_registration_date)
 
 
 def activate_beneficiary_for_eligibility(
@@ -415,8 +415,11 @@ def _is_ubble_allowed_if_subscription_overflow(user: users_models.User) -> bool:
     if not FeatureToggle.ENABLE_UBBLE_SUBSCRIPTION_LIMITATION.is_active():
         return True
 
+    if not user.birth_date:
+        return False
+
     future_age = users_utils.get_age_at_date(
-        user.dateOfBirth,  # type: ignore [arg-type]
+        user.birth_date,
         datetime.datetime.utcnow() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore [arg-type]
     )
     eligibility_ranges = users_constants.ELIGIBILITY_UNDERAGE_RANGE + [users_constants.ELIGIBILITY_AGE_18]

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -602,18 +602,14 @@ def handle_eligibility_difference_between_declaration_and_identity_provider(
 
 
 def update_user_birth_date_if_not_beneficiary(user: users_models.User, birth_date: datetime.date | None) -> None:
-    """Updates the user birth date based on data received from the identity provider.
-    Indeed, if the user is not beneficiary (or underage), user.dateOfBirth was manually declared during account creation.
-    We'd better trust the identity provider so that the user is correctly redirected for the rest of the process.
-
-    Args:
-        user (users_models.User): The user to update.
-        birth_date (datetime.date | None): The birth date to set.
+    """Updates the user validated birth date based on data received from the identity provider
+    so that the user is correctly redirected for the rest of the process.
     """
     if user.is_beneficiary:
         return
-    if user.dateOfBirth != birth_date and birth_date is not None:
-        user.dateOfBirth = birth_date
+    if user.validatedBirthDate != birth_date and birth_date is not None:
+        user.dateOfBirth = birth_date  # TODO (PC-17174) stop overriding this field
+        user.validatedBirthDate = birth_date
         pcapi_repository.repository.save(user)
 
 

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -38,7 +38,7 @@ def update_ubble_workflow(fraud_check: fraud_models.BeneficiaryFraudCheck) -> No
     status = content.status
 
     if not settings.IS_PROD and ubble_fraud_api.does_match_ubble_test_email(fraud_check.user.email):
-        content.birth_date = fraud_check.user.dateOfBirth.date() if fraud_check.user.dateOfBirth else None
+        content.birth_date = fraud_check.user.birth_date
 
     fraud_check.resultContent = content  # type: ignore [call-overload]
     pcapi_repository.repository.save(fraud_check)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -753,7 +753,7 @@ def get_eligibility_start_datetime(
 
 
 def get_eligibility_at_date(
-    date_of_birth: datetime.date | datetime.datetime | None,
+    date_of_birth: datetime.date | None,
     specified_datetime: datetime.datetime,
 ) -> models.EligibilityType | None:
     eligibility_start = get_eligibility_start_datetime(date_of_birth)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -174,7 +174,7 @@ def update_user_information(
     user: models.User,
     first_name: str | None = None,
     last_name: str | None = None,
-    birth_date: datetime.datetime | None = None,
+    validated_birth_date: datetime.date | None = None,
     activity: str | None = None,
     address: str | None = None,
     city: str | None = None,
@@ -191,8 +191,11 @@ def update_user_information(
         user.lastName = last_name
     if first_name is not None or last_name is not None:
         user.publicName = "%s %s" % (first_name, last_name)
-    if birth_date is not None:
-        user.dateOfBirth = birth_date
+    if validated_birth_date is not None:
+        user.dateOfBirth = datetime.datetime.combine(
+            validated_birth_date, datetime.time.min
+        )  # TODO (PC-17174) stop overriding this field
+        user.validatedBirthDate = validated_birth_date
     if activity is not None:
         user.activity = activity
     if address is not None:
@@ -236,7 +239,7 @@ def update_user_information_from_external_source(
         user=user,
         first_name=first_name,
         last_name=last_name,
-        birth_date=datetime.datetime.combine(birth_date, datetime.time(0, 0)),
+        validated_birth_date=birth_date,
         activity=data.get_activity(),
         address=data.get_address(),
         city=data.get_city(),

--- a/api/src/pcapi/core/users/external/__init__.py
+++ b/api/src/pcapi/core/users/external/__init__.py
@@ -186,7 +186,7 @@ def get_user_attributes(user: User) -> UserAttributes:
 
     # A user becomes a former beneficiary only after the last credit is expired or spent or can no longer be claimed
     is_former_beneficiary = (user.has_beneficiary_role and not has_remaining_credit) or (
-        user.has_underage_beneficiary_role and get_eligibility_at_date(user.birth_date, datetime.utcnow()) is None
+        user.has_underage_beneficiary_role and user.eligibility is None
     )
     user_birth_date = datetime.combine(user.birth_date, datetime.min.time()) if user.birth_date else None
 

--- a/api/src/pcapi/core/users/external/__init__.py
+++ b/api/src/pcapi/core/users/external/__init__.py
@@ -186,8 +186,9 @@ def get_user_attributes(user: User) -> UserAttributes:
 
     # A user becomes a former beneficiary only after the last credit is expired or spent or can no longer be claimed
     is_former_beneficiary = (user.has_beneficiary_role and not has_remaining_credit) or (
-        user.has_underage_beneficiary_role and get_eligibility_at_date(user.dateOfBirth, datetime.utcnow()) is None
+        user.has_underage_beneficiary_role and get_eligibility_at_date(user.birth_date, datetime.utcnow()) is None
     )
+    user_birth_date = datetime.combine(user.birth_date, datetime.min.time()) if user.birth_date else None
 
     return UserAttributes(
         booking_categories=bookings_attributes.booking_categories,
@@ -195,7 +196,7 @@ def get_user_attributes(user: User) -> UserAttributes:
         booking_subcategories=bookings_attributes.booking_subcategories,
         city=user.city,
         date_created=user.dateCreated,
-        date_of_birth=user.dateOfBirth,  # type: ignore [arg-type]
+        date_of_birth=user_birth_date,  # type: ignore [arg-type]
         departement_code=user.departementCode,
         deposit_activation_date=user.deposit_activation_date,
         deposit_expiration_date=user.deposit_expiration_date,

--- a/api/src/pcapi/core/users/external/models.py
+++ b/api/src/pcapi/core/users/external/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+import datetime
 import typing
 
 from pcapi.core.users.models import DomainsCredit
@@ -12,11 +12,11 @@ class UserAttributes:
     booking_count: int
     booking_subcategories: list[str]
     city: str | None
-    date_created: datetime
-    date_of_birth: datetime
+    date_created: datetime.datetime
+    date_of_birth: datetime.datetime
     departement_code: str | None
-    deposit_activation_date: datetime | None
-    deposit_expiration_date: datetime | None
+    deposit_activation_date: datetime.datetime | None
+    deposit_expiration_date: datetime.datetime | None
     domains_credit: DomainsCredit | None
     eligibility: EligibilityType | None
     first_name: str | None
@@ -30,10 +30,10 @@ class UserAttributes:
     is_email_validated: bool
     is_phone_validated: bool  # Added for Zendesk
     is_pro: bool
-    last_booking_date: datetime | None
-    last_favorite_creation_date: datetime | None
+    last_booking_date: datetime.datetime | None
+    last_favorite_creation_date: datetime.datetime | None
     last_name: str | None
-    last_visit_date: datetime | None
+    last_visit_date: datetime.datetime | None
     marketing_email_subscription: bool
     marketing_push_subscription: bool
     most_booked_subcategory: str | None  # Single subcategory most frequently booked by the user
@@ -41,7 +41,7 @@ class UserAttributes:
     postal_code: str | None
     products_use_date: dict
     roles: list[str]
-    suspension_date: datetime | None  # Added for Zendesk
+    suspension_date: datetime.datetime | None  # Added for Zendesk
     suspension_reason: str | None  # Added for Zendesk
 
 

--- a/api/src/pcapi/core/users/external/zendesk.py
+++ b/api/src/pcapi/core/users/external/zendesk.py
@@ -209,7 +209,7 @@ def _add_internal_note(
     else:
         html_body += Markup("Utilisateur identifié : <b>{}</b>, {}").format(name, email)
         if attributes.date_of_birth:
-            html_body += f", {users_utils.get_age_from_birth_date(attributes.date_of_birth)} ans"
+            html_body += f", {users_utils.get_age_from_birth_date(attributes.date_of_birth.date())} ans"
         if attributes.is_beneficiary and attributes.domains_credit:
             html_body += Markup("<br/>Bénéficiaire, crédit restant : {remaining:.2f} € sur {initial:.2f} €").format(
                 remaining=float(attributes.domains_credit.all.remaining) if attributes.domains_credit else 0,

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -377,7 +377,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
     def eligibility(self) -> EligibilityType | None:
         from pcapi.core.fraud import api as fraud_api
 
-        return fraud_api.decide_eligibility(self, self.dateOfBirth, datetime.utcnow())
+        return fraud_api.decide_eligibility(self, self.birth_date, datetime.utcnow())
 
     @property
     def has_active_deposit(self):  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -104,12 +104,14 @@ class NotificationSubscriptions:
 
 
 # calculate date of latest birthday
-def _get_latest_birthday(birth_date: date) -> date:
+def _get_latest_birthday(birth_date: date | None) -> date | None:
     """
     Calculates the latest birthday of a given person.
     :param birth_date: The person's birthday.
     :return: The latest birthday's date.
     """
+    if not birth_date:
+        return None
 
     today = date.today()
 
@@ -394,8 +396,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
         return self.eligibility is not None
 
     @property
-    def latest_birthday(self) -> date:
-        return _get_latest_birthday(self.dateOfBirth.date())  # type: ignore [union-attr]
+    def latest_birthday(self) -> date | None:
+        return _get_latest_birthday(self.birth_date)
 
     @property
     def real_wallet_balance(self):  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -337,7 +337,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
 
     @property
     def age(self) -> int | None:
-        return users_utils.get_age_from_birth_date(self.dateOfBirth.date()) if self.dateOfBirth is not None else None
+        return users_utils.get_age_from_birth_date(self.birth_date) if self.birth_date else None
 
     @property
     def birth_date(self) -> date | None:

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -38,9 +38,9 @@ def decode_jwt_token_rs256(jwt_token: str) -> dict:
     return payload
 
 
-def get_age_at_date(birth_date: date | datetime, specified_datetime: datetime) -> int:
+def get_age_at_date(birth_date: date, specified_datetime: datetime) -> int:
     return max(0, relativedelta(specified_datetime, birth_date).years)
 
 
-def get_age_from_birth_date(birth_date: date | datetime) -> int:
+def get_age_from_birth_date(birth_date: date) -> int:
     return get_age_at_date(birth_date, datetime.utcnow())

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -156,14 +156,14 @@ def get_user_subscription_history(user_id: int) -> serialization.GetUserSubscrip
     eligibility_types = []
 
     # Do not show information about eligibility types which are not possible depending on known user age
-    if user.dateOfBirth:
-        age_at_creation = users_utils.get_age_at_date(user.dateOfBirth, user.dateCreated)
+    if user.birth_date:
+        age_at_creation = users_utils.get_age_at_date(user.birth_date, user.dateCreated)
         if age_at_creation <= users_constants.ELIGIBILITY_AGE_18:
             if age_at_creation == users_constants.ELIGIBILITY_AGE_18:
                 eligibility_types.append(users_models.EligibilityType.AGE18)
             else:
                 eligibility_types.append(users_models.EligibilityType.UNDERAGE)
-                age_now = users_utils.get_age_from_birth_date(user.dateOfBirth)
+                age_now = users_utils.get_age_from_birth_date(user.birth_date)
                 if age_now >= users_constants.ELIGIBILITY_AGE_18:
                     eligibility_types.append(users_models.EligibilityType.AGE18)
     else:

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -101,7 +101,7 @@ def update_public_account(user_id: int, body: serialization.PublicAccountUpdateR
         user,
         first_name=body.firstName,
         last_name=body.lastName,
-        birth_date=body.dateOfBirth,
+        validated_birth_date=body.dateOfBirth.date() if body.dateOfBirth else None,
         id_piece_number=body.idPieceNumber,
         address=body.address,
         postal_code=body.postalCode,

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -375,7 +375,7 @@ def profiling_fraud_score(user: users_models.User, body: serializers.UserProfili
             session_id=body.sessionId,  # type: ignore [arg-type]
             user_id=user.id,
             user_email=user.email,
-            birth_date=user.dateOfBirth.date() if user.dateOfBirth else None,
+            birth_date=user.birth_date,
             phone_number=user.phoneNumber,  # type: ignore [arg-type]
             workflow_type=user_profiling.WorkflowType.BENEFICIARY_VALIDATION,
             # depends on loadbalancer configuration

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -129,7 +129,8 @@ class ChangeEmailTokenContent(BaseModel):
 
 class UserProfileResponse(BaseModel):
     booked_offers: dict[str, int]
-    dateOfBirth: datetime.date | None
+    birth_date: datetime.date | None
+    date_of_birth: datetime.date | None  # TODO: remove when all app clients use birth_date field
     deposit_expiration_date: datetime.datetime | None
     deposit_type: DepositType | None
     deposit_version: int | None
@@ -205,7 +206,10 @@ class UserProfileResponse(BaseModel):
         if _should_prevent_from_filling_cultural_survey(user):
             user.needsToFillCulturalSurvey = False
 
-        return super().from_orm(user)
+        serialized_user = super().from_orm(user)
+        serialized_user.date_of_birth = user.birth_date
+
+        return serialized_user
 
 
 def _should_prevent_from_filling_cultural_survey(user: User) -> bool:

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -172,7 +172,7 @@ class UserProfileResponse(BaseModel):
     @staticmethod
     def _show_eligible_card(user: User) -> bool:
         return (
-            relativedelta(user.dateCreated, user.dateOfBirth).years < users_constants.ELIGIBILITY_AGE_18
+            relativedelta(user.dateCreated, user.birth_date).years < users_constants.ELIGIBILITY_AGE_18
             and user.has_beneficiary_role is False
             and user.eligibility == EligibilityType.AGE18
         )
@@ -197,8 +197,8 @@ class UserProfileResponse(BaseModel):
         user.domains_credit = users_api.get_domains_credit(user)
         user.booked_offers = cls._get_booked_offers(user)
         user.isEligibleForBeneficiaryUpgrade = users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility)
-        user.eligibility_end_datetime = users_api.get_eligibility_end_datetime(user.dateOfBirth)
-        user.eligibility_start_datetime = users_api.get_eligibility_start_datetime(user.dateOfBirth)
+        user.eligibility_end_datetime = users_api.get_eligibility_end_datetime(user.birth_date)
+        user.eligibility_start_datetime = users_api.get_eligibility_start_datetime(user.birth_date)
         user.isBeneficiary = user.is_beneficiary
         user.subscriptionMessage = subscription_api.get_subscription_message(user)
 

--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -23,7 +23,7 @@ RECREDIT_BATCH_SIZE = 1000
 
 def has_celebrated_birthday_since_registration(user: users_models.User) -> bool:
     first_registration_datetime = subscription_api.get_first_registration_date(
-        user, user.dateOfBirth, users_models.EligibilityType.UNDERAGE
+        user, user.birth_date, users_models.EligibilityType.UNDERAGE
     )
     if first_registration_datetime is None:
         logger.error("No registration date for user to be recredited", extra={"user_id": user.id})

--- a/api/src/pcapi/scripts/payment/user_recredit.py
+++ b/api/src/pcapi/scripts/payment/user_recredit.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+import datetime
 import logging
+import typing
 
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import joinedload
@@ -28,7 +29,7 @@ def has_celebrated_birthday_since_registration(user: users_models.User) -> bool:
         logger.error("No registration date for user to be recredited", extra={"user_id": user.id})
         return False
 
-    return first_registration_datetime.date() < user.latest_birthday
+    return first_registration_datetime.date() < typing.cast(datetime.date, user.latest_birthday)
 
 
 def can_be_recredited(user: users_models.User) -> bool:
@@ -50,8 +51,8 @@ def has_been_recredited(user: users_models.User) -> bool:
 
 
 def recredit_underage_users() -> None:
-    sixteen_years_ago = datetime.utcnow() - relativedelta(years=16)
-    eighteen_years_ago = datetime.utcnow() - relativedelta(years=18)
+    sixteen_years_ago = datetime.datetime.utcnow() - relativedelta(years=16)
+    eighteen_years_ago = datetime.datetime.utcnow() - relativedelta(years=18)
 
     user_ids = [
         result

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -117,10 +117,14 @@
                 <td>{{ model.phoneNumber }}</td>
             </tr>
             <tr>
-                <th scope="row">Date de naissance</th>
+                <th scope="row">Date de naissance (déclarée lors de l'inscription)</th>
                 <td>{% if model.dateOfBirth %}{{ model.dateOfBirth.strftime('%d/%m/%Y') }}{% else %}Inconnue{% endif
                     %}
                 </td>
+            </tr>
+            <tr>
+                <th scope="row">Date de naissance (validée par la vérification d'identité)</th>
+                <td>{% if model.validatedBirthDate %}{{ model.validatedBirthDate.strftime('%d/%m/%Y') }}{% else %}-{% endif%}</td>
             </tr>
             <tr>
                 <th scope="row">Date de création du compte</th>

--- a/api/tests/core/users/external/external_users_test.py
+++ b/api/tests/core/users/external/external_users_test.py
@@ -368,7 +368,7 @@ def test_get_user_attributes_not_beneficiary():
         booking_categories=[],
         city="Nice",
         date_created=user.dateCreated,
-        date_of_birth=user.dateOfBirth,
+        date_of_birth=datetime.combine(user.birth_date, datetime.min.time()),
         departement_code=None,
         deposit_expiration_date=None,
         domains_credit=None,

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -733,7 +733,7 @@ class BeneficiaryInformationUpdateTest:
         assert beneficiary.publicName == "Jane Doe"
         assert beneficiary.postalCode == "67200"
         assert beneficiary.address == "11 Rue du Test"
-        assert beneficiary.dateOfBirth == datetime.datetime(2000, 5, 1, 0, 0)
+        assert beneficiary.validatedBirthDate == datetime.date(2000, 5, 1)
         assert not beneficiary.has_beneficiary_role
         assert not beneficiary.has_admin_role
         assert beneficiary.password is not None
@@ -756,7 +756,7 @@ class BeneficiaryInformationUpdateTest:
 
         assert new_user.firstName == "Raoul"
         assert new_user.lastName == "Dufy"
-        assert new_user.dateOfBirth == datetime.datetime(2000, 5, 1, 0, 0)
+        assert new_user.validatedBirthDate == datetime.date(2000, 5, 1)
         assert new_user.ineHash == "identifiantnati0naleleve"
 
     def test_update_user_information_from_ubble(self):
@@ -772,7 +772,7 @@ class BeneficiaryInformationUpdateTest:
 
         assert new_user.firstName == "Raoul"
         assert new_user.lastName == "Dufy"
-        assert new_user.dateOfBirth == datetime.datetime(2000, 5, 1, 0, 0)
+        assert new_user.validatedBirthDate == datetime.date(2000, 5, 1)
         assert new_user.idPieceNumber == "123456789"
         assert new_user.civility == "M."
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -99,6 +99,7 @@ class AccountTest:
             deposit__expirationDate=datetime(2040, 1, 1),
             notificationSubscriptions={"marketing_push": True},
             publicName="jdo",
+            validatedBirthDate=datetime(2000, 1, 11),
             **USER_DATA,
         )
 
@@ -117,13 +118,14 @@ class AccountTest:
                 "digital": {"initial": 10000, "remaining": 10000},
                 "physical": None,
             },
-            "dateOfBirth": "2000-01-01",
+            "birthDate": "2000-01-11",
+            "dateOfBirth": "2000-01-11",
             "depositVersion": 2,
             "depositType": "GRANT_18",
             "depositExpirationDate": "2040-01-01T00:00:00Z",
             "eligibility": "age-18",
-            "eligibilityEndDatetime": "2019-01-01T11:00:00Z",
-            "eligibilityStartDatetime": "2015-01-01T00:00:00Z",
+            "eligibilityEndDatetime": "2019-01-11T11:00:00Z",
+            "eligibilityStartDatetime": "2015-01-11T00:00:00Z",
             "isBeneficiary": True,
             "isEligibleForBeneficiaryUpgrade": False,
             "roles": ["BENEFICIARY"],
@@ -137,6 +139,7 @@ class AccountTest:
 
         assert response.status_code == 200
         assert response.json == EXPECTED_DATA
+        assert user.dateOfBirth == datetime(2000, 1, 1)
 
     def test_get_user_not_beneficiary(self, client, app):
         users_factories.UserFactory(email=self.identifier)

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1301,6 +1301,7 @@ def test_public_api(client):
                             "title": "Bookedoffers",
                             "type": "object",
                         },
+                        "birthDate": {"format": "date", "nullable": True, "title": "Birthdate", "type": "string"},
                         "dateOfBirth": {"format": "date", "nullable": True, "title": "Dateofbirth", "type": "string"},
                         "depositExpirationDate": {
                             "format": "date-time",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16955

## But de la pull request

Le but est de garder la trace de la date de naissance déclarée par l'utilisateur lors de l'inscription, pour des raisons de debug, de suivi et de lisibilité.
Aujourd'hui cette date de naissance est écrasée par la date de naissance "validée" par Ubble, Educonnect ou DMS.

Stratégie : 
- [ce ticket] ajout de la propriété `validatedBirthDate` et d'une propriété `user.birth_date` qui retourne la date validée (en priorité) ou la date déclarée
- [PC-17174] rattrapage des données + ne pas écraser user.dateOfBirth + utiliser `validatedBirthDate` dans la recherche de doublons

## Modifications du schéma de la base de données

- Ajout de la colonne `user.validatedBirthDate`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

---

Screen de l'admin
![Screenshot from 2022-09-16 10-50-16](https://user-images.githubusercontent.com/14235661/190681110-5fe2db50-658e-47e7-967f-3e2bc1ad588d.png)



[PC-17174]: https://passculture.atlassian.net/browse/PC-17174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ