### PR TITLE
(PC-15721)[PRO] feat: do not show error if stocks are empty

### DIFF
--- a/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/EventStocks.jsx
@@ -194,7 +194,36 @@ const EventStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
     })
   }
 
-  const submitDraft = e => submitStocks(e, true)
+  const submitDraft = e => {
+    const isEmptyStocks = stocks => {
+      if (stocks.length > 1) {
+        return false
+      }
+      const {
+        price,
+        quantity,
+        beginningTime,
+        bookingLimitDatetime,
+        beginningDate,
+      } = stocks[0]
+
+      if (
+        price === '' &&
+        !quantity &&
+        !beginningTime &&
+        !beginningDate &&
+        !bookingLimitDatetime
+      ) {
+        return true
+      }
+      return false
+    }
+
+    const updatedStocks = existingStocks.filter(stock => stock.updated)
+    if (updatedStocks.length === 0 && isEmptyStocks(stocksInCreation))
+      notification.success('Brouillon sauvegardé dans la liste des offres')
+    else submitStocks(e, true)
+  }
 
   const submitStocks = useCallback(
     (e, isSavingDraft = false) => {

--- a/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -159,7 +159,17 @@ const ThingStocks = ({ offer, reloadOffer, isCompletingDraft }) => {
     })
   }
 
-  const submitDraft = e => submitStocks(e, true)
+  const submitDraft = e => {
+    const isRowEmpty = stock => {
+      if (!stock) return true
+
+      const { price, quantity, bookingLimitDatetime } = stock
+      if (price === '' && !quantity && !bookingLimitDatetime) return true
+      return false
+    }
+    if (!isRowEmpty(stock)) submitStocks(e, true)
+    else notification.success('Brouillon sauvegardé dans la liste des offres')
+  }
 
   const submitStocks = useCallback(
     (e, isSavingDraft = false) => {

--- a/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
+++ b/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.create.spec.jsx
@@ -717,6 +717,30 @@ describe('stocks page', () => {
         })
       })
 
+      it('should show a notification when clicking on save draft button without data', async () => {
+        store = {
+          ...store,
+          features: {
+            list: [
+              {
+                isActive: true,
+                name: 'OFFER_DRAFT_ENABLED',
+                nameKey: 'OFFER_DRAFT_ENABLED',
+              },
+            ],
+          },
+        }
+        renderOffers(props, store, '/offre/AG3A/individuel/creation/stocks')
+
+        await userEvent.click(await screen.findByText('Ajouter un stock'))
+        await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
+
+        // then
+        expect(api.upsertStocks).not.toHaveBeenCalled()
+        expect(
+          screen.getByText('Brouillon sauvegardé dans la liste des offres')
+        ).toBeInTheDocument()
+      })
       it('should save stocks when clicking on save draft button', async () => {
         // given
         api.upsertStocks.mockResolvedValue({})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15721

## But de la pull request

Quand un utilisateur essaye d'enregistrer un brouillon alors que la ligne de stock est vide (il n'a rien enregistré), ne pas afficher d'erreur mais un toaster de succès (même si on fait rien). 

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
