### PR TITLE
(PC-17693)[API] feat: improve perf of function to find duplicate ids

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import re
 
-import sqlalchemy
 from sqlalchemy.orm import Query
 
 from pcapi import settings
@@ -263,12 +262,7 @@ def find_duplicate_id_piece_number_user(id_piece_number: str | None, excluded_us
     return users_models.User.query.filter(
         users_models.User.id != excluded_user_id,
         users_models.User.idPieceNumber.isnot(None),
-        sqlalchemy.sql.func.replace(
-            users_models.User.idPieceNumber,
-            " ",
-            "",
-        )
-        == format_id_piece_number(id_piece_number),
+        users_models.User.idPieceNumber == format_id_piece_number(id_piece_number),
     ).first()
 
 

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -272,9 +272,7 @@ class FindDuplicateUserTest:
         "existing_id_piece_number,new_id_piece_number",
         [
             ("123456789", "123456789"),
-            ("123 456 789", "123456789"),
             ("123456789", "123 456 789"),
-            ("1 2345678 9", "123 456 789"),
         ],
     )
     def test_find_duplicate_id_piece_number_user(self, existing_id_piece_number, new_id_piece_number):


### PR DESCRIPTION
We now save id piece numbers without their spaces. (Barring a few exceptions we manually checked) We can avoid formating during the sql search

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17693

## But de la pull request

Améliorer le temps de recherche des doublons de pièces d'identité.

## Implémentation

- Les `idPieceNumber` sont déjà enregistrés sans espaces (suite à d'autres tickets)
- Dans cette PR, on arrête de formatter les `idPieceNumber` au cours de la requête SQL pour améliorer la perf

## Informations supplémentaires

- None 

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
