### PR TITLE
(BSR) fix: get the running console pod in `pc` script

### DIFF
--- a/pc
+++ b/pc
@@ -99,7 +99,7 @@ function exit_success_restoring_branch() {
 }
 
 function pod_console() {
-  kubectl get pod -n $ENV | grep pcapi-console | awk '{print $1}'
+  kubectl get pod -n $ENV --field-selector status.phase=Running | grep pcapi-console | awk '{print $1}'
 }
 
 # =============================================


### PR DESCRIPTION
## But de la pull request

Eviter que le script `pc` récupère un pod en erreur

## Implémentation

Edition du merveilleux fichier `pc`

## Informations supplémentaires

Sur une idée originale de @dbaty.