### PR TITLE
(BSR)[API] test: use Offerer and UserOfferer factories which set both validation status and token

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -20,6 +20,7 @@ class OffererFactory(BaseFactory):
     city = "Paris"
     siren = factory.Sequence(lambda n: f"{n + 1:09}")
     isActive = True
+    validationStatus = models.ValidationStatus.VALIDATED
 
 
 class NotValidatedOffererFactory(OffererFactory):
@@ -178,7 +179,7 @@ class UserOffererFactory(BaseFactory):
 
 
 class NotValidatedUserOffererFactory(UserOffererFactory):
-    validationToken = factory.Sequence(lambda n: f"attachment-notvalidated-{n}")
+    validationToken = factory.Sequence(lambda n: f"uo-not-validated-{n}")
     validationStatus = models.ValidationStatus.NEW
 
 

--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -495,7 +495,7 @@ class OfferValidationViewTest:
     def test_get_query_and_count(self, db_session):
         offer_view = ValidationOfferView(model=Offer, session=db_session)
         validated_offerer = offerers_factories.OffererFactory()
-        non_validated_offerer = offerers_factories.OffererFactory(validationToken="token")
+        non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
         offer_1 = offers_factories.OfferFactory(
             validation=OfferValidationStatus.PENDING,
             venue__managingOfferer=validated_offerer,
@@ -740,7 +740,7 @@ class OfferValidationViewTest:
             model=educational_models.CollectiveOfferTemplate, session=db_session
         )
         validated_offerer = offerers_factories.OffererFactory()
-        non_validated_offerer = offerers_factories.OffererFactory(validationToken="token")
+        non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
         offer_1 = educational_factories.CollectiveOfferTemplateFactory(
             validation=OfferValidationStatus.PENDING,
             venue__managingOfferer=validated_offerer,
@@ -956,7 +956,7 @@ class OfferValidationViewTest:
     def test_get_query_and_count_on_collective_offer(self, db_session):
         offer_view = ValidationCollectiveOfferView(model=educational_models.CollectiveOffer, session=db_session)
         validated_offerer = offerers_factories.OffererFactory()
-        non_validated_offerer = offerers_factories.OffererFactory(validationToken="token")
+        non_validated_offerer = offerers_factories.NotValidatedOffererFactory()
         offer_1 = educational_factories.CollectiveOfferFactory(
             validation=OfferValidationStatus.PENDING,
             venue__managingOfferer=validated_offerer,

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -591,7 +591,7 @@ class FindByProUserTest:
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory(postalCode="97300")
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer)
 
         venue = offerers_factories.VenueFactory(managingOfferer=offerer, isVirtual=True, siret=None)
         product = offers_factories.ThingProductFactory(name="Harry Potter")
@@ -1359,7 +1359,7 @@ class GetCsvReportTest:
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory(postalCode="97300")
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer)
 
         venue = offerers_factories.VenueFactory(managingOfferer=offerer, isVirtual=True, siret=None)
         product = offers_factories.ThingProductFactory(name="Harry Potter")

--- a/api/tests/core/educational/test_models.py
+++ b/api/tests/core/educational/test_models.py
@@ -9,6 +9,7 @@ from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import EducationalDeposit
+import pcapi.core.offerers.models as offerers_models
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 
@@ -56,7 +57,7 @@ class CollectiveStockIsBookableTest:
 
     def test_not_bookable_if_offerer_is_not_validated(self) -> None:
         collective_stock = factories.CollectiveStockFactory(
-            collectiveOffer__venue__managingOfferer__validationToken="token"
+            collectiveOffer__venue__managingOfferer__validationStatus=offerers_models.ValidationStatus.NEW
         )
         assert not collective_stock.isBookable
 

--- a/api/tests/core/educational/test_repository.py
+++ b/api/tests/core/educational/test_repository.py
@@ -250,7 +250,7 @@ class FindByProUserTest:
     def test_should_not_return_bookings_when_offerer_link_is_not_validated(self, app):
         # Given
         booking_date = datetime.utcnow() - timedelta(days=5)
-        user_offerer = offerers_factories.UserOffererFactory(validationToken="token")
+        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
         educational_factories.CollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
             dateCreated=booking_date,

