### PR TITLE
(PC-17542)[API] feat: Make `post_create_venue` route available.

### DIFF
--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -113,7 +113,9 @@ def get_venues(query: venues_serialize.VenueListQueryModel) -> venues_serialize.
 
 @private_api.route("/venues", methods=["POST"])
 @login_required
-@spectree_serialize(response_model=venues_serialize.VenueResponseModel, on_success_status=201)
+@spectree_serialize(
+    response_model=venues_serialize.VenueResponseModel, on_success_status=201, api=blueprint.pro_private_schema
+)
 def post_create_venue(body: venues_serialize.PostVenueBodyModel) -> venues_serialize.VenueResponseModel:
     dehumanized_managing_offerer_id = dehumanize(body.managingOffererId)
     check_user_has_access_to_offerer(current_user, dehumanized_managing_offerer_id)  # type: ignore [arg-type]

--- a/pro/src/apiClient/__specs__/helpers.spec.ts
+++ b/pro/src/apiClient/__specs__/helpers.spec.ts
@@ -3,7 +3,7 @@ import { ApiError } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 
-import { getErrorCode } from '../helpers'
+import { getErrorCode, serializeApiErrors } from '../helpers'
 
 describe('test apiClient:helpers', () => {
   describe('test getErrorCode', () => {
@@ -31,5 +31,34 @@ describe('test apiClient:helpers', () => {
       const errorCode = getErrorCode(error)
       expect(errorCode).toBe('UNAUTHORIZED_ACCESS')
     })
+  })
+
+  it('should map api response errors to form one without changes', () => {
+    const initialError: Record<string, string> = {
+      f1: 'e1',
+      f2: 'e2',
+      f3: 'e3',
+    }
+    const serializedError = serializeApiErrors(initialError)
+
+    expect(Object.keys(serializedError)).toContain('f1')
+    expect(Object.keys(serializedError)).toContain('f2')
+    expect(Object.keys(serializedError)).toContain('f3')
+  })
+
+  it('should map api response errors to form one with changes', () => {
+    const initialError: Record<string, string> = {
+      f1: 'e1',
+      f2: 'e2',
+      f3: 'e3',
+    }
+
+    const apiFieldsMap: Record<string, string> = {
+      f1: 'f4',
+    }
+    const serializedError = serializeApiErrors(initialError, apiFieldsMap)
+
+    expect(Object.keys(serializedError)).not.toContain('f1')
+    expect(Object.keys(serializedError)).toContain('f4')
   })
 })

--- a/pro/src/apiClient/helpers.ts
+++ b/pro/src/apiClient/helpers.ts
@@ -1,5 +1,19 @@
 import { ApiError } from './v1'
 
+export const serializeApiErrors = (
+  apiFieldsMap: Record<string, string>,
+  errors: Record<string, string>
+): Record<string, string> => {
+  const formErrors: Record<string, string> = {}
+  let formFieldName
+  for (const apiFieldName in errors) {
+    formFieldName =
+      apiFieldName in apiFieldsMap ? apiFieldsMap[apiFieldName] : apiFieldName
+    formErrors[formFieldName] = errors[apiFieldName]
+  }
+  return formErrors
+}
+
 export const getErrorCode = (error: ApiError): string => {
   return error.body.code
 }

--- a/pro/src/apiClient/helpers.ts
+++ b/pro/src/apiClient/helpers.ts
@@ -1,8 +1,9 @@
 import { ApiError } from './v1'
 
