### PR TITLE
Hcapuano/pc 17930 pro page récap texte qui dépasse sur la vue appli

### DIFF
--- a/pro/src/new_components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
+++ b/pro/src/new_components/OfferAppPreview/VenueDetails/VenueDetails.module.scss
@@ -42,6 +42,8 @@
 
   margin-bottom: rem.torem(16px);
 
+  word-break: break-word;
+
   &:last-child {
     margin-bottom: 0;
   }

--- a/pro/src/new_components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/new_components/SummaryLayout/SummaryLayout.module.scss
@@ -72,6 +72,10 @@
       flex-shrink: 0;
     }
 
+    &-description {
+      word-break: break-word;
+    }
+
     &:last-child {
       margin-bottom: 0 !important;
     }

--- a/pro/src/new_components/SummaryLayout/SummaryLayoutRow.tsx
+++ b/pro/src/new_components/SummaryLayout/SummaryLayoutRow.tsx
@@ -19,7 +19,9 @@ const Row = ({
       {title}
       {title && ' : '}
     </span>
-    <span>{description}</span>
+    <span className={style['summary-layout-row-description']}>
+      {description}
+    </span>
   </div>
 )
 

--- a/pro/src/routes/OfferIndividualWizard/Summary/Summary.tsx
+++ b/pro/src/routes/OfferIndividualWizard/Summary/Summary.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import PageTitle from 'components/layout/PageTitle/PageTitle'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import { IOfferIndividual } from 'core/Offers/types'
 import useIsCreation from 'new_components/OfferIndividualStepper/hooks/useIsCreation'
@@ -34,6 +35,7 @@ const Summary = (): JSX.Element | null => {
 
   return (
     <WizardTemplate title="Récapitulatif" withStepper={isCreation}>
+      <PageTitle title="Récapitulatif" />
       <SummaryScreen
         offerId={offer.id}
         providerName={providerName}

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -33,7 +33,6 @@ import { IOfferSectionProps, OfferSection } from './OfferSection'
 import { IStockEventItemProps, StockEventSection } from './StockEventSection'
 import { IStockThingSectionProps, StockThingSection } from './StockThingSection'
 import styles from './Summary.module.scss'
-import PageTitle from 'components/layout/PageTitle/PageTitle'
 
 export interface ISummaryProps {
   offerId: string

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -33,6 +33,7 @@ import { IOfferSectionProps, OfferSection } from './OfferSection'
 import { IStockEventItemProps, StockEventSection } from './StockEventSection'
 import { IStockThingSectionProps, StockThingSection } from './StockThingSection'
 import styles from './Summary.module.scss'
+import PageTitle from 'components/layout/PageTitle/PageTitle'
 
 export interface ISummaryProps {
   offerId: string
@@ -131,6 +132,7 @@ const Summary = ({
 
   return (
     <>
+      <PageTitle title="Récapitulatif" />
       {(isCreation || isDisabledOffer || providerName !== null) && (
         <div className={styles['offer-preview-banners']}>
           {isCreation && <BannerSummary />}

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -131,7 +131,6 @@ const Summary = ({
 
   return (
     <>
-      <PageTitle title="Récapitulatif" />
       {(isCreation || isDisabledOffer || providerName !== null) && (
         <div className={styles['offer-preview-banners']}>
           {isCreation && <BannerSummary />}

--- a/pro/src/screens/OfferIndividual/Template/Template.tsx
+++ b/pro/src/screens/OfferIndividual/Template/Template.tsx
@@ -10,7 +10,7 @@ import styles from './Template.module.scss'
 export interface ITemplateProps {
   title?: string
   withStepper?: boolean
-  children: JSX.Element
+  children: JSX.Element | JSX.Element[]
 }
 
 const Template = ({ title, children, withStepper = true }: ITemplateProps) => {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17930

## But de la pull request

Page récap:
- Couper le texte qui dépasse sur la vue appli.
- Couper le texte qui dépasse sur la vue Web.
- Ajouter un titre à la page lorsqu'on est sur le récapitulatif d'une offre.

## Implémentation

- Modifications CSS et modification du template Summary.
