### PR TITLE
(PC-17242)[API] feat: update wordings of DMS subscription messages

### DIFF
--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -242,7 +242,7 @@ class HandleDmsApplicationTest:
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).one()
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Il semblerait que le champ ‘numéro de pièce d'identité’ soit invalide. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
+            user_message="Il semblerait que ton numéro de pièce d'identité soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
             call_to_action=subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION,
             pop_over_icon=None,
             updated_at=fraud_check.updatedAt,
@@ -285,9 +285,13 @@ class HandleDmsApplicationTest:
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).one()
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le champ ‘numéro de pièce d'identité’ est invalide.",
-            call_to_action=None,
-            pop_over_icon=subscription_models.PopOverIcon.ERROR,
+            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le format du numéro de pièce d'identité renseigné est invalide. Tu peux contacter le support pour mettre à jour ton dossier.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=f"{subscription_messages.MAILTO_SUPPORT}{subscription_messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)}",
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
+            pop_over_icon=None,
             updated_at=fraud_check.updatedAt,
         )
 
@@ -320,9 +324,13 @@ class HandleDmsApplicationTest:
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(user=user).one()
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le champ ‘numéro de pièce d'identité’ est invalide.",
-            call_to_action=None,
-            pop_over_icon=subscription_models.PopOverIcon.ERROR,
+            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le format du numéro de pièce d'identité renseigné est invalide. Tu peux contacter le support pour mettre à jour ton dossier.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=f"{subscription_messages.MAILTO_SUPPORT}{subscription_messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)}",
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
+            pop_over_icon=None,
             updated_at=fraud_check.updatedAt,
         )
 
@@ -361,9 +369,13 @@ class HandleDmsApplicationTest:
 
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le champ ‘numéro de pièce d'identité’ est invalide.",
-            call_to_action=None,
-            pop_over_icon=subscription_models.PopOverIcon.ERROR,
+            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le format du numéro de pièce d'identité renseigné est invalide. Tu peux contacter le support pour mettre à jour ton dossier.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=f"{subscription_messages.MAILTO_SUPPORT}{subscription_messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)}",
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
+            pop_over_icon=None,
             updated_at=fraud_check.updatedAt,
         )
 
@@ -600,7 +612,7 @@ class DmsSubscriptionMessageTest:
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
 
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Il semblerait que le champ ‘date de naissance’ soit invalide. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
+            user_message="Il semblerait que ta date de naissance soit erronée. Tu peux te rendre sur le site demarches-simplifiees.fr pour la rectifier.",
             call_to_action=subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION,
             pop_over_icon=None,
             updated_at=fraud_check.updatedAt,
@@ -621,7 +633,7 @@ class DmsSubscriptionMessageTest:
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
 
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Il semblerait que les champs ‘numéro de pièce d'identité, date de naissance’ soient invalides. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier.",
+            user_message="Il semblerait que tes numéro de pièce d'identité et date de naissance soient erronés. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier.",
             call_to_action=subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION,
             pop_over_icon=None,
             updated_at=fraud_check.updatedAt,

