### PR TITLE
(PC-17474)[API] perf: cache feature endpoints + cache invalidation

### DIFF
--- a/api/src/pcapi/admin/custom_views/feature_view.py
+++ b/api/src/pcapi/admin/custom_views/feature_view.py
@@ -3,6 +3,7 @@ import logging
 from flask_login import current_user
 
 from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.models.feature import invalidate_feature_cache
 import pcapi.notifications.internal.transactional.change_feature_flip as change_feature_flip_internal_message
 
 
@@ -21,7 +22,8 @@ class FeatureView(BaseAdminView):
 
     page_size = 100
 
-    def on_model_change(self, form, model, is_created):  # type: ignore [no-untyped-def]
+    def on_model_change(self, form, model, is_created) -> None:  # type: ignore [no-untyped-def]
         logger.info("Activated or deactivated feature flag", extra={"feature": model.name, "active": model.isActive})
         change_feature_flip_internal_message.send(feature=model, current_user=current_user)
-        return super().on_model_change(form=form, model=model, is_created=is_created)
+        super().on_model_change(form=form, model=model, is_created=is_created)
+        invalidate_feature_cache()

--- a/api/src/pcapi/routes/adage_iframe/features.py
+++ b/api/src/pcapi/routes/adage_iframe/features.py
@@ -4,6 +4,7 @@ from pcapi.routes.adage_iframe.security import adage_jwt_required
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
 from pcapi.routes.serialization import features_serialize
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.cache import cached_view
 
 
 @blueprint.adage_iframe.route("/features", methods=["GET"])
@@ -11,6 +12,7 @@ from pcapi.serialization.decorator import spectree_serialize
 @spectree_serialize(
     response_model=features_serialize.ListFeatureResponseModel, api=blueprint.api, on_error_statuses=[404]
 )
+@cached_view(prefix="features", ignore_args=True, expire=None)
 def list_features(authenticated_information: AuthenticatedInformation) -> features_serialize.ListFeatureResponseModel:
     features = feature_queries.find_all()
     return features_serialize.ListFeatureResponseModel(__root__=features)

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -3,6 +3,7 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.repository import feature_queries
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.settings import OBJECT_STORAGE_URL
+from pcapi.utils.cache import cached_view
 
 from . import blueprint
 from .serialization import settings as serializers
@@ -19,6 +20,7 @@ def _get_features(*requested_features: FeatureToggle):  # type: ignore [no-untyp
 
 @blueprint.native_v1.route("/settings", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.SettingsResponse)
