### PR TITLE
Pc 17662 zendesk sell memory + staging

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -313,6 +313,18 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, NeedsValidati
         return self.bankInformation and self.bankInformation.status == BankInformationStatus.ACCEPTED
 
     @property
+    def has_individual_offers(self) -> bool:
+        from pcapi.core.offers.models import Offer
+
+        return db.session.query(Offer.query.filter(Offer.venueId == self.id).exists()).scalar()
+
+    @property
+    def has_collective_offers(self) -> bool:
+        from pcapi.core.educational.models import CollectiveOffer
+
+        return db.session.query(CollectiveOffer.query.filter(CollectiveOffer.venueId == self.id).exists()).scalar()
+
+    @property
     def nApprovedOffers(self) -> int:  # used in validation rule, do not remove
         from pcapi.core.educational.models import CollectiveOffer
         from pcapi.core.offers.models import Offer

--- a/api/src/pcapi/core/users/external/zendesk_sell.py
+++ b/api/src/pcapi/core/users/external/zendesk_sell.py
@@ -425,6 +425,11 @@ def _get_parent_organization_id(venue: offerers_models.Venue) -> int | None:
 
 def zendesk_create_offerer(offerer: offerers_models.Offerer, session: requests.Session | None = None) -> dict:
     data = _get_offerer_data(offerer, created=True)
+
+    # Read-only on staging
+    if not settings.IS_PROD:
+        return {"id": None}
+
     return _query_api("POST", "/v2/contacts", body=data, session=session)
 
 
@@ -432,6 +437,11 @@ def zendesk_update_offerer(
     zendesk_id: int, offerer: offerers_models.Offerer, session: requests.Session | None = None
 ) -> dict:
     data = _get_offerer_data(offerer)
+
+    # Read-only on staging
+    if not settings.IS_PROD:
+        return {"id": None}
+
     return _query_api("PUT", f"/v2/contacts/{zendesk_id}", body=data, session=session)
 
 
@@ -442,6 +452,11 @@ def zendesk_create_venue(
         parent_organization_id = _get_parent_organization_id(venue)
 
     data = _get_venue_data(venue, parent_organization_id, created=True)
+
+    # Read-only on staging
+    if not settings.IS_PROD:
+        return {"id": None}
+
     return _query_api("POST", "/v2/contacts", body=data, session=session)
 
 
@@ -455,6 +470,11 @@ def zendesk_update_venue(
         parent_organization_id = _get_parent_organization_id(venue)
 
     data = _get_venue_data(venue, parent_organization_id)
+
+    # Read-only on staging
+    if not settings.IS_PROD:
+        return {"id": None}
+
     return _query_api("PUT", f"/v2/contacts/{zendesk_id}", body=data, session=session)
 
 
@@ -463,7 +483,7 @@ def _stub_in_test_env(action: str, data: offerers_models.Offerer | offerers_mode
         testing.zendesk_sell_requests.append({"action": action, "type": type(data).__name__, "id": data.id})
         return True
 
-    if not settings.IS_PROD:
+    if not (settings.IS_PROD or settings.IS_STAGING):
         logger.info("A request to Zendesk Sell API would be sent to %s %s %d", action, type(data).__name__, data.id)
         return True
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17662

## But de la pull request

- Corriger un problème d'utilisation mémoire : la mise à jour de certains lieux gérant beaucoup d'offres explose l'utilisation mémoire
- Pouvoir tester le script d'initialisation Zendesk Sell sur staging, en lecture seule (on n'a pas de sandbox Zendesk Sell donc restons prudents sur les données de prod)
- But : un hotfix sur staging

## Implémentation

## Informations supplémentaires

Cela permettra de tester le script Zendesk Sell affiné d'abord sur staging plutôt que sur la prod.
La dernière version du script fera l'objet d'une PR séparée quand le script aura pu tourner (sans _crash_ ni _kill_) jusqu'au bout sur staging.

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
