### PR TITLE
(PC-17662)[API] fix: DB load when updating venue on Zendesk Sell

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -325,6 +325,25 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, NeedsValidati
         return db.session.query(CollectiveOffer.query.filter(CollectiveOffer.venueId == self.id).exists()).scalar()
 
     @property
+    def has_approved_offers(self) -> bool:
+        """Better performance than nApprovedOffers when we only want to check if there is at least one offer"""
+        from pcapi.core.educational.models import CollectiveOffer
+        from pcapi.core.offers.models import Offer
+        from pcapi.core.offers.models import OfferValidationStatus
+
+        query_offer = db.session.query(
+            Offer.query.filter(Offer.validation == OfferValidationStatus.APPROVED, Offer.venueId == self.id).exists()
+        )
+        query_collective = db.session.query(
+            CollectiveOffer.query.filter(
+                CollectiveOffer.validation == OfferValidationStatus.APPROVED, CollectiveOffer.venueId == self.id
+            ).exists()
+        )
+        results = query_offer.union(query_collective).all()
+
+        return any(result for result, in results)
+
+    @property
     def nApprovedOffers(self) -> int:  # used in validation rule, do not remove
         from pcapi.core.educational.models import CollectiveOffer
         from pcapi.core.offers.models import Offer

--- a/api/src/pcapi/core/users/external/zendesk_sell.py
+++ b/api/src/pcapi/core/users/external/zendesk_sell.py
@@ -137,7 +137,7 @@ def _get_venue_data(venue: offerers_models.Venue, parent_organization_id: int | 
     has_collective_offers = venue.has_collective_offers
 
     if venue.has_individual_offers or has_collective_offers:
-        if venue.nApprovedOffers > 0:
+        if venue.has_approved_offers:
             pc_pro_status = "Acteur Inscrit Actif"
         else:
             pc_pro_status = "Acteur Inscrit non Actif"

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -149,6 +149,7 @@ class VenueNApprovedOffersTest:
         for validation_status in offers_models.OfferValidationStatus:
             offers_factories.OfferFactory(venue=venue, validation=validation_status)
         assert venue.nApprovedOffers == 1
+        assert venue.has_approved_offers
 
     def test_venue_n_approved_offers_and_collective_offers(self):
         educational_factories.CollectiveOfferFactory()
@@ -162,6 +163,14 @@ class VenueNApprovedOffersTest:
         for validation_status in offers_models.OfferValidationStatus:
             offers_factories.OfferFactory(venue=venue, validation=validation_status)
         assert venue.nApprovedOffers == 3
+        assert venue.has_approved_offers
+
+    def test_venue_n_approved_offers_zero(self):
+        venue = factories.VenueFactory()
+        offers_factories.OfferFactory(venue=venue, validation=offers_models.OfferValidationStatus.PENDING)
+        educational_factories.CollectiveOfferFactory(venue=venue, validation=offers_models.OfferValidationStatus.DRAFT)
+        assert venue.nApprovedOffers == 0
+        assert not venue.has_approved_offers
 
 
 class OffererLegalCategoryTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17662

## But de la pull request

Suite à la PR 3721 : https://github.com/pass-culture/pass-culture-main/pull/3721
Un nouveau test sur staging me montre que venue.nApprovedOffers() prend du temps et donc charge la base de données, alors qu'on ne veut que vérifier l'existence d'au moins une offre => nouvelle propriété faisant le minimum.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
