### PR TITLE
(BSR)[API] Ajout et correction d'annotations de type dans `pcapi.core.offerers`, `pcapi.core.monkeypatches` et `pcapi.models` (+ bonus !)

### DIFF
--- a/api/src/pcapi/core/monkeypatches.py
+++ b/api/src/pcapi/core/monkeypatches.py
@@ -1,4 +1,7 @@
 import time
+import typing
+
+import sib_api_v3_sdk.rest
 
 # Re-use the same logger since we log the exact same message.
 from pcapi.utils.requests import logger
@@ -7,7 +10,12 @@ from pcapi.utils.requests import logger
 SENDINBLUE_REQUEST_TIMEOUT = 10
 
 
-def custom_restclient_request(self, method, url, **kwargs):  # type: ignore [no-untyped-def]
+def custom_restclient_request(
+    self: sib_api_v3_sdk.rest.RESTClientObject,
+    method: str,
+    url: str,
+    **kwargs: typing.Any,
+) -> sib_api_v3_sdk.rest.RESTResponse:
     """Wrapper around ``RESTClientObject.request()`` from SendindBlue SDK
     that sets a default timeout and logs the request.
     """
@@ -40,12 +48,12 @@ def custom_restclient_request(self, method, url, **kwargs):  # type: ignore [no-
     return response
 
 
-def monkey_patch_sendinblue():  # type: ignore [no-untyped-def]
+def monkey_patch_sendinblue() -> None:
     from sib_api_v3_sdk.rest import RESTClientObject
 
     RESTClientObject.__orig_request = RESTClientObject.request
     RESTClientObject.request = custom_restclient_request
 
 
-def install_monkey_patches():  # type: ignore [no-untyped-def]
+def install_monkey_patches() -> None:
     monkey_patch_sendinblue()

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -1,7 +1,9 @@
 import datetime
+import typing
 
 import factory
 
+import pcapi.core.finance.models as finance_models
 from pcapi.core.testing import BaseFactory
 import pcapi.core.users.factories as users_factories
 from pcapi.utils import crypto
@@ -38,8 +40,8 @@ class VenueFactory(BaseFactory):
 
     name = factory.Sequence("Le Petit Rintintin {}".format)
     departementCode = factory.LazyAttribute(lambda o: None if o.isVirtual else "75")
-    latitude = 48.87004
-    longitude = 2.37850
+    latitude: float | None = 48.87004
+    longitude: float | None = 2.37850
     managingOfferer = factory.SubFactory(OffererFactory)
     address = factory.LazyAttribute(lambda o: None if o.isVirtual else "1 boulevard Poissonnière")
     postalCode = factory.LazyAttribute(lambda o: None if o.isVirtual else "75000")
@@ -66,7 +68,12 @@ class VenueFactory(BaseFactory):
     dmsToken = factory.LazyFunction(api.generate_dms_token)
 
     @factory.post_generation
-    def business_unit_venue_link(venue, create, extracted, **kwargs):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def business_unit_venue_link(  # pylint: disable=no-self-argument
+        venue: models.Venue,
+        create: bool,
+        extracted: typing.Callable | None,
+        **kwargs: typing.Any,
+    ) -> finance_models.BusinessUnitVenueLink | None:
         import pcapi.core.finance.factories as finance_factories
 
         if not create:
@@ -76,7 +83,12 @@ class VenueFactory(BaseFactory):
         return finance_factories.BusinessUnitVenueLinkFactory(venue=venue, businessUnit=venue.businessUnit)
 
     @factory.post_generation
-    def pricing_point(venue, create, extracted, **kwargs):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def pricing_point(  # pylint: disable=no-self-argument
+        venue: models.Venue,
+        create: bool,
+        extracted: typing.Callable | None,
+        **kwargs: typing.Any,
+    ) -> models.VenuePricingPointLink | None:
         if not create:
             return None
         pricing_point = extracted
@@ -87,7 +99,12 @@ class VenueFactory(BaseFactory):
         return VenuePricingPointLinkFactory(venue=venue, pricingPoint=pricing_point)
 
     @factory.post_generation
