### PR TITLE
(BSR)[PRO] ci: reset coverage check on modified code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,8 +687,8 @@ jobs:
                 command: yarn test:unit:ci
                 working_directory: pro
       - run:
-          name: Unit Test PRO
-          command: yarn test:unit:ci --changedSince=master
+          name: Coverage Unit Test PRO
+          command: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
           working_directory: pro
       - unless:
           condition:


### PR DESCRIPTION
Lien vers les conversations Slack
https://passcultureteam.slack.com/archives/C01CKL7LM6X/p1663578627261009
https://passcultureteam.slack.com/archives/C01CKL7LM6X/p1663773697314929


## But de la pull request
Restaurer la vérification de la couverture de tests sur le code modifié
