### PR TITLE
(PC-17462)[API] feat: Add validation status to offerer, set offerer validation as PENDING in new backoffice

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-246156d69d6f (pre) (head)
+b0f79857ab7d (pre) (head)
 6858182908fe (post) (head)

--- a/api/src/pcapi/admin/custom_views/pro_user_view.py
+++ b/api/src/pcapi/admin/custom_views/pro_user_view.py
@@ -50,6 +50,7 @@ def create_offerer(form: Form) -> offerers_models.Offerer:
     offerer.name = form.offererName.data
     offerer.postalCode = form.offererPostalCode.data
     offerer.city = form.offererCity.data
+    offerer.validationStatus = offerers_models.ValidationStatus.VALIDATED
 
     return offerer
 

--- a/api/src/pcapi/alembic/versions/20220930T103731_b0f79857ab7d_add_offerer_validation_status.py
+++ b/api/src/pcapi/alembic/versions/20220930T103731_b0f79857ab7d_add_offerer_validation_status.py
@@ -1,0 +1,25 @@
+"""add_offerer_validation_status
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "b0f79857ab7d"
+down_revision = "246156d69d6f"
+branch_labels = None
+depends_on = None
+
+
+ValidationStatus = sa.Enum("NEW", "PENDING", "VALIDATED", "REJECTED", name="validationstatus")
+
+
+def upgrade() -> None:
+    ValidationStatus.create(op.get_bind(), checkfirst=True)
+    op.add_column("offerer", sa.Column("validationStatus", ValidationStatus, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("offerer", "validationStatus")
+    ValidationStatus.drop(op.get_bind())

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -807,6 +807,7 @@ def get_collective_offer_by_id_for_adage(offer_id: int) -> educational_models.Co
             .load_only(
                 offerers_models.Offerer.name,
                 offerers_models.Offerer.validationToken,
+                offerers_models.Offerer.validationStatus,
                 offerers_models.Offerer.isActive,
             )
         )
@@ -826,6 +827,7 @@ def get_collective_offer_template_by_id_for_adage(offer_id: int) -> educational_
             .load_only(
                 offerers_models.Offerer.name,
                 offerers_models.Offerer.validationToken,
+                offerers_models.Offerer.validationStatus,
                 offerers_models.Offerer.isActive,
             )
         )

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -24,6 +24,7 @@ class OffererFactory(BaseFactory):
 
 class NotValidatedOffererFactory(OffererFactory):
     validationToken = factory.Sequence(lambda n: f"offerer-not-validated-{n}")
+    validationStatus = models.ValidationStatus.NEW
 
 
 class CollectiveOffererFactory(OffererFactory):

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -26,7 +26,7 @@ class Permissions(enum.Enum):
     SEARCH_PRO_ACCOUNT = "rechercher un acteur culturel"
     READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"
     MANAGE_PRO_ENTITY = "gérer une structure, un lieu ou un compte pro"
-    VALIDATE_OFFERER = "valider une structure"
+    VALIDATE_OFFERER = "gérer la validation des structures"
 
     @classmethod
     def exists(cls, name: str) -> bool:

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -684,6 +684,10 @@ def _generate_offerer(data: dict) -> offerers_models.Offerer:
 
     if not settings.IS_INTEGRATION:
         offerer.generate_validation_token()
+        offerer.validationStatus = offerers_models.ValidationStatus.NEW
+    else:
+        offerer.validationStatus = offerers_models.ValidationStatus.VALIDATED
+
     return offerer
 
 

--- a/api/src/pcapi/models/validation_status_mixin.py
+++ b/api/src/pcapi/models/validation_status_mixin.py
@@ -1,0 +1,26 @@
+import enum
+
+import sqlalchemy as sqla
+import sqlalchemy.ext.hybrid as sqla_hybrid
+from sqlalchemy.orm import declarative_mixin
+from sqlalchemy.sql.elements import BinaryExpression
+
+
+class ValidationStatus(enum.Enum):
+    NEW = "NEW"
+    PENDING = "PENDING"
+    VALIDATED = "VALIDATED"
+    REJECTED = "REJECTED"
+
+
+@declarative_mixin
+class ValidationStatusMixin:
+    validationStatus = sqla.Column(sqla.Enum(ValidationStatus, create_constraint=False), nullable=True)
+
+    @sqla_hybrid.hybrid_property
+    def isValidated(self) -> bool:
+        return self.validationStatus == ValidationStatus.VALIDATED
+
+    @isValidated.expression  # type: ignore [no-redef]
+    def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument # type: ignore[no-redef]
+        return cls.validationStatus == ValidationStatus.VALIDATED

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -185,6 +185,14 @@ def _get_serialized_offerer_last_comment(offerer: offerers_models.Offerer) -> se
     return None
 
 
+def _get_offerer_status(offerer: offerers_models.Offerer) -> str:
+    if offerer.validationStatus is not None:
+        return offerer.validationStatus.value
+    if offerer.validationToken is None:
+        return offerers_models.ValidationStatus.VALIDATED.value
+    return offerers_models.ValidationStatus.NEW.value
+
+
 @blueprint.backoffice_blueprint.route("offerers/to_be_validated", methods=["GET"])
 @spectree_serialize(
     response_model=serialization.ListOffererToBeValidatedResponseModel,
@@ -216,7 +224,7 @@ def list_offerers_to_be_validated(
                 serialization.OffererToBeValidated(
                     id=offerer.id,
                     name=offerer.name,
-                    status=None,  # TODO
+                    status=_get_offerer_status(offerer),
                     step=None,  # TODO
                     siren=offerer.siren,
                     address=offerer.address,

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -119,6 +119,17 @@ def validate_offerer(offerer_id: int) -> None:
         raise api_errors.ResourceNotFoundError(errors={"offerer_id": "La structure n'existe pas"})
 
 
+@blueprint.backoffice_blueprint.route("offerers/<int:offerer_id>/pending", methods=["POST"])
+@spectree_serialize(on_success_status=204, api=blueprint.api)
+@perm_utils.permission_required(perm_models.Permissions.VALIDATE_OFFERER)
+def set_offerer_pending(offerer_id: int, body: serialization.OptionalCommentRequest) -> None:
+    author_user = get_current_user()
+    try:
+        offerers_api.set_offerer_pending(offerer_id, author_user, comment=body.comment)
+    except offerers_exceptions.OffererNotFoundException:
+        raise api_errors.ResourceNotFoundError(errors={"offerer_id": "La structure n'existe pas"})
+
+
 @blueprint.backoffice_blueprint.route("offerers/<int:offerer_id>/comment", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @perm_utils.permission_required(perm_models.Permissions.VALIDATE_OFFERER)

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -383,5 +383,9 @@ class ListOffererToBeValidatedResponseModel(PaginatedResponse):
     data: list[OffererToBeValidated]
 
 
+class OptionalCommentRequest(BaseModel):
+    comment: str | None
+
+
 class CommentRequest(BaseModel):
     comment: str

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -367,7 +367,7 @@ class Comment(BaseModel):
 class OffererToBeValidated(BaseModel):
     id: int
     name: str
-    status: str | None
+    status: str
     step: str | None
     siren: str
     address: str

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -126,7 +126,7 @@ def get_favorites_for(user: User, favorite_id: int | None = None) -> list[Favori
             joinedload(Favorite.offer)
             .joinedload(Offer.venue)
             .joinedload(Venue.managingOfferer)
-            .load_only(Offerer.validationToken, Offerer.isActive)
+            .load_only(Offerer.validationToken, Offerer.validationStatus, Offerer.isActive)
         )
         .options(
             joinedload(Favorite.offer)

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -34,7 +34,7 @@ def get_offer(offer_id: str) -> serializers.OfferResponse:
         .options(
             joinedload(Offer.venue)
             .joinedload(Venue.managingOfferer)
-            .load_only(Offerer.name, Offerer.validationToken, Offerer.isActive)
+            .load_only(Offerer.name, Offerer.validationToken, Offerer.validationStatus, Offerer.isActive)
         )
         .options(joinedload(Offer.mediations))
         .options(joinedload(Offer.product).load_only(Product.id, Product.thumbCount))

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -72,6 +72,7 @@ def get_offerers(query: GetOffererListQueryModel) -> GetOfferersListResponseMode
             offerers_models.Offerer.name,
             offerers_models.Offerer.siren,
             offerers_models.Offerer.validationToken,
+            offerers_models.Offerer.validationStatus,
         ),
     )
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -693,6 +693,7 @@ class ValidateOffererByIdTest:
         # Then
         assert user_offerer.offerer.isValidated
         assert user_offerer.offerer.dateValidated == datetime.datetime.utcnow()
+        assert user_offerer.offerer.validationStatus == offerers_models.ValidationStatus.VALIDATED
 
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_pro_role_is_added_to_user(self, mocked_async_index_offers_of_venue_ids):
@@ -774,6 +775,7 @@ class ValidateOffererByIdTest:
         # Then
         assert not user_offerer.user.has_pro_role
         assert not user_offerer.offerer.isValidated
+        assert user_offerer.offerer.validationStatus == offerers_models.ValidationStatus.NEW
         assert history_models.ActionHistory.query.count() == 0
 
 

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -102,7 +102,7 @@ def test_basics(client):
                 "visualDisabilityCompliant": False,
                 "withdrawalDetails": venue.withdrawalDetails,
             }
-            for venue in offerer.managedVenues
+            for venue in sorted(offerer.managedVenues, key=lambda v: v.publicName)
         ],
         "name": offerer.name,
         "nonHumanizedId": offerer.id,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17462

## But de la pull request

Permettre de modifier le statut d'avancement de la validation de structures.
Ce ticket vise à ajouter la possibilité de « mettre en attente » une validation, donc statut `OFFERER_PENDING`, avec un commentaire optionnel.
L'action devra apparaître dans l'historique de la structure.

## Implémentation

- le champ `validationStatus` est ajouté pour gérer le statut ; cohabitation avec le `validationToken` le temps de la transition
- en l'état, on ne passe pas encore en REJECTED, donc ça n'influence pas les résultats pouvant être affichés dans le portail pro, la structure n'est pour l'instant que validée ou non (nouvelle ou en attente)
- on utilisera le même champ `validationStatus` pour la table `user_offerer` pour le rattachement d'utilisateurs à une structure (d'où le mixin)

## Informations supplémentaires

## Modifications du schéma de la base de données

Ajout de la colonne `validationStatus` à la table `offerer`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
