### PR TITLE
(BSR)[API] fix: LoginBoost.code is Optional

### DIFF
--- a/api/src/pcapi/connectors/serialization/boost_serializers.py
+++ b/api/src/pcapi/connectors/serialization/boost_serializers.py
@@ -10,7 +10,7 @@ BOOST_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
 
 class LoginBoost(BaseModel):
-    code: int
+    code: int | None
     message: str
     token: str | None
 

--- a/api/tests/connectors/api_boost_test.py
+++ b/api/tests/connectors/api_boost_test.py
@@ -25,7 +25,7 @@ class BoostBuildUrlTest:
 class BoostLoginTest:
     def test_login(self, requests_mock):
         cinema_details = providers_factories.BoostCinemaDetailsFactory(cinemaUrl="https://cinema.example.com/")
-        response_json = {"code": 200, "message": "Login successful", "token": "new-token"}
+        response_json = {"message": "Login successful", "token": "new-token"}
         requests_mock.post("https://cinema.example.com/api/vendors/login", json=response_json)
 
         token = boost.login(cinema_details)


### PR DESCRIPTION
## But de la pull request

- Corriger le modèle Pydantic `LoginBoost`, car `code` est optionnel.