### PR TITLE
(BSR)[API] style: Make pylint fail on info messages

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -58,12 +58,14 @@ exclude = """
 
 
 [tool.pylint.MASTER]
+# Include info messages into score so that pylint fails if we have
+# such messages (e.g. "useless-suppression").
+evaluation = "max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention + info) / statement) * 10))"
 extension-pkg-whitelist = [
     "pydantic",
 ]
 load-plugins = [
     "pcapi.utils.pylint",
-    "pylint_strict_informational",
     "pylint_pydantic",
 ]
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -45,7 +45,6 @@ pydantic[email]==1.10.2
 PyJWT[crypto]==2.4.0
 pylint
 pylint-pydantic
-pylint-strict-informational
 pysaml2
 pytest==6.2.5
 pytest-cov==2.10.1

--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -52,7 +52,7 @@ class ShowCDS(BaseModel):
         allow_population_by_field_name = True
 
     @validator("is_empty_seatmap")
-    def string_with_no_digit_to_true(cls, value: str | bool) -> bool:  # pylint: disable=no-self-argument
+    def string_with_no_digit_to_true(cls, value: str | bool) -> bool:
         """
         2022/08/02 a seatmap should be similar to [[1,1,1,0],[1,1,1,0]]
         when empty, it can be "[[],[]]" or ""

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -107,13 +107,13 @@ class PublicAccountUpdateRequest(BaseModel):
     city: str | None
 
     @pydantic.validator("email", pre=True)
-    def validate_email(cls, email: str) -> str:  # pylint: disable=no-self-argument
+    def validate_email(cls, email: str) -> str:
         if not email:
             return email
         return sanitize_email(email)
 
     @pydantic.validator("phoneNumber")
-    def validate_phone_number(cls, phone_number: str) -> str:  # pylint: disable=no-self-argument
+    def validate_phone_number(cls, phone_number: str) -> str:
         if not phone_number:
             return phone_number
 

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -163,11 +163,11 @@ class UserProfileResponse(BaseModel):
         use_enum_values = True
 
     @validator("publicName", pre=True)
-    def format_public_name(cls, publicName: str) -> str | None:  # pylint: disable=no-self-argument
+    def format_public_name(cls, publicName: str) -> str | None:
         return publicName if publicName != VOID_PUBLIC_NAME else None
 
     @validator("firstName", pre=True)
-    def format_first_name(cls, firstName: str | None) -> str | None:  # pylint: disable=no-self-argument
+    def format_first_name(cls, firstName: str | None) -> str | None:
         return firstName if firstName != VOID_FIRST_NAME else None
 
     @staticmethod
@@ -265,7 +265,7 @@ class UserProfilingFraudRequest(BaseModel):
     agentType: AgentType | None
 
     @root_validator()
-    def session_id_alphanumerics(cls, values: dict[str, Any]) -> dict[str, Any]:  # pylint: disable=no-self-argument
+    def session_id_alphanumerics(cls, values: dict[str, Any]) -> dict[str, Any]:
         session_id = values.get("sessionId") or values.get("session_id")
         if not session_id:
             raise ValueError("L'identifiant de session est manquant")
@@ -277,7 +277,7 @@ class UserProfilingFraudRequest(BaseModel):
         return values
 
     @validator("agentType", always=True)
-    def agent_type_validation(cls, agent_type: str) -> str:  # pylint: disable=no-self-argument
+    def agent_type_validation(cls, agent_type: str) -> str:
         if agent_type is None:
             agent_type = AgentType.AGENT_MOBILE
         if agent_type not in (AgentType.BROWSER_COMPUTER, AgentType.BROWSER_MOBILE, AgentType.AGENT_MOBILE):

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -221,7 +221,7 @@ class OfferReportRequest(BaseModel):
     custom_reason: str | None
 
     @validator("custom_reason")
-    def custom_reason_must_not_be_too_long(cls, content: str | None) -> str | None:  # pylint: disable=no-self-argument
+    def custom_reason_must_not_be_too_long(cls, content: str | None) -> str | None:
         if not content:
             return None
 
@@ -231,7 +231,7 @@ class OfferReportRequest(BaseModel):
         return content
 
     @validator("reason")
-    def reason_is_valid_enum_value(cls, reason: str) -> str:  # pylint: disable=no-self-argument
+    def reason_is_valid_enum_value(cls, reason: str) -> str:
         if reason not in {r.value for r in Reason}:
             raise ValueError("unknown reason")
         return reason

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -69,20 +69,20 @@ class ProfileUpdateRequest(BaseModel):
         alias_generator = to_camel
 
     @validator("first_name", "last_name", "address", "city", "postal_code")
-    def mandatory_string_fields_cannot_be_empty(cls, v):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def mandatory_string_fields_cannot_be_empty(cls, v):  # type: ignore [no-untyped-def]
         v = v.strip()
         if not v:
             raise ValueError("This field cannot be empty")
         return v
 
     @validator("first_name", "last_name", "city")
-    def string_must_contain_latin_characters(cls, v):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def string_must_contain_latin_characters(cls, v):  # type: ignore [no-untyped-def]
         if not is_latin(v):
             raise ValueError("Les champs textuels doivent contenir des caractères latins")
         return v
 
     @validator("address")
-    def address_must_be_valid(cls, v):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def address_must_be_valid(cls, v):  # type: ignore [no-untyped-def]
         if not has_latin_or_numeric_chars(v):
             raise ValueError("L'adresse doit contenir des caractères alphanumériques")
 

--- a/api/src/pcapi/validation/routes/dms.py
+++ b/api/src/pcapi/validation/routes/dms.py
@@ -18,7 +18,7 @@ class DMSWebhookRequest(pydantic.BaseModel):
     updated_at: datetime.datetime
 
     @pydantic.validator("updated_at", pre=True)
-    def validate_udpated_at(cls, value):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def validate_udpated_at(cls, value):  # type: ignore [no-untyped-def]
         return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S %z")
 
 

--- a/api/src/pcapi/validation/routes/zendesk.py
+++ b/api/src/pcapi/validation/routes/zendesk.py
@@ -23,7 +23,7 @@ class WebhookRequest(pydantic.BaseModel):
     requester_phone: str | None
 
     @pydantic.validator("requester_phone")
-    def check_email_or_phone(cls, requester_phone, values):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def check_email_or_phone(cls, requester_phone, values):  # type: ignore [no-untyped-def]
         if not values.get("requester_email") and not requester_phone:
             raise ValueError("L'email ou le numéro de téléphone est obligatoire")
         return requester_phone


### PR DESCRIPTION
... such as useless-suppression. That's what we wanted to do with
"pylint_strict_informational" but that plugin does not work with
recent versions of pylint.