### PR TITLE
(PC-17844)[API] feat: New backoffice: Get full history for an offerer

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -12,7 +12,7 @@ from pcapi.models.pc_object import PcObject
 
 class ActionType(enum.Enum):
     # Single comment from admin, on any resource, without status change:
-    COMMENT = "Commentaire"
+    COMMENT = "Commentaire interne"
     # Validation process for offerers:
     OFFERER_NEW = "Nouvelle structure"
     OFFERER_PENDING = "Structure mise en attente"

--- a/api/src/pcapi/core/history/repository.py
+++ b/api/src/pcapi/core/history/repository.py
@@ -1,0 +1,9 @@
+from pcapi.core.history import models
+
+
+def find_all_actions_by_offerer(offerer_id: int) -> list[models.ActionHistory]:
+    return (
+        models.ActionHistory.query.filter(models.ActionHistory.offererId == offerer_id)
+        .order_by(models.ActionHistory.actionDate.desc())
+        .all()
+    )

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -4,6 +4,7 @@ import typing
 import pydantic
 
 from pcapi.core.fraud import models as fraud_models
+import pcapi.core.history.models as history_models
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription.phone_validation import exceptions as phone_validation_exceptions
@@ -356,6 +357,21 @@ class OffererTotalRevenueResponseModel(Response):
 
 class OffererOfferStatsResponseModel(Response):
     data: OffersStats
+
+
+class HistoryItem(BaseModel):
+    class Config:
+        use_enum_values = True
+
+    type: history_models.ActionType
+    date: datetime.datetime
+    authorId: int | None
+    authorName: str | None
+    comment: str | None
+
+
+class HistoryResponseModel(Response):
+    data: list[HistoryItem]
 
 
 class Comment(BaseModel):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17844

## But de la pull request

Le frontend du backoffice a besoin d’un endpoint supplémentaire pour récupérer l’historique complet d’une structure : liste de toutes les actions (nouvelle, mise en attente, validée...), triées par ordre chronologique inverse.

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
