### PR TITLE
(PC-15395)[API] feat: get movies with Boost API

### DIFF
--- a/api/src/pcapi/connectors/boost.py
+++ b/api/src/pcapi/connectors/boost.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 class ResourceBoost(enum.Enum):
     EXAMPLE = "example"
+    MEDIA = "films"
 
 
 LOGIN_ENDPOINT = "api/vendors/login"

--- a/api/src/pcapi/connectors/serialization/boost_serializers.py
+++ b/api/src/pcapi/connectors/serialization/boost_serializers.py
@@ -1,3 +1,4 @@
+import pcapi.core.external_bookings.models as external_bookings_models
 from pcapi.routes.serialization import BaseModel
 
 
@@ -5,3 +6,34 @@ class LoginBoost(BaseModel):
     code: int
     message: str
     token: str | None
+
+
+class Film2(BaseModel):
+    """We transcribe their API schema and keep their name convention"""
+
+    id: int
+    titleCnc: str
+    numVisa: int
+    posterUrl: str
+    thumbUrl: str | None
+    idFilmAllocine: int
+
+    def to_generic_movie(self) -> external_bookings_models.Movie:
+        return external_bookings_models.Movie(
+            id=str(self.id),
+            title=self.titleCnc,
+            duration=1,  # FIXME
+            description="",  # FIXME
+            posterpath=self.posterUrl,
+            visa=str(self.numVisa),
+        )
+
+
+class FilmCollection(BaseModel):
+    data: list[Film2]
+    message: str
+    page: int
+    previousPage: int
+    nextPage: int
+    totalPages: int
+    totalCount: int

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -1,0 +1,40 @@
+from pydantic import parse_obj_as
+
+from pcapi.connectors import boost
+from pcapi.connectors.serialization import boost_serializers
+import pcapi.core.external_bookings.models as external_bookings_models
+
+
+class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
+    def __init__(self, cinema_str_id: str):
+        self.cinema_str_id = cinema_str_id
+
+    # FIXME: define those later
+    def get_shows_remaining_places(self, shows_id: list[int]) -> dict[int, int]:
+        pass
+
+    def cancel_booking(self, barcodes: list[str]) -> None:
+        pass
+
+    def book_ticket(self, show_id: int, quantity: int) -> list[external_bookings_models.Ticket]:
+        pass
+
+    def get_venue_movies(self, per_page: int = 30) -> list[external_bookings_models.Movie]:
+        # XXX: per_page max value seems to be 200
+        venue_movies = []
+        current_page = next_page = 1
+
+        while current_page <= next_page:
+            params = {"page": current_page, "per_page": per_page}
+            json_data = boost.get_resource(self.cinema_str_id, boost.ResourceBoost.MEDIA, params=params)
+            media_list_page: boost_serializers.FilmCollection = parse_obj_as(
+                boost_serializers.FilmCollection, json_data
+            )
+            venue_movies.extend([movie.to_generic_movie() for movie in media_list_page.data])
+            total_pages = media_list_page.totalPages
+            next_page = media_list_page.nextPage
+            current_page += 1
+            if total_pages < current_page:
+                break
+
+        return venue_movies

--- a/api/tests/core/external_bookings/boost/test_client.py
+++ b/api/tests/core/external_bookings/boost/test_client.py
@@ -1,0 +1,107 @@
+import pytest
+
+from pcapi.core.external_bookings.boost.client import BoostClientAPI
+from pcapi.core.external_bookings.models import Movie
+import pcapi.core.providers.factories as providers_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class CineDigitalServiceGetMoviesTest:
+    def test_should_return_movies_information(self, requests_mock):
+        page_1_json_data = {
+            "data": [
+                {
+                    "id": 52,
+                    "titleCnc": "#JESUISLA",
+                    "numVisa": 147956,
+                    "posterUrl": "http://example.com/images/147956.jpg",
+                    "thumbUrl": "http://example.com/img/thumb/film/147956.jpg",
+                    "idFilmAllocine": 267615,
+                },
+                {
+                    "id": 62,
+                    "titleCnc": "10 JOURS SANS MAMAN",
+                    "numVisa": 151172,
+                    "posterUrl": "http://example.com/images/151172.jpg",
+                    "thumbUrl": "http://example.com/img/thumb/film/151172.jpg",
+                    "idFilmAllocine": 273882,
+                },
+            ],
+            "message": "OK",
+            "page": 1,
+            "previousPage": 1,
+            "nextPage": 2,
+            "totalPages": 2,
+            "totalCount": 4,
+        }
+
+        page_2_json_data = {
+            "data": [
+                {
+                    "id": 134,
+                    "titleCnc": "100 % LOUP",
+                    "numVisa": 2020002189,
+                    "posterUrl": "http://example.com/images/2020002189.jpg",
+                    "thumbUrl": "http://example.com/img/thumb/film/2020002189.jpg",
+                    "idFilmAllocine": 264648,
+                },
+                {
+                    "id": 40,
+                    "titleCnc": "1917",
+                    "numVisa": 152284,
+                    "posterUrl": "http://example.com/images/152284.jpg",
+                    "thumbUrl": "http://example.com/img/thumb/film/152284.jpg",
+                    "idFilmAllocine": 265567,
+                },
+            ],
+            "message": "OK",
+            "page": 2,
+            "previousPage": 1,
+            "nextPage": 2,
+            "totalPages": 2,
+            "totalCount": 4,
+        }
+
+        cinema_details = providers_factories.BoostCinemaDetailsFactory()
+        cinema_str_id = cinema_details.cinemaProviderPivot.idAtProvider
+        requests_mock.get("https://cinema-0.example.com/films?page=1&per_page=2", json=page_1_json_data)
+        requests_mock.get("https://cinema-0.example.com/films?page=2&per_page=2", json=page_2_json_data)
+        boost = BoostClientAPI(cinema_str_id)
+        movies = boost.get_venue_movies(per_page=2)
+
+        assert movies == [
+            Movie(
+                id="52",
+                title="#JESUISLA",
+                duration=1,
+                description="",
+                posterpath="http://example.com/images/147956.jpg",
+                visa="147956",
+            ),
+            Movie(
+                id="62",
+                title="10 JOURS SANS MAMAN",
+                duration=1,
+                description="",
+                posterpath="http://example.com/images/151172.jpg",
+                visa="151172",
+            ),
+            Movie(
+                id="134",
+                title="100 % LOUP",
+                duration=1,
+                description="",
+                posterpath="http://example.com/images/2020002189.jpg",
+                visa="2020002189",
+            ),
+            Movie(
+                id="40",
+                title="1917",
+                duration=1,
+                description="",
+                posterpath="http://example.com/images/152284.jpg",
+                visa="152284",
+            ),
+        ]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15395

## But de la pull request

Récupérer les films d'un cinéma via l'API Boost

## Implémentation

- ajout d'une classe `pcapi.core.external_bookings.boost.client.BoostClientAPI` et de sa méthode `get_venue_movies()`
- ajout des _serializers_ adéquats, en reprenant la nomenclature de leur schéma d'API récupéré via Swagger.