### PR TITLE
(PC-17939)(PC-17943)[API] fix: KeyError in backoffice route /offerer<offerer_id>/stats

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -99,12 +99,12 @@ def get_offerer_offers_stats(offerer_id: int) -> serialization.OffererOfferStats
     return serialization.OffererOfferStatsResponseModel(
         data=serialization.OffersStats(
             active=serialization.BaseOffersStats(
-                individual=offers_stats.individual_offers["active"] if offers_stats.individual_offers else 0,
-                collective=offers_stats.collective_offers["active"] if offers_stats.collective_offers else 0,
+                individual=offers_stats.individual_offers.get("active", 0) if offers_stats.individual_offers else 0,
+                collective=offers_stats.collective_offers.get("active", 0) if offers_stats.collective_offers else 0,
             ),
             inactive=serialization.BaseOffersStats(
-                individual=offers_stats.individual_offers["inactive"] if offers_stats.individual_offers else 0,
-                collective=offers_stats.collective_offers["inactive"] if offers_stats.collective_offers else 0,
+                individual=offers_stats.individual_offers.get("inactive", 0) if offers_stats.individual_offers else 0,
+                collective=offers_stats.collective_offers.get("inactive", 0) if offers_stats.collective_offers else 0,
             ),
         )
     )

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -413,6 +413,56 @@ class GetOffererOffersStatsTest:
         assert offer_stats["inactive"]["collective"] == 6
 
     @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_offerer_offers_stats_active_only(
+        self,
+        client,
+        offerer,
+        offerer_active_individual_offers,
+        offerer_active_collective_offers,
+    ):
+        # given
+        admin = users_factories.UserFactory()
+        auth_token = generate_token(admin, [Permissions.READ_PRO_ENTITY])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.get_offerer_offers_stats", offerer_id=offerer.id)
+        )
+
+        # then
+        assert response.status_code == 200
+        offer_stats = response.json["data"]
+        assert offer_stats["active"]["individual"] == 3
+        assert offer_stats["active"]["collective"] == 5
+        assert offer_stats["inactive"]["individual"] == 0
+        assert offer_stats["inactive"]["collective"] == 0
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_offerer_offers_stats_inactive_only(
+        self,
+        client,
+        offerer,
+        offerer_inactive_individual_offers,
+        offerer_inactive_collective_offers,
+    ):
+        # given
+        admin = users_factories.UserFactory()
+        auth_token = generate_token(admin, [Permissions.READ_PRO_ENTITY])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.get_offerer_offers_stats", offerer_id=offerer.id)
+        )
+
+        # then
+        assert response.status_code == 200
+        offer_stats = response.json["data"]
+        assert offer_stats["active"]["individual"] == 0
+        assert offer_stats["active"]["collective"] == 0
+        assert offer_stats["inactive"]["individual"] == 4
+        assert offer_stats["inactive"]["collective"] == 6
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
     def test_offerer_offers_stats_0_if_no_offer(
         self,
         client,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17939
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17943

## But de la pull request

Corriger une exception `KeyError: 'inactive'` dans le backoffice : 
https://sentry.passculture.team/organizations/sentry/issues/396754/?project=5

Au clic sur le profil de certains acteurs culturels, ça charge dans le vide pendant quelques secondes et on est redirigé vers la recherche.

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
