### PR TITLE
(PC-18120)[API] feat: FF: remove APP_ENABLE_COOKIES_V2

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 2e171418aa71 (pre) (head)
-2a2df641b70d (post) (head)
+3b199dcfba04 (post) (head)

--- a/api/src/pcapi/alembic/versions/20221227T083920_3b199dcfba04_remove_app_enable_cookies_v2_feature_flag.py
+++ b/api/src/pcapi/alembic/versions/20221227T083920_3b199dcfba04_remove_app_enable_cookies_v2_feature_flag.py
@@ -1,0 +1,35 @@
+"""
+Remove legacy APP_ENABLE_COOKIES_V2 feature flag
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "3b199dcfba04"
+down_revision = "2a2df641b70d"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="APP_ENABLE_COOKIES_V2",
+        isActive=False,
+        description="Activer la gestion conforme des cookies",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -106,7 +106,6 @@ class FeatureToggle(enum.Enum):
     )
     # FIXME (dbaty, 2022-09-21): remove USE_INSEE_SIRENE_API once v207 is deployed.
     USE_INSEE_SIRENE_API = "Utiliser la nouvelle API Sirene de l'Insee"
-    APP_ENABLE_COOKIES_V2 = "Activer la gestion conforme des cookies"
     VENUE_FORM_V2 = "Afficher la version 2 du formulaire de lieu"
     ENABLE_ZENDESK_SELL_CREATION = "Activer la création de nouvelles entrées dans Zendesk Sell (structures et lieux)"
     ENABLE_BOOST_API_INTEGRATION = "Active la réservation de places de cinéma via l'API Boost"
@@ -171,7 +170,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.PRO_DISABLE_EVENTS_QRCODE,
     FeatureToggle.USER_PROFILING_FRAUD_CHECK,
     FeatureToggle.ENABLE_EAC_FINANCIAL_PROTECTION,
-    FeatureToggle.APP_ENABLE_COOKIES_V2,
     FeatureToggle.VENUE_FORM_V2,
     FeatureToggle.ENABLE_ZENDESK_SELL_CREATION,
     FeatureToggle.ENABLE_BOOST_API_INTEGRATION,

--- a/api/src/pcapi/routes/native/v1/serialization/settings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/settings.py
@@ -25,7 +25,6 @@ class SettingsResponse(BaseModel):
     object_storage_url: str
     pro_disable_events_qrcode: bool
     account_unsuspension_limit: int
-    app_enable_cookies_v2: bool
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -31,7 +31,6 @@ def get_settings() -> serializers.SettingsResponse:
         FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
         FeatureToggle.PRO_DISABLE_EVENTS_QRCODE,
         FeatureToggle.APP_ENABLE_AUTOCOMPLETE,
-        FeatureToggle.APP_ENABLE_COOKIES_V2,
     )
 
     return serializers.SettingsResponse(
@@ -48,5 +47,4 @@ def get_settings() -> serializers.SettingsResponse:
         object_storage_url=OBJECT_STORAGE_URL,
         pro_disable_events_qrcode=features[FeatureToggle.PRO_DISABLE_EVENTS_QRCODE],
         account_unsuspension_limit=constants.ACCOUNT_UNSUSPENSION_DELAY,
-        app_enable_cookies_v2=features[FeatureToggle.APP_ENABLE_COOKIES_V2],
     )

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1163,7 +1163,6 @@ def test_public_api(client):
                         "accountCreationMinimumAge": {"title": "Accountcreationminimumage", "type": "integer"},
                         "accountUnsuspensionLimit": {"title": "Accountunsuspensionlimit", "type": "integer"},
                         "appEnableAutocomplete": {"title": "Appenableautocomplete", "type": "boolean"},
-                        "appEnableCookiesV2": {"title": "Appenablecookiesv2", "type": "boolean"},
                         "depositAmountsByAge": {
                             "allOf": [{"$ref": "#/components/schemas/DepositAmountsByAge"}],
                             "default": {"age_15": 2000, "age_16": 3000, "age_17": 3000, "age_18": 30000},
@@ -1195,7 +1194,6 @@ def test_public_api(client):
                         "objectStorageUrl",
                         "proDisableEventsQrcode",
                         "accountUnsuspensionLimit",
-                        "appEnableCookiesV2",
                     ],
                     "title": "SettingsResponse",
                     "type": "object",

--- a/api/tests/routes/native/v1/settings_test.py
+++ b/api/tests/routes/native/v1/settings_test.py
@@ -37,7 +37,6 @@ class SettingsTest:
             "objectStorageUrl": "http://localhost/storage",
             "proDisableEventsQrcode": False,
             "accountUnsuspensionLimit": 60,
-            "appEnableCookiesV2": False,
         }
 
     @override_features(
@@ -50,7 +49,6 @@ class SettingsTest:
         ID_CHECK_ADDRESS_AUTOCOMPLETION=False,
         PRO_DISABLE_EVENTS_QRCODE=True,
         APP_ENABLE_AUTOCOMPLETE=False,
-        APP_ENABLE_COOKIES_V2=True,
     )
     def test_get_settings_feature_combination_2(self, app):
         response = TestClient(app.test_client()).get("/native/v1/settings")
@@ -69,5 +67,4 @@ class SettingsTest:
             "objectStorageUrl": "http://localhost/storage",
             "proDisableEventsQrcode": True,
             "accountUnsuspensionLimit": 60,
-            "appEnableCookiesV2": True,
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18120

## But de la pull request

Suppression du FF APP_ENABLE_COOKIES_V2

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
