### PR TITLE
(PC-18204)[API] fix: backoffice: timezone-aware datetimes in offerer routes

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -17,6 +17,7 @@ from pcapi.repository import repository
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils import db as db_utils
 from pcapi.utils import regions as regions_utils
+from pcapi.utils.date import format_into_utc_date
 
 from . import blueprint
 from . import serialization
@@ -134,7 +135,7 @@ def get_offerer_history(offerer_id: int) -> serialization.HistoryResponseModel:
         data=[
             serialization.HistoryItem(
                 type=action.actionType.value,
-                date=action.actionDate,
+                date=format_into_utc_date(action.actionDate) if action.actionDate else None,
                 authorId=action.authorUserId,
                 authorName=action.authorUser.publicName if action.authorUser else None,
                 comment=action.comment,
@@ -298,7 +299,7 @@ def _get_serialized_offerer_last_comment(offerer: offerers_models.Offerer) -> se
         if actions_with_comment:
             last = sorted(actions_with_comment, key=lambda a: a.actionDate, reverse=True)[0]
             return serialization.Comment(
-                date=last.actionDate,
+                date=format_into_utc_date(last.actionDate) if last.actionDate else None,
                 author=f"{last.authorUser.firstName} {last.authorUser.lastName}" if last.authorUser else None,
                 content=last.comment,
             )

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -643,7 +643,7 @@ class GetOffererHistoryTest:
         assert response.json["data"] == [
             {
                 "type": "Structure validée",
-                "date": "2022-10-06T16:04:00",
+                "date": "2022-10-06T16:04:00+00:00",
                 "authorId": admin.id,
                 "authorName": admin.publicName,
                 "comment": None,
@@ -652,7 +652,7 @@ class GetOffererHistoryTest:
             },
             {
                 "type": "Commentaire interne",
-                "date": "2022-10-05T15:03:00",
+                "date": "2022-10-05T15:03:00+00:00",
                 "authorId": admin.id,
                 "authorName": admin.publicName,
                 "comment": "Documents reçus",
@@ -661,7 +661,7 @@ class GetOffererHistoryTest:
             },
             {
                 "type": "Structure mise en attente",
-                "date": "2022-10-04T14:02:00",
+                "date": "2022-10-04T14:02:00+00:00",
                 "authorId": admin.id,
                 "authorName": admin.publicName,
                 "comment": "Documents complémentaires demandés",
@@ -670,7 +670,7 @@ class GetOffererHistoryTest:
             },
             {
                 "type": "Nouvelle structure",
-                "date": "2022-10-03T13:01:00",
+                "date": "2022-10-03T13:01:00+00:00",
                 "authorId": user_offerer.user.id,
                 "authorName": user_offerer.user.publicName,
                 "comment": None,
@@ -1486,7 +1486,7 @@ class ListOfferersToBeValidatedTest:
         assert payload["lastComment"] == {
             "author": "Inspecteur Validateur",
             "content": "Houlala",
-            "date": "2022-10-03T14:02:00",
+            "date": "2022-10-03T14:02:00+00:00",
         }
         assert payload["isTopActor"] == (tag in user_offerer.offerer.tags)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18204

## But de la pull request

Ajout de la _timezone_ aux dates de l'historique des validations de structures/rattachement.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
