### PR TITLE
(PC-17880)[API] feat: add user status in `/native/v1/me`

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -601,8 +601,8 @@ def get_suspended_upon_user_request_accounts_since(expiration_delta_in_days: int
         user_ids_and_latest_events, users_models.User.id == user_ids_and_latest_events.c.id
     ).filter(
         user_ids_and_latest_events.c.eventDate <= start,
-        user_ids_and_latest_events.c.eventType == users_models.SuspensionEventType.SUSPENDED,
-        user_ids_and_latest_events.c.reasonCode == users_models.SuspensionReason.UPON_USER_REQUEST,
+        user_ids_and_latest_events.c.eventType == constants.SuspensionEventType.SUSPENDED,
+        user_ids_and_latest_events.c.reasonCode == constants.SuspensionReason.UPON_USER_REQUEST,
     )
 
     return query

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -340,7 +340,7 @@ def suspend_account(user: models.User, reason: constants.SuspensionReason, actor
     user.isActive = False
     user_suspension = models.UserSuspension(
         user=user,
-        eventType=models.SuspensionEventType.SUSPENDED,
+        eventType=constants.SuspensionEventType.SUSPENDED,
         actorUser=actor,  # type: ignore [arg-type]
         reasonCode=reason,
     )
@@ -392,7 +392,7 @@ def unsuspend_account(user: models.User, actor: models.User, send_email: bool = 
     user.isActive = True
     user_suspension = models.UserSuspension(
         user=user,
-        eventType=models.SuspensionEventType.UNSUSPENDED,
+        eventType=constants.SuspensionEventType.UNSUSPENDED,
         actorUser=actor,
     )
     repository.save(user)
@@ -420,7 +420,7 @@ def bulk_unsuspend_account(user_ids: list[int], actor: models.User) -> None:
         db.session.add(
             models.UserSuspension(
                 userId=user_id,
-                eventType=models.SuspensionEventType.UNSUSPENDED,
+                eventType=constants.SuspensionEventType.UNSUSPENDED,
                 actorUser=actor,
             )
         )
@@ -945,8 +945,8 @@ EMAIL_CHANGE_ACTIONS = defaultdict(
 SUSPENSION_ACTIONS = defaultdict(
     lambda: "action de suspension inconnue",
     {
-        models.SuspensionEventType.SUSPENDED: "désactivation de compte",
-        models.SuspensionEventType.UNSUSPENDED: "réactivation de compte",
+        constants.SuspensionEventType.SUSPENDED: "désactivation de compte",
+        constants.SuspensionEventType.UNSUSPENDED: "réactivation de compte",
     },
 )
 

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -1,5 +1,5 @@
 import datetime
-from enum import Enum
+import enum
 
 
 RESET_PASSWORD_TOKEN_LIFE_TIME = datetime.timedelta(hours=24)
@@ -23,7 +23,7 @@ TOKEN_DELETION_AFTER_EXPIRATION_DELAY = datetime.timedelta(days=7)
 EDUCONNECT_SAML_REQUEST_ID_TTL = 24 * 60 * 60  # 1 day in seconds
 
 
-class SuspensionReason(Enum):
+class SuspensionReason(enum.Enum):
     def __str__(self) -> str:
         return str(self.value)
 
@@ -69,7 +69,7 @@ SUSPENSION_REASON_CHOICES = (
 assert set(_t[0] for _t in SUSPENSION_REASON_CHOICES) == set(SuspensionReason)
 
 
-class SuspensionEventType(Enum):
+class SuspensionEventType(enum.Enum):
     SUSPENDED = "SUSPENDED"
     UNSUSPENDED = "UNSUSPENDED"
 

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -80,3 +80,11 @@ SUSPENSION_EVENT_TYPE_CHOICES = (
 )
 
 assert set(_t[0] for _t in SUSPENSION_EVENT_TYPE_CHOICES) == set(SuspensionEventType)
+
+
+class YoungStatusType(enum.Enum):
+    ELIGIBLE = "eligible"
+    NON_ELIGIBLE = "non_eligible"
+    BENEFICIARY = "beneficiary"
+    EX_BENEFICIARY = "ex_beneficiary"
+    SUSPENDED = "suspended"

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -396,7 +396,7 @@ class UserSuspensionBaseFactory(BaseFactory):
 
     user = factory.SubFactory(UserFactory, isActive=False)
     actorUser = factory.SubFactory(AdminFactory)
-    eventType = users_models.SuspensionEventType.SUSPENDED
+    eventType = users_constants.SuspensionEventType.SUSPENDED
     eventDate = factory.LazyFunction(lambda: datetime.utcnow() - relativedelta(days=1))
 
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -21,9 +21,8 @@ from sqlalchemy.sql.elements import BooleanClauseList
 from sqlalchemy.sql.functions import func
 
 from pcapi import settings
+from pcapi.core.users import constants
 from pcapi.core.users import utils as users_utils
-from pcapi.core.users.constants import SuspensionEventType
-from pcapi.core.users.constants import SuspensionReason
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models import db
@@ -420,7 +419,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         if (
             not self.isActive
             and self.suspension_history
-            and self.suspension_history[-1].eventType == SuspensionEventType.SUSPENDED
+            and self.suspension_history[-1].eventType == constants.SuspensionEventType.SUSPENDED
         ):
             return self.suspension_history[-1].reasonCode
         return None
@@ -434,7 +433,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         if (
             not self.isActive
             and self.suspension_history
-            and self.suspension_history[-1].eventType == SuspensionEventType.SUSPENDED
+            and self.suspension_history[-1].eventType == constants.SuspensionEventType.SUSPENDED
         ):
             return self.suspension_history[-1].eventDate
         return None
@@ -447,11 +446,11 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         if self.suspension_history:
             suspension_event = self.suspension_history[-1]
 
-            if suspension_event.eventType == SuspensionEventType.SUSPENDED:
+            if suspension_event.eventType == constants.SuspensionEventType.SUSPENDED:
 
-                if suspension_event.reasonCode == SuspensionReason.DELETED:
+                if suspension_event.reasonCode == constants.SuspensionReason.DELETED:
                     return AccountState.DELETED
-                if suspension_event.reasonCode == SuspensionReason.UPON_USER_REQUEST:
+                if suspension_event.reasonCode == constants.SuspensionReason.UPON_USER_REQUEST:
                     return AccountState.SUSPENDED_UPON_USER_REQUEST
 
                 return AccountState.SUSPENDED
@@ -689,7 +688,7 @@ class UserSuspension(PcObject, Base, Model):
         ),
     )
 
-    eventType: SuspensionEventType = sa.Column(sa.Enum(SuspensionEventType), nullable=False)
+    eventType: constants.SuspensionEventType = sa.Column(sa.Enum(constants.SuspensionEventType), nullable=False)
 
     # nullable because of old suspensions without date migrated here; but mandatory for new actions
     eventDate = sa.Column(sa.DateTime, nullable=True, server_default=sa.func.now())
@@ -700,7 +699,7 @@ class UserSuspension(PcObject, Base, Model):
     actorUser = orm.relationship("User", foreign_keys=[actorUserId])  # type: ignore [misc]
 
     # Reason is filled in only when suspended but could be useful also when unsuspended for support traceability
-    reasonCode = sa.Column(sa.Enum(SuspensionReason), nullable=True)
+    reasonCode = sa.Column(sa.Enum(constants.SuspensionReason), nullable=True)
 
 
 class UserSession(PcObject, Base, Model):

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -321,7 +321,7 @@ def suspend_account(user: users_models.User) -> None:
 @authenticated_maybe_inactive_user_required
 def get_account_suspension_date(user: users_models.User) -> serializers.UserSuspensionDateResponse:
     reason = user.suspension_reason
-    if reason != users_models.SuspensionReason.UPON_USER_REQUEST:
+    if reason != constants.SuspensionReason.UPON_USER_REQUEST:
         # If the account has not been suspended upon user request, it
         # has no reason to ask for its suspension date.
         raise api_errors.ForbiddenError()

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -119,6 +119,16 @@ class ChangeEmailTokenContent(BaseModel):
         return cls(current_email=current_email, new_email=new_email)
 
 
+class YoungStatusResponse(BaseModel):
+    status_type: users_constants.YoungStatusType
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+        allow_mutation = False
+        orm_mode = True
+
+
 class UserProfileResponse(BaseModel):
     booked_offers: dict[str, int]
     birth_date: datetime.date | None
@@ -144,6 +154,7 @@ class UserProfileResponse(BaseModel):
     show_eligible_card: bool
     subscriptions: NotificationSubscriptions  # if we send user.notification_subscriptions, pydantic will take the column and not the property
     subscriptionMessage: subscription_serialization.SubscriptionMessage | None
+    young_status: YoungStatusResponse
 
     _convert_recredit_amount_to_show = validator("recreditAmountToShow", pre=True, allow_reuse=True)(convert_to_cent)
 

--- a/api/src/pcapi/scripts/suspend_fraudulent_beneficiary_users.py
+++ b/api/src/pcapi/scripts/suspend_fraudulent_beneficiary_users.py
@@ -1,8 +1,8 @@
 import logging
 
 from pcapi.core.bookings.repository import find_offers_booked_by_beneficiaries
+from pcapi.core.users import constants as user_constants
 from pcapi.core.users.api import suspend_account
-from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.models import User
 from pcapi.repository.user_queries import find_beneficiary_users_by_email_provider
 
@@ -36,7 +36,7 @@ def suspend_fraudulent_beneficiary_users(fraudulent_users: list[User], admin_use
     if not dry_run:
         n_bookings = 0
         for fraudulent_user in fraudulent_users:
-            result = suspend_account(fraudulent_user, SuspensionReason.FRAUD_SUSPICION, admin_user)
+            result = suspend_account(fraudulent_user, user_constants.SuspensionReason.FRAUD_SUSPICION, admin_user)
             n_bookings += result["cancelled_bookings"]
         logger.info(
             "Fraudulent beneficiaries accounts suspended",

--- a/api/src/pcapi/scripts/suspend_fraudulent_pro_users.py
+++ b/api/src/pcapi/scripts/suspend_fraudulent_pro_users.py
@@ -1,6 +1,6 @@
 from pcapi.core.offerers.exceptions import CannotDeleteOffererWithBookingsException
+from pcapi.core.users import constants as user_constants
 from pcapi.core.users.api import suspend_account
-from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.models import User
 from pcapi.repository.user_queries import find_pro_users_by_email_provider
 from pcapi.scripts.offerer.delete_cascade_offerer_by_id import delete_cascade_offerer_by_id
@@ -32,4 +32,4 @@ def suspend_fraudulent_pro_by_email_providers(
 
 def _suspend_fraudulent_pro_users(users: list[User], admin_user: User) -> None:
     for fraudulent_user in users:
-        suspend_account(fraudulent_user, SuspensionReason.FRAUD_SUSPICION, admin_user)
+        suspend_account(fraudulent_user, user_constants.SuspensionReason.FRAUD_SUSPICION, admin_user)

--- a/api/tests/core/users/user_status_test.py
+++ b/api/tests/core/users/user_status_test.py
@@ -1,0 +1,71 @@
+import dataclasses
+import datetime
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import constants
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class UserStatusTest:
+    @pytest.mark.parametrize("age", [15, 16, 17, 18])
+    def test_eligible_when_age_is_between_15_and_18(self, age):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=age),
+        )
+        assert user.young_status == models.Eligible()
+
+    def test_eligible_when_19yo_with_pending_dms_application(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19),
+        )
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.DMS,
+            resultContent=fraud_factories.DMSContentFactory(
+                registration_datetime=(datetime.datetime.utcnow() - relativedelta(years=1))
+            ),
+        )
+        assert user.young_status == models.Eligible()
+
+    def test_non_eligible_when_too_young(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=15) + relativedelta(days=1),
+        )
+        assert user.young_status == models.NonEligible()
+
+    def test_non_eligible_when_too_old(self):
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, days=1),
+        )
+        assert user.young_status == models.NonEligible()
+
+    def test_beneficiary_when_18yo_and_have_deposit(self):
+        user = users_factories.BeneficiaryGrant18Factory()
+        assert user.young_status == models.Beneficiary()
+
+    def test_beneficiary_when_underage_and_have_deposit(self):
+        user = users_factories.UnderageBeneficiaryFactory()
+        assert user.young_status == models.Beneficiary()
+
+    def test_ex_beneficiary_when_beneficiary_have_his_deposit_expired(self):
+        user = users_factories.BeneficiaryGrant18Factory(
+            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(days=1)
+        )
+        assert user.young_status == models.ExBeneficiary()
+
+    def test_suspended_when_account_is_not_active(self):
+        user = users_factories.BeneficiaryGrant18Factory(isActive=False)
+        assert user.young_status == models.Suspended()
+
+    def test_can_not_mutate(self):
+        status = models.Suspended()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            status.status_type = constants.YoungStatusType.BENEFICIARY

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -6,9 +6,9 @@ from pcapi import settings
 import pcapi.core.finance.factories as finance_factories
 from pcapi.core.finance.models import BankInformationStatus
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.users import constants as user_constants
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import testing as users_testing
-from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.models import PhoneValidationStatusType
 
 
@@ -73,7 +73,7 @@ class ZendeskWebhookTest:
             isActive=False,
         )
         users_factories.UserSuspensionByFraudFactory(
-            user=user, eventDate=datetime(2022, 3, 22, 15), reasonCode=SuspensionReason.FRAUD_HACK
+            user=user, eventDate=datetime(2022, 3, 22, 15), reasonCode=user_constants.SuspensionReason.FRAUD_HACK
         )
 
         response = client.post(

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -133,6 +133,7 @@ class AccountTest:
             "showEligibleCard": False,
             "subscriptions": {"marketingPush": True, "marketingEmail": True},
             "subscriptionMessage": None,
+            "youngStatus": {"statusType": users_constants.YoungStatusType.BENEFICIARY.value},
         }
         EXPECTED_DATA.update(USER_DATA)
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -35,7 +35,6 @@ from pcapi.core.users import models as users_models
 from pcapi.core.users import testing as users_testing
 from pcapi.core.users.api import create_phone_validation_token
 import pcapi.core.users.constants as users_constants