--- a/api/tests/core/subscription/dms/test_messages.py
+++ b/api/tests/core/subscription/dms/test_messages.py
@@ -1,0 +1,181 @@
+from datetime import datetime
+
+import pytest
+
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.subscription import messages
+from pcapi.core.subscription import models as subscription_models
+from pcapi.core.subscription.dms import messages as dms_messages
+from pcapi.core.users import factories as users_factories
+
+
+class DmsMessagesTest:
+    @pytest.mark.parametrize(
+        "error_key, expected_error_message",
+        [
+            (
+                fraud_models.DmsFieldErrorKeyEnum.birth_date,
+                "Il semblerait que ta date de naissance soit erronée. Tu peux te rendre sur le site demarches-simplifiees.fr pour la rectifier.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.first_name,
+                "Il semblerait que ton prénom soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.id_piece_number,
+                "Il semblerait que ton numéro de pièce d'identité soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.last_name,
+                "Il semblerait que ton nom de famille soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.postal_code,
+                "Il semblerait que ton code postal soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier.",
+            ),
+        ],
+    )
+    def test_get_error_updatable_message(self, error_key, expected_error_message):
+        errors = [fraud_models.DmsFieldErrorDetails(key=error_key, value="¯\\_(ツ)_/¯")]
+        application_content = fraud_factories.DMSContentFactory(field_errors=errors)
+
+        expected_message = subscription_models.SubscriptionMessage(
+            user_message=expected_error_message,
+            call_to_action=messages.REDIRECT_TO_DMS_CALL_TO_ACTION,
+            pop_over_icon=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        message = dms_messages.get_error_updatable_message(
+            application_content=application_content, birth_date_error=None, updated_at=datetime(2021, 1, 1)
+        )
+
+        assert message == expected_message
+
+    def test_get_error_updatable_message_with_multiple_errors(self):
+        errors = [
+            fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.birth_date, value="¯\\_(ツ)_/¯"),
+            fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.first_name, value="¯\\_(ツ)_/¯"),
+        ]
+        application_content = fraud_factories.DMSContentFactory(field_errors=errors)
+        expected_error_message = "Il semblerait que tes date de naissance et prénom soient erronés. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier."
+        expected_message = subscription_models.SubscriptionMessage(
+            user_message=expected_error_message,
+            call_to_action=messages.REDIRECT_TO_DMS_CALL_TO_ACTION,
+            pop_over_icon=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        message = dms_messages.get_error_updatable_message(
+            application_content=application_content, birth_date_error=None, updated_at=datetime(2021, 1, 1)
+        )
+
+        assert message == expected_message
+
+    @pytest.mark.usefixtures("db_session")
+    @pytest.mark.parametrize(
+        "error_key, expected_error_message",
+        [
+            (
+                fraud_models.DmsFieldErrorKeyEnum.birth_date,
+                "le format de la date de naissance renseignée est invalide.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.first_name,
+                "le format du prénom renseigné est invalide.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.id_piece_number,
+                "le format du numéro de pièce d'identité renseigné est invalide.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.last_name,
+                "le format du nom de famille renseigné est invalide.",
+            ),
+            (
+                fraud_models.DmsFieldErrorKeyEnum.postal_code,
+                "le format du code postal renseigné est invalide.",
+            ),
+        ],
+    )
+    def test_get_error_not_updatable_message(self, error_key, expected_error_message):
+        user = users_factories.UserFactory()
+        errors = [
+            fraud_models.DmsFieldErrorDetails(key=error_key, value="¯\\_(ツ)_/¯"),
+        ]
+        application_content = fraud_factories.DMSContentFactory(field_errors=errors)
+        expected_message = subscription_models.SubscriptionMessage(
+            user_message=f"Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : {expected_error_message} Tu peux contacter le support pour mettre à jour ton dossier.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=f"{messages.MAILTO_SUPPORT}{messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)}",
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
+            pop_over_icon=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        message = dms_messages.get_error_not_updatable_message(
+            user=user,
+            reason_codes=[fraud_models.FraudReasonCode.ERROR_IN_DATA],
+            application_content=application_content,
+            birth_date_error=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        assert message == expected_message
+
+    @pytest.mark.usefixtures("db_session")
+    def test_get_error_not_updatable_message_with_multiple_errors(self):
+        user = users_factories.UserFactory()
+        errors = [
+            fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.birth_date, value="¯\\_(ツ)_/¯"),
+            fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.first_name, value="¯\\_(ツ)_/¯"),
+        ]
+        application_content = fraud_factories.DMSContentFactory(field_errors=errors)
+        expected_message = subscription_models.SubscriptionMessage(
+            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le format des date de naissance et prénom renseignés est invalide. Tu peux contacter le support pour mettre à jour ton dossier.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=f"{messages.MAILTO_SUPPORT}{messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)}",
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
+            pop_over_icon=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        message = dms_messages.get_error_not_updatable_message(
+            user=user,
+            reason_codes=[fraud_models.FraudReasonCode.ERROR_IN_DATA],
+            application_content=application_content,
+            birth_date_error=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        assert message == expected_message
+
+    @pytest.mark.usefixtures("db_session")
+    def test_get_error_not_updatable_message_with_id_piece_number_errors(self):
+        user = users_factories.UserFactory()
+        application_content = fraud_factories.DMSContentFactory()
+        expected_message = subscription_models.SubscriptionMessage(
+            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : le format du numéro de pièce d'identité renseigné est invalide. Tu peux contacter le support pour plus d'informations.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=f"{messages.MAILTO_SUPPORT}{messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)}",
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
+            pop_over_icon=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        message = dms_messages.get_error_not_updatable_message(
+            user=user,
+            reason_codes=[fraud_models.FraudReasonCode.INVALID_ID_PIECE_NUMBER],
+            application_content=application_content,
+            birth_date_error=None,
+            updated_at=datetime(2021, 1, 1),
+        )
+
+        assert message == expected_message

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -463,7 +463,7 @@ class DmsWebhookApplicationTest:
         assert message.pop_over_icon == None
         assert (
             message.user_message
-            == "Il semblerait que les champs ‘numéro de pièce d'identité, code postal’ soient invalides. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier."
+            == "Il semblerait que tes numéro de pièce d'identité et code postal soient erronés. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier."
         )
         assert message.call_to_action == subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION
 
@@ -591,7 +591,7 @@ class DmsWebhookApplicationTest:
         assert message.call_to_action == subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION
         assert (
             message.user_message
-            == "Il semblerait que le champ ‘numéro de pièce d'identité’ soit invalide. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier."
+            == "Il semblerait que ton numéro de pièce d'identité soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -635,7 +635,7 @@ class DmsWebhookApplicationTest:
         assert message.call_to_action == subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION
         assert (
             message.user_message
-            == "Il semblerait que le champ ‘prénom’ soit invalide. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier."
+            == "Il semblerait que ton prénom soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -692,7 +692,7 @@ class DmsWebhookApplicationTest:
         assert message.call_to_action == subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION
         assert (
             message.user_message
-            == "Il semblerait que les champs ‘prénom, nom de famille’ soient invalides. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier."
+            == "Il semblerait que tes prénom et nom de famille soient erronés. Tu peux te rendre sur le site demarches-simplifiees.fr pour les rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
@@ -738,7 +738,7 @@ class DmsWebhookApplicationTest:
         assert message.call_to_action == subscription_messages.REDIRECT_TO_DMS_CALL_TO_ACTION
         assert (
             message.user_message
-            == "Il semblerait que le champ ‘code postal’ soit invalide. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier."
+            == "Il semblerait que ton code postal soit erroné. Tu peux te rendre sur le site demarches-simplifiees.fr pour le rectifier."
         )
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17242

## But de la pull request

Mise à jour de la formulation des messages dans l'app, quand un utilisateur active son crédit via DMS

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
