### PR TITLE
(PC-17336)[API] fix: Sendinblue automation webhook URL

### DIFF
--- a/api/src/pcapi/core/users/external/sendinblue.py
+++ b/api/src/pcapi/core/users/external/sendinblue.py
@@ -8,7 +8,6 @@ from typing import Callable
 from typing import Iterable
 import urllib.parse
 
-from flask import url_for
 import sib_api_v3_sdk
 from sib_api_v3_sdk.api.contacts_api import ContactsApi
 from sib_api_v3_sdk.models.created_process_id import CreatedProcessId
@@ -321,9 +320,7 @@ def _send_import_request(
     request_contact_import.list_ids = [sib_list_id]
     request_contact_import.notify_url = urllib.parse.urljoin(
         settings.API_URL,
-        url_for(
-            "Public API.sendinblue_notify_importcontacts", list_id=sib_list_id, iteration=iteration, _external=False
-        ),
+        f"/webhooks/sendinblue/importcontacts/{sib_list_id}/{iteration}",
     )
 
     import_response: CreatedProcessId = api_instance.import_contacts(request_contact_import)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17336

## But de la pull request

Corriger l'appel  à Sendinblue dans les automatisations.
L'appel à url_for ne fonctionne pas sur staging (contexte des tâches GCP) à cause de SERVER_NAME.

Erreurs Sentry : 
https://sentry.passculture.team/organizations/sentry/issues/395852/?referrer=slack
https://sentry.passculture.team/organizations/sentry/issues/395678/?referrer=slack
https://sentry.passculture.team/organizations/sentry/issues/395853/?referrer=slack
https://sentry.passculture.team/organizations/sentry/issues/395854/?referrer=slack
https://sentry.passculture.team/organizations/sentry/issues/395857/?referrer=slack

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
