### PR TITLE
(BSR)[API] fix: add missing trigram indexes in Offerer/Venue models

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -144,6 +144,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, NeedsValidati
     __tablename__ = "venue"
 
     name: str = Column(String(140), nullable=False)
+    sa.Index("idx_venue_trgm_name", name, postgresql_using="gin")
 
     siret = Column(String(14), nullable=True, unique=True)
 
@@ -168,6 +169,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, NeedsValidati
     city = Column(String(50), nullable=True)
 
     publicName = Column(String(255), nullable=True)
+    sa.Index("idx_venue_trgm_public_name", publicName, postgresql_using="gin")
 
     isVirtual: bool = Column(
         Boolean,
@@ -594,6 +596,7 @@ class Offerer(
     dateCreated: datetime = Column(DateTime, nullable=False, default=datetime.utcnow)
 
     name: str = Column(String(140), nullable=False)
+    sa.Index("idx_offerer_trgm_name", name, postgresql_using="gin")
 
     UserOfferers: list["UserOfferer"] = sa.orm.relationship("UserOfferer", back_populates="offerer")
 


### PR DESCRIPTION
## But de la pull request

Ajouter les index de recherche par trigramme dans les modèles `Offerer` et `Venue`.
Les index sont déjà créés par une migration.
Ce commit évite de créer des "drop" en auto-générant une nouvelle migration.

## Implémentation

## Informations supplémentaires

Migrations existantes :
- https://github.com/pass-culture/pass-culture-main/blob/v208.0.1/api/src/pcapi/alembic/versions/20220907T165520_3c4183de2005_add_trgm_index_on_offerer_name.py
- https://github.com/pass-culture/pass-culture-main/blob/v208.0.1/api/src/pcapi/alembic/versions/20220909T154021_abc92addfaeb_add_trgm_index_on_venue_name.py
- https://github.com/pass-culture/pass-culture-main/blob/v208.0.1/api/src/pcapi/alembic/versions/20220909T154047_53b7d749990e_add_trgm_index_on_venue_public_name.py

## Modifications du schéma de la base de données

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
