### PR TITLE
(PC-17776)[API] fix: fix swagger security schemes

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/features.py
+++ b/api/src/pcapi/routes/adage_iframe/features.py
@@ -7,10 +7,10 @@ from pcapi.serialization.decorator import spectree_serialize
 
 
 @blueprint.adage_iframe.route("/features", methods=["GET"])
-@adage_jwt_required
 @spectree_serialize(
     response_model=features_serialize.ListFeatureResponseModel, api=blueprint.api, on_error_statuses=[404]
 )
+@adage_jwt_required
 def list_features(authenticated_information: AuthenticatedInformation) -> features_serialize.ListFeatureResponseModel:
     features = feature_queries.find_all()
     return features_serialize.ListFeatureResponseModel(__root__=features)

--- a/api/src/pcapi/routes/adage_iframe/logs.py
+++ b/api/src/pcapi/routes/adage_iframe/logs.py
@@ -7,8 +7,8 @@ from pcapi.serialization.decorator import spectree_serialize
 
 
 @blueprint.adage_iframe.route("/logs/catalog-view", methods=["POST"])
-@adage_jwt_required
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
 def log_catalog_view(
     authenticated_information: AuthenticatedInformation,
     body: serialization.CatalogViewBody,
@@ -24,8 +24,8 @@ def log_catalog_view(
 
 
 @blueprint.adage_iframe.route("/logs/search-button", methods=["POST"])
-@adage_jwt_required
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
 def log_search_button_click(
     authenticated_information: AuthenticatedInformation,
     body: serialization.SearchBody,
@@ -39,8 +39,8 @@ def log_search_button_click(
 
 
 @blueprint.adage_iframe.route("/logs/offer-detail", methods=["POST"])
-@adage_jwt_required
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
 def log_offer_details_button_click(
     authenticated_information: AuthenticatedInformation,
     body: serialization.StockIdBody,
@@ -54,8 +54,8 @@ def log_offer_details_button_click(
 
 
 @blueprint.adage_iframe.route("/logs/offer-template-detail", methods=["POST"])
-@adage_jwt_required
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
 def log_offer_template_details_button_click(
     authenticated_information: AuthenticatedInformation,
     body: serialization.OfferIdBody,
@@ -69,8 +69,8 @@ def log_offer_template_details_button_click(
 
 
 @blueprint.adage_iframe.route("/logs/booking-modal-button", methods=["POST"])
-@adage_jwt_required
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
 def log_booking_modal_button_click(
     authenticated_information: AuthenticatedInformation,
     body: serialization.StockIdBody,
@@ -84,8 +84,8 @@ def log_booking_modal_button_click(
 
 
 @blueprint.adage_iframe.route("/logs/contact-modal-button", methods=["POST"])
-@adage_jwt_required
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404], on_success_status=204)
+@adage_jwt_required
 def log_contact_modal_button_click(
     authenticated_information: AuthenticatedInformation,
     body: serialization.OfferIdBody,

--- a/api/src/pcapi/routes/adage_iframe/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/offers.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 @blueprint.adage_iframe.route("/offers/categories", methods=["GET"])
-@adage_jwt_required
 @spectree_serialize(response_model=serializers.CategoriesResponseModel, api=blueprint.api)
+@adage_jwt_required
 def get_educational_offers_categories(
     authenticated_information: AuthenticatedInformation,
 ) -> serializers.CategoriesResponseModel:
@@ -34,8 +34,8 @@ def get_educational_offers_categories(
 
 
 @blueprint.adage_iframe.route("/collective/offers/<int:offer_id>", methods=["GET"])
-@adage_jwt_required
 @spectree_serialize(response_model=serializers.CollectiveOfferResponseModel, api=blueprint.api, on_error_statuses=[404])
+@adage_jwt_required
 def get_collective_offer(
     authenticated_information: AuthenticatedInformation, offer_id: int
 ) -> serializers.CollectiveOfferResponseModel:
@@ -48,10 +48,10 @@ def get_collective_offer(
 
 
 @blueprint.adage_iframe.route("/collective/offers-template/<int:offer_id>", methods=["GET"])
-@adage_jwt_required
 @spectree_serialize(
     response_model=serializers.CollectiveOfferTemplateResponseModel, api=blueprint.api, on_error_statuses=[404]
 )
+@adage_jwt_required
 def get_collective_offer_template(
     authenticated_information: AuthenticatedInformation, offer_id: int
 ) -> serializers.CollectiveOfferTemplateResponseModel:

--- a/api/src/pcapi/routes/pro/public_api/bookings.py
+++ b/api/src/pcapi/routes/pro/public_api/bookings.py
@@ -112,7 +112,6 @@ def patch_booking_use_by_token(token: str) -> None:
 @blueprint.pro_public_api_v2.route("/bookings/cancel/token/<token>", methods=["PATCH"])
 @ip_rate_limiter(deduct_when=lambda response: response.status_code == 401)
 @basic_auth_rate_limiter()
-@login_or_api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API Contremarque"],
@@ -131,6 +130,7 @@ def patch_booking_use_by_token(token: str) -> None:
         )
     ),
 )
+@login_or_api_key_required
 def patch_cancel_booking_by_token(token: str) -> None:
     # in French, to be used by Swagger for the API documentation
     """Annulation d'une réservation.
@@ -163,7 +163,6 @@ def patch_cancel_booking_by_token(token: str) -> None:
 @blueprint.pro_public_api_v2.route("/bookings/keep/token/<token>", methods=["PATCH"])
 @ip_rate_limiter(deduct_when=lambda response: response.status_code == 401)
 @basic_auth_rate_limiter()
-@login_or_api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API Contremarque"],
@@ -181,6 +180,7 @@ def patch_cancel_booking_by_token(token: str) -> None:
         )
     ),
 )
+@login_or_api_key_required
 def patch_booking_keep_by_token(token: str) -> None:
     # in French, to be used by Swagger for the API documentation
     """Annulation de la validation d'une réservation."""

--- a/api/src/pcapi/routes/pro/public_api/collective/categories.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/categories.py
@@ -13,7 +13,6 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprint.pro_public_api_v2.route("/collective/categories", methods=["GET"])
-@api_key_required
 @lru_cache(maxsize=1)
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
@@ -33,6 +32,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
         )
     ),
 )
+@api_key_required
 def list_categories() -> public_api_collective_offers_serialize.CollectiveOffersListCategoriesResponseModel:
     # in French, to be used by Swagger for the API documentation
     """Récupération de la liste des catégories d'offres proposées."""
@@ -48,7 +48,6 @@ def list_categories() -> public_api_collective_offers_serialize.CollectiveOffers
 
 
 @blueprint.pro_public_api_v2.route("/collective/subcategories", methods=["GET"])
-@api_key_required
 @lru_cache(maxsize=1)
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
@@ -68,6 +67,7 @@ def list_categories() -> public_api_collective_offers_serialize.CollectiveOffers
         )
     ),
 )
+@api_key_required
 def list_subcategories() -> public_api_collective_offers_serialize.CollectiveOffersListSubCategoriesResponseModel:
     # in French, to be used by Swagger for the API documentation
     """Récupération de la liste des sous-catégories d'offres proposées a un public collectif."""

--- a/api/src/pcapi/routes/pro/public_api/collective/categories.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/categories.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from functools import lru_cache
 from typing import cast
 
+from pcapi import settings
 from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories_v2
 from pcapi.routes.pro import blueprint
@@ -13,7 +14,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprint.pro_public_api_v2.route("/collective/categories", methods=["GET"])
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=1 if not (settings.IS_RUNNING_TESTS or settings.IS_DEV) else 0)
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -48,7 +49,7 @@ def list_categories() -> public_api_collective_offers_serialize.CollectiveOffers
 
 
 @blueprint.pro_public_api_v2.route("/collective/subcategories", methods=["GET"])
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=1 if not (settings.IS_RUNNING_TESTS or settings.IS_DEV) else 0)
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],

