### PR TITLE
(BSR)[PRO] fix: flakyness by adding a timeout on equality test

### DIFF
--- a/pro/testcafe/05_venue.js
+++ b/pro/testcafe/05_venue.js
@@ -48,13 +48,13 @@ test.skip('je peux créer un lieu avec un SIRET valide', async t => {
 
   await t
     .click(newVenueButton)
+    .typeText(siretInput, siret, { paste: true })
     .click(venueType)
     .click(venueTypeOption.withText('Festival'))
-    .typeText(siretInput, siret, { paste: true })
     .typeText(descriptionInput, description, { paste: true })
     .click(audioDisabilityCompliant)
     .expect(nameInput.value)
-    .eql(venueName)
+    .eql(venueName, { timeout: 5000 }) // 5s
     .expect(addressInput.value)
     .eql(address)
     .expect(postalCodeInput.value)
@@ -68,7 +68,7 @@ test.skip('je peux créer un lieu avec un SIRET valide', async t => {
   await navigateAfterVenueSubmit('creation')(t)
 })
 
-test.skip('je peux créer un lieu sans SIRET avec une description', async t => {
+test('je peux créer un lieu sans SIRET avec une description', async t => {
   const { offerer, user } = await fetchSandbox(
     'pro_05_venue',
     'get_existing_pro_validated_user_with_validated_offerer_validated_user_offerer_no_physical_venue'
@@ -87,7 +87,9 @@ test.skip('je peux créer un lieu sans SIRET avec une description', async t => {
     .typeText(commentInput, 'Test sans SIRET', { paste: true })
     .click(venueType)
     .click(venueTypeOption.withText('Festival'))
-    .typeText(addressInput, '1 place du trocadéro Paris')
+    .typeText(addressInput, '1 place du trocadéro Paris', { paste: true })
+    .expect(addressSuggestion.innerText)
+    .match(/^(?!\s*$).+/, { timeout: 5000 }) // 5s
     .click(addressSuggestion)
     .click(audioDisabilityCompliant)
     .expect(postalCodeInput.value)


### PR DESCRIPTION
Essai pour fix la flakyness de 2 tests e2e sur la page de lieux. 
-> cas siret on allonge le timeout pour attendre le retour de l'api
-> cas commentaire allonge le timeout pour attendre les propositions d'adresse

## But de la pull request

_Ajout de fonctionnalités, Problèmes résolus, etc_

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
