### PR TITLE
(BSR)[API] refactor: edit kwargs typing of override_features()

### DIFF
--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -255,7 +255,7 @@ class override_features(TestContextDecorator):
     # seen when in the tests. I should try to fix that.
     CAN_BE_USED_ON_CLASSES = False
 
-    def __init__(self, **overrides: dict[str, typing.Any]) -> None:
+    def __init__(self, **overrides: bool) -> None:
         self.overrides = overrides
 
     def enable(self) -> None:


### PR DESCRIPTION
## But de la pull request

Correction du typage des mots-clés du décorateur de contexte `override_features`, surtout pour éviter que mon IDE s'émeuve à chacune de ses utilisations.