### PR TITLE
BSR remove act, fireEvent & fix warnings

### DIFF
--- a/pro/src/components/hooks/__specs/useFrenchQuery.spec.jsx
+++ b/pro/src/components/hooks/__specs/useFrenchQuery.spec.jsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
@@ -24,7 +25,7 @@ describe('useFrenchQuery', () => {
     expect(screen.getByText('venueId: BC')).toBeInTheDocument()
   })
 
-  it('should allow update on french query params from english', () => {
+  it('should allow update on french query params from english', async () => {
     // Given
     render(
       <MemoryRouter
@@ -37,13 +38,11 @@ describe('useFrenchQuery', () => {
     )
 
     // When
-    fireEvent.change(screen.getByLabelText('offererId'), {
-      target: { value: 'DE' },
-    })
-    fireEvent.change(screen.getByLabelText('venueId'), {
-      target: { value: 'FG' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Update query params' }))
+    await userEvent.type(screen.getByLabelText('offererId'), 'DE')
+    await userEvent.type(screen.getByLabelText('venueId'), 'FG')
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update query params' })
+    )
 
     // Then
     expect(screen.queryByText('offererId: AY')).not.toBeInTheDocument()

--- a/pro/src/components/hooks/__specs/useFrenchQuery.spec.jsx
+++ b/pro/src/components/hooks/__specs/useFrenchQuery.spec.jsx
@@ -9,7 +9,6 @@ import { UseFrenchQueryTestingExample } from 'components/hooks/__specs/UseFrench
 
 describe('useFrenchQuery', () => {
   it('should translate french query param to english', () => {
-    // When
     render(
       <MemoryRouter
         initialEntries={[
@@ -20,13 +19,11 @@ describe('useFrenchQuery', () => {
       </MemoryRouter>
     )
 
-    // Then
     expect(screen.getByText('offererId: AY')).toBeInTheDocument()
     expect(screen.getByText('venueId: BC')).toBeInTheDocument()
   })
 
   it('should allow update on french query params from english', async () => {
-    // Given
     render(
       <MemoryRouter
         initialEntries={[
@@ -37,14 +34,12 @@ describe('useFrenchQuery', () => {
       </MemoryRouter>
     )
 
-    // When
     await userEvent.type(screen.getByLabelText('offererId'), 'DE')
     await userEvent.type(screen.getByLabelText('venueId'), 'FG')
     await userEvent.click(
       screen.getByRole('button', { name: 'Update query params' })
     )
 
-    // Then
     expect(screen.queryByText('offererId: AY')).not.toBeInTheDocument()
     expect(screen.queryByText('venueId: BC')).not.toBeInTheDocument()
     expect(screen.getByText('offererId: DE')).toBeInTheDocument()
@@ -52,7 +47,6 @@ describe('useFrenchQuery', () => {
   })
 
   it('should not trigger renders when query did not change', () => {
-    // When
     render(
       <MemoryRouter
         initialEntries={[
@@ -63,12 +57,10 @@ describe('useFrenchQuery', () => {
       </MemoryRouter>
     )
 
-    // Then
     expect(screen.getByText('Number of query changes: 1')).toBeInTheDocument()
   })
 
   it('should guarantee that setter function identity is stable and won’t change on re-renders to avoid unwanted side effects', () => {
-    // When
     render(
       <MemoryRouter
         initialEntries={[
@@ -79,7 +71,6 @@ describe('useFrenchQuery', () => {
       </MemoryRouter>
     )
 
-    // Then
     expect(
       screen.getByText('Number of setter identities: 1')
     ).toBeInTheDocument()

--- a/pro/src/components/layout/Icon.tsx
+++ b/pro/src/components/layout/Icon.tsx
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import React, { ImgHTMLAttributes } from 'react'
 
 import { ROOT_PATH } from 'utils/config'

--- a/pro/src/components/layout/form/fields/__specs__/PasswordField.spec.jsx
+++ b/pro/src/components/layout/form/fields/__specs__/PasswordField.spec.jsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Form } from 'react-final-form'
 
@@ -26,7 +27,7 @@ describe('component | PasswordField', () => {
       label: 'labelTest',
       name: 'nameTest',
     }
-    it('should display custom error message when backend error starts with "ton mot de passe"', () => {
+    it('should display custom error message when backend error starts with "ton mot de passe"', async () => {
       // Given
       render(
         <Form onSubmit={jest.fn}>
@@ -40,7 +41,7 @@ describe('component | PasswordField', () => {
           )}
         </Form>
       )
-      fireEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Afficher le mot de passe' })
       )
 
@@ -48,9 +49,7 @@ describe('component | PasswordField', () => {
       const input = screen.getByRole('textbox', {
         name: 'labelTest Cacher le mot de passe',
       })
-      fireEvent.change(input, {
-        target: { value: 'tutu' },
-      })
+      await userEvent.type(input, 'tutu')
 
       // Then
       expect(
@@ -60,7 +59,7 @@ describe('component | PasswordField', () => {
       ).toBeInTheDocument()
     })
 
-    it('should display backned error message when backend error does not start with "ton mot de passe"', () => {
+    it('should display backned error message when backend error does not start with "ton mot de passe"', async () => {
       // Given
       render(
         <Form onSubmit={jest.fn}>
@@ -71,7 +70,7 @@ describe('component | PasswordField', () => {
           )}
         </Form>
       )
-      fireEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Afficher le mot de passe' })
       )
 
@@ -79,9 +78,7 @@ describe('component | PasswordField', () => {
       const input = screen.getByRole('textbox', {
         name: 'labelTest Cacher le mot de passe',
       })
-      fireEvent.change(input, {
-        target: { value: 'tutu' },
-      })
+      await userEvent.type(input, 'tutu')
 
       // Then
       expect(screen.getByText('An error')).toBeInTheDocument()

--- a/pro/src/components/layout/inputs/DurationInput/__specs__/DurationInput.spec.jsx
+++ b/pro/src/components/layout/inputs/DurationInput/__specs__/DurationInput.spec.jsx
@@ -6,10 +6,6 @@ import React from 'react'
 
 import DurationInput from '../DurationInput'
 
-const renderDurationInput = props => {
-  render(<DurationInput {...props} />)
-}
-
 describe('src | components | inputs | DurationInput', () => {
   let props
 
@@ -23,7 +19,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should display an input with correct name and placeholder', () => {
     // When
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
 
     // Then
     const durationInput = screen.getByRole('textbox')
@@ -34,7 +30,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should init input with empty text when no initial duration is provided', () => {
     // When
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
 
     // Then
     const durationInput = screen.getByRole('textbox')
@@ -46,7 +42,7 @@ describe('src | components | inputs | DurationInput', () => {
     props.initialDurationInMinutes = 75
 
     // When
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
 
     // Then
     const durationInput = screen.getByRole('textbox')
@@ -58,7 +54,7 @@ describe('src | components | inputs | DurationInput', () => {
     props.initialDurationInMinutes = 60
 
     // When
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
 
     // Then
     const durationInput = screen.getByRole('textbox')
@@ -67,7 +63,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should call onChange prop function with updated duration in minutes when user leave field', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
     await userEvent.type(durationInput, '1:25')
 
@@ -81,7 +77,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should consider as minute a single digit after ":" when user leave field', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
     await userEvent.type(durationInput, '1:7')
 
@@ -95,7 +91,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should consider as hours numbers with no ":" when user leave field', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     await userEvent.type(durationInput, '3')
@@ -111,7 +107,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should call onChange prop function with null when user remove the duration', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
     await userEvent.type(durationInput, '1:25')
     await userEvent.tab()
@@ -127,7 +123,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept only numeric caracters', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -139,7 +135,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept only one hours-minutes separator', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -151,7 +147,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept only minutes with two digits', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -163,7 +159,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should not accept minutes to be over 59', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -175,7 +171,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept minutes equal to 59', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -187,7 +183,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should not accept minutes without hours', async () => {
     // Given
-    renderDurationInput(props)
+    render(<DurationInput {...props} />)
     const durationInput = screen.getByRole('textbox')
 
     // When

--- a/pro/src/components/layout/inputs/DurationInput/__specs__/DurationInput.spec.jsx
+++ b/pro/src/components/layout/inputs/DurationInput/__specs__/DurationInput.spec.jsx
@@ -1,13 +1,12 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 import DurationInput from '../DurationInput'
 
-const renderDurationInput = async props => {
+const renderDurationInput = props => {
   render(<DurationInput {...props} />)
 }
 
@@ -22,9 +21,9 @@ describe('src | components | inputs | DurationInput', () => {
     }
   })
 
-  it('should display an input with correct name and placeholder', async () => {
+  it('should display an input with correct name and placeholder', () => {
     // When
-    await renderDurationInput(props)
+    renderDurationInput(props)
 
     // Then
     const durationInput = screen.getByRole('textbox')
@@ -33,33 +32,33 @@ describe('src | components | inputs | DurationInput', () => {
     expect(durationInput).toHaveProperty('placeholder', 'HH:MM')
   })
 
-  it('should init input with empty text when no initial duration is provided', async () => {
+  it('should init input with empty text when no initial duration is provided', () => {
     // When
-    await renderDurationInput(props)
+    renderDurationInput(props)
 
     // Then
     const durationInput = screen.getByRole('textbox')
     expect(durationInput).toHaveValue('')
   })
 
-  it('should init input with duration in minutes converted in hours and minutes', async () => {
+  it('should init input with duration in minutes converted in hours and minutes', () => {
     // Given
     props.initialDurationInMinutes = 75
 
     // When
-    await renderDurationInput(props)
+    renderDurationInput(props)
 
     // Then
     const durationInput = screen.getByRole('textbox')
     expect(durationInput).toHaveValue('1:15')
   })
 
-  it('should pad minutes with 0 when initial duration in hours has less than 10 minutes', async () => {
+  it('should pad minutes with 0 when initial duration in hours has less than 10 minutes', () => {
     // Given
     props.initialDurationInMinutes = 60
 
     // When
-    await renderDurationInput(props)
+    renderDurationInput(props)
 
     // Then
     const durationInput = screen.getByRole('textbox')
@@ -68,12 +67,12 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should call onChange prop function with updated duration in minutes when user leave field', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
     await userEvent.type(durationInput, '1:25')
 
     // When
-    fireEvent.blur(durationInput)
+    await userEvent.tab()
 
     // Then
     expect(props.onChange).toHaveBeenCalledWith(85)
@@ -82,12 +81,12 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should consider as minute a single digit after ":" when user leave field', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
     await userEvent.type(durationInput, '1:7')
 
     // When
-    fireEvent.blur(durationInput)
+    await userEvent.tab()
 
     // Then
     expect(props.onChange).toHaveBeenCalledWith(67)
@@ -96,13 +95,13 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should consider as hours numbers with no ":" when user leave field', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     await userEvent.type(durationInput, '3')
 
     // When
-    fireEvent.blur(durationInput)
+    await userEvent.tab()
 
     // Then
     expect(durationInput).toHaveValue('3:00')
@@ -112,14 +111,14 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should call onChange prop function with null when user remove the duration', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
     await userEvent.type(durationInput, '1:25')
-    fireEvent.blur(durationInput)
+    await userEvent.tab()
     await userEvent.clear(durationInput)
 
     // When
-    fireEvent.blur(durationInput)
+    await userEvent.tab()
 
     // Then
     expect(props.onChange).toHaveBeenLastCalledWith(null)
@@ -128,7 +127,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept only numeric caracters', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -140,7 +139,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept only one hours-minutes separator', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -152,7 +151,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept only minutes with two digits', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -164,7 +163,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should not accept minutes to be over 59', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -176,7 +175,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should accept minutes equal to 59', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     // When
@@ -188,7 +187,7 @@ describe('src | components | inputs | DurationInput', () => {
 
   it('should not accept minutes without hours', async () => {
     // Given
-    await renderDurationInput(props)
+    renderDurationInput(props)
     const durationInput = screen.getByRole('textbox')
 
     // When

--- a/pro/src/components/layout/inputs/Errors/InputError.jsx
+++ b/pro/src/components/layout/inputs/Errors/InputError.jsx
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import PropTypes from 'prop-types'
 import React from 'react'
 

--- a/pro/src/components/layout/inputs/PeriodSelector/__specs__/PeriodSelector.spec.jsx
+++ b/pro/src/components/layout/inputs/PeriodSelector/__specs__/PeriodSelector.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, within, render, screen } from '@testing-library/react'
+import { within, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
@@ -10,7 +10,7 @@ describe('components | PeriodSelector', () => {
   const mockChangePeriodBeginningDateValue = jest.fn()
   const mockChangePeriodEndingDateValue = jest.fn()
   const renderPeriodSelector = () => {
-    return render(
+    render(
       <PeriodSelector
         changePeriodBeginningDateValue={mockChangePeriodBeginningDateValue}
         changePeriodEndingDateValue={mockChangePeriodEndingDateValue}
@@ -32,14 +32,14 @@ describe('components | PeriodSelector', () => {
     const endDateWrapper = screen.getByTestId('period-filter-end-picker')
     const beginCalendar = startingDateWrapper.children[1]
 
-    fireEvent.click(
+    await userEvent.click(
       within(beginCalendar).getByLabelText('Choose jeudi 21 octobre 2021')
     )
     expect(endDateWrapper.children).toHaveLength(2)
 
     const endCalendar = endDateWrapper.children[1]
 
-    fireEvent.click(
+    await userEvent.click(
       within(endCalendar).getByLabelText('Choose samedi 30 octobre 2021')
     )
     expect(endDateWrapper.children).toHaveLength(1)
@@ -55,13 +55,13 @@ describe('components | PeriodSelector', () => {
     const beginCalendar = startingDateWrapper.children[1]
     const endDateWrapper = screen.getByTestId('period-filter-end-picker')
 
-    fireEvent.click(
+    await userEvent.click(
       within(beginCalendar).getByLabelText('Choose jeudi 21 octobre 2021')
     )
 
     const endCalendar = endDateWrapper.children[1]
 
-    fireEvent.click(
+    await userEvent.click(
       within(endCalendar).getByLabelText('Choose samedi 30 octobre 2021')
     )
     expect(mockChangePeriodBeginningDateValue).toHaveBeenCalledTimes(1)

--- a/pro/src/components/layout/inputs/TextInput/__specs__/TextInput.spec.jsx
+++ b/pro/src/components/layout/inputs/TextInput/__specs__/TextInput.spec.jsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 import TextInput from '../TextInput'
@@ -39,10 +39,10 @@ describe('src | components | layout | form | TextInput', () => {
     const newValue = 'My new value'
 
     // when
-    fireEvent.change(offerTypeInput, { target: { value: newValue } })
+    await userEvent.type(offerTypeInput, newValue)
 
     // then
-    expect(props.onChange).toHaveBeenCalledTimes(1)
+    expect(props.onChange).toHaveBeenCalledTimes(12)
   })
 
   it('should not display a length count when input has only a max length', () => {

--- a/pro/src/components/pages/Home/Offerers/__specs__/CreationLinks.spec.jsx
+++ b/pro/src/components/pages/Home/Offerers/__specs__/CreationLinks.spec.jsx
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen, within } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
@@ -11,7 +16,7 @@ import { configureTestStore } from 'store/testUtils'
 import Homepage from '../../Homepage'
 
 jest.mock('repository/pcapi/pcapi', () => ({
-  getBusinessUnits: jest.fn(),
+  getBusinessUnits: jest.fn().mockResolvedValue([{}]),
 }))
 
 jest.mock('apiClient/api', () => ({
@@ -36,15 +41,15 @@ const renderHomePage = async () => {
     },
   })
 
-  return await act(async () => {
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Homepage />
-        </MemoryRouter>
-      </Provider>
-    )
-  })
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Homepage />
+      </MemoryRouter>
+    </Provider>
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }
 describe('creationLinks', () => {
   let baseOfferers

--- a/pro/src/components/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
+++ b/pro/src/components/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -14,7 +18,7 @@ import { configureTestStore } from 'store/testUtils'
 import Homepage from '../../Homepage'
 
 jest.mock('repository/pcapi/pcapi', () => ({
-  getBusinessUnits: jest.fn(),
+  getBusinessUnits: jest.fn().mockResolvedValue([{}]),
 }))
 
 jest.mock('apiClient/api', () => ({
@@ -40,15 +44,14 @@ const renderHomePage = async () => {
     },
   })
 
-  return await act(async () => {
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Homepage />
-        </MemoryRouter>
-      </Provider>
-    )
-  })
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Homepage />
+      </MemoryRouter>
+    </Provider>
+  )
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }
 
 describe('trackers creationLinks', () => {

--- a/pro/src/components/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
+++ b/pro/src/components/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
@@ -30,7 +30,7 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const mockLogEvent = jest.fn()
-const renderHomePage = async () => {
+const renderHomePage = () => {
   const store = configureTestStore({
     user: {
       currentUser: {
@@ -51,7 +51,6 @@ const renderHomePage = async () => {
       </MemoryRouter>
     </Provider>
   )
-  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }
 
 describe('trackers creationLinks', () => {
@@ -174,7 +173,9 @@ describe('trackers creationLinks', () => {
       },
     ]
     api.getOfferer.mockResolvedValue(baseOfferers[0])
-    await renderHomePage()
+    renderHomePage()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
     const createOfferButton = screen.queryByText('Créer une offre')
 
     await userEvent.click(createOfferButton)
@@ -202,7 +203,8 @@ describe('trackers creationLinks', () => {
       },
     ]
     api.getOfferer.mockResolvedValue(baseOfferers[0])
-    await renderHomePage()
+    renderHomePage()
+    await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
     const createVenueButton = screen.queryByText('Créer un lieu')
 

--- a/pro/src/components/pages/Home/Venues/__specs__/Venue.spec.jsx
+++ b/pro/src/components/pages/Home/Venues/__specs__/Venue.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -17,16 +17,14 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderVenue = async (props, store) => {
-  return await act(async () => {
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Venue {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
-  })
+const renderVenue = (props, store) => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Venue {...props} />
+      </MemoryRouter>
+    </Provider>
+  )
 }
 
 describe('venues', () => {
@@ -51,7 +49,7 @@ describe('venues', () => {
 
   it('should display stats tiles', async () => {
     // When
-    await renderVenue(props, store)
+    renderVenue(props, store)
 
     await userEvent.click(screen.getByRole('button', { name: 'Afficher' }))
 
@@ -65,9 +63,7 @@ describe('venues', () => {
       outOfStockOffersStat,
     ] = screen.getAllByTestId('venue-stat')
 
-    await waitFor(() =>
-      expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
-    )
+    expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
 
     expect(
       within(activeOffersStat).getByText('Offres publiées')
@@ -91,12 +87,10 @@ describe('venues', () => {
 
   it('should contain a link for each stats', async () => {
     // When
-    await renderVenue(props, store)
+    renderVenue(props, store)
     await userEvent.click(screen.getByRole('button', { name: 'Afficher' }))
     const [activeOffersStat] = screen.getAllByTestId('venue-stat')
-    await waitFor(() =>
-      expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
-    )
+    expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
 
     // Then
     expect(screen.getAllByRole('link', { name: 'Voir' })).toHaveLength(4)
@@ -104,7 +98,7 @@ describe('venues', () => {
 
   it('should redirect to filtered bookings when clicking on link', async () => {
     // When
-    await renderVenue(props, store)
+    renderVenue(props, store)
     await userEvent.click(screen.getByRole('button', { name: 'Afficher' }))
     // Then
     const [
@@ -114,9 +108,7 @@ describe('venues', () => {
       outOfStockOffersStat,
     ] = screen.getAllByTestId('venue-stat')
 
-    await waitFor(() =>
-      expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
-    )
+    expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
 
     expect(
       within(activeOffersStat).getByRole('link', { name: 'Voir' })
@@ -142,12 +134,10 @@ describe('venues', () => {
       props.isVirtual = true
 
       // When
-      await renderVenue(props, store)
+      renderVenue(props, store)
       await userEvent.click(screen.getByTitle('Afficher'))
       const [activeOffersStat] = screen.getAllByTestId('venue-stat')
-      await waitFor(() =>
-        expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
-      )
+      expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
 
       // Then
       expect(
@@ -162,12 +152,10 @@ describe('venues', () => {
       props.isVirtual = false
 
       // When
-      await renderVenue(props, store)
+      renderVenue(props, store)
       await userEvent.click(screen.getByTitle('Afficher'))
       const [activeOffersStat] = screen.getAllByTestId('venue-stat')
-      await waitFor(() =>
-        expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
-      )
+      expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
 
       // Then
       expect(
@@ -180,12 +168,10 @@ describe('venues', () => {
       props.isVirtual = false
 
       // When
-      await renderVenue(props, store)
+      renderVenue(props, store)
       await userEvent.click(screen.getByRole('button', { name: 'Afficher' }))
       const [activeOffersStat] = screen.getAllByTestId('venue-stat')
-      await waitFor(() =>
-        expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
-      )
+      expect(within(activeOffersStat).getByText('2')).toBeInTheDocument()
 
       // Then
       expect(screen.getByRole('link', { name: 'Modifier' }).href).toBe(
@@ -193,7 +179,7 @@ describe('venues', () => {
       )
     })
 
-    it('should display add bank information when venue does not have a business unit', async () => {
+    it('should display add bank information when venue does not have a business unit', () => {
       // Given
       props.hasBusinessUnit = false
       const storeOverrides = configureTestStore({
@@ -205,7 +191,7 @@ describe('venues', () => {
       })
 
       // When
-      await renderVenue(props, storeOverrides)
+      renderVenue(props, storeOverrides)
 
       // Then
       expect(screen.getByRole('link', { name: 'Ajouter un RIB' }).href).toBe(
@@ -213,7 +199,7 @@ describe('venues', () => {
       )
     })
 
-    it('should display add bank information when venue does not have a reimbursement point', async () => {
+    it('should display add bank information when venue does not have a reimbursement point', () => {
       // Given
       props.hasMissingReimbursementPoint = true
       const storeOverrides = configureTestStore({
@@ -228,7 +214,7 @@ describe('venues', () => {
       })
 
       // When
-      await renderVenue(props, storeOverrides)
+      renderVenue(props, storeOverrides)
 
       // Then
       expect(screen.getByRole('link', { name: 'Ajouter un RIB' }).href).toBe(

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderItem/__specs__/AllocineProviderItem.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderItem/__specs__/AllocineProviderItem.spec.jsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
@@ -67,10 +68,6 @@ describe('src | components | pages | Venue | VenueProvidersManager | AllocinePro
     pcapi.loadProviders.mockResolvedValue([allocineProvider])
   })
 
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-
   it('should show synchronization modalities when venue provider is allocine', async () => {
     // given
     pcapi.loadVenueProviders.mockResolvedValue([allocineVenueProvider])
@@ -126,7 +123,7 @@ describe('src | components | pages | Venue | VenueProvidersManager | AllocinePro
     expect(editAllocineProviderButton).toBeInTheDocument()
 
     // when
-    fireEvent.click(editAllocineProviderButton)
+    await userEvent.click(editAllocineProviderButton)
 
     // then
     expect(

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
@@ -1,6 +1,12 @@
 import '@testing-library/jest-dom'
 
-import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import {
+  render,
+  screen,
+  within,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
@@ -17,15 +23,15 @@ jest.mock('repository/pcapi/pcapi', () => ({
 }))
 
 const renderVenueProvidersManager = async props => {
-  await act(async () => {
-    render(
-      <Provider store={configureTestStore()}>
-        <MemoryRouter>
-          <VenueProvidersManager {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
-  })
+  render(
+    <Provider store={configureTestStore()}>
+      <MemoryRouter>
+        <VenueProvidersManager {...props} />
+      </MemoryRouter>
+    </Provider>
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }
 
 describe('src | VenueProvidersManager', () => {
@@ -159,7 +165,7 @@ describe('src | VenueProvidersManager', () => {
       const importOffersButton = screen.getByText('Synchroniser des offres')
 
       // when
-      fireEvent.click(importOffersButton)
+      await userEvent.click(importOffersButton)
 
       // then
       const providersSelect = screen.getByRole('combobox')
@@ -176,7 +182,7 @@ describe('src | VenueProvidersManager', () => {
       const importOffersButton = screen.getByText('Synchroniser des offres')
 
       // when
-      fireEvent.click(importOffersButton)
+      await userEvent.click(importOffersButton)
 
       // then
       expect(screen.queryByText('Compte')).not.toBeInTheDocument()
@@ -196,13 +202,11 @@ describe('src | VenueProvidersManager', () => {
         pcapi.loadProviders.mockResolvedValue(providers)
         await renderVenueProvidersManager(props)
         const importOffersButton = screen.getByText('Synchroniser des offres')
-        fireEvent.click(importOffersButton)
+        await userEvent.click(importOffersButton)
         const providersSelect = screen.getByRole('combobox')
 
         // when
-        fireEvent.change(providersSelect, {
-          target: { value: providers[0].id },
-        })
+        await userEvent.selectOptions(providersSelect, providers[0].id)
 
         // then
         expect(screen.getByText('Prix de vente/place')).toBeInTheDocument()
@@ -218,13 +222,11 @@ describe('src | VenueProvidersManager', () => {
         pcapi.loadProviders.mockResolvedValue(providers)
         await renderVenueProvidersManager(props)
         const importOffersButton = screen.getByText('Synchroniser des offres')
-        fireEvent.click(importOffersButton)
+        await userEvent.click(importOffersButton)
         const providersSelect = screen.getByRole('combobox')
 
         // when
-        fireEvent.change(providersSelect, {
-          target: { value: providers[0].id },
-        })
+        await userEvent.selectOptions(providersSelect, providers[0].id)
 
         // then
         expect(screen.getByText('Compte')).toBeInTheDocument()

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManagerV2/DeleteVenueProviderButton/DeleteVenueProviderButton.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManagerV2/DeleteVenueProviderButton/DeleteVenueProviderButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import useNotification from 'components/hooks/useNotification'
 import { useModal } from 'hooks/useModal'
@@ -22,13 +22,6 @@ const DeleteVenueProviderButton = ({
   const { visible, showModal, hideModal } = useModal()
   const [isLoading, setIsLoading] = useState(false)
   const notification = useNotification()
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const tryToDeleteVenueProvider = useCallback(async () => {
     setIsLoading(true)
@@ -41,10 +34,8 @@ const DeleteVenueProviderButton = ({
         'Une erreur est survenue. Merci de réessayer plus tard.'
       )
     } finally {
-      if (mountedRef.current) {
-        hideModal()
-        setIsLoading(false)
-      }
+      hideModal()
+      setIsLoading(false)
     }
   }, [notification, hideModal])
   return (

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
@@ -10,10 +10,6 @@ jest.mock('utils/config', () => ({
     'link/to/venue/demarchesSimplifiees/procedure',
 }))
 
-const renderBankInformation = props => {
-  render(<BankInformation {...props} />)
-}
-
 describe('src | Venue | BankInformation', () => {
   const venue = {
     id: 'AA',
@@ -43,7 +39,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         expect(
@@ -93,7 +89,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         expect(screen.getByText(props.offerer.bic)).toBeInTheDocument()
@@ -121,7 +117,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         expect(screen.getByText(props.venue.bic)).toBeInTheDocument()
@@ -145,7 +141,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
@@ -174,7 +170,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
@@ -199,7 +195,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
@@ -229,7 +225,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        renderBankInformation(props)
+        render(<BankInformation {...props} />)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 
 import BankInformation from '../BankInformationFields'
@@ -10,10 +10,8 @@ jest.mock('utils/config', () => ({
     'link/to/venue/demarchesSimplifiees/procedure',
 }))
 
-const renderBankInformation = async props => {
-  return await act(async () => {
-    render(<BankInformation {...props} />)
-  })
+const renderBankInformation = props => {
+  render(<BankInformation {...props} />)
 }
 
 describe('src | Venue | BankInformation', () => {
@@ -33,7 +31,7 @@ describe('src | Venue | BankInformation', () => {
 
   describe('when no application has been made or application has been refused', () => {
     describe('when the offerer has no bank information', () => {
-      it('should render instruction block', async () => {
+      it('should render instruction block', () => {
         // Given
         props = {
           ...props,
@@ -45,7 +43,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         expect(
@@ -78,7 +76,7 @@ describe('src | Venue | BankInformation', () => {
     })
 
     describe('when the offerer has bank information', () => {
-      it('should render offerer information', async () => {
+      it('should render offerer information', () => {
         // Given
         props = {
           ...props,
@@ -95,7 +93,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         expect(screen.getByText(props.offerer.bic)).toBeInTheDocument()
@@ -106,7 +104,7 @@ describe('src | Venue | BankInformation', () => {
 
   describe('when application has been validated', () => {
     describe('when venue and offerer banking information are both provided', () => {
-      it('should render venue informations', async () => {
+      it('should render venue informations', () => {
         // Given
         props = {
           ...props,
@@ -123,7 +121,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         expect(screen.getByText(props.venue.bic)).toBeInTheDocument()
@@ -134,7 +132,7 @@ describe('src | Venue | BankInformation', () => {
 
   describe('when application is in construction or in instruction', () => {
     describe('when offerer has no bank informations', () => {
-      it('should render current application detail', async () => {
+      it('should render current application detail', () => {
         // Given
         props = {
           ...props,
@@ -147,7 +145,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
@@ -158,7 +156,7 @@ describe('src | Venue | BankInformation', () => {
     })
 
     describe('when offerer has bank informations', () => {
-      it('should render current application detail and offerer bank informations', async () => {
+      it('should render current application detail and offerer bank informations', () => {
         // Given
         props = {
           ...props,
@@ -176,7 +174,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
@@ -188,7 +186,7 @@ describe('src | Venue | BankInformation', () => {
         expect(screen.getByText(props.offerer.iban)).toBeInTheDocument()
       })
 
-      it('should render current application detail when demarchesSimplifieesApplicationId is provided', async () => {
+      it('should render current application detail when demarchesSimplifieesApplicationId is provided', () => {
         // Given
         props = {
           ...props,
@@ -201,7 +199,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`
@@ -213,7 +211,7 @@ describe('src | Venue | BankInformation', () => {
         expect(screen.queryByText('IBAN')).not.toBeInTheDocument()
       })
 
-      it('should render current application detail and offerer bank informations when both presents in props', async () => {
+      it('should render current application detail and offerer bank informations when both presents in props', () => {
         // Given
         props = {
           ...props,
@@ -231,7 +229,7 @@ describe('src | Venue | BankInformation', () => {
         }
 
         // when
-        await renderBankInformation(props)
+        renderBankInformation(props)
 
         // then
         const expectedUrl = `https://www.demarches-simplifiees.fr/dossiers/${props.venue.demarchesSimplifieesApplicationId}`

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BicIbanFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BicIbanFields.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { BicIbanFields } from '../BicIbanFields'
@@ -10,20 +10,18 @@ jest.mock('utils/config', () => ({
     'link/to/venue/demarchesSimplifiees/procedure',
 }))
 
-const renderBicIbanFields = async props => {
-  return await act(async () => {
-    render(<BicIbanFields {...props} />)
-  })
+const renderBicIbanFields = props => {
+  render(<BicIbanFields {...props} />)
 }
 
 describe('src | Venue | BicIbanFields', () => {
-  it('should display bank informations', async () => {
+  it('should display bank informations', () => {
     // Given
     const props = {
       bic: '123 456 789',
       iban: 'FRBICAVECUNEVALEURPARDEFAUT',
     }
-    await renderBicIbanFields(props)
+    renderBicIbanFields(props)
 
     // then
     expect(

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BicIbanFields.spec.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BicIbanFields.spec.jsx
@@ -10,10 +10,6 @@ jest.mock('utils/config', () => ({
     'link/to/venue/demarchesSimplifiees/procedure',
 }))
 
-const renderBicIbanFields = props => {
-  render(<BicIbanFields {...props} />)
-}
-
 describe('src | Venue | BicIbanFields', () => {
   it('should display bank informations', () => {
     // Given
@@ -21,7 +17,7 @@ describe('src | Venue | BicIbanFields', () => {
       bic: '123 456 789',
       iban: 'FRBICAVECUNEVALEURPARDEFAUT',
     }
-    renderBicIbanFields(props)
+    render(<BicIbanFields {...props} />)
 
     // then
     expect(

--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/LocationViewer.jsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/LocationFields/LocationViewer.jsx
@@ -47,14 +47,6 @@ class LocationViewer extends PureComponent {
       props.debounceTimeout
     )
   }
-  componentDidMount() {
-    // bad pattern, the real solution is to migrate the component to functional component
-    this.mounted = true
-  }
-
-  componentWillUnmount() {
-    this.mounted = false
-  }
 
   static getDerivedStateFromProps(newProps, state) {
     const latitude = sanitizeCoordinates(newProps.latitude)
@@ -189,41 +181,39 @@ class LocationViewer extends PureComponent {
   }
 
   fetchSuggestions = address => {
-    if (this.mounted) {
-      const { maxSuggestions, placeholder } = this.props
-      this.setState({ isLoading: true })
+    const { maxSuggestions, placeholder } = this.props
+    this.setState({ isLoading: true })
 
-      // NOTE: CANNOT EXPRESS THIS WITH AWAIT ASYNC
-      // BECAUSE this.props cannot be found in that case...
-      // weird
-      getSuggestionsFromAddressAndMaxSuggestions(address, maxSuggestions).then(
-        result => {
-          if (result.error) {
-            return
-          }
+    // NOTE: CANNOT EXPRESS THIS WITH AWAIT ASYNC
+    // BECAUSE this.props cannot be found in that case...
+    // weird
+    getSuggestionsFromAddressAndMaxSuggestions(address, maxSuggestions).then(
+      result => {
+        if (result.error) {
+          return
+        }
 
-          const hasNoData = result.data.length === 0
-          if (hasNoData) {
-            this.setState({
-              isLoading: false,
-            })
-            return
-          }
-
-          const defaultSuggestion = {
-            label: placeholder,
-            placeholder: true,
-            id: 'placeholder',
-          }
-
-          const suggestions = result.data.concat(defaultSuggestion)
+        const hasNoData = result.data.length === 0
+        if (hasNoData) {
           this.setState({
             isLoading: false,
-            suggestions,
           })
+          return
         }
-      )
-    }
+
+        const defaultSuggestion = {
+          label: placeholder,
+          placeholder: true,
+          id: 'placeholder',
+        }
+
+        const suggestions = result.data.concat(defaultSuggestion)
+        this.setState({
+          isLoading: false,
+          suggestions,
+        })
+      }
+    )
   }
 
   renderSuggestionsMenu = suggestionElements => {

--- a/pro/src/components/pages/Offers/Offer/Confirmation/__specs__/Confirmation.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Confirmation/__specs__/Confirmation.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 
 import { api } from 'apiClient/api'
 import { renderOffer } from 'components/pages/Offers/Offer/__specs__/render'
@@ -23,15 +23,17 @@ describe('confirmation page', () => {
     jest.spyOn(api, 'getOffer').mockResolvedValue(offer)
 
     // When
-    await renderOffer({
+    renderOffer({
       pathname: `/offre/${offer.id}/individuel/creation/confirmation`,
     })
 
     // Then
+    await waitFor(() => {
+      expect(
+        screen.getByText('Offre publiée !', { selector: 'h2' })
+      ).toBeInTheDocument()
+    })
     expect(screen.queryByText('active')).not.toBeInTheDocument()
-    expect(
-      screen.getByText('Offre publiée !', { selector: 'h2' })
-    ).toBeInTheDocument()
     expect(
       screen.getByText(
         'Votre offre est désormais disponible à la réservation sur l’application pass Culture.',
@@ -64,15 +66,17 @@ describe('confirmation page', () => {
     jest.spyOn(api, 'getOffer').mockResolvedValue(offer)
 
     // When
-    await renderOffer({
+    renderOffer({
       pathname: `/offre/${offer.id}/individuel/creation/confirmation`,
     })
 
     // Then
+    await waitFor(() => {
+      expect(
+        screen.getByText('Offre en cours de validation', { selector: 'h2' })
+      ).toBeInTheDocument()
+    })
     expect(screen.queryByText('active')).not.toBeInTheDocument()
-    expect(
-      screen.getByText('Offre en cours de validation', { selector: 'h2' })
-    ).toBeInTheDocument()
     expect(
       screen.queryByText(content =>
         content.startsWith(

--- a/pro/src/components/pages/Offers/Offer/Confirmation/__specs__/Confirmation.tracker.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Confirmation/__specs__/Confirmation.tracker.spec.jsx
@@ -86,12 +86,12 @@ describe('confirmation page', () => {
 
   it('should track when clicking on offer creation button', async () => {
     // Given
-    await renderOffer({
+    renderOffer({
       pathname: `/offre/${offer.id}/individuel/creation/confirmation`,
     })
 
     // When
-    await userEvent.click(screen.getByText('Créer une nouvelle offre'))
+    await userEvent.click(await screen.findByText('Créer une nouvelle offre'))
 
     // Then
     expect(mockLogEvent).toHaveBeenCalledTimes(1)
@@ -109,12 +109,12 @@ describe('confirmation page', () => {
 
   it('should track when clicking on got to offers button', async () => {
     // Given
-    await renderOffer({
+    renderOffer({
       pathname: `/offre/${offer.id}/individuel/creation/confirmation`,
     })
 
     // When
-    await userEvent.click(screen.getByText('Voir la liste des offres'))
+    await userEvent.click(await screen.findByText('Voir la liste des offres'))
 
     // Then
     expect(mockLogEvent).toHaveBeenCalledTimes(1)
@@ -132,13 +132,13 @@ describe('confirmation page', () => {
 
   it('should track when clicking on view in app link', async () => {
     // Given
-    await renderOffer({
+    renderOffer({
       pathname: `/offre/${offer.id}/individuel/creation/confirmation`,
     })
 
     // When
     await userEvent.click(
-      screen.getByText('Visualiser l’offre dans l’application')
+      await screen.findByText('Visualiser l’offre dans l’application')
     )
 
     // Then

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferPreview/__specs__/OfferPreview.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferPreview/__specs__/OfferPreview.spec.jsx
@@ -8,17 +8,9 @@ import { loadFakeApiVenue } from 'utils/fakeApi'
 
 import OfferPreview from '../OfferPreview'
 
-const renderOfferPreview = async ({ props = {} }) => {
-  render(<OfferPreview {...props} />)
-
-  await waitFor(() => {
-    expect(screen.getByTestId('offer-preview-section')).toBeInTheDocument()
-  })
-}
-
 describe('offer preview', () => {
   describe('render', () => {
-    it('should display title, description and withdrawal details when given', async () => {
+    it('should display title, description and withdrawal details when given', () => {
       // given
       const props = {
         offerPreviewData: {
@@ -29,7 +21,7 @@ describe('offer preview', () => {
       }
 
       // when
-      await renderOfferPreview({ props })
+      render(<OfferPreview {...props} />)
 
       // then
       expect(screen.getByText('Offer title')).toBeInTheDocument()
@@ -38,7 +30,7 @@ describe('offer preview', () => {
       expect(screen.getByText('Offer withdrawal details')).toBeInTheDocument()
     })
 
-    it('should truncate description text to maximum 300 characters', async () => {
+    it('should truncate description text to maximum 300 characters', () => {
       // given
       const props = {
         offerPreviewData: {
@@ -48,7 +40,7 @@ describe('offer preview', () => {
       }
 
       // when
-      await renderOfferPreview({ props })
+      render(<OfferPreview {...props} />)
 
       // then
       const shrinkedDescriptionText = screen.getByText(
@@ -57,7 +49,7 @@ describe('offer preview', () => {
       expect(shrinkedDescriptionText).toBeInTheDocument()
     })
 
-    it('should not display terms of withdrawal category if not given', async () => {
+    it('should not display terms of withdrawal category if not given', () => {
       // given
       const props = {
         offerPreviewData: {
@@ -68,13 +60,13 @@ describe('offer preview', () => {
       }
 
       // when
-      await renderOfferPreview({ props })
+      render(<OfferPreview {...props} />)
 
       // then
       expect(screen.queryByText('Modalités de retrait')).toBeNull()
     })
 
-    it('should truncate withdrawal details text to maximum 300 characters', async () => {
+    it('should truncate withdrawal details text to maximum 300 characters', () => {
       // given
       const props = {
         offerPreviewData: {
@@ -84,7 +76,7 @@ describe('offer preview', () => {
       }
 
       // when
-      await renderOfferPreview({ props })
+      render(<OfferPreview {...props} />)
 
       // then
       const shrinkedWithdrawalDetailsText = screen.getByText(
@@ -93,7 +85,7 @@ describe('offer preview', () => {
       expect(shrinkedWithdrawalDetailsText).toBeInTheDocument()
     })
 
-    it('should display "isDuo", "Type" and "Price"', async () => {
+    it('should display "isDuo", "Type" and "Price"', () => {
       // given
       const props = {
         offerPreviewData: {
@@ -102,7 +94,7 @@ describe('offer preview', () => {
       }
 
       // when
-      await renderOfferPreview({ props })
+      render(<OfferPreview {...props} />)
 
       // then
       const typeText = screen.getByText('Type')
@@ -125,7 +117,12 @@ describe('offer preview', () => {
         }
 
         // When
-        await renderOfferPreview({ props })
+        render(<OfferPreview {...props} />)
+        await waitFor(() => {
+          expect(
+            screen.getByTestId('offer-preview-section')
+          ).toBeInTheDocument()
+        })
 
         // Then
         expect(
@@ -147,7 +144,12 @@ describe('offer preview', () => {
         }
 
         // When
-        await renderOfferPreview({ props })
+        render(<OfferPreview {...props} />)
+        await waitFor(() => {
+          expect(
+            screen.getByTestId('offer-preview-section')
+          ).toBeInTheDocument()
+        })
 
         // Then
         expect(screen.getByText('Mon Lieu - Ma Ville')).toBeInTheDocument()
@@ -166,7 +168,12 @@ describe('offer preview', () => {
         }
 
         // When
-        await renderOfferPreview({ props })
+        render(<OfferPreview {...props} />)
+        await waitFor(() => {
+          expect(
+            screen.getByTestId('offer-preview-section')
+          ).toBeInTheDocument()
+        })
 
         // Then
         expect(screen.queryByText('Où ?')).not.toBeInTheDocument()

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferPreview/__specs__/OfferPreview.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferPreview/__specs__/OfferPreview.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import { venueFactory } from 'utils/apiFactories'
@@ -8,13 +8,17 @@ import { loadFakeApiVenue } from 'utils/fakeApi'
 
 import OfferPreview from '../OfferPreview'
 
-const renderOfferPreview = ({ props = {} }) => {
-  return render(<OfferPreview {...props} />)
+const renderOfferPreview = async ({ props = {} }) => {
+  render(<OfferPreview {...props} />)
+
+  await waitFor(() => {
+    expect(screen.getByTestId('offer-preview-section')).toBeInTheDocument()
+  })
 }
 
 describe('offer preview', () => {
   describe('render', () => {
-    it('should display title, description and withdrawal details when given', () => {
+    it('should display title, description and withdrawal details when given', async () => {
       // given
       const props = {
         offerPreviewData: {
@@ -25,7 +29,7 @@ describe('offer preview', () => {
       }
 
       // when
-      renderOfferPreview({ props })
+      await renderOfferPreview({ props })
 
       // then
       expect(screen.getByText('Offer title')).toBeInTheDocument()
@@ -34,7 +38,7 @@ describe('offer preview', () => {
       expect(screen.getByText('Offer withdrawal details')).toBeInTheDocument()
     })
 
-    it('should truncate description text to maximum 300 characters', () => {
+    it('should truncate description text to maximum 300 characters', async () => {
       // given
       const props = {
         offerPreviewData: {
@@ -44,7 +48,7 @@ describe('offer preview', () => {
       }
 
       // when
-      renderOfferPreview({ props })
+      await renderOfferPreview({ props })
 
       // then
       const shrinkedDescriptionText = screen.getByText(
@@ -53,7 +57,7 @@ describe('offer preview', () => {
       expect(shrinkedDescriptionText).toBeInTheDocument()
     })
 
-    it('should not display terms of withdrawal category if not given', () => {
+    it('should not display terms of withdrawal category if not given', async () => {
       // given
       const props = {
         offerPreviewData: {
@@ -64,13 +68,13 @@ describe('offer preview', () => {
       }
 
       // when
-      renderOfferPreview({ props })
+      await renderOfferPreview({ props })
 
       // then
       expect(screen.queryByText('Modalités de retrait')).toBeNull()
     })
 
-    it('should truncate withdrawal details text to maximum 300 characters', () => {
+    it('should truncate withdrawal details text to maximum 300 characters', async () => {
       // given
       const props = {
         offerPreviewData: {
@@ -80,7 +84,7 @@ describe('offer preview', () => {
       }
 
       // when
-      renderOfferPreview({ props })
+      await renderOfferPreview({ props })
 
       // then
       const shrinkedWithdrawalDetailsText = screen.getByText(
@@ -89,7 +93,7 @@ describe('offer preview', () => {
       expect(shrinkedWithdrawalDetailsText).toBeInTheDocument()
     })
 
-    it('should display "isDuo", "Type" and "Price"', () => {
+    it('should display "isDuo", "Type" and "Price"', async () => {
       // given
       const props = {
         offerPreviewData: {
@@ -98,7 +102,7 @@ describe('offer preview', () => {
       }
 
       // when
-      renderOfferPreview({ props })
+      await renderOfferPreview({ props })
 
       // then
       const typeText = screen.getByText('Type')
@@ -121,12 +125,12 @@ describe('offer preview', () => {
         }
 
         // When
-        renderOfferPreview({ props })
+        await renderOfferPreview({ props })
 
         // Then
-        await expect(
-          screen.findByText('Mon Lieu - Ma Rue - 11100 - Ma Ville')
-        ).resolves.toBeInTheDocument()
+        expect(
+          screen.getByText('Mon Lieu - Ma Rue - 11100 - Ma Ville')
+        ).toBeInTheDocument()
       })
 
       it('should not display any non given venue field', async () => {
@@ -143,12 +147,10 @@ describe('offer preview', () => {
         }
 
         // When
-        renderOfferPreview({ props })
+        await renderOfferPreview({ props })
 
         // Then
-        await expect(
-          screen.findByText('Mon Lieu - Ma Ville')
-        ).resolves.toBeInTheDocument()
+        expect(screen.getByText('Mon Lieu - Ma Ville')).toBeInTheDocument()
       })
     })
 
@@ -156,7 +158,7 @@ describe('offer preview', () => {
       it('should not display venue information if venue is virtual', async () => {
         // Given
         const venue = venueFactory({ isVirtual: true })
-        const { resolvingVenuePromise } = loadFakeApiVenue(venue)
+        loadFakeApiVenue(venue)
         const props = {
           offerPreviewData: {
             venueId: venue.id,
@@ -164,10 +166,9 @@ describe('offer preview', () => {
         }
 
         // When
-        renderOfferPreview({ props })
+        await renderOfferPreview({ props })
 
         // Then
-        await act(() => resolvingVenuePromise)
         expect(screen.queryByText('Où ?')).not.toBeInTheDocument()
       })
     })

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/FillAccessibilityFromVenue/FillAccessibilityFromVenue.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/FillAccessibilityFromVenue/FillAccessibilityFromVenue.spec.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { getOfferInputForField, setOfferValues } from '../helpers'
+import { setOfferValues } from '../helpers'
 
 import { initialize } from './helpers'
 import {
@@ -23,22 +23,12 @@ describe('should initialize creation form with venue accessibility from query pa
       selectedVenueFromUrl: venuePhysicalUndefinedAccessibility,
       selectedSubcategoryId: 'ID_SUB_CATEGORY_1_ONLINE_OR_OFFLINE',
     })
-
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    screen.getByLabelText(/Auditif/)
+    expect(screen.getByLabelText(/Auditif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 
   it('should have venue accessibilty when venue have accessibility set.', async () => {
@@ -47,21 +37,11 @@ describe('should initialize creation form with venue accessibility from query pa
       selectedSubcategoryId: 'ID_SUB_CATEGORY_1_ONLINE_OR_OFFLINE',
     })
 
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 })
 
@@ -71,21 +51,11 @@ describe('should initialize edition form', () => {
       offer: offerAccessible,
     })
 
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 
   it("should have venue accessibilty venue have accessibility and offer don't.", async () => {
@@ -93,21 +63,11 @@ describe('should initialize edition form', () => {
       offer: offerUndefinedAccessibilityVenueAccessible,
     })
 
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 
   it('should be empty if neither offer and venue have accessibility.', async () => {
@@ -115,21 +75,11 @@ describe('should initialize edition form', () => {
       offer: offerUndefinedAccessibility,
     })
 
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 })
 
@@ -141,39 +91,19 @@ describe('test creation form venue edition', () => {
     })
     await setOfferValues({ venueId: venuePhysicalAccessible.id })
 
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
 
     // virtual venues have all accessibility values as null
     await setOfferValues({ venueId: venueVirtual.id })
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 
   it('should set venue accessibility when subCategory change.', async () => {
@@ -184,21 +114,11 @@ describe('test creation form venue edition', () => {
 
     await setOfferValues({ subcategoryId: 'ID_SUB_CATEGORY_1_ONLINE' })
 
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).not.toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).not.toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 })
 
@@ -215,21 +135,11 @@ describe('test creation form offerer edition', () => {
     })
 
     await screen.findByDisplayValue(offerer2VenuePhysicalAccessible.name)
-    expect(
-      await getOfferInputForField('audioDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('mentalDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('motorDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('visualDisabilityCompliant')
-    ).toBeChecked()
-    expect(
-      await getOfferInputForField('noDisabilityCompliant')
-    ).not.toBeChecked()
+    expect(screen.getByLabelText(/Auditif/)).toBeChecked()
+    expect(screen.getByLabelText(/Psychique ou cognitif/)).toBeChecked()
+    expect(screen.getByLabelText(/Moteur/)).toBeChecked()
+    expect(screen.getByLabelText(/Visuel/)).toBeChecked()
+    expect(screen.getByLabelText(/Non accessible/)).not.toBeChecked()
   })
 })
 
@@ -241,21 +151,11 @@ describe('test accessibily checkbox click', () => {
     })
 
     const accessibilityCheckboxes = {
-      audioDisabilityCompliant: await getOfferInputForField(
-        'audioDisabilityCompliant'
-      ),
-      mentalDisabilityCompliant: await getOfferInputForField(
-        'mentalDisabilityCompliant'
-      ),
-      motorDisabilityCompliant: await getOfferInputForField(
-        'motorDisabilityCompliant'
-      ),
-      visualDisabilityCompliant: await getOfferInputForField(
-        'visualDisabilityCompliant'
-      ),
-      noDisabilityCompliant: await getOfferInputForField(
-        'noDisabilityCompliant'
-      ),
+      audioDisabilityCompliant: screen.getByLabelText(/Auditif/),
+      mentalDisabilityCompliant: screen.getByLabelText(/Psychique ou cognitif/),
+      motorDisabilityCompliant: screen.getByLabelText(/Moteur/),
+      visualDisabilityCompliant: screen.getByLabelText(/Visuel/),
+      noDisabilityCompliant: screen.getByLabelText(/Non accessible/),
     }
 
     // initial value are empty, all values are false

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/FillAccessibilityFromVenue/FillAccessibilityFromVenue.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/FillAccessibilityFromVenue/FillAccessibilityFromVenue.spec.jsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { getOfferInputForField, setOfferValues } from '../helpers'
 
@@ -23,21 +24,21 @@ describe('should initialize creation form with venue accessibility from query pa
       selectedSubcategoryId: 'ID_SUB_CATEGORY_1_ONLINE_OR_OFFLINE',
     })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 
   it('should have venue accessibilty when venue have accessibility set.', async () => {
@@ -46,21 +47,21 @@ describe('should initialize creation form with venue accessibility from query pa
       selectedSubcategoryId: 'ID_SUB_CATEGORY_1_ONLINE_OR_OFFLINE',
     })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 })
 
@@ -70,21 +71,21 @@ describe('should initialize edition form', () => {
       offer: offerAccessible,
     })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 
   it("should have venue accessibilty venue have accessibility and offer don't.", async () => {
@@ -92,21 +93,21 @@ describe('should initialize edition form', () => {
       offer: offerUndefinedAccessibilityVenueAccessible,
     })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 
   it('should be empty if neither offer and venue have accessibility.', async () => {
@@ -114,21 +115,21 @@ describe('should initialize edition form', () => {
       offer: offerUndefinedAccessibility,
     })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 })
 
@@ -140,39 +141,39 @@ describe('test creation form venue edition', () => {
     })
     await setOfferValues({ venueId: venuePhysicalAccessible.id })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
 
     // virtual venues have all accessibility values as null
     await setOfferValues({ venueId: venueVirtual.id })
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 
   it('should set venue accessibility when subCategory change.', async () => {
@@ -183,21 +184,21 @@ describe('test creation form venue edition', () => {
 
     await setOfferValues({ subcategoryId: 'ID_SUB_CATEGORY_1_ONLINE' })
 
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.not.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).not.toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 })
 
@@ -214,21 +215,21 @@ describe('test creation form offerer edition', () => {
     })
 
     await screen.findByDisplayValue(offerer2VenuePhysicalAccessible.name)
-    await expect(
-      getOfferInputForField('audioDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('mentalDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('motorDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('visualDisabilityCompliant')
-    ).resolves.toBeChecked()
-    await expect(
-      getOfferInputForField('noDisabilityCompliant')
-    ).resolves.not.toBeChecked()
+    expect(
+      await getOfferInputForField('audioDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('mentalDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('motorDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('visualDisabilityCompliant')
+    ).toBeChecked()
+    expect(
+      await getOfferInputForField('noDisabilityCompliant')
+    ).not.toBeChecked()
   })
 })
 
@@ -265,7 +266,7 @@ describe('test accessibily checkbox click', () => {
     expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
 
     // one accessibility true, other falses
-    await fireEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
+    await userEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
     expect(accessibilityCheckboxes.audioDisabilityCompliant).toBeChecked()
     expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
@@ -273,7 +274,7 @@ describe('test accessibily checkbox click', () => {
     expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
 
     // all accessibility false, noDisabilityCompliant should be true
-    await fireEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
+    await userEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
     expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
@@ -281,7 +282,7 @@ describe('test accessibily checkbox click', () => {
     expect(accessibilityCheckboxes.noDisabilityCompliant).toBeChecked()
 
     // again, one accessibility true, other falses
-    await fireEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
+    await userEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
     expect(accessibilityCheckboxes.audioDisabilityCompliant).toBeChecked()
     expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
@@ -289,7 +290,7 @@ describe('test accessibily checkbox click', () => {
     expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
 
     // click on noDisabilityCompliant should change other accessibility to false
-    await fireEvent.click(accessibilityCheckboxes.noDisabilityCompliant)
+    await userEvent.click(accessibilityCheckboxes.noDisabilityCompliant)
     expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
@@ -297,7 +298,7 @@ describe('test accessibily checkbox click', () => {
     expect(accessibilityCheckboxes.noDisabilityCompliant).toBeChecked()
 
     // a second click on noDisabilityCompliant shouldn't change values
-    await fireEvent.click(accessibilityCheckboxes.noDisabilityCompliant)
+    await userEvent.click(accessibilityCheckboxes.noDisabilityCompliant)
     expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
     expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForAdmin.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForAdmin.spec.jsx
@@ -27,7 +27,7 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderOffers = async (props, store, queryParams = null) => {
+const renderOffers = (props, store, queryParams = null) => {
   render(
     <Provider store={store}>
       <MemoryRouter
@@ -44,9 +44,6 @@ const renderOffers = async (props, store, queryParams = null) => {
       </MemoryRouter>
     </Provider>
   )
-  await waitFor(() => {
-    expect(screen.getByTestId('offer-page')).toBeInTheDocument()
-  })
 }
 
 describe('offerDetails - Creation - admin user', () => {
@@ -127,7 +124,10 @@ describe('offerDetails - Creation - admin user', () => {
   describe('render when creating a new offer as admin', () => {
     it('should get selected offerer from API', async () => {
       // When
-      await renderOffers(props, store, `?structure=${offerer.id}`)
+      renderOffers(props, store, `?structure=${offerer.id}`)
+      await waitFor(() => {
+        expect(screen.getByTestId('offer-page')).toBeInTheDocument()
+      })
 
       // Then
       expect(api.getOfferer).toHaveBeenLastCalledWith(offerer.id)
@@ -135,7 +135,10 @@ describe('offerDetails - Creation - admin user', () => {
 
     it('should not get venues from API', async () => {
       // When
-      await renderOffers(props, store, `?structure=${offerer.id}`)
+      renderOffers(props, store, `?structure=${offerer.id}`)
+      await waitFor(() => {
+        expect(screen.getByTestId('offer-page')).toBeInTheDocument()
+      })
 
       // Then
       expect(api.getVenues).toHaveBeenCalledTimes(0)
@@ -144,7 +147,7 @@ describe('offerDetails - Creation - admin user', () => {
     describe('when selecting an offer type', () => {
       it('should have offerer selected and select disabled', async () => {
         // Given
-        await renderOffers(props, store, `?structure=${offerer.id}`)
+        renderOffers(props, store, `?structure=${offerer.id}`)
 
         // When
         await setOfferValues({ categoryId: 'ID' })
@@ -159,7 +162,7 @@ describe('offerDetails - Creation - admin user', () => {
 
       it('should have venue selected when given as queryParam', async () => {
         // Given
-        await renderOffers(
+        renderOffers(
           props,
           store,
           `?lieu=${venues[0].id}&structure=${venues[0].managingOffererId}`

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForAdmin.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForAdmin.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { act, render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router'
@@ -28,23 +28,24 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderOffers = async (props, store, queryParams = null) => {
-  await act(async () => {
-    render(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: '/offre/creation/individuel', search: queryParams },
-          ]}
-        >
-          <Route path="/offre/">
-            <>
-              <OfferLayout {...props} />
-              <Notification />
-            </>
-          </Route>
-        </MemoryRouter>
-      </Provider>
-    )
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[
+          { pathname: '/offre/creation/individuel', search: queryParams },
+        ]}
+      >
+        <Route path="/offre/">
+          <>
+            <OfferLayout {...props} />
+            <Notification />
+          </>
+        </Route>
+      </MemoryRouter>
+    </Provider>
+  )
+  await waitFor(() => {
+    expect(screen.getByTestId('offer-page')).toBeInTheDocument()
   })
 }
 

--- a/pro/src/components/pages/Offers/Offer/OfferLayout.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferLayout.jsx
@@ -101,7 +101,7 @@ const OfferLayout = () => {
   }
 
   return (
-    <div className="offer-page">
+    <div className="offer-page" data-testid="offer-page">
       <div
         className={cn('title-section', {
           'without-name': !offer?.name,

--- a/pro/src/components/pages/Offers/Offer/OfferStatus/__specs__/StatusToggleButton.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferStatus/__specs__/StatusToggleButton.spec.jsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import * as useNotification from 'components/hooks/useNotification'
@@ -25,9 +25,7 @@ jest.mock('react-router-dom', () => ({
 const renderStatusToggleButton = (offer, store) => {
   render(
     <Provider store={configureTestStore(store)}>
-      <MemoryRouter>
-        <StatusToggleButton offer={offer} reloadOffer={jest.fn()} />
-      </MemoryRouter>
+      <StatusToggleButton offer={offer} reloadOffer={jest.fn()} />
     </Provider>
   )
 }
@@ -55,18 +53,17 @@ describe('StatusToggleButton', () => {
     renderStatusToggleButton(offer)
 
     // then
-    fireEvent.click(screen.getByRole('button', { name: /Désactiver/ }))
+    await userEvent.click(screen.getByRole('button', { name: /Désactiver/ }))
 
     expect(toggle).toHaveBeenCalledTimes(1)
     expect(toggle).toHaveBeenNthCalledWith(1, {
       ids: ['AG3A'],
       isActive: false,
     })
-    await waitFor(() =>
-      expect(notifySuccess).toHaveBeenNthCalledWith(
-        1,
-        'L’offre a bien été désactivée.'
-      )
+
+    expect(notifySuccess).toHaveBeenNthCalledWith(
+      1,
+      'L’offre a bien été désactivée.'
     )
   })
   it('should activate an offer and confirm', async () => {
@@ -86,17 +83,15 @@ describe('StatusToggleButton', () => {
     })
 
     // then
-    fireEvent.click(screen.getByText(/Publier/))
+    await userEvent.click(screen.getByText(/Publier/))
     expect(toggleFunction).toHaveBeenCalledTimes(1)
     expect(toggleFunction).toHaveBeenNthCalledWith(1, {
       ids: ['AG3A'],
       isActive: true,
     })
-    await waitFor(() =>
-      expect(notifySuccess).toHaveBeenNthCalledWith(
-        1,
-        'L’offre a bien été publiée.'
-      )
+    expect(notifySuccess).toHaveBeenNthCalledWith(
+      1,
+      'L’offre a bien été publiée.'
     )
   })
   it('should display error', async () => {
@@ -112,13 +107,11 @@ describe('StatusToggleButton', () => {
     renderStatusToggleButton(offer)
 
     // then
-    fireEvent.click(screen.getByText(/Désactiver/))
+    await userEvent.click(screen.getByText(/Désactiver/))
     expect(toggleFunction).toHaveBeenCalledTimes(1)
-    await waitFor(() =>
-      expect(notifyError).toHaveBeenNthCalledWith(
-        1,
-        'Une erreur est survenue, veuillez réessayer ultérieurement.'
-      )
+    expect(notifyError).toHaveBeenNthCalledWith(
+      1,
+      'Une erreur est survenue, veuillez réessayer ultérieurement.'
     )
   })
 })

--- a/pro/src/components/pages/Offers/Offer/Stocks/ActivationCodesUploadDialog/__specs__/ActivationCodesUploadDialog.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ActivationCodesUploadDialog/__specs__/ActivationCodesUploadDialog.spec.jsx
@@ -1,20 +1,14 @@
 import '@testing-library/jest-dom'
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import ActivationCodesUploadDialog from 'components/pages/Offers/Offer/Stocks/ActivationCodesUploadDialog/ActivationCodesUploadDialog'
 import { configureTestStore } from 'store/testUtils'
 
-const renderActivationCodesUploadDialog = async (store, props = {}) => {
-  return await act(async () => {
-    return render(
-      <Provider store={store}>
-        <ActivationCodesUploadDialog {...props} />
-      </Provider>
-    )
-  })
+const renderActivationCodesUploadDialog = (store, props = {}) => {
+  render(<ActivationCodesUploadDialog {...props} />)
 }
 
 describe('activationCodesUploadDialog', () => {
@@ -44,7 +38,7 @@ describe('activationCodesUploadDialog', () => {
       }
 
       // When
-      await renderActivationCodesUploadDialog(store, props)
+      renderActivationCodesUploadDialog(store, props)
 
       const uploadButton = screen.getByLabelText(
         'Importer un fichier .csv depuis l’ordinateur'
@@ -61,27 +55,21 @@ describe('activationCodesUploadDialog', () => {
         screen.getByTestId('activation-codes-upload-icon-id')
       ).toBeInTheDocument()
 
-      fireEvent.change(uploadButton, {
-        target: {
-          files: [file],
-        },
-      })
+      await userEvent.upload(uploadButton, file)
 
       // Then
-      waitFor(() =>
-        expect(
-          screen.getByText(
-            'Une erreur s’est produite lors de l’import de votre fichier',
-            { exact: false }
-          )
-        ).toBeInTheDocument()
-      )
+      expect(
+        screen.getByText(
+          'Une erreur s’est produite lors de l’import de votre fichier',
+          { exact: false }
+        )
+      ).toBeInTheDocument()
 
-      await expect(
-        screen.findByText(
+      expect(
+        screen.getByText(
           'Plusieurs codes identiques ont été trouvés dans le fichier : JHB, CEG.'
         )
-      ).resolves.toBeInTheDocument()
+      ).toBeInTheDocument()
 
       expect(
         screen.getByTestId('activation-codes-upload-error-icon-id')

--- a/pro/src/components/pages/Offers/Offer/Stocks/ActivationCodesUploadDialog/__specs__/ActivationCodesUploadDialog.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ActivationCodesUploadDialog/__specs__/ActivationCodesUploadDialog.spec.jsx
@@ -59,7 +59,7 @@ describe('activationCodesUploadDialog', () => {
 
       // Then
       expect(
-        screen.getByText(
+        await screen.findByText(
           'Une erreur s’est produite lors de l’import de votre fichier',
           { exact: false }
         )

--- a/pro/src/components/pages/Offers/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
@@ -56,8 +56,6 @@ const DeleteStockDialog = ({ isEvent, onDelete, setIsDeleting, stockId }) => {
 
 DeleteStockDialog.propTypes = {
   isEvent: PropTypes.bool.isRequired,
-  notifyDeletionError: PropTypes.func.isRequired,
-  notifyDeletionSuccess: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   setIsDeleting: PropTypes.func.isRequired,
   stockId: PropTypes.string.isRequired,

--- a/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -1,5 +1,11 @@
 import PropTypes from 'prop-types'
-import React, { Fragment, useCallback, useEffect, useState } from 'react'
+import React, {
+  Fragment,
+  useRef,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react'
 import { useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import { v4 as generateRandomUuid } from 'uuid'
@@ -61,16 +67,25 @@ const ThingStocks = ({ offer, reloadOffer }) => {
     : `/offre/${offer.id}/individuel/recapitulatif`
   const offersSearchFilters = useSelector(searchFiltersSelector)
   const offersPageNumber = useSelector(searchPageNumberSelector)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
   const loadStocks = useCallback(() => {
     return pcapi.loadStocks(offerId).then(receivedStocks => {
-      if (!receivedStocks.stocks.length) {
-        setStock(null)
-      } else {
-        setStock(
-          formatStock(receivedStocks.stocks[0], offer.venue.departementCode)
-        )
+      if (mountedRef.current) {
+        if (!receivedStocks.stocks.length) {
+          setStock(null)
+        } else {
+          setStock(
+            formatStock(receivedStocks.stocks[0], offer.venue.departementCode)
+          )
+        }
+        setIsLoading(false)
       }
-      setIsLoading(false)
     })
   }, [offerId, offer.venue.departementCode])
 
@@ -211,7 +226,11 @@ const ThingStocks = ({ offer, reloadOffer }) => {
             'Une ou plusieurs erreurs sont présentes dans le formulaire.'
           )
         )
-        .finally(() => setEnableSubmitButtonSpinner(false))
+        .finally(() => {
+          if (mountedRef.current) {
+            setEnableSubmitButtonSpinner(false)
+          }
+        })
     }
   }, [
     stock,

--- a/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -1,11 +1,5 @@
 import PropTypes from 'prop-types'
-import React, {
-  Fragment,
-  useRef,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react'
+import React, { Fragment, useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import { v4 as generateRandomUuid } from 'uuid'
@@ -67,25 +61,17 @@ const ThingStocks = ({ offer, reloadOffer }) => {
     : `/offre/${offer.id}/individuel/recapitulatif`
   const offersSearchFilters = useSelector(searchFiltersSelector)
   const offersPageNumber = useSelector(searchPageNumberSelector)
-  const mountedRef = useRef(true)
 
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
   const loadStocks = useCallback(() => {
     return pcapi.loadStocks(offerId).then(receivedStocks => {
-      if (mountedRef.current) {
-        if (!receivedStocks.stocks.length) {
-          setStock(null)
-        } else {
-          setStock(
-            formatStock(receivedStocks.stocks[0], offer.venue.departementCode)
-          )
-        }
-        setIsLoading(false)
+      if (!receivedStocks.stocks.length) {
+        setStock(null)
+      } else {
+        setStock(
+          formatStock(receivedStocks.stocks[0], offer.venue.departementCode)
+        )
       }
+      setIsLoading(false)
     })
   }, [offerId, offer.venue.departementCode])
 
@@ -227,9 +213,7 @@ const ThingStocks = ({ offer, reloadOffer }) => {
           )
         )
         .finally(() => {
-          if (mountedRef.current) {
-            setEnableSubmitButtonSpinner(false)
-          }
+          setEnableSubmitButtonSpinner(false)
         })
     }
   }, [

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -29,13 +29,13 @@ jest.mock('utils/date', () => ({
     .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
 }))
 
-const renderOffers = async (
+const renderOffers = (
   props,
   storeOverrides,
   pathname = '/offre/AG3A/individuel/stocks'
 ) => {
   const store = configureTestStore(storeOverrides)
-  return render(
+  render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: pathname }]}>
         <Route path="/offre/:offerId([A-Z0-9]+)/individuel">
@@ -152,7 +152,7 @@ describe('stocks page', () => {
   describe('create', () => {
     it('should not display offer status', async () => {
       // Given / When
-      await renderOffers(props, store)
+      renderOffers(props, store)
       await screen.findByRole('heading', { name: 'Stocks et prix' })
 
       // Then
@@ -163,12 +163,10 @@ describe('stocks page', () => {
       // Given
       pcapi.bulkCreateOrEditStock.mockResolvedValue({})
 
-      await renderOffers(props, store)
+      renderOffers(props, store)
 
       await userEvent.click(await screen.findByText('Ajouter un stock'))
-      fireEvent.change(screen.getByLabelText('Prix'), {
-        target: { value: '15' },
-      })
+      await userEvent.type(screen.getByLabelText('Prix'), '15')
 
       // When
       await userEvent.click(screen.getByText('Étape suivante'))
@@ -192,7 +190,7 @@ describe('stocks page', () => {
 
       it('should not display remaining stocks and bookings columns when no stocks yet', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -204,7 +202,7 @@ describe('stocks page', () => {
 
       it('should cancel new stock addition when clicking on cancel button', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
         // When
@@ -224,7 +222,7 @@ describe('stocks page', () => {
           beginningDatetime: '2020-12-20T22:00:00Z',
         }
         pcapi.loadStocks.mockResolvedValue({ stocks: [eventStock] })
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
         // when
@@ -240,7 +238,7 @@ describe('stocks page', () => {
 
       it('should have date, hour, price, limit datetime and quantity fields emptied by default', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -257,7 +255,7 @@ describe('stocks page', () => {
 
       it('should not have remaining stocks and bookings columns', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -270,7 +268,7 @@ describe('stocks page', () => {
 
       it('should have a cancel button to cancel new stock', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -309,7 +307,7 @@ describe('stocks page', () => {
         pcapi.loadStocks
           .mockResolvedValueOnce({ stocks: [] })
           .mockResolvedValueOnce({ stocks: createdStocks })
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
@@ -323,18 +321,14 @@ describe('stocks page', () => {
         )
         await userEvent.click(screen.getByText('20:00'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '15' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '15')
 
         await userEvent.click(
           screen.getAllByLabelText('Date limite de réservation')[0]
         )
         await userEvent.click(screen.getByText('22'))
 
-        fireEvent.change(screen.getByLabelText('Quantité'), {
-          target: { value: '15' },
-        })
+        await userEvent.type(screen.getByLabelText('Quantité'), '15')
 
         await userEvent.click(screen.getByText('Ajouter une date'))
 
@@ -348,9 +342,7 @@ describe('stocks page', () => {
         )
         await userEvent.click(screen.getByText('20:00'))
 
-        fireEvent.change(screen.getAllByLabelText('Prix')[0], {
-          target: { value: '0' },
-        })
+        await userEvent.type(screen.getAllByLabelText('Prix')[0], '0')
 
         await userEvent.click(
           screen.getAllByLabelText('Date limite de réservation')[0]
@@ -382,7 +374,7 @@ describe('stocks page', () => {
 
       it('should be able to add second stock while first one is not validated', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // When
         await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -393,7 +385,7 @@ describe('stocks page', () => {
 
       it('should not display price error when the price is above 300 euros and offer is not educational', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
         await userEvent.click(screen.getByLabelText('Date de l’évènement'))
@@ -403,9 +395,7 @@ describe('stocks page', () => {
         await userEvent.click(screen.getByText('20:00'))
 
         // When
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '301' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '301')
         await userEvent.click(screen.getByText('Étape suivante'))
 
         // Then
@@ -431,7 +421,7 @@ describe('stocks page', () => {
             quantity: 'La quantité est invalide.',
           },
         })
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
         await userEvent.click(screen.getByLabelText('Date de l’évènement'))
@@ -440,9 +430,7 @@ describe('stocks page', () => {
         await userEvent.click(screen.getByLabelText('Heure de l’évènement'))
         await userEvent.click(screen.getByText('20:00'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '10' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '10')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -456,7 +444,7 @@ describe('stocks page', () => {
 
       it('should display error message on pre-submit error', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
         await userEvent.click(screen.getByLabelText('Date de l’évènement'))
@@ -465,12 +453,8 @@ describe('stocks page', () => {
         await userEvent.click(screen.getByLabelText('Heure de l’évènement'))
         await userEvent.click(screen.getByText('20:00'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '-10' },
-        })
-        fireEvent.change(screen.getByLabelText('Quantité'), {
-          target: { value: '-20' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '-10')
+        await userEvent.type(screen.getByLabelText('Quantité'), '-20')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -488,7 +472,7 @@ describe('stocks page', () => {
       it('should redirect to summary page after submitting stock', async () => {
         // Given
         pcapi.bulkCreateOrEditStock.mockResolvedValueOnce({})
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter une date'))
 
         await userEvent.click(screen.getByLabelText('Date de l’évènement'))
@@ -497,9 +481,7 @@ describe('stocks page', () => {
         await userEvent.click(screen.getByLabelText('Heure de l’évènement'))
         await userEvent.click(screen.getByText('20:00'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '10' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '10')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -525,7 +507,7 @@ describe('stocks page', () => {
 
       it('should not display add activation codes option when not digital', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -538,12 +520,10 @@ describe('stocks page', () => {
 
       it('should display price error when the price is above 300 euros and offer is not educational', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         await userEvent.click(await screen.findByText('Ajouter un stock'))
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '301' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '301')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -565,12 +545,10 @@ describe('stocks page', () => {
             quantity: 'La quantité est invalide.',
           },
         })
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter un stock'))
 
-        fireEvent.change(screen.getByLabelText('Quantité'), {
-          target: { value: '15' },
-        })
+        await userEvent.type(screen.getByLabelText('Quantité'), '15')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -584,15 +562,12 @@ describe('stocks page', () => {
 
       it('should display error message on pre-submit error', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter un stock'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '-10' },
-        })
-        fireEvent.change(screen.getByLabelText('Quantité'), {
-          target: { value: '-20' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '-10')
+
+        await userEvent.type(screen.getByLabelText('Quantité'), '-20')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -610,15 +585,11 @@ describe('stocks page', () => {
       it('should redirect to summary page after submitting stock', async () => {
         // Given
         pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter un stock'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '15' },
-        })
-        fireEvent.change(screen.getByLabelText('Quantité'), {
-          target: { value: '15' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '15')
+        await userEvent.type(screen.getByLabelText('Quantité'), '15')
 
         // When
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -630,7 +601,7 @@ describe('stocks page', () => {
 
       it('should cancel new stock addition when clicking on cancel button', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
         await userEvent.click(await screen.findByText('Ajouter un stock'))
 
         // When
@@ -649,7 +620,7 @@ describe('stocks page', () => {
           stocks: [],
         }
         jest.spyOn(api, 'getOffer').mockResolvedValue(thingOffer)
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -667,7 +638,7 @@ describe('stocks page', () => {
           stocks: [],
         }
         jest.spyOn(api, 'getOffer').mockResolvedValue(thingOffer)
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -678,7 +649,7 @@ describe('stocks page', () => {
 
       it('should have price, limit datetime and quantity fields emptied by default', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -693,7 +664,7 @@ describe('stocks page', () => {
 
       it('should not have remaining stocks and bookings columns', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -705,7 +676,7 @@ describe('stocks page', () => {
 
       it('should have a cancel button to cancel new stock', async () => {
         // given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // when
         await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -717,22 +688,18 @@ describe('stocks page', () => {
       it('should add new stock to stocks and remove new empty stock line when clicking on validate button', async () => {
         // given
         pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         await userEvent.click(await screen.findByText('Ajouter un stock'))
 
-        fireEvent.change(screen.getByLabelText('Prix'), {
-          target: { value: '15' },
-        })
+        await userEvent.type(screen.getByLabelText('Prix'), '15')
 
         await userEvent.click(
           screen.getByLabelText('Date limite de réservation')
         )
         await userEvent.click(screen.getByText('22'))
 
-        fireEvent.change(screen.getByLabelText('Quantité'), {
-          target: { value: '15' },
-        })
+        await userEvent.type(screen.getByLabelText('Quantité'), '15')
 
         // when
         await userEvent.click(screen.getByText('Étape suivante'))
@@ -763,7 +730,7 @@ describe('stocks page', () => {
 
         it('should allow the user to add activation codes when offer is digital', async () => {
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // when
           await userEvent.click(await screen.findByText('Ajouter un stock'))
@@ -786,7 +753,7 @@ describe('stocks page', () => {
           }
           jest.spyOn(api, 'getOffer').mockResolvedValue(eventOffer)
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // when
           await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -799,7 +766,7 @@ describe('stocks page', () => {
 
         it('should display number of activation codes to be added', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -814,11 +781,7 @@ describe('stocks page', () => {
           })
 
           // When
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           // Then
           await expect(
@@ -830,7 +793,7 @@ describe('stocks page', () => {
 
         it('should not change step when file is null', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -840,13 +803,12 @@ describe('stocks page', () => {
           const uploadButton = screen.getByLabelText(
             'Importer un fichier .csv depuis l’ordinateur'
           )
+          const file = new File([null], 'activation_codes.csv', {
+            type: 'text/csv',
+          })
 
           // When
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [null],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           // Then
           await waitFor(() => {
@@ -865,7 +827,7 @@ describe('stocks page', () => {
 
         it('should allow user to go back', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -880,11 +842,7 @@ describe('stocks page', () => {
           })
 
           // When
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           await userEvent.click(await screen.findByText('Retour'))
 
@@ -899,7 +857,7 @@ describe('stocks page', () => {
         it('should save changes done to stock with activation codes and readjust bookingLimitDatetime according to activationCodesExpirationDatetime', async () => {
           // Given
           pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -914,11 +872,7 @@ describe('stocks page', () => {
           })
 
           // When
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           await userEvent.click(
             await screen.findByLabelText('Date limite de validité')
@@ -927,8 +881,8 @@ describe('stocks page', () => {
           await userEvent.click(screen.getByText('Valider'))
 
           const priceField = screen.getByLabelText('Prix')
-          fireEvent.change(priceField, { target: { value: null } })
-          fireEvent.change(priceField, { target: { value: '14.01' } })
+          await userEvent.clear(priceField)
+          await userEvent.type(priceField, '14.01')
 
           await userEvent.click(screen.getByText('Étape suivante'))
 
@@ -951,7 +905,7 @@ describe('stocks page', () => {
         it('should save changes done to stock with activation codes and no activationCodesExpirationDatetime', async () => {
           // Given
           pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -966,17 +920,13 @@ describe('stocks page', () => {
           })
 
           // When
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           await userEvent.click(await screen.findByText('Valider'))
 
           const priceField = screen.getByLabelText('Prix')
-          fireEvent.change(priceField, { target: { value: null } })
-          fireEvent.change(priceField, { target: { value: '14.01' } })
+          await userEvent.clear(priceField)
+          await userEvent.type(priceField, '14.01')
 
           await userEvent.click(screen.getByText('Étape suivante'))
 
@@ -998,7 +948,7 @@ describe('stocks page', () => {
 
         it('should change stock quantity and disable activation codes button on upload', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -1013,11 +963,7 @@ describe('stocks page', () => {
           })
 
           // When
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
           await userEvent.click(await screen.findByText('Valider'))
 
           // Then
@@ -1031,7 +977,7 @@ describe('stocks page', () => {
 
         it('should limit expiration datetime when booking limit datetime is set and vice versa', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           await userEvent.click(
             screen.getByLabelText('Date limite de réservation')
@@ -1048,11 +994,7 @@ describe('stocks page', () => {
           const file = new File(['ABH\nJHB'], 'activation_codes.csv', {
             type: 'text/csv',
           })
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           await userEvent.click(
             await screen.findByLabelText('Date limite de validité')
@@ -1096,7 +1038,7 @@ describe('stocks page', () => {
 
         it('should set booking limit datetime on expiration datetime change', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
           await userEvent.click(await screen.findByText('Ajouter un stock'))
 
           const activationCodeButton = screen
@@ -1109,11 +1051,7 @@ describe('stocks page', () => {
           const file = new File(['ABH\nJHB'], 'activation_codes.csv', {
             type: 'text/csv',
           })
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           await userEvent.click(
             await screen.findByLabelText('Date limite de validité')
@@ -1134,7 +1072,7 @@ describe('stocks page', () => {
 
         it('should discard activation codes and expiration datetime and close modal on close button click', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           await userEvent.click(await screen.findByText('Ajouter un stock'))
           const activationCodeButton = screen
@@ -1147,11 +1085,7 @@ describe('stocks page', () => {
           const file = new File(['ABH\nJHB'], 'activation_codes.csv', {
             type: 'text/csv',
           })
-          fireEvent.change(uploadButton, {
-            target: {
-              files: [file],
-            },
-          })
+          await userEvent.upload(uploadButton, file)
 
           await userEvent.click(
             await screen.findByLabelText('Date limite de validité')
@@ -1196,7 +1130,7 @@ describe('stocks page', () => {
           pcapi.loadStocks.mockResolvedValueOnce({ stocks: [createdStock] })
 
           // when
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // then
           await expect(

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.edit.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.edit.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -33,13 +33,13 @@ jest.mock('utils/date', () => ({
     .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
 }))
 
-const renderOffers = async (
+const renderOffers = (
   props,
   storeOverrides,
   pathname = '/offre/AG3A/individuel/stocks'
 ) => {
   const store = configureTestStore(storeOverrides)
-  return render(
+  render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: pathname }]}>
         <Route path="/offre/:offerId([A-Z0-9]+)/individuel">
@@ -147,7 +147,7 @@ describe('stocks page', () => {
         .mockResolvedValueOnce({ stocks: [] })
 
       // When
-      await renderOffers(props, store)
+      renderOffers(props, store)
 
       // Then
       expect(await screen.findByText('publiée')).toBeInTheDocument()
@@ -167,7 +167,7 @@ describe('stocks page', () => {
       // Given
       const stock = stockFactory()
       loadFakeApiStocks([stock])
-      await renderOffers(props, store)
+      renderOffers(props, store)
 
       // When
       await userEvent.click(
@@ -207,7 +207,7 @@ describe('stocks page', () => {
           getToday.mockImplementationOnce(() => dayAfterBeginningDatetime)
 
           // When
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // Then
           expect(await screen.findByLabelText('Prix')).toBeDisabled()
@@ -234,7 +234,7 @@ describe('stocks page', () => {
           }
 
           jest.spyOn(api, 'getOffer').mockResolvedValue(eventOffer)
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // When
           await userEvent.click(await screen.findByTitle('Supprimer le stock'))
@@ -257,7 +257,7 @@ describe('stocks page', () => {
           }
 
           pcapi.loadStocks.mockResolvedValue({ stocks: [eventInThePast] })
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // Then
           expect(
@@ -277,7 +277,7 @@ describe('stocks page', () => {
           }
 
           pcapi.loadStocks.mockResolvedValue({ stocks: [eventInThePast] })
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // Then
           expect(
@@ -296,7 +296,7 @@ describe('stocks page', () => {
           }
 
           pcapi.loadStocks.mockResolvedValue({ stocks: [eventInThePast] })
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // Then
           expect(
@@ -309,7 +309,7 @@ describe('stocks page', () => {
         describe('when editing stock', () => {
           it('should be able to edit beginning date field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             await userEvent.click(await screen.findByDisplayValue('20/12/2020'))
@@ -324,7 +324,7 @@ describe('stocks page', () => {
 
           it('should not be able to select beginning date before today', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             await userEvent.click(await screen.findByDisplayValue('20/12/2020'))
@@ -339,14 +339,11 @@ describe('stocks page', () => {
 
           it('should be able to remove date field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
-            fireEvent.change(
-              await screen.findByLabelText('Date de l’évènement'),
-              {
-                target: { value: null },
-              }
+            await userEvent.clear(
+              await screen.findByLabelText('Date de l’évènement')
             )
 
             // then
@@ -355,7 +352,7 @@ describe('stocks page', () => {
 
           it('should be able to edit hour field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             await userEvent.click(await screen.findByDisplayValue('19:00'))
@@ -368,12 +365,12 @@ describe('stocks page', () => {
 
           it('should be able to edit price field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
             const priceField = await screen.findByDisplayValue('10.01')
 
             // when
-            fireEvent.change(priceField)
-            fireEvent.change(priceField, { target: { value: '127.03' } })
+            await userEvent.clear(priceField)
+            await userEvent.type(priceField, '127.03')
 
             // then
             expect(screen.queryByDisplayValue('10.01')).not.toBeInTheDocument()
@@ -382,7 +379,7 @@ describe('stocks page', () => {
 
           it('should be able to edit booking limit date field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             await userEvent.click(await screen.findByDisplayValue('18/12/2020'))
@@ -397,7 +394,7 @@ describe('stocks page', () => {
 
           it('should not be able to select booking limit date after beginning date', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             await userEvent.click(await screen.findByDisplayValue('18/12/2020'))
@@ -412,7 +409,7 @@ describe('stocks page', () => {
 
           it('should set booking limit datetime to beginning datetime when selecting a beginning datetime prior to booking limit datetime', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             await userEvent.click(await screen.findByDisplayValue('20/12/2020'))
@@ -426,12 +423,12 @@ describe('stocks page', () => {
 
           it('should be able to edit total quantity field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
             const quantityField = await screen.findByDisplayValue('10')
 
             // when
-            fireEvent.change(quantityField, { target: { value: null } })
-            fireEvent.change(quantityField, { target: { value: '23' } })
+            await userEvent.clear(quantityField)
+            await userEvent.type(quantityField, '23')
 
             // then
             expect(screen.queryByDisplayValue('10')).not.toBeInTheDocument()
@@ -440,12 +437,10 @@ describe('stocks page', () => {
 
           it('should not empty date field when emptying hour field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
-            fireEvent.change(await screen.findByDisplayValue('19:00'), {
-              target: { value: null },
-            })
+            await userEvent.clear(await screen.findByDisplayValue('19:00'))
 
             // then
             expect(screen.queryByDisplayValue('20/12/2020')).toBeInTheDocument()
@@ -453,12 +448,12 @@ describe('stocks page', () => {
 
           it('should compute remaining quantity based on inputted total quantity', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
             const quantityField = await screen.findByDisplayValue('10')
 
             // when
-            fireEvent.change(quantityField, { target: { value: null } })
-            fireEvent.change(quantityField, { target: { value: '9' } })
+            await userEvent.clear(quantityField)
+            await userEvent.type(quantityField, '9')
 
             // then
             const initialRemainingQuantity = screen.queryByText(6)
@@ -470,12 +465,10 @@ describe('stocks page', () => {
 
           it('should set remaining quantity to Illimité when emptying total quantity field', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
-            fireEvent.change(await screen.findByDisplayValue('10'), {
-              target: { value: null },
-            })
+            await userEvent.clear(await screen.findByDisplayValue('10'))
 
             // then
             const computedRemainingQuantity = screen.getByText('Illimité')
@@ -496,7 +489,7 @@ describe('stocks page', () => {
             })
 
             // when
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // then
             expect(await screen.findByLabelText('Quantité')).toHaveValue(0)
@@ -513,7 +506,7 @@ describe('stocks page', () => {
 
             it('should update stock', async () => {
               // Given
-              await renderOffers(props, store)
+              renderOffers(props, store)
 
               await userEvent.click(
                 await screen.findByLabelText('Date de l’évènement')
@@ -526,8 +519,8 @@ describe('stocks page', () => {
               await userEvent.click(screen.getByText('20:00'))
 
               const priceField = screen.getByLabelText('Prix')
-              fireEvent.change(priceField, { target: { value: null } })
-              fireEvent.change(priceField, { target: { value: '14.01' } })
+              await userEvent.clear(priceField)
+              await userEvent.type(priceField, '14.01')
 
               await userEvent.click(
                 screen.getByLabelText('Date limite de réservation')
@@ -535,8 +528,8 @@ describe('stocks page', () => {
               await userEvent.click(screen.getByText('25'))
 
               const quantityField = screen.getByLabelText('Quantité')
-              fireEvent.change(quantityField, { target: { value: null } })
-              fireEvent.change(quantityField, { target: { value: '6' } })
+              await userEvent.clear(quantityField)
+              await userEvent.type(quantityField, '6')
 
               // When
               await userEvent.click(
@@ -575,7 +568,7 @@ describe('stocks page', () => {
               pcapi.loadStocks
                 .mockResolvedValueOnce({ stocks: [initialStock] })
                 .mockResolvedValueOnce({ stocks: [updatedStock] })
-              await renderOffers(props, store)
+              renderOffers(props, store)
 
               // When
               await userEvent.click(
@@ -588,12 +581,9 @@ describe('stocks page', () => {
 
             it('should set booking limit datetime to exact beginning datetime when not specified', async () => {
               // Given
-              await renderOffers(props, store)
-              fireEvent.change(
-                await screen.findByLabelText('Date limite de réservation'),
-                {
-                  target: { value: '' },
-                }
+              renderOffers(props, store)
+              await userEvent.clear(
+                await screen.findByLabelText('Date limite de réservation')
               )
 
               // When
@@ -610,7 +600,7 @@ describe('stocks page', () => {
 
             it('should set booking limit datetime to exact beginning datetime when same as beginning date', async () => {
               // Given
-              await renderOffers(props, store)
+              renderOffers(props, store)
               await userEvent.click(
                 await screen.findByLabelText('Date limite de réservation')
               )
@@ -630,7 +620,7 @@ describe('stocks page', () => {
 
             it('should set booking limit time to end of selected locale day when specified and different than beginning date in Cayenne TZ', async () => {
               // Given
-              await renderOffers(props, store)
+              renderOffers(props, store)
               await userEvent.click(
                 await screen.findByLabelText('Date limite de réservation')
               )
@@ -652,7 +642,7 @@ describe('stocks page', () => {
               // Given
               eventOffer.venue.departementCode = PARIS_FRANCE_DEPT
 
-              await renderOffers(props, store)
+              renderOffers(props, store)
               await userEvent.click(
                 await screen.findByLabelText('Date limite de réservation')
               )
@@ -672,10 +662,8 @@ describe('stocks page', () => {
 
             it('should set quantity to null when not specified', async () => {
               // Given
-              await renderOffers(props, store)
-              fireEvent.change(await screen.findByLabelText('Quantité'), {
-                target: { value: null },
-              })
+              renderOffers(props, store)
+              await userEvent.clear(await screen.findByLabelText('Quantité'))
 
               // When
               await userEvent.click(
@@ -695,7 +683,7 @@ describe('stocks page', () => {
                   quantity: 'La quantité est invalide.',
                 },
               })
-              await renderOffers(props, store)
+              renderOffers(props, store)
 
               await userEvent.click(
                 await screen.findByLabelText('Date de l’évènement')
@@ -721,11 +709,11 @@ describe('stocks page', () => {
 
             it('should not be able to submit changes when beginning date field is empty', async () => {
               // given
-              await renderOffers(props, store)
+              renderOffers(props, store)
               const beginningDateField = await screen.findByDisplayValue(
                 '20/12/2020'
               )
-              fireEvent.change(beginningDateField, { target: { value: null } })
+              await userEvent.clear(beginningDateField)
 
               // when
               await userEvent.click(
@@ -742,11 +730,11 @@ describe('stocks page', () => {
 
             it('should not be able to validate changes when hour field is empty', async () => {
               // given
-              await renderOffers(props, store)
+              renderOffers(props, store)
               const beginningHourField = await screen.findByDisplayValue(
                 '19:00'
               )
-              fireEvent.change(beginningHourField, { target: { value: null } })
+              await userEvent.clear(beginningHourField)
 
               // when
               await userEvent.click(
@@ -763,10 +751,8 @@ describe('stocks page', () => {
 
             it('should not display price error when the price is above 300 euros and offer is not educational', async () => {
               // Given
-              await renderOffers(props, store)
-              fireEvent.change(await screen.findByLabelText('Prix'), {
-                target: { value: '301' },
-              })
+              renderOffers(props, store)
+              await userEvent.type(await screen.findByLabelText('Prix'), '301')
 
               // When
               await userEvent.click(
@@ -798,7 +784,7 @@ describe('stocks page', () => {
               pcapi.loadStocks.mockResolvedValue({ stocks: [eventStock] })
               pcapi.bulkCreateOrEditStock.mockResolvedValue({})
 
-              await renderOffers(props, store)
+              renderOffers(props, store)
               await userEvent.click(
                 await screen.findByLabelText('Heure de l’évènement')
               )
@@ -818,7 +804,7 @@ describe('stocks page', () => {
 
             it('should display error message on pre-submit error', async () => {
               // Given
-              await renderOffers(props, store)
+              renderOffers(props, store)
 
               await userEvent.click(
                 await screen.findByLabelText('Date de l’évènement')
@@ -830,12 +816,8 @@ describe('stocks page', () => {
               )
               await userEvent.click(screen.getByText('20:00'))
 
-              fireEvent.change(screen.getByLabelText('Prix'), {
-                target: { value: '-10' },
-              })
-              fireEvent.change(screen.getByLabelText('Quantité'), {
-                target: { value: '-20' },
-              })
+              await userEvent.type(screen.getByLabelText('Prix'), '-10')
+              await userEvent.type(screen.getByLabelText('Quantité'), '-20')
 
               // When
               await userEvent.click(
@@ -852,7 +834,7 @@ describe('stocks page', () => {
             it('should display success message on success', async () => {
               // Given
               pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-              await renderOffers(props, store)
+              renderOffers(props, store)
 
               await userEvent.click(
                 await screen.findByLabelText('Date de l’évènement')
@@ -891,7 +873,7 @@ describe('stocks page', () => {
                 .spyOn(api, 'getOffer')
                 .mockResolvedValueOnce(initialOffer)
                 .mockResolvedValueOnce(updatedOffer)
-              await renderOffers(props, store)
+              renderOffers(props, store)
               api.getOffer.mockClear()
 
               // When
@@ -920,7 +902,7 @@ describe('stocks page', () => {
                 .mockResolvedValueOnce(updatedOffer)
 
               // When
-              await renderOffers(props, store)
+              renderOffers(props, store)
 
               // Then
               const soldOutOfferStatus = await screen.findByText('épuisée')
@@ -944,7 +926,7 @@ describe('stocks page', () => {
         describe('when deleting stock', () => {
           it('should display confirmation dialog box with focus on confirmation button', async () => {
             // Given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -978,7 +960,7 @@ describe('stocks page', () => {
 
           it('should be able to delete a stock', async () => {
             // Given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -994,7 +976,7 @@ describe('stocks page', () => {
 
           it('should not delete stock if aborting on confirmation', async () => {
             // Given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -1018,7 +1000,7 @@ describe('stocks page', () => {
               .mockResolvedValueOnce({ stocks: [initialStock] })
               .mockResolvedValueOnce({ stocks: [] })
 
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -1046,7 +1028,7 @@ describe('stocks page', () => {
               isEvent: true,
             })
 
-            await renderOffers(props, store)
+            renderOffers(props, store)
             await userEvent.click(await screen.findByText('Ajouter une date'))
 
             let nbExpectedRows = 0
@@ -1076,7 +1058,7 @@ describe('stocks page', () => {
 
           it('should display a success message after deletion', async () => {
             // Given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -1095,7 +1077,7 @@ describe('stocks page', () => {
           it('should display an error message when deletion fails', async () => {
             // Given
             pcapi.deleteStock.mockRejectedValue({})
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -1115,7 +1097,7 @@ describe('stocks page', () => {
 
           it('should disable deleting button', async () => {
             // given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // when
             const deleteButton = await screen.findByTitle('Supprimer le stock')
@@ -1143,7 +1125,7 @@ describe('stocks page', () => {
         describe('when editing stock', () => {
           it('should be able to update price and quantity but not beginning date nor hour fields', async () => {
             // When
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // Then
             expect(
@@ -1178,12 +1160,12 @@ describe('stocks page', () => {
       describe('when offer has been manually created', () => {
         it('should be able to edit price field', async () => {
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
           const priceField = await screen.findByDisplayValue('10.01')
 
           // when
-          fireEvent.change(priceField)
-          fireEvent.change(priceField, { target: { value: '127.03' } })
+          await userEvent.clear(priceField)
+          await userEvent.type(priceField, '127.03')
 
           // then
           expect(screen.queryByDisplayValue('10.01')).not.toBeInTheDocument()
@@ -1192,7 +1174,7 @@ describe('stocks page', () => {
 
         it('should be able to edit booking limit date field', async () => {
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // when
           await userEvent.click(await screen.findByDisplayValue('18/12/2020'))
@@ -1207,12 +1189,12 @@ describe('stocks page', () => {
 
         it('should be able to edit total quantity field', async () => {
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
           const quantityField = await screen.findByDisplayValue('10')
 
           // when
-          fireEvent.change(quantityField, { target: { value: null } })
-          fireEvent.change(quantityField, { target: { value: '23' } })
+          await userEvent.clear(quantityField)
+          await userEvent.type(quantityField, '23')
 
           // then
           expect(screen.queryByDisplayValue('10')).not.toBeInTheDocument()
@@ -1221,12 +1203,12 @@ describe('stocks page', () => {
 
         it('should compute remaining quantity based on inputted total quantity', async () => {
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
           const quantityField = await screen.findByDisplayValue('10')
 
           // when
-          fireEvent.change(quantityField, { target: { value: null } })
-          fireEvent.change(quantityField, { target: { value: '9' } })
+          await userEvent.clear(quantityField)
+          await userEvent.type(quantityField, '9')
 
           // then
           const initialRemainingQuantity = screen.queryByText(6)
@@ -1238,12 +1220,10 @@ describe('stocks page', () => {
 
         it('should set remaining quantity to Illimité when emptying total quantity field', async () => {
           // given
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // when
-          fireEvent.change(await screen.findByDisplayValue('10'), {
-            target: { value: null },
-          })
+          await userEvent.clear(await screen.findByDisplayValue('10'))
 
           // then
           const computedRemainingQuantity = screen.getByText('Illimité')
@@ -1257,7 +1237,7 @@ describe('stocks page', () => {
           })
 
           // when
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // then
           expect(await screen.findByLabelText('Quantité')).toHaveValue(0)
@@ -1270,11 +1250,11 @@ describe('stocks page', () => {
           it('should save changes done to stock', async () => {
             // Given
             pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             const priceField = await screen.findByLabelText('Prix')
-            fireEvent.change(priceField, { target: { value: null } })
-            fireEvent.change(priceField, { target: { value: '14.01' } })
+            await userEvent.clear(priceField)
+            await userEvent.type(priceField, '14.01')
 
             await userEvent.click(
               screen.getByLabelText('Date limite de réservation')
@@ -1282,8 +1262,8 @@ describe('stocks page', () => {
             await userEvent.click(screen.getByText('25'))
 
             const quantityField = screen.getByLabelText('Quantité')
-            fireEvent.change(quantityField, { target: { value: null } })
-            fireEvent.change(quantityField, { target: { value: '6' } })
+            await userEvent.clear(quantityField)
+            await userEvent.type(quantityField, '6')
 
             // When
             await userEvent.click(
@@ -1318,7 +1298,7 @@ describe('stocks page', () => {
             pcapi.loadStocks
               .mockResolvedValueOnce({ stocks: [initialStock] })
               .mockResolvedValueOnce({ stocks: [updatedStock] })
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
             // When
             await userEvent.click(
@@ -1332,7 +1312,7 @@ describe('stocks page', () => {
           it('should set booking limit time to end of selected local day when specified in Cayenne TZ', async () => {
             // Given
             pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-            await renderOffers(props, store)
+            renderOffers(props, store)
             await userEvent.click(
               await screen.findByLabelText('Date limite de réservation')
             )
@@ -1355,7 +1335,7 @@ describe('stocks page', () => {
             thingOffer.venue.departementCode = PARIS_FRANCE_DEPT
 
             pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-            await renderOffers(props, store)
+            renderOffers(props, store)
             await userEvent.click(
               await screen.findByLabelText('Date limite de réservation')
             )
@@ -1376,13 +1356,10 @@ describe('stocks page', () => {
           it('should set booking limit datetime to null when not specified', async () => {
             // Given
             pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
-            fireEvent.change(
-              await screen.findByLabelText('Date limite de réservation'),
-              {
-                target: { value: null },
-              }
+            await userEvent.clear(
+              await screen.findByLabelText('Date limite de réservation')
             )
 
             // When
@@ -1398,10 +1375,8 @@ describe('stocks page', () => {
           it('should set quantity to null when not specified', async () => {
             // Given
             pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-            await renderOffers(props, store)
-            fireEvent.change(await screen.findByLabelText('Quantité'), {
-              target: { value: null },
-            })
+            renderOffers(props, store)
+            await userEvent.clear(await screen.findByLabelText('Quantité'))
 
             // When
             await userEvent.click(
@@ -1414,10 +1389,9 @@ describe('stocks page', () => {
 
           it('should display price error when the price is above 300 euros and offer is not educational', async () => {
             // Given
-            await renderOffers(props, store)
-            fireEvent.change(await screen.findByLabelText('Prix'), {
-              target: { value: '301' },
-            })
+            renderOffers(props, store)
+            await userEvent.clear(await screen.findByLabelText('Prix'))
+            await userEvent.type(await screen.findByLabelText('Prix'), '301')
 
             // When
             await userEvent.click(
@@ -1441,11 +1415,9 @@ describe('stocks page', () => {
                 quantity: 'La quantité est invalide.',
               },
             })
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
-            fireEvent.change(await screen.findByLabelText('Quantité'), {
-              target: { value: '10' },
-            })
+            await userEvent.type(await screen.findByLabelText('Quantité'), '10')
 
             // When
             await userEvent.click(
@@ -1461,14 +1433,10 @@ describe('stocks page', () => {
 
           it('should display error message on pre-submit error', async () => {
             // Given
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
-            fireEvent.change(await screen.findByLabelText('Prix'), {
-              target: { value: '-10' },
-            })
-            fireEvent.change(screen.getByLabelText('Quantité'), {
-              target: { value: '-20' },
-            })
+            await userEvent.type(await screen.findByLabelText('Prix'), '-10')
+            await userEvent.type(screen.getByLabelText('Quantité'), '-20')
 
             // When
             await userEvent.click(
@@ -1485,11 +1453,9 @@ describe('stocks page', () => {
           it('should display success message on success', async () => {
             // Given
             pcapi.bulkCreateOrEditStock.mockResolvedValue({})
-            await renderOffers(props, store)
+            renderOffers(props, store)
 
-            fireEvent.change(await screen.findByLabelText('Quantité'), {
-              target: { value: '10' },
-            })
+            await userEvent.type(await screen.findByLabelText('Quantité'), '10')
 
             // When
             await userEvent.click(
@@ -1519,7 +1485,7 @@ describe('stocks page', () => {
 
         it('should not be able to edit a stock', async () => {
           // When
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // Then
           expect(await screen.findByLabelText('Prix')).toBeDisabled()
@@ -1531,7 +1497,7 @@ describe('stocks page', () => {
 
         it('should not be able to delete a stock', async () => {
           // Given
-          await renderOffers(props, store)
+          renderOffers(props, store)
           const deleteButton = await screen.findByTitle(
             'Les stock synchronisés ne peuvent être supprimés'
           )
@@ -1551,7 +1517,7 @@ describe('stocks page', () => {
           jest
             .spyOn(api, 'getOffer')
             .mockResolvedValue({ ...thingOffer, isDigital: true })
-          await renderOffers(props, store)
+          renderOffers(props, store)
 
           // then
           const informationMessage = await screen.findByText(
@@ -1566,7 +1532,7 @@ describe('stocks page', () => {
 
       it('should warn that pending booking will be canceled on thing offer stock deletion', async () => {
         // Given
-        await renderOffers(props, store)
+        renderOffers(props, store)
 
         // When
         await userEvent.click(await screen.findByTitle('Supprimer le stock'))

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.render.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.render.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -36,7 +36,7 @@ const renderOffers = async (
   pathname = '/offre/AG3A/individuel/stocks'
 ) => {
   const store = configureTestStore(storeOverrides)
-  return render(
+  render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: pathname }]}>
         <Route path="/offre/:offerId([A-Z0-9]+)/individuel">
@@ -46,6 +46,10 @@ const renderOffers = async (
       <Notification />
     </Provider>
   )
+
+  await waitFor(() => {
+    expect(screen.getAllByTestId('offer-page')).toBeInTheDocument
+  })
 }
 
 describe('stocks page', () => {
@@ -691,9 +695,7 @@ describe('stocks page', () => {
       await userEvent.click(screen.getByLabelText('Heure de l’évènement'))
       await userEvent.click(screen.getByText('20:00'))
 
-      fireEvent.change(screen.getByLabelText('Prix'), {
-        target: { value: '10' },
-      })
+      await userEvent.type(screen.getByLabelText('Prix'), '10')
 
       // When
       await userEvent.click(screen.getByText('Enregistrer les modifications'))
@@ -714,9 +716,7 @@ describe('stocks page', () => {
       await userEvent.click(screen.getByLabelText('Date de l’évènement'))
       await userEvent.click(screen.getByText('26'))
 
-      fireEvent.change(screen.getByLabelText('Prix'), {
-        target: { value: '10' },
-      })
+      await userEvent.type(screen.getByLabelText('Prix'), '10')
 
       // When
       await userEvent.click(screen.getByText('Enregistrer les modifications'))

--- a/pro/src/components/pages/Offers/Offer/Thumbnail/ImportFromComputer/ImportFromComputer.jsx
+++ b/pro/src/components/pages/Offers/Offer/Thumbnail/ImportFromComputer/ImportFromComputer.jsx
@@ -1,5 +1,5 @@
 import * as PropTypes from 'prop-types'
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef, useEffect } from 'react'
 
 import {
   IMAGE_TYPE,
@@ -19,6 +19,13 @@ const constraints = [
 ]
 
 const ImportFromComputer = ({ setStep, setThumbnail, step }) => {
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
   const onSetImage = useCallback(
     file => {
       setThumbnail(file)
@@ -29,8 +36,8 @@ const ImportFromComputer = ({ setStep, setThumbnail, step }) => {
   const { errors, checkAndSetImage } = useCheckAndSetImage({
     constraints,
     onSetImage,
+    mountedRef,
   })
-
   return (
     <form action="#" className="tnf-form">
       <PreferredOrientation orientation="portrait" />

--- a/pro/src/components/pages/Offers/Offer/Thumbnail/ImportFromComputer/ImportFromComputer.jsx
+++ b/pro/src/components/pages/Offers/Offer/Thumbnail/ImportFromComputer/ImportFromComputer.jsx
@@ -1,5 +1,5 @@
 import * as PropTypes from 'prop-types'
-import React, { useCallback, useRef, useEffect } from 'react'
+import React, { useCallback } from 'react'
 
 import {
   IMAGE_TYPE,
@@ -19,13 +19,6 @@ const constraints = [
 ]
 
 const ImportFromComputer = ({ setStep, setThumbnail, step }) => {
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
   const onSetImage = useCallback(
     file => {
       setThumbnail(file)
@@ -36,7 +29,6 @@ const ImportFromComputer = ({ setStep, setThumbnail, step }) => {
   const { errors, checkAndSetImage } = useCheckAndSetImage({
     constraints,
     onSetImage,
-    mountedRef,
   })
   return (
     <form action="#" className="tnf-form">

--- a/pro/src/components/pages/Offers/Offer/Thumbnail/__specs__/ImageEditor.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Thumbnail/__specs__/ImageEditor.spec.jsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import {
   createImageFile,
@@ -37,16 +38,18 @@ describe('when the user is on the preview step', () => {
     // Given
     renderThumbnail()
     const file = createImageFile()
-    fireEvent.change(
+    await userEvent.upload(
       screen.getByLabelText('Importer une image depuis l’ordinateur'),
-      {
-        target: { files: [file] },
-      }
+      file
     )
-    fireEvent.click(await screen.findByText('Suivant', { selector: 'button' }))
+    await userEvent.click(
+      await screen.findByText('Suivant', { selector: 'button' })
+    )
 
     // When
-    fireEvent.click(screen.getByText('Prévisualiser', { selector: 'button' }))
+    await userEvent.click(
+      screen.getByText('Prévisualiser', { selector: 'button' })
+    )
 
     // Then
     expect(
@@ -68,17 +71,19 @@ describe('when the user is on the preview step', () => {
     // Given
     renderThumbnail()
     const file = createImageFile()
-    fireEvent.change(
+    await userEvent.upload(
       screen.getByLabelText('Importer une image depuis l’ordinateur'),
-      {
-        target: { files: [file] },
-      }
+      file
     )
-    fireEvent.click(await screen.findByText('Suivant', { selector: 'button' }))
-    fireEvent.click(screen.getByText('Prévisualiser', { selector: 'button' }))
+    await userEvent.click(
+      await screen.findByText('Suivant', { selector: 'button' })
+    )
+    await userEvent.click(
+      screen.getByText('Prévisualiser', { selector: 'button' })
+    )
 
     // When
-    fireEvent.click(screen.getByText('Retour', { selector: 'button' }))
+    await userEvent.click(screen.getByText('Retour', { selector: 'button' }))
 
     // Then
     expect(screen.getByText('Recadrer votre image')).toBeInTheDocument()
@@ -94,22 +99,25 @@ describe('when the user is on the preview step', () => {
     })
 
     const file = createImageFile()
-    fireEvent.change(
+    await userEvent.upload(
       screen.getByLabelText('Importer une image depuis l’ordinateur'),
-      {
-        target: { files: [file] },
-      }
+      file
     )
 
-    fireEvent.change(await screen.findByPlaceholderText('Photographe...'), {
-      target: { value: 'Mon crédit' },
-    })
-    fireEvent.click(await screen.findByText('Suivant', { selector: 'button' }))
+    await userEvent.type(
+      await screen.findByPlaceholderText('Photographe...'),
+      'Mon crédit'
+    )
+    await userEvent.click(
+      await screen.findByText('Suivant', { selector: 'button' })
+    )
 
-    fireEvent.click(screen.getByText('Prévisualiser', { selector: 'button' }))
+    await userEvent.click(
+      screen.getByText('Prévisualiser', { selector: 'button' })
+    )
 
     // When
-    fireEvent.click(screen.getByText('Valider', { selector: 'button' }))
+    await userEvent.click(screen.getByText('Valider', { selector: 'button' }))
 
     // Then
     await waitFor(() => {

--- a/pro/src/components/pages/Offers/Offer/Thumbnail/__specs__/Thumbnail.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Thumbnail/__specs__/Thumbnail.spec.jsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import {
   createFile,
@@ -39,7 +40,7 @@ describe('thumbnail edition', () => {
         value: () => Promise.resolve({}),
       })
 
-      it('should display information for importing', async () => {
+      it('should display information for importing', () => {
         // When
         renderThumbnail()
 
@@ -74,12 +75,12 @@ describe('thumbnail edition', () => {
         ).toBeInTheDocument()
       })
 
-      it('should display advices for a good image', () => {
+      it('should display advices for a good image', async () => {
         // Given
         renderThumbnail()
 
         // When
-        fireEvent.click(
+        await userEvent.click(
           screen.getByText('Conseils pour votre image', { selector: 'button' })
         )
 
@@ -125,31 +126,27 @@ describe('thumbnail edition', () => {
           const file = createImageFile()
 
           // When
-          fireEvent.change(
+          await userEvent.upload(
             screen.getByLabelText('Importer une image depuis l’ordinateur'),
-            {
-              target: { files: [file] },
-            }
+            file
           )
 
           // Then
-          await waitFor(() => {
-            expect(
-              screen.queryByText('Formats supportés : JPG, PNG', {
-                selector: 'strong',
-              })
-            ).not.toBeInTheDocument()
-            expect(
-              screen.queryByText('Poids maximal du fichier : 10 Mo', {
-                selector: 'strong',
-              })
-            ).not.toBeInTheDocument()
-            expect(
-              screen.queryByText('Largeur minimale de l’image : 400 px', {
-                selector: 'strong',
-              })
-            ).not.toBeInTheDocument()
-          })
+          expect(
+            screen.queryByText('Formats supportés : JPG, PNG', {
+              selector: 'strong',
+            })
+          ).not.toBeInTheDocument()
+          expect(
+            screen.queryByText('Poids maximal du fichier : 10 Mo', {
+              selector: 'strong',
+            })
+          ).not.toBeInTheDocument()
+          expect(
+            screen.queryByText('Largeur minimale de l’image : 400 px', {
+              selector: 'strong',
+            })
+          ).not.toBeInTheDocument()
         })
 
         it('should not import a file other than png or jpg', async () => {
@@ -158,19 +155,15 @@ describe('thumbnail edition', () => {
           const file = createFile()
 
           // When
-          fireEvent.change(
+          await userEvent.upload(
             screen.getByLabelText('Importer une image depuis l’ordinateur'),
-            {
-              target: { files: [file] },
-            }
+            file
           )
 
           // Then
-          await expect(
-            screen.findByText('Formats supportés : JPG, PNG', {
-              selector: 'strong',
-            })
-          ).resolves.toBeInTheDocument()
+          expect(
+            screen.getByText('Formats supportés : JPG, PNG')
+          ).toBeInTheDocument()
         })
 
         it('should display all the encountered validation errors', async () => {
@@ -179,26 +172,18 @@ describe('thumbnail edition', () => {
           const file = createFile({ sizeInMB: 50 })
 
           // When
-          fireEvent.change(
+          await userEvent.upload(
             screen.getByLabelText('Importer une image depuis l’ordinateur'),
-            {
-              target: { files: [file] },
-            }
+            file
           )
 
           // Then
-          await waitFor(() => {
-            expect(
-              screen.getByText('Formats supportés : JPG, PNG', {
-                selector: 'strong',
-              })
-            ).toBeInTheDocument()
-            expect(
-              screen.queryByText('Poids maximal du fichier : 10 Mo', {
-                selector: 'strong',
-              })
-            ).toBeInTheDocument()
-          })
+          expect(
+            screen.getByText('Formats supportés : JPG, PNG')
+          ).toBeInTheDocument()
+          expect(
+            screen.queryByText('Poids maximal du fichier : 10 Mo')
+          ).toBeInTheDocument()
         })
 
         it('should not import an image which exceeds maximum size', async () => {
@@ -207,19 +192,17 @@ describe('thumbnail edition', () => {
           const bigFile = createImageFile({ sizeInMB: 10 })
 
           // When
-          fireEvent.change(
+          await userEvent.upload(
             screen.getByLabelText('Importer une image depuis l’ordinateur'),
-            {
-              target: { files: [bigFile] },
-            }
+            bigFile
           )
 
           // Then
-          await expect(
-            screen.findByText('Poids maximal du fichier : 10 Mo', {
+          expect(
+            screen.getByText('Poids maximal du fichier : 10 Mo', {
               selector: 'strong',
             })
-          ).resolves.toBeInTheDocument()
+          ).toBeInTheDocument()
         })
 
         it('should not import an image whose width is below minimum', async () => {
@@ -228,19 +211,17 @@ describe('thumbnail edition', () => {
           const file = createImageFile({ width: 200 })
 
           // When
-          fireEvent.change(
+          await userEvent.upload(
             screen.getByLabelText('Importer une image depuis l’ordinateur'),
-            {
-              target: { files: [file] },
-            }
+            file
           )
 
           // Then
-          await expect(
-            screen.findByText('Largeur minimale de l’image : 400 px', {
+          expect(
+            screen.getByText('Largeur minimale de l’image : 400 px', {
               selector: 'strong',
             })
-          ).resolves.toBeInTheDocument()
+          ).toBeInTheDocument()
         })
       })
     })
@@ -252,49 +233,43 @@ describe('thumbnail edition', () => {
         const file = createImageFile()
 
         // When
-        fireEvent.change(
+        await userEvent.upload(
           screen.getByLabelText('Importer une image depuis l’ordinateur'),
-          {
-            target: { files: [file] },
-          }
+          file
         )
 
         // Then
-        await expect(
-          screen.findByText('Crédit image et droits d’utilisation')
-        ).resolves.toBeInTheDocument()
-        await expect(
-          screen.findByText('Crédit image')
-        ).resolves.toBeInTheDocument()
-        const inputCredit = await screen.findByPlaceholderText('Photographe...')
+        expect(
+          screen.getByText('Crédit image et droits d’utilisation')
+        ).toBeInTheDocument()
+        expect(screen.getByText('Crédit image')).toBeInTheDocument()
+        const inputCredit = screen.getByPlaceholderText('Photographe...')
         expect(inputCredit.maxLength).toBe(255)
-        await expect(
-          screen.findByText(
+        expect(
+          screen.getByText(
             'En utilisant ce contenu, je certifie que je suis propriétaire ou que je dispose des autorisations nécessaires pour l’utilisation de celui-ci'
           )
-        ).resolves.toBeInTheDocument()
-        await expect(
-          screen.findByText('Retour', { selector: 'button' })
-        ).resolves.toBeInTheDocument()
-        await expect(
-          screen.findByText('Suivant', { selector: 'button' })
-        ).resolves.toBeInTheDocument()
+        ).toBeInTheDocument()
+        expect(
+          screen.getByText('Retour', { selector: 'button' })
+        ).toBeInTheDocument()
+        expect(
+          screen.getByText('Suivant', { selector: 'button' })
+        ).toBeInTheDocument()
       })
 
       it('should return to the previous page if the return button is clicked', async () => {
         // Given
         renderThumbnail()
         const file = createImageFile()
-        fireEvent.change(
+        await userEvent.upload(
           screen.getByLabelText('Importer une image depuis l’ordinateur'),
-          {
-            target: { files: [file] },
-          }
+          file
         )
 
         // When
-        fireEvent.click(
-          await screen.findByText('Retour', { selector: 'button' })
+        await userEvent.click(
+          screen.getByText('Retour', { selector: 'button' })
         )
 
         // Then
@@ -309,16 +284,14 @@ describe('thumbnail edition', () => {
         // Given
         renderThumbnail()
         const file = createImageFile()
-        fireEvent.change(
+        await userEvent.upload(
           screen.getByLabelText('Importer une image depuis l’ordinateur'),
-          {
-            target: { files: [file] },
-          }
+          file
         )
 
         // When
-        fireEvent.click(
-          await screen.findByText('Suivant', { selector: 'button' })
+        await userEvent.click(
+          screen.getByText('Suivant', { selector: 'button' })
         )
 
         // Then
@@ -339,21 +312,22 @@ describe('thumbnail edition', () => {
         // Given
         renderThumbnail()
         const file = createImageFile()
-        fireEvent.change(
+        await userEvent.upload(
           screen.getByLabelText('Importer une image depuis l’ordinateur'),
-          {
-            target: { files: [file] },
-          }
+          file
         )
-        fireEvent.change(await screen.findByPlaceholderText('Photographe...'), {
-          target: { value: 'A fake credit' },
-        })
-        fireEvent.click(
-          await screen.findByText('Suivant', { selector: 'button' })
+        await userEvent.type(
+          screen.getByPlaceholderText('Photographe...'),
+          'A fake credit'
+        )
+        await userEvent.click(
+          screen.getByText('Suivant', { selector: 'button' })
         )
 
         // When
-        fireEvent.click(screen.getByText('Retour', { selector: 'button' }))
+        await userEvent.click(
+          screen.getByText('Retour', { selector: 'button' })
+        )
 
         // Then
         expect(screen.getByDisplayValue('A fake credit')).toBeInTheDocument()
@@ -363,20 +337,21 @@ describe('thumbnail edition', () => {
         // Given
         renderThumbnail()
         const file = createImageFile()
-        fireEvent.change(
+        await userEvent.upload(
           screen.getByLabelText('Importer une image depuis l’ordinateur'),
-          {
-            target: { files: [file] },
-          }
+          file
         )
-        fireEvent.change(await screen.findByPlaceholderText('Photographe...'), {
-          target: { value: 'A fake credit' },
-        })
-        fireEvent.click(
-          await screen.findByText('Suivant', { selector: 'button' })
+        await userEvent.type(
+          screen.getByPlaceholderText('Photographe...'),
+          'A fake credit'
+        )
+        await userEvent.click(
+          screen.getByText('Suivant', { selector: 'button' })
         )
 
         // When
+        // we need fireEvent here to avoid a warning with value in the slider
+        // Warning: Received NaN for the `value` attribute. If this is expected, cast the value to a string.
         fireEvent.change(screen.getByRole('slider'), { target: { value: 2.3 } })
 
         // Then

--- a/pro/src/components/pages/Offers/Offer/__specs__/Breadcrumb.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/__specs__/Breadcrumb.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 
 import { api } from 'apiClient/api'
 import { renderOffer } from 'components/pages/Offers/Offer/__specs__/render'
@@ -29,10 +29,12 @@ describe('individual offer step', () => {
       getFakeApiVenuesForOfferer(venue)
 
       // When
-      await renderOffer({ pathname: '/offre/creation/individuel' })
+      renderOffer({ pathname: '/offre/creation/individuel' })
 
       // Then
-      expect(screen.getByTestId('stepper')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByTestId('stepper')).toBeInTheDocument()
+      })
       const detailTab = await screen.findByText("Détails de l'offre")
       expect(detailTab).toBeInTheDocument()
       expect(detailTab).not.toHaveAttribute('href')
@@ -56,10 +58,12 @@ describe('individual offer step', () => {
       loadFakeApiCategories()
 
       // When
-      await renderOffer({ pathname: `/offre/${offer.id}/individuel/edition` })
+      renderOffer({ pathname: `/offre/${offer.id}/individuel/edition` })
 
       // Then
-      expect(screen.getByTestId('bc-tab')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByTestId('bc-tab')).toBeInTheDocument()
+      })
       const detailTab = await screen.findByText("Détails de l'offre", {
         selector: 'a',
       })
@@ -85,12 +89,14 @@ describe('stocks step', () => {
       loadFakeApiStocks([])
 
       // When
-      await renderOffer({
+      renderOffer({
         pathname: `/offre/${offer.id}/individuel/creation/stocks`,
       })
 
       // Then
-      expect(screen.getByTestId('stepper')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByTestId('stepper')).toBeInTheDocument()
+      })
       const detailTab = await screen
         .getByText("Détails de l'offre")
         .closest('a')
@@ -120,10 +126,12 @@ describe('stocks step', () => {
       loadFakeApiStocks([stock])
 
       // When
-      await renderOffer({ pathname: `/offre/${offer.id}/individuel/stocks` })
+      renderOffer({ pathname: `/offre/${offer.id}/individuel/stocks` })
 
       // Then
-      expect(screen.getByTestId('bc-tab')).toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.getByTestId('bc-tab')).toBeInTheDocument()
+      })
       const detailTab = await screen.findByText("Détails de l'offre", {
         selector: 'a',
       })
@@ -148,12 +156,14 @@ describe('confirmation step', () => {
       jest.spyOn(api, 'getOffer').mockResolvedValue(offer)
 
       // When
-      await renderOffer({
+      renderOffer({
         pathname: `/offre/${offer.id}/individuel/creation/confirmation`,
       })
 
       // Then
-      expect(screen.queryByText("Détails de l'offre")).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByText("Détails de l'offre")).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/pro/src/components/pages/Offers/Offer/__specs__/render.jsx
+++ b/pro/src/components/pages/Offers/Offer/__specs__/render.jsx
@@ -1,4 +1,4 @@
-import { screen, render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -7,7 +7,7 @@ import OfferLayout from 'components/pages/Offers/Offer/OfferLayout'
 import routes from 'routes/routes_map'
 import { configureTestStore } from 'store/testUtils'
 
-export const renderOffer = async (initialEntries, store) => {
+export const renderOffer = (initialEntries, store) => {
   const defaultStore = configureTestStore({
     user: {
       currentUser: {
@@ -34,8 +34,4 @@ export const renderOffer = async (initialEntries, store) => {
       </MemoryRouter>
     </Provider>
   )
-
-  await waitFor(() => {
-    expect(screen.getByTestId('offer-page')).toBeInTheDocument()
-  })
 }

--- a/pro/src/components/pages/Offers/Offer/__specs__/render.jsx
+++ b/pro/src/components/pages/Offers/Offer/__specs__/render.jsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react'
+import { screen, render, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -25,15 +25,17 @@ export const renderOffer = async (initialEntries, store) => {
     }
   })
 
-  await act(async () => {
-    render(
-      <Provider store={store ? store : defaultStore}>
-        <MemoryRouter initialEntries={[{ ...initialEntries }]}>
-          <Route path={path}>
-            <OfferLayout />
-          </Route>
-        </MemoryRouter>
-      </Provider>
-    )
+  render(
+    <Provider store={store ? store : defaultStore}>
+      <MemoryRouter initialEntries={[{ ...initialEntries }]}>
+        <Route path={path}>
+          <OfferLayout />
+        </Route>
+      </MemoryRouter>
+    </Provider>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByTestId('offer-page')).toBeInTheDocument()
   })
 }

--- a/pro/src/components/pages/Reimbursements/__specs__/ReimbursementWithFilters.spec.jsx
+++ b/pro/src/components/pages/Reimbursements/__specs__/ReimbursementWithFilters.spec.jsx
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom'
 
 import {
-  fireEvent,
   render,
   screen,
   waitFor,
@@ -75,9 +74,11 @@ const renderReimbursements = (storeOverride = {}) => {
 
   const expectFilters = filters => {
     const checkValues = async (venue, perdiodStart, periodEnd) => {
-      await waitFor(() => expect(filters.venue).toHaveValue(venue))
-      await waitFor(() => expect(filters.periodStart).toHaveValue(perdiodStart))
-      await waitFor(() => expect(filters.periodEnd).toHaveValue(periodEnd))
+      await waitFor(() => {
+        expect(filters.venue).toHaveValue(venue)
+        expect(filters.periodStart).toHaveValue(perdiodStart)
+        expect(filters.periodEnd).toHaveValue(periodEnd)
+      })
     }
 
     return {
@@ -88,9 +89,11 @@ const renderReimbursements = (storeOverride = {}) => {
     }
   }
 
-  const setPeriodFilters = (filters, startValue, endValue) => {
-    fireEvent.change(filters.periodStart, { target: { value: startValue } })
-    fireEvent.change(filters.periodEnd, { target: { value: endValue } })
+  const setPeriodFilters = async (filters, startValue, endValue) => {
+    await userEvent.clear(filters.periodStart)
+    await userEvent.clear(filters.periodEnd)
+    startValue && (await userEvent.type(filters.periodStart, startValue))
+    endValue && (await userEvent.type(filters.periodEnd, endValue))
   }
 
   const getElementsOnLoadingComplete = async () => {
@@ -227,7 +230,7 @@ describe('reimbursementsWithFilters', () => {
       await getElementsOnLoadingComplete()
 
     // when
-    setPeriodFilters('', '')
+    await setPeriodFilters('', '')
 
     // then
     await expectFilters.toHaveValues('allVenues', '', '')
@@ -238,7 +241,7 @@ describe('reimbursementsWithFilters', () => {
     )
 
     // when
-    setPeriodFilters('12/11/2020', '')
+    await setPeriodFilters('12/11/2020', '')
 
     // then
     await expectFilters.toHaveValues('allVenues', '12/11/2020', '')
@@ -249,7 +252,7 @@ describe('reimbursementsWithFilters', () => {
     )
 
     // when
-    setPeriodFilters('12/11/2020', '12/12/2020')
+    await setPeriodFilters('12/11/2020', '12/12/2020')
 
     // then
     await expectFilters.toHaveValues('allVenues', '12/11/2020', '12/12/2020')
@@ -293,7 +296,7 @@ describe('reimbursementsWithFilters', () => {
 
     // when
     const options = await within(filters.venue).findAllByRole('option')
-    setPeriodFilters('12/11/1998', '12/12/1999')
+    await setPeriodFilters('12/11/1998', '12/12/1999')
     await userEvent.selectOptions(filters.venue, [options[1].value])
 
     // then
@@ -302,6 +305,7 @@ describe('reimbursementsWithFilters', () => {
       '12/11/1998',
       '12/12/1999'
     )
+
     expect(buttons.resetFilters).toBeEnabled()
 
     // when

--- a/pro/src/components/pages/SetPassword/__specs__/SetPassword.spec.jsx
+++ b/pro/src/components/pages/SetPassword/__specs__/SetPassword.spec.jsx
@@ -1,10 +1,9 @@
 import '@testing-library/jest-dom'
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createBrowserHistory } from 'history'
 import React from 'react'
-import { act } from 'react-dom/test-utils'
 import { Provider } from 'react-redux'
 import { Route, Router } from 'react-router'
 
@@ -52,7 +51,7 @@ describe('src | components | pages | SetPassword', () => {
     expect(historyPushSpy).toHaveBeenCalledWith('/accueil')
   })
 
-  it('should render the default page without redirect', async () => {
+  it('should render the default page without redirect', () => {
     // Given
     renderSetPassword(store, history)
 
@@ -101,9 +100,7 @@ describe('src | components | pages | SetPassword', () => {
     await userEvent.click(submitButton)
 
     // Then
-    await waitFor(() => {
-      expect(pcapi.setPassword).toHaveBeenCalledWith('fakeToken', 'password1')
-    })
+    expect(pcapi.setPassword).toHaveBeenCalledWith('fakeToken', 'password1')
   })
 
   it('should display the success message and redirect to login page', async () => {
@@ -119,14 +116,12 @@ describe('src | components | pages | SetPassword', () => {
     // When
     userEvent.type(passwordInput, 'password1')
     userEvent.type(confirmationPasswordInput, 'password1')
-    await act(async () => userEvent.click(submitButton))
+    await userEvent.click(submitButton)
 
     // Then
-    await waitFor(() => {
-      expect(history.push).toHaveBeenCalledWith(
-        '/creation-de-mot-de-passe-confirmation'
-      )
-    })
+    expect(history.push).toHaveBeenCalledWith(
+      '/creation-de-mot-de-passe-confirmation'
+    )
   })
 
   it('should display the form error', async () => {
@@ -145,21 +140,19 @@ describe('src | components | pages | SetPassword', () => {
     // When
     userEvent.type(passwordInput, 'password1')
     userEvent.type(confirmationPasswordInput, 'password1')
-    await act(async () => userEvent.click(submitButton))
+    await userEvent.click(submitButton)
 
     // Then
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Une erreur s'est produite, veuillez corriger le formulaire."
-        )
-      ).toBeVisible()
-      expect(
-        screen.getByText(
-          'Votre mot de passe doit contenir au moins : - 12 caractères - Un chiffre - Une majuscule et une minuscule - Un caractère spécial'
-        )
-      ).toBeVisible()
-    })
+    expect(
+      screen.getByText(
+        "Une erreur s'est produite, veuillez corriger le formulaire."
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        'Votre mot de passe doit contenir au moins : - 12 caractères - Un chiffre - Une majuscule et une minuscule - Un caractère spécial'
+      )
+    ).toBeVisible()
   })
 
   it('should display the token error', async () => {
@@ -177,14 +170,12 @@ describe('src | components | pages | SetPassword', () => {
     // When
     userEvent.type(passwordInput, 'password1')
     userEvent.type(confirmationPasswordInput, 'password1')
-    await act(async () => userEvent.click(submitButton))
+    await userEvent.click(submitButton)
 
     // Then
-    await waitFor(() => {
-      expect(history.push).toHaveBeenCalledWith(
-        '/creation-de-mot-de-passe-confirmation?error=unvalid-link'
-      )
-    })
+    expect(history.push).toHaveBeenCalledWith(
+      '/creation-de-mot-de-passe-confirmation?error=unvalid-link'
+    )
   })
 
   it('should display the unknown error', async () => {
@@ -202,16 +193,14 @@ describe('src | components | pages | SetPassword', () => {
     // When
     userEvent.type(passwordInput, 'password1')
     userEvent.type(confirmationPasswordInput, 'password1')
-    await act(async () => userEvent.click(submitButton))
+    await userEvent.click(submitButton)
 
     // Then
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Une erreur s'est produite, veuillez contacter le support."
-        )
-      ).toBeVisible()
-    })
+    expect(
+      screen.getByText(
+        "Une erreur s'est produite, veuillez contacter le support."
+      )
+    ).toBeVisible()
   })
 
   it('should redirect the user to reset password page with a toaster when no token', async () => {

--- a/pro/src/components/pages/SignIn/__specs__/SignIn.spec.jsx
+++ b/pro/src/components/pages/SignIn/__specs__/SignIn.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -93,14 +93,14 @@ describe('src | components | pages | SignIn', () => {
       })
 
       // Then
-      fireEvent.click(eyePasswordButton)
+      await userEvent.click(eyePasswordButton)
 
       const password = screen.getByLabelText('Mot de passe')
       expect(password.type).toBe('text')
     })
 
     describe('when user re-click on eye', () => {
-      it('should hide password', () => {
+      it('should hide password', async () => {
         // Given
         renderSignIn(store)
         const eyePasswordButton = screen.getByRole('button', {
@@ -108,8 +108,8 @@ describe('src | components | pages | SignIn', () => {
         })
 
         // When
-        fireEvent.click(eyePasswordButton)
-        fireEvent.click(eyePasswordButton)
+        await userEvent.click(eyePasswordButton)
+        await userEvent.click(eyePasswordButton)
 
         //then
         const password = screen.getByLabelText('Mot de passe')
@@ -170,10 +170,10 @@ describe('src | components | pages | SignIn', () => {
       renderSignIn(store)
 
       const email = screen.getByLabelText('Adresse e-mail')
-      fireEvent.change(email, { target: { value: 'MonPetitEmail' } })
+      await userEvent.type(email, 'MonPetitEmail')
       const password = screen.getByLabelText('Mot de passe')
-      fireEvent.change(password, { target: { value: 'MCSolar85' } })
-      fireEvent.click(
+      await userEvent.type(password, 'MCSolar85')
+      await userEvent.click(
         screen.getByRole('button', {
           name: 'Se connecter',
         })
@@ -196,9 +196,9 @@ describe('src | components | pages | SignIn', () => {
         }
 
         renderSignIn(store)
-        await expect(
-          screen.findByText("I'm logged admin redirect route")
-        ).resolves.toBeInTheDocument()
+        expect(
+          screen.getByText("I'm logged admin redirect route")
+        ).toBeInTheDocument()
       })
       it('should redirect to offerers page if user is not admin', async () => {
         store.user = {
@@ -211,9 +211,9 @@ describe('src | components | pages | SignIn', () => {
         }
 
         renderSignIn(store)
-        await expect(
-          screen.findByText("I'm logged standard user redirect route")
-        ).resolves.toBeInTheDocument()
+        expect(
+          screen.getByText("I'm logged standard user redirect route")
+        ).toBeInTheDocument()
       })
     })
 
@@ -222,9 +222,9 @@ describe('src | components | pages | SignIn', () => {
         renderSignIn(store)
 
         const email = screen.getByLabelText('Adresse e-mail')
-        fireEvent.change(email, { target: { value: 'MonPetitEmail' } })
+        await userEvent.type(email, 'MonPetitEmail')
         const password = screen.getByLabelText('Mot de passe')
-        fireEvent.change(password, { target: { value: 'MCSolar85' } })
+        await userEvent.type(password, 'MCSolar85')
 
         api.signin.mockRejectedValue(
           new ApiError(
@@ -236,15 +236,15 @@ describe('src | components | pages | SignIn', () => {
             }
           )
         )
-        fireEvent.click(
+        await userEvent.click(
           screen.getByRole('button', {
             name: 'Se connecter',
           })
         )
 
-        await expect(
-          screen.findByText('Identifiant ou mot de passe incorrect.')
-        ).resolves.toBeInTheDocument()
+        expect(
+          screen.getByText('Identifiant ou mot de passe incorrect.')
+        ).toBeInTheDocument()
       })
     })
 
@@ -253,9 +253,9 @@ describe('src | components | pages | SignIn', () => {
         renderSignIn(store)
 
         const email = screen.getByLabelText('Adresse e-mail')
-        fireEvent.change(email, { target: { value: 'MonPetitEmail' } })
+        await userEvent.type(email, 'MonPetitEmail')
         const password = screen.getByLabelText('Mot de passe')
-        fireEvent.change(password, { target: { value: 'MCSolar85' } })
+        await userEvent.type(password, 'MCSolar85')
 
         api.signin.mockRejectedValue(
           new ApiError(
@@ -270,17 +270,17 @@ describe('src | components | pages | SignIn', () => {
             }
           )
         )
-        fireEvent.click(
+        await userEvent.click(
           screen.getByRole('button', {
             name: 'Se connecter',
           })
         )
 
-        await expect(
-          screen.findByText(
+        expect(
+          screen.getByText(
             'Nombre de tentatives de connexion dépassé. Veuillez réessayer dans 1 minute.'
           )
-        ).resolves.toBeInTheDocument()
+        ).toBeInTheDocument()
       })
     })
   })

--- a/pro/src/new_components/ButtonDownloadCSV/__specs__/ButtonDownloadCSV.spec.jsx
+++ b/pro/src/new_components/ButtonDownloadCSV/__specs__/ButtonDownloadCSV.spec.jsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import fetch from 'jest-fetch-mock'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -20,28 +20,28 @@ const renderButtonDownloadCSV = async ({ props, storeOverrides }) => {
 describe('src | components | Layout | ButtonDownloadCSV', () => {
   describe('render', () => {
     it('should disable button during download', async () => {
-      await new Promise(resolve => {
-        fetch.mockResponse(JSON.stringify({}), { status: 200 })
+      // await new Promise(resolve => {
+      fetch.mockResponse(JSON.stringify({}), { status: 200 })
 
-        const props = {
-          filename: 'test-csv',
-          href: 'http://test.com',
-          mimeType: 'text/csv',
-          isDisabled: false,
-        }
+      const props = {
+        filename: 'test-csv',
+        href: 'http://test.com',
+        mimeType: 'text/csv',
+        isDisabled: false,
+      }
 
-        renderButtonDownloadCSV({ props })
+      renderButtonDownloadCSV({ props })
 
-        const button = screen.getByText('Fake Title')
+      const button = await screen.findByText('Fake Title')
+      expect(button).toBeEnabled()
+
+      // maybe we need fireEvent here
+      fireEvent.click(button)
+      expect(button).toBeDisabled()
+
+      // then
+      waitFor(() => {
         expect(button).toBeEnabled()
-        fireEvent.click(button)
-        expect(button).toBeDisabled()
-
-        setTimeout(() => {
-          // then
-          expect(button).toBeEnabled()
-          resolve()
-        })
       })
     })
   })

--- a/pro/src/new_components/ConstraintCheck/useCheckAndSetImage.ts
+++ b/pro/src/new_components/ConstraintCheck/useCheckAndSetImage.ts
@@ -5,7 +5,6 @@ import { Constraint, getValidatorErrors } from './imageConstraints'
 type UseCheckAndSetImage = (args: {
   constraints: Constraint[]
   onSetImage: (file: string) => void
-  mountedRef: React.RefObject<boolean>
 }) => {
   errors: string[]
   checkAndSetImage: React.ChangeEventHandler<HTMLInputElement>
@@ -14,7 +13,6 @@ type UseCheckAndSetImage = (args: {
 export const useCheckAndSetImage: UseCheckAndSetImage = ({
   constraints,
   onSetImage,
-  mountedRef,
 }) => {
   const [errors, setErrors] = useState<string[]>([])
 
@@ -33,9 +31,7 @@ export const useCheckAndSetImage: UseCheckAndSetImage = ({
         // FIX ME: don't cast
         onSetImage(currentFile as unknown as string)
       }
-      if (mountedRef.current) {
-        setErrors(validatorErrors)
-      }
+      setErrors(validatorErrors)
     },
     [constraints, onSetImage]
   )

--- a/pro/src/new_components/ConstraintCheck/useCheckAndSetImage.ts
+++ b/pro/src/new_components/ConstraintCheck/useCheckAndSetImage.ts
@@ -5,6 +5,7 @@ import { Constraint, getValidatorErrors } from './imageConstraints'
 type UseCheckAndSetImage = (args: {
   constraints: Constraint[]
   onSetImage: (file: string) => void
+  mountedRef: React.RefObject<boolean>
 }) => {
   errors: string[]
   checkAndSetImage: React.ChangeEventHandler<HTMLInputElement>
@@ -13,6 +14,7 @@ type UseCheckAndSetImage = (args: {
 export const useCheckAndSetImage: UseCheckAndSetImage = ({
   constraints,
   onSetImage,
+  mountedRef,
 }) => {
   const [errors, setErrors] = useState<string[]>([])
 
@@ -31,8 +33,9 @@ export const useCheckAndSetImage: UseCheckAndSetImage = ({
         // FIX ME: don't cast
         onSetImage(currentFile as unknown as string)
       }
-
-      setErrors(validatorErrors)
+      if (mountedRef.current) {
+        setErrors(validatorErrors)
+      }
     },
     [constraints, onSetImage]
   )

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/__specs__/ModalImageCrop.spec.tsx
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/__specs__/ModalImageCrop.spec.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
 
@@ -23,14 +24,14 @@ const defaultProps = {
 }
 
 describe('venue image edit', () => {
-  it('closes the modal on cancel button click', () => {
+  it('closes the modal on cancel button click', async () => {
     const store = configureTestStore()
     const { getByText } = render(
       <Provider store={store}>
         <ModalImageCrop {...defaultProps} />
       </Provider>
     )
-    fireEvent.click(getByText("Remplacer l'image"))
+    await userEvent.click(getByText("Remplacer l'image"))
     expect(mockReplaceImage).toHaveBeenCalledTimes(1)
   })
 })

--- a/pro/src/new_components/RouteLeavingGuard/__specs__/RouteLeavingGuard.spec.tsx
+++ b/pro/src/new_components/RouteLeavingGuard/__specs__/RouteLeavingGuard.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { History } from 'history'
 import { createBrowserHistory } from 'history'
 import React from 'react'
@@ -34,14 +35,12 @@ const renderRouteLeavingGuard = async (
   props: IRouteLeavingGuardProps,
   history: History
 ) => {
-  act(() => {
-    render(
-      <Router history={history}>
-        <MiniAppTest />
-        <RouteLeavingGuard {...props}>{props.children}</RouteLeavingGuard>
-      </Router>
-    )
-  })
+  render(
+    <Router history={history}>
+      <MiniAppTest />
+      <RouteLeavingGuard {...props}>{props.children}</RouteLeavingGuard>
+    </Router>
+  )
 }
 
 describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', () => {
@@ -55,17 +54,17 @@ describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', 
       shouldBlockNavigation: () => shouldBlockReturnValue,
       when: true,
       children: 'Voulez-vous quitter la page actuelle ?',
-      dialogTitle: '',
+      dialogTitle: 'title',
     }
   })
 
   it('should always display the confirmation modal before redirection', async () => {
     // Given
-    await renderRouteLeavingGuard(props, history)
+    renderRouteLeavingGuard(props, history)
 
     // When
     const aboutPageLink = screen.getByText('About')
-    await fireEvent.click(aboutPageLink)
+    await userEvent.click(aboutPageLink)
 
     // Then
     expect(
@@ -78,9 +77,9 @@ describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', 
     props.when = false
 
     //When
-    await renderRouteLeavingGuard(props, history)
+    renderRouteLeavingGuard(props, history)
     const aboutPageLink = screen.getByText('About')
-    fireEvent.click(aboutPageLink)
+    await userEvent.click(aboutPageLink)
 
     //Then
     expect(
@@ -91,13 +90,13 @@ describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', 
 
   it('should be redirected after confirm on dialog', async () => {
     //Given
-    await renderRouteLeavingGuard(props, history)
+    renderRouteLeavingGuard(props, history)
 
     // When
     const aboutPageLink = screen.getByText('About')
-    fireEvent.click(aboutPageLink)
+    await userEvent.click(aboutPageLink)
     const confirmRedirectionButton = screen.getByText('Quitter')
-    fireEvent.click(confirmRedirectionButton)
+    await userEvent.click(confirmRedirectionButton)
 
     // Then
     expect(screen.queryByText('Home page')).not.toBeInTheDocument()
@@ -106,12 +105,12 @@ describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', 
 
   it('should not be redirected after cancel on dialog', async () => {
     //Given
-    await renderRouteLeavingGuard(props, history)
+    renderRouteLeavingGuard(props, history)
     // When
     const aboutPageLink = screen.getByText('About')
-    fireEvent.click(aboutPageLink)
+    await userEvent.click(aboutPageLink)
     const cancelRedirectionButton = screen.getByText('Annuler')
-    fireEvent.click(cancelRedirectionButton)
+    await userEvent.click(cancelRedirectionButton)
 
     // Then
     expect(screen.queryByText('Home page')).toBeInTheDocument()
@@ -129,9 +128,9 @@ describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', 
     }
 
     // When
-    await renderRouteLeavingGuard(props, history)
+    renderRouteLeavingGuard(props, history)
     const contactPageLink = screen.getByText('Contact')
-    fireEvent.click(contactPageLink)
+    await userEvent.click(contactPageLink)
 
     // Then
     expect(screen.queryByText('Home page')).not.toBeInTheDocument()
@@ -139,7 +138,7 @@ describe('new_components | RouteLeavingGuardOfferCreation | RouteLeavingGuard', 
 
     // When
     const aboutPageLink = screen.getByText('About')
-    fireEvent.click(aboutPageLink)
+    await userEvent.click(aboutPageLink)
 
     // Then
     expect(

--- a/pro/src/routes/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/routes/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -1,12 +1,6 @@
 import '@testing-library/jest-dom'
 
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -28,7 +22,7 @@ import {
 } from 'utils/date'
 import { getNthCallNthArg } from 'utils/testHelpers'
 
-import BookingsRecapContainer, { BookingsRouterState } from '../Bookings'
+import BookingsRecapContainer from '../Bookings'
 
 jest.mock('repository/pcapi/pcapi', () => ({
   getFilteredBookingsCSV: jest.fn(),
@@ -65,14 +59,12 @@ const NTH_ARGUMENT_GET_BOOKINGS = {
 
 const renderBookingsRecap = async (
   store: any,
-  routerState?: BookingsRouterState,
+  initialEntries = '/reservations',
   waitDomReady?: boolean
 ) => {
   const rtlReturn = render(
     <Provider store={configureTestStore(store)}>
-      <MemoryRouter
-        initialEntries={[{ pathname: '/reservations', state: routerState }]}
-      >
+      <MemoryRouter initialEntries={[initialEntries]}>
         <BookingsRecapContainer />
         <Notification />
       </MemoryRouter>
@@ -86,8 +78,7 @@ const renderBookingsRecap = async (
   })
 
   const submitFilters = async () => {
-    fireEvent.click(displayBookingsButton)
-    await waitFor(() => expect(displayBookingsButton).not.toBeDisabled())
+    await userEvent.click(displayBookingsButton)
   }
   const submitDownloadFilters = async () => {
     await userEvent.click(downloadBookingsCsvButton)
@@ -141,10 +132,6 @@ describe('components | BookingsRecap | Pro user', () => {
       .mockResolvedValue({ hasBookings: true })
   })
 
-  afterEach(() => {
-    jest.spyOn(api, 'getBookingsPro').mockReset()
-  })
-
   it('should show a pre-filter section', async () => {
     // When
     await renderBookingsRecap(store)
@@ -179,7 +166,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -224,14 +210,12 @@ describe('components | BookingsRecap | Pro user', () => {
       bookingsRecap: [],
     })
     const { submitFilters } = await renderBookingsRecap(store)
-    userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
+    await userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
     await submitFilters()
 
     // When
-    const resetButton = await screen.findByText(
-      'réinitialiser tous les filtres.'
-    )
-    fireEvent.click(resetButton)
+    const resetButton = screen.getByText('réinitialiser tous les filtres.')
+    await userEvent.click(resetButton)
 
     // Then
     expect(screen.getByLabelText('Lieu')).toHaveValue(
@@ -246,7 +230,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -267,18 +250,17 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
-    userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
+    await userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
     const defaultBookingPeriodBeginningDateInput = '16/05/2020'
     const defaultBookingPeriodEndingDateInput = '15/06/2020'
     const bookingPeriodBeginningDateInput = screen.getByDisplayValue(
       defaultBookingPeriodBeginningDateInput
     )
-    fireEvent.click(bookingPeriodBeginningDateInput)
-    fireEvent.click(screen.getAllByText('5')[0])
+    await userEvent.click(bookingPeriodBeginningDateInput)
+    await userEvent.click(screen.getAllByText('5')[0])
     const bookingPeriodEndingDateInput = screen.getByDisplayValue(
       defaultBookingPeriodEndingDateInput
     )
@@ -288,7 +270,7 @@ describe('components | BookingsRecap | Pro user', () => {
 
     // When
     const resetButton = await screen.findByText('Réinitialiser les filtres')
-    fireEvent.click(resetButton)
+    await userEvent.click(resetButton)
 
     // Then
     expect(screen.getByLabelText('Lieu')).toHaveValue(
@@ -309,7 +291,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -318,7 +299,7 @@ describe('components | BookingsRecap | Pro user', () => {
 
     // When
     const resetButton = await screen.findByText('Réinitialiser les filtres')
-    fireEvent.click(resetButton)
+    await userEvent.click(resetButton)
 
     // Then
     expect(
@@ -429,9 +410,9 @@ describe('components | BookingsRecap | Pro user', () => {
     }
     jest
       .spyOn(api, 'getBookingsPro')
-      // @ts-ignore FIX ME
+
       .mockResolvedValueOnce(paginatedBookingRecapReturned)
-      // @ts-ignore FIX ME
+
       .mockResolvedValueOnce(secondPaginatedBookingRecapReturned)
     const { submitFilters } = await renderBookingsRecap(store)
 
@@ -469,14 +450,13 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
 
     // When
-    fireEvent.click(screen.getByLabelText('Date de l’évènement'))
-    fireEvent.click(screen.getByText('8'))
+    await userEvent.click(screen.getByLabelText('Date de l’évènement'))
+    await userEvent.click(screen.getByText('8'))
     await submitFilters()
 
     // Then
@@ -502,14 +482,13 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
 
     // When
-    fireEvent.click(screen.getByLabelText('Date de l’évènement'))
-    fireEvent.click(screen.getByText('8'))
+    await userEvent.click(screen.getByLabelText('Date de l’évènement'))
+    await userEvent.click(screen.getByText('8'))
     await submitFilters()
     // Then
     await screen.findAllByText(bookingRecap.stock.offer_name)
@@ -537,7 +516,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -570,7 +548,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -580,10 +557,10 @@ describe('components | BookingsRecap | Pro user', () => {
       within(bookingPeriodWrapper).getAllByPlaceholderText('JJ/MM/AAAA')
 
     // When
-    fireEvent.click(beginningPeriodInput)
-    fireEvent.click(screen.getByText('10'))
-    fireEvent.click(endingPeriodInput)
-    fireEvent.click(screen.getAllByText('5')[0])
+    await userEvent.click(beginningPeriodInput)
+    await userEvent.click(screen.getByText('10'))
+    await userEvent.click(endingPeriodInput)
+    await userEvent.click(screen.getAllByText('5')[0])
     await submitFilters()
 
     // Then
@@ -621,7 +598,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -629,11 +605,11 @@ describe('components | BookingsRecap | Pro user', () => {
     const bookingPeriodWrapper = screen.getByText('Période de réservation')
     const [beginningPeriodInput, endingPeriodInput] =
       within(bookingPeriodWrapper).getAllByPlaceholderText('JJ/MM/AAAA')
-    fireEvent.click(endingPeriodInput)
-    fireEvent.click(screen.getByText('12'))
+    await userEvent.click(endingPeriodInput)
+    await userEvent.click(screen.getByText('12'))
 
     // When
-    fireEvent.change(beginningPeriodInput, { target: { value: '' } })
+    await userEvent.clear(beginningPeriodInput)
     await submitFilters()
 
     // Then
@@ -658,7 +634,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -666,11 +641,11 @@ describe('components | BookingsRecap | Pro user', () => {
     const bookingPeriodWrapper = screen.getByText('Période de réservation')
     const [beginningPeriodInput, endingPeriodInput] =
       within(bookingPeriodWrapper).getAllByPlaceholderText('JJ/MM/AAAA')
-    fireEvent.click(beginningPeriodInput)
-    fireEvent.click(screen.getByText('10'))
+    await userEvent.click(beginningPeriodInput)
+    await userEvent.click(screen.getByText('10'))
 
     // When
-    fireEvent.change(endingPeriodInput, { target: { value: '' } })
+    await userEvent.clear(endingPeriodInput)
     await submitFilters()
 
     // Then
@@ -695,7 +670,6 @@ describe('components | BookingsRecap | Pro user', () => {
       page: 1,
       pages: 1,
       total: 1,
-      // @ts-ignore FIX ME
       bookingsRecap: [bookingRecap],
     })
     const { submitFilters } = await renderBookingsRecap(store)
@@ -705,8 +679,8 @@ describe('components | BookingsRecap | Pro user', () => {
       within(bookingPeriodWrapper).getAllByPlaceholderText('JJ/MM/AAAA')[1]
 
     // When
-    fireEvent.click(endingPeriodInput)
-    fireEvent.click(screen.getByText('16'))
+    await userEvent.click(endingPeriodInput)
+    await userEvent.click(screen.getByText('16'))
     await submitFilters()
 
     // Then
@@ -742,18 +716,18 @@ describe('components | BookingsRecap | Pro user', () => {
     }
     jest
       .spyOn(api, 'getBookingsPro')
-      // @ts-ignore FIX ME
+
       .mockResolvedValueOnce(otherVenuePaginatedBookingRecapReturned)
-      // @ts-ignore FIX ME
+
       .mockResolvedValueOnce(paginatedBookingRecapReturned)
     const { submitFilters } = await renderBookingsRecap(store)
 
-    userEvent.selectOptions(screen.getByLabelText('Lieu'), otherVenue.id)
+    await userEvent.selectOptions(screen.getByLabelText('Lieu'), otherVenue.id)
     await submitFilters()
     await screen.findAllByText(otherVenueBooking.stock.offer_name)
 
     // When
-    userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
+    await userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
     await submitFilters()
 
     // Then
@@ -786,7 +760,7 @@ describe('components | BookingsRecap | Pro user', () => {
     await renderBookingsRecap(store)
 
     // when
-    userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
+    await userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
     await userEvent.click(screen.getByText('Afficher', { selector: 'button' }))
 
     // Then
@@ -815,11 +789,11 @@ describe('components | BookingsRecap | Pro user', () => {
     await renderBookingsRecap(store)
 
     // when
-    userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
+    await userEvent.selectOptions(screen.getByLabelText('Lieu'), venue.id)
     await userEvent.click(screen.getByText('Afficher', { selector: 'button' }))
 
     // Then
-    await waitFor(() => expect(api.getBookingsPro).toHaveBeenCalledTimes(5))
+    expect(api.getBookingsPro).toHaveBeenCalledTimes(5)
     const informationalMessage = screen.queryByText(
       'L’affichage des réservations a été limité à 5 000 réservations. Vous pouvez modifier les filtres pour affiner votre recherche.'
     )
@@ -832,7 +806,7 @@ describe('components | BookingsRecap | Pro user', () => {
     await submitFilters()
 
     // When
-    userEvent.selectOptions(
+    await userEvent.selectOptions(
       screen.getByLabelText('Lieu'),
       venue.publicName ?? venue.name
     )
@@ -847,13 +821,13 @@ describe('components | BookingsRecap | Pro user', () => {
   it('should not inform the user when the selected filter is the same than the actual filter', async () => {
     // Given
     await renderBookingsRecap(store)
-    userEvent.selectOptions(
+    await userEvent.selectOptions(
       screen.getByLabelText('Lieu'),
       venue.publicName ?? venue.name
     )
 
     // When
-    userEvent.selectOptions(
+    await userEvent.selectOptions(
       screen.getByLabelText('Lieu'),
       screen.getByText('Tous les lieux')
     )
@@ -870,7 +844,7 @@ describe('components | BookingsRecap | Pro user', () => {
     await renderBookingsRecap(store)
 
     // When
-    userEvent.selectOptions(
+    await userEvent.selectOptions(
       screen.getByLabelText('Lieu'),
       venue.publicName ?? venue.name
     )

--- a/pro/src/screens/Bookings/Bookings.tsx
+++ b/pro/src/screens/Bookings/Bookings.tsx
@@ -1,3 +1,4 @@
+import { startOfDay } from 'date-fns'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 
@@ -148,18 +149,18 @@ const Bookings = <
       ? params.has('offerEventDate')
         ? null
         : DEFAULT_PRE_FILTERS.bookingBeginningDate
-      : new Date(params.get('bookingBeginningDate') as string)
+      : startOfDay(new Date(params.get('bookingBeginningDate') as string))
     const paramBookingEndingDate: Date | null = !params.has('bookingEndingDate')
       ? params.has('offerEventDate')
         ? null
         : DEFAULT_PRE_FILTERS.bookingEndingDate
-      : new Date(params.get('bookingEndingDate') as string)
+      : startOfDay(new Date(params.get('bookingEndingDate') as string))
     const paramOfferType: string =
       params.get('offerType') ?? DEFAULT_PRE_FILTERS.offerType
     const paramOfferEventDate: string | Date = params.has('offerEventDate')
       ? params.get('offerEventDate') === 'all'
         ? 'all'
-        : new Date(params.get('offerEventDate') as string)
+        : startOfDay(new Date(params.get('offerEventDate') as string))
       : DEFAULT_PRE_FILTERS.offerEventDate
 
     if (

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableBody.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableBody.tsx
@@ -37,12 +37,16 @@ const TableBody = <
 }: ITableBodyProps<T>) => {
   return (
     <tbody className="bookings-body" {...tableBodyProps}>
-      {page.map(row => {
+      {page.map((row, index) => {
         prepareRow(row)
         return isCollectiveRow(row, audience) ? (
-          <CollectiveTableRow row={row} reloadBookings={reloadBookings} />
+          <CollectiveTableRow
+            key={index}
+            row={row}
+            reloadBookings={reloadBookings}
+          />
         ) : (
-          <IndividualTableRow row={row} />
+          <IndividualTableRow key={index} row={row} />
         )
       })}
     </tbody>

--- a/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
+++ b/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
 import type { Store } from 'redux'
@@ -23,7 +24,7 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderPreFilters = (props: IPreFiltersProps, store: Store) => {
-  return render(
+  render(
     <Provider store={store}>
       <PreFilters {...props} />
     </Provider>
@@ -55,24 +56,20 @@ describe('filter bookings by bookings period', () => {
     store = configureTestStore()
   })
 
-  it('should select 30 days before today as period beginning date by default', async () => {
+  it('should select 30 days before today as period beginning date by default', () => {
     // When
     renderPreFilters(props, store)
 
     // Then
-    await expect(
-      screen.findByDisplayValue('15/11/2020')
-    ).resolves.toBeInTheDocument()
+    expect(screen.getByDisplayValue('15/11/2020')).toBeInTheDocument()
   })
 
-  it('should select today as period ending date by default', async () => {
+  it('should select today as period ending date by default', () => {
     // When
     renderPreFilters(props, store)
 
     // Then
-    await expect(
-      screen.findByDisplayValue('15/12/2020')
-    ).resolves.toBeInTheDocument()
+    expect(screen.getByDisplayValue('15/12/2020')).toBeInTheDocument()
   })
 
   it('should allow to select period ending date before today', async () => {
@@ -81,13 +78,11 @@ describe('filter bookings by bookings period', () => {
     const periodEndingDateInput = screen.getByDisplayValue('15/12/2020')
 
     // When
-    fireEvent.click(periodEndingDateInput)
-    fireEvent.click(screen.getByText('14'))
+    await userEvent.click(periodEndingDateInput)
+    await userEvent.click(screen.getByText('14'))
 
     // Then
-    await expect(
-      screen.findByDisplayValue('14/12/2020')
-    ).resolves.toBeInTheDocument()
+    expect(screen.getByDisplayValue('14/12/2020')).toBeInTheDocument()
   })
 
   it('should not allow to select period ending date after today', async () => {
@@ -95,9 +90,9 @@ describe('filter bookings by bookings period', () => {
     renderPreFilters(props, store)
 
     // When
-    const periodEndingDateInput = await screen.findByDisplayValue('15/12/2020')
-    fireEvent.click(periodEndingDateInput)
-    fireEvent.click(screen.getByText('16'))
+    const periodEndingDateInput = await screen.getByDisplayValue('15/12/2020')
+    await userEvent.click(periodEndingDateInput)
+    await userEvent.click(screen.getByText('16'))
 
     // Then
     expect(screen.queryByDisplayValue('16/12/2020')).not.toBeInTheDocument()
@@ -109,9 +104,9 @@ describe('filter bookings by bookings period', () => {
     const periodEndingDateInput = screen.getByDisplayValue('15/12/2020')
 
     // When
-    fireEvent.click(periodEndingDateInput)
-    fireEvent.click(screen.getByLabelText('Previous Month'))
-    fireEvent.click(screen.getByText('13'))
+    await userEvent.click(periodEndingDateInput)
+    await userEvent.click(screen.getByLabelText('Previous Month'))
+    await userEvent.click(screen.getByText('13'))
 
     // Then
     expect(screen.queryByDisplayValue('13/12/2020')).not.toBeInTheDocument()
@@ -123,13 +118,11 @@ describe('filter bookings by bookings period', () => {
     const periodBeginningDateInput = screen.getByDisplayValue('15/11/2020')
 
     // When
-    fireEvent.click(periodBeginningDateInput)
-    fireEvent.click(screen.getByText('14'))
+    await userEvent.click(periodBeginningDateInput)
+    await userEvent.click(screen.getByText('14'))
 
     // Then
-    await expect(
-      screen.findByDisplayValue('14/11/2020')
-    ).resolves.toBeInTheDocument()
+    expect(screen.getByDisplayValue('14/11/2020')).toBeInTheDocument()
   })
 
   it('should not allow to select period beginning date after ending date', async () => {
@@ -138,14 +131,14 @@ describe('filter bookings by bookings period', () => {
 
     // When
     const periodBeginningDateInput = screen.getByDisplayValue('15/11/2020')
-    fireEvent.click(periodBeginningDateInput)
-    fireEvent.click(screen.getByText('16'))
+    await userEvent.click(periodBeginningDateInput)
+    await userEvent.click(screen.getByText('16'))
 
     // Then
     expect(screen.queryByDisplayValue('16/12/2020')).not.toBeInTheDocument()
   })
 
-  it('should select booked status as booking status filter by default', async () => {
+  it('should select booked status as booking status filter by default', () => {
     props.isBookingFiltersActive = true
     // Given
     renderPreFilters(props, store)
@@ -165,8 +158,8 @@ describe('filter bookings by bookings period', () => {
     )
 
     // When
-    fireEvent.click(bookingStatusFilterInput)
-    fireEvent.click(screen.getByText('Période de validation'))
+    await userEvent.click(bookingStatusFilterInput)
+    await userEvent.click(screen.getByText('Période de validation'))
 
     // Then
     expect(screen.queryByText('Période de validation')).toBeInTheDocument()

--- a/pro/src/screens/Bookings/PreFilters/PreFilters.tsx
+++ b/pro/src/screens/Bookings/PreFilters/PreFilters.tsx
@@ -78,8 +78,21 @@ const PreFilters = ({
     let key: keyof TPreFilters
     let hasFilters = false
     for (key in selectedPreFilters) {
-      if (selectedPreFilters[key] !== DEFAULT_PRE_FILTERS[key])
+      if (
+        key.includes('Date') &&
+        selectedPreFilters[key] instanceof Date &&
+        DEFAULT_PRE_FILTERS[key] instanceof Date
+      ) {
+        if (
+          // @ts-ignore
+          selectedPreFilters[key].getTime() !==
+          // @ts-ignore
+          DEFAULT_PRE_FILTERS[key].getTime()
+        )
+          hasFilters = true
+      } else if (selectedPreFilters[key] !== DEFAULT_PRE_FILTERS[key]) {
         hasFilters = true
+      }
     }
     setHasPreFilters(hasFilters)
   }, [selectedPreFilters])

--- a/pro/src/screens/Bookings/PreFilters/__specs__/FilterByEventDate.spec.tsx
+++ b/pro/src/screens/Bookings/PreFilters/__specs__/FilterByEventDate.spec.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 import { EMPTY_FILTER_VALUE } from 'core/Bookings'
@@ -32,7 +33,8 @@ describe('components | FilterByEventDate', () => {
     const offerDateInput = screen.getByPlaceholderText('JJ/MM/AAAA')
 
     // When
-    fireEvent.change(offerDateInput, { target: { value: selectedDate } })
+    await userEvent.type(offerDateInput, selectedDate.toISOString())
+
     // Then
     expect(props.updateFilters).toHaveBeenCalledWith({
       offerEventDate: selectedDate,

--- a/pro/src/screens/CsvTable/__specs__/CsvTable.spec.tsx
+++ b/pro/src/screens/CsvTable/__specs__/CsvTable.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
@@ -93,7 +94,7 @@ describe('src | components | layout | CsvTable', () => {
       renderCsvTable({ props })
 
       jest.spyOn(global, 'print').mockImplementation()
-      fireEvent.click(await screen.findByText('Imprimer'))
+      await userEvent.click(await screen.findByText('Imprimer'))
 
       expect(global.print).toHaveBeenCalledTimes(1)
     })

--- a/pro/src/screens/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/screens/Desk/__specs__/Desk.spec.tsx
@@ -1,20 +1,20 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
 import { DeskScreen, IDeskProps } from '..'
 
-const renderDeskScreen = async (props: IDeskProps) => {
+const renderDeskScreen = (props: IDeskProps) => {
   const rtlReturns = render(
     <MemoryRouter>
       <DeskScreen {...props} />
     </MemoryRouter>
   )
 
-  const pageTitle = await screen.findByRole('heading', { name: 'Guichet' })
+  const pageTitle = screen.getByRole('heading', { name: 'Guichet' })
 
   return {
     ...rtlReturns,
@@ -49,7 +49,7 @@ describe('src | components | Desk', () => {
   it('test form render', async () => {
     // when
     const { pageTitle, inputToken, buttonSubmitValidated } =
-      await renderDeskScreen(props)
+      renderDeskScreen(props)
 
     expect(pageTitle).toBeInTheDocument()
     expect(inputToken).toBeInTheDocument()
@@ -71,7 +71,7 @@ describe('src | components | Desk', () => {
       tooLong: 'La contremarque ne peut pas faire plus de 6 caractères',
     }
     const getBooking = jest.fn()
-    const { messageContainer, inputToken } = await renderDeskScreen({
+    const { messageContainer, inputToken } = renderDeskScreen({
       ...props,
       getBooking,
     })
@@ -94,7 +94,7 @@ describe('src | components | Desk', () => {
   })
 
   it('test valid token and booking details display', async () => {
-    const { inputToken, buttonSubmitValidated } = await renderDeskScreen(props)
+    const { inputToken, buttonSubmitValidated } = renderDeskScreen(props)
 
     await userEvent.type(inputToken, 'AAAAAA')
 
@@ -123,7 +123,7 @@ describe('src | components | Desk', () => {
         error: alreadyValidatedErrorMessage,
       }),
     }
-    const { inputToken, buttonSubmitValidated } = await renderDeskScreen(props)
+    const { inputToken, buttonSubmitValidated } = renderDeskScreen(props)
 
     await userEvent.type(inputToken, 'AAAAAA')
 
@@ -143,7 +143,7 @@ describe('src | components | Desk', () => {
     const submitValidate = jest
       .fn()
       .mockImplementation(() => Promise.resolve({}))
-    const { inputToken, buttonSubmitValidated } = await renderDeskScreen({
+    const { inputToken, buttonSubmitValidated } = renderDeskScreen({
       ...props,
       submitValidate,
     })
@@ -154,10 +154,10 @@ describe('src | components | Desk', () => {
       'Coupon vérifié, cliquez sur "Valider" pour enregistrer'
     )
 
+    // I don't know how to test this without fireEvent
     fireEvent.click(screen.getByText('Valider la contremarque'))
-    expect(
-      await screen.findByText('Validation en cours...')
-    ).toBeInTheDocument()
+    expect(screen.getByText('Validation en cours...')).toBeInTheDocument()
+
     expect(
       await screen.findByText('Contremarque validée !')
     ).toBeInTheDocument()
@@ -178,14 +178,12 @@ describe('src | components | Desk', () => {
       }),
     }
     const { messageContainer, inputToken, buttonSubmitValidated } =
-      await renderDeskScreen(props)
+      renderDeskScreen(props)
 
     await userEvent.type(inputToken, 'AAAAAA')
-    await waitFor(() => {
-      expect(messageContainer.textContent).toBe(
-        alreadyValidatedErrorMessage.message
-      )
-    })
+    expect(messageContainer.textContent).toBe(
+      alreadyValidatedErrorMessage.message
+    )
     expect(props.getBooking).toHaveBeenCalledWith('AAAAAA')
 
     expect(buttonSubmitValidated).not.toBeInTheDocument()
@@ -214,13 +212,11 @@ describe('src | components | Desk', () => {
       }),
       submitInvalidate: jest.fn().mockImplementation(() => Promise.resolve({})),
     }
-    const { inputToken, buttonSubmitValidated } = await renderDeskScreen(props)
+    const { inputToken, buttonSubmitValidated } = renderDeskScreen(props)
     await userEvent.clear(inputToken)
     await userEvent.type(inputToken, 'AAAAAA')
-    await waitFor(() =>
-      expect(screen.getByTestId('desk-message')).toHaveTextContent(
-        alreadyValidatedErrorMessage.message
-      )
+    expect(screen.getByTestId('desk-message')).toHaveTextContent(
+      alreadyValidatedErrorMessage.message
     )
     const buttonSubmitInvalidated = await screen.findByText(
       'Invalider la contremarque'

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -1,11 +1,10 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createMemoryHistory } from 'history'
 import React from 'react'
 import { Provider } from 'react-redux'
-import { MemoryRouter, Router } from 'react-router'
+import { MemoryRouter } from 'react-router'
 import type { Store } from 'redux'
 
 import { api } from 'apiClient/api'
@@ -30,17 +29,13 @@ import { queryByTextTrimHtml } from 'utils/testHelpers'
 import Offers, { IOffersProps } from '../Offers'
 
 const renderOffers = (props: IOffersProps, store: Store) => {
-  const history = createMemoryHistory()
-  return {
-    ...render(
-      <Provider store={store}>
-        <Router history={history}>
-          <Offers {...props} />
-        </Router>
-      </Provider>
-    ),
-    history,
-  }
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Offers {...props} />
+      </MemoryRouter>
+    </Provider>
+  )
 }
 
 const categoriesAndSubcategories = {
@@ -169,9 +164,7 @@ describe('screen Offers', () => {
       renderOffers(props, store)
 
       // Then
-      await expect(
-        screen.findByText('Lieu', { selector: 'th' })
-      ).resolves.toBeInTheDocument()
+      expect(screen.getByText('Lieu', { selector: 'th' })).toBeInTheDocument()
       expect(screen.getByText('Stocks', { selector: 'th' })).toBeInTheDocument()
     })
 
@@ -190,7 +183,7 @@ describe('screen Offers', () => {
       )
 
       // Then
-      const firstOfferLine = await screen.findByText(firstOffer.name)
+      const firstOfferLine = screen.getByText(firstOffer.name)
       expect(firstOfferLine).toBeInTheDocument()
       expect(screen.getByText(secondOffer.name)).toBeInTheDocument()
     })
@@ -211,7 +204,7 @@ describe('screen Offers', () => {
       )
 
       // Then
-      await screen.findByText(firstOffer.name)
+      screen.getByText(firstOffer.name)
       const selectAllOffersCheckbox =
         screen.queryByLabelText('Tout sélectionner')
       expect(selectAllOffersCheckbox).toBeInTheDocument()
@@ -231,7 +224,7 @@ describe('screen Offers', () => {
         )
 
         // Then
-        await screen.findByText(offersRecap[0].name)
+        screen.getByText(offersRecap[0].name)
         expect(queryByTextTrimHtml(screen, '2 offres')).toBeInTheDocument()
       })
 
@@ -240,7 +233,7 @@ describe('screen Offers', () => {
         renderOffers({ ...props, offers: offersRecap }, store)
 
         // Then
-        await screen.findByText(offersRecap[0].name)
+        screen.getByText(offersRecap[0].name)
         expect(queryByTextTrimHtml(screen, '1 offre')).toBeInTheDocument()
       })
 
@@ -252,7 +245,7 @@ describe('screen Offers', () => {
         renderOffers({ ...props, offers: offersRecap }, store)
 
         // Then
-        await screen.findByText(offersRecap[0].name)
+        screen.getByText(offersRecap[0].name)
         expect(queryByTextTrimHtml(screen, '500\\+ offres')).toBeInTheDocument()
       })
     })
@@ -278,12 +271,12 @@ describe('screen Offers', () => {
         )
         expect(defaultOption).toBeInTheDocument()
 
-        const firstVenueOption = await screen.findByRole('option', {
+        const firstVenueOption = screen.getByRole('option', {
           name: expectedSelectOptions[1].value,
         })
         expect(firstVenueOption).toBeInTheDocument()
 
-        const secondVenueOption = await screen.findByRole('option', {
+        const secondVenueOption = screen.getByRole('option', {
           name: expectedSelectOptions[2].value,
         })
         expect(secondVenueOption).toBeInTheDocument()
@@ -300,7 +293,7 @@ describe('screen Offers', () => {
         renderOffers({ ...props, initialSearchFilters: filters }, store)
 
         // Then
-        const venueSelect = await screen.findByDisplayValue(
+        const venueSelect = screen.getByDisplayValue(
           expectedSelectOptions[0].value
         )
         expect(venueSelect).toBeInTheDocument()
@@ -337,21 +330,19 @@ describe('screen Offers', () => {
         const creationModeSelect = screen.getByLabelText('Mode de création')
 
         // When
-        userEvent.selectOptions(creationModeSelect, 'Manuelle')
+        await userEvent.selectOptions(creationModeSelect, 'Manuelle')
 
         // Then
-        await waitFor(() =>
-          expect(screen.getByDisplayValue('Manuelle')).toBeInTheDocument()
-        )
+        expect(screen.getByDisplayValue('Manuelle')).toBeInTheDocument()
       })
 
-      it('should allow user to select imported creation mode filter', () => {
+      it('should allow user to select imported creation mode filter', async () => {
         // Given
         renderOffers(props, store)
         const creationModeSelect = screen.getByDisplayValue('Tous')
 
         // When
-        fireEvent.change(creationModeSelect, { target: { value: 'imported' } })
+        await userEvent.selectOptions(creationModeSelect, 'imported')
 
         // Then
         expect(screen.getByDisplayValue('Importée')).toBeInTheDocument()
@@ -371,7 +362,7 @@ describe('screen Offers', () => {
           // When
           renderOffers(props, store)
           // Then
-          await expect(screen.findByText('Statut')).resolves.toBeInTheDocument()
+          expect(screen.getByText('Statut')).toBeInTheDocument()
           expect(
             screen.queryByText('Afficher les statuts')
           ).not.toBeInTheDocument()
@@ -391,10 +382,8 @@ describe('screen Offers', () => {
           // Given
           renderOffers(props, store)
           // When
-          fireEvent.click(
-            await screen.findByAltText(
-              'Afficher ou masquer le filtre par statut'
-            )
+          await userEvent.click(
+            screen.getByAltText('Afficher ou masquer le filtre par statut')
           )
           // Then
           expect(screen.queryByText('Afficher les statuts')).toBeInTheDocument()
@@ -416,9 +405,7 @@ describe('screen Offers', () => {
           // Given
           renderOffers(props, store)
           await userEvent.click(
-            await screen.findByAltText(
-              'Afficher ou masquer le filtre par statut'
-            )
+            screen.getByAltText('Afficher ou masquer le filtre par statut')
           )
           // When
           await userEvent.click(
@@ -435,7 +422,7 @@ describe('screen Offers', () => {
           // When
           renderOffers({ ...props, offers: [] }, store)
           // Then
-          const noOffersText = await screen.findByText(
+          const noOffersText = screen.getByText(
             'Vous n’avez pas encore créé d’offre.'
           )
           expect(noOffersText).toBeInTheDocument()
@@ -451,7 +438,7 @@ describe('screen Offers', () => {
             // When
             renderOffers(props, store)
             // Then
-            const statusFiltersIcon = await screen.findByAltText(
+            const statusFiltersIcon = screen.getByAltText(
               'Afficher ou masquer le filtre par statut'
             )
             expect(statusFiltersIcon.closest('button')).toBeDisabled()
@@ -470,9 +457,10 @@ describe('screen Offers', () => {
               store
             )
             // When
-            fireEvent.change(await screen.findByDisplayValue('Ma venue'), {
-              target: { value: 'all' },
-            })
+            await userEvent.selectOptions(
+              screen.getByDisplayValue('Ma venue'),
+              'all'
+            )
             // Then
             const statusFiltersIcon = screen.getByAltText(
               'Afficher ou masquer le filtre par statut'
@@ -483,7 +471,7 @@ describe('screen Offers', () => {
           it('should enable status filters when venue is selected but filter is not applied', async () => {
             // Given
             renderOffers(props, store)
-            const venueOptionToSelect = await screen.findByRole('option', {
+            const venueOptionToSelect = screen.getByRole('option', {
               name: proVenues[0].name,
             })
             // When
@@ -503,9 +491,8 @@ describe('screen Offers', () => {
             // When
             renderOffers(props, store)
             // Then
-            const selectAllOffersCheckbox = await screen.findByLabelText(
-              'Tout sélectionner'
-            )
+            const selectAllOffersCheckbox =
+              screen.getByLabelText('Tout sélectionner')
             expect(selectAllOffersCheckbox).toBeDisabled()
           })
 
@@ -530,9 +517,10 @@ describe('screen Offers', () => {
               })
             )
             // When
-            fireEvent.change(await screen.findByDisplayValue('Ma venue'), {
-              target: { value: 'all' },
-            })
+            await userEvent.selectOptions(
+              screen.getByDisplayValue('Ma venue'),
+              'all'
+            )
             // Then
             const selectAllOffersCheckbox =
               screen.getByLabelText('Tout sélectionner')
@@ -543,11 +531,9 @@ describe('screen Offers', () => {
             // Given
             renderOffers(props, store)
             // When
-            fireEvent.change(
-              await screen.findByDisplayValue('Tous les lieux'),
-              {
-                target: { value: 'JI' },
-              }
+            await userEvent.selectOptions(
+              screen.getByDisplayValue('Tous les lieux'),
+              'JI'
             )
             // Then
             const selectAllOffersCheckbox =
@@ -576,9 +562,8 @@ describe('screen Offers', () => {
               })
             )
             // Then
-            const selectAllOffersCheckbox = await screen.findByLabelText(
-              'Tout sélectionner'
-            )
+            const selectAllOffersCheckbox =
+              screen.getByLabelText('Tout sélectionner')
             expect(selectAllOffersCheckbox).not.toBeDisabled()
           })
           it('should enable select all checkbox when offerer filter is applied', async () => {
@@ -602,9 +587,8 @@ describe('screen Offers', () => {
               })
             )
             // Then
-            const selectAllOffersCheckbox = await screen.findByLabelText(
-              'Tout sélectionner'
-            )
+            const selectAllOffersCheckbox =
+              screen.getByLabelText('Tout sélectionner')
             expect(selectAllOffersCheckbox).not.toBeDisabled()
           })
         })
@@ -634,7 +618,7 @@ describe('screen Offers', () => {
         renderOffers({ ...props, offers }, store)
 
         // Then
-        await screen.findByText(offers[0].name)
+        screen.getByText(offers[0].name)
         expect(
           screen.queryByTestId(`select-offer-${offers[0].id}`)
         ).toBeDisabled()
@@ -653,7 +637,7 @@ describe('screen Offers', () => {
       // Given
       renderOffers(props, store)
       // When
-      fireEvent.click(screen.getByText('Lancer la recherche'))
+      await userEvent.click(screen.getByText('Lancer la recherche'))
       // Then
       expect(props.loadAndUpdateOffers).toHaveBeenCalledWith({
         nameOrIsbn: DEFAULT_SEARCH_FILTERS.nameOrIsbn,
@@ -723,9 +707,7 @@ describe('screen Offers', () => {
       )
 
       // When
-      const checkbox = await screen.findByTestId(
-        `select-offer-${offersRecap[0].id}`
-      )
+      const checkbox = screen.getByTestId(`select-offer-${offersRecap[0].id}`)
       await userEvent.click(checkbox)
 
       // Then
@@ -745,7 +727,7 @@ describe('screen Offers', () => {
         renderOffers(props, store)
 
         // When
-        fireEvent.click(await screen.findByLabelText('Tout sélectionner'))
+        await userEvent.click(screen.getByLabelText('Tout sélectionner'))
 
         // Then
         expect(
@@ -771,21 +753,21 @@ describe('screen Offers', () => {
 
         renderOffers({ ...props, offers }, store)
 
-        const firstOfferCheckbox = await screen.findByTestId(
+        const firstOfferCheckbox = screen.getByTestId(
           `select-offer-${offers[0].id}`
         )
-        const secondOfferCheckbox = await screen.findByTestId(
+        const secondOfferCheckbox = screen.getByTestId(
           `select-offer-${offers[1].id}`
         )
-        const thirdOfferCheckbox = await screen.findByTestId(
+        const thirdOfferCheckbox = screen.getByTestId(
           `select-offer-${offers[2].id}`
         )
-        const fourthOfferCheckbox = await screen.findByTestId(
+        const fourthOfferCheckbox = screen.getByTestId(
           `select-offer-${offers[3].id}`
         )
 
         // When
-        fireEvent.click(screen.getByLabelText('Tout sélectionner'))
+        await userEvent.click(screen.getByLabelText('Tout sélectionner'))
 
         // Then
         expect(firstOfferCheckbox).toBeChecked()
@@ -794,7 +776,7 @@ describe('screen Offers', () => {
         expect(fourthOfferCheckbox).not.toBeChecked()
 
         // When
-        fireEvent.click(screen.getByLabelText('Tout désélectionner'))
+        await userEvent.click(screen.getByLabelText('Tout désélectionner'))
 
         // Then
         expect(firstOfferCheckbox).not.toBeChecked()

--- a/pro/src/ui-kit/CheckboxField/__specs__/CheckboxField.spec.jsx
+++ b/pro/src/ui-kit/CheckboxField/__specs__/CheckboxField.spec.jsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent } from '@testing-library/dom'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Form } from 'react-final-form'
 
@@ -79,13 +79,13 @@ describe('components | CheckboxField', () => {
     expect(checkbox.disabled).toStrictEqual(props.disabled)
   })
 
-  it('should change value on click', () => {
+  it('should change value on click', async () => {
     const initialValues = { ...defaultInitialValues }
     const props = { ...defaultProps }
     renderCheckboxField(props, initialValues)
 
     const checkbox = screen.getByLabelText('Checkbox label')
-    fireEvent.click(checkbox)
+    await userEvent.click(checkbox)
 
     expect(checkbox.checked).toStrictEqual(!initialValues[props.name])
   })

--- a/pro/src/utils/apiFactories.js
+++ b/pro/src/utils/apiFactories.js
@@ -1,3 +1,5 @@
+import { BookingRecapStatus } from 'apiClient/v1/models/BookingRecapStatus'
+
 let offerId = 1
 let venueId = 1
 let offererId = 1
@@ -114,9 +116,7 @@ export const stockFactory = (customStock = {}) => {
 }
 
 export const bookingRecapFactory = (customBookingRecap = {}) => {
-  const offerer = offererFactory()
   const offer = offerFactory()
-  const venue = venueFactory()
 
   return {
     beneficiary: {
@@ -128,26 +128,19 @@ export const bookingRecapFactory = (customBookingRecap = {}) => {
     booking_amount: 0,
     booking_date: '2020-04-12T19:31:12Z',
     booking_is_duo: false,
-    booking_status: 'booked',
+    booking_status: BookingRecapStatus.BOOKED,
     booking_status_history: [
       {
         date: '2020-04-12T19:31:12Z',
-        status: 'booked',
+        status: BookingRecapStatus.BOOKED,
       },
     ],
     booking_token: `TOKEN${bookingId++}`,
-    offerer: {
-      name: offerer.name,
-    },
     stock: {
       offer_identifier: offer.id,
       offer_name: offer.name,
-      type: 'thing',
-    },
-    venue: {
-      venue_identifier: venue.id,
-      is_virtual: venue.isVirtual,
-      name: venue.name,
+      offer_is_educational: false,
+      stock_identifier: offer.stocks[0].id,
     },
     ...customBookingRecap,
   }

--- a/pro/src/utils/fakeApi.js
+++ b/pro/src/utils/fakeApi.js
@@ -26,10 +26,6 @@ export const failToGenerateOffererApiKey = () =>
 
 export const loadFakeApiVenue = venue => {
   jest.spyOn(api, 'getVenue').mockResolvedValueOnce(venue)
-
-  return {
-    resolvingVenuePromise: Promise.resolve(venue),
-  }
 }
 
 export const loadFakeApiCategories = () => {

--- a/pro/src/utils/testHelpers.js
+++ b/pro/src/utils/testHelpers.js
@@ -1,4 +1,3 @@
-import { fireEvent } from '@testing-library/react'
 import omit from 'lodash.omit'
 
 export const queryCallbacks = {
@@ -37,6 +36,3 @@ export function queryByTextTrimHtml(screen, searchString, options = {}) {
 
 export const getNthCallNthArg = (mockedFunction, nthCall, nthArg = 1) =>
   mockedFunction.mock.calls[nthCall - 1][nthArg - 1]
-
-export const clearInputText = input =>
-  fireEvent.change(input, { target: { value: '' } })


### PR DESCRIPTION
BSR

## But de la pull request

_retirer act() des tests
_retirer fireEvent des tests (pas réussi pour trois)
_ correction d'un bug sur sur les preFilters de bookings (le bouton reset n'est pas censé être sélectionnable quand les filtres sont ceux par défaut, le test était un faux positif)  
_ retirer les warnings des tests concernés (sauf un)

