### PR TITLE
(PC-17558)[PRO] feat: remove separator on offer educational stock screen

### DIFF
--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.module.scss
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.module.scss
@@ -20,13 +20,6 @@
   min-height: rem.torem(160px);
 }
 
-.separator {
-  width: rem.torem(40px);
-  height: rem.torem(2px);
-  margin: rem.torem(24px) 0;
-  background: colors.$grey-medium;
-}
-
 .offer-educational-stock-form-layout .offer-educational-stock-banner {
   margin: rem.torem(24px) 0;
 }

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -132,14 +132,14 @@ const OfferEducationalStock = ({
                   <RadioGroup
                     group={showcaseOfferRadios}
                     name="educationalOfferType"
+                    hideFooter
                   />
                 </FormLayout.Row>
               )}
-              {!displayElementsForShowcaseOption && (
+              {displayElementsForShowcaseOption ? (
+                <ShowcaseBannerInfo />
+              ) : (
                 <>
-                  {shouldDisplayShowcaseScreen && (
-                    <div className={styles['separator']} />
-                  )}
                   <Banner
                     className={styles['offer-educational-stock-banner']}
                     links={[
@@ -154,15 +154,6 @@ const OfferEducationalStock = ({
                     Vous pourrez modifier ces informations en fonction de vos
                     échanges avec l'établissement scolaire.
                   </Banner>
-                </>
-              )}
-              {displayElementsForShowcaseOption ? (
-                <>
-                  <ShowcaseBannerInfo />
-                  <div className={styles['separator']} />
-                </>
-              ) : (
-                <>
                   <p className={styles['description-text']}>
                     Indiquez le prix total de l’évènement et le nombre de
                     personnes qui y participeront.

--- a/pro/src/ui-kit/form/RadioButton/RadioButton.module.scss
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.module.scss
@@ -1,10 +1,6 @@
 @use 'styles/mixins/_rem.scss' as rem;
 @use 'styles/variables/_colors.scss' as colors;
 
-.radio-button {
-  margin-bottom: rem.torem(4px);
-}
-
 .with-border {
   border: rem.torem(1px) solid colors.$black;
   padding: rem.torem(16px) rem.torem(16px) rem.torem(12px) rem.torem(16px);

--- a/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
@@ -28,7 +28,7 @@ const RadioButton = ({
 
   return (
     <div
-      className={cn(style['radio-button'], className, {
+      className={cn(className, {
         [style['with-border']]: withBorder,
         [style['with-border-primary']]: withBorder && field.checked,
       })}

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.module.scss
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.module.scss
@@ -1,12 +1,8 @@
 @use 'styles/mixins/_rem.scss' as rem;
 
 .radio-group {
-  &-item {
+  &-item:not(:last-of-type) {
     margin-bottom: rem.torem(8px);
-
-    &:last-of-type {
-      margin-bottom: 0;
-    }
   }
 
   &-horizontal {

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
@@ -14,6 +14,7 @@ export enum Direction {
 export interface IRadioGroupProps {
   direction?: Direction.HORIZONTAL | Direction.VERTICAL
   disabled?: boolean
+  hideFooter?: boolean
   name: string
   legend?: string
   group: {
@@ -27,6 +28,7 @@ export interface IRadioGroupProps {
 const RadioGroup = ({
   direction = Direction.VERTICAL,
   disabled,
+  hideFooter = false,
   group,
   name,
   legend,
@@ -44,7 +46,7 @@ const RadioGroup = ({
       )}
       dataTestId={`wrapper-${name}`}
       error={meta.touched && !!meta.error ? meta.error : undefined}
-      hideFooter={false}
+      hideFooter={hideFooter}
       legend={legend}
       name={`radio-group-${name}`}
     >


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17558

## But de la pull request

Supprimer les séparateurs de la page stock (création d'offre collective)

## Implémentation

- Supression du séparateur
- Ajustement des marges (notamment suppression d'une marge inutile sous les radio-buttons)

## Screenshots 
<p float="left">
  <img width="400" alt="Capture d’écran 2022-09-22 à 12 38 28" src="https://user-images.githubusercontent.com/71768799/191727054-614864c3-83f8-4473-83b4-fcc19821f458.png">

<img width="400" alt="Capture d’écran 2022-09-22 à 12 38 14" src="https://user-images.githubusercontent.com/71768799/191726946-cb47ef2e-eaa4-4a56-bf47-068060d86fac.png">
</p>