--- a/api/tests/core/finance/test_repository.py
+++ b/api/tests/core/finance/test_repository.py
@@ -47,7 +47,7 @@ class GetBusinessUnitsTest:
         venue2 = offerers_factories.VenueFactory(businessUnit=business_unit2)
         offerer2 = venue2.managingOfferer
 
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer2, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer2)
         business_units = list(repository.get_business_units_query(pro))
         assert business_units == [business_unit1]
 
@@ -197,7 +197,7 @@ class GetInvoicesQueryTest:
         reimbursement_point3 = offerers_factories.VenueFactory(reimbursement_point="self")
         factories.InvoiceFactory(businessUnit=None, reimbursementPoint=reimbursement_point3, amount=-15000000)
         offerer2 = reimbursement_point3.managingOfferer
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer2, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer2)
 
         invoices = repository.get_invoices_query(pro).order_by(models.Invoice.id)
         assert list(invoices) == [invoice1, invoice2]
@@ -315,7 +315,7 @@ class LegacyGetInvoicesQueryTest:
         factories.InvoiceFactory(businessUnit=business_unit3, amount=-15000000)
         venue3 = offerers_factories.VenueFactory(businessUnit=business_unit3)
         offerer2 = venue3.managingOfferer
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer2, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer2)
 
         invoices = repository.get_invoices_query(pro).order_by(models.Invoice.id)
         assert list(invoices) == [invoice1, invoice2]

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -244,11 +244,11 @@ class OffererBankInformationTest:
 class IsValidatedTest:
     def test_is_validated_property(self):
         offerer = factories.OffererFactory()
-        factories.UserOffererFactory(offerer=offerer, validationToken="token")
+        factories.NotValidatedUserOffererFactory(offerer=offerer)
         assert offerer.isValidated
 
     def test_is_validated_property_when_still_offerer_has_validation_token(self):
-        offerer = factories.OffererFactory(validationToken="token")
+        offerer = factories.NotValidatedOffererFactory()
         factories.UserOffererFactory(offerer=offerer)
         assert not offerer.isValidated
 

--- a/api/tests/core/offerers/test_repository.py
+++ b/api/tests/core/offerers/test_repository.py
@@ -57,7 +57,7 @@ class GetAllOfferersForUserTest:
     def should_return_non_validated_offerers(self) -> None:
         # Given
         pro = users_factories.ProFactory()
-        pro_offerer_attachment = offerers_factories.UserOffererFactory(user=pro, offerer__validationToken="Token")
+        pro_offerer_attachment = offerers_factories.UserNotValidatedOffererFactory(user=pro)
 
         # When
         offerers = repository.get_all_offerers_for_user(user=pro).all()
@@ -69,7 +69,7 @@ class GetAllOfferersForUserTest:
 
     def should_not_return_offerers_with_non_validated_attachment_to_given_pro(self) -> None:
         pro = users_factories.ProFactory()
-        offerers_factories.UserOffererFactory(user=pro, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro)
         assert repository.get_all_offerers_for_user(user=pro).all() == []
 
     def should_not_return_deactivated_offerers(self) -> None:
@@ -114,9 +114,7 @@ class GetAllOfferersForUserTest:
             # Given
             pro = users_factories.ProFactory()
             pro_attachment_to_validated_offerer = offerers_factories.UserOffererFactory(user=pro)
-            pro_attachment_to_unvalidated_offerer = offerers_factories.UserOffererFactory(
-                user=pro, offerer__validationToken="Token"
-            )
+            pro_attachment_to_unvalidated_offerer = offerers_factories.UserNotValidatedOffererFactory(user=pro)
 
             # When
             offerers = repository.get_all_offerers_for_user(user=pro).all()
@@ -131,9 +129,7 @@ class GetAllOfferersForUserTest:
             # Given
             pro = users_factories.ProFactory()
             pro_attachment_to_validated_offerer = offerers_factories.UserOffererFactory(user=pro)
-            pro_attachment_to_unvalidated_offerer = offerers_factories.UserOffererFactory(
-                user=pro, offerer__validationToken="Token"
-            )
+            pro_attachment_to_unvalidated_offerer = offerers_factories.UserNotValidatedOffererFactory(user=pro)
 
             # When
             offerers = repository.get_all_offerers_for_user(user=pro, validated=True).all()
