### PR TITLE
(PC-15447)[API] feat: new route to bulk delete draft offers

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -74,6 +74,25 @@ def get_offer(offer_id: str) -> offers_serialize.GetIndividualOfferResponseModel
     return offers_serialize.GetIndividualOfferResponseModel.from_orm(offer)
 
 
+@private_api.route("/offers/delete-draft", methods=["POST"])
+@login_required
+@spectree_serialize(
+    on_success_status=204,
+    api=blueprint.pro_private_schema,
+)
+def delete_draft_offers(body: offers_serialize.DeleteOfferRequestBody) -> None:
+    offer_ids = human_ids.dehumanize_ids_list(body.ids)
+    if not offer_ids:
+        raise ApiErrors(
+            errors={
+                "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],
+            },
+            status_code=404,
+        )
+    query = offers_repository.get_offers_by_ids(current_user, offer_ids)  # type: ignore [arg-type]
+    offers_api.batch_delete_draft_offers(query)
+
+
 @private_api.route("/offers", methods=["POST"])
 @login_required
 @spectree_serialize(

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -510,3 +510,7 @@ class ImageBodyModel(BaseModel):
 class CategoriesResponseModel(BaseModel):
     categories: list[CategoryResponseModel]
     subcategories: list[SubcategoryResponseModel]
+
+
+class DeleteOfferRequestBody(BaseModel):
+    ids: list[str | None]

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -8,6 +8,7 @@ from pcapi.sandboxes.scripts.creators.industrial.create_industrial_criterion imp
     associate_criterion_to_one_offer_with_mediation,
 )
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_criterion import create_industrial_criteria
+from pcapi.sandboxes.scripts.creators.industrial.create_industrial_draft_offers import create_industrial_draft_offers
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_educational_bookings import (
     create_industrial_educational_bookings,
 )
@@ -57,6 +58,8 @@ def save_industrial_sandbox() -> None:
     event_offers_by_name = create_industrial_event_offers(event_products_by_name, offerers_by_name)
 
     thing_offers_by_name = create_industrial_thing_offers(thing_products_by_name, offerers_by_name, venues_by_name)
+
+    create_industrial_draft_offers(offerers_by_name)
 
     create_industrial_offers_with_activation_codes()
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_draft_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_draft_offers.py
@@ -1,0 +1,29 @@
+import logging
+
+import pcapi.core.offerers.models as offerers_models
+import pcapi.core.offers.factories as offers_factories
+from pcapi.models import db
+from pcapi.models.offer_mixin import OfferValidationStatus
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_industrial_draft_offers(offerers_by_name: dict[str, offerers_models.Offerer]) -> None:
+    logger.info("create_industrial_individual_draft_offers")
+    index = 0
+    for offerer in offerers_by_name.values():
+        venues = [venue for venue in offerer.managedVenues if not venue.isVirtual]
+        if not venues:
+            continue
+        venue = venues[0]
+
+        offers_factories.OfferFactory(venue=venue, name="Mon offre brouillon", validation=OfferValidationStatus.DRAFT)
+
+        draft_with_stocks = offers_factories.OfferFactory(
+            venue=venue, name="Mon offre brouillon avec stock", validation=OfferValidationStatus.DRAFT
+        )
+        offers_factories.StockFactory(offer=draft_with_stocks)
+        index += 2
+    db.session.commit()
+    logger.info("created %d draft offers", index)

