### PR TITLE
(PC-17965)[API] fix: backoffice: add user_offerer id in offerer users list

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -40,6 +40,7 @@ def get_offerer_users(offerer_id: int) -> serialization.OffererAttachedUsersResp
                 lastName=user_offerer.user.lastName,
                 email=user_offerer.user.email,
                 phoneNumber=user_offerer.user.phoneNumber,
+                user_offerer_id=user_offerer.id,
                 validationStatus=user_offerer.validationStatus,
             )
             for user_offerer in users_offerer

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -292,11 +292,12 @@ class OffererAttachedUser(BaseModel):
     class Config:
         orm_mode = True
 
-    id: int
+    id: int  # user id
     firstName: str | None
     lastName: str | None
     email: str
     phoneNumber: str | None
+    user_offerer_id: int
     validationStatus: offerers_models.ValidationStatus | None
 
 

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -55,6 +55,7 @@ class GetOffererUsersTest:
                 "lastName": None,
                 "email": uo1.user.email,
                 "phoneNumber": uo1.user.phoneNumber,
+                "user_offerer_id": uo1.id,
                 "validationStatus": "VALIDATED",
             },
             {
@@ -63,6 +64,7 @@ class GetOffererUsersTest:
                 "lastName": "Bon",
                 "email": uo2.user.email,
                 "phoneNumber": uo2.user.phoneNumber,
+                "user_offerer_id": uo2.id,
                 "validationStatus": "VALIDATED",
             },
             {
@@ -71,6 +73,7 @@ class GetOffererUsersTest:
                 "lastName": uo3.user.lastName,
                 "email": uo3.user.email,
                 "phoneNumber": uo3.user.phoneNumber,
+                "user_offerer_id": uo3.id,
                 "validationStatus": "NEW",
             },
         ]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17965 (ticket front)

## But de la pull request

Il manquait l'id de l'association user_offerer dans la liste des utilisateurs rattachés à une structure, ou en attente de rattachement.
On en a besoin pour appeler les APIs de validation dessus.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
