### PR TITLE
(PC-15683) ubble names from profile

### DIFF
--- a/api/src/pcapi/alembic/CONTRIBUTING.md
+++ b/api/src/pcapi/alembic/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Pour effectuer une migration du schéma de la base de données, il est recommand
 
 ### 1. Modifier le modèle applicatif dans les fichiers python
 
-### 2. Identifier s'il s'agit d'un migration `pre` ou `post`
+### 2. Identifier s'il s'agit d'une migration `pre` ou `post`
 
 Lors d'un déploiement, on part d'un état stable (version `N` des migrations / version `N` du code) vers un autre état stable (version `N+1` des migrations / version `N+1` du code) en passant par 3 phases :
 

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -13,6 +13,7 @@ from pcapi.core.payments import exceptions as payments_exceptions
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import exceptions as subscription_exceptions
 from pcapi.core.subscription import models as subscription_models
+from pcapi.core.subscription import repository as subscription_repository
 from pcapi.core.users import api as users_api
 from pcapi.core.users import constants
 from pcapi.core.users import models as users_models
@@ -765,7 +766,7 @@ def create_profile_completion_fraud_check(
     eligibility: users_models.EligibilityType | None,
     fraud_check_content: models.ProfileCompletionContent,
 ) -> None:
-    if subscription_api.has_completed_profile(user, eligibility):
+    if subscription_repository.get_completed_profile_check(user, eligibility) is not None:
         logger.warning(
             "Profile completion fraud check for user already exists.",
             extra={"user_id": user.id},

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -135,6 +135,7 @@ FRAUD_CHECK_TYPE_MODEL_ASSOCIATION = {
     models.FraudCheckType.UBBLE: UbbleContentFactory,
     models.FraudCheckType.EDUCONNECT: EduconnectContentFactory,
     models.FraudCheckType.HONOR_STATEMENT: None,
+    models.FraudCheckType.PROFILE_COMPLETION: ProfileCompletionContentFactory,
 }
 
 

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -64,6 +64,7 @@ class DMSContentFactory(factory.Factory):
     annotation = None
     application_number = factory.Faker("pyint")
     birth_date = LazyAttribute(lambda _: (datetime.today() - relativedelta(years=18)).date())
+    city = "Funky Town"
     civility = users_models.GenderEnum.F
     departement = factory.Sequence("{}".format)
     email = factory.Faker("ascii_safe_email")

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -110,6 +110,20 @@ def should_complete_profile(user: users_models.User, eligibility: users_models.E
     return True
 
 
+def get_declared_names(user: users_models.User) -> typing.Tuple[str, str] | None:
+    profile_completion_check = repository.get_completed_profile_check(user, user.eligibility)
+    if profile_completion_check and profile_completion_check.resultContent:
+        profile_data = typing.cast(fraud_models.ProfileCompletionContent, profile_completion_check.source_data())
+        return profile_data.first_name, profile_data.last_name
+
+    dms_filled_check = _get_filled_dms_fraud_check(user, user.eligibility)
+    if dms_filled_check:
+        dms_data = typing.cast(fraud_models.DMSContent, dms_filled_check.source_data())
+        return dms_data.first_name, dms_data.last_name
+
+    return None
+
+
 def is_eligibility_activable(user: users_models.User, eligibility: users_models.EligibilityType | None) -> bool:
     return (
         user.eligibility == eligibility

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -93,13 +93,16 @@ def has_completed_profile(user: users_models.User, eligibility: users_models.Eli
     ).scalar()
 
 
-def _has_completed_profile_in_dms_form(user: users_models.User) -> bool:
+def _has_completed_profile_in_dms_form(
+    user: users_models.User, eligibility: users_models.EligibilityType | None
+) -> bool:
     # If a pending or started DMS fraud check exists, the user has already completed the profile.
     # No need to ask for this information again.
     user_pending_dms_fraud_checks = [
         fraud_check
         for fraud_check in user.beneficiaryFraudChecks
         if fraud_check.type == fraud_models.FraudCheckType.DMS
+        and fraud_check.eligibilityType == eligibility
         and fraud_check.status in (fraud_models.FraudCheckStatus.PENDING, fraud_models.FraudCheckStatus.STARTED)
         and fraud_check.resultContent
         and fraud_check.source_data().city is not None
@@ -108,7 +111,7 @@ def _has_completed_profile_in_dms_form(user: users_models.User) -> bool:
 
 
 def should_complete_profile(user: users_models.User, eligibility: users_models.EligibilityType) -> bool:
-    return not has_completed_profile(user, eligibility) and not _has_completed_profile_in_dms_form(user)
+    return not has_completed_profile(user, eligibility) and not _has_completed_profile_in_dms_form(user, eligibility)
 
 
 def is_eligibility_activable(user: users_models.User, eligibility: users_models.EligibilityType | None) -> bool:

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -102,12 +102,14 @@ def _get_filled_dms_fraud_check(
     )
 
 
-def should_complete_profile(user: users_models.User, eligibility: users_models.EligibilityType) -> bool:
+def has_completed_profile_for_given_eligibility(
+    user: users_models.User, eligibility: users_models.EligibilityType
+) -> bool:
     if repository.get_completed_profile_check(user, eligibility) is not None:
-        return False
+        return True
     if _get_filled_dms_fraud_check(user, eligibility) is not None:
-        return False
-    return True
+        return True
+    return False
 
 
 def get_declared_names(user: users_models.User) -> typing.Tuple[str, str] | None:
@@ -205,7 +207,7 @@ def get_user_profiling_subscription_item(
 def get_profile_completion_subscription_item(
     user: users_models.User, eligibility: users_models.EligibilityType
 ) -> models.SubscriptionItem:
-    if not should_complete_profile(user, eligibility):
+    if has_completed_profile_for_given_eligibility(user, eligibility):
         status = models.SubscriptionItemStatus.OK
     elif is_eligibility_activable(user, eligibility):
         status = models.SubscriptionItemStatus.TODO
@@ -311,7 +313,7 @@ def get_next_subscription_step(user: users_models.User) -> models.SubscriptionSt
     if user_profiling_item.status == models.SubscriptionItemStatus.KO:
         return None
 
-    if should_complete_profile(user, user.eligibility):
+    if not has_completed_profile_for_given_eligibility(user, user.eligibility):
         return models.SubscriptionStep.PROFILE_COMPLETION
 
     if _needs_to_perform_identity_check(user):

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -107,7 +107,7 @@ def _has_completed_profile_in_dms_form(user: users_models.User) -> bool:
     return bool(user_pending_dms_fraud_checks)
 
 
-def should_complete_profile(user: users_models.User, eligibility: users_models.EligibilityType | None) -> bool:
+def should_complete_profile(user: users_models.User, eligibility: users_models.EligibilityType) -> bool:
     return not has_completed_profile(user, eligibility) and not _has_completed_profile_in_dms_form(user)
 
 
@@ -190,7 +190,7 @@ def get_user_profiling_subscription_item(
 
 
 def get_profile_completion_subscription_item(
-    user: users_models.User, eligibility: users_models.EligibilityType | None
+    user: users_models.User, eligibility: users_models.EligibilityType
 ) -> models.SubscriptionItem:
     if not should_complete_profile(user, eligibility):
         status = models.SubscriptionItemStatus.OK
@@ -278,7 +278,7 @@ def get_next_subscription_step(user: users_models.User) -> models.SubscriptionSt
     if not user.isEmailValidated:
         return models.SubscriptionStep.EMAIL_VALIDATION
 
-    if not users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility):
+    if not user.eligibility or not users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility):
         return None
 
     if _should_validate_phone(user, user.eligibility):
@@ -306,7 +306,7 @@ def get_next_subscription_step(user: users_models.User) -> models.SubscriptionSt
             return models.SubscriptionStep.MAINTENANCE
         return models.SubscriptionStep.IDENTITY_CHECK
 
-    if not fraud_api.has_performed_honor_statement(user, user.eligibility):  # type: ignore [arg-type]
+    if not fraud_api.has_performed_honor_statement(user, user.eligibility):
         return models.SubscriptionStep.HONOR_STATEMENT
 
     return None

--- a/api/src/pcapi/core/subscription/repository.py
+++ b/api/src/pcapi/core/subscription/repository.py
@@ -1,0 +1,13 @@
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import models as users_models
+
+
+def get_completed_profile_check(
+    user: users_models.User, eligibility: users_models.EligibilityType | None
+) -> fraud_models.BeneficiaryFraudCheck:
+    return fraud_models.BeneficiaryFraudCheck.query.filter(
+        fraud_models.BeneficiaryFraudCheck.user == user,
+        fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.PROFILE_COMPLETION,
+        fraud_models.BeneficiaryFraudCheck.eligibilityType == eligibility,
+        fraud_models.BeneficiaryFraudCheck.status == fraud_models.FraudCheckStatus.OK,
+    ).first()

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -86,11 +86,11 @@ def update_ubble_workflow(fraud_check: fraud_models.BeneficiaryFraudCheck) -> No
         pcapi_repository.repository.save(fraud_check)
 
 
-def start_ubble_workflow(user: users_models.User, redirect_url: str) -> str:
+def start_ubble_workflow(user: users_models.User, first_name: str, last_name: str, redirect_url: str) -> str:
     content = ubble.start_identification(
         user_id=user.id,
-        first_name=user.firstName,  # type: ignore [arg-type]
-        last_name=user.lastName,  # type: ignore [arg-type]
+        first_name=first_name,
+        last_name=last_name,
         webhook_url=flask.url_for("Public API.ubble_webhook_update_application_status", _external=True),
         redirect_url=redirect_url,
     )

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -114,8 +114,16 @@ def start_identification_session(
     if fraud_check:
         return serializers.IdentificationSessionResponse(identificationUrl=fraud_check.source_data().identification_url)  # type: ignore [union-attr]
 
+    declared_names = subscription_api.get_declared_names(user)
+
+    if not declared_names:
+        logger.error("Ubble: no names found to start identification session", extra={"user_id": user.id})
+        raise api_errors.ApiErrors({"code": "NO_FIRST_NAME_AND_LAST_NAME"})
+
     try:
-        identification_url = ubble_subscription_api.start_ubble_workflow(user, body.redirectUrl)
+        identification_url = ubble_subscription_api.start_ubble_workflow(
+            user, declared_names[0], declared_names[1], body.redirectUrl
+        )
         return serializers.IdentificationSessionResponse(identificationUrl=identification_url)
 
     except requests_utils.ExternalAPIException as exception:

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -17,6 +17,7 @@ import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import models as subscription_models
+from pcapi.core.subscription import repository as subscription_repository
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
@@ -1197,7 +1198,7 @@ class CompleteProfileTest:
 
         subscription_api.complete_profile(user, "address", "city", "12400", "étudiant", "harry", "cover")
 
-        assert subscription_api.has_completed_profile(user, EligibilityType.AGE18)
+        assert subscription_repository.get_completed_profile_check(user, EligibilityType.AGE18)
         assert (
             fraud_models.BeneficiaryFraudCheck.query.filter_by(
                 userId=user.id,

--- a/api/tests/core/subscription/ubble/end_to_end/requests_data.py
+++ b/api/tests/core/subscription/ubble/end_to_end/requests_data.py
@@ -530,7 +530,7 @@ PROCESSED_IDENTIFICATION_RESPONSE = {
                 "issue-date": None,
                 "issue-place": None,
                 "issuing-state-code": "FRA",
-                "last-name": "DE TOUL",
+                "last-name": "DE TOULON",
                 "married-name": None,
                 "media-type": "video",
                 "mrz": "IDFRADETOUL<<<<<<<<<<<<<<<<<<<75P001123456P001233RAOUL<<JEAN<<0001010M8",

--- a/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
+++ b/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
@@ -49,7 +49,10 @@ class UbbleEndToEndTest:
             schoolType=users_models.SchoolTypeEnum.PUBLIC_HIGH_SCHOOL,
             phoneNumber="+33612345678",
         )
-        fraud_factories.ProfileCompletionFraudCheckFactory(user=user)
+        fraud_factories.ProfileCompletionFraudCheckFactory(
+            user=user,
+            resultContent=fraud_factories.ProfileCompletionContentFactory(first_name="Raoul", last_name="de Toulouz"),
+        )
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user, type=fraud_models.FraudCheckType.USER_PROFILING, status=fraud_models.FraudCheckStatus.OK
         )
@@ -76,7 +79,7 @@ class UbbleEndToEndTest:
                 "attributes": {
                     "identification-form": {"external-user-id": user.id, "phone-number": None},
                     "redirect_url": "https://passculture.app/verification-identite/fin",
-                    "reference-data": {"first-name": "Raoul", "last-name": "de Toul"},
+                    "reference-data": {"first-name": "Raoul", "last-name": "de Toulouz"},
                     "webhook": flask.url_for("Public API.ubble_webhook_update_application_status", _external=True),
                 },
                 "type": "identifications",
@@ -207,3 +210,5 @@ class UbbleEndToEndTest:
         assert user.is_beneficiary
         assert user.has_active_deposit
         assert user.deposit.amount == 300
+        assert user.firstName == "RAOUL"
+        assert user.lastName == "DE TOULON"

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -43,7 +43,9 @@ IMAGES_DIR = pathlib.Path(tests.__path__[0]) / "files"
 class UbbleWorkflowTest:
     def test_start_ubble_workflow(self, ubble_mock):
         user = users_factories.UserFactory()
-        redirect_url = ubble_subscription_api.start_ubble_workflow(user, redirect_url="https://example.com")
+        redirect_url = ubble_subscription_api.start_ubble_workflow(
+            user, "Kid", "Paddle", redirect_url="https://example.com"
+        )
         assert redirect_url == "https://id.ubble.ai/29d9eca4-dce6-49ed-b1b5-8bb0179493a8"
 
         fraud_check = user.beneficiaryFraudChecks[0]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15683

## Contexte

Pour démarrer une session Ubble, il faut envoyer le prénom et le nom de l'utilisateur (pour des raisons de sécurité).

Aujourd'hui on envoie à Ubble `user.firstName`, et `user.lastName` qui peuvent avoir été hydratés de deux manières : 

- soit par un résultat Ubble / DMS / Educonnect, au moment où on active le compte bénéficiaire de l'utilisateur.
- soit via l'étape de ProfileCompletion : si `user.firstName`, et `user.lastName` ne sont pas encore définis, on hydrate ces champs avec les données du formulaire. Cette condition est importante car si l'utilisateur a déjà fait un pass 15-17 et a maintenant 18 ans, on ne veut pas overrider le prénom et le nom validés par Ubble (ou DMS) avec les informations **déclaratives** de ProfileCompletion.

Mais envoyer user.firstName, user.lastName pose problème si justement l'utilisateur est un ex 15-17, maintenant 18. Les prénoms-noms peuvent provenir d'Educonnect et ne pas être raccord avec les informations de la carte d'identité.

Ce ticket vise donc à envoyer les informations qui proviennent de ProfileCompletion.

En résumé, voici ce qui se passait avant : 
1. Joachim, 17 ans, fait ProfileCompletion pour UNDERAGE en renseignant Joachim Guichard
2. user.firstName = "Joachim" user.lastName = "Guichard"
3. Joachim se connecte avec son compte Educonnect sur lequel il y a une phote d'orthographe dans le nom de famille
4. user.firstName = "Joachim" user.lastName = "Guichart"
5. Joachim devient bénéf 15-17
6. Joachim a maintenant 18 ans et remplit l'étape ProfileCompletion avec ses prénoms-noms bien orthographiés
7. Joachim démarre une session Ubble -> on envoie les prénom noms du user, donc avec la phote.
8. Le résultat Ubble est KO : les prénoms/noms ne correspondent pas à la carte d'identité

Et maintenant 
7. Joachim démarre une session Ubble -> on envoie les prénom noms du ProfileCompletion, donc sans la phote.
8. Le résultat est Ubble est OK !


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
