### PR TITLE
(BSR)[API] chore: Remove unused `Offer.dateRange` (part 2)

### DIFF
--- a/pro/src/routes/OfferIndividualWizard/__specs__/OfferIndividualWizardAdmin.spec.tsx
+++ b/pro/src/routes/OfferIndividualWizard/__specs__/OfferIndividualWizardAdmin.spec.tsx
@@ -24,7 +24,6 @@ const apiOffer: GetIndividualOfferResponseModel = {
   conditions: null,
   dateCreated: '2022-05-18T08:25:30.991476Z',
   dateModifiedAtLastProvider: '2022-05-18T08:25:30.991481Z',
-  dateRange: ['2022-05-23T08:25:31.009799Z', '2022-05-23T08:25:31.009799Z'],
   description: 'A passionate description of product 80',
   durationMinutes: null,
   extraData: null,


### PR DESCRIPTION
Remove mention of `dateRange` (follow-up of c77cb3251d20c41a3bbfa8b4).
Apparently I cannot grep...