### PR TITLE
(BSR) update-api-client workflow: dont add all changed files

### DIFF
--- a/.github/workflows/update-api-client-template.yml
+++ b/.github/workflows/update-api-client-template.yml
@@ -148,8 +148,8 @@ jobs:
           sudo chown -R $USER .
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git add .
-          git commit -m "(BSR)[PRO] chore: update api client"
+          git add pro/src/apiClient adage-front/src/apiClient
+          git commit -m "(BSR) chore: update api client"
 
       - name: Push changes
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
Pour n'ajouter que les changements dans le dossier apiClient 
Les autres changements de type yarn.lock pas à jour ou autre changement ne devraient pas être commités par ce workflow