### PR TITLE
Revert "(BSR) deployment: simplify release version number"

### DIFF
--- a/.github/workflows/release--build-hotfix.yml
+++ b/.github/workflows/release--build-hotfix.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
       releaseVersion:
-        description: "Nom du hotfix (ex: 200.2)"
+        description: "Nom du hotfix (ex: 200.0.2)"
         required: true
         type: string
 

--- a/.github/workflows/release--build.yml
+++ b/.github/workflows/release--build.yml
@@ -20,7 +20,7 @@ jobs:
     secrets: inherit
     with:
       base_ref: ${{ github.event.inputs.commitHash }}
-      tag_number: ${{ github.event.inputs.releaseNumber }}.0
+      tag_number: ${{ github.event.inputs.releaseNumber }}.0.0
 
   create-maintenance-branch:
     name: Create maintenance branch
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout new tag
         uses: actions/checkout@v3
         with:
-          ref: v${{ github.event.inputs.releaseNumber }}.0
+          ref: v${{ github.event.inputs.releaseNumber }}.0.0
       - name: Create maintenance branch
         run: |
           git checkout -b "$MAINTENANCE_BRANCH"


### PR DESCRIPTION
En fait cette numérotation n’est pas standard, comme le montre l’échec de l’action de déploiement aujourd’hui.

`yarn version --new-version "211.0"` retourne une erreur, on attend plutôt une version à 3 nombres.