### PR TITLE
(BSR)[API] chore: Bump version of notion-client

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -34,7 +34,7 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 MarkupSafe==2.0.1
 mypy
-notion-client==0.9.0
+notion-client==1.0.0
 openpyxl
 pgcli # a tool not used in code. There is no point in pinning its version
 phonenumberslite==8.12.*


### PR DESCRIPTION
Version 1.0.0 has a fix [1] to handle 50x responses from Notion API.
As per the changelog [2], the only other significant change is the
upgrade to version 2022-02-22 of Notion API. Notion documentation [3]
seems to indicate that our code is not concerned by those changes.

[1] https://github.com/ramnes/notion-sdk-py/commit/36fc0e4d2bba3ce7f5c4ded48bcb85609b55d71e
[2] https://github.com/ramnes/notion-sdk-py/releases/tag/1.0.0
[3] https://developers.notion.com/changelog/releasing-notion-version-2022-02-22

---

Exemple d'erreur corrigée : https://sentry.passculture.team/organizations/sentry/issues/399029/activity