### PR TITLE
(PC-17938)[PRO] feat: dont display virtual venue if offerer has no di…

### DIFF
--- a/pro/src/screens/OffererStats/OffererStatsScreen.tsx
+++ b/pro/src/screens/OffererStats/OffererStatsScreen.tsx
@@ -36,15 +36,20 @@ const OffererStatsScreen = ({ offererOptions }: IOffererStatsScreenProps) => {
   }
 
   useEffect(() => {
-    api.getOfferer(selectedOffererId).then(response => {
-      if (response.managedVenues) {
+    api.getOfferer(selectedOffererId).then(offerer => {
+      if (offerer.managedVenues) {
         setVenueOptions([
           ALL_VENUES_OPTION,
           ...sortByDisplayName(
-            response.managedVenues.map(venue => ({
-              id: venue.id,
-              displayName: venue.publicName || venue.name,
-            }))
+            offerer.managedVenues
+              .filter(
+                venue =>
+                  offerer.hasDigitalVenueAtLeastOneOffer || !venue.isVirtual
+              )
+              .map(venue => ({
+                id: venue.id,
+                displayName: venue.publicName || venue.name,
+              }))
           ),
         ])
         setSelectedVenueId(ALL_VENUES_OPTION.id)

--- a/pro/src/screens/OffererStats/__specs__/OffererStatsScreen.spec.tsx
+++ b/pro/src/screens/OffererStats/__specs__/OffererStatsScreen.spec.tsx
@@ -57,7 +57,9 @@ describe('OffererStatsScreen', () => {
     offerers = [
       {
         id: 'A1',
+        hasDigitalVenueAtLeastOneOffer: true,
         managedVenues: [
+          { id: 'D1', name: 'Offre numérique', isVirtual: true },
           { id: 'V1', name: 'Salle 1' },
           { id: 'V2', name: 'Stand popcorn' },
         ],
@@ -96,7 +98,21 @@ describe('OffererStatsScreen', () => {
     await waitFor(() => {
       expect(api.getOfferer).toHaveBeenCalledTimes(1)
     })
+    const virtualVenueOption = screen.getByText('Offre numérique')
     const venueOption = screen.getByText('Salle 1')
+    expect(virtualVenueOption).toBeInTheDocument()
+    expect(venueOption).toBeInTheDocument()
+  })
+  it('should not display virtual venue if offerer has no digital offer', async () => {
+    offerers[0].hasDigitalVenueAtLeastOneOffer = false
+    renderOffererStatsScreen(offererOptions, store)
+
+    await waitFor(() => {
+      expect(api.getOfferer).toHaveBeenCalledTimes(1)
+    })
+    const virtualVenueOption = screen.queryByText('Offre numérique')
+    const venueOption = screen.getByText('Salle 1')
+    expect(virtualVenueOption).not.toBeInTheDocument()
     expect(venueOption).toBeInTheDocument()
   })
   it('should update venues  when selecting offerer and display offerer iframe', async () => {


### PR DESCRIPTION
…gital offer in stats screen

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17938

## But de la pull request

Filter les lieux affichés dans le select de la page statistiques pour ne pas afficher les lieux numériques si une structures ne possèdent pas d'offres numériques

Page `Statistiques` accessible via le header du portail pro ou la page d'accueil d'une structure
FF à activé : ENABLE_OFFERER_STATS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
