### PR TITLE
(PC-17770)[API] feat: offers tags available in Sendinblue to customize booking confirmation email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -94,6 +94,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "EVENT_DATE": formatted_event_beginning_date,
             "EVENT_HOUR": formatted_event_beginning_time,
             "OFFER_PRICE": stock_price,
+            "OFFER_TAGS": ",".join([criterion.name for criterion in offer.criteria]),
             "OFFER_TOKEN": booking_token,
             "OFFER_CATEGORY": offer.category.id,
             "OFFER_SUBCATEGORY": offer.subcategoryId,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17770

## But de la pull request

Faire remonter les tags des offres à Sendinblue pour personnaliser l'email transactionnel de confirmation de réservation.

## Informations supplémentaires

Besoin discuté avec le marketing et avec Thierry.
C'est normalement dans le périmètre de l'équipe pro mais lié à Sendinblue.
Comme Thierry est parti et qu'on en avait parlé ensemble, je le fais pour débloquer le marketing.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
