### PR TITLE
(PC-17957)[API] feat: update sandbox to match venue_label ids with the ones from staging

### DIFF
--- a/api/src/pcapi/scripts/venue/venue_label/create_venue_labels.py
+++ b/api/src/pcapi/scripts/venue/venue_label/create_venue_labels.py
@@ -1,50 +1,53 @@
+from typing import Tuple
+
 from pcapi.core.offerers.models import VenueLabel
 from pcapi.repository import repository
 
 
+# match ids from staging for synchronization with ADAGE
 def create_venue_labels(sandbox: bool = False) -> None:
     venue_label_strings = [
-        "Architecture contemporaine remarquable",
-        "CAC - Centre d'art contemporain d'intérêt national",
-        "CCN - Centre chorégraphique national",
-        "CDCN - Centre de développement chorégraphique national",
-        "CDN - Centre dramatique national",
-        "Centre Culturel de Rencontre",
-        "Cinéma d'art et d'essai",
-        "CNAREP - Centre national des arts de la rue et de l'espace public",
-        "CNCM - Centre national de création musicale",
-        "CRC/CRI - Conservatoire à rayonnement communal ou intercommunal",
-        "CRD - Conservatoire à rayonnement départemental",
-        "CRR - Conservatoire à rayonnement régional",
-        "FRAC - Fonds régional d'art contemporain",
-        "Jardin remarquable",
-        "LIR - Librairie indépendante de référence",
-        "Maison des illustres",
-        "Monuments historiques",
-        "Musée de France",
-        "Opéra national en région",
-        "Orchestre national en région",
-        "Patrimoine européen",
-        "PNC - Pôle national du cirque",
-        "Scène nationale",
-        "Scènes conventionnées",
-        "Sites patrimoniaux remarquables",
-        "SMAC - Scène de musiques actuelles",
-        "Théâtre lyrique conventionné d'intérêt national",
-        "Théâtres nationaux",
-        "UNESCO - Patrimoine mondial",
-        "Ville et Pays d'art et d'histoire",
+        ("Architecture contemporaine remarquable", 1),
+        ("CAC - Centre d'art contemporain d'intérêt national", 2),
+        ("CCN - Centre chorégraphique national", 3),
+        ("CDCN - Centre de développement chorégraphique national", 4),
+        ("CDN - Centre dramatique national", 5),
+        ("Cinéma d'art et d'essai", 6),
+        ("CNAREP - Centre national des arts de la rue et de l'espace public", 7),
+        ("CNCM - Centre national de création musicale", 8),
+        ("CRC/CRI - Conservatoire à rayonnement communal ou intercommunal", 9),
+        ("CRD - Conservatoire à rayonnement départemental", 10),
+        ("CRR - Conservatoire à rayonnement régional", 11),
+        ("FRAC - Fonds régional d'art contemporain", 12),
+        ("Jardin remarquable", 13),
+        ("LIR - Librairie indépendante de référence", 14),
+        ("Maison des illustres", 15),
+        ("Monuments historiques", 16),
+        ("Musée de France", 17),
+        ("Opéra national en région", 18),
+        ("Orchestre national en région", 19),
+        ("Patrimoine européen", 20),
+        ("PNC - Pôle national du cirque", 21),
+        ("Scène nationale", 22),
+        ("Scènes conventionnées", 23),
+        ("Sites patrimoniaux remarquables", 24),
+        ("SMAC - Scène de musiques actuelles", 25),
+        ("Théâtres nationaux", 26),
+        ("UNESCO - Patrimoine mondial", 27),
+        ("Ville et Pays d'art et d'histoire", 28),
+        ("Théâtre lyrique conventionné d'intérêt national", 34),
+        ("Centre Culturel de Rencontre", 35),
     ]
 
     save_new_venue_labels(venue_label_strings, sandbox)
 
 
-def save_new_venue_labels(venue_label_strings: list[str], sandbox: bool = False) -> None:
+def save_new_venue_labels(venue_label_strings: list[Tuple[str, int]], sandbox: bool = False) -> None:
     venue_label_list = []
-    for label_id, label_string in enumerate(venue_label_strings):
+    for label_string, label_id in venue_label_strings:
         venue_label = VenueLabel()
         if sandbox:
-            venue_label.id = label_id + 1
+            venue_label.id = label_id
         venue_label.label = label_string
         venue_label_list.append(venue_label)
     repository.save(*venue_label_list)

--- a/api/tests/scripts/venue/venue_label/create_venue_labels_test.py
+++ b/api/tests/scripts/venue/venue_label/create_venue_labels_test.py
@@ -9,8 +9,8 @@ class SaveNewVenueLabelsTest:
     def test_should_save_venue_labels_to_database(self):
         # Given
         venue_labels_to_create = [
-            "Architecture contemporaine remarquable",
-            "CAC - Centre d'art contemporain d'intérêt national",
+            ("Architecture contemporaine remarquable", 1),
+            ("CAC - Centre d'art contemporain d'intérêt national", 2),
         ]
 
         # When


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17957

Adage se synchronise avec nos ids de labels, pour tester la synchro ils ont besoin d'avoir les mêmes ids que sur staging