### PR TITLE
(PC-17922)[PRO] fix: serializer offer image from thumbUrl

### DIFF
--- a/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/getOfferIndividualAdapter/__specs__/serializers.spec.ts
@@ -158,7 +158,7 @@ describe('serializer', () => {
     },
   ]
   it.each(serializeOfferApiImageDataSet)(
-    'serializeOfferApiImage',
+    'serializeOfferApiImage from mediation',
     ({ mediations, expectedImage }) => {
       const offerApi = {
         mediations,
@@ -167,6 +167,18 @@ describe('serializer', () => {
       expect(serializeOfferApiImage(offerApi)).toEqual(expectedImage)
     }
   )
+  it('serializeOfferApiImage from thumbUrl', () => {
+    const offerApi = {
+      thumbUrl: 'http://image.url',
+      mediations: [],
+    } as unknown as GetIndividualOfferResponseModel
+
+    expect(serializeOfferApiImage(offerApi)).toEqual({
+      originalUrl: 'http://image.url',
+      url: 'http://image.url',
+      credit: '',
+    })
+  })
   it('serializeOffererApi', async () => {
     const offerApi = {
       venue: {

--- a/pro/src/core/Offers/adapters/getOfferIndividualAdapter/serializers.ts
+++ b/pro/src/core/Offers/adapters/getOfferIndividualAdapter/serializers.ts
@@ -104,8 +104,15 @@ export const serializeOfferApiImage = (
       return {
         originalUrl: mediation.thumbUrl,
         url: mediation.thumbUrl,
-        credit: mediation.credit || '',
+        credit: mediation?.credit || '',
       }
+    }
+  } else if (apiOffer.thumbUrl) {
+    // synchronized offers have thumbUrl but no mediation
+    return {
+      originalUrl: apiOffer.thumbUrl,
+      url: apiOffer.thumbUrl,
+      credit: '',
     }
   }
   return undefined


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17922

## But de la pull request

Fixer l'affichage de l'image sur la page de récapitulatif pour les offres synchronisées 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
