### PR TITLE
(PC-18236)[API] fix: backoffice: validation error for OffererToBeValidated

### DIFF
--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -427,7 +427,7 @@ class OffererToBeValidated(BaseModel):
     status: str
     step: str | None
     siren: str
-    address: str
+    address: str | None  # nullable in HasAddressMixin
     postalCode: str
     city: str
     owner: str | None

--- a/api/tests/routes/backoffice/fixtures.py
+++ b/api/tests/routes/backoffice/fixtures.py
@@ -328,7 +328,7 @@ def offerer_tags():
 def offerers_to_be_validated(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
-    no_tag = offerers_factories.NotValidatedOffererFactory(name="A")
+    no_tag = offerers_factories.NotValidatedOffererFactory(name="A", address=None)
     top = offerers_factories.NotValidatedOffererFactory(
         name="B", validationStatus=offerers_models.ValidationStatus.PENDING
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18236

## But de la pull request

Corriger une erreur remontée par Sentry, en production, sur l'écran de validation de structures.
Cela empêche l'affichage de la liste dès lors qu'une des structures renvoyées n'a pas d'adresse (optionnelle), donc potentiellement assez bloquant. Apparue 13 fois sur Sentry, a priori par les utilisateurs côté homologation.

## Informations supplémentaires

```
ValidationError: 1 validation error for OffererToBeValidated address
  none is not an allowed value (type=type_error.none.not_allowed)
```

Actually adress is nullable un HasAddressMixin so it can be null in database

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
