### PR TITLE
Pc 17675 eac tech add has seen offer duplication modal in user model

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-e3d81633703f (pre) (head)
+2c5900b6e16e (pre) (head)
 6858182908fe (post) (head)

--- a/api/src/pcapi/admin/custom_views/admin_user_view.py
+++ b/api/src/pcapi/admin/custom_views/admin_user_view.py
@@ -90,6 +90,7 @@ class AdminUserView(SuspensionMixin, BaseAdminView):
     def on_model_change(self, form: Form, model: User, is_created: bool) -> None:
         model.publicName = f"{model.firstName} {model.lastName}"
         model.add_admin_role()
+        model.hasSeenOfferDuplicationModal = True
         model.hasSeenProTutorials = True
         model.hasSeenProRgs = True
         model.needsToFillCulturalSurvey = False

--- a/api/src/pcapi/alembic/versions/20220929T130342_2c5900b6e16e_add_has_seen_offer_duplication_modal_to_user_model.py
+++ b/api/src/pcapi/alembic/versions/20220929T130342_2c5900b6e16e_add_has_seen_offer_duplication_modal_to_user_model.py
@@ -1,0 +1,22 @@
+"""add_has_seen_offer_duplication_modal_to_user_model
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "2c5900b6e16e"
+down_revision = "e3d81633703f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user", sa.Column("hasSeenOfferDuplicationModal", sa.Boolean(), server_default=sa.text("false"), nullable=False)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "hasSeenOfferDuplicationModal")

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -689,6 +689,11 @@ def _set_offerer_departement_code(new_user: models.User, offerer: offerers_model
     return new_user
 
 
+def set_offer_duplication_modal_as_seen(user: models.User) -> None:
+    user.hasSeenOfferDuplicationModal = True
+    repository.save(user)
+
+
 def set_pro_tuto_as_seen(user: models.User) -> None:
     user.hasSeenProTutorials = True
     repository.save(user)

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -61,6 +61,7 @@ class UserFactory(BaseFactory):
     publicName = "Jean Neige"
     isEmailValidated = True
     roles = []  # type: ignore [var-annotated]
+    hasSeenOfferDuplicationModal = False
     hasSeenProTutorials = True
     postalCode = factory.Faker("postcode")
 
@@ -94,6 +95,7 @@ class AdminFactory(BaseFactory):
     publicName = "Frank Columbo"
     isEmailValidated = True
     roles = [users_models.UserRole.ADMIN]
+    hasSeenOfferDuplicationModal = False
     hasSeenProTutorials = True
 
     @classmethod
@@ -129,6 +131,7 @@ class BeneficiaryGrant18Factory(BaseFactory):
     lastName = "Doux"
     isEmailValidated = True
     roles = [users_models.UserRole.BENEFICIARY]
+    hasSeenOfferDuplicationModal = False
     hasSeenProTutorials = True
     hasSeenProRgs = False
 
@@ -250,6 +253,7 @@ class ProFactory(BaseFactory):
     publicName = "René Coty"
     isEmailValidated = True
     roles = [users_models.UserRole.PRO]
+    hasSeenOfferDuplicationModal = False
     hasSeenProTutorials = True
 
     @classmethod

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -191,6 +191,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):  # ty
     )
     firstName = sa.Column(sa.String(128), nullable=True)
     sa.Index("idx_user_trgm_first_name", firstName, postgresql_using="gin")
+    hasSeenOfferDuplicationModal: bool = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     hasSeenProTutorials: bool = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     hasSeenProRgs: bool = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     idPieceNumber = sa.Column(sa.String, nullable=True, unique=True)

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -27,6 +27,14 @@ from pcapi.utils.rate_limiting import ip_rate_limiter
 from . import blueprint
 
 
+@blueprint.pro_private_api.route("/users/offer-duplication-modal-seen", methods=["PATCH"])
+@login_required
+@spectree_serialize(response_model=None, on_success_status=204, api=blueprint.pro_private_schema)
+def patch_user_offer_duplication_modal_seen() -> None:
+    user = current_user._get_current_object()  # get underlying User object from proxy
+    users_api.set_offer_duplication_modal_as_seen(user)
+
+
 @blueprint.pro_private_api.route("/users/tuto-seen", methods=["PATCH"])
 @login_required
 @spectree_serialize(response_model=None, on_success_status=204, api=blueprint.pro_private_schema)

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -132,6 +132,7 @@ class SharedLoginUserResponseModel(BaseModel):
     email: str
     firstName: str | None
     hasPhysicalVenues: bool | None
+    hasSeenOfferDuplicationModal: bool
     hasSeenProTutorials: bool | None
     # FIXME (mageoffray, 2022-04-04): Optional can be removed after
     # post-deploy migrations have been done
@@ -179,6 +180,7 @@ class SharedCurrentUserResponseModel(BaseModel):
     externalIds: typing.Dict | None
     firstName: str | None
     hasPhysicalVenues: bool | None
+    hasSeenOfferDuplicationModal: bool
     hasSeenProTutorials: bool | None
     hasSeenProRgs: bool | None
     id: str

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -45,6 +45,7 @@ class AdminUserViewTest:
         assert user_created.has_admin_role is True
         assert not user_created.has_beneficiary_role
         assert user_created.has_admin_role
+        assert user_created.hasSeenOfferDuplicationModal is False
         assert user_created.hasSeenProTutorials is True
         assert user_created.hasSeenProRgs is True
         assert user_created.needsToFillCulturalSurvey is False

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -46,6 +46,7 @@ class Returns200Test:
             "externalIds": {},
             "firstName": "Jean",
             "hasPhysicalVenues": False,
+            "hasSeenOfferDuplicationModal": False,
             "hasSeenProTutorials": True,
             "hasSeenProRgs": False,
             "id": humanize(user.id),

--- a/api/tests/routes/pro/patch_user_has_seen_offer_duplication_modal_test.py
+++ b/api/tests/routes/pro/patch_user_has_seen_offer_duplication_modal_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+import pcapi.core.users.factories as users_factories
+
+from tests.conftest import TestClient
+
+
+@pytest.mark.usefixtures("db_session")
+def test_mark_as_seen(client):
+    user = users_factories.UserFactory(hasSeenOfferDuplicationModal=False)
+
+    client = client.with_session_auth(user.email)
+    response = client.patch("/users/offer-duplication-modal-seen")
+
+    assert response.status_code == 204
+    assert user.hasSeenOfferDuplicationModal == True
+
+
+@pytest.mark.usefixtures("db_session")
+def test_mark_as_seen_without_auth(app):
+    user = users_factories.UserFactory(hasSeenOfferDuplicationModal=False)
+
+    client = TestClient(app.test_client())
+    response = client.patch("/users/offer-duplication-modal-seen")
+
+    assert response.status_code == 401
+    assert user.hasSeenOfferDuplicationModal == False

--- a/api/tests/routes/pro/signin_test.py
+++ b/api/tests/routes/pro/signin_test.py
@@ -46,6 +46,7 @@ class Returns200Test:
             "email": "user@example.com",
             "firstName": "Jean",
             "hasPhysicalVenues": False,
+            "hasSeenOfferDuplicationModal": False,
             "hasSeenProTutorials": True,
             "hasSeenProRgs": False,
             "id": humanize(user.id),

--- a/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedCurrentUserResponseModel.ts
@@ -18,6 +18,7 @@ export type SharedCurrentUserResponseModel = {
   externalIds?: any;
   firstName?: string | null;
   hasPhysicalVenues?: boolean | null;
+  hasSeenOfferDuplicationModal: boolean;
   hasSeenProRgs?: boolean | null;
   hasSeenProTutorials?: boolean | null;
   id: string;

--- a/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SharedLoginUserResponseModel.ts
@@ -16,6 +16,7 @@ export type SharedLoginUserResponseModel = {
   email: string;
   firstName?: string | null;
   hasPhysicalVenues?: boolean | null;
+  hasSeenOfferDuplicationModal: boolean;
   hasSeenProRgs?: boolean | null;
   hasSeenProTutorials?: boolean | null;
   id: string;

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1432,6 +1432,22 @@ export class DefaultService {
   }
 
   /**
+   * patch_user_offer_duplication_modal_seen <PATCH>
+   * @returns void
+   * @throws ApiError
+   */
+  public patchUserOfferDuplicationModalSeen(): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'PATCH',
+      url: '/users/offer-duplication-modal-seen',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
    * post_change_password <POST>
    * @param requestBody
    * @returns void


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17675

## But de la pull request

Ajout de hasSeenOfferDuplicationModal dans le modèle des Users. Mis à False par défaut.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
