### PR TITLE
[PC-17389] Remove duplicate yarn build from backoffice deployment

### DIFF
--- a/.github/workflows/deploy-pcapi.yml
+++ b/.github/workflows/deploy-pcapi.yml
@@ -156,5 +156,4 @@ jobs:
       - run: yarn install
       - run: |
           set -a; source ../config/run_envs/${{ inputs.environment }};
-          yarn build:${{ inputs.environment }}
-      - run: yarn deploy:${{ inputs.environment }}
+          yarn deploy:${{ inputs.environment }}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17389

## But de la pull request

La commande `yarn deploy:env` exécute déjà `yarn build:env`, pas besoin de le faire au préalable sinon ça build deux fois.