### PR TITLE
(PC-17991)[API] fix: Booking can be cancelled twice from the API, which sends email every time

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -245,6 +245,14 @@ class Booking(PcObject, Base, Model):  # type: ignore [valid-type, misc]
     def is_used_or_reimbursed(cls) -> bool:  # pylint: disable=no-self-argument
         return cls.status.in_([BookingStatus.USED, BookingStatus.REIMBURSED])
 
+    @hybrid_property
+    def is_cancelled(self) -> bool:
+        return self.status == BookingStatus.CANCELLED
+
+    @is_cancelled.expression  # type: ignore [no-redef]
+    def is_cancelled(cls) -> bool:  # pylint: disable=no-self-argument
+        return cls.status == BookingStatus.CANCELLED
+
     @property
     def firstName(self) -> str | None:
         if self.individualBooking is not None:

--- a/api/src/pcapi/core/bookings/validation.py
+++ b/api/src/pcapi/core/bookings/validation.py
@@ -94,6 +94,8 @@ def check_expenses_limits(user: User, requested_amount: Decimal, offer: Offer) -
 def check_beneficiary_can_cancel_booking(user: User, booking: Booking) -> None:
     if booking.individualBooking is None or booking.individualBooking.userId != user.id:
         raise exceptions.BookingDoesntExist()
+    if booking.is_cancelled:
+        raise exceptions.BookingIsCancelled()
     if booking.is_used_or_reimbursed:
         raise exceptions.BookingIsAlreadyUsed()
     if booking.isConfirmed:

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -209,6 +209,10 @@ def cancel_booking(user: User, booking_id: int) -> None:
     )
     try:
         bookings_api.cancel_booking_by_beneficiary(user, booking)
+    except bookings_exceptions.BookingIsCancelled:
+        # Do not raise an error, to avoid showing an error in case double-click => double call
+        # Booking is cancelled so a success status is ok
+        return
     except bookings_exceptions.BookingIsAlreadyUsed:
         raise ApiErrors({"code": "ALREADY_USED", "message": "La réservation a déjà été utilisée."})
     except bookings_exceptions.CannotCancelConfirmedBooking:

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -528,10 +528,8 @@ class CancelByBeneficiaryTest:
         assert booking.status is BookingStatus.CANCELLED
         assert booking.stock.dnBookedQuantity == (initial_quantity - 1)
 
-        api.cancel_booking_by_beneficiary(booking.individualBooking.user, booking)
-
-        # cancellation can trigger more than one request to Batch
-        assert len(push_testing.requests) >= 1
+        with pytest.raises(exceptions.BookingIsCancelled):
+            api.cancel_booking_by_beneficiary(booking.individualBooking.user, booking)
 
         assert booking.status is BookingStatus.CANCELLED
         assert booking.stock.dnBookedQuantity == (initial_quantity - 1)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17991

## But de la pull request

Un _hunter_ du Bug Bounty (YesWeHack) a rapporté un problème de logique : on peut annuler et ré-annuler à l'infini une réservation par l'API, ce qui déclenche à chaque fois un envoi d'email via Sendinblue. Risque de saturation de la file d'attente en exploitant cette faille.

## Informations supplémentaires

Ce correctif sera déployé en hotfix sur staging afin de montrer notre réactivité aux nouveaux hachers.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
