### PR TITLE
Pc 17321 pro add offerer stats anchor to homepage

### DIFF
--- a/pro/src/components/pages/Home/Homepage.tsx
+++ b/pro/src/components/pages/Home/Homepage.tsx
@@ -14,6 +14,7 @@ import { ProfileAndSupport } from './ProfileAndSupport'
 
 const Homepage = (): JSX.Element => {
   const profileRef = useRef(null)
+  const statsRef = useRef(null)
   const {
     currentUser: { hasSeenProRgs },
   } = useCurrentUser()
@@ -36,14 +37,16 @@ const Homepage = (): JSX.Element => {
       )}
       <HomepageBreadcrumb
         activeStep={STEP_ID_OFFERERS}
+        isOffererStatsActive={isOffererStatsActive}
         profileRef={profileRef}
+        statsRef={statsRef}
       />
 
       <section className="h-section">
         <Offerers />
       </section>
       {isOffererStatsActive && (
-        <section className="h-section">
+        <section className="h-section" ref={statsRef}>
           <OffererStats />
         </section>
       )}

--- a/pro/src/components/pages/Home/HomepageBreadcrumb.jsx
+++ b/pro/src/components/pages/Home/HomepageBreadcrumb.jsx
@@ -9,16 +9,30 @@ import { doesUserPreferReducedMotion } from '../../../utils/windowMatchMedia'
 
 export const STEP_ID_OFFERERS = 'offerers'
 export const STEP_ID_PROFILE = 'profile'
+export const STEP_ID_STATS = 'offererStats'
 export const STEP_OFFERER_HASH = 'structures'
 export const STEP_PROFILE_HASH = 'profil'
+export const STEP_STATS_HASH = 'offererStats'
 
-const HomepageBreadcrumb = ({ activeStep, profileRef }) => {
+const HomepageBreadcrumb = ({
+  activeStep,
+  profileRef,
+  statsRef,
+  isOffererStatsActive,
+}) => {
   const { logEvent } = useAnalytics()
   const jumpToProfileSection = e => {
     e.preventDefault()
     logEvent?.(Events.CLICKED_BREADCRUMBS_PROFILE_AND_HELP)
 
     profileRef?.current.scrollIntoView({
+      behavior: doesUserPreferReducedMotion() ? 'auto' : 'smooth',
+    })
+  }
+  const jumpToStatsSection = e => {
+    e.preventDefault()
+
+    statsRef?.current.scrollIntoView({
       behavior: doesUserPreferReducedMotion() ? 'auto' : 'smooth',
     })
   }
@@ -30,6 +44,14 @@ const HomepageBreadcrumb = ({ activeStep, profileRef }) => {
       hash: STEP_OFFERER_HASH,
       onClick: () => logEvent?.(Events.CLICKED_BREADCRUMBS_STRUCTURES),
     },
+    ...(isOffererStatsActive && {
+      [STEP_ID_STATS]: {
+        id: STEP_ID_STATS,
+        label: 'Statistiques',
+        hash: STEP_STATS_HASH,
+        onClick: jumpToStatsSection,
+      },
+    }),
     [STEP_ID_PROFILE]: {
       id: STEP_ID_PROFILE,
       label: 'Profil et aide',
@@ -50,11 +72,15 @@ const HomepageBreadcrumb = ({ activeStep, profileRef }) => {
 
 HomepageBreadcrumb.defaultProps = {
   profileRef: null,
+  statsRef: null,
+  isOffererStatsActive: false,
 }
 
 HomepageBreadcrumb.propTypes = {
   activeStep: PropTypes.string.isRequired,
   profileRef: PropTypes.shape(),
+  statsRef: PropTypes.shape(),
+  isOffererStatsActive: PropTypes.bool,
 }
 
 export default HomepageBreadcrumb

--- a/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
+++ b/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
@@ -8,6 +8,8 @@ import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { IconLinkBox } from 'ui-kit/IconLinkBox'
 
+import { STEP_STATS_HASH } from '../HomepageBreadcrumb'
+
 import styles from './OffererStats.module.scss'
 
 const OffererStats = () => {
@@ -19,7 +21,7 @@ const OffererStats = () => {
     linkTitle: 'Voir le tableau',
   }
   return (
-    <>
+    <div id={STEP_STATS_HASH}>
       <h2 className="h-section-title">Statistiques</h2>
       <div className={styles['offerer-stats']}>
         <div className={styles['offerer-stats-boxes']}>
@@ -50,7 +52,7 @@ const OffererStats = () => {
           Voir toutes les statistiques
         </ButtonLink>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
+++ b/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
@@ -292,6 +292,29 @@ describe('homepage', () => {
           screen.getByText('Statistiques', { selector: 'h2' })
         ).toBeInTheDocument()
       })
+      describe('when clicking on anchor link to stats', () => {
+        let scrollIntoViewMock
+        beforeEach(async () => {
+          scrollIntoViewMock = jest.fn()
+          Element.prototype.scrollIntoView = scrollIntoViewMock
+          await renderHomePage(store)
+        })
+
+        it('should smooth scroll to section if user doesnt prefer reduced motion', async () => {
+          // given
+          doesUserPreferReducedMotion.mockReturnValue(false)
+
+          // when
+          await userEvent.click(
+            screen.getByRole('link', { name: 'Statistiques' })
+          )
+
+          // then
+          expect(scrollIntoViewMock).toHaveBeenCalledWith({
+            behavior: 'smooth',
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17321

## But de la pull request

Ajouter l'étape statistiques dans le breadcrum de la homepage qui redirige vers l'ancre de la section associée plus bas dans la page.