@@ -148,9 +144,7 @@ class GetAllOfferersForUserTest:
             # Given
             pro = users_factories.ProFactory()
             pro_attachment_to_validated_offerer = offerers_factories.UserOffererFactory(user=pro)
-            pro_attachment_to_unvalidated_offerer = offerers_factories.UserOffererFactory(
-                user=pro, offerer__validationToken="Token"
-            )
+            pro_attachment_to_unvalidated_offerer = offerers_factories.UserNotValidatedOffererFactory(user=pro)
 
             # When
             offerers = repository.get_all_offerers_for_user(user=pro, validated=False).all()
@@ -165,7 +159,7 @@ class GetAllOfferersForUserTest:
 class FindUserOffererByValidationTokenTest:
     def test_return_user_offerer_given_validation_token(self):
         # Given
-        user_offerer_expected = offerers_factories.UserOffererFactory(validationToken="TOKEN")
+        user_offerer_expected = offerers_factories.NotValidatedUserOffererFactory()
 
         # When
         user_offerer_received = repository.find_user_offerer_by_validation_token(user_offerer_expected.validationToken)
@@ -175,7 +169,7 @@ class FindUserOffererByValidationTokenTest:
 
     def test_return_nothing_when_validation_token_does_not_exist(self):
         # Given
-        offerers_factories.UserOffererFactory(validationToken="TOKEN")
+        offerers_factories.NotValidatedUserOffererFactory()
 
         # When
         user_offerer_received = repository.find_user_offerer_by_validation_token("ANOTHER TOKEN")
@@ -187,7 +181,7 @@ class FindUserOffererByValidationTokenTest:
 class FindOffererByValidationTokenTest:
     def test_return_offerer_given_validation_token(self):
         # Given
-        user_offerer_expected = offerers_factories.UserOffererFactory(offerer__validationToken="TOKEN")
+        user_offerer_expected = offerers_factories.UserNotValidatedOffererFactory()
 
         # When
         offerer_received = repository.find_offerer_by_validation_token(user_offerer_expected.offerer.validationToken)
@@ -197,7 +191,7 @@ class FindOffererByValidationTokenTest:
 
     def test_return_nothing_when_validation_token_does_not_exist(self):
         # Given
-        offerers_factories.UserOffererFactory(offerer__validationToken="TOKEN")
+        offerers_factories.UserNotValidatedOffererFactory()
 
         # When
         offerer_received = repository.find_offerer_by_validation_token("ANOTHER TOKEN")

--- a/api/tests/core/offerers/test_repository_get_venues.py
+++ b/api/tests/core/offerers/test_repository_get_venues.py
@@ -11,7 +11,7 @@ class GetFilteredVenuesForProUserTest:
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerers_factories.VenueFactory(name="owned_venue_validated", managingOfferer=offerer)
 
-        offerer_not_validated = offerers_factories.OffererFactory(validationToken="token")
+        offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer_not_validated)
         venue_not_validated = offerers_factories.VenueFactory(
             name="owned_venue_not_validated", managingOfferer=offerer_not_validated
@@ -26,11 +26,7 @@ class GetFilteredVenuesForProUserTest:
 
         offerer_not_validated_for_user = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer_not_validated_for_user)
-        offerers_factories.UserOffererFactory(
-            user=user,
-            offerer=offerer_not_validated_for_user,
-            validationToken="user_token",
-        )
+        offerers_factories.NotValidatedUserOffererFactory(user=user, offerer=offerer_not_validated_for_user)
         venue_not_validated_for_user = offerers_factories.VenueFactory(
             name="owned_venue_not_validated_for_user",
             managingOfferer=offerer_not_validated_for_user,
@@ -50,7 +46,7 @@ class GetFilteredVenuesForProUserTest:
             managingOfferer=other_offerer,
         )
 
