### PR TITLE
(PC-18231)[API] feat: backoffice: filter by status in the list of offerers to validate

### DIFF
--- a/api/tests/routes/backoffice/fixtures.py
+++ b/api/tests/routes/backoffice/fixtures.py
@@ -329,11 +329,17 @@ def offerers_to_be_validated(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
     no_tag = offerers_factories.NotValidatedOffererFactory(name="A")
-    top = offerers_factories.NotValidatedOffererFactory(name="B")
+    top = offerers_factories.NotValidatedOffererFactory(
+        name="B", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
     collec = offerers_factories.NotValidatedOffererFactory(name="C")
-    public = offerers_factories.NotValidatedOffererFactory(name="D")
+    public = offerers_factories.NotValidatedOffererFactory(
+        name="D", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
     top_collec = offerers_factories.NotValidatedOffererFactory(name="E")
-    top_public = offerers_factories.NotValidatedOffererFactory(name="F")
+    top_public = offerers_factories.NotValidatedOffererFactory(
+        name="F", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
 
     for offerer in (top, top_collec, top_public):
         offerers_factories.OffererTagMappingFactory(tagId=top_tag.id, offererId=offerer.id)
@@ -341,5 +347,9 @@ def offerers_to_be_validated(offerer_tags):
         offerers_factories.OffererTagMappingFactory(tagId=collec_tag.id, offererId=offerer.id)
     for offerer in (public, top_public):
         offerers_factories.OffererTagMappingFactory(tagId=public_tag.id, offererId=offerer.id)
+
+    # Other statuses
+    offerers_factories.OffererFactory(name="G")
+    offerers_factories.NotValidatedOffererFactory(name="H", validationStatus=offerers_models.ValidationStatus.REJECTED)
 
     return (no_tag, top, collec, public, top_collec, top_public)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18231

## But de la pull request

Permette le filtrage par état de validation dans la liste des structures à valider du nouveau backoffice.
Par défaut on garde les nouvelles et celles en attente, mais le filtrage permet aussi de voir celles validées ou rejetées (pratique pour le métier).

## Implémentation

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
