### PR TITLE
Pc 17642 add tracker for offer from template tunnel

### DIFF
--- a/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
@@ -30,6 +30,13 @@ const DuplicateOfferCell = ({
     return history.push(`/offre/duplication/collectif/${templateOfferId}`)
   }
 
+  const handleCreateOfferClick = () => {
+    if (!shouldDisplayModal) {
+      return history.push(`/offre/duplication/collectif/${templateOfferId}`)
+    }
+    setIsModalOpen(true)
+  }
+
   return (
     <>
       <td className={styles['duplicate-offer-column']}>
@@ -37,7 +44,7 @@ const DuplicateOfferCell = ({
           <Button
             variant={ButtonVariant.SECONDARY}
             className={styles['button']}
-            onClick={() => setIsModalOpen(true)}
+            onClick={handleCreateOfferClick}
             Icon={PlusIcon}
             iconPosition={IconPositionEnum.CENTER}
             hasTooltip

--- a/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react'
 import { useHistory } from 'react-router'
 
+import {
+  Events,
+  OFFER_FROM_TEMPLATE_ENTRIES,
+} from 'core/FirebaseEvents/constants'
+import useAnalytics from 'hooks/useAnalytics'
 import { ReactComponent as PlusIcon } from 'icons/ico-plus.svg'
 import { Button } from 'ui-kit'
 import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
@@ -9,7 +14,7 @@ import styles from '../../OfferItem.module.scss'
 
 import DuplicateOfferDialog from './DuplicateOfferDialog'
 
-const LOCAL_STORAGE_HAS_SEEN_MODAL_KEY = 'DUPLICATE_OFFER_MODAL_SEEN'
+export const LOCAL_STORAGE_HAS_SEEN_MODAL_KEY = 'DUPLICATE_OFFER_MODAL_SEEN'
 
 const DuplicateOfferCell = ({
   isTemplate,
@@ -19,11 +24,15 @@ const DuplicateOfferCell = ({
   templateOfferId: string
 }) => {
   const history = useHistory()
+  const { logEvent } = useAnalytics()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const shouldDisplayModal =
     localStorage.getItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY) !== 'true'
 
   const onDialogConfirm = (shouldNotDisplayModalAgain: boolean) => {
+    logEvent?.(Events.CLICKED_DUPLICATE_TEMPLATE_OFFER, {
+      from: OFFER_FROM_TEMPLATE_ENTRIES.OFFERS_MODAL,
+    })
     if (shouldNotDisplayModalAgain) {
       localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'true')
     }
@@ -32,6 +41,9 @@ const DuplicateOfferCell = ({
 
   const handleCreateOfferClick = () => {
     if (!shouldDisplayModal) {
+      logEvent?.(Events.CLICKED_DUPLICATE_TEMPLATE_OFFER, {
+        from: OFFER_FROM_TEMPLATE_ENTRIES.OFFERS,
+      })
       return history.push(`/offre/duplication/collectif/${templateOfferId}`)
     }
     setIsModalOpen(true)

--- a/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -7,11 +7,11 @@ import { MemoryRouter, Route } from 'react-router'
 
 import { configureTestStore } from 'store/testUtils'
 
-import DuplicateOfferCell from '../DuplicateOfferCell'
+import DuplicateOfferCell, {
+  LOCAL_STORAGE_HAS_SEEN_MODAL_KEY,
+} from '../DuplicateOfferCell'
 
-const LOCAL_STORAGE_HAS_SEEN_MODAL_KEY = 'DUPLICATE_OFFER_MODAL_SEEN'
-
-const renderDuplicateOfferCell = () => {
+const renderDuplicateOfferCell = (isTemplate = true) => {
   const store = configureTestStore({
     user: {
       initialized: true,
@@ -30,9 +30,9 @@ const renderDuplicateOfferCell = () => {
             <tbody>
               <tr>
                 <DuplicateOfferCell
-                  isTemplate
+                  isTemplate={isTemplate}
                   templateOfferId="AE"
-                ></DuplicateOfferCell>
+                />
               </tr>
             </tbody>
           </table>
@@ -46,6 +46,15 @@ const renderDuplicateOfferCell = () => {
 }
 
 describe('DuplicateOfferCell', () => {
+  it('should not render duplicate button if offer is not template', () => {
+    renderDuplicateOfferCell(false)
+    const button = screen.queryByRole('button', {
+      name: 'Créer une offre réservable pour un établissement',
+    })
+
+    expect(button).not.toBeInTheDocument()
+  })
+
   it('should close dialog when click on cancel button', async () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
@@ -96,7 +105,27 @@ describe('DuplicateOfferCell', () => {
     )
   })
 
-  it('should redirect to offer duplication if user has check option to not display modal again', async () => {
+  it('should not update local storage if user does not check any option', async () => {
+    localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
+    renderDuplicateOfferCell()
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable pour un établissement',
+    })
+    await userEvent.click(button)
+
+    const modalConfirmButton = screen.getByRole('button', {
+      name: 'Créer une offre réservable',
+    })
+    await userEvent.click(modalConfirmButton)
+    expect(
+      screen.getByText("Parcours de duplication d'offre")
+    ).toBeInTheDocument()
+    expect(localStorage.getItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY)).toEqual(
+      'false'
+    )
+  })
+
+  it('should redirect to offer duplication if user has already check option to not display modal again', async () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'true')
     renderDuplicateOfferCell()
     const button = screen.getByRole('button', {

--- a/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/components/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -1,0 +1,112 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route } from 'react-router'
+
+import { configureTestStore } from 'store/testUtils'
+
+import DuplicateOfferCell from '../DuplicateOfferCell'
+
+const LOCAL_STORAGE_HAS_SEEN_MODAL_KEY = 'DUPLICATE_OFFER_MODAL_SEEN'
+
+const renderDuplicateOfferCell = () => {
+  const store = configureTestStore({
+    user: {
+      initialized: true,
+      currentUser: {
+        publicName: 'John Do',
+        isAdmin: false,
+        email: 'email@example.com',
+      },
+    },
+  })
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/offres']}>
+        <Route path="/offres">
+          <table>
+            <tbody>
+              <tr>
+                <DuplicateOfferCell
+                  isTemplate
+                  templateOfferId="AE"
+                ></DuplicateOfferCell>
+              </tr>
+            </tbody>
+          </table>
+        </Route>
+        <Route path="/offre/duplication/collectif/AE">
+          <div>Parcours de duplication d'offre</div>
+        </Route>
+      </MemoryRouter>
+    </Provider>
+  )
+}
+
+describe('DuplicateOfferCell', () => {
+  it('should close dialog when click on cancel button', async () => {
+    localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
+    renderDuplicateOfferCell()
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable pour un établissement',
+    })
+
+    await userEvent.click(button)
+
+    const modalCancelButton = screen.getByRole('button', {
+      name: 'Annuler',
+    })
+    await userEvent.click(modalCancelButton)
+
+    expect(
+      screen.queryByText(
+        'Créer une offre réservable pour un établissement scolaire'
+      )
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Parcours de duplication d'offre")
+    ).not.toBeInTheDocument()
+  })
+
+  it('should update local storage if user check option to not display modal again ', async () => {
+    localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
+    renderDuplicateOfferCell()
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable pour un établissement',
+    })
+
+    await userEvent.click(button)
+
+    const checkBox = screen.getByRole('checkbox', {
+      name: 'Je ne souhaite plus voir cette information',
+    })
+    await userEvent.click(checkBox)
+
+    const modalConfirmButton = screen.getByRole('button', {
+      name: 'Créer une offre réservable',
+    })
+    await userEvent.click(modalConfirmButton)
+    expect(
+      screen.getByText("Parcours de duplication d'offre")
+    ).toBeInTheDocument()
+    expect(localStorage.getItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY)).toEqual(
+      'true'
+    )
+  })
+
+  it('should redirect to offer duplication if user has check option to not display modal again', async () => {
+    localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'true')
+    renderDuplicateOfferCell()
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable pour un établissement',
+    })
+
+    await userEvent.click(button)
+
+    expect(
+      screen.getByText("Parcours de duplication d'offre")
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -37,6 +37,7 @@ export enum Events {
   CLICKED_VIEW_OFFERER_STATS = 'hasClickedViewOffererStats',
   CLICKED_VIEW_ALL_OFFERER_STATS = 'hasClickedViewAllOffererStats',
   CLICKED_EXPAND_COLLECTIVE_BOOKING_DETAILS = 'hasClickedExpandCollectiveBookingDetails',
+  CLICKED_DUPLICATE_TEMPLATE_OFFER = 'hasClickedDuplicateTemplateOffer',
   FIRST_LOGIN = 'firstLogin',
   PAGE_VIEW = 'page_view',
   SIGNUP_FORM_ABORT = 'signupFormAbort',
@@ -78,6 +79,12 @@ export enum OFFER_FORM_NAVIGATION_IN {
   OFFERER = 'Offerer',
   VENUE = 'Venue',
   BOOKINGS = 'Bookings',
+}
+
+export enum OFFER_FROM_TEMPLATE_ENTRIES {
+  OFFERS_MODAL = 'OffersListModal',
+  OFFERS = 'OffersList',
+  OFFER_TEMPLATE_RECAP = 'OfferTemplateRecap',
 }
 
 export const OFFER_FORM_HOMEPAGE = 'OfferFormHomepage'

--- a/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 
 import {
+  Events,
+  OFFER_FROM_TEMPLATE_ENTRIES,
+} from 'core/FirebaseEvents/constants'
+import {
   cancelCollectiveBookingAdapter,
   CollectiveOffer,
   CollectiveOfferTemplate,
@@ -10,6 +14,7 @@ import {
 } from 'core/OfferEducational'
 import { computeURLCollectiveOfferId } from 'core/OfferEducational/utils/computeURLCollectiveOfferId'
 import useActiveFeature from 'hooks/useActiveFeature'
+import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 import CollectiveOfferSummary from 'new_components/CollectiveOfferSummary'
 import OfferEducationalActions from 'new_components/OfferEducationalActions'
@@ -64,6 +69,8 @@ const CollectiveOfferSummaryEdition = ({
     reloadCollectiveOffer?.()
   }
 
+  const { logEvent } = useAnalytics()
+
   const setIsOfferActive = async () => {
     const adapter = offer.isTemplate
       ? patchIsTemplateOfferActiveAdapter
@@ -105,6 +112,11 @@ const CollectiveOfferSummaryEdition = ({
           </p>
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
+            onClick={() =>
+              logEvent?.(Events.CLICKED_DUPLICATE_TEMPLATE_OFFER, {
+                from: OFFER_FROM_TEMPLATE_ENTRIES.OFFER_TEMPLATE_RECAP,
+              })
+            }
             link={{
               isExternal: false,
               to: `/offre/duplication/collectif/${offer.id}`,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17642

## But de la pull request

Ajouter des trackers lors de l'accès au parcours de duplication d'offres vitrine (depuis la liste d'offre ou la page de récap d'une offre vitrine)

## Implémentation

- Fix le fait que le bouton (+) permettant d'accèder au parcours ne fonctionnait plus si l'utilisateur cochait la case pour ne plus afficher la modal 
- Ajout d'un tracker `hasClickedDuplicateTemplateOffer` sur les trois points d'accès avec une propriété from qui varie

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
