### PR TITLE
Bsr fix warnings 2

### DIFF
--- a/pro/src/components/layout/form/fields/SirenField/__specs__/SirenField.spec.jsx
+++ b/pro/src/components/layout/form/fields/SirenField/__specs__/SirenField.spec.jsx
@@ -1,16 +1,24 @@
+import { api } from 'apiClient/api'
+import { ApiError } from 'apiClient/v1'
+
 import { existsInINSEERegistry } from '../validate'
 
 describe('components | SirenField', () => {
   describe('existsInINSEERegistry', () => {
-    beforeEach(() => {
-      fetch.resetMocks()
-    })
-
     it('should call the INSEE API with the formatted SIREN', async () => {
       // given
-      fetch.mockResponseOnce(JSON.stringify({ message: 'no results found' }), {
-        status: 404,
-      })
+      jest.spyOn(api, 'getSirenInfo').mockRejectedValue(
+        new ApiError(
+          {},
+          {
+            status: 404,
+            body: {
+              global: ['no results foud'],
+            },
+          },
+          ''
+        )
+      )
       const siren = '245474278'
       const humanSiren = '245 474 278'
 
@@ -18,32 +26,23 @@ describe('components | SirenField', () => {
       await existsInINSEERegistry(humanSiren)
 
       // then
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/sirene/siren/${siren}`),
-        expect.anything()
+      expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
+      expect(api.getSirenInfo).toHaveBeenCalledWith(
+        expect.stringContaining(`${siren}`)
       )
     })
 
     it('should not return an error message when SIREN exists in INSEE registry', async () => {
       // given
       const siren = '345474278'
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            name: 'nom du lieu',
-            siren: '841166096',
-            address: {
-              street: '3 rue de la gare',
-              city: 'paris',
-              postalCode: '75000',
-            },
-          }),
+      jest.spyOn(api, 'getSirenInfo').mockResolvedValue({
+        name: 'nom du lieu',
+        siren: '841166096',
+        address: {
+          street: '3 rue de la gare',
+          city: 'paris',
+          postalCode: '75000',
+        },
       })
 
       // when
@@ -56,20 +55,20 @@ describe('components | SirenField', () => {
     it('should return an error message when the unite_legal has anonymous data', async () => {
       // given
       const siren = '495474278'
-
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            global: [
-              'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles',
-            ],
-          }),
-      })
+      jest.spyOn(api, 'getSirenInfo').mockRejectedValue(
+        new ApiError(
+          {},
+          {
+            status: 400,
+            body: {
+              global: [
+                'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles',
+              ],
+            },
+          },
+          ''
+        )
+      )
 
       // when
       const errorMessage = await existsInINSEERegistry(siren)
@@ -82,16 +81,18 @@ describe('components | SirenField', () => {
     it('should return an error message when SIREN does not exist in INSEE registry', async () => {
       // given
       const siren = '445474278'
-      jest.spyOn(window, 'fetch').mockResolvedValue({
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            global: ["Ce SIREN ou SIRET n'existe pas."],
-          }),
-      })
+      jest.spyOn(api, 'getSirenInfo').mockRejectedValue(
+        new ApiError(
+          {},
+          {
+            status: 400,
+            body: {
+              global: ["Ce SIREN ou SIRET n'existe pas."],
+            },
+          },
+          ''
+        )
+      )
 
       // when
       const errorMessage = await existsInINSEERegistry(siren)
@@ -103,26 +104,27 @@ describe('components | SirenField', () => {
     it('should check once for same SIREN called in INSEE registery', async () => {
       // given
       const siren = '645474278'
-      jest.spyOn(window, 'fetch').mockRejectedValueOnce({
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.reject({
-            global: ['no results found'],
-          }),
-      })
+      jest.spyOn(api, 'getSirenInfo').mockRejectedValue(
+        new ApiError(
+          {},
+          {
+            status: 400,
+            body: {
+              global: ['no results foud'],
+            },
+          },
+          ''
+        )
+      )
 
       // when
       await existsInINSEERegistry(siren)
       await existsInINSEERegistry(siren)
 
       // then
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/sirene/siren/${siren}`),
-        expect.anything()
+      expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
+      expect(api.getSirenInfo).toHaveBeenCalledWith(
+        expect.stringContaining(`${siren}`)
       )
     })
   })

--- a/pro/src/components/layout/form/fields/SirenField/__specs__/SirenField.spec.jsx
+++ b/pro/src/components/layout/form/fields/SirenField/__specs__/SirenField.spec.jsx
@@ -27,9 +27,7 @@ describe('components | SirenField', () => {
 
       // then
       expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
-      expect(api.getSirenInfo).toHaveBeenCalledWith(
-        expect.stringContaining(`${siren}`)
-      )
+      expect(api.getSirenInfo).toHaveBeenCalledWith(siren)
     })
 
     it('should not return an error message when SIREN exists in INSEE registry', async () => {
@@ -123,9 +121,7 @@ describe('components | SirenField', () => {
 
       // then
       expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
-      expect(api.getSirenInfo).toHaveBeenCalledWith(
-        expect.stringContaining(`${siren}`)
-      )
+      expect(api.getSirenInfo).toHaveBeenCalledWith(siren)
     })
   })
 })

--- a/pro/src/components/layout/form/fields/SirenField/__specs__/decorators.spec.js
+++ b/pro/src/components/layout/form/fields/SirenField/__specs__/decorators.spec.js
@@ -54,9 +54,7 @@ describe('sirenUpdate', () => {
       await sirenUpdate(siren)
 
       // Then
-      expect(api.getSirenInfo).toHaveBeenCalledWith(
-        expect.stringContaining(`${siren}`)
-      )
+      expect(api.getSirenInfo).toHaveBeenCalledWith(siren)
     })
 
     it('should format the SIREN to the API standards', async () => {

--- a/pro/src/components/layout/form/fields/SirenField/__specs__/decorators.spec.js
+++ b/pro/src/components/layout/form/fields/SirenField/__specs__/decorators.spec.js
@@ -1,23 +1,17 @@
+import { api } from 'apiClient/api'
+
 import { sirenUpdate } from '../decorators'
 
 describe('sirenUpdate', () => {
   beforeEach(() => {
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      headers: new Headers({
-        'Content-Type': 'application/json',
-      }),
-      json: () =>
-        Promise.resolve({
-          name: 'nom du lieu',
-          siren: '841166096',
-          address: {
-            street: '3 rue de la gare',
-            city: 'paris',
-            postalCode: '75000',
-          },
-        }),
+    jest.spyOn(api, 'getSirenInfo').mockResolvedValue({
+      name: 'nom du lieu',
+      siren: '841166096',
+      address: {
+        street: '3 rue de la gare',
+        city: 'paris',
+        postalCode: '75000',
+      },
     })
   })
 
@@ -30,7 +24,7 @@ describe('sirenUpdate', () => {
       sirenUpdate(siren)
 
       // Then
-      expect(fetch).not.toHaveBeenCalled()
+      expect(api.getSirenInfo).not.toHaveBeenCalled()
     })
 
     it('should return empty information', async () => {
@@ -60,9 +54,8 @@ describe('sirenUpdate', () => {
       await sirenUpdate(siren)
 
       // Then
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/sirene/siren/${siren}`),
-        expect.anything()
+      expect(api.getSirenInfo).toHaveBeenCalledWith(
+        expect.stringContaining(`${siren}`)
       )
     })
 
@@ -74,9 +67,8 @@ describe('sirenUpdate', () => {
       await sirenUpdate(siren)
 
       // Then
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/sirene/siren/418166096'),
-        expect.anything()
+      expect(api.getSirenInfo).toHaveBeenCalledWith(
+        expect.stringContaining('418166096')
       )
     })
   })
@@ -89,9 +81,8 @@ describe('sirenUpdate', () => {
     await sirenUpdate(siren)
 
     // Then
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/sirene/siren/841166096'),
-      expect.anything()
+    expect(api.getSirenInfo).toHaveBeenCalledWith(
+      expect.stringContaining('841166096')
     )
   })
 

--- a/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
@@ -2,36 +2,61 @@ import '@testing-library/jest-dom'
 
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import fetch from 'jest-fetch-mock'
 import React from 'react'
 import { Form } from 'react-final-form'
 import { Provider } from 'react-redux'
 
+import { apiAdresse } from 'apiClient/adresse'
+import { IAdresseData } from 'apiClient/adresse/types'
+import { api } from 'apiClient/api'
+import { ApiError } from 'apiClient/v1'
+import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
+import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import getSiretData from 'core/Venue/adapters/getSiretDataAdapter'
 import { configureTestStore } from 'store/testUtils'
 
 import SiretField from '../SiretField'
 import siretApiValidate from '../validators/siretApiValidate'
 
-const addressApiDataMock = {
-  features: [
-    {
-      geometry: { type: 'Point', coordinates: [1.9, 1.9] },
-      properties: {
-        label: '3 Rue de Valois 75001 Paris',
-        id: '75101_9575_00003',
-        name: '3 Rue de Valois',
-        postcode: '75001',
-        city: 'Paris',
-      },
+jest.mock('apiClient/adresse', () => {
+  return {
+    ...jest.requireActual('apiClient/adresse'),
+    default: {
+      getDataFromAddress: jest.fn(),
     },
-  ],
+  }
+})
+
+const addressApiDataMock: IAdresseData = {
+  address: '3 Rue de Valois',
+  city: 'Paris',
+  id: '75101_9575_00003',
+  latitude: 1.9,
+  longitude: 1.8,
+  label: '3 Rue de Valois 75001 Paris',
+  postalCode: '75001',
 }
 
 describe('components | SiretField', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(apiAdresse, 'getDataFromAddress')
+      .mockResolvedValue([addressApiDataMock])
+  })
+
   it('should display a error if siret do not include given siren', async () => {
     const siren = '000000000'
-    fetch.mockResponseOnce('')
+    const wrongSiret = '11111111199999'
+    jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
+      name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+      siret: wrongSiret,
+      active: true,
+      address: {
+        street: '19 RUE LAITIERE',
+        city: 'BAYEUX',
+        postalCode: '14400',
+      },
+    })
     const store = configureTestStore()
     render(
       <Provider store={store}>
@@ -50,7 +75,6 @@ describe('components | SiretField', () => {
     const siretField = screen.getByLabelText('Siret field*')
     expect(siretField).toBeInTheDocument()
 
-    const wrongSiret = '11111111199999'
     const wrongSiretMsg =
       'Le code SIRET doit correspondre à un établissement de votre structure'
     await userEvent.type(siretField, wrongSiret)
@@ -64,47 +88,27 @@ describe('components | SiretField', () => {
     expect(screen.queryByText(wrongSiretMsg)).not.toBeInTheDocument()
   })
   describe('getSiretData', () => {
-    beforeEach(() => {
-      fetch.resetMocks()
-    })
     it('should not call API when SIRET is empty', async () => {
       // given
       const siret = ''
+      jest.spyOn(api, 'getSiretInfo')
 
       // when
       await getSiretData(siret)
 
       // then
-      expect(fetch).not.toHaveBeenCalled()
+      expect(api.getSiretInfo).not.toHaveBeenCalled()
     })
     it('should have a latitude and longitude if provided', async () => {
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
-            siret: '12345178901834',
-            active: true,
-            address: {
-              street: '19 RUE LAITIERE',
-              city: 'BAYEUX',
-              postalCode: '14400',
-            },
-          }),
-      })
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () => Promise.resolve(addressApiDataMock),
+      jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
+        name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+        siret: '12345178901834',
+        active: true,
+        address: {
+          street: '19 RUE LAITIERE',
+          city: 'BAYEUX',
+          postalCode: '14400',
+        },
       })
 
       const siret = '12345178901834'
@@ -118,7 +122,7 @@ describe('components | SiretField', () => {
             address: '19 RUE LAITIERE',
             city: 'BAYEUX',
             latitude: 1.9,
-            longitude: 1.9,
+            longitude: 1.8,
             name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
             postalCode: '14400',
             siret: siret,
@@ -128,15 +132,20 @@ describe('components | SiretField', () => {
     })
   })
   describe('siretApiValidate', () => {
-    beforeEach(() => {
-      fetch.resetMocks()
-    })
-
     it('should call the INSEE API with the formatted SIRET', async () => {
       // given
-      fetch.mockResponseOnce(JSON.stringify({ message: 'no results found' }), {
-        status: 404,
-      })
+      jest.spyOn(api, 'getSiretInfo').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            status: 404,
+            body: {
+              global: ['no results foud'],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
       const siret = '12345678901234'
       const humanSiret = '123 456 789 01234'
 
@@ -144,42 +153,23 @@ describe('components | SiretField', () => {
       await siretApiValidate(humanSiret)
 
       // then
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/sirene/siret/${siret}`),
-        expect.anything()
+      expect(api.getSiretInfo).toHaveBeenCalledTimes(1)
+      expect(api.getSiretInfo).toHaveBeenCalledWith(
+        expect.stringContaining(`${siret}`)
       )
     })
     it('should not return an error message when SIRET exists in INSEE registry', async () => {
       // given
       const siret = '17345678901734'
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
-            siret: '12345178901834',
-            active: true,
-            address: {
-              street: '19 RUE LAITIERE',
-              city: 'BAYEUX',
-              postalCode: '14400',
-            },
-          }),
-      })
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () => Promise.resolve(addressApiDataMock),
+      jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
+        name: 'MUSEE DE LA TAPISSERIE DE BAYEUX',
+        siret: '12345178901834',
+        active: true,
+        address: {
+          street: '19 RUE LAITIERE',
+          city: 'BAYEUX',
+          postalCode: '14400',
+        },
       })
 
       // when
@@ -191,20 +181,20 @@ describe('components | SiretField', () => {
     it('should return an error when SIRET is anonymous on INSEE registry', async () => {
       // given
       const siret = '92341678901534'
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            global: [
-              'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.',
-            ],
-          }),
-      })
+      jest.spyOn(api, 'getSiretInfo').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            status: 400,
+            body: {
+              global: [
+                'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.',
+              ],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
 
       // when
       const errorMessage = await siretApiValidate(siret)
@@ -217,19 +207,18 @@ describe('components | SiretField', () => {
     it('should return an error message when SIREN does not exist in INSEE registry', async () => {
       // given
       const siret = '12945678901534'
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            global: ["Ce SIREN ou SIRET n'existe pas."],
-          }),
-      })
-
+      jest.spyOn(api, 'getSiretInfo').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            status: 400,
+            body: {
+              global: ["Ce SIREN ou SIRET n'existe pas."],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
       // when
       const errorMessage = await siretApiValidate(siret)
 
@@ -239,28 +228,27 @@ describe('components | SiretField', () => {
     it('should check once for same SIRET called in INSEE registery', async () => {
       // given
       const siret = '12945678901539'
-      // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            global: ["Ce SIREN ou SIRET n'existe pas."],
-          }),
-      })
+      jest.spyOn(api, 'getSiretInfo').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            status: 400,
+            body: {
+              global: ["Ce SIREN ou SIRET n'existe pas."],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
 
       // when
       await siretApiValidate(siret)
       await siretApiValidate(siret)
 
       // then
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`/sirene/siret/${siret}`),
-        expect.anything()
+      expect(api.getSiretInfo).toHaveBeenCalledTimes(1)
+      expect(api.getSiretInfo).toHaveBeenCalledWith(
+        expect.stringContaining(`${siret}`)
       )
     })
   })

