### PR TITLE
(PC-17849)[API] feat: permettre l’edition du champ isActive lors de l…

### DIFF
--- a/api/src/pcapi/routes/pro/public_api/collective/offers.py
+++ b/api/src/pcapi/routes/pro/public_api/collective/offers.py
@@ -240,6 +240,7 @@ def patch_collective_offer_public(
         "mentalDisabilityCompliant",
         "motorDisabilityCompliant",
         "visualDisabilityCompliant",
+        "isActive",
     ]
     for field in non_nullable_fields:
         if field in new_values and new_values[field] is None:

--- a/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
@@ -367,6 +367,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     visual_disability_compliant: bool = False
     offer_venue: OfferVenueModel
     intervention_area: list[str]
+    isActive: bool
     # stock part
     beginning_datetime: datetime
     booking_limit_datetime: datetime

--- a/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
@@ -417,6 +417,7 @@ class PatchCollectiveOfferBodyModel(BaseModel):
     mentalDisabilityCompliant: bool | None
     motorDisabilityCompliant: bool | None
     visualDisabilityCompliant: bool | None
+    isActive: bool | None
     # stock part
     beginningDatetime: datetime | None
     bookingLimitDatetime: datetime | None

--- a/api/tests/routes/pro/public_api/collective/patch_collective_offer_public_test.py
+++ b/api/tests/routes/pro/public_api/collective/patch_collective_offer_public_test.py
@@ -44,7 +44,7 @@ class CollectiveOffersPublicPatchOfferTest:
                 "otherAddress": None,
             },
             "interventionArea": ["44"],
-            "isActive": True,
+            "isActive": False,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -86,6 +86,7 @@ class CollectiveOffersPublicPatchOfferTest:
         assert offer.mentalDisabilityCompliant == True
         assert offer.motorDisabilityCompliant == True
         assert offer.visualDisabilityCompliant == True
+        assert offer.isActive == False
 
         assert offer.collectiveStock.beginningDatetime == datetime.fromisoformat(payload["beginningDatetime"])
         assert offer.collectiveStock.bookingLimitDatetime == datetime.fromisoformat(payload["bookingLimitDatetime"])
@@ -251,56 +252,3 @@ class CollectiveOffersPublicPatchOfferTest:
 
         # Then
         assert response.status_code == 403
-
-    # test_by_Boris
-    def test_patch_offer_not_active(self, client):
-        # Given
-        offerer = offerers_factories.OffererFactory()
-        offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
-        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
-        domain = educational_factories.EducationalDomainFactory()
-        educational_institution = educational_factories.EducationalInstitutionFactory()
-        stock = educational_factories.CollectiveStockFactory(collectiveOffer__venue=venue)
-
-        payload = {
-            "name": "Un nom en français ævœc des diàcrtîtïqués",
-            "description": "une description d'offre",
-            "subcategoryId": "EVENEMENT_CINE",
-            "venueId": venue2.id,
-            "bookingEmails": ["offerer-email@example.com", "offerer-email2@example.com"],
-            "contactEmail": "offerer-contact@example.com",
-            "contactPhone": "+33100992798",
-            "audioDisabilityCompliant": True,
-            "mentalDisabilityCompliant": True,
-            "motorDisabilityCompliant": True,
-            "visualDisabilityCompliant": True,
-            "domains": [domain.id],
-            "durationMinutes": 183,
-            "students": [educational_models.StudentLevels.COLLEGE4.name],
-            "offerVenue": {
-                "venueId": None,
-                "addressType": "school",
-                "otherAddress": None,
-            },
-            "interventionArea": ["44"],
-            "isActive": None,
-            # stock part
-            "beginningDatetime": "2022-09-25T11:00",
-            "bookingLimitDatetime": "2022-09-15T11:00",
-            "totalPrice": 35621,
-            "numberOfTickets": 30,
-            "educationalPriceDetail": "Justification du prix",
-            # link to educational institution
-            "educationalInstitutionId": educational_institution.id,
-        }
-
-        # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
-            response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
-                f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
-            )
-
-        # Then
-        assert response.status_code == 500

