### PR TITLE
(PC-18114)[API] feat: backoffice: add account name in offerer history endpoint

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -136,6 +136,8 @@ def get_offerer_history(offerer_id: int) -> serialization.HistoryResponseModel:
                 authorId=action.authorUserId,
                 authorName=action.authorUser.publicName if action.authorUser else None,
                 comment=action.comment,
+                accountId=action.userId,
+                accountName=action.user.publicName if action.user else None,
             )
             for action in history
         ]

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -392,9 +392,11 @@ class HistoryItem(BaseModel):
 
     type: history_models.ActionType
     date: datetime.datetime
-    authorId: int | None
+    authorId: int | None  # backoffice user OR pro user who made the action
     authorName: str | None
     comment: str | None
+    accountId: int | None  # pro user attached to the offerer
+    accountName: str | None
 
 
 class HistoryResponseModel(Response):

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -615,6 +615,8 @@ class GetOffererHistoryTest:
                 "authorId": admin.id,
                 "authorName": admin.publicName,
                 "comment": None,
+                "accountId": user_offerer.user.id,
+                "accountName": user_offerer.user.publicName,
             },
             {
                 "type": "Commentaire interne",
@@ -622,6 +624,8 @@ class GetOffererHistoryTest:
                 "authorId": admin.id,
                 "authorName": admin.publicName,
                 "comment": "Documents reçus",
+                "accountId": user_offerer.user.id,
+                "accountName": user_offerer.user.publicName,
             },
             {
                 "type": "Structure mise en attente",
@@ -629,6 +633,8 @@ class GetOffererHistoryTest:
                 "authorId": admin.id,
                 "authorName": admin.publicName,
                 "comment": "Documents complémentaires demandés",
+                "accountId": user_offerer.user.id,
+                "accountName": user_offerer.user.publicName,
             },
             {
                 "type": "Nouvelle structure",
@@ -636,6 +642,8 @@ class GetOffererHistoryTest:
                 "authorId": user_offerer.user.id,
                 "authorName": user_offerer.user.publicName,
                 "comment": None,
+                "accountId": user_offerer.user.id,
+                "accountName": user_offerer.user.publicName,
             },
         ]
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18114

## But de la pull request

Afficher le nom de l'utilisateur pro concerné: `accountName`, dans chaque action de l'historique d'une structure du nouveau backoffice.
Ainsi que `accountId` afin de pouvoir faire un lien vers le détail de l'utilisateur en question.

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
