### PR TITLE
(PC-18306)[API] fix: reindex collective offers and collective offers templates after dump restore

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1000,3 +1000,29 @@ def search_educational_institution(
         .limit(limit)
         .all()
     )
+
+
+def get_paginated_active_collective_offer_ids(limit: int, page: int) -> list[int]:
+    query = (
+        educational_models.CollectiveOffer.query.with_entities(educational_models.CollectiveOffer.id)
+        .filter(
+            educational_models.CollectiveOffer.isActive.is_(True),
+        )
+        .order_by(educational_models.CollectiveOffer.id)
+        .offset(page * limit)
+        .limit(limit)
+    )
+    return [offer_id for offer_id, in query]
+
+
+def get_paginated_active_collective_offer_template_ids(limit: int, page: int) -> list[int]:
+    query = (
+        educational_models.CollectiveOfferTemplate.query.with_entities(educational_models.CollectiveOfferTemplate.id)
+        .filter(
+            educational_models.CollectiveOfferTemplate.isActive.is_(True),
+        )
+        .order_by(educational_models.CollectiveOfferTemplate.id)
+        .offset(page * limit)
+        .limit(limit)
+    )
+    return [offer_id for offer_id, in query]

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -516,12 +516,12 @@ def unindex_venue_ids(venue_ids: Iterable[int]) -> None:
         logger.exception("Could not unindex venues", extra={"venues": venue_ids})
 
 
-def unindex_all_collective_offers() -> None:
+def unindex_all_collective_offers(*, only_template: bool = False, only_non_template: bool = False) -> None:
     if settings.IS_PROD:
         raise ValueError("It is forbidden to unindex all collective offers on this environment")
     backend = _get_backend()
     try:
-        backend.unindex_all_collective_offers()
+        backend.unindex_all_collective_offers(only_template=only_template, only_non_template=only_non_template)
     except Exception:  # pylint: disable=broad-except
         if settings.IS_RUNNING_TESTS:
             raise

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -306,8 +306,13 @@ class AlgoliaBackend(base.SearchBackend):
     def unindex_all_venues(self) -> None:
         self.algolia_venues_client.clear_objects()
 
-    def unindex_all_collective_offers(self) -> None:
-        self.algolia_collective_offers_client.clear_objects()
+    def unindex_all_collective_offers(self, *, only_template: bool = False, only_non_template: bool = False) -> None:
+        if only_template and not only_non_template:
+            self.algolia_collective_offers_client.delete_by({"facetFilters": ["isTemplate:true"]})
+        elif not only_template and only_non_template:
+            self.algolia_collective_offers_client.delete_by({"facetFilters": ["isTemplate:false"]})
+        else:
+            self.algolia_collective_offers_client.clear_objects()
 
     def unindex_all_collective_offers_templates(self) -> None:
         self.algolia_collective_offers_templates_client.clear_objects()

--- a/api/src/pcapi/core/search/backends/base.py
+++ b/api/src/pcapi/core/search/backends/base.py
@@ -74,7 +74,7 @@ class SearchBackend:
     def unindex_venue_ids(self, venue_ids: Iterable[int]) -> None:
         raise NotImplementedError()
 
-    def unindex_all_collective_offers(self) -> None:
+    def unindex_all_collective_offers(self, *, only_template: bool = False, only_non_template: bool = False) -> None:
         raise NotImplementedError()
 
     def unindex_collective_offer_ids(self, collective_offer_ids: Iterable[int]) -> None:

--- a/api/src/pcapi/scripts/algolia_indexing/commands.py
+++ b/api/src/pcapi/scripts/algolia_indexing/commands.py
@@ -3,6 +3,8 @@ import click
 from pcapi.core import search
 import pcapi.core.educational.api as educational_api
 import pcapi.core.offers.api as offers_api
+from pcapi.scripts.algolia_indexing.indexing import batch_indexing_collective_offers_in_algolia_from_database
+from pcapi.scripts.algolia_indexing.indexing import batch_indexing_collective_offers_template_in_algolia_from_database
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_offers_in_algolia_from_database
 from pcapi.scripts.algolia_indexing.indexing import batch_indexing_venues_in_algolia_from_database
 from pcapi.utils.blueprint import Blueprint