-    def reimbursement_point(venue, create, extracted, **kwargs):  # type: ignore [no-untyped-def] # pylint: disable=no-self-argument
+    def reimbursement_point(  # pylint: disable=no-self-argument
+        venue: models.Venue,
+        create: bool,
+        extracted: typing.Callable | None,
+        **kwargs: typing.Any,
+    ) -> models.VenueReimbursementPointLink | None:
         if not create:
             return None
         reimbursement_point = extracted
@@ -125,8 +142,8 @@ class VirtualVenueFactory(VenueFactory):
     departementCode = None
     postalCode = None
     city = None
-    latitude = None  # type: ignore [assignment]
-    longitude = None  # type: ignore [assignment]
+    latitude = None
+    longitude = None
     siret = None
     audioDisabilityCompliant = None
     mentalDisabilityCompliant = None
@@ -237,7 +254,12 @@ class ApiKeyFactory(BaseFactory):
     prefix = DEFAULT_PREFIX
 
     @classmethod
-    def _create(cls, model_class, *args, **kwargs):  # type: ignore [no-untyped-def]
+    def _create(
+        cls,
+        model_class: typing.Type[models.ApiKey],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> models.ApiKey:
         kwargs["secret"] = crypto.hash_password(kwargs.get("secret", DEFAULT_SECRET))
         return super()._create(model_class, *args, **kwargs)
 

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -223,7 +223,7 @@ def find_all_user_offerers_by_offerer_id(offerer_id: int) -> list[models.UserOff
     return models.UserOfferer.query.filter_by(offererId=offerer_id).all()
 
 
-def filter_query_where_user_is_user_offerer_and_is_validated(query, user):  # type: ignore [no-untyped-def]
+def filter_query_where_user_is_user_offerer_and_is_validated(query: BaseQuery, user: User) -> BaseQuery:
     return query.join(models.UserOfferer).filter_by(user=user).filter(models.UserOfferer.isValidated)
 
 

--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -1,4 +1,5 @@
 import decimal
+import typing
 
 import sqlalchemy.orm as sqla_orm
 
@@ -17,7 +18,7 @@ VENUE_BANNER_MAX_SIZE = 10_000_000
 
 
 # FUTURE-NEW-BANK-DETAILS: remove when new bank details journey is complete
-def check_existing_business_unit(business_unit_id: int, offerer: models.Offerer):  # type: ignore [no-untyped-def]
+def check_existing_business_unit(business_unit_id: int, offerer: models.Offerer) -> None:
     business_unit = finance_models.BusinessUnit.query.filter_by(id=business_unit_id).one_or_none()
     if not business_unit:
         raise ApiErrors(errors={"businessUnitId": ["Ce point de facturation n'existe pas."]})
@@ -26,7 +27,7 @@ def check_existing_business_unit(business_unit_id: int, offerer: models.Offerer)
         raise ApiErrors(errors={"businessUnitId": ["Ce point de facturation n'est pas un choix valide pour ce lieu."]})
 
 
-def validate_coordinates(raw_latitude, raw_longitude):  # type: ignore [no-untyped-def]
+def validate_coordinates(raw_latitude: float | str, raw_longitude: float | str) -> None:
     api_errors = ApiErrors()
 
     if raw_latitude:
@@ -40,7 +41,7 @@ def validate_coordinates(raw_latitude, raw_longitude):  # type: ignore [no-untyp
 
 
 # FUTURE-NEW-BANK-DETAILS: cleanup ifs when new bank details journey is complete
-def check_venue_creation(data):  # type: ignore [no-untyped-def]
+def check_venue_creation(data: dict[str, typing.Any]) -> None:
     offerer_id = dehumanize(data.get("managingOffererId"))
     if not offerer_id:
         raise ApiErrors(errors={"managingOffererId": ["Vous devez choisir une structure pour votre lieu."]})
@@ -61,7 +62,7 @@ def check_venue_creation(data):  # type: ignore [no-untyped-def]
             check_existing_business_unit(business_unit_id, offerer)
 
 
-def check_venue_edition(modifications, venue):  # type: ignore [no-untyped-def]
+def check_venue_edition(modifications: dict[str, typing.Any], venue: models.Venue) -> None:
     managing_offerer_id = modifications.get("managingOffererId")
     siret = modifications.get("siret")
     business_unit_id = modifications.get("businessUnitId")
@@ -106,7 +107,7 @@ def check_venue_edition(modifications, venue):  # type: ignore [no-untyped-def]
         check_existing_business_unit(business_unit_id, offerer=venue.managingOfferer)
 
 
-def _validate_longitude(api_errors, raw_longitude):  # type: ignore [no-untyped-def]
+def _validate_longitude(api_errors: ApiErrors, raw_longitude: float | str) -> None:
     try:
         longitude = decimal.Decimal(raw_longitude)
     except decimal.InvalidOperation:
@@ -116,7 +117,7 @@ def _validate_longitude(api_errors, raw_longitude):  # type: ignore [no-untyped-
             api_errors.add_error("longitude", "La longitude doit être comprise entre -180.0 et +180.0")
 
 
-def _validate_latitude(api_errors, raw_latitude):  # type: ignore [no-untyped-def]
+def _validate_latitude(api_errors: ApiErrors, raw_latitude: float | str) -> None:
     try:
         latitude = decimal.Decimal(raw_latitude)
     except decimal.InvalidOperation:

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -9,6 +9,7 @@ from typing import Union
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+import sqlalchemy.exc as sa_exc
 import sqlalchemy.orm as sa_orm
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import relationship
@@ -236,15 +237,15 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
         return Stock.query.filter_by(isSoftDeleted=False)
 
     @staticmethod
-    def restize_internal_error(internal_error):  # type: ignore [no-untyped-def]
+    def restize_internal_error(internal_error: sa_exc.InternalError) -> tuple[str, str]:
         if "check_stock" in str(internal_error.orig):
             if "quantity_too_low" in str(internal_error.orig):
-                return ["quantity", "Le stock total ne peut être inférieur au nombre de réservations"]
+                return ("quantity", "Le stock total ne peut être inférieur au nombre de réservations")
             if "bookingLimitDatetime_too_late" in str(internal_error.orig):
-                return [
+                return (
                     "bookingLimitDatetime",
                     "La date limite de réservation pour cette offre est postérieure à la date de début de l'évènement",
-                ]
+                )
             logger.error("Unexpected error in patch stocks: %s", internal_error)
         return PcObject.restize_internal_error(internal_error)
 

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -20,6 +20,7 @@ from sqlalchemy import case
 from sqlalchemy import exists
 from sqlalchemy import select
 from sqlalchemy import true
+import sqlalchemy.exc as sa_exc
 from sqlalchemy.orm import column_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import expression
@@ -131,10 +132,10 @@ class VenueProvider(PcObject, Base, Model, ProvidableMixin, DeactivableMixin):
     )
 
     @staticmethod
-    def restize_integrity_error(internal_error):  # type: ignore [no-untyped-def]
-        if "unique_venue_provider" in str(internal_error.orig):
-            return ["global", "Votre lieu est déjà lié à cette source"]
-        return PcObject.restize_integrity_error(internal_error)
+    def restize_integrity_error(error: sa_exc.IntegrityError) -> tuple[str, str]:
+        if "unique_venue_provider" in str(error.orig):
+            return ("global", "Votre lieu est déjà lié à cette source")
+        return PcObject.restize_integrity_error(error)
 
     @property
     def nOffers(self):  # type: ignore [no-untyped-def]
@@ -222,18 +223,18 @@ class AllocineVenueProviderPriceRule(PcObject, Base, Model):
     )
 
     @staticmethod
