### PR TITLE
(BSR)[API] chore: Unpin development dependencies

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -33,7 +33,7 @@ isort
 itsdangerous==2.0.1
 Jinja2==3.0.3
 MarkupSafe==2.0.1
-mypy==0.981
+mypy
 notion-client==0.9.0
 openpyxl
 pgcli # a tool not used in code. There is no point in pinning its version
@@ -45,16 +45,16 @@ PyJWT[crypto]==2.4.0
 pylint
 pylint-pydantic
 pysaml2
-pytest==6.2.5
-pytest-cov==2.10.1
-pytest-flask==1.0.0
-pytest-flask-sqlalchemy==1.1.*
-pytest-mock==3.3.1
-pytest-dotenv==0.5.2
+pytest
+pytest-cov
+pytest-flask
+pytest-flask-sqlalchemy
+pytest-mock
+pytest-dotenv
 python-dotenv==0.14.0
 pyyaml==6.0
 requests==2.26.0
-requests_mock==1.8.0
+requests_mock
 rq==1.5.2
 schwifty==2020.9.0
 semver==2.13.0


### PR DESCRIPTION
There is not much point in pinning a specific version of pytest, its
plugins and other dependencies that are only used for development. We
are more likely to benefit from any update than being bothered (by a
regression or a change that requires some modification on our
side). And if we are bothered, we can always pin the dependency to the
latest version that works until we have time to update our code to be
compatible with the latest version.