### PR TITLE
(PC-17455)[API] feat: Add action history for new backoffice, starting with offerer validation history

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-b5d775ddec23 (pre) (head)
+246156d69d6f (pre) (head)
 6858182908fe (post) (head)

--- a/api/src/pcapi/alembic/versions/20220927T102855_246156d69d6f_create_action_history_table.py
+++ b/api/src/pcapi/alembic/versions/20220927T102855_246156d69d6f_create_action_history_table.py
@@ -1,0 +1,44 @@
+"""create_action_history_table
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "246156d69d6f"
+down_revision = "b5d775ddec23"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "action_history",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("jsonData", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("actionType", sa.Text(), nullable=False),
+        sa.Column("actionDate", sa.DateTime(), server_default=sa.text("now()"), nullable=True),
+        sa.Column("authorUserId", sa.BigInteger(), nullable=True),
+        sa.Column("userId", sa.BigInteger(), nullable=True),
+        sa.Column("offererId", sa.BigInteger(), nullable=True),
+        sa.Column("venueId", sa.BigInteger(), nullable=True),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.CheckConstraint('num_nonnulls("userId", "offererId", "venueId") >= 1', name="check_at_least_one_resource"),
+        sa.ForeignKeyConstraint(["authorUserId"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["offererId"], ["offerer.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["userId"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["venueId"], ["venue.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_action_history_offererId"), "action_history", ["offererId"], unique=False)
+    op.create_index(op.f("ix_action_history_userId"), "action_history", ["userId"], unique=False)
+    op.create_index(op.f("ix_action_history_venueId"), "action_history", ["venueId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_action_history_venueId"), table_name="action_history")
+    op.drop_index(op.f("ix_action_history_userId"), table_name="action_history")
+    op.drop_index(op.f("ix_action_history_offererId"), table_name="action_history")
+    op.drop_table("action_history")

--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -1,0 +1,57 @@
+from pcapi.core.history import models
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.users import models as users_models
+from pcapi.repository import repository
+
+
+def log_action(
+    action_type: models.ActionType,
+    author: users_models.User | None,
+    user: users_models.User | None = None,
+    offerer: offerers_models.Offerer | None = None,
+    venue: offerers_models.Venue | None = None,
+    comment: str | None = None,
+    save: bool = True,
+    **extra_data: dict,
+) -> models.ActionHistory:
+    """
+    Set save parameter to False if you want to save the returned object at the same time as modified resources.
+
+    Be careful: author/user/offerer/venue object and its id may not be associated before the action is saved and/or
+    before the new object itself is inserted in the database. RuntimeError are issued in case this function would save
+    new resources in parameters; when such an exception is raised, it shows a bug in our code.
+    """
+    if not user and not offerer and not venue:
+        raise ValueError("No resource (user, offerer, venue)")
+
+    if save:
+        if user is not None and user.id is None:
+            raise RuntimeError("Unsaved user would be saved with action: %s" % (user.email,))
+
+        if offerer is not None and offerer.id is None:
+            raise RuntimeError("Unsaved offerer would be saved with action: %s" % (offerer.name,))
+
+        if venue is not None and venue.id is None:
+            raise RuntimeError("Unsaved venue would be saved with action %s" % (venue.name,))
+
+    if isinstance(author, users_models.User):
+        author_user_id = author.id
+    else:
+        # None or AnonymousUserMixin
+        # Examples: offerer validated by token (without authentication), offerer created by script
+        author_user_id = None
+
+    action = models.ActionHistory(
+        actionType=action_type,
+        authorUserId=author_user_id,
+        user=user,
+        offerer=offerer,
+        venue=venue,
+        comment=comment,
+        extraData=extra_data,
+    )
+
+    if save:
+        repository.save(action)
+
+    return action

--- a/api/src/pcapi/core/history/factories.py
+++ b/api/src/pcapi/core/history/factories.py
@@ -1,0 +1,14 @@
+import factory
+
+from pcapi.core.history import models
+from pcapi.core.testing import BaseFactory
+import pcapi.core.users.factories as users_factories
+
+
+class ActionHistoryFactory(BaseFactory):
+    class Meta:
+        model = models.ActionHistory
+
+    actionType = models.ActionType.COMMENT
+    authorUser = factory.SubFactory(users_factories.AdminFactory)
+    comment = factory.Sequence(lambda n: f"Action #{n:04} created by factory")

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -1,0 +1,106 @@
+import enum
+
+import sqlalchemy as sa
+
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.users import models as users_models
+from pcapi.models import Base
+from pcapi.models import Model
+from pcapi.models.extra_data_mixin import ExtraDataMixin
+from pcapi.models.pc_object import PcObject
+
+
+class ActionType(enum.Enum):
+    # Single comment from admin, on any resource, without status change:
+    COMMENT = "Commentaire"
+    # Validation process for offerers:
+    OFFERER_NEW = "Nouvelle structure"
+    OFFERER_PENDING = "Structure mise en attente"
+    OFFERER_VALIDATED = "Structure validée"
+    OFFERER_REJECTED = "Structure rejetée"
+    OFFERER_SUSPENDED = "Structure désactivée"
+    OFFERER_UNSUSPENDED = "Structure réactivée"
+    # Validation process for user-offerer relationships:
+    USER_OFFERER_NEW = "Nouveau rattachement"
+    USER_OFFERER_PENDING = "Rattachement mis en attente"
+    USER_OFFERER_VALIDATED = "Rattachement validé"
+    USER_OFFERER_REJECTED = "Rattachement rejeté"
+
+
+class ActionHistory(PcObject, Base, Model, ExtraDataMixin):  # type: ignore [valid-type, misc]
+    """
+    This table aims at logging all actions that should appear in a resource history for support, fraud team, etc.
+
+    user, offerer, venue are filled in the log entry depending on the action. So they are nullable.
+    Example: When a user requests to be attached to an offerer, action has both userId and offererId, but no venueId.
+    This enables to filter on either the user or the offerer, and the same action appears in both user history and
+    offerer history in the backoffice.
+
+    user, offerer and venue ids have a dedicated column in the table because this enables to:
+    - easily index and filter to get history list for a resource or select items directly in database for debug
+      (even if this is also possible with JSONB, but using more complex filter in requests),
+    - have a constraint which forces to link the action to at least one resource,
+    - join with user, offerer and venue tables to get the resource data without additional requests
+    - create an action on a resource which is not stored in database yet, so does not have id, so that all objects are
+      stored in a single repository.save(). It would not be possible to store everything in a single db transaction if
+      ids were stored as values in a JSONB column.
+
+    Additional information related to a specific action (e.g. reasonCode which is related to user suspension) may be
+    stored in extraData field.
+
+    Currently, this class is a first "draft" implementation to start storing log information required for offerer
+    validation. Later, it should store information about all resources. Data should also be migrated from UserSuspension
+    table when working on user history features.
+    """
+
+    __tablename__ = "action_history"
+
+    actionType: ActionType = sa.Column(sa.Enum(ActionType, create_constraint=False), nullable=False)
+
+    # nullable because of old suspensions without date migrated here; but mandatory for new actions
+    actionDate = sa.Column(sa.DateTime, nullable=True, server_default=sa.func.now())
+
+    # User (beneficiary, pro, admin...) who *initiated* the action
+    # nullable because of old actions without known author migrated here or lines which must be kept in case an admin
+    # author is removed; but the author is mandatory for any new action
+    authorUserId: int | None = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
+    authorUser: users_models.User | None = sa.orm.relationship("User", foreign_keys=[authorUserId])
+
+    userId: int | None = sa.Column(
+        sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+    user: users_models.User | None = sa.orm.relationship(
+        "User",
+        foreign_keys=[userId],
+        backref=sa.orm.backref(
+            "action_history", order_by="ActionHistory.actionDate.asc().nullsfirst()", passive_deletes=True
+        ),
+    )
+
+    offererId: int | None = sa.Column(
+        sa.BigInteger, sa.ForeignKey("offerer.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+    offerer: offerers_models.Offerer | None = sa.orm.relationship(
+        "Offerer",
+        foreign_keys=[offererId],
+        backref=sa.orm.backref(
+            "action_history", order_by="ActionHistory.actionDate.asc().nullsfirst()", passive_deletes=True
+        ),
+    )
+
+    venueId: int | None = sa.Column(
+        sa.BigInteger, sa.ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=True
+    )
+    venue: offerers_models.Venue | None = sa.orm.relationship(
+        "Venue",
+        foreign_keys=[venueId],
+        backref=sa.orm.backref(
+            "action_history", order_by="ActionHistory.actionDate.asc().nullsfirst()", passive_deletes=True
+        ),
+    )
+
+    comment = sa.Column(sa.Text(), nullable=True)
+
+    __table_args__ = (
+        sa.CheckConstraint('num_nonnulls("userId", "offererId", "venueId") >= 1', name="check_at_least_one_resource"),
+    )

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -22,6 +22,10 @@ class OffererFactory(BaseFactory):
     isActive = True
 
 
+class NotValidatedOffererFactory(OffererFactory):
+    validationToken = factory.Sequence(lambda n: f"offerer-not-validated-{n}")
+
+
 class CollectiveOffererFactory(OffererFactory):
     name = factory.Sequence("[EAC] La structure de Moz'Art {}".format)
 
@@ -169,6 +173,14 @@ class UserOffererFactory(BaseFactory):
 
     user = factory.SubFactory(users_factories.ProFactory)
     offerer = factory.SubFactory(OffererFactory)
+
+
+class UserNotValidatedOffererFactory(BaseFactory):
+    class Meta:
+        model = models.UserOfferer
+
+    user = factory.SubFactory(users_factories.UserFactory)
+    offerer = factory.SubFactory(NotValidatedOffererFactory)
 
 
 class VirtualVenueTypeFactory(BaseFactory):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -17,6 +17,8 @@ import pcapi.core.bookings.repository as bookings_repository
 import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.common.models as common_fraud_models
 import pcapi.core.fraud.models as fraud_models
+import pcapi.core.history.api as history_api
+import pcapi.core.history.models as history_models
 import pcapi.core.mails.transactional as transactional_mails
 import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.models as offerers_models
@@ -623,7 +625,10 @@ def create_pro_user_and_offerer(pro_user: ProUserCreationBodyModel) -> models.Us
         offerer = _generate_offerer(pro_user.dict(by_alias=True))
         user_offerer = offerers_api.grant_user_offerer_access(offerer, new_pro_user)
         digital_venue = offerers_api.create_digital_venue(offerer)
-        objects_to_save.extend([digital_venue, offerer, user_offerer])
+        action = history_api.log_action(
+            history_models.ActionType.OFFERER_NEW, new_pro_user, user=new_pro_user, offerer=offerer, save=False
+        )
+        objects_to_save.extend([digital_venue, offerer, user_offerer, action])
     objects_to_save.append(user_offerer)
     new_pro_user = _set_offerer_departement_code(new_pro_user, offerer)
 

--- a/api/src/pcapi/models/__init__.py
+++ b/api/src/pcapi/models/__init__.py
@@ -17,6 +17,7 @@ def install_models() -> None:
     import pcapi.core.educational.models
     import pcapi.core.finance.models
     import pcapi.core.fraud.models
+    import pcapi.core.history.models
     import pcapi.core.mails.models
     import pcapi.core.offerers.models
     import pcapi.core.offers.models

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -6,6 +6,7 @@ import pcapi.core.educational.models as educational_models
 import pcapi.core.finance.models as finance_models
 from pcapi.core.finance.models import BankInformation
 import pcapi.core.fraud.models as fraud_models
+import pcapi.core.history.models as history_models
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 import pcapi.core.payments.models as payments_models
@@ -102,6 +103,7 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     db.session.execute(f"DELETE FROM {perm_models.role_permission_table.name};")
     perm_models.Permission.query.delete()
     perm_models.Role.query.delete()
+    history_models.ActionHistory.query.delete()
 
     # Dans le cadre du projet EAC, notre partenaire Adage requête notre api sur le endpoint get_pre_bookings.
     # Ils récupèrent les pré-réservations EAC liées à un utilisateur EAC et stockent les ids en base.

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -381,3 +381,7 @@ class OffererToBeValidated(BaseModel):
 
 class ListOffererToBeValidatedResponseModel(PaginatedResponse):
     data: list[OffererToBeValidated]
+
+
+class CommentRequest(BaseModel):
+    comment: str

--- a/api/tests/core/history/test_api.py
+++ b/api/tests/core/history/test_api.py
@@ -1,0 +1,86 @@
+import pytest
+
+from pcapi.core.history import api as history_api
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class LogActionTest:
+    def test_log_action(self):
+        admin = users_factories.AdminFactory()
+        user_offerer = offerers_factories.UserOffererFactory()
+
+        returned_action = history_api.log_action(
+            history_models.ActionType.OFFERER_REJECTED,
+            admin,
+            user=user_offerer.user,
+            offerer=user_offerer.offerer,
+            comment="Test rejected",
+            save=True,
+            custom_data="Test",
+        )
+
+        action = history_models.ActionHistory.query.one()
+        assert action.actionType == history_models.ActionType.OFFERER_REJECTED
+        assert action.authorUserId == admin.id
+        assert action.authorUser == admin
+        assert action.userId == user_offerer.user.id
+        assert action.user == user_offerer.user
+        assert action.offererId == user_offerer.offerer.id
+        assert action.offerer == user_offerer.offerer
+        assert action.venueId is None
+        assert action.venue is None
+        assert action.comment == "Test rejected"
+        assert action.extraData == {"custom_data": "Test"}
+
+        assert returned_action == action
+
+    def test_log_action_without_resource(self):
+        admin = users_factories.AdminFactory()
+
+        with pytest.raises(ValueError) as err:
+            history_api.log_action(history_models.ActionType.OFFERER_PENDING, admin)
+
+        assert "No resource" in str(err.value)
+        assert history_models.ActionHistory.query.count() == 0
+
+    def test_log_action_do_not_save(self):
+        admin = users_factories.AdminFactory()
+        user_offerer = offerers_factories.UserOffererFactory()
+
+        action = history_api.log_action(
+            history_models.ActionType.OFFERER_VALIDATED,
+            admin,
+            user=user_offerer.user,
+            offerer=user_offerer.offerer,
+            save=False,
+        )
+
+        assert action.id is None
+        assert action.actionType == history_models.ActionType.OFFERER_VALIDATED
+        assert action.authorUserId == admin.id
+        assert action.user == user_offerer.user
+        assert action.offerer == user_offerer.offerer
+        assert action.venueId is None
+
+    def test_log_action_unsaved_resource(self):
+        admin = users_factories.AdminFactory()
+        user = users_factories.UserFactory()
+        unsaved_offerer = offerers_models.Offerer()
+        unsaved_offerer.siren = "102030405"
+        unsaved_offerer.name = "Librairie du pass"
+        unsaved_offerer.postalCode = "75018"
+        unsaved_offerer.city = "Paris"
+
+        with pytest.raises(RuntimeError):
+            history_api.log_action(
+                history_models.ActionType.OFFERER_VALIDATED,
+                admin,
+                user=user,
+                offerer=unsaved_offerer,
+            )

--- a/api/tests/core/history/test_factories.py
+++ b/api/tests/core/history/test_factories.py
@@ -1,0 +1,39 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from pcapi.core.history import factories
+from pcapi.core.history import models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class HistoryFactoriesTest:
+    def test_action_history_factory(self):
+        author = users_factories.AdminFactory()
+        user = users_factories.UserFactory()
+        offerer = offerers_factories.OffererFactory()
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        action: models.ActionHistory = factories.ActionHistoryFactory(
+            authorUser=author, user=user, offerer=offerer, venue=venue, extraData={"test": "ok"}
+        )
+
+        assert action.actionType == models.ActionType.COMMENT
+        assert action.actionDate is not None
+        assert action.authorUserId == author.id
+        assert action.authorUser == author
+        assert action.userId == user.id
+        assert action.user == user
+        assert action.offererId == offerer.id
+        assert action.offerer == offerer
+        assert action.venueId == venue.id
+        assert action.venue == venue
+        assert "created by factory" in action.comment
+        assert action.extraData == {"test": "ok"}
+
+    def test_action_history_factory_without_resource(self):
+        with pytest.raises(IntegrityError) as err:
+            factories.ActionHistoryFactory()
+        assert "check_at_least_one_resource" in str(err.value)

--- a/api/tests/routes/pro/get_educational_institutions_test.py
+++ b/api/tests/routes/pro/get_educational_institutions_test.py
@@ -68,8 +68,8 @@ class Return200Test:
 
     def test_get_educational_institutions_limit(self, client: Any) -> None:
         # Given
-        institution1 = EducationalInstitutionFactory()
-        EducationalInstitutionFactory()
+        institution1 = EducationalInstitutionFactory(name="Collège A")
+        EducationalInstitutionFactory(name="Collège B")
         pro_user = users_factories.ProFactory()
 
         client.with_session_auth(pro_user.email)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17455

## But de la pull request

Conserver un historique horodaté de toutes les actions effectuées dans le processus de validation des structures. Les utilisateurs du backoffice doivent pouvoir ajouter un commentaire, associé ou non à une action.
L'objectif est de pouvoir afficher dans le nouveau backoffice, une liste présentant l'historique de la structure..

Cette première version d'historique est censé devenir générique et conserver les actions sur toutes les ressources manipulées dans le backoffice : structures, lieux, utilisateurs pro et jeunes... pour afficher cet historique dans les détails de la ressource.

## Implémentation

## Informations supplémentaires

La route d'ajout d'un commentaire à une structure, demandée dans le nouveau backoffice, est aussi ajoutée dans ce ticket, afin d'illustrer et tester la table de logs.

## Modifications du schéma de la base de données

Ajout d'une nouvelle table `action_history`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
