### PR TITLE
(BSR)[API] fix: FF naming convention

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -124,7 +124,7 @@ class FeatureToggle(enum.Enum):
     TEMP_DISABLE_OFFERER_VALIDATION_EMAIL = (
         "Désactiver l'envoi d'email interne de validation par token pour les structures et rattachements"
     )
-    # TEMP_ prefix should be used for temporary feature flags (work in progress, testing, transition...)
+    # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
 
     def is_active(self) -> bool:
         if flask.has_request_context():


### PR DESCRIPTION
## But de la pull request

Corriger le préfixe à utiliser pour nommer un FF d'une fonctionnalité en cours de développement.

## Informations supplémentaires

Plus de contexte sur [Notion](https://www.notion.so/passcultureapp/Feature-Flag-e7b0da7946f64020b8403e3581b4ed42)