### PR TITLE
(PC-17993)[PRO] fix: redirect user to login page when not connected

### DIFF
--- a/pro/src/app/App/App.tsx
+++ b/pro/src/app/App/App.tsx
@@ -1,7 +1,7 @@
 import { setUser as setSentryUser } from '@sentry/browser'
 import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { useLocation, useHistory } from 'react-router-dom'
+import { useLocation, Redirect } from 'react-router-dom'
 
 import { useConfigureAnalytics } from 'hooks/useAnalytics'
 import useCurrentUser from 'hooks/useCurrentUser'
@@ -16,7 +16,6 @@ interface IAppProps {
 const App = ({ children }: IAppProps): JSX.Element | null => {
   const { currentUser } = useCurrentUser()
   const location = useLocation()
-  const history = useHistory()
   const isMaintenanceActivated = useSelector(maintenanceSelector)
   const [isRoutePublic, fromUrl] = useIsRoutePublic()
 
@@ -26,16 +25,14 @@ const App = ({ children }: IAppProps): JSX.Element | null => {
     window.scrollTo(0, 0)
   }, [location.pathname])
 
-  useEffect(() => {
-    if (currentUser !== null) {
-      setSentryUser({ id: currentUser.id })
-    } else if (!isRoutePublic) {
-      const loginUrl = fromUrl.includes('logout')
-        ? '/connexion'
-        : `/connexion?de=${fromUrl}`
-      history.push(loginUrl)
-    }
-  }, [currentUser, isRoutePublic])
+  if (currentUser !== null) {
+    setSentryUser({ id: currentUser.id })
+  } else if (!isRoutePublic) {
+    const loginUrl = fromUrl.includes('logout')
+      ? '/connexion'
+      : `/connexion?de=${fromUrl}`
+    return <Redirect to={loginUrl} />
+  }
 
   if (isMaintenanceActivated) {
     return <RedirectToMaintenance />

--- a/pro/src/app/__specs__/App.spec.jsx
+++ b/pro/src/app/__specs__/App.spec.jsx
@@ -11,6 +11,8 @@ import { URL_FOR_MAINTENANCE } from 'utils/config'
 
 import { App } from '../App'
 
+jest.mock('hooks/useAnalytics')
+
 const renderApp = ({ props, store: storeOverride, initialEntries = '/' }) => {
   const store = configureTestStore(storeOverride)
   return render(
@@ -82,7 +84,7 @@ describe('src | App', () => {
       expect(setHrefSpy).toHaveBeenCalledWith(URL_FOR_MAINTENANCE)
     })
   })
-  it('should render a Redirect component when route is private and user not logged in', async () => {
+  it('should render a Redirect component when route is private and user not logged in', () => {
     store = {
       ...store,
       user: { initialized: false, currentUser: null },
@@ -91,7 +93,7 @@ describe('src | App', () => {
 
     expect(screen.getByText('Sub component')).toBeInTheDocument()
   })
-  it('should render a Redirect component when loging out', async () => {
+  it('should render a Redirect component when loging out', () => {
     store = {
       ...store,
       user: { initialized: false, currentUser: null },

--- a/pro/src/utils/config.js
+++ b/pro/src/utils/config.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 const NODE_ENV = process.env.NODE_ENV || 'development'
 // NOTE -> le script PC remplace
 // la valeur de `LAST_DEPLOYED_COMMIT`


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17993

## But de la pull request

Rediriger l'utilisateur vers /login quand il se logout ou qu'il arrive sur une page privée non connecté

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
