### PR TITLE
(BSR)[API] test: Remove nose-like setup functions

### DIFF
--- a/api/tests/connectors/dms/graphql_test.py
+++ b/api/tests/connectors/dms/graphql_test.py
@@ -11,7 +11,7 @@ from .schema import DmsSchema
 
 
 class DMSGraphQLTest:
-    def setup(self):
+    def setup_method(self):
         self.client = Client(schema=DmsSchema)
         self.expected_dossier = dms_models.DmsApplicationResponse(
             annotations=[],

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -812,7 +812,7 @@ class IsFraudCheckUpdToDateUnitTest:
 
 @pytest.mark.usefixtures("db_session")
 class ShouldImportDmsApplicationTest:
-    def setup(self):
+    def setup_method(self):
         self.user_email = "john.stiles@example.com"
 
     def start_id_check(self, fields):


### PR DESCRIPTION
Support for nose tests has been deprecated in pytest 7.2.0 (and will
be removed in a future version): usage of `setup()` and `teardown()`
now yields a warning. We only have to rename methods.

See https://docs.pytest.org/en/stable/deprecations.html#nose-deprecation.