### PR TITLE
(PC-17292)[API] feat: add logs for draft offers

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -352,6 +352,19 @@ def batch_update_offers(query, update_fields):  # type: ignore [no-untyped-def]
         "Batch update of offers",
         extra={"updated_fields": update_fields, "nb_offers": len(offer_ids), "venue_ids": venue_ids},
     )
+    if "isActive" in update_fields.keys():
+        if update_fields["isActive"]:
+            logger.info(
+                "Offers has been activated",
+                extra={"offer_ids": offer_ids, "venue_id": venue_ids},
+                technical_message_id="offers.activated",
+            )
+        else:
+            logger.info(
+                "Offers has been deactivated",
+                extra={"offer_ids": offer_ids, "venue_id": venue_ids},
+                technical_message_id="offers.deactivated",
+            )
 
     number_of_offers_to_update = len(offer_ids)
     batch_size = 1000
@@ -615,6 +628,11 @@ def publish_offer(offer_id: int, user: User) -> Offer:
     offer.isActive = True
     update_offer_fraud_information(offer, user)
     search.async_index_offer_ids([offer.id])
+    logger.info(  # type: ignore [call-arg]
+        "Offer has been published",
+        extra={"offer_id": offer.id, "venue_id": offer.venueId, "offer_status": offer.status},
+        technical_message_id="offer.published",
+    )
     return offer
 
 
@@ -967,7 +985,7 @@ def update_pending_offer_validation(offer: Offer, validation_status: OfferValida
     elif isinstance(offer, educational_models.CollectiveOfferTemplate):
         search.async_index_collective_offer_template_ids([offer.id])
     template = f"{type(offer)} validation status updated"
-    logger.info(template, extra={"offer": offer.id})
+    logger.info(template, extra={"offer": offer.id}, technical_message_id="offers.validation_updated")  # type: ignore [call-arg]
     return True
 
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1240,15 +1240,18 @@ class BatchUpdateOffersTest:
         assert not models.Offer.query.get(pending_offer.id).isActive
         mocked_async_index_offer_ids.assert_not_called()
 
-        assert len(caplog.records) == 1
-        record = caplog.records[0]
+        assert len(caplog.records) == 2
+        first_record = caplog.records[0]
+        second_record = caplog.records[1]
 
-        assert record.message == "Batch update of offers"
-        assert record.extra == {
+        assert first_record.message == "Batch update of offers"
+        assert first_record.extra == {
             "nb_offers": 0,
             "updated_fields": {"isActive": True},
             "venue_ids": [],
         }
+        assert second_record.message == "Offers has been activated"
+        assert second_record.extra == {"offer_ids": [], "venue_id": []}
 
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_activate(self, mocked_async_index_offer_ids, caplog):
@@ -1272,14 +1275,20 @@ class BatchUpdateOffersTest:
         mocked_async_index_offer_ids.assert_called_once()
         assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer1.id, offer2.id])
 
-        assert len(caplog.records) == 1
-        record = caplog.records[0]
+        assert len(caplog.records) == 2
+        first_record = caplog.records[0]
+        second_record = caplog.records[1]
 
-        assert record.message == "Batch update of offers"
-        assert record.extra == {
+        assert first_record.message == "Batch update of offers"
+        assert first_record.extra == {
             "nb_offers": 2,
             "updated_fields": {"isActive": True},
             "venue_ids": [offer1.venueId, offer2.venueId],
+        }
+        assert second_record.message == "Offers has been activated"
+        assert second_record.extra == {
+            "offer_ids": (offer1.id, offer2.id),
+            "venue_id": [offer1.venueId, offer2.venueId],
         }
 
     def test_deactivate(self, caplog):
@@ -1295,14 +1304,20 @@ class BatchUpdateOffersTest:
         assert not models.Offer.query.get(offer2.id).isActive
         assert models.Offer.query.get(offer3.id).isActive
 
-        assert len(caplog.records) == 1
-        record = caplog.records[0]
+        assert len(caplog.records) == 2
+        first_record = caplog.records[0]
+        second_record = caplog.records[1]
 
-        assert record.message == "Batch update of offers"
-        assert record.extra == {
+        assert first_record.message == "Batch update of offers"
+        assert first_record.extra == {
             "nb_offers": 2,
             "updated_fields": {"isActive": False},
             "venue_ids": [offer1.venueId, offer2.venueId],
+        }
+        assert second_record.message == "Offers has been deactivated"
+        assert second_record.extra == {
+            "offer_ids": (offer1.id, offer2.id),
+            "venue_id": [offer1.venueId, offer2.venueId],
         }
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17292

## But de la pull request

_Rajouter des logs pour que la data puisse tracker les offres

## Informations supplémentaires

relecteur, j'ai un peu peur que du log ajouté dans `batch_update_offers` s'il y a beaucoup d'offre updaté ça peut poser problème ? 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
