### PR TITLE
(PC-17086)[API] feat: stop downgrading fraud_check if user has already an active deposit

### DIFF
--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -356,8 +356,8 @@ class FraudReasonCode(enum.Enum):
     AGE_NOT_VALID = "age_is_not_valid"
     AGE_TOO_OLD = "age_too_old"
     AGE_TOO_YOUNG = "age_too_young"
-    ALREADY_BENEFICIARY = "already_beneficiary"
-    ALREADY_HAS_ACTIVE_DEPOSIT = "already_has_active_deposit"
+    ALREADY_BENEFICIARY = "already_beneficiary"  # Deprecated but kept because of old data
+    ALREADY_HAS_ACTIVE_DEPOSIT = "already_has_active_deposit"  # Deprecated but kept because of old data
     BLACKLISTED_PHONE_NUMBER = "blacklisted_phone_number"
     DUPLICATE_ID_PIECE_NUMBER = "duplicate_id_piece_number"
     DUPLICATE_INE = "duplicate_ine"

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -9,6 +9,7 @@ import pcapi.core.fraud.models as fraud_models
 import pcapi.core.fraud.repository as fraud_repository
 import pcapi.core.mails.transactional as transactional_mails
 from pcapi.core.payments import api as payments_api
+from pcapi.core.payments import exceptions as payments_exceptions
 from pcapi.core.subscription import messages as subscription_messages
 from pcapi.core.subscription.dms import api as dms_subscription_api
 from pcapi.core.subscription.educonnect import api as educonnect_subscription_api
@@ -523,7 +524,12 @@ def activate_beneficiary_if_no_missing_step(user: users_models.User) -> bool:
     source_data = typing.cast(common_fraud_models.IdentityCheckContent, activable_fraud_check.source_data())
     users_api.update_user_information_from_external_source(user, source_data, commit=False)
 
-    activate_beneficiary_for_eligibility(user, activable_fraud_check.get_detailed_source(), activable_eligibility)
+    try:
+        activate_beneficiary_for_eligibility(user, activable_fraud_check.get_detailed_source(), activable_eligibility)
+    except (payments_exceptions.DepositTypeAlreadyGrantedException, payments_exceptions.UserHasAlreadyActiveDeposit):
+        # this error may happen on identity provider concurrent requests
+        logger.info("A deposit already exists for user %s", user.id)
+        return False
 
     return True
 

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -159,20 +159,6 @@ class CommonFraudCheckTest:
 
         assert fraud_item.status == fraud_models.FraudStatus.OK
 
-    def test_underage_user_validation_is_beneficiary(self):
-        user = users_factories.UnderageBeneficiaryFactory()
-        fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
-            type=fraud_models.FraudCheckType.EDUCONNECT,
-            user=user,
-            resultContent=fraud_factories.EduconnectContentFactory(),
-            eligibilityType=users_models.EligibilityType.UNDERAGE,
-        )
-
-        fraud_items = fraud_api.on_identity_fraud_check_result(user, fraud_check)
-        invalid_codes = filter_invalid_fraud_items_to_reason_code(fraud_items)
-        assert fraud_models.FraudReasonCode.ALREADY_HAS_ACTIVE_DEPOSIT in invalid_codes
-        assert fraud_models.FraudReasonCode.ALREADY_BENEFICIARY in invalid_codes
-
     @pytest.mark.parametrize(
         "fraud_check_type",
         [fraud_models.FraudCheckType.DMS],
@@ -198,18 +184,6 @@ class CommonFraudCheckTest:
 
         invalid_codes = filter_invalid_fraud_items_to_reason_code(fraud_items)
         assert fraud_models.FraudReasonCode.EMAIL_NOT_VALIDATED in invalid_codes
-
-    @pytest.mark.parametrize("fraud_check_type", [fraud_models.FraudCheckType.DMS])
-    def test_previously_validated_user_with_retry(self, fraud_check_type):
-        # The user is already beneficiary, and has already done all the checks but
-        # for any circumstances, someone is trying to redo the validation
-        # an error should be raised
-        user = users_factories.BeneficiaryGrant18Factory()
-        fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(type=fraud_check_type, user=user)
-        fraud_items = fraud_api.on_identity_fraud_check_result(user, fraud_check)
-        invalid_codes = filter_invalid_fraud_items_to_reason_code(fraud_items)
-        assert fraud_models.FraudReasonCode.ALREADY_HAS_ACTIVE_DEPOSIT in invalid_codes
-        assert fraud_models.FraudReasonCode.ALREADY_BENEFICIARY in invalid_codes
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
we don't want to downgrade a FraudCheck from OK to KO, which may be the case on concurrent Ubble webhook requests. (see this [issue on sentry](https://sentry.passculture.team/organizations/sentry/issues/394934/?environment=production&project=5&query=is%3Aunresolved+Deposit&statsPeriod=14d) and [this discussion](https://passcultureteam.slack.com/archives/C02RQP7APRA/p1663756354784269)). 

In that case, we used to override fraud_check with KO status and ALREADY_HAS_ACTIVE_DEPOSIT + ALREADY_BENEFICIARY reason codes. Now we will let a OK result, but the beneficiary role or another deposit wont be given again thanks to check performed in `create_deposit` and `_get_activable_eligibility` methods

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17086

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
