### PR TITLE
(PC-18019)[BACKOFFICE] Add status labels to pro search results

### DIFF
--- a/backoffice/src/resources/Pro/Components/ValidationStatusBadge.tsx
+++ b/backoffice/src/resources/Pro/Components/ValidationStatusBadge.tsx
@@ -1,12 +1,14 @@
 import { Chip } from '@mui/material'
 
 import { ValidationStatus } from '../../../TypesFromApi'
+import { ProTypeEnum } from '../types'
 
 type Props = {
   status: ValidationStatus
+  resourceType: ProTypeEnum
 }
 
-export const ValidationStatusBadge = ({ status }: Props) => {
+export const ValidationStatusBadge = ({ status, resourceType }: Props) => {
   let label = ''
   let color:
     | 'default'
@@ -19,7 +21,7 @@ export const ValidationStatusBadge = ({ status }: Props) => {
 
   switch (status) {
     case ValidationStatus.NEW:
-      label = 'Nouveau'
+      label = resourceType == ProTypeEnum.offerer ? 'Nouvelle' : 'Nouveau'
       color = 'info'
       break
     case ValidationStatus.PENDING:
@@ -27,11 +29,11 @@ export const ValidationStatusBadge = ({ status }: Props) => {
       color = 'warning'
       break
     case ValidationStatus.REJECTED:
-      label = 'Rejeté'
+      label = resourceType == ProTypeEnum.offerer ? 'Rejetée' : 'Rejeté'
       color = 'error'
       break
     case ValidationStatus.VALIDATED:
-      label = 'Validé'
+      label = resourceType == ProTypeEnum.offerer ? 'Validée' : 'Validé'
       color = 'success'
       break
     default:
@@ -39,5 +41,13 @@ export const ValidationStatusBadge = ({ status }: Props) => {
       color = 'default'
       break
   }
-  return <Chip color={color} label={label} />
+  return (
+    <Chip
+      color={color}
+      label={label}
+      style={{
+        fontSize: '0.95rem',
+      }}
+    />
+  )
 }

--- a/backoffice/src/resources/Pro/Offerers/OffererDetail.tsx
+++ b/backoffice/src/resources/Pro/Offerers/OffererDetail.tsx
@@ -38,7 +38,7 @@ import { BankAccountStatusBadge } from '../Components/BankAccountStatusBadge'
 import { CommentOfferer } from '../Components/CommentOfferer'
 import { OffererUserssToValidateContextTableMenu } from '../Components/OffererUsersToValidateContextTableMenu'
 import { ProTypeBadge } from '../Components/ProTypeBadge'
-import { ValidationStatusBadge } from '../Components/VallidationStatusBadge'
+import { ValidationStatusBadge } from '../Components/ValidationStatusBadge'
 import { ProTypeEnum } from '../types'
 
 const cardStyle = {
@@ -134,9 +134,17 @@ export const OffererDetail = () => {
     offererStats.inactive.individual + offererStats.inactive.collective
   const offererRevenue = offererInfo.revenue
 
-  const activeBadge = <StatusBadge active={offererInfo.isActive} />
+  const activeBadge = (
+    <StatusBadge active={offererInfo.isActive} feminine={true} />
+  )
   const protypeBadge = (
     <ProTypeBadge type={ProTypeEnum.offerer} resource={offererInfo} />
+  )
+  const validationStatusBadge = (
+    <ValidationStatusBadge
+      status={offererInfo.validationStatus}
+      resourceType={ProTypeEnum.offerer}
+    />
   )
 
   return (
@@ -170,8 +178,9 @@ export const OffererDetail = () => {
                     <div>
                       <Typography variant="h5" gutterBottom component="div">
                         {offererInfo.name}
-                        &nbsp; &nbsp; {offererInfo.isActive && activeBadge}{' '}
-                        &nbsp; {offererInfo && protypeBadge}
+                        &nbsp; &nbsp; {offererInfo && protypeBadge}
+                        &nbsp; {offererInfo && validationStatusBadge}
+                        &nbsp; {!offererInfo.isActive && activeBadge}
                       </Typography>
                       <Typography
                         variant="body1"
@@ -402,6 +411,7 @@ export const OffererDetail = () => {
                           <TableCell>
                             <ValidationStatusBadge
                               status={user.validationStatus}
+                              resourceType={ProTypeEnum.proUser}
                             />
                           </TableCell>
                           <TableCell component="th" scope="row">

--- a/backoffice/src/resources/Pro/ProSearch.tsx
+++ b/backoffice/src/resources/Pro/ProSearch.tsx
@@ -38,9 +38,11 @@ import {
 import { apiProvider } from '../../providers/apiProvider'
 import { ProResult, SearchProRequest } from '../../TypesFromApi'
 import { CustomSearchIcon } from '../Icons/CustomSearchIcon'
+import { StatusBadge } from '../PublicUsers/Components/StatusBadge'
 import { PermissionsEnum } from '../PublicUsers/types'
 
 import { ProTypeBadge } from './Components/ProTypeBadge'
+import { ValidationStatusBadge } from './Components/ValidationStatusBadge'
 import {
   isOfferer,
   isProUser,
@@ -80,13 +82,49 @@ const proResources = [
 ]
 
 const ProCard = ({ record }: { record: ProResult }) => {
-  const { id, resourceType, payload }: ProResult = record //TODO: implémenter le badge de status quand la valeur sera renvoyée depuis l'API
+  const { id, resourceType, payload }: ProResult = record
 
   return (
-    <Card sx={{ minWidth: 275 }}>
+    <Card sx={{ minWidth: 330 }}>
       <CardContent>
         <Stack direction={'row'} spacing={2} sx={{ mb: 2 }}>
           <ProTypeBadge type={resourceType as ProTypeEnum} resource={record} />
+          {payload &&
+            isProUser(payload as ProUser) &&
+            !(payload as ProUser).isActive && (
+              <>
+                <StatusBadge active={(payload as ProUser).isActive} />
+              </>
+            )}
+          {payload && isOfferer(payload as Offerer) && (
+            <>
+              <ValidationStatusBadge
+                status={(payload as Offerer).validationStatus}
+                resourceType={resourceType as ProTypeEnum}
+              />
+              {!(payload as Offerer).isActive && (
+                <>
+                  <StatusBadge
+                    active={(payload as Offerer).isActive}
+                    feminine={true}
+                  />
+                </>
+              )}
+            </>
+          )}
+          {payload && isVenue(payload as Venue) && (
+            <>
+              <ValidationStatusBadge
+                status={(payload as Venue).validationStatus}
+                resourceType={resourceType as ProTypeEnum}
+              />
+              {!(payload as Venue).isActive && (
+                <>
+                  <StatusBadge active={(payload as Venue).isActive} />
+                </>
+              )}
+            </>
+          )}
         </Stack>
         {payload && isProUser(payload as ProUser) && (
           <>

--- a/backoffice/src/resources/Pro/types.tsx
+++ b/backoffice/src/resources/Pro/types.tsx
@@ -1,8 +1,11 @@
+import { ValidationStatus } from '../../TypesFromApi'
+
 export interface ProUser {
   firstName: string
   lastName: string
   email: string
   phoneNumber: string
+  isActive: boolean
 }
 
 export function isProUser(obj: ProUser | Venue | Offerer): obj is ProUser {
@@ -19,6 +22,8 @@ export interface Venue {
   email: string
   siret: string
   permanent: boolean
+  validationStatus: ValidationStatus
+  isActive: boolean
 }
 
 export function isVenue(obj: ProUser | Venue | Offerer): obj is Venue {
@@ -28,6 +33,8 @@ export function isVenue(obj: ProUser | Venue | Offerer): obj is Venue {
 export interface Offerer {
   name: string
   siren: string
+  validationStatus: ValidationStatus
+  isActive: boolean
 }
 
 export function isOfferer(obj: ProUser | Venue | Offerer): obj is Offerer {

--- a/backoffice/src/resources/PublicUsers/Components/StatusBadge.tsx
+++ b/backoffice/src/resources/PublicUsers/Components/StatusBadge.tsx
@@ -4,14 +4,15 @@ import { Chip } from '@mui/material'
 
 type Props = {
   active?: boolean
+  feminine?: boolean
 }
 
-export const StatusBadge = ({ active }: Props) => {
+export const StatusBadge = ({ active, feminine }: Props) => {
   if (active) {
     return (
       <Chip
         color={'success'}
-        label={'Actif'}
+        label={feminine ? 'Active' : 'Actif'}
         icon={<CheckCircleOutlineIcon />}
         style={{
           fontSize: '0.95rem',
@@ -19,5 +20,15 @@ export const StatusBadge = ({ active }: Props) => {
       />
     )
   }
-  return <Chip color={'error'} label={'Suspendu'} icon={<HighlightOffIcon />} />
+  return (
+    <Chip
+      color={'error'}
+      label={feminine ? 'Suspendue' : 'Suspendu'}
+      icon={<HighlightOffIcon />}
+      style={{
+        fontSize: '0.95rem',
+        backgroundColor: 'black',
+      }}
+    />
+  )
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18019

## But de la pull request

Dans l'interface du nouveau backoffice, ajout d'une étiquette sur l'état de validation de la structure dans le profil et les résultats de recherche. Aussi l'état inactif (suspendu) est affiché, mais on ignore l'état actif, peu significatif.

## Implémentation

## Informations supplémentaires

- La couleur de l'étiquette "Suspendu" est désormais noire pour respecter le ticket, et ne pas confondre avec "Rejeté". Cela affecte aussi les étiquettes sur les utilisateurs (même badge) et il est cohérent d'utiliser la même couleur pour la même information.

## Modifications du schéma de la base de données

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