--- a/api/src/pcapi/routes/pro/public_api/collective/domains.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/domains.py
@@ -11,7 +11,6 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprint.pro_public_api_v2.route("/collective/educational-domains", methods=["GET"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -30,6 +29,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
         )
     ),
 )
+@api_key_required
 @cached_view(prefix="pro_public_api_v2")
 def list_educational_domains() -> public_api_collective_offers_serialize.CollectiveOffersListDomainsResponseModel:
     # in French, to be used by Swagger for the API documentation

--- a/api/src/pcapi/routes/pro/public_api/collective/educational_institutions.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/educational_institutions.py
@@ -10,7 +10,6 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprint.pro_public_api_v2.route("/collective/educational-institutions/", methods=["GET"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -33,6 +32,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
         )
     ),
 )
+@api_key_required
 def list_educational_institutions(
     query: public_api_collective_offers_serialize.GetListEducationalInstitutionsQueryModel,
 ) -> public_api_collective_offers_serialize.CollectiveOffersListEducationalInstitutionResponseModel:

--- a/api/src/pcapi/routes/pro/public_api/collective/offers.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/offers.py
@@ -23,7 +23,6 @@ BASE_CODE_DESCRIPTIONS = {
 
 
 @blueprint.pro_public_api_v2.route("/collective/offers/", methods=["GET"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -39,6 +38,7 @@ BASE_CODE_DESCRIPTIONS = {
         )
     ),
 )
+@api_key_required
 def get_collective_offers_public(
     query: public_api_collective_offers_serialize.ListCollectiveOffersQueryModel,
 ) -> public_api_collective_offers_serialize.CollectiveOffersListResponseModel:
@@ -62,7 +62,6 @@ def get_collective_offers_public(
 
 
 @blueprint.pro_public_api_v2.route("/collective/offers/<int:offer_id>", methods=["GET"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -78,6 +77,7 @@ def get_collective_offers_public(
         )
     ),
 )
+@api_key_required
 def get_collective_offer_public(
     offer_id: int,
 ) -> public_api_collective_offers_serialize.GetPublicCollectiveOfferResponseModel:
@@ -112,7 +112,6 @@ def get_collective_offer_public(
 
 
 @blueprint.pro_public_api_v2.route("/collective/offers/", methods=["POST"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -140,6 +139,7 @@ def get_collective_offer_public(
         )
     ),
 )
+@api_key_required
 def post_collective_offer_public(
     body: public_api_collective_offers_serialize.PostCollectiveOfferBodyModel,
 ) -> public_api_collective_offers_serialize.GetPublicCollectiveOfferResponseModel:
@@ -183,7 +183,6 @@ def post_collective_offer_public(
 
 
 @blueprint.pro_public_api_v2.route("/collective/offers/<int:offer_id>", methods=["PATCH"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -215,6 +214,7 @@ def post_collective_offer_public(
         )
     ),
 )
+@api_key_required
 def patch_collective_offer_public(
     offer_id: int,
     body: public_api_collective_offers_serialize.PatchCollectiveOfferBodyModel,

--- a/api/src/pcapi/routes/pro/public_api/collective/students_levels.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/students_levels.py
@@ -11,7 +11,6 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprint.pro_public_api_v2.route("/collective/student-levels", methods=["GET"])
-@api_key_required
 @lru_cache(maxsize=1)
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
@@ -31,6 +30,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
         )
     ),
 )
+@api_key_required
 def list_students_levels() -> public_api_collective_offers_serialize.CollectiveOffersListStudentLevelsResponseModel:
     # in French, to be used by Swagger for the API documentation
     """Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées."""

--- a/api/src/pcapi/routes/pro/public_api/collective/students_levels.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/students_levels.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import cast
 
+from pcapi import settings
 from pcapi.core.educational import models as educational_models
 from pcapi.routes.pro import blueprint
 from pcapi.routes.serialization import BaseModel
@@ -11,7 +12,7 @@ from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprint.pro_public_api_v2.route("/collective/student-levels", methods=["GET"])
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=1 if not (settings.IS_RUNNING_TESTS or settings.IS_DEV) else 0)
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],

