### PR TITLE
Pc 17480 add offer type filter for collective offers

### DIFF
--- a/api/src/pcapi/core/offers/serialize.py
+++ b/api/src/pcapi/core/offers/serialize.py
@@ -1,2 +1,10 @@
+import enum
+
+
 def serialize_offer_type_educational_or_individual(offer_is_educational: bool) -> str:
     return "offre collective" if offer_is_educational else "offre grand public"
+
+
+class CollectiveOfferType(enum.Enum):
+    offer = "offer"
+    template = "template"

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -12,6 +12,7 @@ from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers.models import Venue
 import pcapi.core.offers.models as offers_models
+from pcapi.core.offers.serialize import CollectiveOfferType
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
 from pcapi.routes.serialization import BaseModel
@@ -29,11 +30,6 @@ from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 T_GetCollectiveOfferBaseResponseModel = typing.TypeVar(
     "T_GetCollectiveOfferBaseResponseModel", bound="GetCollectiveOfferBaseResponseModel"
 )
-
-
-class CollectiveOfferType(enum.Enum):
-    offer = "offer"
-    template = "template"
 
 
 class ListCollectiveOffersQueryModel(BaseModel):

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -12,6 +12,7 @@ from pcapi.core.categories.conf import can_create_from_isbn
 from pcapi.core.categories.subcategories import SubcategoryIdEnum
 from pcapi.core.offers import models as offers_models
 from pcapi.core.offers import repository as offers_repository
+from pcapi.core.offers.serialize import CollectiveOfferType
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.routes.native.v1.serialization.common_models import AccessibilityComplianceMixin
@@ -258,6 +259,7 @@ class ListOffersQueryModel(BaseModel):
     creation_mode: str | None
     period_beginning_date: str | None
     period_ending_date: str | None
+    collective_offer_type: CollectiveOfferType | None
 
     _dehumanize_venue_id = dehumanize_field("venue_id")
     _dehumanize_offerer_id = dehumanize_field("offerer_id")

