### PR TITLE
(PC-17765)[API] fix: drop the filter on wether user is still in the s…

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -884,16 +884,14 @@ def search_public_account(terms: typing.Iterable[str], order_by: list[str] | Non
     # In Flask-Admin backoffice, the difference was made from user_offerer table, which turns the user into a "pro"
     # account ; the same filter is kept here.
     # However, some young users, including beneficiaries, work for organizations and are associated with offerers
-    # using the same email as their personal account. So let's include "pro" users who are beneficiaries or have at
-    # least started subscription process.
+    # using the same email as their personal account. So let's include "pro" users who are beneficiaries (doesn't
+    # include those who are only in the subscription process).
     public_accounts = (
         models.User.query.outerjoin(offerers_models.UserOfferer)
-        .outerjoin(fraud_models.BeneficiaryFraudCheck)
         .filter(
             sa.or_(
                 offerers_models.UserOfferer.userId.is_(None),
                 models.User.is_beneficiary.is_(True),  # type: ignore [attr-defined]
-                sa.not_(fraud_models.BeneficiaryFraudCheck.userId.is_(None)),
             )
         )
         .distinct(models.User.id)

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -344,14 +344,11 @@ class PublicAccountSearchTest:
     def test_can_search_public_account_young_but_also_pro(self, client):
         # given
         # She has started subscription process, but is also hired by an offerer
-        young_and_pro = users_factories.UserFactory(
+        young_and_pro = users_factories.BeneficiaryGrant18Factory(
             firstName="Maud",
             lastName="Zarella",
             email="mz@example.com",
             dateOfBirth=datetime.date.today() - relativedelta(years=16, days=5),
-        )
-        fraud_factories.BeneficiaryFraudCheckFactory(
-            user=young_and_pro, eligibilityType=users_models.EligibilityType.UNDERAGE
         )
         offerers_factories.UserOffererFactory(user=young_and_pro)
         user = users_factories.UserFactory()


### PR DESCRIPTION
…ubscription process

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17765

## But de la pull request

Améliorer les performances de la recherche d'acteurs publics

## Implémentation

Abandon du filtre permettant de cherche les utilisateurs bénéficiaires et pros toujours en cours de validation. C'est un cas très spécifique et trop coûteux en performances.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
