### PR TITLE
(BSR)[API] fix: dates in user automation tests

### DIFF
--- a/api/tests/core/users/external/user_automations_test.py
+++ b/api/tests/core/users/external/user_automations_test.py
@@ -44,7 +44,7 @@ class UserAutomationsTest:
             dateOfBirth=today - relativedelta(days=user_automations.DAYS_IN_18_YEARS - 30),
         )
 
-    @freeze_time("2021-08-01 10:00:00")
+    @freeze_time("2033-08-01 10:00:00")
     def test_get_emails_who_will_turn_eighteen_in_one_month(self):
         self._create_users_around_18()
 
@@ -80,7 +80,7 @@ class UserAutomationsTest:
         assert result is True
 
     def _create_users_with_deposits(self):
-        with freeze_time("2020-11-15 15:00:00"):
+        with freeze_time("2032-11-15 15:00:00"):
             user0 = users_factories.UserFactory(
                 email="beneficiary0+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=17, days=5),
@@ -88,51 +88,51 @@ class UserAutomationsTest:
             )
             assert user0.deposit is None
 
-        with freeze_time("2020-10-31 15:00:00"):
+        with freeze_time("2032-10-31 15:00:00"):
             user1 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary1+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=1),
             )
-            assert user1.deposit.expirationDate == datetime(2022, 10, 31, 15, 0, 0)
+            assert user1.deposit.expirationDate == datetime(2034, 10, 31, 15, 0, 0)
 
-        with freeze_time("2020-11-01 15:00:00"):
+        with freeze_time("2032-11-01 15:00:00"):
             user2 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary2+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=2),
             )
-            assert user2.deposit.expirationDate == datetime(2022, 11, 1, 15, 0, 0)
+            assert user2.deposit.expirationDate == datetime(2034, 11, 1, 15, 0, 0)
             bookings_factories.UsedIndividualBookingFactory(individualBooking__user=user2, quantity=1, amount=10)
             assert user2.real_wallet_balance > 0
 
-        with freeze_time("2020-12-01 15:00:00"):
+        with freeze_time("2032-12-01 15:00:00"):
             user3 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary3+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=3),
             )
-            assert user3.deposit.expirationDate == datetime(2022, 12, 1, 15, 0, 0)
+            assert user3.deposit.expirationDate == datetime(2034, 12, 1, 15, 0, 0)
 
-        with freeze_time("2021-01-30 15:00:00"):
+        with freeze_time("2033-01-30 15:00:00"):
             user4 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary4+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=4),
             )
-            assert user4.deposit.expirationDate == datetime(2023, 1, 30, 15, 0, 0)
+            assert user4.deposit.expirationDate == datetime(2035, 1, 30, 15, 0, 0)
 
-        with freeze_time("2021-01-31 15:00:00"):
+        with freeze_time("2033-01-31 15:00:00"):
             user5 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary5+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=5),
             )
-            assert user5.deposit.expirationDate == datetime(2023, 1, 31, 15, 0, 0)
+            assert user5.deposit.expirationDate == datetime(2035, 1, 31, 15, 0, 0)
 
-        with freeze_time("2021-03-10 15:00:00"):
+        with freeze_time("2033-03-10 15:00:00"):
             user6 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary6+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=5),
             )
-            assert user6.deposit.expirationDate == datetime(2023, 3, 10, 15, 0, 0)
+            assert user6.deposit.expirationDate == datetime(2035, 3, 10, 15, 0, 0)
 
