### PR TITLE
(BSR)[MAIN] ci: ignore pro coverage for maintenance branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,16 +680,26 @@ jobs:
           key: node-14.18-jest-cache-
       - when:
           condition:
-            equal: ["master", << pipeline.git.branch >>]
+            or:
+              - equal: ["master", << pipeline.git.branch >>]
+              - matches:
+                  pattern: "^maint/.+$"
+                  value: << pipeline.git.branch >>
           steps:
             - run:
                 name: Run Unit Test PRO
                 command: yarn test:unit:ci
                 working_directory: pro
-      - run:
-          name: Coverage Unit Test PRO
-          command: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
-          working_directory: pro
+      - unless:
+          condition:
+            matches:
+              pattern: "^maint/.+$"
+              value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: Coverage Unit Test PRO
+                command: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
+                working_directory: pro
       - unless:
           condition:
             equal: ["master", << pipeline.git.branch >>]


### PR DESCRIPTION
BSR

## But de la pull request

_Améliorer la ci pour les branches de maintenances `maint/v<number>`

Actuellement on lançait le coverage de pro sur les branches de maintenances et il a la facheuse tendance à être toujours rouge
Pour rendre l'esprit plus tranquil aux développeurs / PO qui mergent des hotfix nous jouons les tests sans le coverage sur ces branches

doc ci : https://circleci.com/docs/configuration-reference/#logic-statements

le workflow en succès : https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/29538/workflows/f798b87e-3025-4cf3-ba68-987f344d9155/jobs/225059
(il n'y a pas l'étape sur la dernière ci car j'ai enlevé la modif sur pro qui nous a permis de tester)
