### PR TITLE
(PC-18059)[API] feat: add showType to Algolia offers index

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -14,6 +14,7 @@ import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 from pcapi.core.search.backends import base
 from pcapi.domain.music_types import MUSIC_TYPES_DICT
+from pcapi.domain.show_types import SHOW_TYPES_DICT
 import pcapi.utils.date as date_utils
 from pcapi.utils.stopwords import STOPWORDS
 
@@ -350,6 +351,14 @@ class AlgoliaBackend(base.SearchBackend):
             except (ValueError, KeyError, TypeError):
                 logger.warning("bad music type encountered", extra={"offer": offer.id, "music_type": music_type})
 
+        show_type_label = None
+        show_type = extra_data.get("showType", "").strip()
+        if show_type:
+            try:
+                show_type_label = SHOW_TYPES_DICT[int(show_type)]
+            except (ValueError, KeyError, TypeError):
+                logger.warning("bad show type encountered", extra={"offer": offer.id, "show_type": show_type})
+
         object_to_index = {
             "distinct": distinct,
             "objectID": offer.id,
@@ -373,6 +382,7 @@ class AlgoliaBackend(base.SearchBackend):
                 # home page label migration is over.
                 "searchGroupName": offer.subcategory.search_group_name,
                 "searchGroupNamev2": offer.subcategory_v2.search_group_name,
+                "showType": show_type_label,
                 "stocksDateCreated": sorted(stocks_date_created),
                 "students": extra_data.get("students") or [],
                 "subcategoryId": offer.subcategory.id,

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -45,7 +45,6 @@ def test_serialize_offer():
         "objectID": offer.id,
         "offer": {
             "artist": "Author Performer Speaker Stage Director",
-            "rankingWeight": 2,
             "dateCreated": offer.dateCreated.timestamp(),
             "dates": [],
             "description": "livre bien lire",
@@ -55,17 +54,19 @@ def test_serialize_offer():
             "isEvent": False,
             "isForbiddenToUnderage": offer.is_forbidden_to_underage,
             "isThing": True,
+            "musicType": None,
             "name": "Titre formidable",
             "prices": [decimal.Decimal("10.00")],
+            "rankingWeight": 2,
             "searchGroupName": "LIVRE",
             "searchGroupNamev2": "LIVRES",
+            "showType": None,
             "stocksDateCreated": [stock.dateCreated.timestamp()],
             "students": [],
             "subcategoryId": offer.subcategory.id,
             "thumbUrl": None,
             "tags": [],
             "times": [],
-            "musicType": None,
         },
         "offerer": {
             "name": "Les Librairies Associées",
@@ -81,15 +82,19 @@ def test_serialize_offer():
 
 
 @pytest.mark.parametrize(
-    "extra_data, expected_music_style",
+    "extra_data, expected_music_style, expected_show_type",
     (
-        ({"musicType": "501"}, "Jazz"),
-        ({"musicType": "600"}, "Classique"),
-        ({"musicType": "-1"}, "Autre"),
-        ({"musicType": " "}, None),
+        ({"musicType": "501"}, "Jazz", None),
+        ({"musicType": "600"}, "Classique", None),
+        ({"musicType": "-1"}, "Autre", None),
+        ({"musicType": " "}, None, None),
+        ({"showType": "100"}, None, "Arts de la rue"),
+        ({"showType": "1200"}, None, "Spectacle Jeunesse"),
+        ({"showType": "-1"}, None, "Autre"),
+        ({"showType": " "}, None, None),
     ),
 )
-def test_serialize_offer_extra_data(extra_data, expected_music_style):
+def test_serialize_offer_extra_data(extra_data, expected_music_style, expected_show_type):
     # given
     offer = offers_factories.OfferFactory(extraData=extra_data)
 
@@ -98,6 +103,7 @@ def test_serialize_offer_extra_data(extra_data, expected_music_style):
 
     # then
     assert serialized["offer"]["musicType"] == expected_music_style
+    assert serialized["offer"]["showType"] == expected_show_type
 
 
 def test_serialize_offer_event():


### PR DESCRIPTION
 Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Ajouter le type de spectacle aux infos remontées à Algolia lors des l'indexation des offres

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
