### PR TITLE
(PC-16567)[API] fix: cds fix arguments get_shows_stock call

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1059,7 +1059,7 @@ def report_offer(user: User, offer: Offer, reason: str, custom_reason: str | Non
         logger.warning("Could not send email reported offer by user", extra={"user_id": user.id})
 
 
-def update_stock_quantity_to_match_cinemma_venue_provider_remaining_place(
+def update_stock_quantity_to_match_cinema_venue_provider_remaining_place(
     offer: Offer, venue_provider: providers_models.VenueProvider
 ) -> None:
     sentry_sdk.set_tag("cinema-venue-provider", venue_provider.provider.localClass)
@@ -1075,7 +1075,7 @@ def update_stock_quantity_to_match_cinemma_venue_provider_remaining_place(
         "Getting up-to-date show stock from booking provider on offer view",
         extra={"offer": offer.id, "venue_provider": venue_provider.id},
     )
-    shows_remaining_places = get_shows_stock(offer.venue, shows_id)
+    shows_remaining_places = get_shows_stock(offer.venueId, shows_id)
 
     for show_id, remaining_places in shows_remaining_places.items():
         stock = next((s for s in offer.activeStocks if get_cds_show_id_from_uuid(s.idAtProviders) == str(show_id)))

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -52,7 +52,7 @@ def get_offer(offer_id: str) -> serializers.OfferResponse:
             and cinema_venue_provider.provider.localClass == "CDSStocks"
             and check_offer_is_from_current_cinema_provider(offer)
         ):
-            api.update_stock_quantity_to_match_cinemma_venue_provider_remaining_place(offer, cinema_venue_provider)
+            api.update_stock_quantity_to_match_cinema_venue_provider_remaining_place(offer, cinema_venue_provider)
 
     return serializers.OfferResponse.from_orm(offer)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16567

- Correction des paramètres d'appel de la fonction `get_shows_stock`.
- Ajout d'un test de récupération d'offre synchronisée via Ciné Office.