-        other_offerer_not_validated = offerers_factories.OffererFactory(validationToken="other_token")
+        other_offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=other_user_offerer.user, offerer=other_offerer_not_validated)
         other_venue_not_validated = offerers_factories.VenueFactory(
             name="other_venue_not_validated",
@@ -220,7 +216,7 @@ class GetFilteredVenuesForAdminTest:
         user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(name="venue", managingOfferer=offerer)
 
-        offerer_not_validated = offerers_factories.OffererFactory(validationToken="token")
+        offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=user_offerer.user, offerer=offerer_not_validated)
         venue_not_validated = offerers_factories.VenueFactory(
             name="venue_not_validated", managingOfferer=offerer_not_validated
@@ -230,7 +226,7 @@ class GetFilteredVenuesForAdminTest:
         other_user_offerer = offerers_factories.UserOffererFactory(offerer=other_offerer)
         other_venue = offerers_factories.VenueFactory(name="other_venue", managingOfferer=other_offerer)
 
-        other_offerer_not_validated = offerers_factories.OffererFactory(validationToken="other_token")
+        other_offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=other_user_offerer.user, offerer=other_offerer_not_validated)
         other_venue_not_validated = offerers_factories.VenueFactory(
             name="other_venue_not_validated",

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -6,6 +6,7 @@ import pytest
 import pcapi.core.bookings.constants as bookings_constants
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.categories import subcategories
+import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offers import factories
 from pcapi.core.offers import models
 import pcapi.core.providers.factories as providers_factories
@@ -510,7 +511,9 @@ class StockIsBookableTest:
         assert not stock.isBookable
 
     def test_not_bookable_if_offerer_is_not_validated(self):
-        stock = factories.StockFactory(offer__venue__managingOfferer__validationToken="token")
+        stock = factories.StockFactory(
+            offer__venue__managingOfferer__validationStatus=offerers_models.ValidationStatus.NEW
+        )
         assert not stock.isBookable
 
     def test_not_bookable_if_offerer_is_not_active(self):

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -288,7 +288,7 @@ class HasAccessTest:
         assert not user.has_access(offerer.id)
 
     def test_does_not_have_access_if_not_validated(self):
-        user_offerer = offerers_factories.UserOffererFactory(validationToken="token")
+        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
         offerer = user_offerer.offerer
         user = user_offerer.user
 

--- a/api/tests/core/users/test_repository.py
+++ b/api/tests/core/users/test_repository.py
@@ -98,11 +98,9 @@ class GetApplicantOfOffererUnderValidationTest:
         # Given
         applicant = users_factories.UserFactory()
         user_who_asked_for_attachment = users_factories.UserFactory()
-        applied_offerer = offerers_factories.OffererFactory(validationToken="TOKEN")
+        applied_offerer = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(offerer=applied_offerer, user=applicant)
-        offerers_factories.UserOffererFactory(
-            offerer=applied_offerer, user=user_who_asked_for_attachment, validationToken="OTHER_TOKEN"
-        )
+        offerers_factories.NotValidatedUserOffererFactory(offerer=applied_offerer, user=user_who_asked_for_attachment)
 
         # When
         applicants_found = get_users_with_validated_attachment_by_offerer(applied_offerer)

--- a/api/tests/domain/admin_emails_test.py
+++ b/api/tests/domain/admin_emails_test.py
@@ -27,7 +27,7 @@ def test_maybe_send_offerer_validation_email_sends_email_to_pass_culture_when_ob
         }
     )
     user = users_factories.UserFactory()
