### PR TITLE
(PC-18140)[API] feat: backoffice: get offerers stats

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1286,6 +1286,19 @@ def get_venue_offers_stats(venue_id: int) -> sa.engine.Row:
     return db.session.execute(offers_stats_query).one_or_none()
 
 
+def get_offerers_stats() -> dict[offerers_models.ValidationStatus, int]:
+    stats = (
+        offerers_models.Offerer.query.with_entities(
+            offerers_models.Offerer.validationStatus,
+            sa.func.count(offerers_models.Offerer.validationStatus).label("count"),
+        )
+        .group_by(offerers_models.Offerer.validationStatus)
+        .all()
+    )
+
+    return dict(stats)
+
+
 def list_offerers_to_be_validated(filter_: list[dict[str, typing.Any]]) -> sa.orm.Query:
     query = offerers_models.Offerer.query.filter(offerers_models.Offerer.isWaitingForValidation).options(
         sa.orm.joinedload(offerers_models.Offerer.UserOfferers).joinedload(offerers_models.UserOfferer.user),

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -281,6 +281,17 @@ def remove_tag_from_offerer(offerer_id: int, tag_name: str) -> None:
     repository.delete(mapping_to_delete)
 
 
+@blueprint.backoffice_blueprint.route("offerers/stats", methods=["GET"])
+@spectree_serialize(response_model=serialization.OfferersStatsResponseModel, on_success_status=200, api=blueprint.api)
+@perm_utils.permission_required(perm_models.Permissions.VALIDATE_OFFERER)
+def get_offerers_stats() -> serialization.OfferersStatsResponseModel:
+    stats = offerers_api.get_offerers_stats()
+
+    return serialization.OfferersStatsResponseModel(
+        data={status.name: stats.get(status, 0) for status in offerers_models.ValidationStatus}
+    )
+
+
 def _get_serialized_offerer_last_comment(offerer: offerers_models.Offerer) -> serialization.Comment | None:
     if offerer.action_history:
         actions_with_comment = list(filter(lambda a: bool(a.comment), offerer.action_history))

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -405,6 +405,10 @@ class Comment(BaseModel):
     content: str
 
 
+class OfferersStatsResponseModel(BaseModel):
+    data: dict[str, int]  # keys are validationStatus names
+
+
 class OffererToBeValidated(BaseModel):
     id: int
     name: str

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -101,7 +101,9 @@ class GetOffererUsersTest:
     def test_cannot_get_offerer_users_without_permission(self, client):
         # given
         offerer1 = offerers_factories.OffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.READ_PRO_ENTITY]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).get(
@@ -265,7 +267,7 @@ class GetOffererBasicInfoTest:
     def test_cannot_get_offerer_without_permission(self, client):
         # given
         user = users_factories.UserFactory()
-        auth_token = generate_token(user, [])
+        auth_token = generate_token(user, [perm for perm in Permissions if perm != Permissions.READ_PRO_ENTITY])
 
         # when
         response = client.with_explicit_token(auth_token).get(
@@ -395,7 +397,7 @@ class GetOffererTotalRevenueTest:
     def test_cannot_get_offerer_without_permission(self, client):
         # given
         user = users_factories.UserFactory()
-        auth_token = generate_token(user, [])
+        auth_token = generate_token(user, [perm for perm in Permissions if perm != Permissions.READ_PRO_ENTITY])
 
         # when
         response = client.with_explicit_token(auth_token).get(
@@ -552,7 +554,7 @@ class GetOffererOffersStatsTest:
     def test_cannot_get_offerer_offers_stats_without_permission(self, client):
         # given
         user = users_factories.UserFactory()
-        auth_token = generate_token(user, [])
+        auth_token = generate_token(user, [perm for perm in Permissions if perm != Permissions.READ_PRO_ENTITY])
 
         # when
         response = client.with_explicit_token(auth_token).get(
@@ -718,7 +720,7 @@ class GetOffererHistoryTest:
     def test_cannot_get_offerer_history_without_permission(self, client, offerer):
         # given
         user = users_factories.UserFactory()
-        auth_token = generate_token(user, [])
+        auth_token = generate_token(user, [perm for perm in Permissions if perm != Permissions.READ_PRO_ENTITY])
 
         # when
         response = client.with_explicit_token(auth_token).get(
@@ -799,7 +801,9 @@ class ValidateOffererTest:
     def test_cannot_validate_offerer_without_permission(self, client):
         # given
         user_offerer = offerers_factories.UserNotValidatedOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -893,7 +897,9 @@ class RejectOffererTest:
     def test_cannot_reject_offerer_without_permission(self, client):
         # given
         user_offerer = offerers_factories.UserNotValidatedOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -957,7 +963,9 @@ class SetOffererPendingTest:
     def test_cannot_set_offerer_pending_without_permission(self, client):
         # given
         offerer = offerers_factories.NotValidatedOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1015,7 +1023,9 @@ class CommentOffererTest:
     def test_cannot_comment_offerer_without_permission(self, client):
         # given
         offerer = offerers_factories.NotValidatedOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1078,7 +1088,9 @@ class GetOfferersTagsTest:
     def test_cannot_get_offerers_tags_list_without_permission(self, client):
         # given
         offerers_factories.OffererTagFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.MANAGE_PRO_ENTITY]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).get(url_for("backoffice_blueprint.get_offerers_tags_list"))
@@ -1143,7 +1155,9 @@ class AddOffererTagTest:
         # given
         offerer = offerers_factories.OffererFactory()
         tag = offerers_factories.OffererTagFactory(name="test-tag", label="Test Tag")
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.MANAGE_PRO_ENTITY]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1259,7 +1273,9 @@ class RemoveOffererTagTest:
         offerer = offerers_factories.OffererFactory()
         tag = offerers_factories.OffererTagFactory(name="test-tag", label="Test Tag")
         mapping = offerers_factories.OffererTagMappingFactory(offererId=offerer.id, tagId=tag.id)
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.MANAGE_PRO_ENTITY]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).delete(
@@ -1597,7 +1613,7 @@ class ListOfferersToBeValidatedTest:
     def test_cannot_list_without_permission(self, client):
         # given
         user = users_factories.UserFactory()
-        auth_token = generate_token(user, [])
+        auth_token = generate_token(user, [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER])
 
         # when
         response = client.with_explicit_token(auth_token).get(
@@ -1737,7 +1753,9 @@ class ValidateOffererAttachmentTest:
     def test_cannot_validate_offerer_attachment_without_permission(self, client):
         # given
         user_offerer = offerers_factories.NotValidatedUserOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1811,7 +1829,9 @@ class RejectOffererAttachmentTest:
     def test_cannot_reject_offerer_attachment_without_permission(self, client):
         # given
         user_offerer = offerers_factories.UserNotValidatedOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1875,7 +1895,9 @@ class SetOffererAttachmentPendingTest:
     def test_cannot_set_offerer_pending_without_permission(self, client):
         # given
         user_offerer = offerers_factories.NotValidatedUserOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1935,7 +1957,9 @@ class CommentOffererAttachmentTest:
     def test_cannot_comment_offerer_attachment_without_permission(self, client):
         # given
         user_offerer = offerers_factories.NotValidatedUserOffererFactory()
-        auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
+        auth_token = generate_token(
+            users_factories.UserFactory(), [perm for perm in Permissions if perm != Permissions.VALIDATE_OFFERER]
+        )
 
         # when
         response = client.with_explicit_token(auth_token).post(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18140

## But de la pull request

Fournir au frontend du backoffice un endpoint pour récupérer le nombre de structures réparties par état (nouvelle, en attente, validée, rejetée).

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