-    def restize_integrity_error(internal_error):  # type: ignore [no-untyped-def]
-        if "unique_allocine_venue_provider_price_rule" in str(internal_error.orig):
-            return ["global", "Vous ne pouvez avoir qu''un seul prix par catégorie"]
-        if "check_price_is_not_negative" in str(internal_error.orig):
-            return ["global", "Vous ne pouvez renseigner un prix négatif"]
-        return PcObject.restize_integrity_error(internal_error)
+    def restize_integrity_error(error: sa_exc.IntegrityError) -> tuple[str, str]:
+        if "unique_allocine_venue_provider_price_rule" in str(error.orig):
+            return ("global", "Vous ne pouvez avoir qu''un seul prix par catégorie")
+        if "check_price_is_not_negative" in str(error.orig):
+            return ("global", "Vous ne pouvez renseigner un prix négatif")
+        return PcObject.restize_integrity_error(error)
 
     @staticmethod
-    def restize_data_error(data_error):  # type: ignore [no-untyped-def]
+    def restize_data_error(data_error: sa_exc.DataError) -> tuple[str, str]:
         if "wrong_price" in str(data_error):
-            return ["global", "Le prix doit être un nombre décimal"]
-        return PcObject.restize_integrity_error(data_error)
+            return ("global", "Le prix doit être un nombre décimal")
+        return PcObject.restize_data_error(data_error)
 
 
 @dataclass

