### PR TITLE
(BSR)[API] feat: prevent some transactional emails to be sent in EHP

### DIFF
--- a/api/src/pcapi/core/mails/models.py
+++ b/api/src/pcapi/core/mails/models.py
@@ -48,6 +48,7 @@ class Template:
     tags: list[str] = dataclasses.field(default_factory=list)
     use_priority_queue: bool = False
     sender: TransactionalSender = TransactionalSender.SUPPORT
+    send_to_ehp: bool = True
 
     @property
     def id(self) -> int:

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -10,7 +10,9 @@ class TransactionalEmail(Enum):
     ACCEPTED_AS_EAC_BENEFICIARY = models.Template(
         id_prod=257, id_not_prod=27, tags=["jeunes_pass_credite_eac"], use_priority_queue=True
     )
-    BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER = models.Template(id_prod=78, id_not_prod=32, tags=["anniversaire_18_ans"])
+    BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER = models.Template(
+        id_prod=78, id_not_prod=32, tags=["anniversaire_18_ans"], send_to_ehp=False
+    )
     BOOKING_CANCELLATION_BY_BENEFICIARY = models.Template(
         id_prod=223, id_not_prod=33, tags=["jeunes_offre_annulee_jeune"]
     )
@@ -54,7 +56,9 @@ class TransactionalEmail(Enum):
     PRE_SUBSCRIPTION_DMS_ERROR_TO_BENEFICIARY = models.Template(
         id_prod=510, id_not_prod=53, tags=["jeunes_erreur_importation_dms"]
     )
-    RECREDIT_TO_UNDERAGE_BENEFICIARY = models.Template(id_prod=303, id_not_prod=31, tags=["anniversaire_16_17_ans"])
+    RECREDIT_TO_UNDERAGE_BENEFICIARY = models.Template(
+        id_prod=303, id_not_prod=31, tags=["anniversaire_16_17_ans"], send_to_ehp=False
+    )
     REPORTED_OFFER_BY_USER = models.Template(id_prod=589, id_not_prod=70, tags=["interne_offre_signale"])
     SUBSCRIPTION_FOREIGN_DOCUMENT_ERROR = models.Template(
         id_prod=385,


### PR DESCRIPTION
## But de la pull request

Pouvoir débrayer l'envoi de mails transactionnels en EHP

## Implémentation

Ajout de l'attribut `send_to_ehp` à `Template` dans `core/mails/models.py` 

## Informations supplémentaires

2 templates ont été ainsi désactivés: 
- BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER
- RECREDIT_TO_UNDERAGE_BENEFICIARY
