### PR TITLE
(PC-17776)[API] refactor: configure routes security directly from security_schemes

### DIFF
--- a/api/src/pcapi/core/permissions/utils.py
+++ b/api/src/pcapi/core/permissions/utils.py
@@ -15,8 +15,6 @@ from pcapi.core.auth.utils import _set_current_user
 from pcapi.core.permissions.models import Permissions
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.feature import FeatureToggle
-from pcapi.routes.backoffice.blueprint import BACKOFFICE_AUTH
-from pcapi.serialization.spec_tree import add_security_scheme
 
 
 logger = logging.getLogger(__name__)
@@ -24,8 +22,6 @@ logger = logging.getLogger(__name__)
 
 def permission_required(permission: Permissions) -> typing.Callable:
     def wrapper(func: typing.Callable) -> typing.Callable:
-        add_security_scheme(func, BACKOFFICE_AUTH)
-
         @wraps(func)
         def wrapped(*args, **kwargs) -> tuple[Response, int] | typing.Callable:  # type: ignore[no-untyped-def]
             if not FeatureToggle.ENABLE_BACKOFFICE_API.is_active():

--- a/api/src/pcapi/routes/adage/security.py
+++ b/api/src/pcapi/routes/adage/security.py
@@ -4,13 +4,9 @@ from flask import request
 
 from pcapi import settings
 from pcapi.models.api_errors import ForbiddenError
-from pcapi.routes.adage.v1.blueprint import EAC_API_KEY_AUTH
-from pcapi.serialization.spec_tree import add_security_scheme
 
 
 def adage_api_key_required(route_function):  # type: ignore [no-untyped-def]
-    add_security_scheme(route_function, EAC_API_KEY_AUTH)
-
     @wraps(route_function)
     def wrapper(*args, **kwds):  # type: ignore [no-untyped-def]
         mandatory_authorization_type = "Bearer "

--- a/api/src/pcapi/routes/adage_iframe/security.py
+++ b/api/src/pcapi/routes/adage_iframe/security.py
@@ -8,17 +8,13 @@ from jwt import InvalidTokenError
 
 from pcapi.core.users import utils as user_utils
 from pcapi.models.api_errors import ForbiddenError
-from pcapi.routes.adage_iframe.blueprint import JWT_AUTH
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
-from pcapi.serialization.spec_tree import add_security_scheme
 
 
 logger = logging.getLogger(__name__)
 
 
 def adage_jwt_required(route_function):  # type: ignore [no-untyped-def]
-    add_security_scheme(route_function, JWT_AUTH)
-
     @wraps(route_function)
     def wrapper(*args, **kwargs):  # type: ignore [no-untyped-def]
         mandatory_authorization_type = "Bearer "

--- a/api/src/pcapi/routes/native/security.py
+++ b/api/src/pcapi/routes/native/security.py
@@ -11,8 +11,6 @@ import sentry_sdk
 from pcapi.core.users.models import User
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.models.api_errors import ForbiddenError
-from pcapi.routes.native.v1.blueprint import JWT_AUTH
-from pcapi.serialization.spec_tree import add_security_scheme
 
 
 logger = logging.getLogger(__name__)
@@ -23,8 +21,6 @@ RouteDecorator = typing.Callable[..., typing.Any]
 
 
 def authenticated_and_active_user_required(route_function: RouteFunc) -> RouteDecorator:
