### PR TITLE
(PC-18162)[API] fix: do not fail prebooking notification if institution has no email

### DIFF
--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -25,10 +25,8 @@ class AdageHttpClient(AdageClient):
             data=data.json(),
         )
 
-        if api_response.status_code == 404:
-            return models.AdageApiResult(sent_data=data, response=dict(api_response.json()), success=True)  # type: ignore [arg-type]
-
-        if api_response.status_code != 201:
+        # Adage returns a 404 if the institution does not have any email
+        if api_response.status_code not in (201, 404):
             raise exceptions.AdageException(
                 "Error posting new prebooking to Adage API.", api_response.status_code, api_response.text
             )
@@ -108,7 +106,8 @@ class AdageHttpClient(AdageClient):
             api_url, headers={self.header_key: self.api_key, "Content-Type": "application/json"}, data=data.json()
         )
 
-        if api_response.status_code != 201:
+        # Adage returns a 404 if the institution does not have any email
+        if api_response.status_code not in (201, 404):
             raise exceptions.AdageException("Error getting Adage API", api_response.status_code, api_response.text)
 
         return models.AdageApiResult(sent_data=data.dict(), response=dict(api_response.json()), success=True)

--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -25,6 +25,9 @@ class AdageHttpClient(AdageClient):
             data=data.json(),
         )
 
+        if api_response.status_code == 404:
+            return models.AdageApiResult(sent_data=data, response=dict(api_response.json()), success=True)  # type: ignore [arg-type]
+
         if api_response.status_code != 201:
             raise exceptions.AdageException(
                 "Error posting new prebooking to Adage API.", api_response.status_code, api_response.text

--- a/api/src/pcapi/core/educational/api.py
+++ b/api/src/pcapi/core/educational/api.py
@@ -143,7 +143,7 @@ def book_collective_offer(
         )
     except ValidationError:
         logger.exception(
-            "Coulf not notify adage of prebooking, hence send confirmation email to educational institution, as educationalBooking serialization failed.",
+            "Could not notify adage of prebooking, hence send confirmation email to educational institution, as educationalBooking serialization failed.",
             extra={
                 "bookingId": booking.id,
             },

--- a/api/tests/core/educational/adage_backends/test_adage.py
+++ b/api/tests/core/educational/adage_backends/test_adage.py
@@ -1,8 +1,12 @@
 import pytest
 
 from pcapi.core.educational.adage_backends.adage import AdageHttpClient
+from pcapi.core.educational.adage_backends.serialize import serialize_collective_offer
 from pcapi.core.educational.exceptions import AdageException
 from pcapi.core.educational.factories import CollectiveBookingFactory
+from pcapi.core.educational.factories import CollectiveOfferFactory
+from pcapi.core.educational.factories import CollectiveStockFactory
+from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.models import AdageApiResult
 from pcapi.core.testing import override_settings
 from pcapi.routes.adage.v1.serialization import prebooking
@@ -11,6 +15,7 @@ from pcapi.routes.adage.v1.serialization import prebooking
 MOCK_API_URL = "http://adage.fr"
 
 
+@pytest.mark.usefixtures("db_session")
 class AdageHttpClientTest:
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_prebooking_returns_result_if_adage_answers_201_response_code(self, requests_mock):
@@ -60,3 +65,58 @@ class AdageHttpClientTest:
         # When
         with pytest.raises(AdageException):
             adage_client.notify_prebooking(booking_data)
+
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_notify_institution_association_returns_result_if_adage_answers_201_response_code(self, requests_mock):
+        # Given
+        adage_client = AdageHttpClient()
+        offer = CollectiveOfferFactory(
+            institution=EducationalInstitutionFactory(), collectiveStock=CollectiveStockFactory()
+        )
+        offer_data = serialize_collective_offer(offer)
+
+        response_data = {"result": "ok"}
+        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=201, json=response_data)
+
+        # When
+        result = adage_client.notify_institution_association(offer_data)
+
+        # Then
+        assert isinstance(result, AdageApiResult)
+        assert result.success == True
+        assert result.response == response_data
+
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_notify_institution_association_returns_result_if_adage_answers_404_response_code(self, requests_mock):
+        # Given
+        adage_client = AdageHttpClient()
+        offer = CollectiveOfferFactory(
+            institution=EducationalInstitutionFactory(), collectiveStock=CollectiveStockFactory()
+        )
+        offer_data = serialize_collective_offer(offer)
+
+        response_data = {"result": "EMAIL_ADDRESS_DOES_NOT_EXIST"}
+        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=404, json=response_data)
+
+        # When
+        result = adage_client.notify_institution_association(offer_data)
+
+        # Then
+        assert isinstance(result, AdageApiResult)
+        assert result.success == True
+        assert result.response == response_data
+
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_notify_institution_association_raises_if_adage_answers_error_response_code(self, requests_mock):
+        # Given
+        adage_client = AdageHttpClient()
+        offer = CollectiveOfferFactory(
+            institution=EducationalInstitutionFactory(), collectiveStock=CollectiveStockFactory()
+        )
+        offer_data = serialize_collective_offer(offer)
+
+        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=500)
+
+        # When
+        with pytest.raises(AdageException):
+            adage_client.notify_institution_association(offer_data)