--- a/api/tests/routes/pro/public_api/collective/patch_collective_offer_public_test.py
+++ b/api/tests/routes/pro/public_api/collective/patch_collective_offer_public_test.py
@@ -44,6 +44,7 @@ class CollectiveOffersPublicPatchOfferTest:
                 "otherAddress": None,
             },
             "interventionArea": ["44"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -250,3 +251,56 @@ class CollectiveOffersPublicPatchOfferTest:
 
         # Then
         assert response.status_code == 403
+
+    # test_by_Boris
+    def test_patch_offer_not_active(self, client):
+        # Given
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(offerer=offerer)
+        offerers_factories.ApiKeyFactory(offerer=offerer)
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
+        domain = educational_factories.EducationalDomainFactory()
+        educational_institution = educational_factories.EducationalInstitutionFactory()
+        stock = educational_factories.CollectiveStockFactory(collectiveOffer__venue=venue)
+
+        payload = {
+            "name": "Un nom en français ævœc des diàcrtîtïqués",
+            "description": "une description d'offre",
+            "subcategoryId": "EVENEMENT_CINE",
+            "venueId": venue2.id,
+            "bookingEmails": ["offerer-email@example.com", "offerer-email2@example.com"],
+            "contactEmail": "offerer-contact@example.com",
+            "contactPhone": "+33100992798",
+            "audioDisabilityCompliant": True,
+            "mentalDisabilityCompliant": True,
+            "motorDisabilityCompliant": True,
+            "visualDisabilityCompliant": True,
+            "domains": [domain.id],
+            "durationMinutes": 183,
+            "students": [educational_models.StudentLevels.COLLEGE4.name],
+            "offerVenue": {
+                "venueId": None,
+                "addressType": "school",
+                "otherAddress": None,
+            },
+            "interventionArea": ["44"],
+            "isActive": None,
+            # stock part
+            "beginningDatetime": "2022-09-25T11:00",
+            "bookingLimitDatetime": "2022-09-15T11:00",
+            "totalPrice": 35621,
+            "numberOfTickets": 30,
+            "educationalPriceDetail": "Justification du prix",
+            # link to educational institution
+            "educationalInstitutionId": educational_institution.id,
+        }
+
+        # When
+        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+            response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
+                f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
+            )
+
+        # Then
+        assert response.status_code == 500

--- a/api/tests/routes/pro/public_api/collective/post_collective_offer_public_test.py
+++ b/api/tests/routes/pro/public_api/collective/post_collective_offer_public_test.py
@@ -43,6 +43,7 @@ class CollectiveOffersPublicPostOfferTest:
                 "otherAddress": "",
             },
             "interventionArea": ["44"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -105,6 +106,7 @@ class CollectiveOffersPublicPostOfferTest:
                 "otherAddress": "",
             },
             "interventionArea": ["44"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -154,6 +156,7 @@ class CollectiveOffersPublicPostOfferTest:
                 "otherAddress": "",
             },
             "interventionArea": ["44"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -205,6 +208,7 @@ class CollectiveOffersPublicPostOfferTest:
                 "otherAddress": "",
             },
             "interventionArea": ["44"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -254,6 +258,7 @@ class CollectiveOffersPublicPostOfferTest:
                 "otherAddress": "",
             },
             "interventionArea": ["44", "158"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",
@@ -302,6 +307,7 @@ class CollectiveOffersPublicPostOfferTest:
                 "otherAddress": "",
             },
             "interventionArea": ["44"],
+            "isActive": True,
             # stock part
             "beginningDatetime": "2022-09-25T11:00",
             "bookingLimitDatetime": "2022-09-15T11:00",

--- a/api/tests/routes/pro/public_api/openapi_test.py
+++ b/api/tests/routes/pro/public_api/openapi_test.py
@@ -370,6 +370,7 @@ def test_public_api(client, app):
                             "title": "Interventionarea",
                             "type": "array",
                         },
+                        "isActive": {"nullable": True, "title": "Isactive", "type": "boolean"},
                         "mentalDisabilityCompliant": {
                             "nullable": True,
                             "title": "Mentaldisabilitycompliant",
@@ -436,6 +437,7 @@ def test_public_api(client, app):
                             "type": "string",
                         },
                         "interventionArea": {"items": {"type": "string"}, "title": "Interventionarea", "type": "array"},
+                        "isActive": {"title": "Isactive", "type": "boolean"},
                         "mentalDisabilityCompliant": {
                             "default": False,
                             "title": "Mentaldisabilitycompliant",
@@ -471,6 +473,7 @@ def test_public_api(client, app):
                         "students",
                         "offerVenue",
                         "interventionArea",
+                        "isActive",
                         "beginningDatetime",
                         "bookingLimitDatetime",
                         "totalPrice",

--- a/pro/src/apiClient/v2/models/PatchCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v2/models/PatchCollectiveOfferBodyModel.ts
@@ -17,6 +17,7 @@ export type PatchCollectiveOfferBodyModel = {
   educationalInstitutionId?: number | null;
   educationalPriceDetail?: string | null;
   interventionArea?: Array<string> | null;
+  isActive?: boolean | null;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name?: string | null;

--- a/pro/src/apiClient/v2/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v2/models/PostCollectiveOfferBodyModel.ts
@@ -17,6 +17,7 @@ export type PostCollectiveOfferBodyModel = {
   educationalInstitutionId?: number | null;
   educationalPriceDetail?: string | null;
   interventionArea: Array<string>;
+  isActive: boolean;
   mentalDisabilityCompliant?: boolean;
   motorDisabilityCompliant?: boolean;
   name: string;


### PR DESCRIPTION
…’edition d’une offre

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17849

## But de la pull request

permettre l’edition du champ isActive lors de l’edition d’une offre