--- a/api/src/pcapi/routes/pro/public_api/collective/venues.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/venues.py
@@ -11,7 +11,6 @@ from pcapi.validation.routes.users_authentifications import current_api_key
 
 
 @blueprint.pro_public_api_v2.route("/collective/venues", methods=["GET"])
-@api_key_required
 @spectree_serialize(
     api=blueprint.pro_public_schema_v2,
     tags=["API offres collectives BETA"],
@@ -30,6 +29,7 @@ from pcapi.validation.routes.users_authentifications import current_api_key
         )
     ),
 )
+@api_key_required
 def list_venues() -> public_api_collective_offers_serialize.CollectiveOffersListVenuesResponseModel:
     # in French, to be used by Swagger for the API documentation
     """Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.

--- a/api/src/pcapi/routes/pro/public_api/stocks.py
+++ b/api/src/pcapi/routes/pro/public_api/stocks.py
@@ -15,10 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 @blueprint.pro_public_api_v2.route("/venue/<int:venue_id>/stocks", methods=["POST"])
-@api_key_required
 @spectree_serialize(
     on_success_status=204, on_error_statuses=[401, 404], api=blueprint.pro_public_schema_v2, tags=["API Stocks"]
 )
+@api_key_required
 def update_stocks(venue_id: int, body: UpdateVenueStocksBodyModel) -> None:
     # in French, to be used by Swagger for the API documentation
     """Mise à jour des stocks d'un lieu enregistré auprès du pass Culture.