--- a/api/src/pcapi/models/api_errors.py
+++ b/api/src/pcapi/models/api_errors.py
@@ -1,4 +1,5 @@
 import json
+import typing
 
 
 class ApiErrors(Exception):
@@ -47,7 +48,12 @@ class UnauthorizedError(ApiErrors):
     www_authenticate = None
     realm = None
 
-    def __init__(self, www_authenticate=None, realm=None, **kwargs):  # type: ignore [no-untyped-def]
+    def __init__(
+        self,
+        www_authenticate: str | None = None,
+        realm: str | None = None,
+        **kwargs: typing.Any,
+    ) -> None:
         self.www_authenticate = www_authenticate
         self.realm = realm
         super().__init__(**kwargs)

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import Enum
 import typing
 
@@ -12,7 +11,6 @@ from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models import db
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
-from pcapi.models.beneficiary_import_status import ImportStatus
 from pcapi.models.pc_object import PcObject
 
 
@@ -54,15 +52,6 @@ class BeneficiaryImport(PcObject, Base, Model):
     beneficiary: sa_orm.Mapped["User"] = relationship(
         "User", foreign_keys=[beneficiaryId], backref="beneficiaryImports"
     )
-
-    def setStatus(self, status: ImportStatus, detail: str | None = None, author: "User | None" = None) -> None:
-        new_status = BeneficiaryImportStatus()
-        new_status.status = status
-        new_status.detail = detail
-        new_status.date = datetime.utcnow()
-        new_status.author = author
-
-        self.statuses.append(new_status)
 
     @hybrid_property
     def currentStatus(self):

--- a/api/src/pcapi/models/beneficiary_import_status.py
+++ b/api/src/pcapi/models/beneficiary_import_status.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import enum
+import typing
 
 from sqlalchemy import BigInteger
 from sqlalchemy import Column
@@ -8,11 +9,17 @@ from sqlalchemy import Enum
 from sqlalchemy import ForeignKey
 from sqlalchemy import String
 from sqlalchemy import func
+import sqlalchemy.orm as sa_orm
 from sqlalchemy.orm import relationship
 
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+
+
+if typing.TYPE_CHECKING:
+    import pcapi.core.users.models as users_models
+    from pcapi.models.beneficiary_import import BeneficiaryImport
 
 
 class ImportStatus(enum.Enum):
