### PR TITLE
(PC-18279)[API] feat: backoffice: add request dates in the list of offerers to validate

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1313,7 +1313,7 @@ def list_offerers_to_be_validated(search_query: str | None, filter_: list[dict[s
     query = offerers_models.Offerer.query.options(
         sa.orm.joinedload(offerers_models.Offerer.UserOfferers).joinedload(offerers_models.UserOfferer.user),
         sa.orm.joinedload(offerers_models.Offerer.tags),
-        sa.orm.joinedload(offerers_models.Offerer.action_history),
+        sa.orm.joinedload(offerers_models.Offerer.action_history).joinedload(history_models.ActionHistory.authorUser),
     )
 
     if search_query:

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -424,6 +424,7 @@ class OfferersStatsResponseModel(BaseModel):
 class OffererToBeValidated(BaseModel):
     id: int
     name: str
+    requestDate: datetime.datetime
     status: str
     step: str | None
     siren: str

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1377,6 +1377,11 @@ class OfferersStatsTest:
 
 
 class ListOfferersToBeValidatedTest:
+    # 2: permission_required: features (ENABLE_BACKOFFICE_API) + user
+    # +1: query should load all data in a single query
+    # +1: count() for pagination
+    N_QUERIES = 4
+
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_list_only_offerers_to_be_validated(self, client):
         # given
@@ -1396,12 +1401,8 @@ class ListOfferersToBeValidatedTest:
         admin = users_factories.UserFactory()
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-        n_queries += 1  # count() for pagination
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated")
             )
@@ -1462,9 +1463,10 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.list_offerers_to_be_validated")
-        )
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for("backoffice_blueprint.list_offerers_to_be_validated")
+            )
 
         # then
         assert response.status_code == 200
@@ -1529,9 +1531,10 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.list_offerers_to_be_validated")
-        )
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for("backoffice_blueprint.list_offerers_to_be_validated")
+            )
 
         # then
         assert response.status_code == 200
@@ -1555,9 +1558,10 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.list_offerers_to_be_validated")
-        )
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for("backoffice_blueprint.list_offerers_to_be_validated")
+            )
 
         # then
         assert response.status_code == 200
@@ -1654,12 +1658,13 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for(
-                "backoffice_blueprint.list_offerers_to_be_validated",
-                filter=json.dumps([{"field": "tags", "value": tag_filter}]),
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for(
+                    "backoffice_blueprint.list_offerers_to_be_validated",
+                    filter=json.dumps([{"field": "tags", "value": tag_filter}]),
+                )
             )
-        )
 
         # then
         assert response.status_code == 200
@@ -1673,9 +1678,10 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.list_offerers_to_be_validated", q="123004004")
-        )
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for("backoffice_blueprint.list_offerers_to_be_validated", q="123004004")
+            )
 
         # then
         assert response.status_code == 200
@@ -1707,9 +1713,10 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.list_offerers_to_be_validated", q=search_filter)
-        )
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for("backoffice_blueprint.list_offerers_to_be_validated", q=search_filter)
+            )
 
         # then
         assert response.status_code == 200
@@ -1737,12 +1744,13 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for(
-                "backoffice_blueprint.list_offerers_to_be_validated",
-                filter=json.dumps([{"field": "status", "value": status_filter}]),
+        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+            response = client.with_explicit_token(auth_token).get(
+                url_for(
+                    "backoffice_blueprint.list_offerers_to_be_validated",
+                    filter=json.dumps([{"field": "status", "value": status_filter}]),
+                )
             )
-        )
 
         # then
         assert response.status_code == 200


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18279

## But de la pull request

Renvoyer la date de la demande dans l'endpoint de liste de structures à valider.
Si la structure a été inscrite, rejetée puis réinscrite, c'est la date de dernière demande qui compte.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
