### PR TITLE
(PC-18058)[API] feat: add musicType to Algolia offers index

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -13,6 +13,7 @@ import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 from pcapi.core.search.backends import base
+from pcapi.domain.music_types import MUSIC_TYPES_DICT
 import pcapi.utils.date as date_utils
 from pcapi.utils.stopwords import STOPWORDS
 
@@ -341,6 +342,14 @@ class AlgoliaBackend(base.SearchBackend):
         distinct = extra_data.get("isbn") or extra_data.get("visa") or str(offer.id)
         distinct += extra_data.get("diffusionVersion", "")
 
+        music_type_label = None
+        music_type = extra_data.get("musicType", "").strip()
+        if music_type:
+            try:
+                music_type_label = MUSIC_TYPES_DICT[int(music_type)]
+            except (ValueError, KeyError, TypeError):
+                logger.warning("bad music type encountered", extra={"offer": offer.id, "music_type": music_type})
+
         object_to_index = {
             "distinct": distinct,
             "objectID": offer.id,
@@ -356,6 +365,7 @@ class AlgoliaBackend(base.SearchBackend):
                 "isEvent": offer.isEvent,
                 "isForbiddenToUnderage": offer.is_forbidden_to_underage,
                 "isThing": offer.isThing,
+                "musicType": music_type_label,
                 "name": offer.name,
                 "prices": prices_sorted,
                 # TODO(jeremieb): keep searchGroupNamev2 and remove

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -65,6 +65,7 @@ def test_serialize_offer():
             "thumbUrl": None,
             "tags": [],
             "times": [],
+            "musicType": None,
         },
         "offerer": {
             "name": "Les Librairies Associées",
@@ -77,6 +78,26 @@ def test_serialize_offer():
         },
         "_geoloc": {"lat": 48.87004, "lng": 2.3785},
     }
+
+
+@pytest.mark.parametrize(
+    "extra_data, expected_music_style",
+    (
+        ({"musicType": "501"}, "Jazz"),
+        ({"musicType": "600"}, "Classique"),
+        ({"musicType": "-1"}, "Autre"),
+        ({"musicType": " "}, None),
+    ),
+)
+def test_serialize_offer_extra_data(extra_data, expected_music_style):
+    # given
+    offer = offers_factories.OfferFactory(extraData=extra_data)
+
+    # when
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer)
+
+    # then
+    assert serialized["offer"]["musicType"] == expected_music_style
 
 
 def test_serialize_offer_event():


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18058

## But de la pull request

Ajouter le genre musical aux infos remontées à Algolia lors des l'indexation des offres

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