--- a/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ListOffersQueryModel.ts
@@ -2,8 +2,11 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { CollectiveOfferType } from './CollectiveOfferType';
+
 export type ListOffersQueryModel = {
   categoryId?: string | null;
+  collectiveOfferType?: CollectiveOfferType | null;
   creationMode?: string | null;
   nameOrIsbn?: string | null;
   offererId?: number | null;

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1030,6 +1030,7 @@ export class DefaultService {
    * @param creationMode
    * @param periodBeginningDate
    * @param periodEndingDate
+   * @param collectiveOfferType
    * @returns ListOffersResponseModel OK
    * @throws ApiError
    */
@@ -1042,6 +1043,7 @@ export class DefaultService {
     creationMode?: string | null,
     periodBeginningDate?: string | null,
     periodEndingDate?: string | null,
+    collectiveOfferType?: CollectiveOfferType | null,
   ): CancelablePromise<ListOffersResponseModel> {
     return this.httpRequest.request({
       method: 'GET',
@@ -1055,6 +1057,7 @@ export class DefaultService {
         'creationMode': creationMode,
         'periodBeginningDate': periodBeginningDate,
         'periodEndingDate': periodEndingDate,
+        'collectiveOfferType': collectiveOfferType,
       },
       errors: {
         403: `Forbidden`,

--- a/pro/src/components/pages/Offers/Offers/Offers.scss
+++ b/pro/src/components/pages/Offers/Offers/Offers.scss
@@ -82,6 +82,7 @@
     }
   }
 
+  // Remove when WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE is removed cause style will be the same for individual and collective filters
   .collective-form-row {
     display: flex;
     flex-direction: row;

--- a/pro/src/core/Offers/constants.ts
+++ b/pro/src/core/Offers/constants.ts
@@ -47,6 +47,7 @@ export const ALL_OFFERERS = 'all'
 export const ALL_CATEGORIES = 'all'
 export const ALL_STATUS = 'all'
 export const ALL_CREATION_MODES = 'all'
+export const ALL_COLLECTIVE_OFFER_TYPE = 'all'
 export const ALL_EVENT_PERIODS = ''
 export const DEFAULT_PAGE = 1
 export const NUMBER_OF_OFFERS_PER_PAGE = 10
@@ -60,6 +61,7 @@ export const DEFAULT_SEARCH_FILTERS: TSearchFilters = {
   categoryId: ALL_CATEGORIES,
   status: ALL_STATUS,
   creationMode: ALL_CREATION_MODES,
+  collectiveOfferType: ALL_COLLECTIVE_OFFER_TYPE,
   periodBeginningDate: ALL_EVENT_PERIODS,
   periodEndingDate: ALL_EVENT_PERIODS,
 }
@@ -77,8 +79,19 @@ const CREATION_MODES_OPTIONS = [
   { displayName: 'Manuelle', id: 'manual' },
   { displayName: 'Importée', id: 'imported' },
 ]
+const COLLECTIVE_OFFER_TYPES_OPTIONS = [
+  { displayName: 'Tout', id: ALL_CREATION_MODES },
+  { displayName: 'Offre vitrine', id: 'template' },
+  { displayName: 'Offre réservable', id: 'offer' },
+]
+
 export const [DEFAULT_CREATION_MODE, ...CREATION_MODES_FILTERS] =
   CREATION_MODES_OPTIONS
+
+export const [
+  DEFAULT_COLLECTIVE_OFFER_TYPE,
+  ...COLLECTIVE_OFFER_TYPES_FILTERS
+] = COLLECTIVE_OFFER_TYPES_OPTIONS
 export const ADMINS_DISABLED_FILTERS_MESSAGE =
   'Sélectionnez une structure et/ou un lieu pour activer les filtres'
 

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -14,6 +14,7 @@ export type TSearchFilters = {
   categoryId: string
   status: string
   creationMode: string
+  collectiveOfferType: string
   periodBeginningDate: string
   periodEndingDate: string
 }

--- a/pro/src/routes/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/routes/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -189,6 +189,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -266,6 +267,7 @@ describe('route CollectiveOffers', () => {
               undefined,
               undefined,
               undefined,
+              undefined,
               undefined
             )
           })
@@ -298,6 +300,7 @@ describe('route CollectiveOffers', () => {
               undefined,
               undefined,
               undefined,
+              undefined,
               undefined
             )
           })
@@ -322,6 +325,7 @@ describe('route CollectiveOffers', () => {
             )
             expect(statusFiltersIcon.closest('button')).toBeDisabled()
             expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -359,6 +363,7 @@ describe('route CollectiveOffers', () => {
               undefined,
               'INACTIVE',
               venueId,
+              undefined,
               undefined,
               undefined,
               undefined,
@@ -411,6 +416,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -431,6 +437,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             proVenues[0].id,
+            undefined,
             undefined,
             undefined,
             undefined,
@@ -459,6 +466,7 @@ describe('route CollectiveOffers', () => {
             'CINEMA',
             undefined,
             undefined,
+            undefined,
             undefined
           )
         })
@@ -483,6 +491,7 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             '2020-12-25T00:00:00Z',
+            undefined,
             undefined
           )
         })
@@ -507,7 +516,28 @@ describe('route CollectiveOffers', () => {
             undefined,
             undefined,
             undefined,
-            '2020-12-27T23:59:59Z'
+            '2020-12-27T23:59:59Z',
+            undefined
+          )
+        })
+        it('should load offers with selected offer type', async () => {
+          // Given
+          await renderOffers(store)
+          const offerTypeSelect = screen.getByLabelText("Type de l'offre")
+          await userEvent.selectOptions(offerTypeSelect, 'template')
+          // When
+          await userEvent.click(screen.getByText('Lancer la recherche'))
+          // Then
+          expect(api.getCollectiveOffers).toHaveBeenLastCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'template'
           )
         })
       })