-        with freeze_time("2021-05-01 17:00:00"):
+        with freeze_time("2033-05-01 17:00:00"):
             # user6 becomes ex-beneficiary
             bookings_factories.UsedIndividualBookingFactory(
                 individualBooking__user=user6, quantity=1, amount=int(user6.real_wallet_balance)
@@ -144,19 +144,19 @@ class UserAutomationsTest:
     def test_get_users_beneficiary_three_months_before_credit_expiration(self):
         users = self._create_users_with_deposits()
 
-        with freeze_time("2022-10-31 16:00:00"):
+        with freeze_time("2034-10-31 16:00:00"):
             results = user_automations.get_users_beneficiary_credit_expiration_within_next_3_months()
             assert sorted([user.email for user in results]) == [user.email for user in users[1:4]]
 
-        with freeze_time("2022-11-01 14:00:00"):
+        with freeze_time("2034-11-01 14:00:00"):
             results = user_automations.get_users_beneficiary_credit_expiration_within_next_3_months()
             assert sorted([user.email for user in results]) == [user.email for user in users[2:5]]
 
-        with freeze_time("2022-11-02 12:00:00"):
+        with freeze_time("2034-11-02 12:00:00"):
             results = user_automations.get_users_beneficiary_credit_expiration_within_next_3_months()
             assert sorted([user.email for user in results]) == [user.email for user in users[3:6]]
 
-        with freeze_time("2023-01-15 08:00:00"):
+        with freeze_time("2035-01-15 08:00:00"):
             results = user_automations.get_users_beneficiary_credit_expiration_within_next_3_months()
             assert sorted([user.email for user in results]) == [user.email for user in users[4:7]]
 
@@ -164,7 +164,7 @@ class UserAutomationsTest:
     def test_users_beneficiary_credit_expiration_within_next_3_months_automation(self, mock_import_contacts):
         users = self._create_users_with_deposits()
 
-        with freeze_time("2022-11-01 16:00:00"):
+        with freeze_time("2034-11-01 16:00:00"):
             result = user_automations.users_beneficiary_credit_expiration_within_next_3_months_automation()
 
         mock_import_contacts.assert_called_once()
@@ -193,11 +193,11 @@ class UserAutomationsTest:
     def test_get_users_ex_beneficiary(self):
         users = self._create_users_with_deposits()
 
-        with freeze_time("2022-12-01 16:00:00"):
+        with freeze_time("2034-12-01 16:00:00"):
             results = user_automations.get_users_ex_beneficiary()
             assert sorted([user.email for user in results]) == [user.email for user in users[1:3] + [users[6]]]
 
-        with freeze_time("2022-12-02 16:00:00"):
+        with freeze_time("2034-12-02 16:00:00"):
             results = user_automations.get_users_ex_beneficiary()
             assert sorted([user.email for user in results]) == [user.email for user in users[1:4] + [users[6]]]
 
@@ -205,7 +205,7 @@ class UserAutomationsTest:
     def test_user_ex_beneficiary_automation(self, mock_import_contacts):
         users = self._create_users_with_deposits()
 
-        with freeze_time("2022-12-01 16:00:00"):
+        with freeze_time("2034-12-01 16:00:00"):
             result = user_automations.users_ex_beneficiary_automation()
 
         mock_import_contacts.assert_called_once()
@@ -231,34 +231,34 @@ class UserAutomationsTest:
         assert result is True
 
     def test_get_email_for_inactive_user_since_thirty_days(self):
-        with freeze_time("2021-08-01 15:00:00") as frozen_time:
+        with freeze_time("2033-08-01 15:00:00") as frozen_time:
             beneficiary = users_factories.BeneficiaryGrant18Factory(
-                email="fabien+test@example.net", lastConnectionDate=datetime(2021, 8, 1)
+                email="fabien+test@example.net", lastConnectionDate=datetime(2033, 8, 1)
             )
             not_beneficiary = users_factories.UserFactory(
-                email="marc+test@example.net", lastConnectionDate=datetime(2021, 8, 2)
+                email="marc+test@example.net", lastConnectionDate=datetime(2033, 8, 2)
             )
-            users_factories.ProFactory(email="pierre+test@example.net", lastConnectionDate=datetime(2021, 8, 1))
-            users_factories.UserFactory(email="daniel+test@example.net", lastConnectionDate=datetime(2021, 8, 3))
-            users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2021, 7, 31))
-            users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2021, 9, 1))
+            users_factories.ProFactory(email="pierre+test@example.net", lastConnectionDate=datetime(2033, 8, 1))
+            users_factories.UserFactory(email="daniel+test@example.net", lastConnectionDate=datetime(2033, 8, 3))
+            users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2033, 7, 31))
+            users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2033, 9, 1))
 
-            frozen_time.move_to("2021-09-01 15:00:01")
+            frozen_time.move_to("2033-09-01 15:00:01")
             results = user_automations.get_email_for_inactive_user_since_thirty_days()
             assert sorted(results) == sorted([beneficiary.email, not_beneficiary.email])
 
     @patch("pcapi.core.users.external.sendinblue.sib_api_v3_sdk.api.contacts_api.ContactsApi.import_contacts")
     def test_users_inactive_since_30_days_automation(self, mock_import_contacts):
-        with freeze_time("2021-08-01 15:00:00") as frozen_time:
+        with freeze_time("2033-08-01 15:00:00") as frozen_time:
             users_factories.BeneficiaryGrant18Factory(
-                email="fabien+test@example.net", lastConnectionDate=datetime(2021, 8, 1)
+                email="fabien+test@example.net", lastConnectionDate=datetime(2033, 8, 1)
             )
