### PR TITLE
(PC-17831)[PRO] fix: route map order and offer type in stock creation…

### DIFF
--- a/pro/src/routes/CollectiveOfferStockCreationFromTemplate/CollectiveOfferStockCreationFromTemplate.tsx
+++ b/pro/src/routes/CollectiveOfferStockCreationFromTemplate/CollectiveOfferStockCreationFromTemplate.tsx
@@ -4,12 +4,12 @@ import { useParams } from 'react-router-dom'
 import useNotification from 'components/hooks/useNotification'
 import Spinner from 'components/layout/Spinner'
 import {
-  CollectiveOfferTemplate,
+  CollectiveOffer,
   DEFAULT_EAC_STOCK_FORM_VALUES,
   Mode,
   OfferEducationalStockFormValues,
 } from 'core/OfferEducational'
-import getCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
+import getCollectiveOfferAdapter from 'core/OfferEducational/adapters/getCollectiveOfferAdapter'
 import { useAdapter } from 'hooks'
 import CollectiveOfferLayout from 'new_components/CollectiveOfferLayout'
 import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
@@ -22,7 +22,7 @@ const CollectiveOfferStockCreationFromTemplate = (): JSX.Element | null => {
   const notify = useNotification()
 
   const handleSubmitStock = async (
-    offer: CollectiveOfferTemplate,
+    offer: CollectiveOffer,
     values: OfferEducationalStockFormValues
   ) => {
     const response = await postCollectiveStockAdapter({
@@ -36,7 +36,7 @@ const CollectiveOfferStockCreationFromTemplate = (): JSX.Element | null => {
   }
 
   const { isLoading, error, data } = useAdapter(() =>
-    getCollectiveOfferTemplateAdapter(offerId)
+    getCollectiveOfferAdapter(offerId)
   )
 
   if (error) {

--- a/pro/src/routes/routes_map.tsx
+++ b/pro/src/routes/routes_map.tsx
@@ -288,18 +288,6 @@ const routes: IRoute[] = [
     title: 'Offres',
   },
   {
-    component: CollectiveOfferEditionRoutes,
-    exact: false,
-    path: '/offre/:offerId([A-Z0-9]+)/collectif',
-    title: 'Edition d’une offre collective',
-  },
-  {
-    component: CollectiveOfferTemplateEditionRoutes,
-    exact: false,
-    path: '/offre/:offerId(T-[A-Z0-9]+)/collectif',
-    title: 'Edition d’une offre collective',
-  },
-  {
     component: OfferEducationalStockCreation,
     exact: true,
     path: '/offre/:offerId([A-Z0-9]+)/collectif/stocks',
@@ -329,6 +317,18 @@ const routes: IRoute[] = [
     exact: true,
     path: '/offre/:offerId(T-[A-Z0-9]+)/collectif/confirmation',
     title: 'Page de confirmation de création d’offre',
+  },
+  {
+    component: CollectiveOfferEditionRoutes,
+    exact: false,
+    path: '/offre/:offerId([A-Z0-9]+)/collectif',
+    title: 'Edition d’une offre collective',
+  },
+  {
+    component: CollectiveOfferTemplateEditionRoutes,
+    exact: false,
+    path: '/offre/:offerId(T-[A-Z0-9]+)/collectif',
+    title: 'Edition d’une offre collective',
   },
   {
     component: LostPassword,


### PR DESCRIPTION
… from template

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17831

## But de la pull request

Changer l'ordre des routes d'édition d'offre collective (template ou non) pour éviter les conflits
Fix un bug sur le type utilisé dans la création de stock à partir d'une offre vitrine (parcours duplication d'offre)

