### PR TITLE
(PC-18116)[API] fix: set filter type to string

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -1,3 +1,4 @@
+import json
 import typing
 import urllib
 
@@ -309,7 +310,10 @@ def _get_offerer_status(offerer: offerers_models.Offerer) -> str:
 def list_offerers_to_be_validated(
     query: serialization.OffererToBeValidatedQuery,
 ) -> serialization.ListOffererToBeValidatedResponseModel:
-    offerers = offerers_api.list_offerers_to_be_validated([dict(f) for f in query.filter])
+    filters = []
+    if query.filter:
+        filters = json.loads(urllib.parse.unquote_plus(query.filter))
+    offerers = offerers_api.list_offerers_to_be_validated(filters)
 
     sorts = urllib.parse.unquote_plus(query.sort or "[]")
     try:

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -1,6 +1,5 @@
 import datetime
 import typing
-import urllib
 
 import pydantic
 
@@ -77,10 +76,7 @@ class PaginableQuery(BaseModel):
 
 
 class FilterableQuery(BaseModel):
-    filter: pydantic.Json[list[dict]] = []  # pylint: disable=unsubscriptable-object
-
-    def validate_filter(self, value: str) -> str:
-        return urllib.parse.unquote_plus(value)
+    filter: str | None = None
 
 
 class OffererToBeValidatedQuery(PaginableQuery, FilterableQuery):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18116

## But de la pull request

passage à `string` du type du paramètre de filtrage pour la liste des structures à valider

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
