### PR TITLE
(PC-17319)[PRO] feat: add view offerer stats button on homepage

### DIFF
--- a/pro/src/components/pages/Home/OffererStats/OffererStats.module.scss
+++ b/pro/src/components/pages/Home/OffererStats/OffererStats.module.scss
@@ -1,0 +1,13 @@
+@use 'styles/mixins/_rem.scss' as rem;
+
+.offerer-stats {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: rem.torem(32px);
+  &-description {
+    margin-top: rem.torem(16px);
+    align-self: stretch;
+    flex: 1;
+  }
+}

--- a/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
+++ b/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
@@ -1,10 +1,30 @@
 import React from 'react'
 
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+import styles from './OffererStats.module.scss'
+
 const OffererStats = () => {
+  const offererStatsUrl = '/statistiques'
   return (
     <>
       <h2 className="h-section-title">Statistiques</h2>
-      <p>A venir, section statistiques</p>
+      <div className={styles['offerer-stats']}>
+        <p className={styles['offerer-stats-description']}>
+          A venir, section statistiques
+        </p>
+        <ButtonLink
+          variant={ButtonVariant.SECONDARY}
+          className={styles['offerer-stats-button']}
+          link={{
+            to: offererStatsUrl,
+            isExternal: false,
+          }}
+        >
+          Voir toutes les statistiques
+        </ButtonLink>
+      </div>
     </>
   )
 }

--- a/pro/src/routes/OffererStats/OffererStats.tsx
+++ b/pro/src/routes/OffererStats/OffererStats.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import { OffererStatsScreen } from 'screens/OffererStats'
+
+const OffererStats = (): JSX.Element | null => {
+  return <OffererStatsScreen />
+}
+
+export default OffererStats

--- a/pro/src/routes/OffererStats/index.ts
+++ b/pro/src/routes/OffererStats/index.ts
@@ -1,0 +1,1 @@
+export { default as OffererStats } from './OffererStats'

--- a/pro/src/routes/routes_map.tsx
+++ b/pro/src/routes/routes_map.tsx
@@ -39,6 +39,8 @@ import { VenueCreation } from 'routes/VenueCreation'
 import { VenueEdition } from 'routes/VenueEdition'
 import { UNAVAILABLE_ERROR_PAGE } from 'utils/routes'
 
+import { OffererStats } from './OffererStats'
+
 interface ILayoutConfig {
   pageName?: string
   fullscreen?: boolean
@@ -368,6 +370,12 @@ const routes: IRoute[] = [
     path: '/profile',
     title: 'Profil',
     featureName: 'ENABLE_IN_PAGE_PROFILE_FORM',
+  },
+  {
+    component: OffererStats,
+    path: '/statistiques',
+    title: 'Statistiques',
+    featureName: 'ENABLE_OFFERER_STATS',
   },
 ]
 

--- a/pro/src/screens/OffererStats/OffererStatsScreen.tsx
+++ b/pro/src/screens/OffererStats/OffererStatsScreen.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import PageTitle from 'components/layout/PageTitle/PageTitle'
+import Titles from 'components/layout/Titles/Titles'
+
+const OffererStatsScreen = () => {
+  return (
+    <>
+      <PageTitle title="Statistiques" />
+      <Titles title="Statistiques" />
+      <p>
+        Vos statistiques sont calculées et mises à jour quotidiennement dans la
+        nuit.
+      </p>
+    </>
+  )
+}
+
+export default OffererStatsScreen

--- a/pro/src/screens/OffererStats/index.ts
+++ b/pro/src/screens/OffererStats/index.ts
@@ -1,0 +1,1 @@
+export { default as OffererStatsScreen } from './OffererStatsScreen'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17319

## But de la pull request
Dans la section statistiques de la homepage : 

- Ajouter un bouton permettant d'accèder à la page des satistiques d'une structure
