### PR TITLE
(PC-18063)[API] fix: IntegrityError when an offerer or a venue is deleted and the venue is used as a pricing point

### DIFF
--- a/api/src/pcapi/admin/custom_views/offerer_view.py
+++ b/api/src/pcapi/admin/custom_views/offerer_view.py
@@ -11,10 +11,10 @@ from markupsafe import escape
 from wtforms import Form
 
 from pcapi.admin.base_configuration import BaseAdminView
-from pcapi.core.bookings.exceptions import CannotDeleteOffererWithBookingsException
 from pcapi.core.bookings.repository import offerer_has_ongoing_bookings
 from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
+import pcapi.core.offerers.exceptions as offerers_exceptions
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import OffererTag
 from pcapi.core.offerers.models import ValidationStatus
@@ -132,8 +132,15 @@ class OffererView(BaseAdminView):
 
         try:
             delete_cascade_offerer_by_id(offerer.id)
-        except CannotDeleteOffererWithBookingsException:
+        except offerers_exceptions.CannotDeleteOffererWithBookingsException:
             flash("Impossible d'effacer une structure juridique pour laquelle il existe des réservations.", "error")
+            return False
+        except offerers_exceptions.CannotDeleteOffererUsedAsPricingPointException:
+            flash(
+                "Impossible d'effacer une structure juridique dont un lieu est utilisé comme point de valorisation "
+                "pour un lieu d'une autre structure.",
+                "error",
+            )
             return False
 
         for email in emails:

--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -27,12 +27,12 @@ from wtforms.fields import IntegerField
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.connectors import sirene
 from pcapi.core import search
-from pcapi.core.bookings.exceptions import CannotDeleteVenueWithBookingsException
 import pcapi.core.criteria.api as criteria_api
 import pcapi.core.criteria.models as criteria_models
 import pcapi.core.finance.exceptions as finance_exceptions
 import pcapi.core.finance.validation as finance_validation
 import pcapi.core.offerers.api as offerers_api
+import pcapi.core.offerers.exceptions as offerers_exception
 from pcapi.core.offerers.models import Offerer
 from pcapi.core.offerers.models import Venue
 import pcapi.core.offerers.repository as offerers_repository
@@ -233,8 +233,10 @@ class VenueView(BaseAdminView):
             for email in emails:
                 update_external_pro(email)
             return True
-        except CannotDeleteVenueWithBookingsException:
+        except offerers_exception.CannotDeleteVenueWithBookingsException:
             flash("Impossible d'effacer un lieu pour lequel il existe des réservations.", "error")
+        except offerers_exception.CannotDeleteVenueUsedAsPricingPointException:
+            flash("Impossible d'effacer un lieu utilisé comme point de valorisation d'un autre lieu.", "error")
         return False
 
     def update_model(self, edit_venue_form: Form, venue: Venue) -> bool:

--- a/api/src/pcapi/core/bookings/exceptions.py
+++ b/api/src/pcapi/core/bookings/exceptions.py
@@ -108,22 +108,6 @@ class CannotDeleteBookingWithReimbursementException(ClientError):
         )
 
 
-class CannotDeleteOffererWithBookingsException(ClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "cannotDeleteOffererWithBookingsException",
-            "Structure juridique non supprimable car elle contient des réservations",
-        )
-
-
-class CannotDeleteVenueWithBookingsException(ClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "cannotDeleteVenueWithBookingsException",
-            "Lieu non supprimable car il contient des réservations",
-        )
-
-
 class ConfirmationLimitDateHasPassed(Exception):
     pass
 

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -1,3 +1,6 @@
+from pcapi.domain.client_exceptions import ClientError
+
+
 class ApiKeyCountMaxReached(Exception):
     pass
 
@@ -64,3 +67,35 @@ class UserOffererNotFoundException(Exception):
 
 class UserOffererAlreadyValidatedException(Exception):
     pass
+
+
+class CannotDeleteOffererWithBookingsException(ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "cannotDeleteOffererWithBookingsException",
+            "Structure juridique non supprimable car elle contient des réservations",
+        )
+
+
+class CannotDeleteVenueWithBookingsException(ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "cannotDeleteVenueWithBookingsException",
+            "Lieu non supprimable car il contient des réservations",
+        )
+
+
+class CannotDeleteOffererUsedAsPricingPointException(ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "cannotDeleteOffererUsedAsPricingPointException",
+            "Structure juridique non supprimable car elle est utilisée comme point de valorisation d'un lieu",
+        )
+
+
+class CannotDeleteVenueUsedAsPricingPointException(ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "cannotDeleteVenueUsedAsPricingPointException",
+            "Lieu non supprimable car il est utilisé comme point de valorisation d'un autre lieu",
+        )

--- a/api/src/pcapi/scripts/suspend_fraudulent_pro_users.py
+++ b/api/src/pcapi/scripts/suspend_fraudulent_pro_users.py
@@ -1,4 +1,4 @@
-from pcapi.core.bookings.exceptions import CannotDeleteOffererWithBookingsException
+from pcapi.core.offerers.exceptions import CannotDeleteOffererWithBookingsException
 from pcapi.core.users.api import suspend_account
 from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.models import User


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18053

## But de la pull request

Corriger une erreur 500 reçue par le support et remontée par Sentry, lors de la suppression d'une structure dont un lieu est utilisé comme point de valorisation : 
`ForeignKeyViolation: update or delete on table "venue" violates foreign key constraint "venue_pricing_point_link_pricingPointId_fkey" on table "venue_pricing_point_link"`

https://sentry.passculture.team/organizations/sentry/issues/395820/?project=5&referrer=jira_integration

Le but est donc de renvoyer un message d'erreur explicite.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
