### PR TITLE
(PC-17970)[PRO] fix: toaster notification timer reset on page change

### DIFF
--- a/pro/src/Root.tsx
+++ b/pro/src/Root.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 
 import { App, AppRouter } from 'app'
+import Notification from 'components/layout/Notification/Notification'
 import NavigationLogger from 'components/router/NavigationLogger'
 import { AnalyticsContextProvider } from 'context/analyticsContext'
 import StoreProvider from 'store/StoreProvider/StoreProvider'
@@ -13,7 +14,10 @@ const Root = (): JSX.Element => {
         <BrowserRouter>
           <NavigationLogger />
           <App>
-            <AppRouter />
+            <>
+              <AppRouter />
+              <Notification />
+            </>
           </App>
         </BrowserRouter>
       </AnalyticsContextProvider>

--- a/pro/src/app/AppLayout.jsx
+++ b/pro/src/app/AppLayout.jsx
@@ -4,7 +4,6 @@ import React from 'react'
 import ReactTooltip from 'react-tooltip'
 
 import Header from 'components/layout/Header/Header'
-import Notification from 'components/layout/Notification/Notification'
 import DomainNameBanner from 'new_components/DomainNameBanner'
 import GoBackLink from 'new_components/GoBackLink'
 import TutorialDialog from 'new_components/TutorialDialog'
@@ -22,7 +21,6 @@ const AppLayout = props => {
     ...defaultConfig,
     ...layoutConfig,
   }
-
   return (
     <>
       {!fullscreen && <Header />}
@@ -51,13 +49,15 @@ const AppLayout = props => {
               })}
             >
               <DomainNameBanner />
-              {backTo && <GoBackLink to={backTo.path} title={backTo.label} />}
+              {
+                /* istanbul ignore next: DEBT, TO FIX */
+                backTo && <GoBackLink to={backTo.path} title={backTo.label} />
+              }
               {children}
             </div>
           </div>
         )}
         <TutorialDialog />
-        <Notification />
       </main>
     </>
   )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17970

## But de la pull request

Fix le comportement du toaster de notification qui apparait à chaque changement de page tant qu'on ne laisse pas le timer s'écouler.

## Implémentation

- Déplacement de `Notification` au niveau du `Switch` dans `AppRouter` pour éviter le re-render du composant à chaque changement de route. 