-    add_security_scheme(route_function, JWT_AUTH)
-
     @wraps(route_function)
     @jwt_required()
     def retrieve_authenticated_user(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
@@ -35,8 +31,6 @@ def authenticated_and_active_user_required(route_function: RouteFunc) -> RouteDe
 
 
 def authenticated_maybe_inactive_user_required(route_function: RouteFunc) -> RouteDecorator:
-    add_security_scheme(route_function, JWT_AUTH)
-
     @wraps(route_function)
     @jwt_required()
     def retrieve_authenticated_user(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:

--- a/api/src/pcapi/serialization/decorator.py
+++ b/api/src/pcapi/serialization/decorator.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from functools import wraps
 import logging
 from typing import Any
@@ -114,7 +113,11 @@ def spectree_serialize(
         else:
             spectree_response = SpectreeResponse(**response_codes)
 
-        security = deepcopy(getattr(route, "requires_authentication", None))
+        security: list[dict[str, list]] | None = (
+            [{security_scheme.name: []} for security_scheme in api.config.security_schemes]
+            if api.config.security_schemes
+            else None
+        )
 
         @wraps(route)
         @api.validate(

--- a/api/src/pcapi/serialization/spec_tree.py
+++ b/api/src/pcapi/serialization/spec_tree.py
@@ -22,16 +22,6 @@ def get_model_schema(model):  # type: ignore [no-untyped-def]
     )
 
 
-def add_security_scheme(route_function: Callable, auth_key: str, scopes: list[str] | None = None) -> None:
-    """Declare a sufficient security scheme to access the route.
-    The 'auth_key' should correspond to a scheme declared in
-    the SpecTree initialization of the route's BluePrint.
-    """
-    if not hasattr(route_function, "requires_authentication"):
-        route_function.requires_authentication = []  # type: ignore [attr-defined]
-    route_function.requires_authentication.append({auth_key: scopes or []})  # type: ignore [attr-defined]
-
-
 def build_operation_id(func: Callable) -> str:
     return "".join([*[part.capitalize() for part in func.__name__.split("_")]])
 

--- a/api/src/pcapi/validation/routes/users_authentifications.py
+++ b/api/src/pcapi/validation/routes/users_authentifications.py
@@ -15,9 +15,6 @@ from pcapi.core.users import repository as users_repo
 from pcapi.core.users.models import User
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import UnauthorizedError
-from pcapi.routes.pro.blueprint import API_KEY_AUTH
-from pcapi.routes.pro.blueprint import COOKIE_AUTH
-from pcapi.serialization.spec_tree import add_security_scheme
 
 
 logger = logging.getLogger(__name__)
@@ -31,9 +28,6 @@ def check_user_is_logged_in_or_email_is_provided(user: User, email: str | None) 
 
 
 def login_or_api_key_required(function: Callable) -> Callable:
-    add_security_scheme(function, API_KEY_AUTH)
-    add_security_scheme(function, COOKIE_AUTH)
-
     @wraps(function)
     def wrapper(*args, **kwds):  # type: ignore[no-untyped-def]
         _fill_current_api_key()
@@ -47,8 +41,6 @@ def login_or_api_key_required(function: Callable) -> Callable:
 
 
 def api_key_required(route_function: Callable) -> Callable:
-    add_security_scheme(route_function, API_KEY_AUTH)
-
     @wraps(route_function)
     def wrapper(*args, **kwds):  # type: ignore[no-untyped-def]
         _fill_current_api_key()

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1765,6 +1765,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "create_account <POST>",
                     "tags": [],
                 }
@@ -2026,6 +2027,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "cookies_consent <POST>",
                     "tags": [],
                 }
@@ -2295,6 +2297,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_offer <GET>",
                     "tags": [],
                 }
@@ -2486,6 +2489,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "validate_user_email <PUT>",
                     "tags": [],
                 }
@@ -2510,6 +2514,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "refresh <POST>",
                     "tags": [],
                 }
@@ -2535,6 +2540,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "request_password_reset <POST>",
                     "tags": [],
                 }
@@ -2561,6 +2567,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "resend_email_validation <POST>",
                     "tags": [],
                 }
@@ -2586,6 +2593,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "reset_password <POST>",
                     "tags": [],
                 }
@@ -2716,6 +2724,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_settings <GET>",
                     "tags": [],
                 }
@@ -2743,6 +2752,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "signin <POST>",
                     "tags": [],
                 }
@@ -2769,6 +2779,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_subcategories <GET>",
                     "tags": [],
                 }
@@ -2795,6 +2806,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_subcategories_v2 <GET>",
                     "tags": [],
                 }
