### PR TITLE
(BSR)[API] test: Remove gratuitous (but dangerous) calls to `freeze_time()`

### DIFF
--- a/api/tests/core/bookings/external/test_booking_notifications.py
+++ b/api/tests/core/bookings/external/test_booking_notifications.py
@@ -16,7 +16,9 @@ from pcapi.notifications.push import testing
 
 
 @pytest.mark.usefixtures("db_session")
-@freeze_time("2020-10-15 15:00:00")
+# Set time to evening so that `send_today_events_notifications_metropolitan_france()`
+# finds test stock in its `13:00 - 24:00` window.
+@freeze_time("20:00:00")
 def test_send_today_events_notifications_only_to_individual_bookings_users():
     """
     Test that each stock that is linked to an offer that occurs today and

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -2305,7 +2305,6 @@ class SoonExpiringBookingsTest:
             list(booking_repository.get_soon_expiring_bookings(remaining_days))
 
 
-@freeze_time("2020-10-15 09:00:00")
 class GetTomorrowEventOfferTest:
     def test_find_tomorrow_event_offer(self):
         tomorrow = datetime.utcnow() + timedelta(days=1)

--- a/api/tests/core/bookings/test_validation.py
+++ b/api/tests/core/bookings/test_validation.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
 
-from freezegun import freeze_time
 import pytest
 import sqlalchemy.exc
 
@@ -387,7 +386,6 @@ class CheckIsUsableTest:
         booking = factories.IndividualBookingFactory(stock__beginningDatetime=next_week, dateCreated=three_days_ago)
         validation.check_is_usable(booking)
 
-    @freeze_time("2020-10-15 09:00:00")
     def should_not_validate_when_event_booking_not_confirmed(self):
         # Given
         next_week = datetime.utcnow() + timedelta(weeks=1)


### PR DESCRIPTION
There is no point in using `freeze_time()` in those tests, since we
use a relative time (e.g. `now() + timedelta(days=1)`).

In fact, it made those tests fail because we tried to create a booking
with a user whose deposit is more than 2 years old (i.e. expired).