### PR TITLE
(PC-18294)[API] fix: backoffice: avoid CannotFindOffererUserEmail exception when offerer has no user attached

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -608,11 +608,12 @@ def _validate_offerer(offerer: models.Offerer, author_user: users_models.User | 
 
     zendesk_sell.update_offerer(offerer)
 
-    if not transactional_mails.send_new_offerer_validation_email_to_pro(offerer):
-        logger.warning(
-            "Could not send validation confirmation email to offerer",
-            extra={"offerer": offerer.id},
-        )
+    if applicants:
+        if not transactional_mails.send_new_offerer_validation_email_to_pro(offerer):
+            logger.warning(
+                "Could not send validation confirmation email to offerer",
+                extra={"offerer": offerer.id},
+            )
 
 
 def validate_offerer_by_token(token: str) -> None:
@@ -661,11 +662,12 @@ def reject_offerer(offerer_id: int, author_user: users_models.User, comment: str
         )
     )
 
-    if not transactional_mails.send_new_offerer_rejection_email_to_pro(offerer):
-        logger.warning(
-            "Could not send rejection confirmation email to offerer",
-            extra={"offerer": offerer.id},
-        )
+    if applicants:
+        if not transactional_mails.send_new_offerer_rejection_email_to_pro(offerer):
+            logger.warning(
+                "Could not send rejection confirmation email to offerer",
+                extra={"offerer": offerer.id},
+            )
 
     # Detach user from offerer after sending transactional email to applicant
     models.UserOfferer.query.filter_by(offererId=offerer_id).delete()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18294

## But de la pull request

Éviter une exception à l'envoi de mail si on valide ou rejette une structure qui n'a aucun utilisateur attaché.

Ce cas ne devrait a priori pas se produire en production dans un cheminement "normal", mais se produit avec la sandbox sur testing, ou lors de tests. Ce cas se produit cependant forcément si on tente de valider une structure rejetée.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
