### PR TITLE
(BSR)[PRO] chore: normalize departementCode

### DIFF
--- a/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManagerV2/VenueProviderListV2/VenueProviderListV2.tsx
+++ b/pro/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManagerV2/VenueProviderListV2/VenueProviderListV2.tsx
@@ -26,7 +26,7 @@ const VenueProviderListV2 = ({
           afterSubmit={afterVenueProviderEdit}
           key={venueProvider.id}
           venueProvider={venueProvider}
-          venueDepartmentCode={venue.departmentCode}
+          venueDepartmentCode={venue.departementCode}
         />
       ))}
     </ul>

--- a/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
@@ -341,7 +341,7 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
             <tbody>
               {stocksInCreation.map(stockInCreation => (
                 <StockItem
-                  departmentCode={offer.venue.departementCode}
+                  departementCode={offer.venue.departementCode}
                   errors={formErrors[stockInCreation.key]}
                   initialStock={stockInCreation}
                   isDigital={offer.isDigital}
@@ -356,7 +356,7 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
 
               {existingStocks.map(stock => (
                 <StockItem
-                  departmentCode={offer.venue.departementCode}
+                  departementCode={offer.venue.departementCode}
                   errors={formErrors[stock.key]}
                   initialStock={stock}
                   isDigital={offer.isDigital}

--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
@@ -19,7 +19,7 @@ import StockItemOptionsMenu from '../StockItemOptionsMenu/StockItemOptionsMenu'
 const noOperation = () => {}
 
 const StockItem = ({
-  departmentCode,
+  departementCode,
   errors,
   isDigital,
   isEvent,
@@ -31,7 +31,7 @@ const StockItem = ({
   removeStockInCreation,
   initialStock,
 }) => {
-  const today = getLocalDepartementDateTimeFromUtc(getToday(), departmentCode)
+  const today = getLocalDepartementDateTimeFromUtc(getToday(), departementCode)
 
   const [isDeleting, setIsDeleting] = useState(false)
   const [beginningDate, setBeginningDate] = useState(
@@ -356,7 +356,7 @@ const StockItem = ({
 }
 
 StockItem.defaultProps = {
-  departmentCode: '',
+  departementCode: '',
   errors: {},
   isDigital: false,
   isDisabled: false,
@@ -366,7 +366,7 @@ StockItem.defaultProps = {
 }
 
 StockItem.propTypes = {
-  departmentCode: PropTypes.string,
+  departementCode: PropTypes.string,
   errors: PropTypes.shape(),
   initialStock: PropTypes.shape({
     id: PropTypes.string,

--- a/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -309,7 +309,7 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
           <tbody>
             {inCreateMode ? (
               <StockItem
-                departmentCode={offer.venue.departementCode}
+                departementCode={offer.venue.departementCode}
                 errors={formErrors}
                 initialStock={stock}
                 isDigital={offer.isDigital}
@@ -322,7 +322,7 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
               />
             ) : (
               <StockItem
-                departmentCode={offer.venue.departementCode}
+                departementCode={offer.venue.departementCode}
                 errors={formErrors}
                 initialStock={stock}
                 isDigital={offer.isDigital}

--- a/pro/src/core/OfferEducational/utils/buildDatetimesForStockPayload.ts
+++ b/pro/src/core/OfferEducational/utils/buildDatetimesForStockPayload.ts
@@ -34,7 +34,7 @@ export const getBookingLimitDatetime = (
 export const buildBeginningDatetimeForStockPayload = (
   eventDate: Date,
   eventTime: Date,
-  departmentCode: string
+  departementCode: string
 ): string => {
   const beginningDateTimeInDepartmentTimezone = buildBeginningDatetime(
     eventDate,
@@ -42,7 +42,7 @@ export const buildBeginningDatetimeForStockPayload = (
   )
   const beginningDateTimeInUTCTimezone = getUtcDateTimeFromLocalDepartement(
     beginningDateTimeInDepartmentTimezone,
-    departmentCode
+    departementCode
   )
   return toISOStringWithoutMilliseconds(beginningDateTimeInUTCTimezone)
 }
@@ -51,7 +51,7 @@ export const buildBookingLimitDatetimeForStockPayload = (
   eventDate: Date,
   eventTime: Date,
   bookingLimitDatetime: Date | null,
-  departmentCode: string
+  departementCode: string
 ): string => {
   const beginningDateTimeInDepartmentTimezone = buildBeginningDatetime(
     eventDate,
@@ -62,7 +62,7 @@ export const buildBookingLimitDatetimeForStockPayload = (
       bookingLimitDatetime,
       beginningDateTimeInDepartmentTimezone
     ),
-    departmentCode
+    departementCode
   )
   return toISOStringWithoutMilliseconds(bookingLimitDatetimeUtc)
 }

--- a/pro/src/core/OfferEducational/utils/createPatchStockDataPayload.ts
+++ b/pro/src/core/OfferEducational/utils/createPatchStockDataPayload.ts
@@ -22,25 +22,25 @@ const serializer = {
   eventDate: (
     values: OfferEducationalStockFormValuesForSerializer,
     changedValues: CollectiveStockEditionBodyModel,
-    departmentCode: string
+    departementCode: string
   ) => ({
     ...changedValues,
     beginningDatetime: buildBeginningDatetimeForStockPayload(
       values.eventDate,
       values.eventTime,
-      departmentCode
+      departementCode
     ),
   }),
   eventTime: (
     values: OfferEducationalStockFormValuesForSerializer,
     changedValues: CollectiveStockEditionBodyModel,
-    departmentCode: string
+    departementCode: string
   ) => ({
     ...changedValues,
     beginningDatetime: buildBeginningDatetimeForStockPayload(
       values.eventDate,
       values.eventTime,
-      departmentCode
+      departementCode
     ),
   }),
   numberOfPlaces: (
@@ -60,14 +60,14 @@ const serializer = {
   bookingLimitDatetime: (
     values: OfferEducationalStockFormValuesForSerializer,
     changedValues: CollectiveStockEditionBodyModel,
-    departmentCode: string
+    departementCode: string
   ) => ({
     ...changedValues,
     bookingLimitDatetime: buildBookingLimitDatetimeForStockPayload(
       values.eventDate,
       values.eventTime,
       values.bookingLimitDatetime,
-      departmentCode
+      departementCode
     ),
   }),
   priceDetail: (
@@ -108,7 +108,7 @@ const getValuesWithoutEducationalOfferTypeAttribute = (
 
 export const createPatchStockDataPayload = (
   values: OfferEducationalStockFormValues,
-  departmentCode: string,
+  departementCode: string,
   initialValues: OfferEducationalStockFormValues
 ): CollectiveStockEditionBodyModel => {
   let changedValues: CollectiveStockEditionBodyModel = {}
@@ -132,7 +132,7 @@ export const createPatchStockDataPayload = (
         changedValues = serializer[key](
           valuesWithoutEducationalOfferType,
           changedValues,
-          departmentCode
+          departementCode
         )
       }
     })

--- a/pro/src/core/OfferEducational/utils/createStockDataPayload.ts
+++ b/pro/src/core/OfferEducational/utils/createStockDataPayload.ts
@@ -9,7 +9,7 @@ import {
 
 export const createStockDataPayload = (
   values: OfferEducationalStockFormValues,
-  departmentCode: string,
+  departementCode: string,
   offerId: string
 ): CollectiveStockCreationBodyModel => {
   if (
@@ -25,13 +25,13 @@ export const createStockDataPayload = (
     beginningDatetime: buildBeginningDatetimeForStockPayload(
       values.eventDate,
       values.eventTime,
-      departmentCode
+      departementCode
     ),
     bookingLimitDatetime: buildBookingLimitDatetimeForStockPayload(
       values.eventDate,
       values.eventTime,
       values.bookingLimitDatetime,
-      departmentCode
+      departementCode
     ),
     totalPrice: values.totalPrice,
     numberOfTickets: values.numberOfPlaces,

--- a/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/serializers.spec.ts
@@ -214,7 +214,7 @@ describe('serializer', () => {
       isVirtual: false,
       address: 'venue address',
       postalCode: 'venue postalCode',
-      departmentCode: '75',
+      departementCode: '75',
       city: 'venue city',
       offerer: {
         id: 'Offerer ID',
@@ -505,7 +505,7 @@ describe('serializer', () => {
         },
         postalCode: '75000',
         publicName: 'Cinéma synchro avec booking provider',
-        departmentCode: '75',
+        departementCode: '75',
         accessibility: {
           none: true,
           audio: false,

--- a/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/useGetIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/useGetIndividualOffer.spec.ts
@@ -251,7 +251,7 @@ describe('useGetOfferIndividual', () => {
         },
         postalCode: '75000',
         publicName: 'Cinéma synchro avec booking provider',
-        departmentCode: '75',
+        departementCode: '75',
         accessibility: {
           none: true,
           audio: false,

--- a/pro/src/core/Offers/adapters/getOfferIndividualAdapter/serializers.ts
+++ b/pro/src/core/Offers/adapters/getOfferIndividualAdapter/serializers.ts
@@ -38,7 +38,7 @@ export const serializeVenueApi = (
     isVirtual: apiOffer.venue.isVirtual,
     address: apiOffer.venue.address || '',
     postalCode: apiOffer.venue.postalCode || '',
-    departmentCode: apiOffer.venue.departementCode || '',
+    departementCode: apiOffer.venue.departementCode || '',
     city: apiOffer.venue.city || '',
     offerer: serializeOffererApi(apiOffer),
     accessibility: {

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -116,7 +116,7 @@ export interface IOfferIndividualVenue {
   postalCode: string
   city: string
   offerer: IOfferIndividualOfferer
-  departmentCode: string
+  departementCode: string
   accessibility: IAccessibiltyFormValues
 }
 

--- a/pro/src/core/Venue/adapters/__specs__/useGetVenue.spec.ts
+++ b/pro/src/core/Venue/adapters/__specs__/useGetVenue.spec.ts
@@ -111,7 +111,7 @@ describe('useGetVenue', () => {
       longitude: 14.2,
       postalCode: '75000',
       publicName: 'Cinéma des iles',
-      departmentCode: '',
+      departementCode: '',
       description: 'description du lieu',
       dmsToken: '',
       fieldsUpdated: [],

--- a/pro/src/core/Venue/adapters/getVenueAdapter/serializers.ts
+++ b/pro/src/core/Venue/adapters/getVenueAdapter/serializers.ts
@@ -33,7 +33,7 @@ export const serializeVenueApi = (venue: GetVenueResponseModel): IVenue => {
       email: venue.contact?.email || '',
       webSite: venue.contact?.website || '',
     },
-    departmentCode: venue.departementCode || '',
+    departementCode: venue.departementCode || '',
     description: venue.description || '',
     collectiveDomains: venue.collectiveDomains || [],
     dateCreated: venue.dateCreated || '',

--- a/pro/src/core/Venue/types.ts
+++ b/pro/src/core/Venue/types.ts
@@ -49,7 +49,7 @@ export interface IVenue {
     webSite: string
   }
   description: string
-  departmentCode: string
+  departementCode: string
   dmsToken: string
   id: string
   isPermanent: boolean

--- a/pro/src/new_components/OfferIndividualForm/utils/__specs__/setInitialFormValues.spec.ts
+++ b/pro/src/new_components/OfferIndividualForm/utils/__specs__/setInitialFormValues.spec.ts
@@ -56,7 +56,7 @@ describe('setFormReadOnlyFields', () => {
           id: 'OFID',
           name: 'Offerer name',
         },
-        departmentCode: '75',
+        departementCode: '75',
         accessibility: {
           [AccessiblityEnum.AUDIO]: false,
           [AccessiblityEnum.MENTAL]: false,

--- a/pro/src/new_components/VenueForm/Informations/constants.ts
+++ b/pro/src/new_components/VenueForm/Informations/constants.ts
@@ -8,5 +8,5 @@ export const DEFAULT_INFORMATIONS_FORM_VALUES = {
   siret: '',
   venueType: '',
   venueLabel: '',
-  departmentCode: '',
+  departementCode: '',
 }

--- a/pro/src/new_components/VenueForm/types.ts
+++ b/pro/src/new_components/VenueForm/types.ts
@@ -11,7 +11,7 @@ export interface IVenueFormValues {
   city: string
   comment: string
   description: string
-  departmentCode: string
+  departementCode: string
   email: string
   id: string
   isAccessibilityAppliedOnAllOffers: boolean

--- a/pro/src/new_components/VenueForm/utils/setInitialFormValues.ts
+++ b/pro/src/new_components/VenueForm/utils/setInitialFormValues.ts
@@ -18,7 +18,7 @@ const setInitialFormValues = (venue: IVenue): IVenueFormValues => {
     id: venue.id,
     isAccessibilityAppliedOnAllOffers: false,
     isPermanent: venue.isPermanent,
-    departmentCode: venue.departmentCode,
+    departementCode: venue.departementCode,
     isVenueVirtual: venue.isVenueVirtual,
     latitude: venue.latitude,
     longitude: venue.longitude,

--- a/pro/src/routes/CollectiveOfferTemplateStockEdition/CollectiveOfferTemplateStockEdition.tsx
+++ b/pro/src/routes/CollectiveOfferTemplateStockEdition/CollectiveOfferTemplateStockEdition.tsx
@@ -49,7 +49,7 @@ const CollectiveOfferTemplateStockEdition = ({
     const stockResponse = await adapter({
       offerId: offer.id,
       values,
-      departmentCode: offer.venue.departementCode ?? '',
+      departementCode: offer.venue.departementCode ?? '',
     })
 
     if (

--- a/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateIntoCollectiveOffer.spec.ts
+++ b/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/__specs__/patchCollectiveOfferTemplateIntoCollectiveOffer.spec.ts
@@ -15,7 +15,7 @@ describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
     const response =
       await patchCollectiveOfferTemplateIntoCollectiveOfferAdapter({
         offerId: '',
-        departmentCode: '1',
+        departementCode: '1',
         values: {
           eventDate: new Date(),
           eventTime: new Date(),
@@ -50,7 +50,7 @@ describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
     const response =
       await patchCollectiveOfferTemplateIntoCollectiveOfferAdapter({
         offerId: '12',
-        departmentCode: '1',
+        departementCode: '1',
         values: {
           eventDate: new Date(),
           eventTime: new Date(),
@@ -79,7 +79,7 @@ describe('patchCollectiveOfferTemplateIntoCollectiveOfferAdapter', () => {
     const response =
       await patchCollectiveOfferTemplateIntoCollectiveOfferAdapter({
         offerId: '12',
-        departmentCode: '1',
+        departementCode: '1',
         values: {
           eventDate: new Date(),
           eventTime: new Date(),

--- a/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/patchCollectiveOfferTemplateIntoCollectiveOffer.ts
+++ b/pro/src/routes/CollectiveOfferTemplateStockEdition/adapters/patchCollectiveOfferTemplateIntoCollectiveOffer.ts
@@ -8,7 +8,7 @@ import {
 
 export type Params = {
   offerId: string
-  departmentCode: string
+  departementCode: string
   values: OfferEducationalStockFormValues
 }
 
@@ -31,12 +31,12 @@ const UNKNOWN_FAILING_RESPONSE: AdapterFailure<null> = {
 }
 
 export const patchCollectiveOfferTemplateIntoCollectiveOfferAdapter: patchCollectiveOfferTemplateIntoCollectiveOfferAdapter =
-  async ({ offerId, departmentCode, values }) => {
+  async ({ offerId, departementCode, values }) => {
     try {
       // the api returns no understandable error when the id is not valid, so we deal before calling the api
       if (!offerId || offerId === '')
         throw new Error('L’identifiant de l’offre n’est pas valide.')
-      const payload = createStockDataPayload(values, departmentCode, offerId)
+      const payload = createStockDataPayload(values, departementCode, offerId)
       const updatedOffer =
         await api.transformCollectiveOfferTemplateIntoCollectiveOffer(
           offerId,

--- a/pro/src/routes/OfferIndividualWizard/Summary/__specs__/serializer.spec.ts
+++ b/pro/src/routes/OfferIndividualWizard/Summary/__specs__/serializer.spec.ts
@@ -66,7 +66,7 @@ describe('routes::Summary::serializers', () => {
           id: 'OFID',
           name: 'Offerer name',
         },
-        departmentCode: '75',
+        departementCode: '75',
         accessibility: {
           [AccessiblityEnum.AUDIO]: false,
           [AccessiblityEnum.MENTAL]: false,
@@ -194,14 +194,14 @@ describe('routes::Summary::serializers', () => {
         price: 12,
         bookingLimitDatetime: '01-01-2023',
         beginningDatetime: '01-12-2023',
-        departmentCode: '75',
+        departementCode: '75',
       },
       {
         quantity: 10,
         price: 12,
         bookingLimitDatetime: '01-01-2022',
         beginningDatetime: '01-12-2022',
-        departmentCode: '75',
+        departementCode: '75',
       },
 
       {
@@ -209,7 +209,7 @@ describe('routes::Summary::serializers', () => {
         price: 12,
         bookingLimitDatetime: '01-01-2021',
         beginningDatetime: null,
-        departmentCode: '75',
+        departementCode: '75',
       },
 
       {
@@ -217,7 +217,7 @@ describe('routes::Summary::serializers', () => {
         price: 12,
         bookingLimitDatetime: '01-01-2024',
         beginningDatetime: null,
-        departmentCode: '75',
+        departementCode: '75',
       },
     ])
     expect(previewSerialized).toEqual({

--- a/pro/src/routes/OfferIndividualWizard/Summary/serializer.ts
+++ b/pro/src/routes/OfferIndividualWizard/Summary/serializer.ts
@@ -97,7 +97,7 @@ const serializerOfferSectionProps = (
 
     venueName: offer.venue.name,
     venuePublicName: offer.venue.publicName,
-    venueDepartmentCode: offer.venue.departmentCode,
+    venueDepartmentCode: offer.venue.departementCode,
     isVenueVirtual: offer.venue.isVirtual,
     offererName: offer.venue.offerer.name,
     bookingEmail: offer.bookingEmail,
@@ -158,7 +158,7 @@ const serializerStockEventSectionProps = (
       price: stock.price,
       bookingLimitDatetime: stock.bookingLimitDatetime,
       beginningDatetime: stock.beginningDatetime,
-      departmentCode: offer.venue.departmentCode,
+      departementCode: offer.venue.departementCode,
     }))
 }
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveBookingDetails/utils.ts
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveBookingDetails/utils.ts
@@ -21,13 +21,13 @@ export const getLocalBeginningDatetime = (
 ): string => {
   if (!venuePostalCode) return ''
 
-  const departmentCode = extractDepartmentCode(venuePostalCode)
+  const departementCode = extractDepartmentCode(venuePostalCode)
   const stockBeginningDate = new Date(beginningDatetime)
   const stockBeginningDateISOString =
     toISOStringWithoutMilliseconds(stockBeginningDate)
   const stockLocalBeginningDate = formatLocalTimeDateString(
     stockBeginningDateISOString,
-    departmentCode,
+    departementCode,
     'dd/MM/yyyy à HH:mm'
   )
 

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -176,7 +176,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
           id: 'OFID',
           name: 'Offerer name',
         },
-        departmentCode: '75',
+        departementCode: '75',
         accessibility: {
           [AccessiblityEnum.AUDIO]: false,
           [AccessiblityEnum.MENTAL]: false,

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventItem/StockEventItem.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventItem/StockEventItem.tsx
@@ -11,7 +11,7 @@ export interface IStockEventItemProps {
   quantity?: number | null
   bookingLimitDatetime: string | Date | null
   activationCodesExpirationDatetime?: Date | null
-  departmentCode: string
+  departementCode: string
 }
 
 const StockEventItem = ({
@@ -20,7 +20,7 @@ const StockEventItem = ({
   price,
   quantity,
   bookingLimitDatetime,
-  departmentCode,
+  departementCode,
 }: IStockEventItemProps): JSX.Element => {
   return (
     <div className={className}>
@@ -29,7 +29,7 @@ const StockEventItem = ({
           title="Date"
           description={formatLocalTimeDateString(
             beginningDatetime,
-            departmentCode,
+            departementCode,
             FORMAT_DD_MM_YYYY
           )}
         />
@@ -39,7 +39,7 @@ const StockEventItem = ({
           title="Horaire"
           description={formatLocalTimeDateString(
             beginningDatetime,
-            departmentCode,
+            departementCode,
             FORMAT_HH_mm
           )}
         />
@@ -50,7 +50,7 @@ const StockEventItem = ({
           title="Date limite de réservation"
           description={formatLocalTimeDateString(
             bookingLimitDatetime,
-            departmentCode,
+            departementCode,
             FORMAT_DD_MM_YYYY
           )}
         />

--- a/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockEventSection/StockEventSection.tsx
@@ -75,7 +75,7 @@ const StockEventSection = ({
           price={s.price}
           quantity={s.quantity}
           bookingLimitDatetime={s.bookingLimitDatetime}
-          departmentCode={s.departmentCode}
+          departementCode={s.departementCode}
         />
       ))}
 


### PR DESCRIPTION
## But de la pull request

Notre base de donnée contient une erreur de wording: `departementCode` au lieu de `departmentCode`.
Notre base de code utilise parfois l'un et parfois l'autre, et convertir l'un vers l'autre est assez énervant.

Toutes les occurance presente dans `apiClient/` sont `departementCode` (iso avec la db)

Je propose ici de normalizer le nommage de cette propriété (dans le front pro uniquement) vers `departementCode` plutot que d'update le champ en db