### PR TITLE
(PC-17453)[API] fix: Do not reject rejected offerer or validate valid…

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -499,6 +499,9 @@ def validate_offerer_by_id(offerer_id: int, author_user: users_models.User) -> N
     if offerer is None:
         raise exceptions.OffererNotFoundException()
 
+    if offerer.isValidated:
+        raise exceptions.OffererAlreadyValidatedException()
+
     _validate_offerer(offerer, author_user)
 
 
@@ -506,6 +509,9 @@ def reject_offerer(offerer_id: int, author_user: users_models.User, comment: str
     offerer = offerers_repository.find_offerer_by_id(offerer_id)
     if offerer is None:
         raise exceptions.OffererNotFoundException()
+
+    if offerer.isRejected:
+        raise exceptions.OffererAlreadyRejectedException()
 
     # A first applicant created the offerer and attachment is automatically validated.
     # But another applicant may signup and register the same offerer, this other user attachment must be validated later

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -48,3 +48,11 @@ class VenueNotFoundException(Exception):
 
 class OffererNotFoundException(Exception):
     pass
+
+
+class OffererAlreadyValidatedException(Exception):
+    pass
+
+
+class OffererAlreadyRejectedException(Exception):
+    pass

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -117,6 +117,8 @@ def validate_offerer(offerer_id: int) -> None:
         offerers_api.validate_offerer_by_id(offerer_id, author_user)
     except offerers_exceptions.OffererNotFoundException:
         raise api_errors.ResourceNotFoundError(errors={"offerer_id": "La structure n'existe pas"})
+    except offerers_exceptions.OffererAlreadyValidatedException:
+        raise api_errors.ApiErrors(errors={"offerer_id": "La structure est déjà validée"})
 
 
 @blueprint.backoffice_blueprint.route("offerers/<int:offerer_id>/reject", methods=["POST"])
@@ -128,6 +130,8 @@ def reject_offerer(offerer_id: int, body: serialization.OptionalCommentRequest) 
         offerers_api.reject_offerer(offerer_id, author_user, comment=body.comment)
     except offerers_exceptions.OffererNotFoundException:
         raise api_errors.ResourceNotFoundError(errors={"offerer_id": "La structure n'existe pas"})
+    except offerers_exceptions.OffererAlreadyRejectedException:
+        raise api_errors.ApiErrors(errors={"offerer_id": "La structure est déjà rejetée"})
 
 
 @blueprint.backoffice_blueprint.route("offerers/<int:offerer_id>/pending", methods=["POST"])


### PR DESCRIPTION
…ated offerer + missing tests

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17453

## But de la pull request

Empêcher de : 
- valider une structure déjà validée
- rejeter une structure déjà rejetée

Ainsi qu'ajouter les tests de la route de rejet, qui avaient mystérieusement disparu dans les manipulations successives de branches.

## Implémentation

## Informations supplémentaires

Erreur Sentry en testant en recette PM, si on appelle deux fois de suite la route /reject sur la même structure : 
https://sentry.passculture.team/organizations/sentry/issues/396780/?project=5

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
