### PR TITLE
[PC-17977][API] Whitelist YesWeHack email aliases for Boug Bounty on staging

### DIFF
--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -13,7 +13,7 @@ from pcapi.core.users import utils as users_utils
 from pcapi.models import db
 
 
-UBBLE_TEST_EMAIL_RE = re.compile(r"^.+\+ubble_test@.+$")
+UBBLE_TEST_EMAIL_RE = re.compile(r"^.+(\+ubble_test@.+|@yeswehack.ninja)$")
 
 logger = logging.getLogger(__name__)
 

--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -81,6 +81,10 @@ class ToDevSendinblueBackend(SendinblueBackend):
         for recipient in recipient_list:
             # Imported test users are whitelisted (Internal users, Bug Bounty, audit, etc.)
             user = find_user_by_email(recipient)
-            if (user and user.has_test_role) or recipient in settings.WHITELISTED_EMAIL_RECIPIENTS:
+            if (
+                (user and user.has_test_role)
+                or recipient in settings.WHITELISTED_EMAIL_RECIPIENTS
+                or (settings.IS_STAGING and recipient.endswith("@yeswehack.ninja"))
+            ):
                 whitelisted_recipients.add(recipient)
         return list(whitelisted_recipients)

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -1291,8 +1291,8 @@ class UbbleWebhookTest:
         assert response.status_code == 200
         assert fraud_check.status == fraud_models.FraudCheckStatus.OK
 
-    def test_birth_date_overrided_with_ubble_test_emails(self, client, ubble_mocker, mocker):
-        email = "whatever+ubble_test@example.com"
+    @pytest.mark.parametrize("email", ["whatever+ubble_test@example.com", "Test-ywh-12345678@yeswehack.ninja"])
+    def test_birth_date_overrided_with_ubble_test_emails(self, client, ubble_mocker, mocker, email):
         subscription_birth_date = datetime.datetime.combine(
             datetime.date.today(), datetime.time(0, 0)
         ) - relativedelta.relativedelta(years=18, months=6)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17977

Afin que les gentils hackers participant au Bug Bounty puissent créer de nouveaux comptes (non bénéficiaires, ou pro non validés) pour suivre le parcours d’inscription (d’un jeune ou d’une structure) et tenter de casser nos protections, suite à des discussions ce matin, nous avons décidé de white-lister tous les emails d’alias YesWeHack (de la forme @yeswehack.ninja), sur staging uniquement, pour ces deux cas : 
- envoi d’emails (au lieu de rediriger à dev+staging@pc)
- identification Ubble, afin que la date de naissance soit ignorée (comme pour +ubble_test@)

On pourrait envisager une liste de domaines white-listés dans une variable d'environnement ou un secret, mais pour l'instant parons au plus urgent pour valider les modifications du Bug Bounty.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
