### PR TITLE
(BSR)[API] chore: Remove unused Offer.dateRange 

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -33,7 +33,6 @@ from pcapi.models.offer_mixin import ValidationMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.models.providable_mixin import ProvidableMixin
 from pcapi.models.soft_deletable_mixin import SoftDeletableMixin
-from pcapi.utils.date import DateTimes
 
 
 logger = logging.getLogger(__name__)
@@ -484,15 +483,6 @@ class Offer(PcObject, Base, Model, ExtraDataMixin, DeactivableMixin, ValidationM
     @isPermanent.expression  # type: ignore [no-redef]
     def isPermanent(cls) -> bool:  # pylint: disable=no-self-argument
         return cls.subcategoryId.in_(subcategories.PERMANENT_SUBCATEGORIES)
-
-    @property
-    def dateRange(self) -> DateTimes:
-        if self.isThing or not self.activeStocks:
-            return DateTimes()
-
-        start = min(stock.beginningDatetime for stock in self.activeStocks)  # type: ignore [type-var]
-        end = max(stock.beginningDatetime for stock in self.activeStocks)  # type: ignore [type-var]
-        return DateTimes(start, end)
 
     @sa.ext.hybrid.hybrid_property
     def isEvent(self) -> bool:

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -21,7 +21,6 @@ from pcapi.serialization.utils import dehumanize_field
 from pcapi.serialization.utils import dehumanize_list_field
 from pcapi.serialization.utils import humanize_field
 from pcapi.serialization.utils import to_camel
-from pcapi.utils.date import DateTimes
 from pcapi.utils.date import format_into_utc_date
 from pcapi.validation.routes.offers import check_offer_isbn_is_valid
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
@@ -450,7 +449,6 @@ class GetOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     conditions: str | None
     dateCreated: datetime
     dateModifiedAtLastProvider: datetime | None
-    dateRange: list[datetime]
     description: str | None
     durationMinutes: int | None
     extraData: Any
@@ -488,14 +486,6 @@ class GetOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     _humanize_product_id = humanize_field("productId")
     _humanize_venue_id = humanize_field("venueId")
     _humanize_last_provider_id = humanize_field("lastProviderId")
-
-    @validator("dateRange", pre=True)
-    def extract_datetime_list_from_DateTimes_type(  # pylint: disable=no-self-argument
-        cls, date_range: DateTimes
-    ) -> list[datetime]:
-        if isinstance(date_range, DateTimes):
-            return date_range.datetimes
-        return date_range
 
     @classmethod
     def from_orm(cls, offer):  # type: ignore

--- a/api/src/pcapi/routes/serialization/serializer.py
+++ b/api/src/pcapi/routes/serialization/serializer.py
@@ -7,7 +7,6 @@ from psycopg2._range import DateTimeRange
 import sqlalchemy
 from sqlalchemy import Integer
 
-from pcapi.utils.date import DateTimes
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.human_ids import humanize
 
@@ -53,8 +52,3 @@ def _(value, column=None):  # type: ignore [no-untyped-def]
 @serialize.register(list)
 def _(value, column=None):  # type: ignore [no-untyped-def]
     return [serialize(d) for d in value]
-
-
-@serialize.register(DateTimes)
-def _(value, column=None):  # type: ignore [no-untyped-def]
-    return [format_into_utc_date(v) for v in value.datetimes]

--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -77,14 +77,6 @@ class FrenchParserInfo(parserinfo):
     ]
 
 
-class DateTimes:
-    def __init__(self, *datetimes):  # type: ignore [no-untyped-def]
-        self.datetimes = list(datetimes)
-
-    def __eq__(self, other):  # type: ignore [no-untyped-def]
-        return self.datetimes == other.datetimes
-
-
 def format_datetime(date_time: datetime) -> str:
     return babel_format_datetime(date_time, format="long", locale="fr")[:-9]
 

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -14,7 +14,6 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.models.pc_object import DeletedRecordException
 from pcapi.repository import repository
 from pcapi.utils import human_ids
-from pcapi.utils.date import DateTimes
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -42,35 +41,6 @@ class ProductModelTest:
             assert product.can_be_synchronized == can_be_synchronized
             assert models.Product.query.filter(models.Product.can_be_synchronized).count() == int(can_be_synchronized)
             models.Product.query.delete()
