### PR TITLE
Pc 17765 interne fix public users search performance on new backoffice

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -856,7 +856,7 @@ def _filter_user_accounts(
         filters.append(sa.or_(*term_filters) if len(term_filters) > 1 else term_filters[0])
 
     # each result must match all terms in any column
-    accounts = accounts.filter(*filters)
+    accounts = accounts.filter(*filters).from_self()
 
     if order_by:
         try:
@@ -897,14 +897,13 @@ def search_public_account(terms: typing.Iterable[str], order_by: list[str] | Non
             )
         )
         .distinct(models.User.id)
-        .from_self()
     )
     return _filter_user_accounts(public_accounts, terms, order_by=order_by)
 
 
 def search_pro_account(terms: typing.Iterable[str], order_by: list[str] | None = None) -> BaseQuery:
     # Any account which is associated with at least one offerer
-    pro_accounts = models.User.query.join(offerers_models.UserOfferer).distinct(models.User.id).from_self()
+    pro_accounts = models.User.query.join(offerers_models.UserOfferer).distinct(models.User.id)
     return _filter_user_accounts(pro_accounts, terms, order_by=order_by)
 
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -884,16 +884,14 @@ def search_public_account(terms: typing.Iterable[str], order_by: list[str] | Non
     # In Flask-Admin backoffice, the difference was made from user_offerer table, which turns the user into a "pro"
     # account ; the same filter is kept here.
     # However, some young users, including beneficiaries, work for organizations and are associated with offerers
-    # using the same email as their personal account. So let's include "pro" users who are beneficiaries or have at
-    # least started subscription process.
+    # using the same email as their personal account. So let's include "pro" users who are beneficiaries (doesn't
+    # include those who are only in the subscription process).
     public_accounts = (
         models.User.query.outerjoin(offerers_models.UserOfferer)
-        .outerjoin(fraud_models.BeneficiaryFraudCheck)
         .filter(
             sa.or_(
                 offerers_models.UserOfferer.userId.is_(None),
                 models.User.is_beneficiary.is_(True),  # type: ignore [attr-defined]
-                sa.not_(fraud_models.BeneficiaryFraudCheck.userId.is_(None)),
             )
         )
         .distinct(models.User.id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17765

## But de la pull request

Résoudre les problèmes de performance lors d'une recherche sur les utilisateurs publics

## Implémentation

Suppression du filtre sur les utilisateurs bénéficiaires et "pros" toujours en cours de validation; ce sont des cas très spécifiques, et ce filtre impacte trop les performances.


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
