### PR TITLE
(BSR)[API] feat: stop deleting feature flags when resetting databse

### DIFF
--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -16,7 +16,6 @@ from pcapi.local_providers.install import install_local_providers
 from pcapi.models import db
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
-from pcapi.models.feature import Feature
 from pcapi.models.feature import install_feature_flags
 
 
@@ -98,7 +97,6 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     educational_models.EducationalInstitution.query.delete()
     educational_models.EducationalYear.query.delete()
     educational_models.EducationalRedactor.query.delete()
-    Feature.query.delete()
     db.session.execute(f"DELETE FROM {perm_models.role_permission_table.name};")
     perm_models.Permission.query.delete()
     perm_models.Role.query.delete()


### PR DESCRIPTION
## But de la pull request

Comme discuté en synchro backend, le fait de réinitialiser les Feature Flags à chaque fois qu'on "relance la sandbox" est source d'incompréhensions / de perte de temps lors des tests sur l'environnement de testing. 