-from pcapi.core.users.constants import SuspensionReason
 from pcapi.core.users.email import update as email_update
 from pcapi.core.users.utils import ALGORITHM_HS_256
 from pcapi.models import db
@@ -1383,7 +1382,7 @@ class SuspendAccountTest:
         assert booking.status == BookingStatus.CANCELLED
         db.session.refresh(user)
         assert not user.isActive
-        assert user.suspension_reason == SuspensionReason.UPON_USER_REQUEST
+        assert user.suspension_reason == users_constants.SuspensionReason.UPON_USER_REQUEST
         assert user.suspension_date
         assert len(user.suspension_history) == 1
         assert user.suspension_history[0].userId == user.id

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1486,6 +1486,7 @@ def test_public_api(client):
                         "recreditAmountToShow": {"nullable": True, "title": "Recreditamounttoshow", "type": "integer"},
                         "roles": {"items": {"$ref": "#/components/schemas/UserRole"}, "type": "array"},
                         "showEligibleCard": {"title": "Showeligiblecard", "type": "boolean"},
+                        "youngStatus": {"$ref": "#/components/schemas/YoungStatusResponse"},
                         "subscriptionMessage": {
                             "anyOf": [{"$ref": "#/components/schemas/SubscriptionMessage"}],
                             "nullable": True,
@@ -1503,6 +1504,7 @@ def test_public_api(client):
                         "roles",
                         "showEligibleCard",
                         "subscriptions",
+                        "youngStatus",
                     ],
                     "title": "UserProfileResponse",
                     "type": "object",