--- a/api/tests/routes/pro/public_api/openapi_test.py
+++ b/api/tests/routes/pro/public_api/openapi_test.py
@@ -562,6 +562,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Annulation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
@@ -594,6 +595,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Annulation de la validation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
@@ -698,6 +700,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récupération de la liste des catégories d'offres proposées.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -729,6 +732,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -811,6 +815,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récupération de la liste établissements scolaires.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -883,6 +888,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récuperation de l'offre collective avec l'identifiant offer_id. Cette api ignore les offre vitrines et les offres commencées sur l'interface web et non finalisées.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -937,6 +943,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Création d'une offre collective.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -988,6 +995,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récuperation de l'offre collective avec l'identifiant offer_id.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -1050,6 +1058,7 @@ def test_public_api(client, app):
                             "description": "Cetains champs ne peuvent pas être édités selon l'état de l'offre",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Édition d'une offre collective.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -1083,6 +1092,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -1116,6 +1126,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récupération de la liste des sous-catégories d'offres proposées a un public collectif.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -1147,6 +1158,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -1181,6 +1193,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}],
                     "summary": "Mise à jour des stocks d'un lieu enregistré auprès du pass Culture.",
                     "tags": ["API Stocks"],
                 }


### PR DESCRIPTION
Bug : le champ `security` est absent du schéma openapi de certaines routes, comme [update_stocks](https://backend.integration.passculture.app/v2/swagger#/API%20Stocks/UpdateStocks).

Impact : tester ces routes via le swagger n'est pas fonctionnel. En effet la clé d'api qu'on ajoute à partir du bouton "Authorize" n'est pas transmise dans les headers des requêtes.

Fix : the add_security_scheme method should be called before spectree_serialize method so that the 'requires_authentication' attribute is defined when we try to use it in spectree_serialize

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17776


### Pour aller plus loin : 
Le plus propre ne serait-il pas d'utiliser directement les security_schemes du ExtendedSpectree ? 

Cf [cette PR](https://github.com/pass-culture/pass-culture-main/pull/3859).

Problème : certains endpoints ne demandent pas d'authentification. Pourtant ils utilisent le même schéma. Ex : [create_account](https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/native/v1/account.py#L161)

Ça demanderait de dupliquer les schéma pour avoir un schéma authentifié et un schéma non authentifié ?