### PR TITLE
(PC-18116)[API] fix: revert fine typing of filter for unvalidated offerers list

### DIFF
--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -76,33 +76,15 @@ class PaginableQuery(BaseModel):
     sort: str | None = None
 
 
-class BaseFilter(BaseModel):
-    """
-    base class for backoffice filters, should probably be specialized for each endpoint
-    """
-
-    field: str
-    value: typing.Any
-
-
-class BaseFilterableQuery(BaseModel):
-    """
-    base class for backoffice filterable query, should probably be specialized for each endpoint
-    """
-
-    filter: pydantic.Json[list[BaseFilter]] = []
+class FilterableQuery(BaseModel):
+    filter: pydantic.Json[list[dict]] = []  # pylint: disable=unsubscriptable-object
 
     def validate_filter(self, value: str) -> str:
         return urllib.parse.unquote_plus(value)
 
 
-class ToBeValidatedOffererFilter(BaseFilter):
-    field: typing.Literal["tags"]
-    value: list[typing.Literal["Collectivité", "Top acteur", "Établissement public"]]
-
-
-class OffererToBeValidatedQuery(PaginableQuery, BaseFilterableQuery):
-    filter: pydantic.Json[list[ToBeValidatedOffererFilter]] = []  # type: ignore [assignment] # pylint: disable=unsubscriptable-object
+class OffererToBeValidatedQuery(PaginableQuery, FilterableQuery):
+    pass
 
 
 class SearchQuery(PaginableQuery):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

suppression du typage fin des filtres pour le endpoint de liste des structures à valider

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