+@cached_view(prefix="features", ignore_args=True, expire=None)
 def get_settings() -> serializers.SettingsResponse:
 
     features = _get_features(

--- a/api/src/pcapi/routes/pro/features.py
+++ b/api/src/pcapi/routes/pro/features.py
@@ -2,12 +2,14 @@ from pcapi.repository import feature_queries
 from pcapi.routes.apis import public_api
 from pcapi.routes.serialization import features_serialize
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.cache import cached_view
 
 from . import blueprint
 
 
 @public_api.route("/features", methods=["GET"])
 @spectree_serialize(response_model=features_serialize.ListFeatureResponseModel, api=blueprint.pro_private_schema)
+@cached_view(prefix="features", ignore_args=True, expire=None)
 def list_features() -> features_serialize.ListFeatureResponseModel:
     features = feature_queries.find_all()
     return features_serialize.ListFeatureResponseModel(__root__=features)

--- a/api/src/pcapi/utils/cache.py
+++ b/api/src/pcapi/utils/cache.py
@@ -86,8 +86,8 @@ def cached_view(
     By default it only caches the case where no arguments are passed to the view and the cache liftime is set to 24h.
 
     :param prefix: String to differentiate multiple view with the same name.
-    :param expire: The number of seconds before the cache expire. If None it will be set to 24h (default behavior). if
-        it is not strictly positive (> 0) the cache will be permanent
+    :param expire: The number of seconds before the cache expires. If None it will be set to never expire.
+        It's default value is 86400 (24h).
     :param cache_only_if_no_arguments: When True only the case when there are no args or kwargs is cached, any other
         case will be a passthrough. Default to True
     :param: ignore_args: If True, the decorator will not look a the args to generate the key and it will always

--- a/api/tests/admin/custom_views/feature_view_test.py
+++ b/api/tests/admin/custom_views/feature_view_test.py
@@ -1,19 +1,28 @@
 from unittest.mock import patch
 
+from flask import current_app
+import pytest
+
 import pcapi.core.users.factories as users_factories
 from pcapi.models.feature import Feature
+from pcapi.models.feature import NATIVE_FEATURE_CACHE
+from pcapi.models.feature import PRO_FEATURE_CACHE
 from pcapi.notifications.internal import testing as internal_notification_testing
 
 from tests.conftest import clean_database
 
 
+@pytest.mark.usefixtures("clear_redis")
 class FeatureViewTest:
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_feature_edition(self, mocked_validate_csrf_token, client):
+        redis_client = current_app.redis_client
         users_factories.AdminFactory(email="admin@example.com")
         inactive_feature = Feature.query.filter_by(isActive=False).first()
         active_feature = Feature.query.filter_by(isActive=True).first()
+        redis_client.set(NATIVE_FEATURE_CACHE, "native canary 123546")
+        redis_client.set(NATIVE_FEATURE_CACHE, "pro canary 987456")
 
         data = {"isActive": "true"}
         response = client.with_session_auth("admin@example.com").post(
@@ -30,3 +39,4 @@ class FeatureViewTest:
         assert response.status_code == 302
         assert not Feature.query.get(active_feature.id).isActive
         assert len(internal_notification_testing.requests) == 2
+        assert redis_client.exists(NATIVE_FEATURE_CACHE, PRO_FEATURE_CACHE) == 0

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -104,6 +104,8 @@ def clear_outboxes():
 
 @pytest.fixture(autouse=True)
 def clear_redis(app):
+    # some test can leak redis keys due to added cache
+    app.redis_client.flushdb()
     try:
         yield
     finally:

--- a/api/tests/routes/adage_iframe/features_test.py
+++ b/api/tests/routes/adage_iframe/features_test.py
@@ -1,0 +1,142 @@
+import json
+from typing import ByteString
+from typing import Optional
+
+from flask import current_app
+import pytest
+
+from pcapi.models.feature import Feature
+from pcapi.models.feature import PRO_FEATURE_CACHE
+
+from tests.conftest import TestClient
+from tests.routes.adage_iframe.utils_create_test_token import create_adage_jwt_fake_valid_token
+
+
+@pytest.mark.usefixtures("clear_redis")
+@pytest.mark.usefixtures("db_session")
+class Returns200Test:
+    valid_user = {
+        "mail": "sabine.laprof@example.com",
+        "uai": "EAU123",
+    }
+
+    def _create_adage_valid_token(self, uai_code: Optional[str]) -> ByteString:
+        return create_adage_jwt_fake_valid_token(
+            civility=self.valid_user.get("civilite"),
+            lastname=self.valid_user.get("nom"),
+            firstname=self.valid_user.get("prenom"),
+            email=self.valid_user.get("mail"),
+            uai=uai_code,
+        )
+
+    def test_should_create_feature_cache(self, app) -> None:
+        redis_client = current_app.redis_client
+        # Given
+        valid_encoded_token = self._create_adage_valid_token(uai_code=self.valid_user.get("uai"))
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {valid_encoded_token}"}
+
+        expected = []
+        assert redis_client.get(PRO_FEATURE_CACHE) == None
+        for feature in Feature.query.order_by(Feature.id).all():
+            expected.append(
+                {
+                    "description": feature.description,
+                    "id": str(feature.id),
+                    "isActive": feature.isActive,
+                    "name": feature.name,
+                    "nameKey": feature.nameKey,
+                }
+            )
+        # When
+        response = test_client.get("/adage-iframe/features")
+
+        cache = redis_client.get(PRO_FEATURE_CACHE)
+        # Then
+        assert response.status_code == 200
+        assert sorted(response.json, key=lambda x: x["id"]) == expected
+        assert sorted(json.loads(cache), key=lambda x: x["id"]) == expected
+
+    def test_should_use_feature_cache(self, app) -> None:
+        redis_client = current_app.redis_client
+        # Given
+        valid_encoded_token = self._create_adage_valid_token(uai_code=self.valid_user.get("uai"))
+        test_client = TestClient(app.test_client())
+        test_client.auth_header = {"Authorization": f"Bearer {valid_encoded_token}"}
+        expected = [
+            {
+                "description": "description1",
+                "id": "1",
+                "isActive": True,
+                "name": "namé1",
+                "nameKey": "nameKey1",
+            },
+            {
+                "description": "description2",
+                "id": "2",
+                "isActive": False,
+                "name": "name2",
+                "nameKey": "nameKey2",
+            },
+            {
+                "description": "description3",
+                "id": "3",
+                "isActive": True,
+                "name": "name3",
+                "nameKey": "nameKey3",
+            },
+        ]
+
+        redis_client.set(PRO_FEATURE_CACHE, json.dumps(expected))
+        # When
+        response = test_client.get("/adage-iframe/features")
+        cache = redis_client.get(PRO_FEATURE_CACHE)
+
+        # Then
+        assert response.status_code == 200
+        assert response.json == expected
+        assert json.loads(cache) == expected
+
+
+@pytest.mark.usefixtures("clear_redis")
+@pytest.mark.usefixtures("db_session")
+class Returns403Test:
+    def test_should_preserve_authentication(self, app) -> None:
+        redis_client = current_app.redis_client
+        # Given
+        test_client = TestClient(app.test_client())
+        expected = [
+            {
+                "description": "description1",
+                "id": "1",
+                "isActive": True,
+                "name": "namé1",
+                "nameKey": "nameKey1",
+            },
+            {
+                "description": "description2",
+                "id": "2",
+                "isActive": False,
+                "name": "name2",
+                "nameKey": "nameKey2",
+            },
+            {
+                "description": "description3",
+                "id": "3",
+                "isActive": True,
+                "name": "name3",
+                "nameKey": "nameKey3",
+            },
+        ]
+
+        redis_client.set(PRO_FEATURE_CACHE, json.dumps(expected))
+        # When
+        response = test_client.get("/adage-iframe/features")
+        cache = redis_client.get(PRO_FEATURE_CACHE)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json == {
+            "Authorization": "Unrecognized token",
+        }
+        assert json.loads(cache) == expected

--- a/api/tests/routes/native/v1/settings_test.py
+++ b/api/tests/routes/native/v1/settings_test.py
@@ -1,13 +1,16 @@
+import json
+
+from flask import current_app
 import pytest
 
 from pcapi.core.testing import override_features
-
-from tests.conftest import TestClient
+from pcapi.models.feature import NATIVE_FEATURE_CACHE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
+@pytest.mark.usefixtures("clear_redis")
 class SettingsTest:
     @override_features(
         DISPLAY_DMS_REDIRECTION=True,
@@ -21,8 +24,8 @@ class SettingsTest:
         APP_ENABLE_AUTOCOMPLETE=True,
         APP_ENABLE_CATEGORY_FILTER_PAGE=False,
     )
-    def test_get_settings_feature_combination_1(self, app):
-        response = TestClient(app.test_client()).get("/native/v1/settings")
+    def test_get_settings_feature_combination_1(self, client):
+        response = client.get("/native/v1/settings")
         assert response.status_code == 200
         assert response.json == {
             "accountCreationMinimumAge": 15,
@@ -61,8 +64,8 @@ class SettingsTest:
         APP_ENABLE_CATEGORY_FILTER_PAGE=True,
         APP_ENABLE_COOKIES_V2=True,
     )
-    def test_get_settings_feature_combination_2(self, app):
-        response = TestClient(app.test_client()).get("/native/v1/settings")
+    def test_get_settings_feature_combination_2(self, client):
+        response = client.get("/native/v1/settings")
         assert response.status_code == 200
         assert response.json == {
             "accountCreationMinimumAge": 15,
@@ -87,3 +90,85 @@ class SettingsTest:
             "accountUnsuspensionLimit": 60,
             "appEnableCookiesV2": True,
         }
+
+    @override_features(
+        DISPLAY_DMS_REDIRECTION=False,
+        ENABLE_FRONT_IMAGE_RESIZING=False,
+        ENABLE_NATIVE_APP_RECAPTCHA=False,
+        ENABLE_NATIVE_CULTURAL_SURVEY=False,
+        ENABLE_NATIVE_ID_CHECK_VERBOSE_DEBUGGING=True,
+        ENABLE_PHONE_VALIDATION=False,
+        ID_CHECK_ADDRESS_AUTOCOMPLETION=False,
+        PRO_DISABLE_EVENTS_QRCODE=True,
+        APP_ENABLE_AUTOCOMPLETE=False,
+        APP_ENABLE_CATEGORY_FILTER_PAGE=True,
+        APP_ENABLE_COOKIES_V2=True,
+    )
+    def test_cache_setup(self, client):
+        redis_client = current_app.redis_client
+
+        expected = {
+            "accountCreationMinimumAge": 15,
+            "appEnableAutocomplete": False,
+            "appEnableCategoryFilterPage": True,
+            "autoActivateDigitalBookings": True,
+            "depositAmountsByAge": {"age_15": 2000, "age_16": 3000, "age_17": 3000, "age_18": 30000},
+            "displayDmsRedirection": False,
+            "enableFrontImageResizing": False,
+            "enableNativeCulturalSurvey": False,
+            "enableNativeEacIndividual": True,
+            "enableNativeIdCheckVerboseDebugging": True,
+            "enableNewIdentificationFlow": False,
+            "enablePhoneValidation": False,
+            "enableUnderageGeneralisation": True,
+            "enableUserProfiling": False,
+            "idCheckAddressAutocompletion": False,
+            "isRecaptchaEnabled": False,
+            "isWebappV2Enabled": True,
+            "objectStorageUrl": "http://localhost/storage",
+            "proDisableEventsQrcode": True,
+            "accountUnsuspensionLimit": 60,
+            "appEnableCookiesV2": True,
+        }
+
+        assert redis_client.get(NATIVE_FEATURE_CACHE) == None
+        response = client.get("/native/v1/settings")
+        cache = redis_client.get(NATIVE_FEATURE_CACHE)
+        assert response.status_code == 200
+        assert response.json == expected
+        assert json.loads(cache) == expected
+
+    def test_cache_usage(self, client):
+        redis_client = current_app.redis_client
+
+        expected = {
+            "accountCreationMinimumAge": 15,
+            "appEnableAutocomplete": False,
+            "appEnableCategoryFilterPage": True,
+            "autoActivateDigitalBookings": True,
+            "depositAmountsByAge": {"age_15": 3546, "age_16": 3000, "age_17": 123456789987456321, "age_18": 666},
+            "displayDmsRedirection": False,
+            "enableFrontImageResizing": True,
+            "enableNativeCulturalSurvey": False,
+            "enableNativeEacIndividual": True,
+            "enableNativeIdCheckVerboseDebugging": True,
+            "enableNewIdentificationFlow": False,
+            "enablePhoneValidation": False,
+            "enableUnderageGeneralisation": True,
+            "enableUserProfiling": False,
+            "idCheckAddressAutocompletion": False,
+            "isRecaptchaEnabled": False,
+            "isWebappV2Enabled": True,
+            "objectStorageUrl": "http://localhost/storage",
+            "proDisableEventsQrcode": True,
+            "accountUnsuspensionLimit": 60,
+            "appEnableCookiesV2": True,
+        }
+        redis_client.set(NATIVE_FEATURE_CACHE, json.dumps(expected))
+
+        response = client.get("/native/v1/settings")
+
+        cache = redis_client.get(NATIVE_FEATURE_CACHE)
+        assert response.status_code == 200
+        assert response.json == expected
+        assert json.loads(cache) == expected

--- a/api/tests/routes/pro/get_features_test.py
+++ b/api/tests/routes/pro/get_features_test.py
@@ -1,26 +1,101 @@
+import json
+
+from flask import current_app
 import pytest
 
 from pcapi.core.users import factories as users_factories
+from pcapi.models.feature import Feature
+from pcapi.models.feature import PRO_FEATURE_CACHE
 
 
+@pytest.mark.usefixtures("clear_redis")
+@pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    @pytest.mark.usefixtures("db_session")
-    def when_user_is_logged_in(self, client):
-        # given
+    def test_should_create_feature_cache(self, client) -> None:
+        redis_client = current_app.redis_client
+        # Given
         user = users_factories.UserFactory()
 
-        # when
+        expected = []
+        assert redis_client.get(PRO_FEATURE_CACHE) == None
+        for feature in Feature.query.order_by(Feature.id).all():
+            expected.append(
+                {
+                    "description": feature.description,
+                    "id": str(feature.id),
+                    "isActive": feature.isActive,
+                    "name": feature.name,
+                    "nameKey": feature.nameKey,
+                }
+            )
+        # When
         response = client.with_session_auth(user.email).get("/features")
 
-        # then
+        cache = redis_client.get(PRO_FEATURE_CACHE)
+        # Then
         assert response.status_code == 200
-        feature_name_keys = [feature_dict["nameKey"] for feature_dict in response.json]
-        assert "SYNCHRONIZE_ALLOCINE" in feature_name_keys
+        assert sorted(response.json, key=lambda x: x["id"]) == expected
+        assert sorted(json.loads(cache), key=lambda x: x["id"]) == expected
 
-    @pytest.mark.usefixtures("db_session")
-    def when_user_is_not_logged_in(self, client):
-        # when
+    def test_should_use_feature_cache(self, client) -> None:
+        redis_client = current_app.redis_client
+        # Given
+        user = users_factories.UserFactory()
+        expected = [
+            {
+                "description": "description1",
+                "id": "1",
+                "isActive": True,
+                "name": "namé1",
+                "nameKey": "nameKey1",
+            },
+            {
+                "description": "description2",
+                "id": "2",
+                "isActive": False,
+                "name": "name2",
+                "nameKey": "nameKey2",
+            },
+            {
+                "description": "description3",
+                "id": "3",
+                "isActive": True,
+                "name": "name3",
+                "nameKey": "nameKey3",
+            },
+        ]
+
+        redis_client.set(PRO_FEATURE_CACHE, json.dumps(expected))
+        # When
+        response = client.with_session_auth(user.email).get("/features")
+        cache = redis_client.get(PRO_FEATURE_CACHE)
+
+        # Then
+        assert response.status_code == 200
+        assert response.json == expected
+        assert json.loads(cache) == expected
+
+    def when_user_is_not_logged_in(self, client) -> None:
+        redis_client = current_app.redis_client
+        # Given
+
+        expected = []
+        assert redis_client.get(PRO_FEATURE_CACHE) == None
+        for feature in Feature.query.order_by(Feature.id).all():
+            expected.append(
+                {
+                    "description": feature.description,
+                    "id": str(feature.id),
+                    "isActive": feature.isActive,
+                    "name": feature.name,
+                    "nameKey": feature.nameKey,
+                }
+            )
+        # When
         response = client.get("/features")
 
-        # then
+        cache = redis_client.get(PRO_FEATURE_CACHE)
+        # Then
         assert response.status_code == 200
+        assert sorted(response.json, key=lambda x: x["id"]) == expected
+        assert sorted(json.loads(cache), key=lambda x: x["id"]) == expected


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17474


Mettre un cache sur les endpoints de feature pour essayer de soulager la DB/améliorer le temps de réponse.