### PR TITLE
(BSR)[API] fix: add index to beneficiary_fraud_check.thirdPartyId

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 fb3966303e2e (pre) (head)
-8ab2b534c85b (post) (head)
+6cdf0c518f89 (post) (head)

--- a/api/src/pcapi/alembic/versions/20221017T124613_6cdf0c518f89_.py
+++ b/api/src/pcapi/alembic/versions/20221017T124613_6cdf0c518f89_.py
@@ -1,0 +1,25 @@
+"""add index on beneficiary_fraud_check.thirdPartyId
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "6cdf0c518f89"
+down_revision = "8ab2b534c85b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_beneficiary_fraud_check_thirdPartyId" ON "beneficiary_fraud_check" ("thirdPartyId")
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.drop_index("ix_beneficiary_fraud_check_thirdPartyId", table_name="beneficiary_fraud_check")

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -423,7 +423,7 @@ class BeneficiaryFraudCheck(PcObject, Base, Model):  # type: ignore [valid-type,
     )
     resultContent = sa.Column(sa.dialects.postgresql.JSONB(none_as_null=True))
     status = sa.Column(sa.Enum(FraudCheckStatus, create_constraint=False), nullable=True)
-    thirdPartyId: str = sa.Column(sa.TEXT(), nullable=False)
+    thirdPartyId: str = sa.Column(sa.TEXT(), index=True, nullable=False)
     type: FraudCheckType = sa.Column(sa.Enum(FraudCheckType, create_constraint=False), nullable=False)
     updatedAt: datetime.datetime = sa.Column(
         sa.DateTime, nullable=True, default=datetime.datetime.utcnow, onupdate=sa.func.now()


### PR DESCRIPTION
~Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX~

## But de la pull request

Eviter des timeouts quand on cherche un fraud check par son identifiant externe (Ubble par exemple)
Corriger [cette issue Sentry](https://sentry.passculture.team/organizations/sentry/issues/386345/activity/?environment=staging&project=5&query=&statsPeriod=14d) avant qu'elle débarque en prod 

## Implémentation

- Ajout d'un index sur thirdPartyId

## Informations supplémentaires

- RAS

## Modifications du schéma de la base de données

- Ajout d'un index sur beneficiary_fraud_check.thirdPartyId (Ne change pas les data)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