-            users_factories.ProFactory(email="pierre+test@example.net", lastConnectionDate=datetime(2021, 8, 1))
-            users_factories.UserFactory(email="daniel+test@example.net", lastConnectionDate=datetime(2021, 8, 4))
-            users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2021, 7, 31))
-            users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2021, 9, 1))
+            users_factories.ProFactory(email="pierre+test@example.net", lastConnectionDate=datetime(2033, 8, 1))
+            users_factories.UserFactory(email="daniel+test@example.net", lastConnectionDate=datetime(2033, 8, 4))
+            users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2033, 7, 31))
+            users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2033, 9, 1))
 
-            frozen_time.move_to("2021-09-02 15:00:01")
+            frozen_time.move_to("2033-09-02 15:00:01")
 
             result = user_automations.users_inactive_since_30_days_automation()
 
@@ -280,16 +280,16 @@ class UserAutomationsTest:
 
     @patch("pcapi.core.users.external.sendinblue.sib_api_v3_sdk.api.contacts_api.ContactsApi.import_contacts")
     def test_users_inactive_since_30_days_automation_no_result(self, mock_import_contacts):
-        with freeze_time("2021-08-01 15:00:00") as frozen_time:
+        with freeze_time("2033-08-01 15:00:00") as frozen_time:
             users_factories.BeneficiaryGrant18Factory(
-                email="fabien+test@example.net", lastConnectionDate=datetime(2021, 8, 1)
+                email="fabien+test@example.net", lastConnectionDate=datetime(2033, 8, 1)
             )
-            users_factories.UserFactory(email="marc+test@example.net", lastConnectionDate=datetime(2021, 8, 1))
-            users_factories.UserFactory(email="daniel+test@example.net", lastConnectionDate=datetime(2021, 8, 2))
-            users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2021, 7, 31))
-            users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2021, 9, 1))
+            users_factories.UserFactory(email="marc+test@example.net", lastConnectionDate=datetime(2033, 8, 1))
+            users_factories.UserFactory(email="daniel+test@example.net", lastConnectionDate=datetime(2033, 8, 2))
+            users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2033, 7, 31))
+            users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2033, 9, 1))
 
-            frozen_time.move_to("2021-08-30 15:00:01")
+            frozen_time.move_to("2033-08-30 15:00:01")
 
             result = user_automations.users_inactive_since_30_days_automation()
 
@@ -300,33 +300,33 @@ class UserAutomationsTest:
     def test_get_email_for_users_created_one_year_ago_per_month(self):
         matching_users = []
 
-        users_factories.UserFactory(email="fabien+test@example.net", dateCreated=datetime(2021, 7, 31))
+        users_factories.UserFactory(email="fabien+test@example.net", dateCreated=datetime(2033, 7, 31))
         matching_users.append(
-            users_factories.UserFactory(email="pierre+test@example.net", dateCreated=datetime(2021, 8, 1))
+            users_factories.UserFactory(email="pierre+test@example.net", dateCreated=datetime(2033, 8, 1))
         )
         matching_users.append(
-            users_factories.UserFactory(email="marc+test@example.net", dateCreated=datetime(2021, 8, 10))
+            users_factories.UserFactory(email="marc+test@example.net", dateCreated=datetime(2033, 8, 10))
         )
         matching_users.append(
-            users_factories.UserFactory(email="daniel+test@example.net", dateCreated=datetime(2021, 8, 31))
+            users_factories.UserFactory(email="daniel+test@example.net", dateCreated=datetime(2033, 8, 31))
         )
-        users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2021, 9, 1))
-        users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2021, 9, 21))
+        users_factories.UserFactory(email="billy+test@example.net", dateCreated=datetime(2033, 9, 1))
+        users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2033, 9, 21))
 
-        # matching: from 2021-08-01 to 2021-08-31
-        with freeze_time("2022-08-10 15:00:00"):
+        # matching: from 2033-08-01 to 2033-08-31
+        with freeze_time("2034-08-10 15:00:00"):
             results = user_automations.get_email_for_users_created_one_year_ago_per_month()
             assert sorted(results) == sorted([user.email for user in matching_users])
 
     @patch("pcapi.core.users.external.sendinblue.sib_api_v3_sdk.api.contacts_api.ContactsApi.import_contacts")
     def test_users_nearly_one_year_with_pass_automation(self, mock_import_contacts):
