### PR TITLE
Pc 17836 pro offererer stats fix wording nb bookings

### DIFF
--- a/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
+++ b/pro/src/components/pages/Home/OffererStats/OffererStats.tsx
@@ -43,7 +43,7 @@ const OffererStats = () => {
             {...defaultIconLinkProps}
           />
           <IconLinkBox
-            title="Nombre de réservations par semaine"
+            title="Nombre de réservations"
             IconHeader={CalendarIcon}
             {...defaultIconLinkProps}
           />

--- a/pro/src/components/pages/Home/OffererStats/__specs__/OffererStats.spec.tsx
+++ b/pro/src/components/pages/Home/OffererStats/__specs__/OffererStats.spec.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import * as useAnalytics from 'components/hooks/useAnalytics'
+import { Events } from 'core/FirebaseEvents/constants'
+
+import OffererStats from '../OffererStats'
+
+const mockLogEvent = jest.fn()
+
+const renderOffererStats = () => {
+  return render(
+    <MemoryRouter initialEntries={['/accueil']}>
+      <OffererStats />
+    </MemoryRouter>
+  )
+}
+
+describe('OffererStats', () => {
+  describe('log events', () => {
+    it('should log events when click on one box link', async () => {
+      // When
+      jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+        logEvent: mockLogEvent,
+        setLogEvent: null,
+      }))
+      renderOffererStats()
+      const viewStatsButton = screen.getAllByRole('link', {
+        name: 'Voir le tableau',
+      })[0]
+      await userEvent.click(viewStatsButton)
+
+      // Then
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenCalledWith(
+        Events.CLICKED_VIEW_OFFERER_STATS,
+        { from: '/accueil' }
+      )
+    })
+    it('should log events when click on view all stats', async () => {
+      // When
+      jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+        logEvent: mockLogEvent,
+        setLogEvent: null,
+      }))
+      renderOffererStats()
+      const viewAllStatsButton = screen.getByRole('link', {
+        name: 'Voir toutes les statistiques',
+      })
+      await userEvent.click(viewAllStatsButton)
+
+      // Then
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenCalledWith(
+        Events.CLICKED_VIEW_ALL_OFFERER_STATS,
+        { from: '/accueil' }
+      )
+    })
+  })
+})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17836

## But de la pull request

Modifier le wording d'un des blocs de statistiques sur la page d'accueil

## Implémentation

- Fix du wording
- BSR : ajout de tests sur les events envoyés au click sur les différents boutons du composant

