### PR TITLE
(BSR)[API] feat: stop capturing error in sentry when occuring in flask shell

### DIFF
--- a/api/src/pcapi/utils/sentry.py
+++ b/api/src/pcapi/utils/sentry.py
@@ -1,3 +1,6 @@
+import sys
+import typing
+
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -8,7 +11,15 @@ from pcapi import settings
 from pcapi.utils.health_checker import read_version_from_file
 
 
-def init_sentry_sdk():  # type: ignore [no-untyped-def]
+def ignore_flask_shell_event(
+    event: dict[str, typing.Any], _hint: dict[str, typing.Any]
+) -> dict[str, typing.Any] | None:
+    if len(sys.argv) >= 2 and "flask" in sys.argv[0] and sys.argv[1] == "shell":
+        return None
+    return event
+
+
+def init_sentry_sdk() -> None:
     if settings.IS_DEV:
         return
     sentry_sdk.init(
@@ -17,4 +28,5 @@ def init_sentry_sdk():  # type: ignore [no-untyped-def]
         release=read_version_from_file(),
         environment=settings.ENV,
         traces_sample_rate=settings.SENTRY_SAMPLE_RATE,
+        before_send=ignore_flask_shell_event,
     )


### PR DESCRIPTION
## But de la pull request

Eviter d'avoir du bruit sur sentry avec les erreurs qui arrivent dans le pod console, comme par exemple [celle-ci](https://passcultureteam.slack.com/archives/C01FVUFTXV1/p1664272022500549)