### PR TITLE
(BSR)[PRO] test: decrease time of CollectiveDataEdition test

### DIFF
--- a/pro/src/components/hooks/useNotification.js
+++ b/pro/src/components/hooks/useNotification.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { useCallback, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 


### PR DESCRIPTION
BSR

## But de la pull request

_ Rajouter un mock pour un test pour qu'il ne timeout plus

je n'ai pas réussi à simplement mocker juste ce que je voulais, les autres objets se construisaient à partir du `mainlandOptions` 
non mocké, donc le test échouait, relecteur si tu as une idée je suis preneur !
