### PR TITLE
(BSR)[PRO] fix: do not use useEffect. We always have features loaded

### DIFF
--- a/pro/src/app/AppRouter/AppRouter.tsx
+++ b/pro/src/app/AppRouter/AppRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { useSelector } from 'react-redux'
 import { Redirect, Route, Switch } from 'react-router'
 
@@ -6,32 +6,18 @@ import AppLayout from 'app/AppLayout'
 import useActiveFeature from 'components/hooks/useActiveFeature'
 import NotFound from 'components/pages/Errors/NotFound/NotFound'
 import { Logout } from 'routes/Logout'
-import routes, { IRoute, routesWithoutLayout } from 'routes/routes_map'
+import routes, { routesWithoutLayout } from 'routes/routes_map'
 import { selectActiveFeatures } from 'store/features/selectors'
 
 const AppRouter = (): JSX.Element => {
   const activeFeatures = useSelector(selectActiveFeatures)
-  const [activeRoutes, setActiveRoutes] = useState<IRoute[]>([])
-  const [activeRoutesWithoutLayout, setActiveRoutesWithoutLayout] = useState<
-    IRoute[]
-  >([])
+  const activeRoutes = routes.filter(
+    route => !route.featureName || activeFeatures.includes(route.featureName)
+  )
+  const activeRoutesWithoutLayout = routesWithoutLayout.filter(
+    route => !route.featureName || activeFeatures.includes(route.featureName)
+  )
   const isOfferFormV3 = useActiveFeature('OFFER_FORM_V3')
-
-  useEffect(() => {
-    setActiveRoutes(
-      routes.filter(
-        route =>
-          !route.featureName || activeFeatures.includes(route.featureName)
-      )
-    )
-
-    setActiveRoutesWithoutLayout(
-      routesWithoutLayout.filter(
-        route =>
-          !route.featureName || activeFeatures.includes(route.featureName)
-      )
-    )
-  }, [activeFeatures])
 
   return (
     <Switch>


### PR DESCRIPTION
Au premier chargement de l'application les routes ne sont pas encore initialisées et <NotFound /> est rendu. 
Nous n'avons pas besoin du useEffect, les features sont déjà chargées dans le storeProvider (un spinner est affiché quand on les load). 

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