-    offerer = offerers_factories.OffererFactory(validationToken="12356")
+    offerer = offerers_factories.NotValidatedOffererFactory()
     user_offerer = offerers_factories.UserOffererFactory(offerer=offerer, user=user)
     siren_info = sirene.SirenInfo(
         siren="123456789",

--- a/api/tests/emails/offerer_validation_test.py
+++ b/api/tests/emails/offerer_validation_test.py
@@ -22,14 +22,14 @@ def generate_siren_info() -> sirene.SirenInfo:
 def test_write_object_validation_email():
     # Given
     validation_token = secrets.token_urlsafe(20)
-    offerer = offerers_factories.OffererFactory.build(
+    offerer = offerers_factories.NotValidatedOffererFactory.build(
         id=123,
         validationToken=validation_token,
     )
 
     user = users_factories.ProFactory.build()
 
-    user_offerer = offerers_factories.UserOffererFactory.build(
+    user_offerer = offerers_factories.NotValidatedUserOffererFactory.build(
         user=user,
         offerer=offerer,
         validationToken=validation_token,

--- a/api/tests/routes/pro/get_educational_offerers_test.py
+++ b/api/tests/routes/pro/get_educational_offerers_test.py
@@ -12,7 +12,7 @@ class GetEducationalOfferersTest:
         pro_user = users_factories.ProFactory()
         offerer_1 = offerers_factories.OffererFactory()
         offerer_2 = offerers_factories.OffererFactory()
-        not_validated_offerer = offerers_factories.OffererFactory(validationToken="validationToken")
+        not_validated_offerer = offerers_factories.NotValidatedOffererFactory()
         venue_offerer_1 = offerers_factories.VenueFactory(managingOfferer=offerer_1, collectiveInterventionArea=None)
         venue_offerer_2 = offerers_factories.CollectiveVenueFactory(managingOfferer=offerer_2)
         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer_1)
@@ -75,7 +75,7 @@ class GetEducationalOfferersTest:
         admin_user = users_factories.AdminFactory()
         offerer_1 = offerers_factories.OffererFactory()
         offerer_2 = offerers_factories.OffererFactory()
-        offerers_factories.OffererFactory(validationToken="validationToken")
+        offerers_factories.NotValidatedOffererFactory()
         offerers_factories.VenueFactory(managingOfferer=offerer_1)
         offerers_factories.VenueFactory(managingOfferer=offerer_2)
 

--- a/api/tests/routes/pro/get_invoices_test.py
+++ b/api/tests/routes/pro/get_invoices_test.py
@@ -90,7 +90,7 @@ class GetInvoicesFalseFFTest:
 
         pro = users_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer2, validationToken="token")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer2)
 
         client = client.with_session_auth(pro.email)
         response = client.get("/finance/invoices")
@@ -261,7 +261,7 @@ class GetInvoicesTest:
             businessUnit=None, reimbursementPoint=reimbursement_point3, amount=-15000000
         )
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer2, validationToken="pasEncoreValidé")
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer2)
 
         client = client.with_session_auth(pro.email)
         response = client.get("/finance/invoices")

--- a/api/tests/routes/pro/get_offerers_names_test.py
+++ b/api/tests/routes/pro/get_offerers_names_test.py
@@ -12,7 +12,7 @@ class Returns200ForProUserTest:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
 
-        offerer_not_validated = offerers_factories.OffererFactory(validationToken="token")
+        offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer_not_validated)
 
         offerer_validated_for_user = offerers_factories.OffererFactory()
@@ -21,16 +21,12 @@ class Returns200ForProUserTest:
 
         offerer_not_validated_for_user = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer_not_validated_for_user)
-        offerers_factories.UserOffererFactory(
-            user=user,
-            offerer=offerer_not_validated_for_user,
-            validationToken="user_token",
-        )
+        offerers_factories.NotValidatedUserOffererFactory(user=user, offerer=offerer_not_validated_for_user)
 
         other_offerer = offerers_factories.OffererFactory()
         other_user_offerer = offerers_factories.UserOffererFactory(offerer=other_offerer)
 
-        other_offerer_not_validated = offerers_factories.OffererFactory(validationToken="other_token")
+        other_offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=other_user_offerer.user, offerer=other_offerer_not_validated)
 
         return {
@@ -144,13 +140,13 @@ class Returns200ForAdminTest:
         offerer = offerers_factories.OffererFactory()
         user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
 
-        offerer_not_validated = offerers_factories.OffererFactory(validationToken="token")
+        offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=user_offerer.user, offerer=offerer_not_validated)
 
         other_offerer = offerers_factories.OffererFactory()
         other_user_offerer = offerers_factories.UserOffererFactory(offerer=other_offerer)
 
-        other_offerer_not_validated = offerers_factories.OffererFactory(validationToken="other_token")
+        other_offerer_not_validated = offerers_factories.NotValidatedOffererFactory()
         offerers_factories.UserOffererFactory(user=other_user_offerer.user, offerer=other_offerer_not_validated)
         return {
             "offerer": offerer,

--- a/api/tests/routes/pro/get_offerers_test.py
+++ b/api/tests/routes/pro/get_offerers_test.py
@@ -30,7 +30,7 @@ def test_access_by_pro(client):
     offerers_factories.UserOffererFactory(offerer=offerer2, user=pro)
     offerers_factories.UserOffererFactory(offerer=inactive, user=pro)
     # Non-validated offerers should not be included.
-    offerers_factories.UserOffererFactory(user=pro, offerer=offerer3, validationToken="TOKEN")
+    offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer3)
     # Offerer that belongs to another user should not be returned.
     offerers_factories.OffererFactory(name="not returned")
 

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -1,4 +1,3 @@
-import secrets
 from unittest.mock import patch
 
 from pcapi.core import testing
