### PR TITLE
[PC-17363] Specify helm repo username as env var only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -944,6 +944,7 @@ jobs:
       - run:
           name: Deploy new ExternalSecret only if needed
           command: |
+            PASSCULTURE_USERNAME="_json_key" \
             PASSCULTURE_PASSWORD=${GCP_INFRA_KEY} \
             PCAPI_VALUES_FILE=<(helm -n <<parameters.helm_environment>> get values <<parameters.helm_environment>>) \
             PCAPI_SECRETS_FILE=/tmp/workspace/pcapi-secrets.yaml \
@@ -959,6 +960,7 @@ jobs:
       - run:
           name: Deploy pcapi
           command: |
+            PASSCULTURE_USERNAME="_json_key" \
             PASSCULTURE_PASSWORD=${GCP_INFRA_KEY} \
             PCAPI_VALUES_FILE=~/pass-culture-deployment/helm/pcapi/values.<<parameters.helm_environment>>.yaml \
             PCAPI_SECRETS_FILE=/tmp/workspace/pcapi-secrets.yaml \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,7 @@ jobs:
           helmfile-version: "v0.147.0"
       - name: Deploy pcapi
         run: |
+          PASSCULTURE_USERNAME="oauth2accesstoken" \
           PASSCULTURE_PASSWORD=${{ steps.openid-auth-infra.outputs.access_token }} \
           PCAPI_VALUES_FILE=./pass-culture-deployment/helm/pcapi/values.${{ inputs.environment }}.yaml \
           PCAPI_SECRETS_FILE=<(echo '${{ needs.generate-pcapi-helm-secrets-file.outputs.pcapi_helm_secrets_file_base64 }}' | base64 -d) \

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -5,7 +5,6 @@ repositories:
   - name: passCulture
     url: europe-west1-docker.pkg.dev/passculture-infra-prod
     oci: true
-    username: oauth2accesstoken
 
 releases:
   - name: {{ .Environment.Name }}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17363

## But de la pull request

Comme Circle CI utilise une authentification par clé privée et Github Actions utilise OpenID Connect, le nom d'utilisateur à fournir varie. On l'enlève du fichier `helmfile.yaml` et on le passe uniquement via la variable d'environnement `PASSCULTURE_USERNAME`.