@@ -2891,6 +2903,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_profile_options <GET>",
                     "tags": [],
                 }
@@ -3006,6 +3019,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "validate_email <POST>",
                     "tags": [],
                 }
@@ -3062,6 +3076,7 @@ def test_public_api(client):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"JWTAuth": []}],
                     "summary": "get_venue <GET>",
                     "tags": [],
                 }

--- a/api/tests/routes/pro/public_api/openapi_test.py
+++ b/api/tests/routes/pro/public_api/openapi_test.py
@@ -562,6 +562,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Annulation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
@@ -594,6 +595,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Annulation de la validation d'une réservation.",
                     "tags": ["API Contremarque"],
                 }
@@ -698,6 +700,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récupération de la liste des catégories d'offres proposées.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -729,6 +732,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récupération de la liste des domaines d'éducation pouvant être associés aux offres collectives.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -811,6 +815,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récupération de la liste établissements scolaires.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -883,6 +888,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récuperation de l'offre collective avec l'identifiant offer_id. Cette api ignore les offre vitrines et les offres commencées sur l'interface web et non finalisées.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -937,6 +943,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Création d'une offre collective.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -988,6 +995,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récuperation de l'offre collective avec l'identifiant offer_id.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -1050,6 +1058,7 @@ def test_public_api(client, app):
                             "description": "Cetains champs ne peuvent pas être édités selon l'état de l'offre",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Édition d'une offre collective.",
                     "tags": ["API offres collectives BETA"],
                 },
@@ -1083,6 +1092,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récupération de la liste des publics cibles pour lesquelles des offres collectives peuvent être proposées.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -1116,6 +1126,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récupération de la liste des sous-catégories d'offres proposées a un public collectif.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -1147,6 +1158,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.",
                     "tags": ["API offres collectives BETA"],
                 }
@@ -1181,6 +1193,7 @@ def test_public_api(client, app):
                             "description": "Unprocessable Entity",
                         },
                     },
+                    "security": [{"ApiKeyAuth": []}, {"SessionAuth": []}],
                     "summary": "Mise à jour des stocks d'un lieu enregistré auprès du pass Culture.",
                     "tags": ["API Stocks"],
                 }


### PR DESCRIPTION
Cette PR fait suite au bug sur le swagger réglé dans [cette PR](https://github.com/pass-culture/pass-culture-main/pull/3854) (les appels fait sur le swagger update_stocks renvoyaient des "unautorhized" même si on renseignait l'api key en haut de la page du swagger).

Proposition pour ne pas que le bug revienne : on peut déduire le champ `security` du schéma openapi à partir du `security_scheme` défini dans le blueprint, au lieu de le rajouter quand on fait un `@api_key_required` par exemple. 

Problème avec cette PR : 

-> on ajoute un `security` pour des endpoints "non authentifiés" du blueprint native. cf [ici](https://github.com/pass-culture/pass-culture-main/pull/3859/files#diff-2d45079b7565e009a9264d4b7a963f37fa1c81432545a413da1a409b775fbed5R1768).

C'est embêtant car le "swagger codegen" du front se base sur ce champ `security` de la doc openapi pour ajouter ou non le jwt de l'utilisateur dans la requête.


2 Solutions : 
- ajouter un blueprint "non authentifié" pour les routes de l'app native ; on aurait
   - not_authenticated_young_api
   - authenticated_young_api
- ajouter un paramètre `disable_security=True` dans le décorateur `spectree_serialize` -> peut-être source d'erreur si le développeur ne pense pas à remplir ce champ lorsqu'il implémente une route authentifiée



-----

Historique de ce `requires_authentication` : 
- [introduction](https://github.com/pass-culture/pass-culture-api/commit/4c92bacdfc0d8112c938846e6386735c5f7a1ff2)
- [mise à jour](https://github.com/pass-culture/pass-culture-main/commit/7a2f1999e5456c81d1313131b5955cee8172160f)