@@ -35,6 +37,51 @@ def process_offers_from_database(  # type: ignore [no-untyped-def]
     if clear:
         search.unindex_all_offers()
     batch_indexing_offers_in_algolia_from_database(ending_page=ending_page, limit=limit, starting_page=starting_page)
+
+
+@blueprint.cli.command("process_collective_offers_from_database")
+@click.option("--clear", help="Clear search index", type=bool, default=False)
+@click.option(
+    "-epc", "--ending-page-collective-offer", help="Ending page for indexing collective offers", type=int, default=None
+)
+@click.option(
+    "-epct",
+    "--ending-page-collective-offer-template",
+    help="Ending page for indexing collective offers templates",
+    type=int,
+    default=None,
+)
+@click.option("-l", "--limit", help="Number of offers per page", type=int, default=10_000)
+@click.option(
+    "-spc", "--starting-page-collective-offer", help="Starting page for indexing collective offers", type=int, default=0
+)
+@click.option(
+    "-spct",
+    "--starting-page-collective-offer-template",
+    help="Starting page for indexing collective offer templates",
+    type=int,
+    default=0,
+)
+def process_collective_offers_from_database(  # type: ignore [no-untyped-def]
+    clear: bool,
+    ending_page_collective_offer: int,
+    ending_page_collective_offer_template: int,
+    limit: int,
+    starting_page_collective_offer: int,
+    starting_page_collective_offer_template: int,
+):
+    if clear:
+        # collective offers and collective offers template share the same index
+        # thus they are all unindex after this command
+        search.unindex_all_collective_offers()
+    batch_indexing_collective_offers_in_algolia_from_database(
+        ending_page=ending_page_collective_offer, limit=limit, starting_page=starting_page_collective_offer
+    )
+    batch_indexing_collective_offers_template_in_algolia_from_database(
+        ending_page=ending_page_collective_offer_template,
+        limit=limit,
+        starting_page=starting_page_collective_offer_template,
+    )
 
 
 @blueprint.cli.command("process_expired_offers")

--- a/api/src/pcapi/scripts/algolia_indexing/commands.py
+++ b/api/src/pcapi/scripts/algolia_indexing/commands.py
@@ -41,46 +41,51 @@ def process_offers_from_database(  # type: ignore [no-untyped-def]
 
 @blueprint.cli.command("process_collective_offers_from_database")
 @click.option("--clear", help="Clear search index", type=bool, default=False)
+@click.option("-ep", "--ending-page", help="Ending page for indexing collective offers", type=int, default=None)
+@click.option("-l", "--limit", help="Number of offers per page", type=int, default=10_000)
+@click.option("-sp", "--starting-page", help="Starting page for indexing collective offers", type=int, default=0)
+def process_collective_offers_from_database(  # type: ignore [no-untyped-def]
+    clear: bool,
+    ending_page: int,
+    limit: int,
+    starting_page: int,
+):
+    if clear:
+        search.unindex_all_collective_offers(only_non_template=True)
+    batch_indexing_collective_offers_in_algolia_from_database(
+        ending_page=ending_page, limit=limit, starting_page=starting_page
+    )
+
+
+@blueprint.cli.command("process_collective_offers_template_from_database")
+@click.option("--clear", help="Clear search index", type=bool, default=False)
 @click.option(
-    "-epc", "--ending-page-collective-offer", help="Ending page for indexing collective offers", type=int, default=None
-)
-@click.option(
-    "-epct",
-    "--ending-page-collective-offer-template",
+    "-ep",
+    "--ending-page",
     help="Ending page for indexing collective offers templates",
     type=int,
     default=None,
 )
 @click.option("-l", "--limit", help="Number of offers per page", type=int, default=10_000)
 @click.option(
-    "-spc", "--starting-page-collective-offer", help="Starting page for indexing collective offers", type=int, default=0
-)
-@click.option(
-    "-spct",
-    "--starting-page-collective-offer-template",
+    "-sp",
+    "--starting-page",
     help="Starting page for indexing collective offer templates",
     type=int,
     default=0,
 )
-def process_collective_offers_from_database(  # type: ignore [no-untyped-def]
+def process_collective_offers_template_from_database(  # type: ignore [no-untyped-def]
     clear: bool,
-    ending_page_collective_offer: int,
-    ending_page_collective_offer_template: int,
+    ending_page: int,
     limit: int,
-    starting_page_collective_offer: int,
-    starting_page_collective_offer_template: int,
+    starting_page: int,
 ):
     if clear:
-        # collective offers and collective offers template share the same index
-        # thus they are all unindex after this command
-        search.unindex_all_collective_offers()
-    batch_indexing_collective_offers_in_algolia_from_database(
-        ending_page=ending_page_collective_offer, limit=limit, starting_page=starting_page_collective_offer
-    )
+        search.unindex_all_collective_offers(only_template=True)
     batch_indexing_collective_offers_template_in_algolia_from_database(
-        ending_page=ending_page_collective_offer_template,
+        ending_page=ending_page,
         limit=limit,
-        starting_page=starting_page_collective_offer_template,
+        starting_page=starting_page,
     )
 
 

--- a/api/src/pcapi/scripts/algolia_indexing/indexing.py
+++ b/api/src/pcapi/scripts/algolia_indexing/indexing.py
@@ -1,6 +1,7 @@
 import logging
 
 from pcapi.core import search
+import pcapi.core.educational.repository as collective_offers_repository
 from pcapi.core.offerers import api as offerers_api
 import pcapi.core.offers.repository as offers_repository
 from pcapi.utils.chunks import get_chunks
@@ -22,6 +23,42 @@ def batch_indexing_offers_in_algolia_from_database(
             break
         search.reindex_offer_ids(offer_ids)
         logger.info("[ALGOLIA] Processed %d offers from page %d", len(offer_ids), page)
+        page += 1
+
+
+def batch_indexing_collective_offers_in_algolia_from_database(
+    ending_page: int = None, limit: int = 10000, starting_page: int = 0
+) -> None:
+    page = starting_page
+    backend = search._get_backend()
+    while True:
+        if ending_page and ending_page == page:
+            break
+
+        offer_ids = collective_offers_repository.get_paginated_active_collective_offer_ids(limit=limit, page=page)
+        if not offer_ids:
+            break
+        search._reindex_collective_offer_ids(backend, offer_ids)
+        logger.info("[ALGOLIA] Processed %d collective offers from page %d", len(offer_ids), page)
+        page += 1
+
+
+def batch_indexing_collective_offers_template_in_algolia_from_database(
+    ending_page: int = None, limit: int = 10000, starting_page: int = 0
+) -> None:
+    page = starting_page
+    backend = search._get_backend()
+    while True:
+        if ending_page and ending_page == page:
+            break
+
+        offer_ids = collective_offers_repository.get_paginated_active_collective_offer_template_ids(
+            limit=limit, page=page
+        )
+        if not offer_ids:
+            break
+        search._reindex_collective_offer_template_ids(backend, offer_ids)
+        logger.info("[ALGOLIA] Processed %d collective offers templates from page %d", len(offer_ids), page)
         page += 1
 
 

--- a/api/tests/core/search/test_backend_algolia.py
+++ b/api/tests/core/search/test_backend_algolia.py
@@ -383,11 +383,33 @@ def test_unindex_collective_offer_ids():
         assert posted_json["requests"][0]["body"]["objectID"] == 1
 
 
-def test_unindex_all_collective_offers():
+def test_unindex_all_collective_offers_for_all_objects():
     backend = get_backend()
     with requests_mock.Mocker() as mock:
         posted = mock.post("https://dummy-app-id.algolia.net/1/indexes/testing-collective-offers/clear", json={})
         backend.unindex_all_collective_offers()
+        assert posted.called
+
+
+def test_unindex_all_collective_offers_only_for_template():
+    backend = get_backend()
+    with requests_mock.Mocker() as mock:
+        posted = mock.post(
+            "https://dummy-app-id.algolia.net/1/indexes/testing-collective-offers/deleteByQuery",
+            json={"facetFilter": ["isTemplate:true"]},
+        )
+        backend.unindex_all_collective_offers(only_template=True)
+        assert posted.called
+
+
+def test_unindex_all_collective_offers():
+    backend = get_backend()
+    with requests_mock.Mocker() as mock:
+        posted = mock.post(
+            "https://dummy-app-id.algolia.net/1/indexes/testing-collective-offers/deleteByQuery",
+            json={"facetFilter": ["isTemplate:false"]},
+        )
+        backend.unindex_all_collective_offers(only_non_template=True)
         assert posted.called
 
 


### PR DESCRIPTION
Les offres collectives et templates n'étaient plus désindexées puis réindexées après le dump/restore en staging suite à la séparation des modèles

Pour réparer ca : 
- création d'une commande qui reindexe les offres collectives et les offres collectives template