### PR TITLE
(BSR) deployment: simplify deprecated deploy-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,43 +1,15 @@
-name: '[Deprecated] Tag a RC and deploy to staging'
+name: "[Deprecated] Deploy a tag to staging"
 
 on:
   workflow_dispatch:
     inputs:
-      releaseCandidateVersion:
-        description: "Numéro de la RC sans le .0.0 (ex: 2150)"
-        required: true
-        type: string
-
-      releaseNumber:
-        description: "Numéro de l'itération (ex: 199)"
+      releaseVersion:
+        description: "Nom de la release (ex: 199.0.0)"
         required: true
         type: string
 
 jobs:
-  tag-version:
-    uses: ./.github/workflows/tag.yml
-    secrets: inherit
-    with:
-      base_ref: RC-${{ github.event.inputs.releaseCandidateVersion }}.0.0
-      tag_number: ${{ github.event.inputs.releaseNumber }}.0.0
-
-  create-maintenance-branch:
-    needs: tag-version
-    runs-on: ubuntu-latest
-    env:
-      MAINTENANCE_BRANCH: maint/v${{ github.event.inputs.releaseNumber }}
-    steps:
-      - name: Checkout new tag
-        uses: actions/checkout@v3
-        with:
-          ref: v${{ github.event.inputs.releaseNumber }}.0.0
-      - name: Create maintenance branch
-        run: |
-          git checkout -b "$MAINTENANCE_BRANCH"
-          git push origin "$MAINTENANCE_BRANCH"
-
   deploy-to-staging:
-    needs: tag-version
     runs-on: ubuntu-latest
     environment:
       name: staging
@@ -46,7 +18,7 @@ jobs:
       - name: Checkout Release
         uses: actions/checkout@v3
         with:
-          ref: v${{ github.event.inputs.releaseNumber }}.0.0
-      - name: Push release to staging
+          ref: v${{ github.event.inputs.releaseVersion }}
+      - name: Deploy Release to staging
         run: |
           git push -f origin HEAD:staging


### PR DESCRIPTION
we still need this workflow today because the new workflow is not present on the target tag 207.0.0