### PR TITLE
[API] fix: add missing vars inside .env.* files

### DIFF
--- a/api/.env.production
+++ b/api/.env.production
@@ -66,3 +66,4 @@ WEBAPP_V2_URL=https://passculture.app
 WEBAPP_V2_REDIRECT_URL=https://redirect.passculture.app
 ZENDESK_API_URL=https://passculture.zendesk.com/api/v2
 ZENDESK_SELL_API_URL=https://api.getbase.com
+BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME="passculture-data-production.backend_prod.favorites_not_booked"

--- a/api/.env.staging
+++ b/api/.env.staging
@@ -67,3 +67,4 @@ SLACK_CHANGE_FEATURE_FLIP_CHANNEL=feature-flip-ehp
 WEBAPP_V2_URL=https://app.staging.passculture.team
 WEBAPP_V2_REDIRECT_URL=https://redirect.staging.passculture.team
 ZENDESK_SELL_API_URL=https://api.getbase.com
+BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME="passculture-data-ehp.backend_stg.favorites_not_booked"

--- a/api/.env.testing
+++ b/api/.env.testing
@@ -69,3 +69,4 @@ SLACK_CHANGE_FEATURE_FLIP_CHANNEL=feature-flip-ehp
 WEBAPP_V2_URL=https://app.testing.passculture.team
 WEBAPP_V2_REDIRECT_URL=https://redirect.testing.passculture.team
 ZENDESK_SELL_API_URL=https://api.getbase.com
+BIG_QUERY_NOTIFICATIONS_TABLE_BASENAME="passculture-data-ehp.backend_dev.favorites_not_booked"


### PR DESCRIPTION
Missing: google big query table base names.