--- a/api/tests/routes/pro/delete_draft_offer_test.py
+++ b/api/tests/routes/pro/delete_draft_offer_test.py
@@ -1,0 +1,54 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+import pcapi.core.offers.models as offer_models
+import pcapi.core.users.factories as users_factory
+from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.utils.human_ids import humanize
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class Returns204Test:
+    def test_delete_draft(self, client):
+        pro = users_factory.ProFactory()
+        draft_offer = offers_factories.OfferFactory(validation=OfferValidationStatus.DRAFT)
+        validated_offer = offers_factories.OfferFactory(
+            validation=OfferValidationStatus.APPROVED, venue=draft_offer.venue
+        )
+        offerers_factories.UserOffererFactory(user=pro, offerer=draft_offer.venue.managingOfferer)
+        data = {"ids": [humanize(draft_offer.id), humanize(validated_offer.id)]}
+
+        response = client.with_session_auth(pro.email).post("/offers/delete-draft", json=data)
+
+        assert response.status_code == 204
+
+        assert offer_models.Offer.query.one() == validated_offer
+
+    def test_delete_unaccessible_draft(self, client):
+        pro = users_factory.ProFactory()
+        draft_offer = offers_factories.OfferFactory(validation=OfferValidationStatus.DRAFT)
+        offerers_factories.UserOffererFactory(offerer=draft_offer.venue.managingOfferer)
+        data = {"ids": [humanize(draft_offer.id)]}
+
+        response = client.with_session_auth(pro.email).post("/offers/delete-draft", json=data)
+
+        assert response.status_code == 204
+
+        assert offer_models.Offer.query.count() == 1
+
+
+class Returns401Test:
+    def test_delete_not_connected_draft(self, client):
+        pro = users_factory.ProFactory()
+        draft_offer = offers_factories.OfferFactory(validation=OfferValidationStatus.DRAFT)
+        offerers_factories.UserOffererFactory(user=pro, offerer=draft_offer.venue.managingOfferer)
+        data = {"ids": [humanize(draft_offer.id)]}
+
+        response = client.post("/offers/delete-draft", json=data)
+
+        assert response.status_code == 401
+
+        assert offer_models.Offer.query.count() == 1

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -50,6 +50,7 @@ export type { CreateOffererQueryModel } from './models/CreateOffererQueryModel';
 export type { CreateThumbnailResponseModel } from './models/CreateThumbnailResponseModel';
 export type { CropParams } from './models/CropParams';
 export type { CulturalPartner } from './models/CulturalPartner';
+export type { DeleteOfferRequestBody } from './models/DeleteOfferRequestBody';
 export type { EditVenueBodyModel } from './models/EditVenueBodyModel';
 export type { EditVenueCollectiveDataBodyModel } from './models/EditVenueCollectiveDataBodyModel';
 export type { EducationalInstitutionResponseModel } from './models/EducationalInstitutionResponseModel';

--- a/pro/src/apiClient/v1/models/DeleteOfferRequestBody.ts
+++ b/pro/src/apiClient/v1/models/DeleteOfferRequestBody.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type DeleteOfferRequestBody = {
+  ids: Array<string>;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -22,6 +22,7 @@ import type { CollectiveStockIdResponseModel } from '../models/CollectiveStockId
 import type { CollectiveStockResponseModel } from '../models/CollectiveStockResponseModel';
 import type { CreateOffererQueryModel } from '../models/CreateOffererQueryModel';
 import type { CreateThumbnailResponseModel } from '../models/CreateThumbnailResponseModel';
+import type { DeleteOfferRequestBody } from '../models/DeleteOfferRequestBody';
 import type { EditVenueBodyModel } from '../models/EditVenueBodyModel';
 import type { EditVenueCollectiveDataBodyModel } from '../models/EditVenueCollectiveDataBodyModel';
 import type { EducationalInstitutionsResponseModel } from '../models/EducationalInstitutionsResponseModel';
@@ -1128,6 +1129,27 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/offers/categories',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * delete_draft_offers <POST>
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public deleteDraftOffers(
+    requestBody?: DeleteOfferRequestBody,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/offers/delete-draft',
+      body: requestBody,
+      mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15447

## But de la pull request

- 1er commit : 
Code très ressemblant au cron `delete_past_draft_offers` qui sera supprimé bientôt
Nouvelle route pour supprimer des brouillons par lot. Cette route se base sur une liste d'id pour chercher quelles offres à supprimer. 
Une 2eme route arrivera après permettant de supprimer des brouillons à partir des filtres utilisés sur la page offres.

- 2eme commit : 
Ajout de quelques offres brouillon dans la sanbox. Pour le moment 2 offres sont créés par lieux physique (1 avec stock). Ca fait 18 offres brouillons. Si on a besoin d'event/des catégories différentes je modifierai ensuite

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