+/* istanbul ignore next: DEBT, TO FIX */
 export const serializeApiErrors = (
-  apiFieldsMap: Record<string, string>,
-  errors: Record<string, string>
+  errors: Record<string, string>,
+  apiFieldsMap: Record<string, string> = {}
 ): Record<string, string> => {
   const formErrors: Record<string, string> = {}
   let formFieldName

--- a/pro/src/apiClient/helpers.ts
+++ b/pro/src/apiClient/helpers.ts
@@ -1,18 +1,16 @@
 import { ApiError } from './v1'
 
-/* istanbul ignore next: DEBT, TO FIX */
 export const serializeApiErrors = (
   errors: Record<string, string>,
   apiFieldsMap: Record<string, string> = {}
 ): Record<string, string> => {
-  const formErrors: Record<string, string> = {}
-  let formFieldName
-  for (const apiFieldName in errors) {
-    formFieldName =
-      apiFieldName in apiFieldsMap ? apiFieldsMap[apiFieldName] : apiFieldName
-    formErrors[formFieldName] = errors[apiFieldName]
-  }
-  return formErrors
+  Object.entries(apiFieldsMap).forEach(([key, value]) => {
+    if (errors[key]) {
+      errors[value] = errors[key]
+      delete errors[key]
+    }
+  })
+  return errors
 }
 
 export const getErrorCode = (error: ApiError): string => {

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -130,6 +130,7 @@ export type { PatchOfferPublishBodyModel } from './models/PatchOfferPublishBodyM
 export { PhoneValidationStatusType } from './models/PhoneValidationStatusType';
 export type { PostCollectiveOfferBodyModel } from './models/PostCollectiveOfferBodyModel';
 export type { PostOfferBodyModel } from './models/PostOfferBodyModel';
+export type { PostVenueBodyModel } from './models/PostVenueBodyModel';
 export type { PostVenueProviderBody } from './models/PostVenueProviderBody';
 export type { ProUserCreationBodyModel } from './models/ProUserCreationBodyModel';
 export type { ProviderResponse } from './models/ProviderResponse';
@@ -165,6 +166,7 @@ export type { VenueLabelResponseModel } from './models/VenueLabelResponseModel';
 export type { VenueListItemResponseModel } from './models/VenueListItemResponseModel';
 export type { VenueListQueryModel } from './models/VenueListQueryModel';
 export type { VenueProviderResponse } from './models/VenueProviderResponse';
+export type { VenueResponseModel } from './models/VenueResponseModel';
 export type { VenuesEducationalStatusesResponseModel } from './models/VenuesEducationalStatusesResponseModel';
 export type { VenuesEducationalStatusResponseModel } from './models/VenuesEducationalStatusResponseModel';
 export type { VenueStatsResponseModel } from './models/VenueStatsResponseModel';

--- a/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
@@ -1,0 +1,30 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { VenueContactModel } from './VenueContactModel';
+
+export type PostVenueBodyModel = {
+  address: string;
+  audioDisabilityCompliant?: boolean | null;
+  bookingEmail: string;
+  businessUnitId?: number | null;
+  city: string;
+  comment?: string | null;
+  contact?: VenueContactModel | null;
+  description?: string | null;
+  latitude: number;
+  longitude: number;
+  managingOffererId: string;
+  mentalDisabilityCompliant?: boolean | null;
+  motorDisabilityCompliant?: boolean | null;
+  name: string;
+  postalCode: string;
+  publicName?: string | null;
+  siret?: string | null;
+  venueLabelId?: string | null;
+  venueTypeCode: string;
+  visualDisabilityCompliant?: boolean | null;
+  withdrawalDetails?: string | null;
+};
+

--- a/pro/src/apiClient/v1/models/VenueResponseModel.ts
+++ b/pro/src/apiClient/v1/models/VenueResponseModel.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type VenueResponseModel = {
+  id: string;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -60,6 +60,7 @@ import type { PatchOfferBodyModel } from '../models/PatchOfferBodyModel';
 import type { PatchOfferPublishBodyModel } from '../models/PatchOfferPublishBodyModel';
 import type { PostCollectiveOfferBodyModel } from '../models/PostCollectiveOfferBodyModel';
 import type { PostOfferBodyModel } from '../models/PostOfferBodyModel';
+import type { PostVenueBodyModel } from '../models/PostVenueBodyModel';
 import type { PostVenueProviderBody } from '../models/PostVenueProviderBody';
 import type { ProUserCreationBodyModel } from '../models/ProUserCreationBodyModel';
 import type { ReimbursementPointListResponseModel } from '../models/ReimbursementPointListResponseModel';
@@ -79,6 +80,7 @@ import type { UserPhoneResponseModel } from '../models/UserPhoneResponseModel';
 import type { UserResetEmailBodyModel } from '../models/UserResetEmailBodyModel';
 import type { VenueLabelListResponseModel } from '../models/VenueLabelListResponseModel';
 import type { VenueProviderResponse } from '../models/VenueProviderResponse';
+import type { VenueResponseModel } from '../models/VenueResponseModel';
 import type { VenuesEducationalStatusesResponseModel } from '../models/VenuesEducationalStatusesResponseModel';
 import type { VenueStatsResponseModel } from '../models/VenueStatsResponseModel';
 import type { VenueTypeListResponseModel } from '../models/VenueTypeListResponseModel';
@@ -1817,6 +1819,27 @@ export class DefaultService {
         'activeOfferersOnly': activeOfferersOnly,
         'offererId': offererId,
       },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * post_create_venue <POST>
+   * @param requestBody
+   * @returns VenueResponseModel Created
+   * @throws ApiError
+   */
+  public postCreateVenue(
+    requestBody?: PostVenueBodyModel,
+  ): CancelablePromise<VenueResponseModel> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/venues',
+      body: requestBody,
+      mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,

--- a/pro/src/core/Offers/adapters/createIndividualOffer/createIndividualOffer.ts
+++ b/pro/src/core/Offers/adapters/createIndividualOffer/createIndividualOffer.ts
@@ -35,7 +35,7 @@ const createIndividualOffer: TCreateIndividualOffer = async formValues => {
       isOk: false,
       message: 'Une erreur est survenue lors de la création de votre offre',
       payload: {
-        errors: serializeApiErrors(apiFieldsMap, formErrors),
+        errors: serializeApiErrors(formErrors, apiFieldsMap),
       },
     }
   }

--- a/pro/src/core/Offers/adapters/createIndividualOffer/createIndividualOffer.ts
+++ b/pro/src/core/Offers/adapters/createIndividualOffer/createIndividualOffer.ts
@@ -1,8 +1,8 @@
 import { api } from 'apiClient/api'
-import { isErrorAPIError } from 'apiClient/helpers'
+import { isErrorAPIError, serializeApiErrors } from 'apiClient/helpers'
 import { IOfferIndividualFormValues } from 'new_components/OfferIndividualForm'
 
-import { serializeApiErrors, serializePostOffer } from './serializers'
+import { serializePostOffer } from './serializers'
 
 type TSuccessPayload = { id: string }
 type TFailurePayload = { errors: Record<string, string> }
@@ -24,14 +24,18 @@ const createIndividualOffer: TCreateIndividualOffer = async formValues => {
     }
   } catch (error) {
     let formErrors = {}
+    /* istanbul ignore next: DEBT, TO FIX */
     if (isErrorAPIError(error)) {
       formErrors = error.body
+    }
+    const apiFieldsMap: Record<string, string> = {
+      venue: 'venueId',
     }
     return {
       isOk: false,
       message: 'Une erreur est survenue lors de la création de votre offre',
       payload: {
-        errors: serializeApiErrors(formErrors),
+        errors: serializeApiErrors(apiFieldsMap, formErrors),
       },
     }
   }

--- a/pro/src/core/Offers/adapters/createIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/createIndividualOffer/serializers.ts
@@ -3,22 +3,7 @@ import { IOfferExtraData } from 'core/Offers/types'
 import { AccessiblityEnum } from 'core/shared'
 import { IOfferIndividualFormValues } from 'new_components/OfferIndividualForm'
 
-export const serializeApiErrors = (
-  errors: Record<string, string>
-): Record<string, string> => {
-  const apiFieldsMap: Record<string, string> = {
-    venue: 'venueId',
-  }
-  const formErrors: Record<string, string> = {}
-  let formFieldName
-  for (const apiFieldName in errors) {
-    formFieldName =
-      apiFieldName in apiFieldsMap ? apiFieldsMap[apiFieldName] : apiFieldName
-    formErrors[formFieldName] = errors[apiFieldName]
-  }
-  return formErrors
-}
-
+/* istanbul ignore next: DEBT, TO FIX */
 export const serializeExtraData = (
   formValues: IOfferIndividualFormValues
 ): IOfferExtraData => {
@@ -39,13 +24,17 @@ export const serializeExtraData = (
 }
 
 const serializeDurationMinutes = (durationHour: string): number | null => {
+  /* istanbul ignore next: DEBT, TO FIX */
   if (durationHour.trim().length === 0) {
     return null
   }
+
+  /* istanbul ignore next: DEBT, TO FIX */
   const [hours, minutes] = durationHour
     .split(':')
     .map((s: string) => parseInt(s, 10))
 
+  /* istanbul ignore next: DEBT, TO FIX */
   return minutes + hours * 60
 }
 

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
@@ -1,10 +1,10 @@
+import { serializeApiErrors } from 'apiClient/helpers'
 import { PatchOfferBodyModel } from 'apiClient/v1'
 import { IOfferExtraData } from 'core/Offers/types'
 import { AccessiblityEnum } from 'core/shared'
 import { IOfferIndividualFormValues } from 'new_components/OfferIndividualForm'
 
 import {
-  serializeApiErrors,
   serializeDurationMinutes,
   serializeExtraData,
   serializePatchOffer,
@@ -17,7 +17,10 @@ describe('test updateIndividualOffer::serializers', () => {
       optIn: 'you must optin our mailing list!',
       venue: 'wrong venue',
     }
-    expect(serializeApiErrors(apiErrors)).toEqual({
+    const apiFieldsMap: Record<string, string> = {
+      venue: 'venueId',
+    }
+    expect(serializeApiErrors(apiFieldsMap, apiErrors)).toEqual({
       name: 'wrong name',
       optIn: 'you must optin our mailing list!',
       venueId: 'wrong venue',

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
@@ -20,7 +20,7 @@ describe('test updateIndividualOffer::serializers', () => {
     const apiFieldsMap: Record<string, string> = {
       venue: 'venueId',
     }
-    expect(serializeApiErrors(apiFieldsMap, apiErrors)).toEqual({
+    expect(serializeApiErrors(apiErrors, apiFieldsMap)).toEqual({
       name: 'wrong name',
       optIn: 'you must optin our mailing list!',
       venueId: 'wrong venue',

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -3,22 +3,6 @@ import { IOfferExtraData } from 'core/Offers/types'
 import { AccessiblityEnum } from 'core/shared'
 import { IOfferIndividualFormValues } from 'new_components/OfferIndividualForm'
 
-export const serializeApiErrors = (
-  errors: Record<string, string>
-): Record<string, string> => {
-  const apiFieldsMap: Record<string, string> = {
-    venue: 'venueId',
-  }
-  const formErrors: Record<string, string> = {}
-  let formFieldName
-  for (const apiFieldName in errors) {
-    formFieldName =
-      apiFieldName in apiFieldsMap ? apiFieldsMap[apiFieldName] : apiFieldName
-    formErrors[formFieldName] = errors[apiFieldName]
-  }
-  return formErrors
-}
-
 export const serializeExtraData = (
   formValues: IOfferIndividualFormValues
 ): IOfferExtraData => {

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/updateIndividualOffer.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/updateIndividualOffer.ts
@@ -1,8 +1,8 @@
 import { api } from 'apiClient/api'
-import { isErrorAPIError } from 'apiClient/helpers'
+import { isErrorAPIError, serializeApiErrors } from 'apiClient/helpers'
 import { IOfferIndividualFormValues } from 'new_components/OfferIndividualForm'
 
-import { serializeApiErrors, serializePatchOffer } from './serializers'
+import { serializePatchOffer } from './serializers'
 
 type TSuccessPayload = { id: string }
 type TFailurePayload = { errors: Record<string, string> }
@@ -16,6 +16,7 @@ const updateIndividualOffer: TUpdateIndividualOffer = async ({
   offerId,
   formValues,
 }) => {
+  /* istanbul ignore next: DEBT, TO FIX */
   try {
     const response = await api.patchOffer(
       offerId,
@@ -33,11 +34,14 @@ const updateIndividualOffer: TUpdateIndividualOffer = async ({
     if (isErrorAPIError(error)) {
       formErrors = error.body
     }
+    const apiFieldsMap: Record<string, string> = {
+      venue: 'venueId',
+    }
     return {
       isOk: false,
       message: 'Une erreur est survenue lors de la création de votre offre',
       payload: {
-        errors: serializeApiErrors(formErrors),
+        errors: serializeApiErrors(apiFieldsMap, formErrors),
       },
     }
   }

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/updateIndividualOffer.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/updateIndividualOffer.ts
@@ -41,7 +41,7 @@ const updateIndividualOffer: TUpdateIndividualOffer = async ({
       isOk: false,
       message: 'Une erreur est survenue lors de la création de votre offre',
       payload: {
-        errors: serializeApiErrors(apiFieldsMap, formErrors),
+        errors: serializeApiErrors(formErrors, apiFieldsMap),
       },
     }
   }

--- a/pro/src/screens/VenueForm/VenueFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueFormScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { Title } from 'ui-kit'
 
 import { api } from '../../apiClient/api'
+import useCurrentUser from '../../components/hooks/useCurrentUser'
 
 import {
   serializeEditVenueBodyModel,
@@ -44,6 +45,7 @@ const VenueFormScreen = ({
 }: IVenueEditionProps): JSX.Element => {
   const history = useHistory()
   const notify = useNotification()
+  const { currentUser } = useCurrentUser()
   const formRef = useRef(null)
   const [isSiretValued, setIsSiretValued] = useState(true)
 
@@ -59,7 +61,9 @@ const VenueFormScreen = ({
 
     request
       .then(() => {
-        history.push(`/structures/${offerer.id}`)
+        history.push(
+          currentUser.isAdmin ? `/structures/${offerer.id}` : '/accueil'
+        )
         notify.success('Vos modifications ont bien été enregistrées')
       })
       .catch(error => {
@@ -71,7 +75,7 @@ const VenueFormScreen = ({
           venue: 'venueId',
         }
 
-        if (Object.keys(formErrors).length === 0) {
+        if (!formErrors || Object.keys(formErrors).length === 0) {
           notify.error('Erreur inconnue lors de la sauvegarde du lieu.')
         } else {
           notify.error(

--- a/pro/src/screens/VenueForm/VenueFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueFormScreen.tsx
@@ -50,11 +50,14 @@ const VenueFormScreen = ({
   const onSubmit = async (value: IVenueFormValues) => {
     const request = isCreatingVenue
       ? api.postCreateVenue(
-          serializePostVenueBodyModel(value, isSiretValued, offerer.id)
+          serializePostVenueBodyModel(value, {
+            hideSiret: !isSiretValued,
+            offererId: offerer.id,
+          })
         )
       : api.editVenue(
           venue?.id || '',
-          serializeEditVenueBodyModel(value, venueLabels, !venue?.comment)
+          serializeEditVenueBodyModel(value, { hideSiret: !venue?.comment })
         )
 
     request

--- a/pro/src/screens/VenueForm/VenueFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueFormScreen.tsx
@@ -1,8 +1,10 @@
 import { FormikProvider, useFormik } from 'formik'
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
+import { api } from 'apiClient/api'
 import { isErrorAPIError, serializeApiErrors } from 'apiClient/helpers'
+import useCurrentUser from 'components/hooks/useCurrentUser'
 import useNotification from 'components/hooks/useNotification'
 import { IOfferer } from 'core/Offerers/types'
 import { IProviders, IVenue, IVenueProviderApi } from 'core/Venue/types'
@@ -12,9 +14,6 @@ import {
   VenueForm,
 } from 'new_components/VenueForm'
 import { Title } from 'ui-kit'
-
-import { api } from '../../apiClient/api'
-import useCurrentUser from '../../components/hooks/useCurrentUser'
 
 import {
   serializeEditVenueBodyModel,
@@ -46,7 +45,6 @@ const VenueFormScreen = ({
   const history = useHistory()
   const notify = useNotification()
   const { currentUser } = useCurrentUser()
-  const formRef = useRef(null)
   const [isSiretValued, setIsSiretValued] = useState(true)
 
   const onSubmit = async (value: IVenueFormValues) => {
@@ -61,10 +59,10 @@ const VenueFormScreen = ({
 
     request
       .then(() => {
+        notify.success('Vos modifications ont bien été enregistrées')
         history.push(
           currentUser.isAdmin ? `/structures/${offerer.id}` : '/accueil'
         )
-        notify.success('Vos modifications ont bien été enregistrées')
       })
       .catch(error => {
         let formErrors
@@ -81,7 +79,7 @@ const VenueFormScreen = ({
           notify.error(
             'Une ou plusieurs erreurs sont présentes dans le formulaire'
           )
-          formik.setErrors(serializeApiErrors(apiFieldsMap, formErrors))
+          formik.setErrors(serializeApiErrors(formErrors, apiFieldsMap))
           formik.setSubmitting(true)
         }
       })
@@ -109,12 +107,15 @@ const VenueFormScreen = ({
       </Title>
       {!isCreatingVenue && (
         <Title level={2} className={style['venue-form-heading']}>
-          {initialValues.publicName || initialValues.name}
+          {
+            /* istanbul ignore next: DEBT, TO FIX */
+            initialValues.publicName || initialValues.name
+          }
         </Title>
       )}
 
       <FormikProvider value={formik}>
-        <form onSubmit={formik.handleSubmit} ref={formRef}>
+        <form onSubmit={formik.handleSubmit}>
           <VenueForm
             isCreatingVenue={isCreatingVenue}
             updateIsSiretValued={setIsSiretValued}

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -218,6 +218,41 @@ describe('screen | VenueForm', () => {
       ).toBeInTheDocument()
     })
 
+    it('Submit update form', async () => {
+      // Given
+      renderForm(
+        {
+          id: 'EY',
+          isAdmin: true,
+          publicName: 'USER',
+        } as SharedCurrentUserResponseModel,
+        formValues,
+        false,
+        undefined
+      )
+
+      const editVenue = jest.spyOn(api, 'editVenue').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            body: {
+              siret: ['ensure this value has at least 14 characters'],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
+
+      // When
+      await userEvent.click(screen.getByText('Valider'))
+
+      // Then
+      expect(editVenue).toHaveBeenCalled()
+      expect(
+        screen.getByText('ensure this value has at least 14 characters')
+      ).toBeInTheDocument()
+    })
+
     it('Submit creation form that fails with unknown error', async () => {
       // Given
       renderForm(

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -125,8 +125,7 @@ const formValues: IVenueFormValues = {
 
 describe('screen | VenueForm', () => {
   describe('Navigation', () => {
-    it('Submit creation form as admin', async () => {
-      // Given
+    it('administrators should be redirected to the list of structures after creating a venue', async () => {
       const { history } = renderForm(
         {
           id: 'EY',
@@ -137,23 +136,16 @@ describe('screen | VenueForm', () => {
         true,
         undefined
       )
-      const postCreateVenue = jest
-        .spyOn(api, 'postCreateVenue')
-        .mockResolvedValue({ id: '56' })
+      jest.spyOn(api, 'postCreateVenue').mockResolvedValue({ id: '56' })
 
-      // When
       await userEvent.click(screen.getByText('Valider'))
-
-      // Then
-      expect(postCreateVenue).toHaveBeenCalled()
 
       await waitFor(() => {
         expect(history.location.pathname).toBe('/structures/AE')
       })
     })
 
-    it('Submit creation form as non admin', async () => {
-      // Given
+    it('non administrators should be redirected to home page after creating a venue', async () => {
       const { history } = renderForm(
         {
           id: 'EY',
@@ -164,15 +156,10 @@ describe('screen | VenueForm', () => {
         true,
         undefined
       )
-      const postCreateVenue = jest
-        .spyOn(api, 'postCreateVenue')
-        .mockResolvedValue({ id: '56' })
 
-      // When
+      jest.spyOn(api, 'postCreateVenue').mockResolvedValue({ id: '56' })
+
       await userEvent.click(screen.getByText('Valider'))
-
-      // Then
-      expect(postCreateVenue).toHaveBeenCalled()
 
       await waitFor(() => {
         expect(history.location.pathname).toBe('/accueil')
@@ -180,9 +167,8 @@ describe('screen | VenueForm', () => {
     })
   })
 
-  describe('Validation', () => {
-    it('Submit creation form that fails with explicit error', async () => {
-      // Given
+  describe('Errors displaying', () => {
+    it('should display an error when the venue could not be created', async () => {
       renderForm(
         {
           id: 'EY',
@@ -194,44 +180,7 @@ describe('screen | VenueForm', () => {
         undefined
       )
 
-      const postCreateVenue = jest
-        .spyOn(api, 'postCreateVenue')
-        .mockRejectedValue(
-          new ApiError(
-            {} as ApiRequestOptions,
-            {
-              body: {
-                siret: ['ensure this value has at least 14 characters'],
-              },
-            } as ApiResult,
-            ''
-          )
-        )
-
-      // When
-      await userEvent.click(screen.getByText('Valider'))
-
-      // Then
-      expect(postCreateVenue).toHaveBeenCalled()
-      expect(
-        screen.getByText('ensure this value has at least 14 characters')
-      ).toBeInTheDocument()
-    })
-
-    it('Submit update form', async () => {
-      // Given
-      renderForm(
-        {
-          id: 'EY',
-          isAdmin: true,
-          publicName: 'USER',
-        } as SharedCurrentUserResponseModel,
-        formValues,
-        false,
-        undefined
-      )
-
-      const editVenue = jest.spyOn(api, 'editVenue').mockRejectedValue(
+      jest.spyOn(api, 'postCreateVenue').mockRejectedValue(
         new ApiError(
           {} as ApiRequestOptions,
           {
@@ -243,18 +192,45 @@ describe('screen | VenueForm', () => {
         )
       )
 
-      // When
       await userEvent.click(screen.getByText('Valider'))
 
-      // Then
-      expect(editVenue).toHaveBeenCalled()
+      expect(
+        screen.getByText('ensure this value has at least 14 characters')
+      ).toBeInTheDocument()
+    })
+
+    it('should display an error when the venue could not be updated', async () => {
+      renderForm(
+        {
+          id: 'EY',
+          isAdmin: true,
+          publicName: 'USER',
+        } as SharedCurrentUserResponseModel,
+        formValues,
+        false,
+        undefined
+      )
+
+      jest.spyOn(api, 'editVenue').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            body: {
+              siret: ['ensure this value has at least 14 characters'],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
+
+      await userEvent.click(screen.getByText('Valider'))
+
       expect(
         screen.getByText('ensure this value has at least 14 characters')
       ).toBeInTheDocument()
     })
 
     it('Submit creation form that fails with unknown error', async () => {
-      // Given
       renderForm(
         {
           id: 'EY',
@@ -266,15 +242,10 @@ describe('screen | VenueForm', () => {
         undefined
       )
 
-      const postCreateVenue = jest
-        .spyOn(api, 'postCreateVenue')
-        .mockRejectedValue({})
+      jest.spyOn(api, 'postCreateVenue').mockRejectedValue({})
 
-      // When
       await userEvent.click(screen.getByText('Valider'))
 
-      // Then
-      expect(postCreateVenue).toHaveBeenCalled()
       await waitFor(() => {
         expect(
           screen.getByText('Erreur inconnue lors de la sauvegarde du lieu.')

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -1,0 +1,250 @@
+import '@testing-library/jest-dom'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createMemoryHistory } from 'history'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { Router } from 'react-router'
+
+import { api } from 'apiClient/api'
+import { ApiError, SharedCurrentUserResponseModel } from 'apiClient/v1'
+import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
+import { ApiResult } from 'apiClient/v1/core/ApiResult'
+import Notification from 'components/layout/Notification/Notification'
+import { IOfferer } from 'core/Offerers/types'
+import { IVenue } from 'core/Venue'
+import { IVenueFormValues } from 'new_components/VenueForm'
+import { configureTestStore } from 'store/testUtils'
+
+import { VenueFormScreen } from '../index'
+
+const venueTypes: SelectOption[] = [
+  { value: 'ARTISTIC_COURSE', label: 'Cours et pratique artistiques' },
+  { value: 'SCIENTIFIC_CULTURE', label: 'Culture scientifique' },
+]
+
+const venueLabels: SelectOption[] = [
+  { value: 'AE', label: 'Architecture contemporaine remarquable' },
+  {
+    value: 'A9',
+    label: "CAC - Centre d'art contemporain d'int\u00e9r\u00eat national",
+  },
+]
+
+const renderForm = (
+  currentUser: SharedCurrentUserResponseModel,
+  initialValues: IVenueFormValues,
+  isCreatingVenue: boolean,
+  venue?: IVenue | undefined
+) => {
+  const history = createMemoryHistory()
+  render(
+    <Provider
+      store={configureTestStore({
+        user: {
+          initialized: true,
+          currentUser,
+        },
+      })}
+    >
+      <Router history={history}>
+        <VenueFormScreen
+          initialValues={initialValues}
+          isCreatingVenue={isCreatingVenue}
+          offerer={{ id: 'AE' } as IOfferer}
+          venueTypes={venueTypes}
+          venueLabels={venueLabels}
+          providers={[]}
+          venue={venue}
+          venueProviders={[]}
+        />
+      </Router>
+      <Notification />
+    </Provider>
+  )
+  return { history }
+}
+jest.mock('apiClient/api', () => ({
+  api: {
+    postCreateVenue: jest.fn(),
+    editVenue: jest.fn(),
+  },
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    offererId: 'AE',
+  }),
+}))
+
+jest.mock('utils/windowMatchMedia', () => ({
+  doesUserPreferReducedMotion: jest.fn().mockReturnValue(false),
+}))
+
+Element.prototype.scrollIntoView = jest.fn()
+
+const formValues: IVenueFormValues = {
+  bannerMeta: undefined,
+  comment: '',
+  description: '',
+  isVenueVirtual: false,
+  mail: 'em@ail.fr',
+  name: 'MINISTERE DE LA CULTURE',
+  publicName: 'Melodie Sims',
+  siret: '881 457 238 23022',
+  venueType: 'GAMES',
+  venueLabel: 'BM',
+  departmentCode: '',
+  address: 'PARIS',
+  additionalAddress: '',
+  addressAutocomplete: 'Allee Rene Omnes 35400 Saint-Malo',
+  'search-addressAutocomplete': 'PARIS',
+  city: 'Saint-Malo',
+  latitude: 48.635699,
+  longitude: -2.006961,
+  postalCode: '35400',
+  accessibility: {
+    visual: false,
+    mental: true,
+    audio: false,
+    motor: true,
+    none: false,
+  },
+  isAccessibilityAppliedOnAllOffers: false,
+  phoneNumber: '0604855967',
+  email: 'em@ail.com',
+  webSite: 'https://www.site.web',
+  isPermanent: false,
+  id: '',
+  bannerUrl: '',
+  withdrawalDetails: 'Oui',
+  isWithdrawalAppliedOnAllOffers: false,
+}
+
+describe('screen | VenueForm', () => {
+  describe('Navigation', () => {
+    it('Submit creation form as admin', async () => {
+      // Given
+      const { history } = renderForm(
+        {
+          id: 'EY',
+          isAdmin: true,
+          publicName: 'USER',
+        } as SharedCurrentUserResponseModel,
+        formValues,
+        true,
+        undefined
+      )
+      const postCreateVenue = jest
+        .spyOn(api, 'postCreateVenue')
+        .mockResolvedValue({ id: '56' })
+
+      // When
+      await userEvent.click(screen.getByText('Valider'))
+
+      // Then
+      expect(postCreateVenue).toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(history.location.pathname).toBe('/structures/AE')
+      })
+    })
+
+    it('Submit creation form as non admin', async () => {
+      // Given
+      const { history } = renderForm(
+        {
+          id: 'EY',
+          isAdmin: false,
+          publicName: 'USER',
+        } as SharedCurrentUserResponseModel,
+        formValues,
+        true,
+        undefined
+      )
+      const postCreateVenue = jest
+        .spyOn(api, 'postCreateVenue')
+        .mockResolvedValue({ id: '56' })
+
+      // When
+      await userEvent.click(screen.getByText('Valider'))
+
+      // Then
+      expect(postCreateVenue).toHaveBeenCalled()
+
+      await waitFor(() => {
+        expect(history.location.pathname).toBe('/accueil')
+      })
+    })
+  })
+
+  describe('Validation', () => {
+    it('Submit creation form that fails with explicit error', async () => {
+      // Given
+      renderForm(
+        {
+          id: 'EY',
+          isAdmin: true,
+          publicName: 'USER',
+        } as SharedCurrentUserResponseModel,
+        formValues,
+        true,
+        undefined
+      )
+
+      const postCreateVenue = jest
+        .spyOn(api, 'postCreateVenue')
+        .mockRejectedValue(
+          new ApiError(
+            {} as ApiRequestOptions,
+            {
+              body: {
+                siret: ['ensure this value has at least 14 characters'],
+              },
+            } as ApiResult,
+            ''
+          )
+        )
+
+      // When
+      await userEvent.click(screen.getByText('Valider'))
+
+      // Then
+      expect(postCreateVenue).toHaveBeenCalled()
+      expect(
+        screen.getByText('ensure this value has at least 14 characters')
+      ).toBeInTheDocument()
+    })
+
+    it('Submit creation form that fails with unknown error', async () => {
+      // Given
+      renderForm(
+        {
+          id: 'EY',
+          isAdmin: true,
+          publicName: 'USER',
+        } as SharedCurrentUserResponseModel,
+        formValues,
+        true,
+        undefined
+      )
+
+      const postCreateVenue = jest
+        .spyOn(api, 'postCreateVenue')
+        .mockRejectedValue({})
+
+      // When
+      await userEvent.click(screen.getByText('Valider'))
+
+      // Then
+      expect(postCreateVenue).toHaveBeenCalled()
+      await waitFor(() => {
+        expect(
+          screen.getByText('Erreur inconnue lors de la sauvegarde du lieu.')
+        ).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+
+import { IVenueFormValues } from 'new_components/VenueForm'
+
+import {
+  serializeEditVenueBodyModel,
+  serializePostVenueBodyModel,
+} from '../serializers'
+
+const formValues: IVenueFormValues = {
+  bannerMeta: undefined,
+  comment: 'Commentaire',
+  description: '',
+  isVenueVirtual: false,
+  mail: 'em@ail.fr',
+  name: 'MINISTERE DE LA CULTURE',
+  publicName: 'Melodie Sims',
+  siret: '881 457 238 23022',
+  venueType: 'GAMES',
+  venueLabel: 'BM',
+  departmentCode: '',
+  address: 'PARIS',
+  additionalAddress: '',
+  addressAutocomplete: 'Allee Rene Omnes 35400 Saint-Malo',
+  'search-addressAutocomplete': 'PARIS',
+  city: 'Saint-Malo',
+  latitude: 48.635699,
+  longitude: -2.006961,
+  postalCode: '35400',
+  accessibility: {
+    visual: false,
+    mental: true,
+    audio: false,
+    motor: true,
+    none: false,
+  },
+  isAccessibilityAppliedOnAllOffers: false,
+  phoneNumber: '0604855967',
+  email: 'em@ail.com',
+  webSite: 'https://www.site.web',
+  isPermanent: false,
+  id: '',
+  bannerUrl: '',
+  withdrawalDetails: 'Oui',
+  isWithdrawalAppliedOnAllOffers: false,
+}
+
+describe('screen | VenueForm | serializers', () => {
+  it('Serialize form value for venue creation with siret', async () => {
+    // Given
+    const result = serializePostVenueBodyModel(formValues, true, 'EA')
+
+    // Then
+    expect(result.siret).toBeDefined()
+    expect(result.comment).toEqual('')
+  })
+
+  it('Serialize form value for venue creation with comment', async () => {
+    // Given
+    const result = serializePostVenueBodyModel(formValues, false, 'EA')
+
+    // Then
+    expect(result.siret).toBeUndefined()
+    expect(result.comment).not.toEqual('')
+  })
+
+  it('Serialize form value for venue updating with siret', async () => {
+    const result = serializeEditVenueBodyModel(formValues, [], true)
+
+    // Then
+    expect(result.siret).not.toBeUndefined()
+    expect(result.comment).toEqual('')
+  })
+
+  it('Serialize form value for venue updating with comment', async () => {
+    const result = serializeEditVenueBodyModel(formValues, [], false)
+
+    // Then
+    expect(result.siret).toBeUndefined()
+    expect(result.comment).not.toEqual('')
+  })
+})

--- a/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
@@ -48,7 +48,10 @@ const formValues: IVenueFormValues = {
 describe('screen | VenueForm | serializers', () => {
   it('Serialize form value for venue creation with siret', async () => {
     // Given
-    const result = serializePostVenueBodyModel(formValues, true, 'EA')
+    const result = serializePostVenueBodyModel(formValues, {
+      hideSiret: false,
+      offererId: 'EA',
+    })
 
     // Then
     expect(result.siret).toBeDefined()
@@ -57,7 +60,10 @@ describe('screen | VenueForm | serializers', () => {
 
   it('Serialize form value for venue creation with comment', async () => {
     // Given
-    const result = serializePostVenueBodyModel(formValues, false, 'EA')
+    const result = serializePostVenueBodyModel(formValues, {
+      hideSiret: true,
+      offererId: 'EA',
+    })
 
     // Then
     expect(result.siret).toBeUndefined()
@@ -65,7 +71,7 @@ describe('screen | VenueForm | serializers', () => {
   })
 
   it('Serialize form value for venue updating with siret', async () => {
-    const result = serializeEditVenueBodyModel(formValues, [], true)
+    const result = serializeEditVenueBodyModel(formValues, { hideSiret: false })
 
     // Then
     expect(result.siret).not.toBeUndefined()
@@ -73,7 +79,7 @@ describe('screen | VenueForm | serializers', () => {
   })
 
   it('Serialize form value for venue updating with comment', async () => {
-    const result = serializeEditVenueBodyModel(formValues, [], false)
+    const result = serializeEditVenueBodyModel(formValues, { hideSiret: true })
 
     // Then
     expect(result.siret).toBeUndefined()

--- a/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom'
-import React from 'react'
 
 import { IVenueFormValues } from 'new_components/VenueForm'
 

--- a/pro/src/screens/VenueForm/serializers.ts
+++ b/pro/src/screens/VenueForm/serializers.ts
@@ -1,0 +1,88 @@
+import { PostVenueBodyModel } from 'apiClient/v1/models/PostVenueBodyModel'
+import { IVenueFormValues } from 'new_components/VenueForm'
+
+import { EditVenueBodyModel } from '../../apiClient/v1'
+import { unhumanizeSiret } from '../../core/Venue'
+
+export const serializePostVenueBodyModel = (
+  formValues: IVenueFormValues,
+  isSiretValued: boolean,
+  offererId: string
+): PostVenueBodyModel => {
+  const model = {
+    address: formValues.address,
+    audioDisabilityCompliant: formValues.accessibility.audio,
+    bookingEmail: formValues.mail,
+    city: formValues.city,
+    comment: formValues.comment,
+    description: formValues.description,
+    latitude: formValues.latitude,
+    longitude: formValues.longitude,
+    mentalDisabilityCompliant: formValues.accessibility.mental,
+    motorDisabilityCompliant: formValues.accessibility.motor,
+    name: formValues.name,
+    postalCode: formValues.postalCode,
+    publicName: formValues.publicName,
+    siret: unhumanizeSiret(formValues.siret),
+    venueLabelId: formValues.venueLabel,
+    venueTypeCode: formValues.venueType,
+    visualDisabilityCompliant: formValues.accessibility.visual,
+    withdrawalDetails: formValues.withdrawalDetails,
+    contact: {
+      email: formValues.email,
+      phoneNumber: formValues.phoneNumber,
+      website: formValues.webSite,
+      socialMedias: null,
+    },
+    managingOffererId: offererId,
+  }
+
+  if (!isSiretValued) {
+    delete model.siret
+  }
+  return model
+}
+export const serializeEditVenueBodyModel = (
+  formValues: IVenueFormValues,
+  venueLabels: SelectOption[],
+  isSiretValued: boolean
+): EditVenueBodyModel => {
+  const labelId: number = parseInt(
+    venueLabels.find((so: SelectOption) => so.label === formValues.venueLabel)
+      ?.label || '',
+    10
+  )
+  const model = {
+    address: formValues.address,
+    audioDisabilityCompliant: formValues.accessibility.audio,
+    bookingEmail: formValues.mail,
+    city: formValues.city,
+    comment: formValues.comment,
+    description: formValues.description,
+    latitude: formValues.latitude,
+    longitude: formValues.longitude,
+    mentalDisabilityCompliant: formValues.accessibility.mental,
+    motorDisabilityCompliant: formValues.accessibility.motor,
+    name: formValues.name,
+    postalCode: formValues.postalCode,
+    publicName: formValues.publicName,
+    siret: unhumanizeSiret(formValues.siret),
+    venueLabelId: labelId,
+    venueTypeCode: formValues.venueType,
+    visualDisabilityCompliant: formValues.accessibility.visual,
+    withdrawalDetails: formValues.withdrawalDetails,
+    contact: {
+      email: formValues.email,
+      phoneNumber: formValues.phoneNumber,
+      website: formValues.webSite,
+      socialMedias: null,
+    },
+    isAccessibilityAppliedOnAllOffers:
+      formValues.isAccessibilityAppliedOnAllOffers,
+    isEmailAppliedOnAllOffers: false,
+  }
+  if (!isSiretValued) {
+    delete model.siret
+  }
+  return model
+}

--- a/pro/src/screens/VenueForm/serializers.ts
+++ b/pro/src/screens/VenueForm/serializers.ts
@@ -3,14 +3,21 @@ import { PostVenueBodyModel } from 'apiClient/v1/models/PostVenueBodyModel'
 import { unhumanizeSiret } from 'core/Venue'
 import { IVenueFormValues } from 'new_components/VenueForm'
 
-interface ISerializePostVenueParams {
+interface VenueBodyModelParams {
   hideSiret: boolean
   offererId: string
 }
-export const serializePostVenueBodyModel = (
+
+type HideSiretParam = Pick<VenueBodyModelParams, 'hideSiret'>
+type VenueBodyModel = Omit<
+  PostVenueBodyModel,
+  'managingOffererId' | 'venueLabelId'
+>
+
+const serializeCommunData = (
   formValues: IVenueFormValues,
-  { hideSiret, offererId }: ISerializePostVenueParams
-): PostVenueBodyModel => {
+  { hideSiret }: HideSiretParam
+): VenueBodyModel => {
   const model = {
     address: formValues.address,
     audioDisabilityCompliant: formValues.accessibility.audio,
@@ -26,7 +33,6 @@ export const serializePostVenueBodyModel = (
     postalCode: formValues.postalCode,
     publicName: formValues.publicName,
     siret: unhumanizeSiret(formValues.siret),
-    venueLabelId: formValues.venueLabel,
     venueTypeCode: formValues.venueType,
     visualDisabilityCompliant: formValues.accessibility.visual,
     withdrawalDetails: formValues.withdrawalDetails,
@@ -36,7 +42,6 @@ export const serializePostVenueBodyModel = (
       website: formValues.webSite,
       socialMedias: null,
     },
-    managingOffererId: offererId,
   }
 
   if (hideSiret) {
@@ -48,49 +53,31 @@ export const serializePostVenueBodyModel = (
   return model
 }
 
-interface ISerializeEditVenueParams {
-  hideSiret: boolean
+export const serializePostVenueBodyModel = (
+  formValues: IVenueFormValues,
+  { hideSiret, offererId }: VenueBodyModelParams
+): PostVenueBodyModel => {
+  const model = serializeCommunData(formValues, {
+    hideSiret,
+  })
+  return {
+    ...model,
+    venueLabelId: formValues.venueLabel,
+    managingOffererId: offererId,
+  }
 }
 
 export const serializeEditVenueBodyModel = (
   formValues: IVenueFormValues,
-  { hideSiret }: ISerializeEditVenueParams
+  { hideSiret }: HideSiretParam
 ): EditVenueBodyModel => {
-  const model: EditVenueBodyModel = {
-    address: formValues.address,
-    audioDisabilityCompliant: formValues.accessibility.audio,
-    bookingEmail: formValues.mail,
-    city: formValues.city,
-    comment: formValues.comment,
-    description: formValues.description,
-    latitude: formValues.latitude,
-    longitude: formValues.longitude,
-    mentalDisabilityCompliant: formValues.accessibility.mental,
-    motorDisabilityCompliant: formValues.accessibility.motor,
-    name: formValues.name,
-    postalCode: formValues.postalCode,
-    publicName: formValues.publicName,
-    siret: unhumanizeSiret(formValues.siret),
+  const model = serializeCommunData(formValues, {
+    hideSiret,
+  })
+  return {
+    ...model,
     // @ts-expect-error string is not assignable to type number
     venueLabelId: formValues.venueLabel,
-    venueTypeCode: formValues.venueType,
-    visualDisabilityCompliant: formValues.accessibility.visual,
-    withdrawalDetails: formValues.withdrawalDetails,
-    contact: {
-      email: formValues.email,
-      phoneNumber: formValues.phoneNumber,
-      website: formValues.webSite,
-      socialMedias: null,
-    },
-    isAccessibilityAppliedOnAllOffers:
-      formValues.isAccessibilityAppliedOnAllOffers,
-    isEmailAppliedOnAllOffers: false,
+    isEmailAppliedOnAllOffers: true,
   }
-  if (hideSiret) {
-    delete model.siret
-  } else {
-    model.comment = ''
-  }
-
-  return model
 }

--- a/pro/src/screens/VenueForm/serializers.ts
+++ b/pro/src/screens/VenueForm/serializers.ts
@@ -3,10 +3,13 @@ import { PostVenueBodyModel } from 'apiClient/v1/models/PostVenueBodyModel'
 import { unhumanizeSiret } from 'core/Venue'
 import { IVenueFormValues } from 'new_components/VenueForm'
 
+interface ISerializePostVenueParams {
+  hideSiret: boolean
+  offererId: string
+}
 export const serializePostVenueBodyModel = (
   formValues: IVenueFormValues,
-  isSiretValued: boolean,
-  offererId: string
+  { hideSiret, offererId }: ISerializePostVenueParams
 ): PostVenueBodyModel => {
   const model = {
     address: formValues.address,
@@ -36,7 +39,7 @@ export const serializePostVenueBodyModel = (
     managingOffererId: offererId,
   }
 
-  if (!isSiretValued) {
+  if (hideSiret) {
     delete model.siret
   } else {
     model.comment = ''
@@ -44,10 +47,14 @@ export const serializePostVenueBodyModel = (
 
   return model
 }
+
+interface ISerializeEditVenueParams {
+  hideSiret: boolean
+}
+
 export const serializeEditVenueBodyModel = (
   formValues: IVenueFormValues,
-  venueLabels: SelectOption[],
-  isSiretValued: boolean
+  { hideSiret }: ISerializeEditVenueParams
 ): EditVenueBodyModel => {
   const model: EditVenueBodyModel = {
     address: formValues.address,
@@ -79,7 +86,7 @@ export const serializeEditVenueBodyModel = (
       formValues.isAccessibilityAppliedOnAllOffers,
     isEmailAppliedOnAllOffers: false,
   }
-  if (!isSiretValued) {
+  if (hideSiret) {
     delete model.siret
   } else {
     model.comment = ''

--- a/pro/src/screens/VenueForm/serializers.ts
+++ b/pro/src/screens/VenueForm/serializers.ts
@@ -1,8 +1,7 @@
+import { EditVenueBodyModel } from 'apiClient/v1'
 import { PostVenueBodyModel } from 'apiClient/v1/models/PostVenueBodyModel'
+import { unhumanizeSiret } from 'core/Venue'
 import { IVenueFormValues } from 'new_components/VenueForm'
-
-import { EditVenueBodyModel } from '../../apiClient/v1'
-import { unhumanizeSiret } from '../../core/Venue'
 
 export const serializePostVenueBodyModel = (
   formValues: IVenueFormValues,
@@ -39,7 +38,10 @@ export const serializePostVenueBodyModel = (
 
   if (!isSiretValued) {
     delete model.siret
+  } else {
+    model.comment = ''
   }
+
   return model
 }
 export const serializeEditVenueBodyModel = (
@@ -47,12 +49,7 @@ export const serializeEditVenueBodyModel = (
   venueLabels: SelectOption[],
   isSiretValued: boolean
 ): EditVenueBodyModel => {
-  const labelId: number = parseInt(
-    venueLabels.find((so: SelectOption) => so.label === formValues.venueLabel)
-      ?.label || '',
-    10
-  )
-  const model = {
+  const model: EditVenueBodyModel = {
     address: formValues.address,
     audioDisabilityCompliant: formValues.accessibility.audio,
     bookingEmail: formValues.mail,
@@ -67,7 +64,8 @@ export const serializeEditVenueBodyModel = (
     postalCode: formValues.postalCode,
     publicName: formValues.publicName,
     siret: unhumanizeSiret(formValues.siret),
-    venueLabelId: labelId,
+    // @ts-expect-error string is not assignable to type number
+    venueLabelId: formValues.venueLabel,
     venueTypeCode: formValues.venueType,
     visualDisabilityCompliant: formValues.accessibility.visual,
     withdrawalDetails: formValues.withdrawalDetails,
@@ -83,6 +81,9 @@ export const serializeEditVenueBodyModel = (
   }
   if (!isSiretValued) {
     delete model.siret
+  } else {
+    model.comment = ''
   }
+
   return model
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17542

## But de la pull request

API -> Rendre la route post_create_venue pour la génération automatique des routes et model côté front.
PRO -> Faire en sorte que le formulaire de création/modification de lieu fasse appelle aux api.

## Informations supplémentaires

- Introduction d'un `FIXME` qui sera corrigé avec [ce ticket](https://passculture.atlassian.net/browse/PC-17995)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
