### PR TITLE
(PC-17866)[API] feat: email reminder pro offer creation 5j and 10j after offerer validation

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1,4 +1,3 @@
-from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
@@ -7,13 +6,11 @@ import typing
 from typing import List
 
 from flask_sqlalchemy import BaseQuery
-import sqlalchemy as sqla
 from sqlalchemy import and_
 from sqlalchemy import false
 from sqlalchemy import func
 from sqlalchemy import not_
 from sqlalchemy import or_
-from sqlalchemy.orm import Query
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
@@ -378,17 +375,6 @@ def venue_already_has_validated_offer(offer: Offer) -> bool:
         )
         .first()
         is not None
-    )
-
-
-def venues_with_no_offer_since_x_days(number_of_days: int) -> Query:
-    return (
-        db.session.query(Venue.id, Venue.bookingEmail)
-        .outerjoin(Offer, Offer.venueId == Venue.id)
-        .filter(
-            Offer.venueId.is_(None),
-            sqla.cast(Venue.dateCreated, sqla.Date) == (date.today() - timedelta(days=number_of_days)),
-        )
     )
 
 

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -16,6 +16,9 @@ import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.utils as finance_utils
 import pcapi.core.fraud.api as fraud_api
 import pcapi.core.mails.transactional as transactional_mails
+from pcapi.core.offerers.repository import (
+    find_venues_of_offerers_with_no_offer_and_at_least_one_physical_venue_and_validated_x_days_ago,
+)
 from pcapi.core.offerers.repository import find_offerers_validated_3_days_ago_with_no_venues
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
@@ -23,7 +26,6 @@ from pcapi.core.offers.repository import check_stock_consistency
 from pcapi.core.offers.repository import delete_past_draft_collective_offers
 from pcapi.core.offers.repository import delete_past_draft_offers
 from pcapi.core.offers.repository import find_event_stocks_happening_in_x_days
-from pcapi.core.offers.repository import venues_with_no_offer_since_x_days
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.core.users import api as users_api
 import pcapi.core.users.constants as users_constants
@@ -228,7 +230,7 @@ def send_email_reminder_tomorrow_event_to_beneficiaries() -> None:
 @log_cron_with_transaction
 def send_email_reminder_offer_creation_j5_to_pro() -> None:
     """Triggers email reminder to pro 5 days after venue creation if no offer is created"""
-    venues = venues_with_no_offer_since_x_days(5)
+    venues = find_venues_of_offerers_with_no_offer_and_at_least_one_physical_venue_and_validated_x_days_ago(5)
     for venue_id, venue_booking_email in venues:
         try:
             transactional_mails.send_reminder_offer_creation_j5_to_pro(venue_booking_email)
@@ -245,7 +247,7 @@ def send_email_reminder_offer_creation_j5_to_pro() -> None:
 @log_cron_with_transaction
 def send_email_reminder_offer_creation_j10_to_pro() -> None:
     """Triggers email reminder to pro 10 days after venue creation if no offer is created"""
-    venues = venues_with_no_offer_since_x_days(10)
+    venues = find_venues_of_offerers_with_no_offer_and_at_least_one_physical_venue_and_validated_x_days_ago(10)
     for venue_id, venue_booking_email in venues:
         try:
             transactional_mails.send_reminder_offer_creation_j10_to_pro(venue_booking_email)

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1353,31 +1353,3 @@ class UpdateStockQuantityToDnBookedQuantityTest:
         repository.update_stock_quantity_to_dn_booked_quantity(stock.id)
         # then
         assert stock.quantity == 6
-
-
-@pytest.mark.usefixtures("db_session")
-class GetVenueWithNoOfferTest:
-    def test_get_venue_booking_email_with_no_offer(self):
-        # Given
-        five_days_ago = datetime.utcnow() - timedelta(days=5)
-        booking_email_test = "get_this_email@app.fr"
-        venue_with_no_offer = offerers_factories.VenueFactory(
-            dateCreated=five_days_ago, bookingEmail=booking_email_test
-        )
-        venue_with_no_offer2 = offerers_factories.VenueFactory(dateCreated=five_days_ago)
-        venue_with_no_offer3 = offerers_factories.VenueFactory()
-        venue_with_offer = offerers_factories.VenueFactory()
-        factories.OfferFactory(venue=venue_with_offer)
-
-        # When
-        query = repository.venues_with_no_offer_since_x_days(5)
-        emails = [venue_email for venue_id, venue_email in query]
-        ids = [venue_id for venue_id, venue_email in query]
-
-        assert emails == [venue_with_no_offer.bookingEmail, venue_with_no_offer2.bookingEmail]
-        assert ids == [venue_with_no_offer.id, venue_with_no_offer2.id]
-
-        assert venue_with_no_offer3.id not in ids
-        assert venue_with_no_offer3.bookingEmail not in emails
-        assert venue_with_offer.id not in ids
-        assert venue_with_offer.bookingEmail not in emails


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17866

## But de la pull request

Envoi de mail de relance de création d'offre pour les lieux physiques appartenant à des structures qui n’ont créé aucune offre ET dont la structure est validée 5j/10j avant


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
