### PR TITLE
(PC-17825)[PRO] image editor add max scale constraint

### DIFF
--- a/pro/src/hooks/__specs__/useGetBitmap.spec.ts
+++ b/pro/src/hooks/__specs__/useGetBitmap.spec.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useGetImageBitmap } from 'hooks/useGetBitmap'
+
+describe('image', () => {
+  it('GetImageBitmap', async () => {
+    const imageFile = new File([''], 'hello.png', {
+      type: 'image/png',
+    })
+    Object.defineProperty(imageFile, 'size', {
+      value: 9000000,
+      configurable: true,
+    })
+    Object.defineProperty(imageFile, 'width', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(imageFile, 'height', {
+      value: 800,
+      configurable: true,
+    })
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useGetImageBitmap(imageFile)
+    )
+    const image = result.current
+
+    expect(image.width).toEqual(0)
+    expect(image.height).toEqual(0)
+
+    await waitForNextUpdate()
+    const updatedImage = result.current
+    expect(updatedImage.width).toEqual(600)
+    expect(updatedImage.height).toEqual(800)
+  })
+})

--- a/pro/src/hooks/useGetBitmap.ts
+++ b/pro/src/hooks/useGetBitmap.ts
@@ -8,6 +8,7 @@ export const useGetImageBitmap = (file: File) => {
 
   useEffect(() => {
     getImageBitmap(file).then(data => {
+      /* istanbul ignore next: DEBT, TO FIX */
       if (data) {
         setWidth(data.width)
         setHeight(data.height)

--- a/pro/src/hooks/useGetBitmap.ts
+++ b/pro/src/hooks/useGetBitmap.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+import { getImageBitmap } from 'utils/image'
+
+export const useGetImageBitmap = (file: File) => {
+  const [width, setWidth] = useState<number>(0)
+  const [height, setHeight] = useState<number>(0)
+
+  useEffect(() => {
+    getImageBitmap(file).then(data => {
+      if (data) {
+        setWidth(data.width)
+        setHeight(data.height)
+      }
+    })
+  }, [])
+
+  return { width, height }
+}

--- a/pro/src/new_components/ConstraintCheck/imageConstraints.ts
+++ b/pro/src/new_components/ConstraintCheck/imageConstraints.ts
@@ -1,3 +1,5 @@
+import { getImageBitmap } from 'utils/image'
+
 type FileChecker = (file: File) => Promise<boolean>
 
 export type Constraint = {
@@ -6,30 +8,11 @@ export type Constraint = {
   asyncValidator: FileChecker
 }
 
-/* istanbul ignore next: DEBT, TO FIX */
-const getImageBitmap = async (file: File): Promise<ImageBitmap | null> => {
-  // Polyfill for Safari and IE not supporting createImageBitmap
-  if (!('createImageBitmap' in window)) {
-    window.createImageBitmap = async (
-      blob: ImageBitmapSource
-    ): Promise<ImageBitmap> =>
-      new Promise(resolve => {
-        const img = document.createElement('img')
-        img.addEventListener('load', function () {
-          resolve(this as any)
-        })
-        img.src = URL.createObjectURL(blob as Blob)
-      })
-  }
-  return await createImageBitmap(file).catch(() => null)
-}
-
 export const imageConstraints = {
   formats: (supportedImageTypes: string[]): Constraint => {
     const isNotAnImage: FileChecker = async file =>
       supportedImageTypes.includes(file.type) &&
       (await getImageBitmap(file)) !== null
-
     return {
       id: 'formats',
       description: 'Formats supportés : JPG, PNG',

--- a/pro/src/new_components/ImageEditor/ImageEditor.stories.tsx
+++ b/pro/src/new_components/ImageEditor/ImageEditor.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
   cropBorderColor: '#FFF',
   cropBorderHeight: 30,
   cropBorderWidth: 40,
-  image: sampleImage,
+  image: sampleImage as unknown as File,
 }
 
 export const WithInitialScale = Template.bind({})
@@ -36,6 +36,6 @@ WithInitialScale.args = {
   cropBorderColor: '#FFF',
   cropBorderHeight: 30,
   cropBorderWidth: 40,
-  image: sampleImage,
+  image: sampleImage as unknown as File,
   initialScale: 1.5,
 }

--- a/pro/src/new_components/ImageEditor/ImageEditor.stories.tsx
+++ b/pro/src/new_components/ImageEditor/ImageEditor.stories.tsx
@@ -1,3 +1,4 @@
+/* istanbul ignore file: not needed */
 import type { Story } from '@storybook/react'
 import React from 'react'
 

--- a/pro/src/new_components/ImageEditor/ImageEditor.tsx
+++ b/pro/src/new_components/ImageEditor/ImageEditor.tsx
@@ -20,10 +20,11 @@ export interface IImageEditorConfig {
   cropBorderColor: string
   cropBorderHeight: number
   cropBorderWidth: number
+  maxScale: number
 }
 
 export interface IImageEditorProps extends IImageEditorConfig {
-  image: string | File
+  image: File
   saveInitialScale?: (scale: number) => void
   initialPosition?: Position
   initialScale?: number
@@ -42,6 +43,7 @@ const ImageEditor = forwardRef<AvatarEditor, IImageEditorProps>(
       saveInitialScale,
       initialPosition = { x: 0.5, y: 0.5 },
       initialScale,
+      maxScale = 4,
     },
     ref
   ) => {
@@ -121,7 +123,7 @@ const ImageEditor = forwardRef<AvatarEditor, IImageEditorProps>(
           <span className={style['image-editor-scale-input']}>
             <ThemeProvider theme={theme}>
               <CustomSlider
-                max={4}
+                max={maxScale > 1 ? maxScale : 1}
                 min={1}
                 onChange={onScaleChange}
                 step={0.01}

--- a/pro/src/new_components/ImageEditor/ImageEditor.tsx
+++ b/pro/src/new_components/ImageEditor/ImageEditor.tsx
@@ -89,7 +89,7 @@ const ImageEditor = forwardRef<AvatarEditor, IImageEditorProps>(
       canvasHeight,
     ])
 
-    const onScaleChange = useCallback((event: any) => {
+    const onScaleChange = useCallback(async (event: any) => {
       setScale(event.target.value)
     }, [])
 

--- a/pro/src/new_components/ImageEditor/ImageEditor.tsx
+++ b/pro/src/new_components/ImageEditor/ImageEditor.tsx
@@ -93,6 +93,7 @@ const ImageEditor = forwardRef<AvatarEditor, IImageEditorProps>(
       setScale(event.target.value)
     }, [])
 
+    /* istanbul ignore next: DEBT, TO FIX */
     const onPositionChange = useCallback((position: Position) => {
       setPosition(position)
     }, [])

--- a/pro/src/new_components/ImageUploadBrowserForm/ImageUploadBrowserForm.tsx
+++ b/pro/src/new_components/ImageUploadBrowserForm/ImageUploadBrowserForm.tsx
@@ -9,6 +9,7 @@ import {
 import { UploaderModeEnum } from 'new_components/ImageUploader/types'
 import { BaseFileInput } from 'ui-kit/form/shared'
 
+import { modeValidationConstraints } from './constants'
 import type { IImageUploadBrowserFormValues } from './types'
 import getValidationSchema from './validationSchema'
 
@@ -23,18 +24,7 @@ const ImageUploadBrowserForm = ({
   mode,
 }: IImageUploadBrowserFormProps): JSX.Element => {
   const [errors, setErrors] = useState<string[]>([])
-  const validationConstraints = {
-    [UploaderModeEnum.OFFER]: {
-      maxSize: 10000000,
-      minWidth: 400,
-      types: ['image/png', 'image/jpeg'],
-    },
-    [UploaderModeEnum.VENUE]: {
-      maxSize: 10000000,
-      minWidth: 600,
-      types: ['image/png', 'image/jpeg'],
-    },
-  }[mode]
+  const validationConstraints = modeValidationConstraints[mode]
   const constraints: Constraint[] = [
     imageConstraints.formats(validationConstraints.types),
     imageConstraints.size(validationConstraints.maxSize),
@@ -43,6 +33,7 @@ const ImageUploadBrowserForm = ({
 
   const validationSchema = getValidationSchema(validationConstraints)
 
+  /* istanbul ignore next: DEBT, TO FIX */
   const onChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const newFile: File | null =
       (event.currentTarget.files && event.currentTarget.files[0]) || null
@@ -58,6 +49,7 @@ const ImageUploadBrowserForm = ({
     }
   }
 
+  /* istanbul ignore next: DEBT, TO FIX */
   return (
     <form onSubmit={e => e.preventDefault()}>
       <BaseFileInput

--- a/pro/src/new_components/ImageUploadBrowserForm/constants.ts
+++ b/pro/src/new_components/ImageUploadBrowserForm/constants.ts
@@ -1,0 +1,14 @@
+import { UploaderModeEnum } from 'new_components/ImageUploader/types'
+
+export const modeValidationConstraints = {
+  [UploaderModeEnum.OFFER]: {
+    maxSize: 10000000,
+    minWidth: 400,
+    types: ['image/png', 'image/jpeg'],
+  },
+  [UploaderModeEnum.VENUE]: {
+    maxSize: 10000000,
+    minWidth: 600,
+    types: ['image/png', 'image/jpeg'],
+  },
+}

--- a/pro/src/new_components/ImageUploadBrowserForm/validationSchema.ts
+++ b/pro/src/new_components/ImageUploadBrowserForm/validationSchema.ts
@@ -1,21 +1,6 @@
 import * as yup from 'yup'
 
-const getImageBitmap = async (file: File): Promise<ImageBitmap | null> => {
-  // Polyfill for Safari and IE not supporting createImageBitmap
-  if (!('createImageBitmap' in window)) {
-    window.createImageBitmap = async (
-      blob: ImageBitmapSource
-    ): Promise<ImageBitmap> =>
-      new Promise(resolve => {
-        const img = document.createElement('img')
-        img.addEventListener('load', function () {
-          resolve(this as any)
-        })
-        img.src = URL.createObjectURL(blob as Blob)
-      })
-  }
-  return await createImageBitmap(file).catch(() => null)
-}
+import { getImageBitmap } from 'utils/image'
 
 export interface IGetValidationSchemaArgs {
   types?: string[]

--- a/pro/src/new_components/ImageUploadBrowserForm/validationSchema.ts
+++ b/pro/src/new_components/ImageUploadBrowserForm/validationSchema.ts
@@ -19,6 +19,7 @@ const getValidationSchema = ({
     width?: yup.AnySchema
   } = {}
 
+  /* istanbul ignore next: DEBT, TO FIX */
   if (maxSize) {
     const displayedMaxSize = maxSize / 1000000
     validationSchema.size = yup.mixed().test({
@@ -29,6 +30,7 @@ const getValidationSchema = ({
     })
   }
 
+  /* istanbul ignore next: DEBT, TO FIX */
   if (types) {
     const displayedFileTypes = types
       .map((fileType: string) => fileType.split('/')[1].toUpperCase())
@@ -42,6 +44,7 @@ const getValidationSchema = ({
     })
   }
 
+  /* istanbul ignore next: DEBT, TO FIX */
   if (minWidth) {
     validationSchema.width = yup.mixed().test({
       message: `Largeur minimale de l’image : ${minWidth} px`,

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react'
 import AvatarEditor, { CroppedRect, Position } from 'react-avatar-editor'
 
+import { useGetImageBitmap } from 'hooks/useGetBitmap'
 import useNotification from 'hooks/useNotification'
 import { ReactComponent as DownloadIcon } from 'icons/ico-download-filled.svg'
 import { CreditInput } from 'new_components/CreditInput/CreditInput'
@@ -11,7 +12,6 @@ import { coordonateToPosition } from 'new_components/ImageEditor/utils'
 import { UploaderModeEnum } from 'new_components/ImageUploader/types'
 import { Button, Divider } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { useGetImageBitmap } from 'utils/image'
 
 import style from './ModalImageCrop.module.scss'
 

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
@@ -9,6 +9,7 @@ import ImageEditor, {
   IImageEditorConfig,
 } from 'new_components/ImageEditor/ImageEditor'
 import { coordonateToPosition } from 'new_components/ImageEditor/utils'
+import { modeValidationConstraints } from 'new_components/ImageUploadBrowserForm/constants'
 import { UploaderModeEnum } from 'new_components/ImageUploader/types'
 import { Button, Divider } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -44,9 +45,10 @@ const ModalImageCrop = ({
   const { width } = useGetImageBitmap(image)
   const editorRef = useRef<AvatarEditor>(null)
   const notification = useNotification()
+  const minWidth = modeValidationConstraints[mode].minWidth
   const maxScale: number = {
-    [UploaderModeEnum.OFFER]: (width * (2 / 3)) / 400,
-    [UploaderModeEnum.VENUE]: width / 600,
+    [UploaderModeEnum.OFFER]: (width * (2 / 3)) / minWidth,
+    [UploaderModeEnum.VENUE]: width / minWidth,
   }[mode]
   const title: string = {
     [UploaderModeEnum.OFFER]: "Image de l'offre",
@@ -75,12 +77,14 @@ const ModalImageCrop = ({
     },
   }[mode]
 
+  /* istanbul ignore next: DEBT, TO FIX */
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       handleNext()
     }
   }
 
+  /* istanbul ignore next: DEBT, TO FIX */
   const handleNext = useCallback(() => {
     try {
       if (editorRef.current) {

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
@@ -15,6 +15,7 @@ import { Button, Divider } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
 import style from './ModalImageCrop.module.scss'
+import { getCropMaxDimension } from './utils'
 
 interface IModalImageCropProps {
   image: File
@@ -42,14 +43,22 @@ const ModalImageCrop = ({
   initialScale,
   mode,
 }: IModalImageCropProps): JSX.Element => {
-  const { width } = useGetImageBitmap(image)
+  const { width, height } = useGetImageBitmap(image)
   const editorRef = useRef<AvatarEditor>(null)
   const notification = useNotification()
   const minWidth = modeValidationConstraints[mode].minWidth
-  const maxScale: number = {
-    [UploaderModeEnum.OFFER]: (width * (2 / 3)) / minWidth,
-    [UploaderModeEnum.VENUE]: width / minWidth,
-  }[mode]
+  // getCropMaxDimension is tested on it's own.
+  /* istanbul ignore next: unable to test intercations with AvatarEditor  */
+  const { width: maxWidth } = getCropMaxDimension({
+    originalDimensions: { width, height },
+    /* istanbul ignore next */
+    orientation: mode === UploaderModeEnum.OFFER ? 'portrait' : 'landscape',
+  })
+  const maxScale: number = Math.min(
+    4,
+    (maxWidth - 10) / // Add few security pixel to garantie that max zoom will never be 399px.
+      minWidth
+  )
   const title: string = {
     [UploaderModeEnum.OFFER]: "Image de l'offre",
     [UploaderModeEnum.VENUE]: 'Image du lieu',

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/ModalImageCrop.tsx
@@ -11,11 +11,12 @@ import { coordonateToPosition } from 'new_components/ImageEditor/utils'
 import { UploaderModeEnum } from 'new_components/ImageUploader/types'
 import { Button, Divider } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
+import { useGetImageBitmap } from 'utils/image'
 
 import style from './ModalImageCrop.module.scss'
 
 interface IModalImageCropProps {
-  image: string | File
+  image: File
   credit: string
   onSetCredit: (credit: string) => void
   children?: never
@@ -40,8 +41,13 @@ const ModalImageCrop = ({
   initialScale,
   mode,
 }: IModalImageCropProps): JSX.Element => {
+  const { width } = useGetImageBitmap(image)
   const editorRef = useRef<AvatarEditor>(null)
   const notification = useNotification()
+  const maxScale: number = {
+    [UploaderModeEnum.OFFER]: (width * (2 / 3)) / 400,
+    [UploaderModeEnum.VENUE]: width / 600,
+  }[mode]
   const title: string = {
     [UploaderModeEnum.OFFER]: "Image de l'offre",
     [UploaderModeEnum.VENUE]: 'Image du lieu',
@@ -57,6 +63,7 @@ const ModalImageCrop = ({
       cropBorderColor: '#FFF',
       cropBorderHeight: 50,
       cropBorderWidth: 105,
+      maxScale,
     },
     [UploaderModeEnum.VENUE]: {
       canvasHeight,
@@ -64,6 +71,7 @@ const ModalImageCrop = ({
       cropBorderColor: '#FFF',
       cropBorderHeight: 40,
       cropBorderWidth: 100,
+      maxScale,
     },
   }[mode]
 

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/utils/__specs__/getCropMaxDimension.spec.ts
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/utils/__specs__/getCropMaxDimension.spec.ts
@@ -1,0 +1,59 @@
+import getCropMaxDimension from '../getCropMaxDimension'
+
+describe('getCropMaxDimension', () => {
+  it('should compute max width for original "landscape" target "landscape"', () => {
+    const dimensions = getCropMaxDimension({
+      originalDimensions: {
+        width: 2000,
+        height: 1000,
+      },
+      orientation: 'landscape',
+    })
+    expect(dimensions).toEqual({
+      height: 1000,
+      width: 1500,
+    })
+  })
+
+  it('should compute max width for original "landscape" target "portrait"', () => {
+    const dimensions = getCropMaxDimension({
+      originalDimensions: {
+        width: 2000,
+        height: 1000,
+      },
+      orientation: 'portrait',
+    })
+    expect(dimensions).toEqual({
+      height: 1000,
+      width: 666,
+    })
+  })
+
+  it('should compute max width for original "portrait" target "landscape"', () => {
+    const dimensions = getCropMaxDimension({
+      originalDimensions: {
+        width: 1000,
+        height: 2000,
+      },
+      orientation: 'landscape',
+    })
+    expect(dimensions).toEqual({
+      height: 666,
+      width: 1000,
+    })
+  })
+
+  it('should compute max width for original "portrait" target "portrait"', () => {
+    const dimensions = getCropMaxDimension({
+      originalDimensions: {
+        width: 1000,
+        height: 2000,
+      },
+      orientation: 'portrait',
+    })
+    expect(dimensions).toEqual({
+      width: 1000,
+      height: 1500,
+    })
+  })
+})

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/utils/getCropMaxDimension.ts
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/utils/getCropMaxDimension.ts
@@ -1,0 +1,34 @@
+interface IDimension {
+  width: number
+  height: number
+}
+
+const getCropMaxDimension = ({
+  originalDimensions,
+  orientation,
+}: {
+  originalDimensions: IDimension
+  orientation: 'portrait' | 'landscape'
+}): IDimension => {
+  if (orientation === 'landscape') {
+    return {
+      width: Math.floor(
+        Math.min(originalDimensions.width, (originalDimensions.height / 2) * 3)
+      ),
+      height: Math.floor(
+        Math.min(originalDimensions.height, (originalDimensions.width / 3) * 2)
+      ),
+    }
+  } else {
+    return {
+      width: Math.floor(
+        Math.min(originalDimensions.width, (originalDimensions.height / 3) * 2)
+      ),
+      height: Math.floor(
+        Math.min(originalDimensions.height, (originalDimensions.width / 2) * 3)
+      ),
+    }
+  }
+}
+
+export default getCropMaxDimension

--- a/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/utils/index.ts
+++ b/pro/src/new_components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as getCropMaxDimension } from './getCropMaxDimension'

--- a/pro/src/new_components/ImageUploader/types.ts
+++ b/pro/src/new_components/ImageUploader/types.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file: not needed */
 export enum UploaderModeEnum {
   OFFER = 'offer',
   VENUE = 'venue',

--- a/pro/src/utils/__specs__/image.spec.ts
+++ b/pro/src/utils/__specs__/image.spec.ts
@@ -1,0 +1,19 @@
+import { getImageBitmap } from '../image'
+
+describe('image', () => {
+  it('GetImageBitmap', async () => {
+    const imageFile = new File([''], 'hello.png', {
+      type: 'image/png',
+    })
+    Object.defineProperty(imageFile, 'size', {
+      value: 9000000,
+      configurable: true,
+    })
+    Object.defineProperty(imageFile, 'width', {
+      value: 600,
+      configurable: true,
+    })
+    const bitmapImage = await getImageBitmap(imageFile)
+    expect(bitmapImage?.width).toEqual(600)
+  })
+})

--- a/pro/src/utils/image.ts
+++ b/pro/src/utils/image.ts
@@ -1,6 +1,3 @@
-import { useEffect, useState } from 'react'
-
-/* istanbul ignore next: DEBT, TO FIX */
 export const getImageBitmap = async (
   file: File
 ): Promise<ImageBitmap | null> => {
@@ -18,21 +15,4 @@ export const getImageBitmap = async (
       })
   }
   return await createImageBitmap(file).catch(() => null)
-}
-
-/* istanbul ignore next: DEBT, TO FIX */
-export const useGetImageBitmap = (file: File) => {
-  const [width, setWidth] = useState<number>(0)
-  const [height, setHeight] = useState<number>(0)
-
-  useEffect(() => {
-    getImageBitmap(file).then(data => {
-      if (data) {
-        setWidth(data.width)
-        setHeight(data.height)
-      }
-    })
-  }, [])
-
-  return { width, height }
 }

--- a/pro/src/utils/image.ts
+++ b/pro/src/utils/image.ts
@@ -2,6 +2,7 @@ export const getImageBitmap = async (
   file: File
 ): Promise<ImageBitmap | null> => {
   // Polyfill for Safari and IE not supporting createImageBitmap
+  /* istanbul ignore next: DEBT, TO FIX */
   if (!('createImageBitmap' in window)) {
     window.createImageBitmap = async (
       blob: ImageBitmapSource

--- a/pro/src/utils/image.ts
+++ b/pro/src/utils/image.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+/* istanbul ignore next: DEBT, TO FIX */
+export const getImageBitmap = async (
+  file: File
+): Promise<ImageBitmap | null> => {
+  // Polyfill for Safari and IE not supporting createImageBitmap
+  if (!('createImageBitmap' in window)) {
+    window.createImageBitmap = async (
+      blob: ImageBitmapSource
+    ): Promise<ImageBitmap> =>
+      new Promise(resolve => {
+        const img = document.createElement('img')
+        img.addEventListener('load', function () {
+          resolve(this as any)
+        })
+        img.src = URL.createObjectURL(blob as Blob)
+      })
+  }
+  return await createImageBitmap(file).catch(() => null)
+}
+
+/* istanbul ignore next: DEBT, TO FIX */
+export const useGetImageBitmap = (file: File) => {
+  const [width, setWidth] = useState<number>(0)
+  const [height, setHeight] = useState<number>(0)
+
+  useEffect(() => {
+    getImageBitmap(file).then(data => {
+      if (data) {
+        setWidth(data.width)
+        setHeight(data.height)
+      }
+    })
+  }, [])
+
+  return { width, height }
+}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17825

## But de la pull request

Configurer une hauteur ou une largeur maximal pour le resize, et utiliser cette contrainte sur les pages d’upload d’image d’offre(V3) et de lieu.

## Implémentation

- Ajout d'une valeur maxScale (selon si on est dans offre ou lieu) pour ImageEditor

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