--- a/api/tests/core/educational/adage_backends/test_adage.py
+++ b/api/tests/core/educational/adage_backends/test_adage.py
@@ -13,6 +13,12 @@ from pcapi.routes.adage.v1.serialization import prebooking
 
 
 MOCK_API_URL = "http://adage.fr"
+ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL = {
+    "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+    "title": "Not Found",
+    "status": 404,
+    "detail": "EMAIL_ADDRESS_DOES_NOT_EXIST",
+}
 
 
 @pytest.mark.usefixtures("db_session")
@@ -42,8 +48,10 @@ class AdageHttpClientTest:
         booking = CollectiveBookingFactory()
         booking_data = prebooking.serialize_collective_booking(booking)
 
-        response_data = {"result": "EMAIL_ADDRESS_DOES_NOT_EXIST"}
-        requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=404, json=response_data)
+        response_data = ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL
+        requests_mock.post(
+            f"{MOCK_API_URL}/v1/prereservation", status_code=404, json=ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL
+        )
 
         # When
         result = adage_client.notify_prebooking(booking_data)
@@ -95,8 +103,9 @@ class AdageHttpClientTest:
         )
         offer_data = serialize_collective_offer(offer)
 
-        response_data = {"result": "EMAIL_ADDRESS_DOES_NOT_EXIST"}
-        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=404, json=response_data)
+        requests_mock.post(
+            f"{MOCK_API_URL}/v1/offre-assoc", status_code=404, json=ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL
+        )
 
         # When
         result = adage_client.notify_institution_association(offer_data)
@@ -104,7 +113,7 @@ class AdageHttpClientTest:
         # Then
         assert isinstance(result, AdageApiResult)
         assert result.success == True
-        assert result.response == response_data
+        assert result.response == ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_institution_association_raises_if_adage_answers_error_response_code(self, requests_mock):

