### PR TITLE
(PC-17691)[API] feat: save idPieceNumber with same format as duplicate search

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -253,6 +253,10 @@ def duplicate_id_piece_number_fraud_item(user: users_models.User, id_piece_numbe
     return models.FraudItem(status=models.FraudStatus.OK, detail="La pièce d'identité n'est pas déjà utilisée")
 
 
+def format_id_piece_number(id_piece_number: str) -> str:
+    return id_piece_number.replace(" ", "")
+
+
 def find_duplicate_id_piece_number_user(id_piece_number: str | None, excluded_user_id: int) -> users_models.User | None:
     if not id_piece_number:
         return None
@@ -264,7 +268,7 @@ def find_duplicate_id_piece_number_user(id_piece_number: str | None, excluded_us
             " ",
             "",
         )
-        == id_piece_number.replace(" ", ""),
+        == format_id_piece_number(id_piece_number),
     ).first()
 
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -14,6 +14,7 @@ import sqlalchemy as sa
 from pcapi import settings
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.bookings.repository as bookings_repository
+import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.common.models as common_fraud_models
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.mails.transactional as transactional_mails
@@ -206,7 +207,7 @@ def update_user_information(
     if civility is not None:
         user.civility = civility
     if id_piece_number is not None:
-        user.idPieceNumber = id_piece_number
+        user.idPieceNumber = fraud_api.format_id_piece_number(id_piece_number)
     if ine_hash is not None:
         user.ineHash = ine_hash
     if married_name is not None:

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -46,6 +46,7 @@ class CommonTest:
             "040211-5703",  # ID Suédoise
             "339546T",  # Titre de séjour Français
             "32363144 4 ZZ7",  # ID Portugaise
+            "323631444ZZ7",  # ID Portugaise
         ],
     )
     def test_id_piece_number_valid_format(self, id_piece_number):

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -814,7 +814,7 @@ class BeneficiaryInformationUpdateTest:
 
     def test_update_id_piece_number(self):
         user = users_factories.UserFactory(activity="Etudiant", postalCode="75001", idPieceNumber=None)
-        dms_data = fraud_factories.DMSContentFactory(id_piece_number="140767100016")
+        dms_data = fraud_factories.DMSContentFactory(id_piece_number="140 767100 016")
 
         users_api.update_user_information_from_external_source(user, dms_data)
         assert user.idPieceNumber == "140767100016"


### PR DESCRIPTION
it has two benefits: we ensure the unicity is respected ; the duplicate search will be more perfomant (we will stop formatting idPieceNumber column on the fly)

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17691

