### PR TITLE
(PC-18005)[PRO] fix: display banner on collective offer confirmation …

### DIFF
--- a/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/screens/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { OfferStatus } from 'apiClient/v1'
+import useActiveFeature from 'components/hooks/useActiveFeature'
 import { ReactComponent as PendingIcon } from 'icons/pending.svg'
 import { ReactComponent as ValidateIcon } from 'icons/validate.svg'
 import { Banner, Title } from 'ui-kit'
@@ -92,6 +93,10 @@ const CollectiveOfferConfirmation = ({
     institutionDisplayName
   )
 
+  const isCollectiveOfferDuplicationActive = useActiveFeature(
+    'WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE'
+  )
+
   return (
     <div className={styles['confirmation-wrapper']}>
       <div className={styles['confirmation']}>
@@ -121,32 +126,34 @@ const CollectiveOfferConfirmation = ({
           </Link>
         </div>
       </div>
-      <Banner
-        type="notification-info"
-        className={styles['confirmation-banner']}
-      >
-        <h2 className={styles['confirmation-banner-title']}>
-          Quelle est la prochaine étape ?
-        </h2>
-        {isShowcase ? (
-          <>
-            Les enseignants intéressés par votre offre vitrine vous contacterons
-            par mail ou téléphone. <br />
-            Après un accord mutuel, vous pourrez créer une offre réservable en
-            complétant la date, le prix et l’établissement convenus avec
-            l’enseignant. <br />
-            Cette nouvelle offre apparaitra sur ADAGE et pourra être
-            pré-réservée par l’enseignant.
-          </>
-        ) : (
-          <>
-            L’enseignant doit préréserver votre offre depuis son compte ADAGE.
-            <br />
-            Une fois la préréservation faite, vous verrez une réservation
-            portant le statut préréservé.
-          </>
-        )}
-      </Banner>
+      {isCollectiveOfferDuplicationActive && (
+        <Banner
+          type="notification-info"
+          className={styles['confirmation-banner']}
+        >
+          <h2 className={styles['confirmation-banner-title']}>
+            Quelle est la prochaine étape ?
+          </h2>
+          {isShowcase ? (
+            <>
+              Les enseignants intéressés par votre offre vitrine vous
+              contacterons par mail ou téléphone. <br />
+              Après un accord mutuel, vous pourrez créer une offre réservable en
+              complétant la date, le prix et l’établissement convenus avec
+              l’enseignant. <br />
+              Cette nouvelle offre apparaitra sur ADAGE et pourra être
+              pré-réservée par l’enseignant.
+            </>
+          ) : (
+            <>
+              L’enseignant doit préréserver votre offre depuis son compte ADAGE.
+              <br />
+              Une fois la préréservation faite, vous verrez une réservation
+              portant le statut préréservé.
+            </>
+          )}
+        </Banner>
+      )}
     </div>
   )
 }

--- a/pro/src/screens/CollectiveOfferConfirmation/__specs__/CollectiveOfferConfirmation.spec.tsx
+++ b/pro/src/screens/CollectiveOfferConfirmation/__specs__/CollectiveOfferConfirmation.spec.tsx
@@ -8,6 +8,12 @@ import { OfferStatus } from 'apiClient/v1'
 
 import CollectiveOfferConfirmation from '../CollectiveOfferConfirmation'
 
+// TO REMOVE WHEN WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE IS REMOVED
+jest.mock('components/hooks/useActiveFeature', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(true),
+}))
+
 describe('CollectiveOfferConfirmation', () => {
   it('should render confirmation page when offer is pending', () => {
     render(
@@ -77,5 +83,22 @@ describe('CollectiveOfferConfirmation', () => {
     )
 
     expect(screen.getByText('Offre créée avec succès !')).toBeInTheDocument()
+  })
+
+  it('should render banner at the bottom of the page', () => {
+    render(
+      <Router history={createBrowserHistory()}>
+        <CollectiveOfferConfirmation
+          offererId=""
+          offerStatus={OfferStatus.ACTIVE}
+          isShowcase={true}
+          institutionDisplayName=""
+        />
+      </Router>
+    )
+
+    expect(
+      screen.getByText('Quelle est la prochaine étape ?')
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
…only if duplication offer FF is active

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18005

## But de la pull request

Mettre l'affichage des bannières sous le FF WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE sur la page de confirmation de création d'une offre collective (vitrine ou non)

## Screenshot

![Capture d’écran 2022-10-17 à 08 55 39](https://user-images.githubusercontent.com/71768799/196109092-54adaeb1-4cb9-45e0-a56c-d855a25b5f73.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