@@ -34,7 +41,7 @@ class BeneficiaryImportStatus(PcObject, Base, Model):
     When this data is either transferred to the new model or deleted, we can remove this model.
     """
 
-    def __repr__(self):  # type: ignore [no-untyped-def]
+    def __repr__(self) -> str:
         author = self.author.publicName if self.author else "import automatisé"
         updated_at = datetime.strftime(self.date, "%d/%m/%Y")
         return f"{self.status.value}, le {updated_at} par {author}"
@@ -47,8 +54,10 @@ class BeneficiaryImportStatus(PcObject, Base, Model):
 
     beneficiaryImportId: int = Column(BigInteger, ForeignKey("beneficiary_import.id"), index=True, nullable=False)
 
-    beneficiaryImport = relationship("BeneficiaryImport", foreign_keys=[beneficiaryImportId], backref="statuses")  # type: ignore [misc]
+    beneficiaryImport: sa_orm.Mapped["BeneficiaryImport"] = relationship(
+        "BeneficiaryImport", foreign_keys=[beneficiaryImportId], backref="statuses"
+    )
 
     authorId = Column(BigInteger, ForeignKey("user.id"), nullable=True)
 
-    author = relationship("User", foreign_keys=[authorId])  # type: ignore [misc]
+    author: sa_orm.Mapped["users_models.User | None"] = relationship("User", foreign_keys=[authorId])

--- a/api/src/pcapi/models/needs_validation_mixin.py
+++ b/api/src/pcapi/models/needs_validation_mixin.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql.elements import BinaryExpression
 class NeedsValidationMixin:
     validationToken = sqla.Column(sqla.String(27), unique=True, nullable=True)
 
-    def generate_validation_token(self):  # type: ignore [no-untyped-def]
+    def generate_validation_token(self) -> None:
         self.validationToken = secrets.token_urlsafe(20)
 
     @sqla_hybrid.hybrid_property
@@ -18,5 +18,5 @@ class NeedsValidationMixin:
         return self.validationToken is None
 
     @isValidated.expression  # type: ignore [no-redef]
-    def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument # type: ignore[no-redef]
+    def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         return cls.validationToken.is_(None)

--- a/api/src/pcapi/models/offer_mixin.py
+++ b/api/src/pcapi/models/offer_mixin.py
@@ -88,5 +88,5 @@ class ValidationMixin:
     )
 
     @property
-    def isApproved(self):  # type: ignore [no-untyped-def]
+    def isApproved(self) -> bool:
         return self.validation == OfferValidationStatus.APPROVED

--- a/api/src/pcapi/models/pc_object.py
+++ b/api/src/pcapi/models/pc_object.py
@@ -4,8 +4,7 @@ from decimal import InvalidOperation
 import logging
 from pprint import pprint
 import re
-from typing import Any
-from typing import Iterable
+import typing
 import uuid
 
 from sqlalchemy import BigInteger
@@ -15,13 +14,13 @@ from sqlalchemy import Integer
 from sqlalchemy import Numeric
 from sqlalchemy import String
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped
+import sqlalchemy.exc as sa_exc
+import sqlalchemy.orm as sa_orm
 from sqlalchemy.sql.schema import Column
 
 from pcapi.models.api_errors import DateTimeCastError
 from pcapi.models.api_errors import DecimalCastError
 from pcapi.models.api_errors import UuidCastError
-from pcapi.models.soft_deletable_mixin import SoftDeletableMixin
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.human_ids import humanize
 
@@ -39,31 +38,32 @@ class DeletedRecordException(Exception):
 
 
 class PcObject:
-    id: Mapped[int] = Column(BigInteger, primary_key=True, autoincrement=True)  # type: ignore [assignment]
+    id: sa_orm.Mapped[int] = Column(BigInteger, primary_key=True, autoincrement=True)  # type: ignore [assignment]
 
-    def __init__(self, **kwargs):  # type: ignore [no-untyped-def]
+    def __init__(self, **kwargs: typing.Any) -> None:
         from_dict = kwargs.pop("from_dict", None)
         if from_dict:
             self.populate_from_dict(from_dict)
         super().__init__(**kwargs)
 
-    def __repr__(self):  # type: ignore [no-untyped-def]
+    def __repr__(self) -> str:
         if self.id is None:
             object_id = "unsaved"
         else:
             object_id = f"{self.id}/{humanize(self.id)}"
         return "<%s #%s>" % (self.__class__.__name__, object_id)
 
-    def dump(self):  # type: ignore [no-untyped-def]
+    def dump(self) -> None:
         pprint(vars(self))
 
-    def populate_from_dict(self, data: dict, skipped_keys: Iterable[str] = ()):  # type: ignore [no-untyped-def]
+    def populate_from_dict(self, data: dict, skipped_keys: typing.Iterable[str] = ()) -> None:
         self._check_not_soft_deleted()
-        columns = self.__mapper__.all_orm_descriptors  # type: ignore [attr-defined]
+        mapper: sa_orm.Mapper = self.__mapper__  # type: ignore [attr-defined]
+        columns = mapper.all_orm_descriptors
         keys_to_populate = self._get_keys_to_populate(columns.keys(), data, skipped_keys)
 
         for key in keys_to_populate:
-            column = self.__mapper__.column_attrs.get(key)  # type: ignore [attr-defined]
+            column = mapper.column_attrs.get(key)
             if not column:  # key is not a column, so probably an hybrid property
                 setattr(self, key, data.get(key))
                 continue
@@ -85,91 +85,91 @@ class PcObject:
             else:
                 setattr(self, key, value)
 
-    def is_soft_deleted(self):  # type: ignore [no-untyped-def]
-        return issubclass(type(self), SoftDeletableMixin) and self.isSoftDeleted
+    def is_soft_deleted(self) -> bool:
+        return getattr(self, "isSoftDeleted", False)
 
     @staticmethod
-    def restize_global_error(global_error):  # type: ignore [no-untyped-def]
+    def restize_global_error(global_error: Exception) -> tuple[str, str]:
         logger.exception("UNHANDLED ERROR : %s", global_error)
-        return [
+        return (
             "global",
             "Une erreur technique s'est produite. Elle a été notée, et nous allons investiguer au plus vite.",
-        ]
+        )
 
     @staticmethod
-    def restize_data_error(data_error):  # type: ignore [no-untyped-def]
-        if (
-            data_error.args
-            and len(data_error.args) > 0
-            and data_error.args[0].startswith("(psycopg2.DataError) value too long for type")
-        ):
-            max_length = re.search(
+    def restize_data_error(data_error: sa_exc.DataError) -> tuple[str, str]:
+        if data_error.args and len(data_error.args) > 0:
+            if match := re.search(
                 r"\(psycopg2.DataError\) value too long for type (.*?) varying\((.*?)\)",
                 data_error.args[0],
                 re.IGNORECASE,
-            ).group(2)
-            return ["global", "La valeur d'une entrée est trop longue (max " + max_length + ")"]
+            ):
+                max_length = match.group(2)
+                return ("global", "La valeur d'une entrée est trop longue (max " + max_length + ")")
         return PcObject.restize_global_error(data_error)
 
     @staticmethod
-    def restize_integrity_error(integrity_error):  # type: ignore [no-untyped-def]
-        if (
-            hasattr(integrity_error, "orig")
-            and hasattr(integrity_error.orig, "pgcode")
-            and integrity_error.orig.pgcode == DUPLICATE_KEY_ERROR_CODE
-        ):
-            field = re.search(r"Key \((.*?)\)=", str(integrity_error._message), re.IGNORECASE).group(1)
-            if "," in field:
-                field = "global"
-            return [field, "Une entrée avec cet identifiant existe déjà dans notre base de données"]
-        if (
-            hasattr(integrity_error, "orig")
-            and hasattr(integrity_error.orig, "pgcode")
-            and integrity_error.orig.pgcode == NOT_FOUND_KEY_ERROR_CODE
-        ):
-            field = re.search(r"Key \((.*?)\)=", str(integrity_error._message), re.IGNORECASE).group(1)
-            return [field, "Aucun objet ne correspond à cet identifiant dans notre base de données"]
-        if (
-            hasattr(integrity_error, "orig")
-            and hasattr(integrity_error.orig, "pgcode")
-            and integrity_error.orig.pgcode == OBLIGATORY_FIELD_ERROR_CODE
-        ):
-            field = re.search('column "(.*?)"', integrity_error.orig.pgerror, re.IGNORECASE).group(1)
-            return [field, "Ce champ est obligatoire"]
+    def restize_integrity_error(integrity_error: sa_exc.IntegrityError) -> tuple[str, str]:
+        message = integrity_error.args[0]
+        if not hasattr(getattr(integrity_error, "orig"), "pgcode"):
+            return PcObject.restize_global_error(integrity_error)
+        if integrity_error.orig.pgcode == DUPLICATE_KEY_ERROR_CODE:
+            if m := re.search(r"Key \((.*?)\)=", message, re.IGNORECASE):
+                field = m.group(1)
+                if "," in field:
+                    field = "global"
+                return (field, "Une entrée avec cet identifiant existe déjà dans notre base de données")
+        elif integrity_error.orig.pgcode == NOT_FOUND_KEY_ERROR_CODE:
+            if m := re.search(r"Key \((.*?)\)=", message, re.IGNORECASE):
+                field = m.group(1)
+                return (field, "Aucun objet ne correspond à cet identifiant dans notre base de données")
+        if integrity_error.orig.pgcode == OBLIGATORY_FIELD_ERROR_CODE:
+            if m := re.search('column "(.*?)"', integrity_error.orig.pgerror, re.IGNORECASE):
+                field = m.group(1)
+                return (field, "Ce champ est obligatoire")
         return PcObject.restize_global_error(integrity_error)
 
     @staticmethod
-    def restize_internal_error(internal_error):  # type: ignore [no-untyped-def]
+    def restize_internal_error(internal_error: sa_exc.InternalError) -> tuple[str, str]:
         return PcObject.restize_global_error(internal_error)
 
     @staticmethod
-    def restize_type_error(type_error):  # type: ignore [no-untyped-def]
+    def restize_type_error(type_error: TypeError) -> tuple[str, str]:
         if type_error.args and len(type_error.args) > 1 and type_error.args[1] == "geography":
-            return [type_error.args[2], "doit etre une liste de nombre décimaux comme par exemple : [2.22, 3.22]"]
+            return (type_error.args[2], "doit etre une liste de nombre décimaux comme par exemple : [2.22, 3.22]")
         if type_error.args and len(type_error.args) > 1 and type_error.args[1] and type_error.args[1] == "decimal":
-            return [type_error.args[2], "doit être un nombre décimal"]
+            return (type_error.args[2], "doit être un nombre décimal")
         if type_error.args and len(type_error.args) > 1 and type_error.args[1] and type_error.args[1] == "integer":
-            return [type_error.args[2], "doit être un entier"]
+            return (type_error.args[2], "doit être un entier")
         return PcObject.restize_global_error(type_error)
 
     @staticmethod
-    def restize_value_error(value_error):  # type: ignore [no-untyped-def]
+    def restize_value_error(value_error: ValueError) -> tuple[str, str]:
         if len(value_error.args) > 1 and value_error.args[1] == "enum":
-            return [
+            return (
                 value_error.args[2],
                 " doit etre dans cette liste : " + ",".join(map(lambda x: '"' + x + '"', value_error.args[3])),
-            ]
+            )
         return PcObject.restize_global_error(value_error)
 
     @staticmethod
-    def _get_keys_to_populate(columns: Iterable[str], data: dict, skipped_keys: Iterable[str]) -> set[str]:
+    def _get_keys_to_populate(
+        columns: typing.Iterable[str],
+        data: dict,
+        skipped_keys: typing.Iterable[str],
+    ) -> set[str]:
         requested_columns_to_update = set(data.keys())
         forbidden_columns = {"id", "deleted"} | set(skipped_keys)
         allowed_columns_to_update = requested_columns_to_update - forbidden_columns
         keys_to_populate = set(columns).intersection(allowed_columns_to_update)
         return keys_to_populate
 
-    def _try_to_set_attribute_with_deserialized_datetime(self, col, key, value):  # type: ignore [no-untyped-def]
+    def _try_to_set_attribute_with_deserialized_datetime(
+        self,
+        col: sa_orm.ColumnProperty,
+        key: str,
+        value: typing.Any,
+    ) -> None:
         try:
             datetime_value = _deserialize_datetime(value)
             setattr(self, key, datetime_value)
@@ -178,7 +178,12 @@ class PcObject:
             error.add_error(col.expression.name, "Invalid value for %s (datetime): %r" % (key, value))
             raise error
 
-    def _try_to_set_attribute_with_uuid(self, col, key, value):  # type: ignore [no-untyped-def]
+    def _try_to_set_attribute_with_uuid(
+        self,
+        col: sa_orm.ColumnProperty,
+        key: str,
+        value: typing.Any,
+    ) -> None:
         try:
             uuid.UUID(value)
             setattr(self, key, value)
@@ -187,7 +192,13 @@ class PcObject:
             error.add_error(col.expression.name, "Invalid value for %s (uuid): %r" % (key, value))
             raise error
 
-    def _try_to_set_attribute_with_decimal_value(self, col, key, value, expected_format):  # type: ignore [no-untyped-def]
+    def _try_to_set_attribute_with_decimal_value(
+        self,
+        col: sa_orm.ColumnProperty,
+        key: str,
+        value: typing.Any,
+        expected_format: str,
+    ) -> None:
         try:
             setattr(self, key, Decimal(value))
         except InvalidOperation:
@@ -195,18 +206,18 @@ class PcObject:
             error.add_error(col.expression.name, "Invalid value for {} ({}): '{}'".format(key, expected_format, value))
             raise error
 
-    def _check_not_soft_deleted(self):  # type: ignore [no-untyped-def]
+    def _check_not_soft_deleted(self) -> None:
         if self.is_soft_deleted():
             raise DeletedRecordException
 
 
-def _dehumanize_if_needed(column, value: Any) -> Any:  # type: ignore [no-untyped-def]
+def _dehumanize_if_needed(column: sa_orm.ColumnProperty, value: typing.Any) -> typing.Any:
     if _is_human_id_column(column) and not isinstance(value, int):
         return dehumanize(value)
     return value
 
 
-def _deserialize_datetime(value):  # type: ignore [no-untyped-def]
+def _deserialize_datetime(value: str | None) -> datetime | None:
     if value is None:
         return None
 
@@ -220,10 +231,10 @@ def _deserialize_datetime(value):  # type: ignore [no-untyped-def]
     raise TypeError()
 
 
-def _is_human_id_column(column: Column) -> bool:
+def _is_human_id_column(column: sa_orm.ColumnProperty) -> bool:
     if column is None:
         return None
     column_name = column.key
-    is_column_primary_key_or_foreign_key = column_name == "id" or column_name.endswith("Id")  # type: ignore [union-attr]
+    is_column_primary_key_or_foreign_key = column_name == "id" or column_name.endswith("Id")
     is_column_a_number = isinstance(column.expression.type, (Integer, BigInteger))
     return is_column_primary_key_or_foreign_key and is_column_a_number

--- a/api/src/pcapi/models/providable_mixin.py
+++ b/api/src/pcapi/models/providable_mixin.py
@@ -1,4 +1,3 @@
-""" providable mixin """
 from datetime import datetime
 
 from sqlalchemy import BigInteger
@@ -16,8 +15,8 @@ from sqlalchemy.orm import relationship
 
 @declarative_mixin
 class ProvidableMixin:
-    @declared_attr  # type: ignore [misc]
-    def lastProviderId(cls):  # pylint: disable=no-self-argument
+    @declared_attr
+    def lastProviderId(cls) -> Mapped[int | None]:  # pylint: disable=no-self-argument
         return Column(BigInteger, ForeignKey("provider.id"), nullable=True)
 
     @declared_attr  # type: ignore [misc]

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1003,7 +1003,11 @@ class GetUserHistoryTest:
         )
 
         dms_author = users_factories.UserFactory(email="dms_author@exemple.com")
-        beneficiary_import.setStatus(ImportStatus.CREATED, author=dms_author)
+        users_factories.BeneficiaryImportStatusFactory(
+            beneficiaryImport=beneficiary_import,
+            status=ImportStatus.CREATED,
+            author=dms_author,
+        )
 
         fraud_factories.BeneficiaryFraudCheckFactory(
             user=user,


### PR DESCRIPTION
Au menu : 
- ajouts et corrections d'annotations de type ;
- correction de requêtes SQL N+1 ;
- suppression de `BenecifiaryImport.setStatus()`, inutilisée.

Commits à relire séparément.