-        users_factories.UserFactory(email="fabien+test@example.net", dateCreated=datetime(2021, 8, 31))
-        users_factories.UserFactory(email="pierre+test@example.net", dateCreated=datetime(2021, 9, 1))
-        users_factories.UserFactory(email="daniel+test@example.net", dateCreated=datetime(2021, 10, 1))
-        users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2021, 10, 31))
+        users_factories.UserFactory(email="fabien+test@example.net", dateCreated=datetime(2033, 8, 31))
+        users_factories.UserFactory(email="pierre+test@example.net", dateCreated=datetime(2033, 9, 1))
+        users_factories.UserFactory(email="daniel+test@example.net", dateCreated=datetime(2033, 10, 1))
+        users_factories.UserFactory(email="gerard+test@example.net", dateCreated=datetime(2033, 10, 31))
 
-        # matching: from 2021-09-01 to 2021-09-31
-        with freeze_time("2022-09-10 15:00:00"):
+        # matching: from 2033-09-01 to 2033-09-31
+        with freeze_time("2034-09-10 15:00:00"):
             result = user_automations.users_one_year_with_pass_automation()
 
         mock_import_contacts.assert_called_once_with(
@@ -348,11 +348,11 @@ class UserAutomationsTest:
     def test_get_users_whose_credit_expired_today(self):
         users = self._create_users_with_deposits()
 
-        with freeze_time("2022-11-01 05:00:00"):
+        with freeze_time("2034-11-01 05:00:00"):
             results = list(user_automations.get_users_whose_credit_expired_today())
             assert results == [users[1]]
 
-        with freeze_time("2022-11-02 05:00:00"):
+        with freeze_time("2034-11-02 05:00:00"):
             results = list(user_automations.get_users_whose_credit_expired_today())
             assert results == [users[2]]
 
@@ -361,7 +361,7 @@ class UserAutomationsTest:
     def test_users_whose_credit_expired_today_automation(self, mock_update_sendinblue, mock_update_batch):
         users = self._create_users_with_deposits()
 
-        with freeze_time("2022-11-02 05:00:00"):
+        with freeze_time("2034-11-02 05:00:00"):
             user_automations.users_whose_credit_expired_today_automation()
 
         mock_update_sendinblue.assert_called_once()
@@ -374,39 +374,39 @@ class UserAutomationsTest:
         assert mock_update_batch.call_args.args[1].is_former_beneficiary is True
 
     def test_get_ex_underage_beneficiaries_who_can_no_longer_recredit(self):
-        with freeze_time("2021-09-10 15:00:00"):
+        with freeze_time("2033-09-10 15:00:00"):
             user = users_factories.UnderageBeneficiaryFactory(
                 email="underage+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=17, months=1),
             )
-            assert user.deposit.expirationDate == datetime(2022, 8, 10)  # at birthday
+            assert user.deposit.expirationDate == datetime(2034, 8, 10)  # at birthday
 
-        with freeze_time("2022-08-10 05:00:00"):
+        with freeze_time("2034-08-10 05:00:00"):
             results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
             assert not results
 
-        with freeze_time("2023-08-10 05:00:00"):
+        with freeze_time("2035-08-10 05:00:00"):
             results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
             assert not results
 
-        with freeze_time("2023-08-11 05:00:00"):
+        with freeze_time("2035-08-11 05:00:00"):
             results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
             assert results == [user]
 
-        with freeze_time("2023-08-12 05:00:00"):
+        with freeze_time("2035-08-12 05:00:00"):
             results = list(user_automations.get_ex_underage_beneficiaries_who_can_no_longer_recredit())
             assert not results
 
     @patch("pcapi.core.users.external.update_batch_user")
     @patch("pcapi.core.users.external.update_sendinblue_user")
     def test_users_whose_credit_expired_today_automation_underage(self, mock_update_sendinblue, mock_update_batch):
-        with freeze_time("2021-09-10 15:00:00"):
+        with freeze_time("2033-09-10 15:00:00"):
             user = users_factories.UnderageBeneficiaryFactory(
                 email="underage+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=17, months=1),
             )
 
-        with freeze_time("2023-08-11 05:00:00"):
+        with freeze_time("2035-08-11 05:00:00"):
             user_automations.users_whose_credit_expired_today_automation()
 
         mock_update_sendinblue.assert_called_once()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Réparer les tests des _user automations_ qui, écrits il y a un an, ne passent plus à cause des dates figées.

## Implémentation

Pour réparer vite, je décale toutes les dates de 12 ans (multiple de 4 pour tomber pareil sur les années bissextiles).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
