### PR TITLE
[PC-16927] Deploy new pcapi externalsecret before upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -931,6 +931,20 @@ jobs:
           name: Get GKE cluster credentials
           command: gcloud container clusters get-credentials --region ${GCP_REGION} ${GKE_CLUSTER_NAME}
       - run:
+          name: Deploy new ExternalSecret only if needed
+          command: |
+            PASSCULTURE_PASSWORD=${GCP_INFRA_KEY} \
+            PCAPI_VALUES_FILE=<(helm get values <<parameters.helm_environment>>)
+            PCAPI_SECRETS_FILE=/tmp/workspace/pcapi-secrets.yaml \
+            helmfile -e <<parameters.helm_environment>> apply --detailed-exitcode || HELMFILE_EXIT_CODE=$?
+            if [[ $HELMFILE_EXIT_CODE -eq 2 ]]; then
+              STATUS=$(kubectl get externalsecret.external-secrets.io pcapi-<<parameters.helm_environment>> -o jsonpath={..status..status})
+              if [[ $STATUS == "False" ]]
+                kubectl get events --field-selector involvedObject.name=pcapi-<<parameters.helm_environment>>,involvedObject.kind=ExternalSecret
+                helm rollback <<parameters.helm_environment>>
+                exit 1
+            fi
+      - run:
           name: Deploy pcapi
           command: |
             PASSCULTURE_PASSWORD=${GCP_INFRA_KEY} \


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16927

## But de la pull request

Déployer l'externalsecret de pcapi avant les upgrade helm pour que la synchro puisse avoir lieu avant le démarrage de la nouvelle version.