### PR TITLE
Pc 16951 eac use recipients as bcc when sending notifications email

### DIFF
--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -265,7 +265,8 @@ def refuse_collective_booking(educational_booking_id: int) -> educational_models
                 "EDUCATIONAL_INSTITUTION_POSTAL_CODE": collective_booking.educationalInstitution.postalCode,
             },
         )
-        mails.send(recipients=booking_emails, data=data)
+        main_recipient, bcc_recipients = [booking_emails[0]], booking_emails[1:]
+        mails.send(recipients=main_recipient, bcc_recipients=bcc_recipients, data=data)
 
     search.async_index_collective_offer_ids([collective_booking.collectiveStock.collectiveOfferId])
 

--- a/api/src/pcapi/core/mails/__init__.py
+++ b/api/src/pcapi/core/mails/__init__.py
@@ -10,6 +10,7 @@ def send(
     *,
     recipients: Iterable[str],
     data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
+    bcc_recipients: Iterable[str] = None,
 ) -> bool:
     """Try to send an e-mail and return whether it was successful."""
     if isinstance(recipients, str):
@@ -17,5 +18,5 @@ def send(
             raise ValueError("Recipients should be a sequence, not a single string.")
         recipients = [recipients]
     backend = import_string(settings.EMAIL_BACKEND)
-    result = backend().send_mail(recipients=recipients, data=data)
+    result = backend().send_mail(recipients=recipients, bcc_recipients=bcc_recipients, data=data)
     return result.successful

--- a/api/src/pcapi/core/mails/backends/base.py
+++ b/api/src/pcapi/core/mails/backends/base.py
@@ -8,5 +8,6 @@ class BaseBackend:
         self,
         recipients: Iterable,
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
+        bcc_recipients: Iterable = None,
     ) -> models.MailResult:
         raise NotImplementedError()

--- a/api/src/pcapi/core/mails/backends/logger.py
+++ b/api/src/pcapi/core/mails/backends/logger.py
@@ -19,10 +19,13 @@ class LoggerBackend(BaseBackend):
         self,
         recipients: typing.Iterable[str],
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
+        bcc_recipients: typing.Iterable[str] = None,
     ) -> models.MailResult:
         recipients = ", ".join(recipients)
+        if bcc_recipients:
+            bcc_recipients = ", ".join(bcc_recipients)
         sent_data = asdict(data)
-        logger.info("An e-mail would be sent via Sendinblue to=%s: %s", recipients, sent_data)
+        logger.info("An e-mail would be sent via Sendinblue to=%s, bcc=%s: %s", recipients, bcc_recipients, sent_data)
         result = models.MailResult(sent_data=sent_data, successful=True)
 
         return result

--- a/api/src/pcapi/core/mails/backends/testing.py
+++ b/api/src/pcapi/core/mails/backends/testing.py
@@ -15,9 +15,12 @@ class TestingBackend(BaseBackend):
         self,
         recipients: Iterable[str],
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
+        bcc_recipients: Iterable[str] = None,
     ) -> models.MailResult:
         sent_data = asdict(data)
         sent_data["To"] = ", ".join(recipients)
+        if bcc_recipients:
+            sent_data["Bcc"] = ", ".join(bcc_recipients)
         result = models.MailResult(sent_data=sent_data, successful=True)
         testing.outbox.append(result)
         return result
@@ -30,7 +33,10 @@ class FailingBackend(BaseBackend):
         self,
         recipients: Iterable[str],
         data: models.TransactionalEmailData | models.TransactionalWithoutTemplateEmailData,
+        bcc_recipients: Iterable[str] = None,
     ) -> models.MailResult:
         sent_data = asdict(data)
         sent_data["To"] = ", ".join(recipients)
