### PR TITLE
(PC-18139)[API] feat: backoffice: search offerers to validate by SIREN or name

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -36,6 +36,7 @@ import pcapi.routes.serialization.base as serialize_base
 from pcapi.utils import crypto
 from pcapi.utils import human_ids
 from pcapi.utils import image_conversion
+from pcapi.utils.clean_accents import clean_accents
 import pcapi.utils.db as db_utils
 import pcapi.utils.email as email_utils
 
@@ -1306,12 +1307,22 @@ def get_offerers_stats() -> dict[offerers_models.ValidationStatus, int]:
     return dict(stats)
 
 
-def list_offerers_to_be_validated(filter_: list[dict[str, typing.Any]]) -> sa.orm.Query:
+def list_offerers_to_be_validated(search_query: str | None, filter_: list[dict[str, typing.Any]]) -> sa.orm.Query:
     query = offerers_models.Offerer.query.options(
         sa.orm.joinedload(offerers_models.Offerer.UserOfferers).joinedload(offerers_models.UserOfferer.user),
         sa.orm.joinedload(offerers_models.Offerer.tags),
         sa.orm.joinedload(offerers_models.Offerer.action_history),
     )
+
+    if search_query:
+        if search_query.isnumeric():
+            if len(search_query) != 9:
+                raise exceptions.InvalidSiren("Le SIREN doit faire 9 caractères")
+            query = query.filter(offerers_models.Offerer.siren == search_query)
+        else:
+            name = search_query.replace(" ", "%").replace("-", "%")
+            name = clean_accents(name)
+            query = query.filter(sa.func.unaccent(offerers_models.Offerer.name).ilike(f"%{name}%"))
 
     filter_dict = {f["field"]: f["value"] for f in filter_}
 

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -69,6 +69,10 @@ class UserOffererAlreadyValidatedException(Exception):
     pass
 
 
+class InvalidSiren(Exception):
+    pass
+
+
 class CannotDeleteOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -327,7 +327,7 @@ def list_offerers_to_be_validated(
     filters = []
     if query.filter:
         filters = json.loads(urllib.parse.unquote_plus(query.filter))
-    offerers = offerers_api.list_offerers_to_be_validated(filters)
+    offerers = offerers_api.list_offerers_to_be_validated(query.q, filters)
 
     sorts = urllib.parse.unquote_plus(query.sort or "[]")
     try:

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -80,7 +80,7 @@ class FilterableQuery(BaseModel):
 
 
 class OffererToBeValidatedQuery(PaginableQuery, FilterableQuery):
-    pass
+    q: str | None
 
 
 class SearchQuery(PaginableQuery):

--- a/api/tests/routes/backoffice/fixtures.py
+++ b/api/tests/routes/backoffice/fixtures.py
@@ -328,17 +328,17 @@ def offerer_tags():
 def offerers_to_be_validated(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
-    no_tag = offerers_factories.NotValidatedOffererFactory(name="A", address=None)
+    no_tag = offerers_factories.NotValidatedOffererFactory(name="A", siren="123001001", address=None)
     top = offerers_factories.NotValidatedOffererFactory(
-        name="B", validationStatus=offerers_models.ValidationStatus.PENDING
+        name="B", siren="123002002", validationStatus=offerers_models.ValidationStatus.PENDING
     )
-    collec = offerers_factories.NotValidatedOffererFactory(name="C")
+    collec = offerers_factories.NotValidatedOffererFactory(name="C", siren="123003003")
     public = offerers_factories.NotValidatedOffererFactory(
-        name="D", validationStatus=offerers_models.ValidationStatus.PENDING
+        name="D", siren="123004004", validationStatus=offerers_models.ValidationStatus.PENDING
     )
-    top_collec = offerers_factories.NotValidatedOffererFactory(name="E")
+    top_collec = offerers_factories.NotValidatedOffererFactory(name="E", siren="123005005")
     top_public = offerers_factories.NotValidatedOffererFactory(
-        name="F", validationStatus=offerers_models.ValidationStatus.PENDING
+        name="F", siren="123006006", validationStatus=offerers_models.ValidationStatus.PENDING
     )
 
     for offerer in (top, top_collec, top_public):


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18139

## But de la pull request

Permettre une recherche par SIREN ou nom sur l'écran de validation de structure 

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
