### PR TITLE
(PC-17780)[API] feat: flag collective offeres created by the public api

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-b0f79857ab7d (pre) (head)
+ac10b3d69c25 (pre) (head)
 8ab2b534c85b (post) (head)

--- a/api/src/pcapi/alembic/versions/20221010T092930_ac10b3d69c25_add_flag_for_collective_offers_from_api.py
+++ b/api/src/pcapi/alembic/versions/20221010T092930_ac10b3d69c25_add_flag_for_collective_offers_from_api.py
@@ -1,0 +1,22 @@
+"""add_flag_for_collective_offers_from_api
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "ac10b3d69c25"
+down_revision = "b0f79857ab7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "collective_offer", sa.Column("isPublicApi", sa.Boolean(), server_default=sa.text("false"), nullable=False)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("collective_offer", "isPublicApi")

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -1025,6 +1025,7 @@ def create_collective_offer_public(
         offerVenue=offer_venue,
         interventionArea=body.intervention_area,
         institutionId=body.educational_institution_id,
+        isPublicApi=True,
     )
     collective_offer.bookingEmails = body.booking_emails
     collective_stock = educational_models.CollectiveStock(

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -147,6 +147,8 @@ class CollectiveOffer(PcObject, Base, offer_mixin.ValidationMixin, Accessibility
         "CollectiveOfferTemplate", foreign_keys=[templateId], back_populates="collectiveOffers"
     )
 
+    isPublicApi: bool = sa.Column(sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False)
+
     @property
     def isEducational(self) -> bool:
         # FIXME (rpaoloni, 2022-03-7): Remove legacy support layer

--- a/api/tests/routes/pro/public_api/collective/post_collective_offer_public_test.py
+++ b/api/tests/routes/pro/public_api/collective/post_collective_offer_public_test.py
@@ -74,6 +74,7 @@ class CollectiveOffersPublicPostOfferTest:
             "addressType": "offererVenue",
             "otherAddress": "",
         }
+        assert offer.isPublicApi == True
 
     def test_invalid_api_key(self, client):
         # Given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17780

## Modifications du schéma de la base de données

- Ajout d'une colone `isPublicApi` dans la table `collective_offer` qui vaut `true` si l'offre a été créée par l'api collective publique et `false` sinon