@@ -1549,6 +1551,23 @@ def test_public_api(client):
                     "description": "An enumeration.",
                     "enum": ["ADMIN", "BENEFICIARY", "PRO", "UNDERAGE_BENEFICIARY", "TEST"],
                     "title": "UserRole",
+                },
+                "YoungStatusResponse": {
+                    "properties": {"statusType": {"$ref": "#/components/schemas/YoungStatusType"}},
+                    "required": ["statusType"],
+                    "title": "YoungStatusResponse",
+                    "type": "object",
+                },
+                "YoungStatusType": {
+                    "description": "An enumeration.",
+                    "enum": [
+                        "eligible",
+                        "non_eligible",
+                        "beneficiary",
+                        "ex_beneficiary",
+                        "suspended",
+                    ],
+                    "title": "YoungStatusType",
                 },
                 "UserSuspensionDateResponse": {
                     "properties": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17880

## But de la pull request

Ajout des [statuts principaux des utilisateurs](https://github.com/pass-culture/pass-culture-app-native/blob/chantier-cta/user_status.mmd)

## Implémentation

- on a fait différentes classes pour pouvoir étendre avec certaines informations propre à certains statuts : ex: `Eligible` aura un champs `subscriptionStatus` qui pourra avoir l'une de ces valeur `has_subscription_pending`, `has_to_complete_subscription` ou `has_subscription_issues`

## Informations supplémentaires

- on a uniformiser les imports de certaines constants, ça a cassé quelques imports, car apparemment il est possible d'importer un import d'un autre fichier

```python
# a.py
toto = "toto"

# b.py
from a import toto

# c.py
from b import toto # chelou d'importer depuis `b` et pas depuis `a`
```

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
