### PR TITLE
[PC-17363] Fix missing env var in helm secrets generation CI

### DIFF
--- a/.github/workflows/deploy-pcapi.yml
+++ b/.github/workflows/deploy-pcapi.yml
@@ -35,6 +35,7 @@ jobs:
         id: generate-secrets-file
         uses: addnab/docker-run-action@v3
         with:
+          options: -e GITHUB_OUTPUT
           registry: '${{ env.REGION }}-docker.pkg.dev'
           username: 'oauth2accesstoken'
           password: '${{ steps.openid-auth.outputs.access_token }}'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17363

## But de la pull request

Passage de la variable d'env [`GITHUB_OUTPUT`](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs) au step de génération des secrets helm dans la CI. 