--- a/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
+++ b/pro/src/components/layout/form/fields/SiretField/__specs__/SiretField.spec.tsx
@@ -154,9 +154,7 @@ describe('components | SiretField', () => {
 
       // then
       expect(api.getSiretInfo).toHaveBeenCalledTimes(1)
-      expect(api.getSiretInfo).toHaveBeenCalledWith(
-        expect.stringContaining(`${siret}`)
-      )
+      expect(api.getSiretInfo).toHaveBeenCalledWith(siret)
     })
     it('should not return an error message when SIRET exists in INSEE registry', async () => {
       // given
@@ -247,9 +245,7 @@ describe('components | SiretField', () => {
 
       // then
       expect(api.getSiretInfo).toHaveBeenCalledTimes(1)
-      expect(api.getSiretInfo).toHaveBeenCalledWith(
-        expect.stringContaining(`${siret}`)
-      )
+      expect(api.getSiretInfo).toHaveBeenCalledWith(siret)
     })
   })
 })

--- a/pro/src/components/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateAllOffersActiveStatusAdapter.spec.ts
+++ b/pro/src/components/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateAllOffersActiveStatusAdapter.spec.ts
@@ -1,12 +1,11 @@
+import { api } from 'apiClient/api'
+
 import { updateAllOffersActiveStatusAdapter } from '../updateAllOffersActiveStatusAdapter'
 
 describe('updateAllOffersActiveStatusAdapter', () => {
   it('should deactivate all offers and confirm', async () => {
     // given
-    // @ts-ignore
-    jest
-      .spyOn(window, 'fetch')
-      .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
+    jest.spyOn(api, 'patchAllOffersActiveStatus').mockResolvedValue({})
 
     const response = await updateAllOffersActiveStatusAdapter({
       searchFilters: { isActive: false },
@@ -22,10 +21,7 @@ describe('updateAllOffersActiveStatusAdapter', () => {
 
   it('should activate all offers and confirm', async () => {
     // given
-    // @ts-ignore
-    jest
-      .spyOn(window, 'fetch')
-      .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
+    jest.spyOn(api, 'patchAllOffersActiveStatus').mockResolvedValue({})
 
     const response = await updateAllOffersActiveStatusAdapter({
       searchFilters: { isActive: true },
@@ -41,12 +37,7 @@ describe('updateAllOffersActiveStatusAdapter', () => {
 
   it('should return an error when the update has failed', async () => {
     // given
-    // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce(
-      new Response(new Blob(), {
-        status: 422,
-      })
-    )
+    jest.spyOn(api, 'patchAllOffersActiveStatus').mockRejectedValue({})
 
     // when
     const response = await updateAllOffersActiveStatusAdapter({

--- a/pro/src/components/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateAllOffersActiveStatusAdapter.spec.ts
+++ b/pro/src/components/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateAllOffersActiveStatusAdapter.spec.ts
@@ -42,9 +42,11 @@ describe('updateAllOffersActiveStatusAdapter', () => {
   it('should return an error when the update has failed', async () => {
     // given
     // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-      status: 422,
-    })
+    jest.spyOn(window, 'fetch').mockResolvedValueOnce(
+      new Response(new Blob(), {
+        status: 422,
+      })
+    )
 
     // when
     const response = await updateAllOffersActiveStatusAdapter({

--- a/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
@@ -51,13 +51,13 @@ const DuplicateOfferCell = ({
             </Button>
           </TooltipWrapper>
         ) : null}
+        {isModalOpen && shouldDisplayModal && (
+          <DuplicateOfferDialog
+            onCancel={() => setIsModalOpen(false)}
+            onConfirm={onDialogConfirm}
+          />
+        )}
       </td>
-      {isModalOpen && shouldDisplayModal && (
-        <DuplicateOfferDialog
-          onCancel={() => setIsModalOpen(false)}
-          onConfirm={onDialogConfirm}
-        />
-      )}
     </>
   )
 }

--- a/pro/src/core/OfferEducational/adapters/__specs__/cancelCollectiveBookingsAdapter.spec.ts
+++ b/pro/src/core/OfferEducational/adapters/__specs__/cancelCollectiveBookingsAdapter.spec.ts
@@ -42,11 +42,7 @@ describe('cancelCollectiveBookingAdapter', () => {
   })
   it('should return a confirmation when the booking was cancelled', async () => {
     // given
-    // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-      ok: true,
-      status: 204,
-    })
+    jest.spyOn(api, 'cancelCollectiveOfferBooking').mockResolvedValue()
 
     // when
     const response = await cancelCollectiveBookingAdapter({ offerId: '12' })

--- a/pro/src/core/OfferEducational/adapters/__specs__/getStockCollectiveOfferTemplateAdapter.spec.ts
+++ b/pro/src/core/OfferEducational/adapters/__specs__/getStockCollectiveOfferTemplateAdapter.spec.ts
@@ -39,7 +39,6 @@ describe('getStockCollectiveOfferTemplateAdapter', () => {
 
     it('should not return an error when offer has been found', async () => {
       // given
-      // @ts-ignore
       jest.spyOn(api, 'getCollectiveOfferTemplate').mockResolvedValueOnce({
         id: 'A1',
         isActive: true,

--- a/pro/src/core/OfferEducational/adapters/__specs__/getStockCollectiveOfferTemplateAdapter.spec.ts
+++ b/pro/src/core/OfferEducational/adapters/__specs__/getStockCollectiveOfferTemplateAdapter.spec.ts
@@ -1,5 +1,10 @@
 import { api } from 'apiClient/api'
-import { ApiError } from 'apiClient/v1'
+import {
+  ApiError,
+  OfferAddressType,
+  OfferStatus,
+  SubcategoryIdEnum,
+} from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 
@@ -35,24 +40,50 @@ describe('getStockCollectiveOfferTemplateAdapter', () => {
     it('should not return an error when offer has been found', async () => {
       // given
       // @ts-ignore
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          // @ts-ignore
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            id: 'A1',
-            venue: {
-              managingOffererId: 'A1',
-              departementCode: 'A1',
-            },
+      jest.spyOn(api, 'getCollectiveOfferTemplate').mockResolvedValueOnce({
+        id: 'A1',
+        isActive: true,
+        offerId: 'A1',
+        bookingEmails: [],
+        name: 'mon offre',
+        contactEmail: 'mail',
+        contactPhone: 'phone',
+        dateCreated: 'date',
+        description: 'description',
+        domains: [],
+        hasBookingLimitDatetimesPassed: false,
+        interventionArea: [],
+        isCancellable: true,
+        isEditable: true,
+        nonHumanizedId: 1,
+        offerVenue: {
+          addressType: OfferAddressType.OFFERER_VENUE,
+          otherAddress: '',
+          venueId: 'A1',
+        },
+        status: OfferStatus.ACTIVE,
+        students: [],
+        subcategoryId: SubcategoryIdEnum.CONCERT,
+        venue: {
+          fieldsUpdated: [],
+          id: 'A1',
+          isValidated: true,
+          isVirtual: false,
+          managingOfferer: {
+            city: 'Vélizy',
+            dateCreated: 'date',
+            id: '1',
             isActive: true,
-            status: 'ACTIVE',
-            offerId: 'A1',
-          }),
+            isValidated: true,
+            name: 'mon offerer',
+            postalCode: '78sang40',
+            thumbCount: 1,
+          },
+          managingOffererId: 'A1',
+          name: 'mon lieu',
+          thumbCount: 1,
+        },
+        venueId: 'A1',
       })
 
       // when

--- a/pro/src/core/OfferEducational/adapters/__specs__/patchIsTemplateOfferActiveAdapter.spec.ts
+++ b/pro/src/core/OfferEducational/adapters/__specs__/patchIsTemplateOfferActiveAdapter.spec.ts
@@ -1,3 +1,5 @@
+import { api } from 'apiClient/api'
+
 import { patchIsTemplateOfferActiveAdapter } from '../patchIsTemplateOfferActiveAdapter'
 
 describe('patchIsTemplateOfferActiveAdapter', () => {
@@ -19,10 +21,9 @@ describe('patchIsTemplateOfferActiveAdapter', () => {
 
   it('should return an error when the update has failed', async () => {
     // given
-    // @ts-ignore
-    jest.spyOn(window, 'fetch').mockRejectedValueOnce({
-      status: 422,
-    })
+    jest
+      .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
+      .mockRejectedValue({})
 
     // when
     const response = await patchIsTemplateOfferActiveAdapter({
@@ -38,11 +39,9 @@ describe('patchIsTemplateOfferActiveAdapter', () => {
   })
   it('should confirm when the offer was activated', async () => {
     // given
-    // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-      ok: true,
-      status: 204,
-    })
+    jest
+      .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
+      .mockResolvedValue()
 
     // when
     const response = await patchIsTemplateOfferActiveAdapter({
@@ -58,11 +57,9 @@ describe('patchIsTemplateOfferActiveAdapter', () => {
   })
   it('should confirm when the offer was deactivated', async () => {
     // given
-    // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-      ok: true,
-      status: 204,
-    })
+    jest
+      .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
+      .mockResolvedValue()
 
     // when
     const response = await patchIsTemplateOfferActiveAdapter({

--- a/pro/src/core/Offerers/adapters/__specs__/getSirenDataAdapter.spec.js
+++ b/pro/src/core/Offerers/adapters/__specs__/getSirenDataAdapter.spec.js
@@ -77,7 +77,7 @@ describe('getSirenDataAdapter', () => {
 
       // then
       expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
-      expect(api.getSirenInfo).toHaveBeenCalledWith(`${siren}`)
+      expect(api.getSirenInfo).toHaveBeenCalledWith(siren)
       expect(response.isOk).toBeTruthy()
       expect(response.message).toBe(
         `Informations récupéré avec success pour le SIREN: ${unhumanizeSiren(

--- a/pro/src/core/Offerers/adapters/__specs__/getSirenDataAdapter.spec.js
+++ b/pro/src/core/Offerers/adapters/__specs__/getSirenDataAdapter.spec.js
@@ -1,21 +1,21 @@
+import { api } from 'apiClient/api'
+import { ApiError } from 'apiClient/v1'
 import { unhumanizeSiren } from 'core/Offerers/utils'
 
 import getSirenDataAdapter from '../getSirenDataAdapter'
 
 describe('getSirenDataAdapter', () => {
-  beforeEach(() => {
-    fetch.resetMocks()
-  })
   describe('when the SIREN is invalidate', () => {
     it('should not call API when SIREN is empty', async () => {
       // given
       const siren = ''
+      jest.spyOn(api, 'getSirenInfo')
 
       // when
       const response = await getSirenDataAdapter(siren)
 
       // then
-      expect(fetch).not.toHaveBeenCalled()
+      expect(api.getSirenInfo).not.toHaveBeenCalled()
       expect(response.payload).toStrictEqual({
         values: {
           address: '',
@@ -32,23 +32,24 @@ describe('getSirenDataAdapter', () => {
     it('test invalid siret response', async () => {
       // given
       const siren = '245474278'
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            global: ['Le format de ce SIREN ou SIRET est incorrect.'],
-          }),
-      })
+      jest.spyOn(api, 'getSirenInfo').mockRejectedValue(
+        new ApiError(
+          {},
+          {
+            status: 400,
+            body: {
+              global: ['Le format de ce SIREN ou SIRET est incorrect.'],
+            },
+          },
+          ''
+        )
+      )
 
       // when
       const response = await getSirenDataAdapter(siren)
 
       // then
-      expect(fetch.mock.calls).toHaveLength(1)
+      expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
       expect(response.isOk).toBeFalsy()
       expect(response.message).toBe(
         'Le format de ce SIREN ou SIRET est incorrect.'
@@ -61,29 +62,22 @@ describe('getSirenDataAdapter', () => {
     it('should return location values', async () => {
       // given
       const siren = '445474278'
-      jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        headers: new Headers({
-          'Content-Type': 'application/json',
-        }),
-        json: () =>
-          Promise.resolve({
-            name: 'nom du lieu',
-            siren: siren,
-            address: {
-              street: '3 rue de la gare',
-              city: 'paris',
-              postalCode: '75000',
-            },
-          }),
+      jest.spyOn(api, 'getSirenInfo').mockResolvedValue({
+        name: 'nom du lieu',
+        siren: siren,
+        address: {
+          street: '3 rue de la gare',
+          city: 'paris',
+          postalCode: '75000',
+        },
       })
 
       // when
       const response = await getSirenDataAdapter(siren)
+
       // then
-      expect(fetch.mock.calls).toHaveLength(1)
-      expect(fetch.mock.calls[0][0]).toContain(`/sirene/siren/${siren}`)
+      expect(api.getSirenInfo).toHaveBeenCalledTimes(1)
+      expect(api.getSirenInfo).toHaveBeenCalledWith(`${siren}`)
       expect(response.isOk).toBeTruthy()
       expect(response.message).toBe(
         `Informations récupéré avec success pour le SIREN: ${unhumanizeSiren(

--- a/pro/src/core/Venue/adapters/getSiretDataAdapter.ts
+++ b/pro/src/core/Venue/adapters/getSiretDataAdapter.ts
@@ -25,7 +25,7 @@ const getSiretDataAdapter: GetSiretDataAdapter = async (humanSiret: string) => {
   if (humanSiret === '') {
     return {
       isOk: true,
-      message: 'SIRET vide',
+      message: '',
       payload: {
         values: {
           address: '',

--- a/pro/src/core/Venue/adapters/getSiretDataAdapter.ts
+++ b/pro/src/core/Venue/adapters/getSiretDataAdapter.ts
@@ -25,7 +25,7 @@ const getSiretDataAdapter: GetSiretDataAdapter = async (humanSiret: string) => {
   if (humanSiret === '') {
     return {
       isOk: true,
-      message: '',
+      message: 'SIRET vide',
       payload: {
         values: {
           address: '',

--- a/pro/src/new_components/VenueForm/Informations/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/new_components/VenueForm/Informations/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -56,7 +56,7 @@ const SiretOrCommentFields = ({
       return null
     }
     getSiretDataFromApi().then(response => {
-      if (response?.isOk && response?.message !== 'SIRET vide') {
+      if (response?.isOk) {
         setIsFieldNameFrozen(true)
         setFieldValue('name', response.payload.values?.name)
       }

--- a/pro/src/new_components/VenueForm/Informations/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/new_components/VenueForm/Informations/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -56,7 +56,7 @@ const SiretOrCommentFields = ({
       return null
     }
     getSiretDataFromApi().then(response => {
-      if (response?.isOk) {
+      if (response?.isOk && response?.message !== 'SIRET vide') {
         setIsFieldNameFrozen(true)
         setFieldValue('name', response.payload.values?.name)
       }

--- a/pro/src/new_components/VenueForm/Informations/__specs__/Informations.spec.tsx
+++ b/pro/src/new_components/VenueForm/Informations/__specs__/Informations.spec.tsx
@@ -2,17 +2,20 @@ import '@testing-library/jest-dom'
 
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Formik } from 'formik'
+import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'
 
 import { IVenueFormValues } from 'new_components/VenueForm'
 import { SubmitButton } from 'ui-kit'
 
-import { validationSchema as informationsValidationSchema } from '../'
+import {
+  DEFAULT_INFORMATIONS_FORM_VALUES,
+  validationSchema as informationsValidationSchema,
+} from '../'
 import Informations, { IInformations } from '../Informations'
 
-const renderInformations = async ({
+const renderInformations = ({
   initialValues,
   onSubmit = jest.fn(),
   props,
@@ -28,12 +31,10 @@ const renderInformations = async ({
       onSubmit={onSubmit}
       validationSchema={validationSchema}
     >
-      {({ handleSubmit }) => (
-        <form onSubmit={handleSubmit}>
-          <Informations {...props} />
-          <SubmitButton isLoading={false}>Submit</SubmitButton>
-        </form>
-      )}
+      <Form>
+        <Informations {...props} />
+        <SubmitButton isLoading={false}>Submit</SubmitButton>
+      </Form>
     </Formik>
   )
 
@@ -52,7 +53,7 @@ describe('components | Informations', () => {
 
   beforeEach(() => {
     const updateIsSiretValued = jest.fn()
-    initialValues = { description: '' }
+    initialValues = { ...DEFAULT_INFORMATIONS_FORM_VALUES }
     props = {
       isCreatedEntity: true,
       readOnly: false,
@@ -64,7 +65,7 @@ describe('components | Informations', () => {
   })
 
   it('should submit form without errors', async () => {
-    const { buttonSubmit } = await renderInformations({
+    const { buttonSubmit } = renderInformations({
       initialValues,
       onSubmit,
       props,
@@ -91,7 +92,7 @@ describe('components | Informations', () => {
   })
 
   it('should validate required fields on submit', async () => {
-    await renderInformations({
+    renderInformations({
       initialValues,
       onSubmit,
       props,

--- a/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateAdapter.spec.ts
+++ b/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateAdapter.spec.ts
@@ -1,5 +1,5 @@
 import { api } from 'apiClient/api'
-import { ApiError } from 'apiClient/v1'
+import { ApiError, GetCollectiveOfferTemplateResponseModel } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { EducationalOfferType } from 'core/OfferEducational'
@@ -8,9 +8,7 @@ import { patchCollectiveOfferTemplateAdapter } from '../patchCollectiveOfferTemp
 
 describe('patchCollectiveOfferTemplateAdapter', () => {
   it('should return an error when the offer id is not valid', async () => {
-    // given
-
-    // when
+    // given / when
     const response = await patchCollectiveOfferTemplateAdapter({
       offerId: '',
       values: {
@@ -33,7 +31,6 @@ describe('patchCollectiveOfferTemplateAdapter', () => {
 
   it('should return an error when there is an error in the form', async () => {
     // given
-    // @ts-ignore
     jest
       .spyOn(api, 'editCollectiveOfferTemplate')
       .mockRejectedValueOnce(
@@ -68,8 +65,8 @@ describe('patchCollectiveOfferTemplateAdapter', () => {
   it('should return a confirmation when the offer was updated', async () => {
     // given
     jest
-      .spyOn(window, 'fetch')
-      .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
+      .spyOn(api, 'editCollectiveOfferTemplate')
+      .mockResolvedValue({} as GetCollectiveOfferTemplateResponseModel)
 
     // when
     const response = await patchCollectiveOfferTemplateAdapter({

--- a/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateIntoCollectiveOffer.spec.ts
+++ b/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateIntoCollectiveOffer.spec.ts
@@ -1,12 +1,17 @@
+import { api } from 'apiClient/api'
+import {
+  ApiError,
+  CollectiveOfferFromTemplateResponseModel,
+} from 'apiClient/v1'
+import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
+import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { EducationalOfferType } from 'core/OfferEducational'
 
 import { patchCollectiveOfferTemplateIntoCollectiveOfferAdapter } from '../patchCollectiveOfferTemplateIntoCollectiveOffer'
 
 describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
   it('should return an error when the offer id is not valid', async () => {
-    // given
-
-    // when
+    // given / when
     const response =
       await patchCollectiveOfferTemplateIntoCollectiveOfferAdapter({
         offerId: '',
@@ -31,12 +36,15 @@ describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
 
   it('should return an error when there is an error in the form', async () => {
     // given
-    // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce(
-      new Response(new Blob(), {
-        status: 400,
-      })
-    )
+    jest
+      .spyOn(api, 'transformCollectiveOfferTemplateIntoCollectiveOffer')
+      .mockRejectedValueOnce(
+        new ApiError(
+          {} as ApiRequestOptions,
+          { body: {}, status: 400 } as ApiResult,
+          ''
+        )
+      )
 
     // when
     const response =
@@ -64,8 +72,8 @@ describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
   it('should return a confirmation when the offer was updated', async () => {
     // given
     jest
-      .spyOn(window, 'fetch')
-      .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
+      .spyOn(api, 'transformCollectiveOfferTemplateIntoCollectiveOffer')
+      .mockResolvedValue({} as CollectiveOfferFromTemplateResponseModel)
 
     // when
     const response =

--- a/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateIntoCollectiveOffer.spec.ts
+++ b/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateIntoCollectiveOffer.spec.ts
@@ -32,12 +32,11 @@ describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
   it('should return an error when there is an error in the form', async () => {
     // given
     // @ts-ignore
-    jest.spyOn(window, 'fetch').mockResolvedValueOnce({
-      status: 400,
-      json: async () => ({
-        code: '',
-      }),
-    })
+    jest.spyOn(window, 'fetch').mockResolvedValueOnce(
+      new Response(new Blob(), {
+        status: 400,
+      })
+    )
 
     // when
     const response =

--- a/pro/src/routes/Desk/__specs__/Desk.spec.tsx
+++ b/pro/src/routes/Desk/__specs__/Desk.spec.tsx
@@ -108,7 +108,7 @@ describe('src | routes | Desk', () => {
       .mockResolvedValue(apiBooking)
     const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
 
-    userEvent.click(buttonGetBooking)
+    await userEvent.click(buttonGetBooking)
     await waitFor(() => {
       expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
         testToken
@@ -144,7 +144,7 @@ describe('src | routes | Desk', () => {
 
     const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
 
-    userEvent.click(buttonGetBooking)
+    await userEvent.click(buttonGetBooking)
     await waitFor(() => {
       expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
         testToken
@@ -175,7 +175,7 @@ describe('src | routes | Desk', () => {
 
     const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
 
-    userEvent.click(buttonGetBooking)
+    await userEvent.click(buttonGetBooking)
     await waitFor(() => {
       expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
         testToken
@@ -206,7 +206,7 @@ describe('src | routes | Desk', () => {
 
     const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
 
-    userEvent.click(buttonGetBooking)
+    await userEvent.click(buttonGetBooking)
     await waitFor(() => {
       expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
         testToken
@@ -241,7 +241,7 @@ describe('src | routes | Desk', () => {
 
     const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
 
-    userEvent.click(buttonGetBooking)
+    await userEvent.click(buttonGetBooking)
     await waitFor(() => {
       expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
         testToken
@@ -271,7 +271,7 @@ describe('src | routes | Desk', () => {
 
     const { buttonGetBooking, responseDataContainer } = await renderDeskRoute()
 
-    userEvent.click(buttonGetBooking)
+    await userEvent.click(buttonGetBooking)
     await waitFor(() => {
       expect(apiContremarque.getBookingByTokenV2).toHaveBeenCalledWith(
         testToken
@@ -293,7 +293,7 @@ describe('src | routes | Desk', () => {
     const { buttonSubmitInvalidate, responseDataContainer } =
       await renderDeskRoute()
 
-    userEvent.click(buttonSubmitInvalidate)
+    await userEvent.click(buttonSubmitInvalidate)
     await waitFor(() => {
       expect(apiContremarque.patchBookingKeepByToken).toHaveBeenCalledWith(
         testToken
@@ -322,7 +322,7 @@ describe('src | routes | Desk', () => {
     const { buttonSubmitInvalidate, responseDataContainer } =
       await renderDeskRoute()
 
-    userEvent.click(buttonSubmitInvalidate)
+    await userEvent.click(buttonSubmitInvalidate)
     await waitFor(() => {
       expect(apiContremarque.patchBookingKeepByToken).toHaveBeenCalledWith(
         testToken
@@ -344,7 +344,7 @@ describe('src | routes | Desk', () => {
     const { buttonSubmitValidate, responseDataContainer } =
       await renderDeskRoute()
 
-    userEvent.click(buttonSubmitValidate)
+    await userEvent.click(buttonSubmitValidate)
     await waitFor(() => {
       expect(apiContremarque.patchBookingUseByToken).toHaveBeenCalledWith(
         testToken
@@ -373,7 +373,7 @@ describe('src | routes | Desk', () => {
     const { buttonSubmitValidate, responseDataContainer } =
       await renderDeskRoute()
 
-    userEvent.click(buttonSubmitValidate)
+    await userEvent.click(buttonSubmitValidate)
     await waitFor(() => {
       expect(apiContremarque.patchBookingUseByToken).toHaveBeenCalledWith(
         testToken

--- a/pro/src/routes/VenueEdition/VenueEdition.tsx
+++ b/pro/src/routes/VenueEdition/VenueEdition.tsx
@@ -76,12 +76,13 @@ const VenueEdition = (): JSX.Element | null => {
     ].find(error => error !== undefined)
     if (loadingError !== undefined) {
       notify.error(loadingError.message)
+      // RomainC Redirect fix this warning here :
+      // Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
+      // which was caused by the setState in useGetVenue
+      // push is used to keep history of navigation
+      return <Redirect push to={homePath} />
     }
-    // RomainC Redirect fix this warning here :
-    // Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
-    // which was caused by the setState in useGetVenue
-    // push is used to keep history of navigation
-    return <Redirect push to={homePath} />
+    return null
   }
 
   const initialValues = setInitialFormValues(venue)

--- a/pro/src/routes/VenueEdition/VenueEdition.tsx
+++ b/pro/src/routes/VenueEdition/VenueEdition.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useHistory, useParams } from 'react-router'
+import { useParams, Redirect } from 'react-router'
 
 import useNotification from 'components/hooks/useNotification'
 import Spinner from 'components/layout/Spinner'
@@ -19,7 +19,6 @@ const VenueEdition = (): JSX.Element | null => {
   const { offererId } = useParams<{ offererId: string }>()
   const { venueId } = useParams<{ venueId: string }>()
   const notify = useNotification()
-  const history = useHistory()
   const {
     isLoading: isLoadingVenue,
     error: errorVenue,
@@ -77,9 +76,12 @@ const VenueEdition = (): JSX.Element | null => {
     ].find(error => error !== undefined)
     if (loadingError !== undefined) {
       notify.error(loadingError.message)
-      history.push(homePath)
     }
-    return null
+    // RomainC Redirect fix this warning here :
+    // Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
+    // which was caused by the setState in useGetVenue
+    // push is used to keep history of navigation
+    return <Redirect push to={homePath} />
   }
 
   const initialValues = setInitialFormValues(venue)

--- a/pro/src/routes/VenueEdition/__specs__/VenueEdition.spec.tsx
+++ b/pro/src/routes/VenueEdition/__specs__/VenueEdition.spec.tsx
@@ -18,7 +18,7 @@ import { configureTestStore } from 'store/testUtils'
 
 import VenueEdition from '../VenueEdition'
 
-const renderVenueEdition = async (
+const renderVenueEdition = (
   venueId: string,
   offererId: string,
   store: Store
@@ -127,7 +127,7 @@ describe('route VenueEdition', () => {
   })
   it('should call getVenue and display Venue Form screen on success', async () => {
     // When
-    await renderVenueEdition(venue.id, offerer.id, store)
+    renderVenueEdition(venue.id, offerer.id, store)
 
     // Then
     const venuePublicName = await screen.findByRole('heading', {
@@ -138,17 +138,18 @@ describe('route VenueEdition', () => {
   })
 
   it('should return to home when not able to get venue informations', async () => {
-    jest
-      .spyOn(api, 'getVenue')
-      .mockRejectedValue('Impossible de récupérer le lieu')
+    jest.spyOn(api, 'getVenue').mockRejectedValue({
+      status: 403,
+    })
     // When
-    await renderVenueEdition(venue.id, offerer.id, store)
+    renderVenueEdition(venue.id, offerer.id, store)
+    // await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
     // Then
+    expect(api.getVenue).toHaveBeenCalledTimes(1)
     const homeTitle = await screen.findByRole('heading', {
       name: 'Home',
     })
-    expect(api.getVenue).toHaveBeenCalledTimes(1)
     expect(homeTitle).toBeInTheDocument()
   })
 })

--- a/pro/src/routes/VenueEdition/__specs__/VenueEdition.spec.tsx
+++ b/pro/src/routes/VenueEdition/__specs__/VenueEdition.spec.tsx
@@ -8,10 +8,13 @@ import '@testing-library/jest-dom'
 
 import { api } from 'apiClient/api'
 import {
+  ApiError,
   GetOffererResponseModel,
   GetVenueResponseModel,
   SharedCurrentUserResponseModel,
 } from 'apiClient/v1'
+import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
+import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { IProviders, IVenueProviderApi } from 'core/Venue/types'
 import * as pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
@@ -138,12 +141,20 @@ describe('route VenueEdition', () => {
   })
 
   it('should return to home when not able to get venue informations', async () => {
-    jest.spyOn(api, 'getVenue').mockRejectedValue({
-      status: 403,
-    })
+    jest.spyOn(api, 'getVenue').mockRejectedValue(
+      new ApiError(
+        {} as ApiRequestOptions,
+        {
+          status: 404,
+          body: {
+            global: ['error'],
+          },
+        } as ApiResult,
+        ''
+      )
+    )
     // When
     renderVenueEdition(venue.id, offerer.id, store)
-    // await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
     // Then
     expect(api.getVenue).toHaveBeenCalledTimes(1)

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/CollectiveTableRow.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/CollectiveTableRow.tsx
@@ -46,15 +46,19 @@ const CollectiveTableRow = ({ row, reloadBookings }: ITableBodyProps) => {
           <tr />
           <tr className={styles['details-container']}>
             {isLoading ? (
-              <Spinner className={styles['loader']} />
+              <td className={styles['loader']}>
+                <Spinner />
+              </td>
             ) : (
               bookingDetails && (
-                <CollectiveBookingDetails
-                  bookingDetails={bookingDetails}
-                  offerId={row.original.stock.offer_identifier}
-                  canCancelBooking={bookingDetails.isCancellable}
-                  reloadBookings={reloadBookings}
-                />
+                <td>
+                  <CollectiveBookingDetails
+                    bookingDetails={bookingDetails}
+                    offerId={row.original.stock.offer_identifier}
+                    canCancelBooking={bookingDetails.isCancellable}
+                    reloadBookings={reloadBookings}
+                  />
+                </td>
               )
             )}
           </tr>

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/CollectiveTableRow.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/CollectiveTableRow.tsx
@@ -51,7 +51,7 @@ const CollectiveTableRow = ({ row, reloadBookings }: ITableBodyProps) => {
               </td>
             ) : (
               bookingDetails && (
-                <td>
+                <td className={styles['details-content']}>
                   <CollectiveBookingDetails
                     bookingDetails={bookingDetails}
                     offerId={row.original.stock.offer_identifier}

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/TableRow.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/TableRow.module.scss
@@ -5,7 +5,7 @@
   padding: rem.torem(16px);
   border-top: 1px solid colors.$grey-medium;
 
-  td {
+  .details-content {
     padding: unset;
     font-size: unset;
     font-weight: unset;

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/TableRow.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/TableRow.module.scss
@@ -2,10 +2,17 @@
 @use 'styles/variables/_colors.scss' as colors;
 
 .details-container {
-    padding: rem.torem(16px);
-    border-top: 1px solid colors.$grey-medium;
+  padding: rem.torem(16px);
+  border-top: 1px solid colors.$grey-medium;
+
+  td {
+    padding: unset;
+    font-size: unset;
+    font-weight: unset;
+    line-height: unset;
+  }
 }
 
 .loader {
-    margin: auto;
+  margin: auto;
 }

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/__specs__/CollectiveTableRow.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/__specs__/CollectiveTableRow.spec.tsx
@@ -31,12 +31,13 @@ const renderCollectiveTableRow = (props: ITableBodyProps) =>
   render(
     <Router history={createBrowserHistory()}>
       <Provider store={configureTestStore({})}>
-        <CollectiveTableRow {...props} />
+        <table>
+          <tbody>
+            <CollectiveTableRow {...props} />
+          </tbody>
+        </table>
       </Provider>
-    </Router>,
-    {
-      container: document.body.appendChild(document.createElement('tbody')),
-    }
+    </Router>
   )
 
 describe('CollectiveTableRow', () => {

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/__specs__/CollectiveTableRow.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/__specs__/CollectiveTableRow.spec.tsx
@@ -33,7 +33,10 @@ const renderCollectiveTableRow = (props: ITableBodyProps) =>
       <Provider store={configureTestStore({})}>
         <CollectiveTableRow {...props} />
       </Provider>
-    </Router>
+    </Router>,
+    {
+      container: document.body.appendChild(document.createElement('tbody')),
+    }
   )
 
 describe('CollectiveTableRow', () => {

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -133,7 +133,9 @@ describe('CollectiveOfferVisibility', () => {
   })
 
   it('should save selected institution and call onSuccess props', async () => {
-    const spyPatch = jest.fn().mockResolvedValue({ isOk: true })
+    const spyPatch = jest
+      .fn()
+      .mockResolvedValue({ isOk: true, payload: { institutions: [] } })
     renderVisibilityStep({ ...props, patchInstitution: spyPatch })
     await userEvent.click(
       screen.getByLabelText(/Un établissement en particulier/)
@@ -148,7 +150,13 @@ describe('CollectiveOfferVisibility', () => {
       screen.getByRole('button', { name: /Valider et créer l’offre/ })
     )
     expect(spyPatch).toHaveBeenCalledTimes(1)
-    expect(props.onSuccess).toHaveBeenCalledWith({ offerId: 'BQ', message: '' })
+    expect(props.onSuccess).toHaveBeenCalledWith({
+      offerId: 'BQ',
+      message: '',
+      payload: {
+        institutions: [],
+      },
+    })
   })
 
   it('should display an error when the institution could not be saved', async () => {

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
@@ -59,24 +59,24 @@ describe('screens | OfferEducational', () => {
     }
     renderEACOfferForm(props, store)
 
-    const inputs = await Promise.all([
-      await screen.findByLabelText(CATEGORY_LABEL),
-      await screen.findByLabelText(SUBCATEGORY_LABEL),
-      await screen.findByLabelText(TITLE_LABEL),
-      await screen.findByLabelText(CATEGORY_LABEL),
-      await screen.findByLabelText(DURATION_LABEL, { exact: false }),
-      await screen.findByLabelText(OFFERER_LABEL),
-      await screen.findByLabelText(VENUE_LABEL),
-      await screen.findByLabelText('Autre'), // one of every option
-      await screen.findByLabelText('Collège - 3e'), // one of every option
-      await screen.findByLabelText('Visuel'), // one of every option
-      await screen.findByLabelText(PHONE_LABEL),
-      await screen.findByLabelText(EMAIL_LABEL),
-      await screen.findByLabelText(NOTIFICATIONS_LABEL),
-      await screen.findByLabelText(NOTIFICATIONS_EMAIL_LABEL),
-      await screen.findByLabelText(INTERVENTION_AREA_LABEL),
-    ])
-    const submitButton = await screen.findByRole('button', {
+    const inputs = [
+      screen.getByLabelText(CATEGORY_LABEL),
+      screen.getByLabelText(SUBCATEGORY_LABEL),
+      screen.getByLabelText(TITLE_LABEL),
+      screen.getByLabelText(CATEGORY_LABEL),
+      screen.getByLabelText(DURATION_LABEL, { exact: false }),
+      screen.getByLabelText(OFFERER_LABEL),
+      screen.getByLabelText(VENUE_LABEL),
+      screen.getByLabelText('Autre'), // one of every option
+      screen.getByLabelText('Collège - 3e'), // one of every option
+      screen.getByLabelText('Visuel'), // one of every option
+      screen.getByLabelText(PHONE_LABEL),
+      screen.getByLabelText(EMAIL_LABEL),
+      screen.getByLabelText(NOTIFICATIONS_LABEL),
+      screen.getByLabelText(NOTIFICATIONS_EMAIL_LABEL),
+      screen.getByLabelText(INTERVENTION_AREA_LABEL),
+    ]
+    const submitButton = await screen.getByRole('button', {
       name: 'Enregistrer',
     })
 

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
@@ -60,21 +60,21 @@ describe('screens | OfferEducational', () => {
     renderEACOfferForm(props, store)
 
     const inputs = await Promise.all([
-      screen.findByLabelText(CATEGORY_LABEL),
-      screen.findByLabelText(SUBCATEGORY_LABEL),
-      screen.findByLabelText(TITLE_LABEL),
-      screen.findByLabelText(CATEGORY_LABEL),
-      screen.findByLabelText(DURATION_LABEL, { exact: false }),
-      screen.findByLabelText(OFFERER_LABEL),
-      screen.findByLabelText(VENUE_LABEL),
-      screen.findByLabelText('Autre'), // one of every option
-      screen.findByLabelText('Collège - 3e'), // one of every option
-      screen.findByLabelText('Visuel'), // one of every option
-      screen.findByLabelText(PHONE_LABEL),
-      screen.findByLabelText(EMAIL_LABEL),
-      screen.findByLabelText(NOTIFICATIONS_LABEL),
-      screen.findByLabelText(NOTIFICATIONS_EMAIL_LABEL),
-      screen.findByLabelText(INTERVENTION_AREA_LABEL),
+      await screen.findByLabelText(CATEGORY_LABEL),
+      await screen.findByLabelText(SUBCATEGORY_LABEL),
+      await screen.findByLabelText(TITLE_LABEL),
+      await screen.findByLabelText(CATEGORY_LABEL),
+      await screen.findByLabelText(DURATION_LABEL, { exact: false }),
+      await screen.findByLabelText(OFFERER_LABEL),
+      await screen.findByLabelText(VENUE_LABEL),
+      await screen.findByLabelText('Autre'), // one of every option
+      await screen.findByLabelText('Collège - 3e'), // one of every option
+      await screen.findByLabelText('Visuel'), // one of every option
+      await screen.findByLabelText(PHONE_LABEL),
+      await screen.findByLabelText(EMAIL_LABEL),
+      await screen.findByLabelText(NOTIFICATIONS_LABEL),
+      await screen.findByLabelText(NOTIFICATIONS_EMAIL_LABEL),
+      await screen.findByLabelText(INTERVENTION_AREA_LABEL),
     ])
     const submitButton = await screen.findByRole('button', {
       name: 'Enregistrer',

--- a/pro/src/screens/OfferEducational/__tests-utils__/defaultProps.ts
+++ b/pro/src/screens/OfferEducational/__tests-utils__/defaultProps.ts
@@ -1,5 +1,9 @@
 import { OfferAddressType, SubcategoryIdEnum } from 'apiClient/v1'
-import { DEFAULT_EAC_FORM_VALUES, Mode } from 'core/OfferEducational'
+import {
+  DEFAULT_EAC_FORM_VALUES,
+  IOfferEducationalFormValues,
+  Mode,
+} from 'core/OfferEducational'
 import { buildStudentLevelsMapWithDefaultValue } from 'core/OfferEducational/utils/buildStudentLevelsMapWithDefaultValue'
 
 import { IOfferEducationalProps } from '../OfferEducational'
@@ -60,7 +64,7 @@ const allParticipantsOptionsToTrue = {
   ...buildStudentLevelsMapWithDefaultValue(true),
 }
 
-const editionFormValues = {
+const editionFormValues: IOfferEducationalFormValues = {
   category: 'MUSEE',
   subCategory: SubcategoryIdEnum.VISITE_GUIDEE,
   title: 'offer title',
@@ -87,6 +91,8 @@ const editionFormValues = {
   notifications: true,
   notificationEmails: ['email.notification@email.com'],
   domains: [],
+  'search-domains': '',
+  'search-interventionArea': '',
 }
 
 export const defaultEditionProps: IOfferEducationalProps = {

--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStockShowcaseOffer.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStockShowcaseOffer.spec.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom'
 
-import { waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import {
@@ -40,13 +39,11 @@ describe('screens | OfferEducationalStock : showcase offer', () => {
     renderOfferEducationalStock(props)
     const showCaseOptionRadioButton = queryShowcaseOfferRadio()
 
-    await waitFor(() => expect(showCaseOptionRadioButton).toBeInTheDocument())
+    expect(showCaseOptionRadioButton).toBeInTheDocument()
 
     expect(showCaseOptionRadioButton?.checked).toBe(false)
-    userEvent.click(showCaseOptionRadioButton as HTMLInputElement)
-    await waitFor(() =>
-      expect(expect(showCaseOptionRadioButton?.checked).toBe(true))
-    )
+    await userEvent.click(showCaseOptionRadioButton as HTMLInputElement)
+    expect(showCaseOptionRadioButton?.checked).toBe(true)
 
     const beginningDateInput = queryBeginningDateInput()
     const beginningTimeInput = queryBeginningTimeInput()
@@ -78,16 +75,16 @@ describe('screens | OfferEducationalStock : showcase offer', () => {
 
     const showCaseOptionRadioButton = queryShowcaseOfferRadio()
 
-    await waitFor(() => expect(showCaseOptionRadioButton).toBeInTheDocument())
+    expect(showCaseOptionRadioButton).toBeInTheDocument()
     expect(showCaseOptionRadioButton?.checked).toBe(true)
 
     const priceDetailsTextArea = queryPriceDetailsTextarea()
     expect(priceDetailsTextArea).toHaveValue('Détail du prix')
 
     const classicOptionRadioButton = queryClassicOfferRadio()
-    userEvent.click(classicOptionRadioButton as HTMLInputElement)
+    await userEvent.click(classicOptionRadioButton as HTMLInputElement)
 
-    await waitFor(() => expect(showCaseOptionRadioButton?.checked).toBe(false))
+    expect(showCaseOptionRadioButton?.checked).toBe(false)
     expect(classicOptionRadioButton?.checked).toBe(true)
 
     const beginningDateInput = queryBeginningDateInput()
@@ -107,7 +104,7 @@ describe('screens | OfferEducationalStock : showcase offer', () => {
     expect(bookingLimitDatetimeInput?.value).toBe('')
   })
 
-  it('should not show radio buttons if offer has a stock and is not showcase', async () => {
+  it('should not show radio buttons if offer has a stock and is not showcase', () => {
     const testProps: IOfferEducationalStockProps = {
       ...defaultProps,
       offer: offerFactory({ isShowcase: false }),

--- a/pro/src/store/StoreProvider/__specs__/StoreProvider.spec.tsx
+++ b/pro/src/store/StoreProvider/__specs__/StoreProvider.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderStoreProvider = () => {
-  render(
+  return render(
     <StoreProvider>
       <p>Sub component</p>
     </StoreProvider>

--- a/pro/src/store/StoreProvider/__specs__/StoreProvider.spec.tsx
+++ b/pro/src/store/StoreProvider/__specs__/StoreProvider.spec.tsx
@@ -12,7 +12,7 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderStoreProvider = () => {
-  return render(
+  render(
     <StoreProvider>
       <p>Sub component</p>
     </StoreProvider>
@@ -39,7 +39,7 @@ describe('src | App', () => {
     expect(api.getProfile).toHaveBeenCalled()
   })
   it('should load features', async () => {
-    await renderStoreProvider()
+    renderStoreProvider()
     await screen.findByText('Sub component')
 
     // Then

--- a/pro/src/ui-kit/IconLinkBox/IconLinkBox.tsx
+++ b/pro/src/ui-kit/IconLinkBox/IconLinkBox.tsx
@@ -42,7 +42,7 @@ const IconLinkBox = ({
           variant={ButtonVariant.TERNARY}
           link={{
             to: linkUrl,
-            isExternal: true,
+            isExternal: false,
           }}
           onClick={onClick}
           Icon={IconLink}

--- a/pro/src/ui-kit/form/MultiSelectAutoComplete/__specs__/MultiSelectAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/MultiSelectAutoComplete/__specs__/MultiSelectAutocomplete.spec.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
@@ -36,7 +36,7 @@ describe('MultiSelectAutocomplete', () => {
     ],
     pluralLabel: 'Départements',
   }
-  const initialValues = { departement: ['01', '02'] }
+  const initialValues = { departement: ['01', '02'], 'search-departement': '' }
 
   it('should display field', () => {
     render(
@@ -53,7 +53,7 @@ describe('MultiSelectAutocomplete', () => {
         <MultiSelectAutocomplete {...props} />
       </Formik>
     )
-    expect(await screen.findByText('2')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
   })
 
   describe('Options', () => {
@@ -100,9 +100,7 @@ describe('MultiSelectAutocomplete', () => {
         </Formik>
       )
       await userEvent.click(screen.getByRole('textbox'))
-      await userEvent.click(
-        await screen.findByRole('button', { name: 'Outside' })
-      )
+      await userEvent.click(screen.getByRole('button', { name: 'Outside' }))
       expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
     })
 
@@ -113,8 +111,8 @@ describe('MultiSelectAutocomplete', () => {
         </Formik>
       )
       await userEvent.click(screen.getByRole('textbox'))
-      await userEvent.click(await screen.findByLabelText('Aveyron'))
-      await userEvent.click(await screen.findByLabelText('Calvados'))
+      await userEvent.click(screen.getByLabelText('Aveyron'))
+      await userEvent.click(screen.getByLabelText('Calvados'))
       expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(
         initialValues.departement.length + ['Aveyron', 'Calvados'].length
       )
@@ -127,7 +125,7 @@ describe('MultiSelectAutocomplete', () => {
         </Formik>
       )
       await userEvent.click(screen.getByRole('textbox'))
-      await userEvent.click(await screen.findByLabelText('Ain'))
+      await userEvent.click(screen.getByLabelText('Ain'))
       expect(screen.getAllByRole('checkbox', { checked: true })).toHaveLength(
         initialValues.departement.length - ['Ain'].length
       )
@@ -175,8 +173,8 @@ describe('MultiSelectAutocomplete', () => {
         </Formik>
       )
       await userEvent.click(screen.getByRole('textbox'))
-      await userEvent.click(await screen.findByLabelText('Aveyron'))
-      await userEvent.click(await screen.findByLabelText('Calvados'))
+      await userEvent.click(screen.getByLabelText('Aveyron'))
+      await userEvent.click(screen.getByLabelText('Calvados'))
       expect(
         screen.getByRole('button', { name: 'Aveyron' })
       ).toBeInTheDocument()
@@ -192,8 +190,8 @@ describe('MultiSelectAutocomplete', () => {
         </Formik>
       )
       await userEvent.click(screen.getByRole('textbox'))
-      await userEvent.click(await screen.findByLabelText('Aveyron'))
-      await userEvent.click(await screen.findByLabelText('Calvados'))
+      await userEvent.click(screen.getByLabelText('Aveyron'))
+      await userEvent.click(screen.getByLabelText('Calvados'))
       expect(
         screen.queryByRole('button', { name: 'Aveyron' })
       ).not.toBeInTheDocument()
@@ -247,12 +245,10 @@ describe('MultiSelectAutocomplete', () => {
     ).not.toBeInTheDocument()
     await userEvent.click(screen.getByRole('textbox'))
     // and unselects default options
-    await userEvent.click(await screen.findByLabelText('Ain'))
-    await userEvent.click(await screen.findByLabelText('Aisne'))
-    await waitFor(() => {
-      expect(
-        screen.queryByText('Veuillez renseigner un département')
-      ).toBeInTheDocument()
-    })
+    await userEvent.click(screen.getByLabelText('Ain'))
+    await userEvent.click(screen.getByLabelText('Aisne'))
+    expect(
+      screen.queryByText('Veuillez renseigner un département')
+    ).toBeInTheDocument()
   })
 })

--- a/pro/src/ui-kit/form/SelectAutocomplete/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutocomplete/SelectAutocomplete.tsx
@@ -162,7 +162,7 @@ const SelectAutocomplete = ({
               role="option"
               aria-selected={field.value === value}
               disabled={disabled}
-              checked={field.value === value}
+              defaultChecked={field.value === value}
               onClick={() => {
                 helpers.setValue(value)
                 setIsOpen(false)

--- a/pro/src/ui-kit/form/SelectAutocomplete/__specs__/SelectAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/SelectAutocomplete/__specs__/SelectAutocomplete.spec.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
@@ -36,7 +36,7 @@ describe('src | ui-kit | form | SelectAutocomplete', () => {
         { value: '15', label: 'Cantal' },
       ],
     }
-    const initialValues = { departement: '' }
+    const initialValues = { departement: '', 'search-departement': '' }
 
     it('should display field', () => {
       render(
@@ -65,7 +65,7 @@ describe('src | ui-kit | form | SelectAutocomplete', () => {
           </Formik>
         )
         await userEvent.click(screen.getByRole('textbox'))
-        expect(await screen.findAllByRole('option')).toHaveLength(15)
+        expect(screen.getAllByRole('option')).toHaveLength(15)
       })
 
       it('should close and hide all options when the user triggers the close arrow button', async () => {
@@ -89,9 +89,7 @@ describe('src | ui-kit | form | SelectAutocomplete', () => {
           </Formik>
         )
         await userEvent.click(screen.getByRole('textbox'))
-        await userEvent.click(
-          await screen.findByRole('button', { name: 'Outside' })
-        )
+        await userEvent.click(screen.getByRole('button', { name: 'Outside' }))
         expect(screen.queryAllByRole('option')).toHaveLength(0)
       })
 
@@ -102,7 +100,7 @@ describe('src | ui-kit | form | SelectAutocomplete', () => {
           </Formik>
         )
         await userEvent.click(screen.getByRole('textbox'))
-        await userEvent.click(await screen.findByLabelText('Aveyron'))
+        await userEvent.click(screen.getByLabelText('Aveyron'))
         expect(screen.getByRole('textbox')).toHaveValue('Aveyron')
       })
 
@@ -113,7 +111,7 @@ describe('src | ui-kit | form | SelectAutocomplete', () => {
           </Formik>
         )
         await userEvent.click(screen.getByRole('textbox'))
-        const additionalOption = await screen.findByLabelText(
+        const additionalOption = screen.getByLabelText(
           /5 résultats maximum. Veuillez affiner votre recherche/
         )
         expect(additionalOption).toBeDisabled()
@@ -176,11 +174,9 @@ describe('src | ui-kit | form | SelectAutocomplete', () => {
       ).not.toBeInTheDocument()
       await userEvent.click(screen.getByRole('textbox'))
       await userEvent.click(screen.getByAltText('Masquer les options'))
-      await waitFor(() => {
-        expect(
-          screen.queryByText('Veuillez renseigner un département')
-        ).toBeInTheDocument()
-      })
+      expect(
+        screen.getByText('Veuillez renseigner un département')
+      ).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
BSR

## But de la pull request

_Retirer les warnings des tests de PRO

sauf 16 warnings de 3 sortes :

1.
```
      Warning: The <default /> component appears to be a function component that returns a class instance. 
      Change default to a class that extends React.Component instead. I
      f you can't use a class try assigning the prototype on the function as a workaround. `default.prototype = React.Component.prototype`. Don't use an arrow function since it cannot be called with `new` by React.
```
une occurence, le plus mystérieux, lié à  `AvatarEditor` dans  `'react-avatar-editor'`

2. 
```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
&
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
```
8 warnings
liés à `Autocomplete` de la lib `react-autocomplete`  dans l'unique composant LocationViewer
le lien dit que ça empêche de passer à react 17
vu que c'est dans venueV1 peut être que la squad activation va le remplacer par autre chose 

3.
```
Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application. 
To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```
7 warnings,
en gros on fait un setState une fois le composant unmount et react n'aime pas
ça se résolvera tout seul dans react 18
en attendant je propose de les enlevés en utilisant le workaround décrit ici https://stackoverflow.com/questions/58038008/how-to-stop-memory-leak-in-useeffect-hook-react
et en laissant des commentaire pour indiquer de l'enlever après la migration