--- a/api/tests/core/educational/adage_backends/test_adage.py
+++ b/api/tests/core/educational/adage_backends/test_adage.py
@@ -1,0 +1,62 @@
+import pytest
+
+from pcapi.core.educational.adage_backends.adage import AdageHttpClient
+from pcapi.core.educational.exceptions import AdageException
+from pcapi.core.educational.factories import CollectiveBookingFactory
+from pcapi.core.educational.models import AdageApiResult
+from pcapi.core.testing import override_settings
+from pcapi.routes.adage.v1.serialization import prebooking
+
+
+MOCK_API_URL = "http://adage.fr"
+
+
+class AdageHttpClientTest:
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_notify_prebooking_returns_result_if_adage_answers_201_response_code(self, requests_mock):
+        # Given
+        adage_client = AdageHttpClient()
+        booking = CollectiveBookingFactory()
+        booking_data = prebooking.serialize_collective_booking(booking)
+
+        response_data = {"result": "ok"}
+        requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=201, json=response_data)
+
+        # When
+        result = adage_client.notify_prebooking(booking_data)
+
+        # Then
+        assert isinstance(result, AdageApiResult)
+        assert result.success == True
+        assert result.response == response_data
+
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_notify_prebooking_returns_result_if_adage_answers_404_response_code(self, requests_mock):
+        # Given
+        adage_client = AdageHttpClient()
+        booking = CollectiveBookingFactory()
+        booking_data = prebooking.serialize_collective_booking(booking)
+
+        response_data = {"result": "EMAIL_ADDRESS_DOES_NOT_EXIST"}
+        requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=404, json=response_data)
+
+        # When
+        result = adage_client.notify_prebooking(booking_data)
+
+        # Then
+        assert isinstance(result, AdageApiResult)
+        assert result.success == True
+        assert result.response == response_data
+
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_notify_prebooking_raises_if_adage_answers_error_response_code(self, requests_mock):
+        # Given
+        adage_client = AdageHttpClient()
+        booking = CollectiveBookingFactory()
+        booking_data = prebooking.serialize_collective_booking(booking)
+
+        requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=500)
+
+        # When
+        with pytest.raises(AdageException):
+            adage_client.notify_prebooking(booking_data)

--- a/api/tests/routes/adage_iframe/post_collective_booking_test.py
+++ b/api/tests/routes/adage_iframe/post_collective_booking_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import CollectiveBooking
+import pcapi.core.educational.testing as adage_api_testing
 from pcapi.core.educational.utils import get_hashed_user_id
 from pcapi.models.offer_mixin import OfferValidationStatus
 
@@ -59,6 +60,8 @@ class Returns200Test:
             "userId": get_hashed_user_id(educational_redactor.email),
         }
 
+        assert len(adage_api_testing.adage_requests) == 1
+
     def test_post_educational_booking_with_less_redactor_information(self, app):
         # Given
         stock = educational_factories.CollectiveStockFactory(beginningDatetime=stock_date)
@@ -99,6 +102,8 @@ class Returns200Test:
 
         assert response.json["bookingId"] == booking.id
 
+        assert len(adage_api_testing.adage_requests) == 1
+
 
 @freeze_time("2020-11-17 15:00:00")
 class Returns400Test:
@@ -132,6 +137,7 @@ class Returns400Test:
         # Then
         assert response.status_code == 400
         assert response.json == {"code": "UNKNOWN_EDUCATIONAL_INSTITUTION"}
+        assert len(adage_api_testing.adage_requests) == 0
 
     def test_should_not_allow_booking_when_stock_has_no_remaining_quantity(self, test_data, app):
         # Given
@@ -156,6 +162,7 @@ class Returns400Test:
         # Then
         assert response.status_code == 400
         assert response.json == {"stock": "Cette offre n'est pas disponible à la réservation"}
+        assert len(adage_api_testing.adage_requests) == 0
 
 
 @freeze_time("2020-11-17 15:00:00")
@@ -190,6 +197,7 @@ class Returns403Test:
         assert response.json == {
             "authorization": "Des informations sur le rédacteur de projet, et nécessaires à la préréservation, sont manquantes"
         }
+        assert len(adage_api_testing.adage_requests) == 0
 
     def test_should_not_allow_prebooking_when_uai_code_does_not_match_offer_institution_id(self, client) -> None:
         # Given
@@ -218,3 +226,4 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json == {"code": "WRONG_UAI_CODE"}
+        assert len(adage_api_testing.adage_requests) == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18162

## But de la pull request

Règle cette issue Sentry : https://sentry.passculture.team/organizations/sentry/issues/398218/?project=5
Adage renvoyait une 500 si l'établissement n'avait pas d'email. Maintenant une 404 est renvoyée, il faut la gérer pour ne pas lever d'erreur dans Sentry
