### PR TITLE
(BSR)[API] fix: Provider creation in install_local_providers()

### DIFF
--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -49,7 +49,7 @@ class APIProviderFactory(BaseFactory):
     class Meta:
         model = models.Provider
 
-    name = factory.Sequence("Provider {}".format)
+    name = factory.Sequence("API Provider {}".format)
     apiUrl = factory.Sequence("https://{}.example.org/stocks".format)
     enabledForPro = True
     isActive = True
@@ -100,7 +100,7 @@ class AllocineProviderFactory(BaseFactory):
         model = models.Provider
         sqlalchemy_get_or_create = ["localClass"]
 
-    name = factory.Sequence("Provider {}".format)
+    name = factory.Sequence("Allociné Provider {}".format)
     localClass = "AllocineStocks"
     enabledForPro = True
     isActive = True

--- a/api/src/pcapi/local_providers/install.py
+++ b/api/src/pcapi/local_providers/install.py
@@ -1,25 +1,8 @@
-from pcapi import settings
-from pcapi.core.providers.models import Provider
-from pcapi.core.providers.repository import get_provider_by_local_class
+from pcapi.core.providers.factories import ProviderFactory
 import pcapi.local_providers
-from pcapi.models import db
 
 
 def install_local_providers():  # type: ignore [no-untyped-def]
-    # It is a lot easier in tests when all providers are active by
-    # default (and manually inactivated if a particular test needs
-    # that).
-    activate_and_enable_for_pro = settings.IS_RUNNING_TESTS
     for class_name in pcapi.local_providers.__all__:
         provider_class = getattr(pcapi.local_providers, class_name)
-        db_provider = get_provider_by_local_class(class_name)
-
-        if not db_provider:
-            provider = Provider()
-            provider.name = provider_class.name
-            provider.localClass = class_name
-            provider.isActive = activate_and_enable_for_pro
-            provider.enabledForPro = activate_and_enable_for_pro
-            db.session.add(provider)
-
-    db.session.commit()
+        ProviderFactory(name=provider_class.name, localClass=class_name)

--- a/api/src/pcapi/sandboxes/scripts/creators/allocine/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/allocine/__init__.py
@@ -50,8 +50,6 @@ def save_allocine_sandbox() -> None:
     )
 
     provider = get_provider_by_local_class("AllocineStocks")
-    provider.isActive = True
-    provider.enabledForPro = True
 
     venue_provider = providers_factories.VenueProviderFactory(venue=venue, provider=provider)
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_venues.py
@@ -106,7 +106,7 @@ def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType
                 pricing_point="self" if siret else None,
                 reimbursement_point="self" if siret else None,
             )
-            providers_factories.VenueProviderFactory(venue=venue)
+            providers_factories.VenueProviderFactory(venue=venue, provider__name=f"API Provider for {venue_name}")
 
             if image_venue_counter < DEFAULT_VENUE_IMAGES:
                 add_default_image_to_venue(image_venue_counter, offerer, venue)
@@ -149,10 +149,6 @@ def create_industrial_venues(offerers_by_name: dict, venue_types: list[VenueType
     )
     providers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
     venue_by_name[venue_synchronized_with_allocine.name] = venue_synchronized_with_allocine
-
-    # FIXME (viconnex): understand why these properties are not set with right values in factories
-    allocine_provider.isActive = True
-    allocine_provider.enabledForPro = True
 
     logger.info("created %d venues", len(venue_by_name))
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_cinema_venue_provider_and_external_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_cinema_venue_provider_and_external_bookings.py
@@ -31,9 +31,6 @@ def create_offerer_with_cinema_venue_provider_and_external_bookings() -> None:
     )
     stock_duo = EventStockFactory(offer=offer_duo)
 
-    cds_provider.isActive = True
-    cds_provider.enabledForPro = True
-
     cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
         venue=venue, provider=cds_provider, idAtProvider="cdsdemorc1"
     )


### PR DESCRIPTION
## But de la pull request

Corriger la fonction `install_local_providers()`

## Implémentation

- La variable `activate_and_enable_for_pro` allait à l'encontre de son usage spécifié en commentaire, et désactivait par défaut les Providers créés dans cette fonction, ce qui obligeait à modifier leurs attributs dans le script de sandbox.
- Pour simplifier, on utilise désormais une `ProviderFactory`, dont les valeurs par défaut pour `isActive` et `enabledForPro` sont True.
- La logique précédente de création en cas d'absence en DB est couverte par la propriété `sqlalchemy_get_or_create` 

## Information supplémentaires

- Doc factoryboy sur [sqlalchemy_get_or_create](https://factoryboy.readthedocs.io/en/stable/orms.html#factory.alchemy.SQLAlchemyOptions.sqlalchemy_get_or_create)
- Cette PR active par défaut les Providers Titelive, on va désactiver dans une autre PR les [tâches programmées Titelive en testing](https://github.com/pass-culture/pass-culture-deployment/blob/a77a47051853e0811d4a8953ddeb37a037b34e52/helm/pcapi/values.testing.yaml#L409) ?