@@ -563,6 +593,7 @@ describe('route CollectiveOffers', () => {
       // Then
       expect(api.getCollectiveOffers).toHaveBeenCalledWith(
         'search string',
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -766,6 +797,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
     })
@@ -898,6 +930,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -913,6 +946,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -923,6 +957,7 @@ describe('route CollectiveOffers', () => {
       expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         3,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -963,6 +998,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -977,6 +1013,7 @@ describe('route CollectiveOffers', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         undefined
       )
 
@@ -984,6 +1021,7 @@ describe('route CollectiveOffers', () => {
       expect(api.getCollectiveOffers).toHaveBeenCalledTimes(3)
       expect(api.getCollectiveOffers).toHaveBeenNthCalledWith(
         3,
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/pro/src/routes/CollectiveOffers/adapters/getFilteredCollectiveOffersAdapter.ts
+++ b/pro/src/routes/CollectiveOffers/adapters/getFilteredCollectiveOffersAdapter.ts
@@ -35,6 +35,7 @@ export const getFilteredCollectiveOffersAdapter: GetFilteredCollectiveOffersAdap
         creationMode,
         periodBeginningDate,
         periodEndingDate,
+        collectiveOfferType,
       } = serializeApiFilters(apiFilters)
 
       const offers = await api.getCollectiveOffers(
@@ -45,7 +46,8 @@ export const getFilteredCollectiveOffersAdapter: GetFilteredCollectiveOffersAdap
         categoryId,
         creationMode,
         periodBeginningDate,
-        periodEndingDate
+        periodEndingDate,
+        collectiveOfferType
       )
 
       return {

--- a/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
@@ -9,13 +9,16 @@ import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import {
   ALL_CATEGORIES_OPTION,
   ALL_VENUES_OPTION,
+  COLLECTIVE_OFFER_TYPES_FILTERS,
   CREATION_MODES_FILTERS,
+  DEFAULT_COLLECTIVE_OFFER_TYPE,
   DEFAULT_CREATION_MODE,
   DEFAULT_SEARCH_FILTERS,
 } from 'core/Offers/constants'
 import { Offerer, Option, TSearchFilters } from 'core/Offers/types'
 import { hasSearchFilters } from 'core/Offers/utils'
 import { Audience } from 'core/shared'
+import useActiveFeature from 'hooks/useActiveFeature'
 import { ReactComponent as ResetIcon } from 'icons/reset.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -94,6 +97,13 @@ const SearchFilters = ({
     [updateSearchFilters]
   )
 
+  const storeCollectiveOfferType = useCallback(
+    (event: FormEvent<HTMLSelectElement>) => {
+      updateSearchFilters({ collectiveOfferType: event.currentTarget.value })
+    },
+    [updateSearchFilters]
+  )
+
   const changePeriodBeginningDateValue = useCallback(
     (periodBeginningDate: Date) => {
       const dateToFilter = periodBeginningDate
@@ -133,6 +143,11 @@ const SearchFilters = ({
   const resetFilterButtonProps = !hasSearchFilters(selectedFilters)
     ? { 'aria-current': 'page', isDisabled: true }
     : {}
+
+  const isCollectiveOfferDuplicationActive = useActiveFeature(
+    'WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE'
+  )
+
   return (
     <>
       {offerer && (
@@ -154,7 +169,8 @@ const SearchFilters = ({
         />
         <div
           className={
-            audience === Audience.INDIVIDUAL
+            audience === Audience.INDIVIDUAL ||
+            isCollectiveOfferDuplicationActive
               ? 'form-row'
               : 'collective-form-row'
           }
@@ -188,6 +204,18 @@ const SearchFilters = ({
               selectedValue={selectedFilters.creationMode}
             />
           )}
+          {audience === Audience.COLLECTIVE &&
+            isCollectiveOfferDuplicationActive && (
+              <Select
+                defaultOption={DEFAULT_COLLECTIVE_OFFER_TYPE}
+                handleSelection={storeCollectiveOfferType}
+                isDisabled={disableAllFilters}
+                label="Type de l'offre"
+                name="collectiveOfferType"
+                options={COLLECTIVE_OFFER_TYPES_FILTERS}
+                selectedValue={selectedFilters.collectiveOfferType}
+              />
+            )}
           <PeriodSelector
             changePeriodBeginningDateValue={changePeriodBeginningDateValue}
             changePeriodEndingDateValue={changePeriodEndingDateValue}

--- a/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
+++ b/pro/src/screens/Offers/SearchFilters/SearchFilters.tsx
@@ -66,33 +66,29 @@ const SearchFilters = ({
   )
 
   const storeNameOrIsbnSearchValue = useCallback(
-    (event: Event) => {
-      const target = event.target as HTMLSelectElement
-      updateSearchFilters({ nameOrIsbn: target.value })
+    (event: FormEvent<HTMLSelectElement>) => {
+      updateSearchFilters({ nameOrIsbn: event.currentTarget.value })
     },
     [updateSearchFilters]
   )
 
   const storeSelectedVenue = useCallback(
-    (event: Event) => {
-      const target = event.target as HTMLSelectElement
-      updateSearchFilters({ venueId: target.value })
+    (event: FormEvent<HTMLSelectElement>) => {
+      updateSearchFilters({ venueId: event.currentTarget.value })
     },
     [updateSearchFilters]
   )
 
   const storeSelectedCategory = useCallback(
-    (event: Event) => {
-      const target = event.target as HTMLSelectElement
-      updateSearchFilters({ categoryId: target.value })
+    (event: FormEvent<HTMLSelectElement>) => {
+      updateSearchFilters({ categoryId: event.currentTarget.value })
     },
     [updateSearchFilters]
   )
 
   const storeCreationMode = useCallback(
-    (event: Event) => {
-      const target = event.target as HTMLSelectElement
-      updateSearchFilters({ creationMode: target.value })
+    (event: FormEvent<HTMLSelectElement>) => {
+      updateSearchFilters({ creationMode: event.currentTarget.value })
     },
     [updateSearchFilters]
   )

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -16,6 +16,7 @@ import {
   ALL_STATUS,
   ALL_VENUES,
   ALL_VENUES_OPTION,
+  DEFAULT_COLLECTIVE_OFFER_TYPE,
   DEFAULT_CREATION_MODE,
   DEFAULT_SEARCH_FILTERS,
 } from 'core/Offers/constants'
@@ -148,6 +149,7 @@ describe('screen Offers', () => {
         creationMode: DEFAULT_CREATION_MODE.id,
         periodBeginningDate: ALL_EVENT_PERIODS,
         periodEndingDate: ALL_EVENT_PERIODS,
+        collectiveOfferType: DEFAULT_COLLECTIVE_OFFER_TYPE.id,
       })
     })
 
@@ -643,6 +645,7 @@ describe('screen Offers', () => {
         creationMode: DEFAULT_SEARCH_FILTERS.creationMode,
         periodBeginningDate: DEFAULT_SEARCH_FILTERS.periodBeginningDate,
         periodEndingDate: DEFAULT_SEARCH_FILTERS.periodEndingDate,
+        collectiveOfferType: DEFAULT_COLLECTIVE_OFFER_TYPE.id,
       })
     })
   })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17480

## But de la pull request

Ajouter un filtre permettant de filtrer les offres affichées entre 'offre vitrine' ou 'offre réservable'

Page : Offres > Offres collectives 
FF : WIP_CREATE_COLLECTIVE_OFFER_FROM_TEMPLATE

## Screenshot 

![Capture d’écran 2022-10-24 à 14 40 47](https://user-images.githubusercontent.com/71768799/197527702-111ef8b1-607f-4c22-9dc1-f72592beee18.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
