### PR TITLE
(PC-18042)[API] feat: backoffice: get validation status in offerer details or list

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1050,6 +1050,7 @@ def get_offerer_basic_info(offerer_id: int) -> sa.engine.Row:
     offerer_query = sa.select(
         offerers_models.Offerer.id,
         offerers_models.Offerer.name,
+        offerers_models.Offerer.validationStatus,
         offerers_models.Offerer.isActive,
         offerers_models.Offerer.siren,
         offerers_models.Offerer.postalCode,

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -70,6 +70,7 @@ def get_offerer_basic_info(offerer_id: int) -> serialization.OffererBasicInfoRes
         data=serialization.OffererBasicInfo(
             id=offerer_basic_info.id,
             name=offerer_basic_info.name,
+            validationStatus=offerer_basic_info.validationStatus,
             isActive=offerer_basic_info.isActive,
             siren=offerer_basic_info.siren,
             region=regions_utils.get_region_name_from_postal_code(offerer_basic_info.postalCode),

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -255,11 +255,14 @@ class ProUserPayload(ProResultPayload):
     lastName: str | None
     email: str
     phoneNumber: str | None
+    isActive: bool
 
 
 class OffererPayload(ProResultPayload):
     name: str | None
     siren: str | None
+    validationStatus: offerers_models.ValidationStatus
+    isActive: bool
 
 
 class VenuePayload(ProResultPayload):
@@ -267,6 +270,8 @@ class VenuePayload(ProResultPayload):
     email: str | None
     siret: str | None
     permanent: bool
+    validationStatus: offerers_models.ValidationStatus
+    isActive: bool
 
     @classmethod
     def from_orm(cls: typing.Type["VenuePayload"], venue: offerers_models.Venue) -> "VenuePayload":
@@ -275,6 +280,8 @@ class VenuePayload(ProResultPayload):
         else:
             venue.email = venue.bookingEmail
         venue.permanent = venue.isPermanent
+        venue.validationStatus = venue.managingOfferer.validationStatus
+        venue.isActive = venue.managingOfferer.isActive
         return super().from_orm(venue)
 
 
@@ -291,6 +298,7 @@ class SearchProResponseModel(PaginatedResponse):
 class OffererAttachedUser(BaseModel):
     class Config:
         orm_mode = True
+        use_enum_values = True
 
     id: int  # user id
     firstName: str | None
@@ -298,7 +306,7 @@ class OffererAttachedUser(BaseModel):
     email: str
     phoneNumber: str | None
     user_offerer_id: int
-    validationStatus: offerers_models.ValidationStatus | None
+    validationStatus: offerers_models.ValidationStatus
 
 
 class OffererAttachedUsersResponseModel(BaseModel):
@@ -331,8 +339,12 @@ class ReimbursementsStats(BaseModel):
 
 
 class OffererBasicInfo(BaseModel):
+    class Config:
+        use_enum_values = True
+
     id: int
     name: str
+    validationStatus: offerers_models.ValidationStatus
     isActive: bool
     siren: str
     region: str

--- a/api/tests/routes/backoffice/fixtures.py
+++ b/api/tests/routes/backoffice/fixtures.py
@@ -9,6 +9,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.providers import factories as providers_factories
@@ -45,7 +46,9 @@ __all__ = (
 
 @pytest.fixture
 def offerer():
-    offerer = offerers_factories.OffererFactory(postalCode="46150")
+    offerer = offerers_factories.OffererFactory(
+        postalCode="46150", validationStatus=offerers_models.ValidationStatus.VALIDATED
+    )
     return offerer
 
 

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -140,6 +140,7 @@ class GetOffererBasicInfoTest:
         payload = response.json["data"]
         assert "id" in payload
         assert "name" in payload
+        assert "validationStatus" in payload
         assert "isActive" in payload
         assert "siren" in payload
         assert "region" in payload
@@ -164,6 +165,7 @@ class GetOffererBasicInfoTest:
         payload = response.json["data"]
         assert payload["id"] == offerer.id
         assert payload["name"] == offerer.name
+        assert payload["validationStatus"] == offerers_models.ValidationStatus.VALIDATED.value
         assert payload["isActive"] == offerer.isActive
         assert payload["siren"] == offerer.siren
         assert payload["region"] == "Occitanie"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18042

## But de la pull request

Renvoyer le `validationStatus` de la structure dans les détails d'un acteur culturel et dans les listes de résultats (structure, lieu) afin d'afficher l'étiquette avec l'état de validation, à côté de celle d'un AC désactivé à partir de `isActive`, aussi dans la réponse.

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