+        if bcc_recipients:
+            sent_data["Bcc"] = ", ".join(bcc_recipients)
         return models.MailResult(sent_data=sent_data, successful=False)

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_institution.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_institution.py
@@ -33,4 +33,5 @@ def send_education_booking_cancellation_by_institution_email(booking: Collective
     if not booking_emails:
         return True
     data = get_education_booking_cancellation_by_institution_email_data(booking)
-    return mails.send(recipients=booking_emails, data=data)
+    main_recipient, bcc_recipients = [booking_emails[0]], booking_emails[1:]
+    return mails.send(recipients=main_recipient, bcc_recipients=bcc_recipients, data=data)

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
@@ -73,4 +73,5 @@ def send_collective_booking_cancellation_confirmation_by_pro_email(booking: Coll
     if not offerer_booking_emails:
         return True
     data = get_collective_booking_cancellation_confirmation_by_pro_email_data(booking)
-    return mails.send(recipients=offerer_booking_emails, data=data)
+    main_recipient, bcc_recipients = [offerer_booking_emails[0]], offerer_booking_emails[1:]
+    return mails.send(recipients=main_recipient, bcc_recipients=bcc_recipients, data=data)

--- a/api/src/pcapi/core/mails/transactional/educational/eac_new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/educational/eac_new_booking_to_pro.py
@@ -11,7 +11,8 @@ def send_eac_new_booking_email_to_pro(booking: CollectiveBooking) -> bool:
     if not booking_emails:
         return True
     data = get_eac_new_booking_to_pro_email_data(booking)
-    return mails.send(recipients=booking_emails, data=data)
+    main_recipient, bcc_recipients = [booking_emails[0]], booking_emails[1:]
+    return mails.send(recipients=main_recipient, bcc_recipients=bcc_recipients, data=data)
 
 
 def get_eac_new_booking_to_pro_email_data(booking: CollectiveBooking) -> models.TransactionalEmailData:

--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
     to = [{"email": email} for email in payload.recipients]
+    bcc = [{"email": email} for email in payload.bcc_recipients] if payload.bcc_recipients else None
     sender = payload.sender
     reply_to = payload.reply_to
 
@@ -24,7 +25,7 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> bool:
         "reply_to": payload.reply_to,
     }
 
-    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(to=to, sender=sender, reply_to=reply_to)
+    send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(to=to, bcc=bcc, sender=sender, reply_to=reply_to)
 
     # Can send email with: to, sender, template_id, tags, params
 

--- a/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
+++ b/api/src/pcapi/tasks/serialization/sendinblue_tasks.py
@@ -10,6 +10,7 @@ class UpdateSendinblueContactRequest(BaseModel):
 
 class SendTransactionalEmailRequest(BaseModel):
     recipients: list[str]
+    bcc_recipients: list[str] | None = None
     params: dict | None = None
     template_id: int | None = None
     tags: list[str] | None = None

--- a/api/tests/core/mails/tests.py
+++ b/api/tests/core/mails/tests.py
@@ -14,6 +14,7 @@ from pcapi.utils.module_loading import import_string
 @pytest.mark.usefixtures("db_session")
 class SendinblueBackendTest:
     recipients = ["lucy.ellingson@example.com", "avery.kelly@example.com"]
+    bcc_recipients = ["catherine.clark@example.com", "tate.walker@example.com"]
     mock_template = models.Template(
         id_prod=1, id_not_prod=10, tags=["this_is_such_a_great_tag", "it_would_be_a_pity_if_anything_happened_to_it"]
     )
@@ -23,6 +24,7 @@ class SendinblueBackendTest:
 
     expected_sent_data = sendinblue_tasks.SendTransactionalEmailRequest(
         recipients=recipients,
+        bcc_recipients=bcc_recipients,
         params=params,
         template_id=data.template.id,
         tags=data.template.tags,
@@ -33,14 +35,24 @@ class SendinblueBackendTest:
     def _get_backend(self):
         return import_string("pcapi.core.mails.backends.sendinblue.SendinblueBackend")
 
+    @override_settings(
+        WHITELISTED_EMAIL_RECIPIENTS=[
+            "lucy.ellingson@example.com",
+            "avery.kelly@example.com",
+            "catherine.clark@example.com",
+            "tate.walker@example.com",
+        ]
+    )
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail(self, mock_send_transactional_email_secondary_task):
         backend = self._get_backend()
-        result = backend().send_mail(recipients=self.recipients, data=self.data)
+        result = backend().send_mail(recipients=self.recipients, bcc_recipients=self.bcc_recipients, data=self.data)
 
         assert mock_send_transactional_email_secondary_task.call_count == 1
         task_param = mock_send_transactional_email_secondary_task.call_args[0][0]
-        assert list(task_param.recipients) == list(self.expected_sent_data.recipients)
+
+        assert set(task_param.recipients) == set(self.expected_sent_data.recipients)
+        assert set(task_param.bcc_recipients) == set(self.expected_sent_data.bcc_recipients)
         assert task_param.params == self.expected_sent_data.params
         assert task_param.template_id == self.expected_sent_data.template_id
         assert task_param.tags == self.expected_sent_data.tags
@@ -48,12 +60,13 @@ class SendinblueBackendTest:
         assert task_param.reply_to == self.expected_sent_data.reply_to
         assert result.successful
 
+    @override_settings(WHITELISTED_EMAIL_RECIPIENTS=["lucy.ellingson@example.com", "avery.kelly@example.com"])
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail_with_no_reply_equal_overrided_by_sender(self, mock_send_transactional_email_secondary_task):
 
         self.data = models.TransactionalEmailData(template=self.mock_template, params=self.params, reply_to=None)
 
-        expected_sent_data = sendinblue_tasks.SendTransactionalEmailRequest(
+        expected_sent_data_no_reply = sendinblue_tasks.SendTransactionalEmailRequest(
             recipients=self.recipients,
             params=SendinblueBackendTest.params,
             template_id=SendinblueBackendTest.data.template.id,
@@ -67,20 +80,21 @@ class SendinblueBackendTest:
 
         assert mock_send_transactional_email_secondary_task.call_count == 1
         task_param = mock_send_transactional_email_secondary_task.call_args[0][0]
-        assert list(task_param.recipients) == list(self.expected_sent_data.recipients)
-        assert task_param.params == expected_sent_data.params
-        assert task_param.template_id == expected_sent_data.template_id
-        assert task_param.tags == expected_sent_data.tags
-        assert task_param.sender == expected_sent_data.sender
-        assert task_param.reply_to == expected_sent_data.reply_to
+        assert set(task_param.recipients) == set(expected_sent_data_no_reply.recipients)
+        assert task_param.params == expected_sent_data_no_reply.params
+        assert task_param.template_id == expected_sent_data_no_reply.template_id
+        assert task_param.tags == expected_sent_data_no_reply.tags
+        assert task_param.sender == expected_sent_data_no_reply.sender
+        assert task_param.reply_to == expected_sent_data_no_reply.reply_to
         assert result.successful
 
 
 @pytest.mark.usefixtures("db_session")
 class ToDevSendinblueBackendTest(SendinblueBackendTest):
 
-    expected_sent_data = sendinblue_tasks.SendTransactionalEmailRequest(
+    expected_sent_data_to_dev = sendinblue_tasks.SendTransactionalEmailRequest(
         recipients=["dev@example.com"],
+        bcc_recipients=["test@example.com"],
         params=SendinblueBackendTest.params,
         template_id=SendinblueBackendTest.data.template.id,
         tags=SendinblueBackendTest.data.template.tags,
@@ -91,19 +105,21 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
     def _get_backend(self):
         return import_string("pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
 
+    @override_settings(WHITELISTED_EMAIL_RECIPIENTS=["test@example.com"])
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail_to_dev(self, mock_send_transactional_email_secondary_task):
         backend = self._get_backend()
-        result = backend().send_mail(recipients=self.recipients, data=self.data)
+        result = backend().send_mail(recipients=self.recipients, bcc_recipients=["test@example.com"], data=self.data)
 
         assert mock_send_transactional_email_secondary_task.call_count == 1
         task_param = mock_send_transactional_email_secondary_task.call_args[0][0]
-        assert list(task_param.recipients) == list(self.expected_sent_data.recipients)
-        assert task_param.params == self.expected_sent_data.params
-        assert task_param.template_id == self.expected_sent_data.template_id
-        assert task_param.tags == self.expected_sent_data.tags
-        assert task_param.sender == self.expected_sent_data.sender
-        assert task_param.reply_to == self.expected_sent_data.reply_to
+        assert set(task_param.recipients) == set(self.expected_sent_data_to_dev.recipients)
+        assert set(task_param.bcc_recipients) == set(self.expected_sent_data_to_dev.bcc_recipients)
+        assert task_param.params == self.expected_sent_data_to_dev.params
+        assert task_param.template_id == self.expected_sent_data_to_dev.template_id
+        assert task_param.tags == self.expected_sent_data_to_dev.tags
+        assert task_param.sender == self.expected_sent_data_to_dev.sender
+        assert task_param.reply_to == self.expected_sent_data_to_dev.reply_to
         assert result.successful
 
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")

--- a/api/tests/routes/adage/v1/refuse_prebookings_test.py
+++ b/api/tests/routes/adage/v1/refuse_prebookings_test.py
@@ -59,7 +59,9 @@ class Returns200Test:
             mails_testing.outbox[0].sent_data["template"]
             == TransactionalEmail.EDUCATIONAL_BOOKING_CANCELLATION_BY_INSTITUTION.value.__dict__
         )
-        assert mails_testing.outbox[0].sent_data["To"] == "test_collective@mail.com, test2_collective@mail.com"
+        assert mails_testing.outbox[0].sent_data["To"] == "test_collective@mail.com"
+        assert mails_testing.outbox[0].sent_data["Bcc"] == "test2_collective@mail.com"
+
         assert mails_testing.outbox[0].sent_data["params"] == {
             "OFFER_NAME": collective_offer.name,
             "EDUCATIONAL_INSTITUTION_NAME": educational_institution.name,

--- a/api/tests/scripts/booking/handle_expired_bookings_test.py
+++ b/api/tests/scripts/booking/handle_expired_bookings_test.py
@@ -390,7 +390,9 @@ class NotifyOfferersOfExpiredBookingsTest:
             mails_testing.outbox[0].sent_data["template"]
             == TransactionalEmail.EDUCATIONAL_BOOKING_CANCELLATION_BY_INSTITUTION.value.__dict__
         )
-        assert mails_testing.outbox[0].sent_data["To"] == "test@mail.com, test2@mail.com"
+        assert mails_testing.outbox[0].sent_data["To"] == "test@mail.com"
+        assert mails_testing.outbox[0].sent_data["Bcc"] == "test2@mail.com"
+
         assert mails_testing.outbox[0].sent_data["params"] == {
             "OFFER_NAME": "Ma première offre expirée",
             "EDUCATIONAL_INSTITUTION_NAME": institution.name,
@@ -405,7 +407,8 @@ class NotifyOfferersOfExpiredBookingsTest:
         }
 
         second_educational_institution = second_expired_booking.educationalInstitution
-        assert mails_testing.outbox[1].sent_data["To"] == "new_test@mail.com, newer_test@mail.com"
+        assert mails_testing.outbox[1].sent_data["To"] == "new_test@mail.com"
+        assert mails_testing.outbox[1].sent_data["Bcc"] == "newer_test@mail.com"
         assert mails_testing.outbox[1].sent_data["params"] == {
             "OFFER_NAME": "Ma deuxième offre expirée",
             "EDUCATIONAL_INSTITUTION_NAME": second_educational_institution.name,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16951

## But de la pull request

Dans le cas ou l'acteur culturel renseigne plusieurs mail de notifications : 

- Le premier mail renseigné sert de destinataire principal 
- Les autres mails renseignés sont envoyés en copie cachées (cci)

## Implémentation

- Ajout de la possibilité d'ajouter des mails en cci dans les mails sendinblue
- Modification des différents envoie de mails de notifs

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
