### PR TITLE
(PC-18002)[API] fix: fix sorting for the list of offerers to be validated

### DIFF
--- a/api/src/pcapi/routes/backoffice/utils.py
+++ b/api/src/pcapi/routes/backoffice/utils.py
@@ -21,11 +21,12 @@ def get_user_or_error(user_id: int, error_code: int = 400) -> users_models.User:
 def sort_query(
     query: BaseQuery,
     ordering_clauses: list[sa.sql.ColumnElement | sa.sql.elements.UnaryExpression],
+    default_ordering: sa.sql.ColumnElement | sa.sql.elements.UnaryExpression | None = None,
 ) -> BaseQuery:
     if ordering_clauses:
         sorted_query = query.order_by(*ordering_clauses)
-    else:
-        sorted_query = query.order_by(sa.text("id"))
+    elif default_ordering:
+        sorted_query = query.order_by(default_ordering)
     return sorted_query
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18002

## But de la pull request

corriger le filtrage sur la liste des structures à valider

## Implémentation

- utilisation du [format spécifié dans Notion](https://www.notion.so/passcultureapp/Contrat-d-interface-entre-Back-et-Front-effea55e1a6d493790ab13d137788973) pour le paramètre de filtrage
- renvoi d'une 400 au lieu d'une 500 en cas de mauvaise valeur fournie

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RASn technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
