### PR TITLE
(PC-17884)[API] fix: parse gender once when handling Ubble parsing

### DIFF
--- a/api/src/pcapi/core/fraud/ubble/models.py
+++ b/api/src/pcapi/core/fraud/ubble/models.py
@@ -24,14 +24,6 @@ class UbbleScore(enum.Enum):
     UNDECIDABLE = -1.0
 
 
-def _parse_ubble_gender(ubble_gender: str | None) -> users_models.GenderEnum | None:
-    if ubble_gender == "M":
-        return users_models.GenderEnum.M
-    if ubble_gender == "F":
-        return users_models.GenderEnum.F
-    return None
-
-
 class UbbleContent(IdentityCheckContent):
     birth_date: datetime.date | None
     comment: str | None
@@ -58,7 +50,6 @@ class UbbleContent(IdentityCheckContent):
     _parse_birth_date = pydantic.validator("birth_date", pre=True, allow_reuse=True)(
         lambda d: datetime.datetime.strptime(d, "%Y-%m-%d").date() if d is not None else None
     )
-    _parse_gender = pydantic.validator("gender", pre=True, allow_reuse=True)(_parse_ubble_gender)
 
     def get_birth_date(self) -> datetime.date | None:
         return self.birth_date

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.connectors.beneficiaries import ubble
 from pcapi.core.fraud.ubble import models as ubble_fraud_models
+from pcapi.core.users.models import GenderEnum
 from pcapi.utils import requests as requests_utils
 
 from tests.core.subscription.test_factories import UbbleIdentificationResponseFactory
@@ -132,3 +133,17 @@ class GetContentTest:
         assert record.extra["request_type"] == "get-content"
         assert record.extra["error_type"] == "http"
         assert exc_info.value.is_retryable == True
+
+
+class HelperFunctionsTest:
+    @pytest.mark.parametrize(
+        "ubble_gender, expected",
+        [
+            ("M", GenderEnum.M),
+            ("F", GenderEnum.F),
+            ("X", None),
+            (None, None),
+        ],
+    )
+    def test_parse_ubble_gender(self, ubble_gender, expected):
+        assert ubble._parse_ubble_gender(ubble_gender) == expected

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -53,6 +53,7 @@ class UbbleWorkflowTest:
         assert fraud_check.thirdPartyId is not None
         assert fraud_check.resultContent is not None
         assert fraud_check.status == fraud_models.FraudCheckStatus.STARTED
+        assert fraud_check.source_data().gender == users_models.GenderEnum.M
 
         ubble_request = ubble_mock.last_request.json()
         assert ubble_request["data"]["attributes"]["webhook"] == "http://localhost/webhooks/ubble/application_status"

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -799,7 +799,7 @@ class BeneficiaryInformationUpdateTest:
             last_name="Dufy",
             birth_date=datetime.date(2000, 5, 1).isoformat(),
             id_document_number="123456789",
-            gender="M",
+            gender=users_models.GenderEnum.M,
         )
         new_user = users_api.update_user_information_from_external_source(user, ubble_data)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17884

## But de la pull request

Corriger le parsing de "gender" du Ubble, pour ne le faire qu'une fois. Sinon, au second parsing, on remplace par None 

## Implémentation

- RAS

## Informations supplémentaires

- RAS

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
