### PR TITLE
(PC-17447)[PRO] feat: add button to create offer from template in col…

### DIFF
--- a/pro/src/new_components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
+++ b/pro/src/new_components/CollectiveOfferLayout/CollectiveOfferLayout.module.scss
@@ -3,6 +3,10 @@
 .eac-layout {
   position: relative;
 
+  &-tag {
+    margin-bottom: rem.torem(4px);
+  }
+
   &-headings {
     margin-bottom: rem.torem(32px);
   }

--- a/pro/src/new_components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/new_components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -4,7 +4,7 @@ import HelpLink from 'new_components/HelpLink'
 import OfferBreadcrumb, {
   OfferBreadcrumbStep,
 } from 'new_components/OfferBreadcrumb'
-import { Title } from 'ui-kit'
+import { Tag, Title } from 'ui-kit'
 
 import styles from './CollectiveOfferLayout.module.scss'
 
@@ -16,6 +16,7 @@ interface IBreadcrumbProps {
 interface ICollectiveOfferLayout {
   children: React.ReactNode | React.ReactNode[]
   breadCrumpProps?: IBreadcrumbProps
+  isTemplate?: boolean
   title: string
   subTitle?: string
 }
@@ -23,12 +24,16 @@ interface ICollectiveOfferLayout {
 const CollectiveOfferLayout = ({
   children,
   breadCrumpProps,
+  isTemplate = false,
   title,
   subTitle,
 }: ICollectiveOfferLayout): JSX.Element => {
   return (
     <div className={styles['eac-layout']}>
       <div className={styles['eac-layout-headings']}>
+        {isTemplate && (
+          <Tag label="Offre vitrine" className={styles['eac-layout-tag']} />
+        )}
         <Title level={1}>{title}</Title>
         {subTitle && (
           <Title level={4} className={styles['eac-layout-sub-heading']}>
@@ -36,15 +41,19 @@ const CollectiveOfferLayout = ({
           </Title>
         )}
       </div>
-      {breadCrumpProps && (
-        <OfferBreadcrumb
-          activeStep={breadCrumpProps.activeStep}
-          className={styles['eac-layout-breadcrumb']}
-          isCreatingOffer={breadCrumpProps.isCreatingOffer}
-          isOfferEducational
-          offerId={breadCrumpProps.offerId}
-        />
-      )}
+
+      {
+        /* istanbul ignore next: DEBT, TO FIX */
+        breadCrumpProps && (
+          <OfferBreadcrumb
+            activeStep={breadCrumpProps.activeStep}
+            className={styles['eac-layout-breadcrumb']}
+            isCreatingOffer={breadCrumpProps.isCreatingOffer}
+            isOfferEducational
+            offerId={breadCrumpProps.offerId}
+          />
+        )
+      }
       {children}
       <HelpLink />
     </div>

--- a/pro/src/new_components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
+++ b/pro/src/new_components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import CollectiveOfferLayout from '../CollectiveOfferLayout'
+
+const renderCollectiveOfferLayout = ({
+  isTemplate,
+  title,
+  subTitle,
+}: {
+  isTemplate?: boolean
+  title: string
+  subTitle?: string
+}) => {
+  render(
+    <CollectiveOfferLayout
+      title={title}
+      subTitle={subTitle}
+      isTemplate={isTemplate}
+    >
+      Test
+    </CollectiveOfferLayout>
+  )
+}
+
+describe('CollectiveOfferLayout', () => {
+  let props: { isTemplate?: boolean; title: string; subTitle?: string }
+  beforeEach(() => {
+    props = {
+      title: 'Offre collective',
+      subTitle: 'Ma super offre',
+    }
+  })
+  it('should render subtitle if provided', () => {
+    renderCollectiveOfferLayout(props)
+
+    const offerTitle = screen.getByText('Offre collective')
+    const offersubTitle = screen.getByText('Ma super offre')
+    const tagOfferTemplate = screen.queryByText('Offre vitrine')
+
+    expect(offerTitle).toBeInTheDocument()
+    expect(offersubTitle).toBeInTheDocument()
+    expect(tagOfferTemplate).not.toBeInTheDocument()
+  })
+  it("should render 'offer template' tag is offer is template", () => {
+    props.isTemplate = true
+    renderCollectiveOfferLayout(props)
+
+    const tagOfferTemplate = screen.getByText('Offre vitrine')
+
+    expect(tagOfferTemplate).toBeInTheDocument()
+  })
+})

--- a/pro/src/routes/CollectiveOfferTemplateEditionRoutes/CollectiveOfferTemplateEditionRoutes.tsx
+++ b/pro/src/routes/CollectiveOfferTemplateEditionRoutes/CollectiveOfferTemplateEditionRoutes.tsx
@@ -13,6 +13,7 @@ import CollectiveOfferEdition from 'routes/CollectiveOfferEdition'
 import CollectiveOfferTemplateStockEdition from 'routes/CollectiveOfferTemplateStockEdition'
 import CollectiveOfferTemplateSummary from 'routes/CollectiveOfferTemplateSummary'
 
+/* istanbul ignore next: DEBT, TO FIX */
 const CollectiveOfferTemplateEditionRoutes = (): JSX.Element => {
   const { offerId: offerIdFromParams } = useParams<{ offerId: string }>()
   const { offerId } =
@@ -47,6 +48,7 @@ const CollectiveOfferTemplateEditionRoutes = (): JSX.Element => {
 
   return (
     <CollectiveOfferLayout
+      isTemplate
       title={isSummaryPage ? 'Récapitulatif' : 'Éditer une offre collective'}
       subTitle={offer.name}
       breadCrumpProps={

--- a/pro/src/screens/CollectiveOfferSummary/CollectiveOfferSummary.module.scss
+++ b/pro/src/screens/CollectiveOfferSummary/CollectiveOfferSummary.module.scss
@@ -1,6 +1,14 @@
+@use 'styles/mixins/_rem.scss' as rem;
+
 .actions {
-    position: absolute;
-    top: 0;
-    right: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.duplicate-offer {
+  margin-bottom: rem.torem(32px);
+  &-description {
+    margin-bottom: rem.torem(24px);
   }
-  
+}

--- a/pro/src/screens/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/screens/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import useActiveFeature from 'components/hooks/useActiveFeature'
 import useNotification from 'components/hooks/useNotification'
 import {
   cancelCollectiveBookingAdapter,
@@ -40,6 +41,7 @@ const CollectiveOfferSummary = ({
 }: ICollectiveOfferSummaryProps) => {
   const notify = useNotification()
 
+  /* istanbul ignore next: DEBT, TO FIX */
   const setIsOfferActive = async () => {
     const adapter = offer.isTemplate
       ? patchIsTemplateOfferActiveAdapter
@@ -57,6 +59,7 @@ const CollectiveOfferSummary = ({
     notify.error(response.message)
   }
 
+  /* istanbul ignore next: DEBT, TO FIX */
   const cancelActiveBookings = async () => {
     if (offer.isTemplate) {
       return
@@ -73,6 +76,10 @@ const CollectiveOfferSummary = ({
     notify.success(message)
     reloadCollectiveOffer?.()
   }
+
+  const isCollectiveOfferDuplicationActive = useActiveFeature(
+    'WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE'
+  )
 
   const offerEditLink = `/offre/${computeURLCollectiveOfferId(
     offer.id,
@@ -98,6 +105,27 @@ const CollectiveOfferSummary = ({
         isOfferActive={offer.isActive}
         setIsOfferActive={setIsOfferActive}
       />
+      {isCollectiveOfferDuplicationActive && offer.isTemplate && (
+        <div className={styles['duplicate-offer']}>
+          <p className={styles['duplicate-offer-description']}>
+            Vous pouvez dupliquer cette offre autant de fois que vous le
+            souhaitez pour l’associer aux établissements scolaires qui vous
+            contactent. <br />
+            &nbsp;· L’offre vitrine restera visible sur ADAGE <br />
+            &nbsp;· L’offre associée à l’établissement devra être pré-réservée
+            par l’enseignant(e) qui vous a contacté
+          </p>
+          <ButtonLink
+            variant={ButtonVariant.PRIMARY}
+            link={{
+              isExternal: false,
+              to: `/offre/duplication/collectif/${offer.id}`,
+            }}
+          >
+            Créer une offre réservable pour un établissement scolaire
+          </ButtonLink>
+        </div>
+      )}
       <SummaryLayout>
         <SummaryLayout.Content fullWidth>
           <SummaryLayout.Section

--- a/pro/src/screens/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummary/__specs__/CollectiveOfferSummary.spec.tsx
@@ -1,0 +1,107 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+
+import {
+  CollectiveOffer,
+  CollectiveOfferTemplate,
+  EducationalCategories,
+} from 'core/OfferEducational'
+import {
+  categoriesFactory,
+  subCategoriesFactory,
+} from 'screens/OfferEducational/__tests-utils__'
+import {
+  collectiveOfferStockFactory,
+  collectiveOfferTemplateFactory,
+  offerFactory,
+} from 'screens/OfferEducationalStock/__tests-utils__'
+import { configureTestStore } from 'store/testUtils'
+
+import CollectiveOfferSummary from '../CollectiveOfferSummary'
+
+const renderCollectiveOfferSummary = (
+  offer: CollectiveOfferTemplate | CollectiveOffer,
+  categories: EducationalCategories
+) => {
+  const store = configureTestStore({
+    user: {
+      initialized: true,
+      currentUser: {
+        firstName: 'John',
+        dateCreated: '2022-07-29T12:18:43.087097Z',
+        email: 'john@do.net',
+        id: '1',
+        nonHumanizedId: '1',
+        isAdmin: false,
+        isEmailValidated: true,
+        roles: [],
+      },
+    },
+    features: {
+      list: [
+        {
+          isActive: true,
+          nameKey: 'WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE',
+        },
+      ],
+    },
+  })
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <CollectiveOfferSummary offer={offer} categories={categories} />
+      </MemoryRouter>
+    </Provider>
+  )
+}
+
+describe('CollectiveOfferSummary', () => {
+  let offer: CollectiveOfferTemplate | CollectiveOffer
+  let categories: EducationalCategories
+
+  beforeEach(() => {
+    offer = collectiveOfferTemplateFactory({ isTemplate: true })
+    categories = {
+      educationalCategories: categoriesFactory([{ id: 'CAT_1' }]),
+      educationalSubCategories: subCategoriesFactory([
+        { categoryId: 'CAT_1', id: 'SUBCAT_1' },
+      ]),
+    }
+  })
+  it('should render create from template button if offer is template', () => {
+    renderCollectiveOfferSummary(offer, categories)
+
+    const createFromTemplateButton = screen.getByRole('link', {
+      name: 'Créer une offre réservable pour un établissement scolaire',
+    })
+
+    expect(createFromTemplateButton).toBeInTheDocument()
+  })
+  it('should display desactive offer option when offer is active and not booked', () => {
+    offer = collectiveOfferTemplateFactory({ isTemplate: true, isActive: true })
+    renderCollectiveOfferSummary(offer, categories)
+
+    const desactivateOffer = screen.getByRole('button', {
+      name: 'Désactiver l’offre',
+    })
+
+    expect(desactivateOffer).toBeInTheDocument()
+  })
+  it('should display cancel booking button when offer is booked', () => {
+    offer = offerFactory({
+      isTemplate: false,
+      isActive: true,
+      collectiveStock: collectiveOfferStockFactory({ isBooked: true }),
+    })
+    renderCollectiveOfferSummary(offer, categories)
+
+    const cancelBooking = screen.getByRole('button', {
+      name: 'Annuler la réservation',
+    })
+
+    expect(cancelBooking).toBeInTheDocument()
+  })
+})

--- a/pro/src/screens/OfferEducationalStock/__tests-utils__/offerFactory.ts
+++ b/pro/src/screens/OfferEducationalStock/__tests-utils__/offerFactory.ts
@@ -1,4 +1,5 @@
 import {
+  GetCollectiveOfferCollectiveStockResponseModel,
   OfferAddressType,
   OfferStatus,
   StudentLevels,
@@ -57,6 +58,16 @@ export const offerFactory = (
   isBookable: true,
   isVisibilityEditable: true,
   ...offerExtend,
+})
+
+export const collectiveOfferStockFactory = (
+  stockExtend: Partial<GetCollectiveOfferCollectiveStockResponseModel>
+): GetCollectiveOfferCollectiveStockResponseModel => ({
+  id: 'STOCK_ID',
+  isBooked: false,
+  isCancellable: true,
+  price: 10,
+  ...stockExtend,
 })
 
 export const collectiveOfferTemplateFactory = (


### PR DESCRIPTION
…lective offer template summary header

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17447

## But de la pull request

Modifier l'en-tête de l'édition d'une offre vitrine pour y faire un bouton permettant d'accèder au parcours de duplication d'offre. 
Ajout d'un tag indiquant qu'il s'agit d'une offre vitrine dans le header. 


FF à activer : WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE
Lien de la maquette : https://www.figma.com/file/VLyZMVOGJ1kO5OrChl0pwY/Duplication-d'offres?node-id=1320%3A103034

## Screenshot

![Capture d’écran 2022-10-13 à 14 17 55](https://user-images.githubusercontent.com/71768799/195594646-72f8d0f7-b97d-49e5-9a40-69746bda90c9.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
