### PR TITLE
[PC-17363] Use PassCulture-SA PAT to clone deployment repo

### DIFF
--- a/.github/workflows/deploy-pcapi.yml
+++ b/.github/workflows/deploy-pcapi.yml
@@ -53,6 +53,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: pass-culture/pass-culture-deployment
+          token: ${{ secrets.PASSCULTURE_SA_ACCESS_TOKEN }}
           path: ./pass-culture-deployment
       - id: openid-auth
         name: "OpenID Connect Authentication"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17363

## But de la pull request

Permettre de cloner pass-culture-deployment depuis la CI