### PR TITLE
(PC-17809)[API] fix: manage obsolete perms

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -28,6 +28,15 @@ class Permissions(enum.Enum):
     MANAGE_PRO_ENTITY = "gérer une structure, un lieu ou un compte pro"
     VALIDATE_OFFERER = "valider une structure"
 
+    @classmethod
+    def exists(cls, name: str) -> bool:
+        try:
+            cls[name]
+        except KeyError:
+            return False
+        else:
+            return True
+
 
 def sync_enum_with_db_field(session: sa.orm.Session, py_enum: Type[enum.Enum], db_field: sa.Column) -> None:
     db_values = set(p.name for p in session.query(db_field).all())

--- a/api/src/pcapi/routes/backoffice/permissions.py
+++ b/api/src/pcapi/routes/backoffice/permissions.py
@@ -32,6 +32,7 @@ def list_roles() -> serialization.ListRoleResponseModel:
                         id=perm.id, name=perm_models.Permissions[perm.name].value, category=perm.category
                     )
                     for perm in role.permissions
+                    if perm_models.Permissions.exists(perm.name)
                 ],
             )
             for role in roles
@@ -52,6 +53,7 @@ def list_permissions() -> serialization.ListPermissionResponseModel:
         permissions=[
             serialization.Permission(id=perm.id, name=perm_models.Permissions[perm.name].value, category=perm.category)
             for perm in permissions
+            if perm_models.Permissions.exists(perm.name)
         ]
     )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17809

## But de la pull request

corriger l'erreur qui survient quand on cherche à lister les permissions alors qu'il en existe encore en base qui ont été retirées de l'enum Python `Permissions` ou quand on cherche à lister les role alors qu'un de ces rôles est associé à une permission obsolète

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
