### PR TITLE
[PC-17363] Fix GCS front upload folder

### DIFF
--- a/.github/workflows/deploy-pcapi-gcs-front.yml
+++ b/.github/workflows/deploy-pcapi-gcs-front.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           path: ${{ inputs.app_directory }}/build
           destination: ${{ secrets.gcp_project }}-${{ inputs.environment }}-${{ inputs.app_name }}
+          parent: false
       - if: ${{ inputs.environment == 'production' }}
         run: |
           gcloud compute url-maps invalidate-cdn-cache ${{ inputs.environment }}-${{ inputs.app_name }}-url-map --path "/*"  --async


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17363

## But de la pull request

Upload les assests à la racine du bucket et non pas dans le dossier `/build`.