@@ -331,7 +330,7 @@ class Returns404Test:
         # Given
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer, validationToken=secrets.token_urlsafe(20))
+        offerers_factories.NotValidatedUserOffererFactory(user=pro, offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offers_factories.ThingOfferFactory(venue=venue)
 

--- a/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
@@ -78,7 +78,7 @@ class Returns403Test:
     def test_user_does_not_have_access_to_offerer(self, client):
         user = user_factories.UserFactory()
         offerer = offerers_factories.OffererFactory()
-        offerers_factories.UserOffererFactory(user=user, offerer=offerer, validationToken="validationToken")
+        offerers_factories.NotValidatedUserOffererFactory(user=user, offerer=offerer)
 
         offer = CollectiveOfferFactory(venue__managingOfferer=offerer)
 

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -103,7 +103,7 @@ def test_new_user_offerer_has_validation_token(client):
     # Given
     pro = users_factories.ProFactory()
     offerer = offerers_factories.OffererFactory()
-    offerers_factories.UserOffererFactory(offerer=offerer, validationToken=None)
+    offerers_factories.UserOffererFactory(offerer=offerer)
     offerers_factories.VirtualVenueTypeFactory()
     body = {
         "name": offerer.name,

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -97,7 +97,7 @@ class Returns204Test:
 
     def when_successful_and_existing_offerer_creates_editor_user_offerer_and_does_not_log_in(self, client):
         # Given
-        offerer = offerers_factories.OffererFactory(siren="349974931", validationToken="not_validated")
+        offerer = offerers_factories.NotValidatedOffererFactory(siren="349974931")
         pro = ProFactory(email="bobby@test.com", publicName="bobby")
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 

--- a/api/tests/routes/pro/validate_offerer_attachment_test.py
+++ b/api/tests/routes/pro/validate_offerer_attachment_test.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class Returns202Test:
     def expect_user_offerer_attachment_to_be_validated(self, client):
         # Given
-        user_offerer = offerers_factories.UserOffererFactory(validationToken="TOKEN")
+        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
 
         # When
         response = client.with_session_auth(user_offerer.user.email).get(

--- a/api/tests/routes/pro/validate_offerer_test.py
+++ b/api/tests/routes/pro/validate_offerer_test.py
@@ -18,7 +18,7 @@ class Returns202Test:
     def expect_offerer_to_be_validated(self, app):
         with freeze_time("2021-06-22 14:48:00") as frozen_time:
             # Given
-            user_offerer = offerers_factories.UserOffererFactory(offerer__validationToken="TOKEN")
+            user_offerer = offerers_factories.UserNotValidatedOffererFactory()
 
             # When
             frozen_time.move_to("2021-06-23 11:00:00")
@@ -36,9 +36,9 @@ class Returns202Test:
 
     def expect_offerer_to_be_validated_even_when_user_offerer_has_already_been_activated(self, app):
         # Given
-        offerer = offerers_factories.OffererFactory(validationToken="TOKEN")
+        offerer = offerers_factories.NotValidatedOffererFactory()
         user_offerer1 = offerers_factories.UserOffererFactory(offerer=offerer)
-        user_offerer2 = offerers_factories.UserOffererFactory(validationToken=None, offerer=offerer)
+        user_offerer2 = offerers_factories.UserOffererFactory(offerer=offerer)
 
         # When
         response = TestClient(app.test_client()).get(f"/validate/offerer/{offerer.validationToken}")


### PR DESCRIPTION

BSR, pas de ticket Jira

## But de la pull request

Utiliser les _factories_ qui remplissent à la fois `validationStatus` et `validationToken` sur les structures et rattachements.
Cela en attendant la future disparition de `validationToken`.
On se rapproche ainsi des données telles qu'elles sont en base de production.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
