### PR TITLE
(PC-15721)[PRO] feat: add buttons to save draft on offer page

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Offer.scss
+++ b/pro/src/components/pages/Offers/Offer/Offer.scss
@@ -107,6 +107,10 @@
     width: rem.torem(600px);
   }
 
+  .draft-buttons {
+    width: rem.torem(828px);
+  }
+
   .offer-details-offer-preview-app-link {
     text-align: center;
 

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
@@ -157,17 +157,23 @@ const OfferDetails = ({
   )
 
   const handleSubmitOffer = useCallback(
-    async offerValues => {
+    async (offerValues, isSavingDraft) => {
       try {
         if (offer) {
           await api.patchOffer(offer.id, offerValues)
-          if (!isCreatingOffer)
+          if (isSavingDraft) {
+            notification.success(
+              'Brouillon sauvegardé dans la liste des offres'
+            )
+          } else if (!isCreatingOffer)
             notification.success('Vos modifications ont bien été enregistrées')
           reloadOffer()
           setFormErrors({})
           setThumbnailError(false)
           setThumbnailMsgError('')
-          if (isCreatingOffer || isCompletingDraft) {
+          if (isSavingDraft) {
+            return Promise.resolve(null)
+          } else if (isCreatingOffer || isCompletingDraft) {
             return Promise.resolve(() => goToStockAndPrice(offer.id))
           } else {
             return Promise.resolve(() =>
@@ -178,6 +184,14 @@ const OfferDetails = ({
           const response = await api.postOffer(offerValues)
           const createdOfferId = response.id
           await postThumbnail(createdOfferId, thumbnailInfo)
+          if (isSavingDraft) {
+            notification.success(
+              'Brouillon sauvegardé dans la liste des offres'
+            )
+            return Promise.resolve(() =>
+              history.push(`/offre/${createdOfferId}/individuel/brouillon`)
+            )
+          }
           if (Object.keys(thumbnailInfo).length === 0) {
             return Promise.resolve(() => goToStockAndPrice(createdOfferId))
           }

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import isEqual from 'lodash.isequal'
 import PropTypes from 'prop-types'
 import React, {
@@ -7,7 +8,6 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { Link } from 'react-router-dom'
 
 import CheckboxInput from 'components/layout/inputs/CheckboxInput'
 import DurationInput from 'components/layout/inputs/DurationInput/DurationInput'
@@ -29,7 +29,7 @@ import useAnalytics from 'hooks/useAnalytics'
 import { OfferRefundWarning, WithdrawalReminder } from 'new_components/Banner'
 import FormLayout from 'new_components/FormLayout'
 import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
-import { SubmitButton } from 'ui-kit'
+import useIsCreation from 'new_components/OfferIndividualStepper/hooks/useIsCreation'
 import InternalBanner from 'ui-kit/Banners/InternalBanner'
 import { getOfferConditionalFields } from 'utils/getOfferConditionalFields'
 import { sortByDisplayName } from 'utils/strings'
@@ -51,6 +51,7 @@ import AccessibilityCheckboxList, {
   getAccessibilityValues,
 } from './AccessibilityCheckboxList'
 import OfferCategories from './OfferCategories'
+import { OfferFormActions } from './OfferFormActions'
 import OfferOptions from './OfferOptions'
 import { OfferWithdrawalTypeOptions } from './OfferWithdrawalTypeOptions'
 import SynchronizedProviderInformation from './SynchronisedProviderInfos'
@@ -89,6 +90,7 @@ const OfferForm = ({
       }))
     )
   )
+  const isCreation = useIsCreation()
   const [offerFormFields, setOfferFormFields] = useState(
     Object.keys(DEFAULT_FORM_VALUES)
   )
@@ -589,16 +591,6 @@ const OfferForm = ({
       showErrorNotification,
     ]
   )
-
-  const onCancelClick = () => {
-    if (isEdition)
-      logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
-        from: OfferBreadcrumbStep.DETAILS,
-        to: OfferBreadcrumbStep.SUMMARY,
-        used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
-        isEdition: isEdition,
-      })
-  }
 
   const handleChangeVenue = useCallback(
     event => {
@@ -1194,21 +1186,20 @@ const OfferForm = ({
         )}
 
       <section
-        className={
-          isEdition ? 'actions-section edit-buttons' : 'actions-section'
-        }
+        className={cn('actions-section', {
+          'edit-buttons': isEdition,
+          'draft-buttons': isCreation && formValues.subcategoryId,
+        })}
       >
-        <Link className="secondary-link" to={backUrl} onClick={onCancelClick}>
-          {'Annuler et quitter'}
-        </Link>
-        <SubmitButton
-          className="primary-button"
-          disabled={isDisabled}
-          isLoading={isSubmitLoading}
-          onClick={submitForm}
-        >
-          {isEdition ? 'Enregistrer les modifications' : 'Étape suivante'}
-        </SubmitButton>
+        <OfferFormActions
+          canSaveDraft={isCreation && formValues.subcategoryId}
+          isDisabled={isDisabled}
+          isSubmitLoading={isSubmitLoading}
+          isEdition={isEdition}
+          cancelUrl={backUrl}
+          onClickNext={submitForm}
+          onClickSaveDraft={submitForm}
+        />
       </section>
     </form>
   )

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.module.scss
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.module.scss
@@ -1,0 +1,10 @@
+.form-actions {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  .action {
+    flex: 1;
+  }
+
+}

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.module.scss
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.module.scss
@@ -7,4 +7,7 @@
     flex: 1;
   }
 
+  .last-action {
+    z-index: 1;
+  }
 }

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.tsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.tsx
@@ -1,0 +1,81 @@
+import cn from 'classnames'
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
+import useAnalytics from 'hooks/useAnalytics'
+import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
+import { Button, ButtonLink, SubmitButton } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+import styles from './OfferFormActions.module.scss'
+
+interface IOfferFormActionsProps {
+  canSaveDraft: boolean
+  cancelUrl: string
+  onClickNext: () => void
+  onClickSaveDraft: () => void
+  isDisabled: boolean
+  isSubmitLoading: boolean
+  isEdition: boolean
+}
+
+const OfferFormActions = ({
+  canSaveDraft,
+  isDisabled,
+  isSubmitLoading,
+  isEdition,
+  cancelUrl,
+  onClickNext,
+  onClickSaveDraft,
+}: IOfferFormActionsProps) => {
+  const { logEvent } = useAnalytics()
+  const onCancelClick = () => {
+    if (isEdition)
+      logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+        from: OfferBreadcrumbStep.DETAILS,
+        to: OfferBreadcrumbStep.SUMMARY,
+        used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+        isEdition: isEdition,
+      })
+  }
+
+  return (
+    <div className={cn(styles['form-actions'])}>
+      <ButtonLink
+        className={cn(styles['action'], styles['action-cancel'])}
+        link={{
+          to: cancelUrl,
+          isExternal: false,
+        }}
+        variant={ButtonVariant.SECONDARY}
+        onClick={onCancelClick}
+      >
+        {'Annuler et quitter'}
+      </ButtonLink>
+
+      {canSaveDraft && (
+        <Button
+          className={styles['action']}
+          disabled={isDisabled || isSubmitLoading}
+          onClick={onClickSaveDraft}
+          variant={ButtonVariant.SECONDARY}
+        >
+          Enregistrer un brouillon
+        </Button>
+      )}
+      <SubmitButton
+        disabled={isDisabled}
+        isLoading={isSubmitLoading}
+        onClick={onClickNext}
+      >
+        {isEdition ? 'Enregistrer les modifications' : 'Étape suivante'}
+      </SubmitButton>
+    </div>
+  )
+}
+
+export default OfferFormActions

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.tsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/OfferFormActions.tsx
@@ -1,11 +1,11 @@
 import cn from 'classnames'
 import React from 'react'
-import { Link } from 'react-router-dom'
 
 import {
   Events,
   OFFER_FORM_NAVIGATION_MEDIUM,
 } from 'core/FirebaseEvents/constants'
+import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
 import { OfferBreadcrumbStep } from 'new_components/OfferBreadcrumb'
 import { Button, ButtonLink, SubmitButton } from 'ui-kit'
@@ -33,6 +33,7 @@ const OfferFormActions = ({
   onClickSaveDraft,
 }: IOfferFormActionsProps) => {
   const { logEvent } = useAnalytics()
+  const isDraftEnabled = useActiveFeature('OFFER_DRAFT_ENABLED')
   const onCancelClick = () => {
     if (isEdition)
       logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
@@ -46,7 +47,7 @@ const OfferFormActions = ({
   return (
     <div className={cn(styles['form-actions'])}>
       <ButtonLink
-        className={cn(styles['action'], styles['action-cancel'])}
+        className={styles['action']}
         link={{
           to: cancelUrl,
           isExternal: false,
@@ -57,7 +58,7 @@ const OfferFormActions = ({
         {'Annuler et quitter'}
       </ButtonLink>
 
-      {canSaveDraft && (
+      {canSaveDraft && isDraftEnabled && (
         <Button
           className={styles['action']}
           disabled={isDisabled || isSubmitLoading}
@@ -68,6 +69,7 @@ const OfferFormActions = ({
         </Button>
       )}
       <SubmitButton
+        className={styles['last-action']}
         disabled={isDisabled}
         isLoading={isSubmitLoading}
         onClick={onClickNext}

--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/index.ts
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferFormActions/index.ts
@@ -1,0 +1,1 @@
+export { default as OfferFormActions } from './OfferFormActions'

--- a/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
@@ -185,8 +185,10 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
     })
   }
 
+  const submitDraft = e => submitStocks(e, true)
+
   const submitStocks = useCallback(
-    e => {
+    (e, isSavingDraft = false) => {
       e.preventDefault()
       const updatedStocks = existingStocks.filter(stock => stock.updated)
       if (areValid([...stocksInCreation, ...updatedStocks], offer.isEvent)) {
@@ -228,22 +230,25 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
                 used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
                 isEdition: !isOfferDraft,
               })
+              if (isSavingDraft)
+                notification.success(
+                  'Brouillon sauvegardé dans la liste des offres'
+                )
             } else {
               await loadStocks()
               await reloadOffer()
               notification.success(
                 'Vos modifications ont bien été enregistrées'
               )
-              setIsSendingStocksOfferCreation(false)
             }
-            history.push(`${summaryStepUrl}${queryString}`)
+            if (!isSavingDraft) history.push(`${summaryStepUrl}${queryString}`)
           })
           .catch(() => {
             notification.error(
               'Une ou plusieurs erreurs sont présentes dans le formulaire.'
             )
-            setIsSendingStocksOfferCreation(false)
           })
+          .finally(() => setIsSendingStocksOfferCreation(false))
       }
     },
     [
@@ -383,6 +388,7 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
               isDraft={isOfferDraft}
               isSubmiting={isSendingStocksOfferCreation}
               onSubmit={submitStocks}
+              onSubmitDraft={submitDraft}
               onCancelClick={onCancelClick}
             />
           </section>

--- a/pro/src/components/pages/Offers/Offer/Stocks/FormActions/FormActions.tsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/FormActions/FormActions.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 
+import useActiveFeature from 'hooks/useActiveFeature'
+import useIsCompletingDraft from 'new_components/OfferIndividualStepper/hooks/useIsCompletingDraft'
+import useIsCreation from 'new_components/OfferIndividualStepper/hooks/useIsCreation'
 import { SubmitButton } from 'ui-kit'
-import { ButtonLink } from 'ui-kit/Button'
+import { Button, ButtonLink } from 'ui-kit/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
 interface IFormActionsProps {
@@ -11,6 +14,7 @@ interface IFormActionsProps {
   isSubmiting: boolean
   onSubmit: () => void
   onCancelClick?: () => void
+  onSubmitDraft: () => void
 }
 
 const FormActions = ({
@@ -19,8 +23,13 @@ const FormActions = ({
   canSubmit,
   isSubmiting,
   onSubmit,
+  onSubmitDraft,
   onCancelClick,
 }: IFormActionsProps): JSX.Element => {
+  const isCreation = useIsCreation()
+  const isCompletingDraft = useIsCompletingDraft()
+  const isDraftEnabled = useActiveFeature('OFFER_DRAFT_ENABLED')
+
   return (
     <>
       {cancelUrl && (
@@ -33,13 +42,25 @@ const FormActions = ({
         </ButtonLink>
       )}
 
-      <SubmitButton
-        disabled={!canSubmit}
-        isLoading={isSubmiting}
-        onClick={onSubmit}
-      >
-        {isDraft ? 'Étape suivante' : 'Enregistrer les modifications'}
-      </SubmitButton>
+      <div>
+        {(isCreation || isCompletingDraft) && isDraftEnabled && (
+          <Button
+            disabled={!canSubmit}
+            onClick={onSubmitDraft}
+            variant={ButtonVariant.SECONDARY}
+          >
+            Sauvegarder le brouillon
+          </Button>
+        )}
+
+        <SubmitButton
+          disabled={!canSubmit}
+          isLoading={isSubmiting}
+          onClick={onSubmit}
+        >
+          {isDraft ? 'Étape suivante' : 'Enregistrer les modifications'}
+        </SubmitButton>
+      </div>
     </>
   )
 }

--- a/pro/src/components/pages/Offers/Offer/Stocks/Stocks.scss
+++ b/pro/src/components/pages/Offers/Offer/Stocks/Stocks.scss
@@ -88,7 +88,7 @@ $buttonHeight: rem.torem(40px);
     padding-top: $actionsPaddingTop;
     position: sticky;
     z-index: 2;
-    justify-content: left;
+    justify-content: space-between;
 
     button,
     a {

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
@@ -64,8 +64,13 @@ describe('stocks page', () => {
         initialized: true,
       },
       features: {
-        initialized: true,
-        list: [],
+        list: [
+          {
+            isActive: true,
+            name: 'OFFER_DRAFT_ENABLED',
+            nameKey: 'OFFER_DRAFT_ENABLED',
+          },
+        ],
       },
     }
     props = {}
@@ -707,6 +712,38 @@ describe('stocks page', () => {
 
         // when
         await userEvent.click(screen.getByText('Étape suivante'))
+
+        // then
+        expect(api.upsertStocks).toHaveBeenCalledWith({
+          offerId: 'AG3A',
+          stocks: [
+            {
+              bookingLimitDatetime: '2020-12-23T02:59:59Z',
+              price: '15',
+              quantity: '15',
+            },
+          ],
+        })
+      })
+
+      it('should save stocks when clicking on save draft button', async () => {
+        // given
+        api.upsertStocks.mockResolvedValue({})
+        renderOffers(props, store, '/offre/AG3A/individuel/creation/stocks')
+
+        await userEvent.click(await screen.findByText('Ajouter un stock'))
+
+        await userEvent.type(screen.getByLabelText('Prix'), '15')
+
+        await userEvent.click(
+          screen.getByLabelText('Date limite de réservation')
+        )
+        await userEvent.click(screen.getByText('22'))
+
+        await userEvent.type(screen.getByLabelText('Quantité'), '15')
+
+        // when
+        await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
 
         // then
         expect(api.upsertStocks).toHaveBeenCalledWith({

--- a/pro/src/new_components/RouteLeavingGuardOfferIndividual/RouteLeavingGuardOfferIndividual.tsx
+++ b/pro/src/new_components/RouteLeavingGuardOfferIndividual/RouteLeavingGuardOfferIndividual.tsx
@@ -10,6 +10,8 @@ const STEP_STOCKS = 'stocks'
 const STEP_SUMMARY = 'recapitulatif'
 const STEP_CONFIRMATION = 'confirmation'
 
+const DRAFT_STATE = 'brouillon'
+
 const urlPatterns: { [key: string]: RegExp } = {
   [STEP_OFFER]: /\/offre\/([A-Z0-9]+\/)?individuel\/creation/g,
   [STEP_STOCKS]: /\/offre\/([A-Z0-9]+)\/individuel\/creation\/stocks/g,
@@ -29,6 +31,12 @@ const RouteLeavingGuardOfferIndividual = ({
   const shouldBlockNavigation = useCallback(
     (nextLocation: Location): IShouldBlockNavigationReturnValue => {
       let redirectPath = null
+
+      const urlMatch = nextLocation.pathname.match(/[a-z]+$/)
+      const stateName = urlMatch && urlMatch[0]
+      if (stateName === DRAFT_STATE) {
+        return { shouldBlock: false }
+      }
 
       // when multiples url match (example: offer and stocks),
       // we're keeping the last one (example: stocks)

--- a/pro/src/screens/OfferIndividual/Summary/ActionsFormV2/ActionsFormsV2.module.scss
+++ b/pro/src/screens/OfferIndividual/Summary/ActionsFormV2/ActionsFormsV2.module.scss
@@ -1,0 +1,10 @@
+@use 'styles/mixins/_rem.scss' as rem;
+
+.draft-actions {
+    width: rem.torem(828px);
+    display: flex;
+    justify-content: space-between;
+    .actions-last {
+        z-index: 1;
+    }
+}

--- a/pro/src/screens/OfferIndividual/Summary/Summary.module.scss
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.module.scss
@@ -24,7 +24,6 @@
 
 .offer-creation-preview-actions {
   flex: 1;
-  justify-content: center;
   margin-top: rem.torem(64px);
 
   button,

--- a/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
@@ -20,6 +20,15 @@ jest.mock('apiClient/api', () => ({
 
 const renderSummary = (props: ISummaryProps) => {
   const store = configureTestStore({
+    features: {
+      list: [
+        {
+          isActive: true,
+          name: 'OFFER_DRAFT_ENABLED',
+          nameKey: 'OFFER_DRAFT_ENABLED',
+        },
+      ],
+    },
     user: {
       initialized: true,
       currentUser: {
@@ -251,6 +260,11 @@ describe('Summary', () => {
 
         // then
         expect(screen.getByText('Étape précédente')).toBeInTheDocument()
+        const saveDraftButton = screen.getByText(
+          'Sauvegarder le brouillon et quitter'
+        )
+        expect(saveDraftButton).toBeInTheDocument()
+        expect(saveDraftButton).toHaveAttribute('href', '/offres')
         expect(screen.getByText("Publier l'offre")).toBeInTheDocument()
       })
     })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15721

## But de la pull request

Ajout de 3 boutons "Sauvegarder le brouillon".
Sur la page de détail des stocks et de récap. Sur le récap ce bouton n'a pas d'autres actions que de ramener à la page /offres

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
