### PR TITLE
[PC-17363] Fix helm secrets generation in CI

### DIFF
--- a/.github/workflows/deploy-pcapi.yml
+++ b/.github/workflows/deploy-pcapi.yml
@@ -39,7 +39,7 @@ jobs:
           username: 'oauth2accesstoken'
           password: '${{ steps.openid-auth.outputs.access_token }}'
           image: '${{ env.DOCKER_REPO }}/pcapi:${{ github.sha }}'
-          run: echo "::set-output name=secrets_file_base64::$(flask print_secret_keys | base64)"
+          run: echo "secrets_file_base64=$(flask print_secret_keys | base64 -w 0)" >> $GITHUB_OUTPUT
 
   deploy-helm-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17363

## But de la pull request

Utilisation de la nouvelle syntaxe pour les outputs et désactivation du line wrapping automatique de base64 qui pose problème