-
-
-class OfferDateRangeTest:
-    def test_thing_offer(self):
-        offer = factories.ThingOfferFactory()
-        factories.StockFactory(offer=offer)
-        assert offer.dateRange == DateTimes()
-
-    def test_event_offer(self):
-        offer = factories.EventOfferFactory()
-        first = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-        last = datetime.datetime.utcnow() + datetime.timedelta(days=5)
-        factories.StockFactory(offer=offer, beginningDatetime=first)
-        factories.StockFactory(offer=offer, beginningDatetime=last)
-        assert offer.dateRange == DateTimes(first, last)
-
-    def test_single_stock(self):
-        offer = factories.EventOfferFactory()
-        stock = factories.StockFactory(offer=offer)
-        assert offer.dateRange == DateTimes(stock.beginningDatetime, stock.beginningDatetime)
-
-    def test_no_stock(self):
-        offer = factories.EventOfferFactory()
-        assert offer.dateRange == DateTimes()
-
-    def test_deleted_stock_is_ignored(self):
-        offer = factories.EventOfferFactory()
-        factories.StockFactory(offer=offer, isSoftDeleted=True)
-        assert offer.dateRange == DateTimes()
 
 
 class OfferIsDigitalTest:

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -172,7 +172,6 @@ class Returns200Test:
             "conditions": None,
             "dateCreated": "2020-10-15T00:00:00Z",
             "dateModifiedAtLastProvider": "2020-10-15T00:00:00Z",
-            "dateRange": ["2020-10-15T01:00:00Z", "2020-10-15T01:00:00Z"],
             "description": "Tatort, but slower",
             "durationMinutes": 60,
             "extraData": None,

--- a/api/tests/routes/serialization/serializer_test.py
+++ b/api/tests/routes/serialization/serializer_test.py
@@ -2,13 +2,11 @@ import datetime
 import enum
 
 from pcapi.routes.serialization.serializer import serialize
-from pcapi.utils.date import DateTimes
 
 
-def test_serialize_custom_datetimes_class():
-    assert serialize(DateTimes()) == []  # pylint: disable=use-implicit-booleaness-not-comparison
+def test_serialize_datetime():
     d = datetime.datetime(2022, 1, 1, 12, 34, 56)
-    assert serialize(DateTimes(d)) == ["2022-01-01T12:34:56Z"]
+    assert serialize(d) == "2022-01-01T12:34:56Z"
 
 
 def test_serialize_enum():

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -20,7 +20,6 @@ export type GetIndividualOfferResponseModel = {
   conditions?: string | null;
   dateCreated: string;
   dateModifiedAtLastProvider?: string | null;
-  dateRange: Array<string>;
   description?: string | null;
   durationMinutes?: number | null;
   externalTicketOfficeUrl?: string | null;

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
@@ -80,7 +80,6 @@ describe('stocks page', () => {
       status: 'DRAFT',
       stocks: [],
       dateCreated: '',
-      dateRange: [],
       fieldsUpdated: [],
       hasBookingLimitDatetimesPassed: true,
       isActive: true,

--- a/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/useGetIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/useGetIndividualOffer.spec.ts
@@ -21,7 +21,6 @@ describe('useGetOfferIndividual', () => {
       conditions: null,
       dateCreated: '2022-05-18T08:25:30.991476Z',
       dateModifiedAtLastProvider: '2022-05-18T08:25:30.991481Z',
-      dateRange: ['2022-05-23T08:25:31.009799Z', '2022-05-23T08:25:31.009799Z'],
       description: 'A passionate description of product 80',
       durationMinutes: null,
       extraData: null,

--- a/pro/src/routes/OfferIndividualWizard/__specs__/OfferIndividualWizard.spec.tsx
+++ b/pro/src/routes/OfferIndividualWizard/__specs__/OfferIndividualWizard.spec.tsx
@@ -24,7 +24,6 @@ const apiOffer: GetIndividualOfferResponseModel = {
   conditions: null,
   dateCreated: '2022-05-18T08:25:30.991476Z',
   dateModifiedAtLastProvider: '2022-05-18T08:25:30.991481Z',
-  dateRange: ['2022-05-23T08:25:31.009799Z', '2022-05-23T08:25:31.009799Z'],
   description: 'A passionate description of product 80',
   durationMinutes: null,
   extraData: null,

--- a/pro/src/store/selectors/data/__specs__/mockState.json
+++ b/pro/src/store/selectors/data/__specs__/mockState.json
@@ -89,10 +89,6 @@
           "conditions": null,
           "dateCreated": "2019-05-06T09:39:21.385332Z",
           "dateModifiedAtLastProvider": "2019-05-06T09:39:21.385288Z",
-          "dateRange": [
-            "2019-05-26T09:39:24Z",
-            "2019-05-27T10:39:24Z"
-          ],
           "description": "Raoul Taburin, c\"est l\"histoire d\"un petit garçon devenu grand sans savoir faire du vélo. L\"histoire d\"un immense malentendu vécu comme une malédiction. Un imposteur malgré lui.",
           "durationMinutes": 120,
           "extraData": {


### PR DESCRIPTION
It was used in the old web app. Now it's not used anywhere anymore.