### PR TITLE
(PC-17585)[PRO] fix: tutorial display

### DIFF
--- a/pro/src/new_components/TutorialDialog/TutorialDialog.tsx
+++ b/pro/src/new_components/TutorialDialog/TutorialDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import { useDispatch } from 'react-redux'
 
 import useAnalytics from 'components/hooks/useAnalytics'
 import useCurrentUser from 'components/hooks/useCurrentUser'
@@ -12,6 +13,7 @@ import styles from './TutorialDialog.module.scss'
 
 const TutorialDialog = (): JSX.Element => {
   const { currentUser } = useCurrentUser()
+  const dispatch = useDispatch()
   const [areTutoDisplayed, setAreTutoDisplayed] = useState(
     currentUser && !currentUser.hasSeenProTutorials
   )
@@ -22,7 +24,7 @@ const TutorialDialog = (): JSX.Element => {
     pcapi
       .setHasSeenTutos()
       .then(() => {
-        setCurrentUser({ ...currentUser, hasSeenProTutorials: true })
+        dispatch(setCurrentUser({ ...currentUser, hasSeenProTutorials: true }))
       })
       .finally(() => setAreTutoDisplayed(false))
   }, [currentUser, logEvent])


### PR DESCRIPTION
  fix against: ddda93d1

Slack 
> Thomas a relevé un bug pendant la recette sur le portail pro : à la 1ère connexion pour les structures non validées, la pop up tuto de la page d'accueil des acteurs culturels s'affiche à chaque changement de page.