### PR TITLE
(PC-18010)[PRO] fix: Offers column size for buttons

### DIFF
--- a/pro/src/components/pages/Offers/Offers/OfferItem/OfferItem.module.scss
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/OfferItem.module.scss
@@ -38,13 +38,13 @@
   margin-bottom: rem.torem(8px);
 }
 
-.edit-column,
-.draft-column {
+.edit-column {
   width: rem.torem(40px);
 }
 
-.switch-column {
-  width: rem.torem(96px);
+.switch-column,
+.draft-column {
+  width: rem.torem(136px);
 }
 
 .stock-column,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18010

## But de la pull request

_Mettre la même longueur à la colonne avec le bouton brouillon qu'avec le bouton stock (pour qu'elle ne change pas de taille)

![image](https://user-images.githubusercontent.com/15941528/197168042-46d849c7-14cb-4424-b2d5-ff081e78d4ec.png)

