### PR TITLE
(PC-15721)[PRO] fix: ultime fixes for draft release

### DIFF
--- a/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
+++ b/pro/src/components/pages/Offers/Offer/OfferDetails/OfferDetails.jsx
@@ -163,12 +163,6 @@ const OfferDetails = ({
       try {
         if (offer) {
           await api.patchOffer(offer.id, offerValues)
-          if (isSavingDraft) {
-            notification.success(
-              'Brouillon sauvegardé dans la liste des offres'
-            )
-          } else if (!isCreatingOffer)
-            notification.success('Vos modifications ont bien été enregistrées')
           reloadOffer()
           setFormErrors({})
           setThumbnailError(false)
@@ -184,6 +178,9 @@ const OfferDetails = ({
               isDraft: true,
               offerId: offer?.id,
             })
+            notification.success(
+              'Brouillon sauvegardé dans la liste des offres'
+            )
             return Promise.resolve(null)
           } else if (isCreatingOffer || isCompletingDraft) {
             // Click on "Etape suivante" when on /creation or /brouillon
@@ -195,6 +192,11 @@ const OfferDetails = ({
               isDraft: true,
               offerId: offer?.id,
             })
+            if (isDraftEnabled) {
+              notification.success(
+                'Brouillon sauvegardé dans la liste des offres'
+              )
+            }
             return Promise.resolve(() => goToStockAndPrice(offer.id))
           } else {
             // Click on "Enregistrer les modifications" when on /edition
@@ -206,6 +208,7 @@ const OfferDetails = ({
               isDraft: false,
               offerId: offer?.id,
             })
+            notification.success('Vos modifications ont bien été enregistrées')
             return Promise.resolve(() =>
               history.push(`/offre/${offer.id}/individuel/recapitulatif`)
             )

--- a/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
@@ -241,8 +241,8 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
               queryString += `&lieu=${queryParams.lieu}`
             }
             if (isOfferDraft) {
+              await loadStocks()
               await reloadOffer(true)
-
               logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
                 from: OfferBreadcrumbStep.STOCKS,
                 to: isSavingDraft
@@ -367,7 +367,7 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
                 <th>Date limite de réservation</th>
                 <th>Quantité</th>
                 {(stocksInCreation.length === 0 || existingStocks.length > 0) &&
-                  !isCompletingDraft && (
+                  !isOfferDraft && (
                     <Fragment>
                       <th>Stock restant</th>
                       <th>Réservations</th>
@@ -400,7 +400,7 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
                   isDigital={offer.isDigital}
                   isDisabled={isDisabled}
                   isEvent
-                  isDraft={isCompletingDraft}
+                  shouldDisplayDetails={!isOfferDraft}
                   key={stock.id}
                   lastProvider={offer.lastProvider}
                   onChange={updateStock}

--- a/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/StockItem/StockItem.jsx
@@ -23,7 +23,7 @@ const StockItem = ({
   errors,
   isDigital,
   isEvent,
-  isDraft,
+  shouldDisplayDetails,
   isNewStock,
   isDisabled: isOfferDisabled,
   lastProvider,
@@ -310,8 +310,10 @@ const StockItem = ({
           value={totalQuantityValue}
         />
       </td>
-      <td>{!isNewStock && !isDraft && remainingQuantityValue}</td>
-      <td>{!isNewStock && !isDraft && initialStock.bookingsQuantity}</td>
+      <td>{!isNewStock && shouldDisplayDetails && remainingQuantityValue}</td>
+      <td>
+        {!isNewStock && shouldDisplayDetails && initialStock.bookingsQuantity}
+      </td>
       <td className="action-column">
         <StockItemOptionsMenu
           canAddActivationCodes={isDigital && !isEvent}

--- a/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -189,6 +189,7 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
               queryString += `&lieu=${queryParams.lieu}`
             }
             if (isOfferDraft) {
+              loadStocks()
               reloadOffer(true)
               if (quantityOfActivationCodes) {
                 notification.success(
@@ -275,7 +276,6 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
   const isDisabled = offer.status ? isOfferDisabled(offer.status) : false
   const hasNoStock = !stock
   const hasAStock = !hasNoStock
-  const inCreateMode = hasNoStock || !stock.id
   const cancelUrl = isOfferDraft
     ? isCompletingDraft
       ? `/offre/${offerId}/individuel/brouillon`
@@ -338,7 +338,7 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
               <th>Date limite de réservation</th>
               {displayExpirationDatetime && <th>Date limite de validité</th>}
               <th>Quantité</th>
-              {!inCreateMode && (
+              {!isOfferDraft && (
                 <Fragment>
                   <th>Stock restant</th>
                   <th>Réservations</th>
@@ -348,7 +348,7 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
             </tr>
           </thead>
           <tbody>
-            {inCreateMode ? (
+            {isOfferDraft ? (
               <StockItem
                 departmentCode={offer.venue.departementCode}
                 errors={formErrors}
@@ -365,6 +365,7 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
               <StockItem
                 departmentCode={offer.venue.departementCode}
                 errors={formErrors}
+                shouldDisplayDetails={!isOfferDraft}
                 initialStock={stock}
                 isDigital={offer.isDigital}
                 isDisabled={isDisabled}

--- a/pro/src/new_components/RouteLeavingGuardOfferIndividual/RouteLeavingGuardOfferIndividual.tsx
+++ b/pro/src/new_components/RouteLeavingGuardOfferIndividual/RouteLeavingGuardOfferIndividual.tsx
@@ -61,6 +61,10 @@ const RouteLeavingGuardOfferIndividual = ({
         to = toMatchs.reverse()[0]
       }
 
+      if (from === STEP_SUMMARY) {
+        return { shouldBlock: false }
+      }
+
       if (from == STEP_OFFER) {
         if (to === undefined) {
           return {

--- a/pro/src/new_components/RouteLeavingGuardOfferIndividual/__specs__/RouteLeavingGuardOfferIndividual.spec.tsx
+++ b/pro/src/new_components/RouteLeavingGuardOfferIndividual/__specs__/RouteLeavingGuardOfferIndividual.spec.tsx
@@ -170,18 +170,13 @@ describe('new_components | RouteLeavingGuardOfferIndividual', () => {
   })
 
   describe('from summary page', () => {
-    it('should display confirmation modal when exiting creation funnel', async () => {
+    it('should not display confirmation modal when exiting creation funnel', async () => {
       history.push(stepsUrls['summary'])
-      const spyHistory = jest.spyOn(history, 'push')
       renderRouteLeavingGuard(props, history)
       await userEvent.click(screen.getByText('About'))
       expect(
-        await screen.findByText(/Voulez-vous quitter la création d’offre ?/)
-      ).toBeInTheDocument()
-      await userEvent.click(screen.getByText('Quitter'))
-      expect(spyHistory).toHaveBeenLastCalledWith(
-        expect.objectContaining({ pathname: '/about' })
-      )
+        screen.queryByText(/Voulez-vous quitter la création d’offre ?/)
+      ).not.toBeInTheDocument()
     })
 
     it('should not display confirmation modal when going to offer', async () => {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

- Ne pas afficher certaines colonnes en completion de brouillon
- Ne afficher de popin pour les utilisateurs qui veulent quitter depuis la page de recap. L'offre est déjà enregistrée
- Reload les stocks quand on save en draft. Bug duplication de stocks sinon. Correction de l'affichage des stocks restants. On les affichait quand on avait un stock, on les affiche maintenant juste quand l'offre n'est plus draft (ie. en edition).

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
