### PR TITLE
(PC-18043)[API] feat: Add a feature flag to disable internal offerer validation email

### DIFF
--- a/api/src/pcapi/domain/admin_emails.py
+++ b/api/src/pcapi/domain/admin_emails.py
@@ -7,6 +7,7 @@ from pcapi.core.educational.models import CollectiveOfferTemplate
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferValidationStatus
+from pcapi.models.feature import FeatureToggle
 from pcapi.utils.mailing import make_offer_creation_notification_email
 from pcapi.utils.mailing import make_offer_rejection_notification_email
 from pcapi.utils.mailing import make_offerer_internal_validation_email
@@ -18,6 +19,8 @@ def maybe_send_offerer_validation_email(
     user_offerer: offerers_models.UserOfferer,
     siren_info: sirene.SirenInfo | None,
 ) -> bool:
+    if FeatureToggle.TEMP_DISABLE_OFFERER_VALIDATION_EMAIL.is_active():
+        return True
     if offerer.isValidated and user_offerer.isValidated:
         return True
     email = make_offerer_internal_validation_email(offerer, user_offerer, siren_info)

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -122,6 +122,10 @@ class FeatureToggle(enum.Enum):
     WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE = "Active la duplication d'offres sur le portail pro"
     DISABLE_STORE_REVIEW = "Désactive la demande de notation sur les stores à la suite d’une réservation"
     TEMP_ENABLE_JOB_HIGHLIGHTS_BANNER = "Activer la bannière pour les Temps forts métiers"
+    TEMP_DISABLE_OFFERER_VALIDATION_EMAIL = (
+        "Désactiver l'envoi d'email interne de validation par token pour les structures et rattachements"
+    )
+    # TEMP_ prefix should be used for temporary feature flags (work in progress, testing, transition...)
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -186,6 +190,7 @@ FEATURES_DISABLED_BY_DEFAULT = (
     FeatureToggle.WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE,
     FeatureToggle.DISABLE_STORE_REVIEW,
     FeatureToggle.TEMP_ENABLE_JOB_HIGHLIGHTS_BANNER,
+    FeatureToggle.TEMP_DISABLE_OFFERER_VALIDATION_EMAIL,
 )
 
 


### PR DESCRIPTION
This FF will be turned on when switching to offerer validation in the new backoffice instead of offerer management in Front

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18043

## But de la pull request

Ajout d'un FF pour baculer de la validation des structures et rattachements dans Front, à partir de l'email de validation contenant un token dans le lien, vers la validation dans le nouveau backoffice.

Il s'agit d'un FF temporaire, afin qu'un PM puisse facilement décider l'arrêt des emails, sans besoin de hotfix.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
