### PR TITLE
(PC-18079)[API] fix: CDS make movie visa number optional

### DIFF
--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -71,7 +71,7 @@ class MediaCDS(BaseModel):
     duration: int  # CDS api returns duration in seconds
     posterpath: str | None
     storyline: str
-    visanumber: str
+    visanumber: str | None
 
     class Config:
         allow_population_by_field_name = True

--- a/api/src/pcapi/core/external_bookings/models.py
+++ b/api/src/pcapi/core/external_bookings/models.py
@@ -15,7 +15,7 @@ class Movie:
     duration: int  # duration in minutes
     description: str
     posterpath: str | None
-    visa: str
+    visa: str | None
 
 
 class ExternalBookingsClientAPI:

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -1223,6 +1223,13 @@ class CineDigitalServiceGetMoviesTest:
                 "storyline": "Test description #2",
                 "visanumber": "456",
             },
+            {
+                "id": 2,
+                "title": "Test movie #2",
+                "duration": 5400,
+                "storyline": "Test description #2",
+                # No visanumber
+            },
         ]
 
         mocked_get_resource.return_value = json_movies
@@ -1238,7 +1245,7 @@ class CineDigitalServiceGetMoviesTest:
 
         # then
         mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
-        assert len(movies) == 2
+        assert len(movies) == 3
 
 
 class CineDigitalServiceGetHardcodedSeatmapTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18079

## But de la pull request

Rendre l'attribut `visanumber` pour CDS optionnel 
