### PR TITLE
(BSR)[PRO] fix: button link margin top

### DIFF
--- a/pro/src/ui-kit/InfoBox/InfoBox.module.scss
+++ b/pro/src/ui-kit/InfoBox/InfoBox.module.scss
@@ -32,6 +32,10 @@
       margin-right: rem.torem(8px);
     }
   }
+
+  &-link {
+    margin-top: rem.torem(8px);
+  }
 }
 
 .info {


### PR DESCRIPTION
Fix bug introduced in this [commit](https://github.com/pass-culture/pass-culture-main/pull/3376/commits/9fdf265f6b48fd7e28b976126e699e17f1469cc4#diff-f0feee59f9e7ffc26bda218f4d764f450ce9fbc5a1eca812dc6092e9cde42c4a) because of `height: auto` 