### PR TITLE
(BSR)[API] tests: add test util assert_no_duplicated_queries

### DIFF
--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -33,10 +33,7 @@ class BeneficiaryUserViewTest:
         users_factories.BeneficiaryGrant18Factory.create_batch(3)
 
         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        n_queries = testing.AUTHENTICATION_QUERIES
-        n_queries += 1  # select COUNT
-        n_queries += 1  # select users
-        with testing.assert_num_queries(n_queries):
+        with testing.assert_no_duplicated_queries():
             response = client.get("/pc/back-office/beneficiary_users")
 
         assert response.status_code == 200

--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -539,10 +539,7 @@ class OfferValidationViewTest:
 
         client = client.with_session_auth(admin.email)
 
-        n_queries = testing.AUTHENTICATION_QUERIES
-        n_queries += 1  # count
-        n_queries += 1  # select offers
-        with testing.assert_num_queries(n_queries):
+        with testing.assert_no_duplicated_queries():
             response = client.get(url_for("validation.index_view"))
 
         assert response.status_code == 200
@@ -1000,10 +997,7 @@ class OfferValidationViewTest:
 
         client = client.with_session_auth(admin.email)
 
-        n_queries = testing.AUTHENTICATION_QUERIES
-        n_queries += 1  # count
-        n_queries += 1  # select offers
-        with testing.assert_num_queries(n_queries):
+        with testing.assert_no_duplicated_queries():
             response = client.get(url_for("validation-collective-offer.index_view"))
 
         assert response.status_code == 200

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -157,7 +157,7 @@ def _db(app):
     return mock_db
 
 
-pcapi.core.testing.register_event_for_assert_num_queries()
+pcapi.core.testing.register_event_for_query_logger()
 
 
 @pytest.fixture(name="client")

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -34,7 +34,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.providers.repository import get_provider_by_local_class
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import override_features
 from pcapi.core.users.external.batch import BATCH_DATETIME_FORMAT
 import pcapi.core.users.factories as users_factories
@@ -481,24 +481,9 @@ class CancelByBeneficiaryTest:
         stock = offers_factories.StockFactory(offer__bookingEmail="offerer@example.com")
         booking = booking_factories.IndividualBookingFactory.create_batch(20, stock=stock)[0]
 
-        queries = 2  # select stock ; select booking
-        queries += 1  # update booking
-        queries += 1  # select feature_flag
-        queries += 3  # update stock ; update booking ;  release savepoint
-        queries += 7  # (update batch attributes): select booking ; individualBooking ; user_offerer exists ; user.bookings ;  favorites ; deposit ; wallet balance
-        queries += 1  # select venue by id
-        queries += 2  # select user by email ; select venue by same booking email
-        queries += 1  # select offerer by id
-        queries += 1  # select bank_information by venue.id
-        queries += 1  # select exists offer
-        queries += 1  # select exists booking
-        queries += 1  # select stock
-        queries += 1  # select booking ; offer
-        queries += 1  # select external_booking
-
         individual_booking = booking.individualBooking
         user = individual_booking.user
-        with assert_num_queries(queries):
+        with assert_no_duplicated_queries():
             api.cancel_booking_by_beneficiary(user, booking)
 
         # cancellation can trigger more than one request to Batch

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -23,7 +23,7 @@ from pcapi.core.categories import subcategories
 import pcapi.core.finance.api as finance_api
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 import pcapi.core.users.factories as users_factories
 from pcapi.core.users.models import EligibilityType
 from pcapi.domain.booking_recap import booking_recap_history
@@ -2269,12 +2269,12 @@ def test_get_deposit_booking():
     previous_deposit_id = user.deposits[0].id
     current_deposit_id = user.deposit.id
 
-    with assert_num_queries(1):
+    with assert_no_duplicated_queries():
         previous_deposit_bookings = get_bookings_from_deposit(previous_deposit_id)
 
     assert previous_deposit_bookings == [previous_deposit_booking]
 
-    with assert_num_queries(1):
+    with assert_no_duplicated_queries():
         current_deposit_bookings = get_bookings_from_deposit(current_deposit_id)
 
     assert set(current_deposit_bookings) == {current_deposit_booking, current_deposit_booking_2}
@@ -2301,7 +2301,7 @@ class SoonExpiringBookingsTest:
         bookings = [bookings_factories.IndividualBookingFactory(stock=stock) for stock in stocks]
 
         remaining_days = (bookings[0].expirationDate.date() - date.today()).days
-        with assert_num_queries(1):
+        with assert_no_duplicated_queries():
             list(booking_repository.get_soon_expiring_bookings(remaining_days))
 
 
@@ -2358,7 +2358,7 @@ class GetTomorrowEventOfferTest:
             )
         )
 
-        with assert_num_queries(1):
+        with assert_no_duplicated_queries():
             bookings = booking_repository.find_individual_bookings_event_happening_tomorrow_query()
 
         assert len(bookings) == 1

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -7,6 +7,7 @@ from pcapi.core.offerers import models as offerers_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.search.testing as search_testing
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
@@ -98,10 +99,7 @@ class ReindexOfferIdsTest:
     def test_no_unexpected_query_made(self):
         offer_ids = [make_bookable_offer().id for _ in range(3)]
 
-        # 1: get offers
-        # 2. get FF
-        # 3. get the offers's venue id
-        with assert_num_queries(3):
+        with assert_no_duplicated_queries():
             search.reindex_offer_ids(offer_ids)
 
     def test_unindex_unbookable_offer(self, app):
@@ -162,6 +160,7 @@ class ReindexVenueIdsTest:
         # load venues (1 query)
         # load FF (1 query)
         # find whether venue has at least one bookable offer (1 query per venue)
+        # TODO(atrancart): the query to find bookable offers is duplicated, we might want fix this N+1 problem
         with assert_num_queries(5):
             search.reindex_venue_ids(venue_ids)
 

--- a/api/tests/core/testing/tests.py
+++ b/api/tests/core/testing/tests.py
@@ -31,24 +31,6 @@ class AssertNoDuplicatedQueriesTest:
                 self._run_dummy_query()
                 self._run_dummy_query()
 
-    def test_passes_when_duplicated_query_and_max_param(self):
-        with assert_no_duplicated_queries(max_number_of_duplicated_queries=1):
-            self._run_dummy_query()
-            self._run_dummy_query()
-            self._run_dummy_query()
-
-    def test_passes_when_duplicated_query_below_duplication_limit(self):
-        with assert_no_duplicated_queries(max_number_of_duplications=2):
-            self._run_dummy_query()
-            self._run_dummy_query()
-
-    def test_fails_when_duplicated_query_above_duplication_limit(self):
-        with pytest.raises(AssertionError):
-            with assert_no_duplicated_queries(max_number_of_duplications=2):
-                self._run_dummy_query()
-                self._run_dummy_query()
-                self._run_dummy_query()
-
 
 @override_settings(IS_RUNNING_TESTS=2)
 def test_override_settings_on_function():

--- a/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
+++ b/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
@@ -3,7 +3,7 @@ import pytest
 from pcapi.core.educational.factories import CollectiveBookingFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalYearFactory
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -29,7 +29,7 @@ class Returns200Test:
         client = client.with_eac_token()
         adage_id = booking1.educationalYear.adageId
 
-        with assert_num_queries(2):
+        with assert_no_duplicated_queries():
             response = client.get(f"/adage/v1/years/{adage_id}/prebookings")
 
         assert response.status_code == 200

--- a/api/tests/routes/adage/v1/get_educational_bookings_test.py
+++ b/api/tests/routes/adage/v1/get_educational_bookings_test.py
@@ -4,7 +4,7 @@ from pcapi.core.educational.factories import CollectiveBookingFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.offers.utils import offer_app_link
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -26,7 +26,7 @@ class Returns200Test:
 
         client = client.with_eac_token()
 
-        with assert_num_queries(3):
+        with assert_no_duplicated_queries():
             response = client.get(
                 f"/adage/v1/years/{educational_year.adageId}/educational_institution/{educational_institution.institutionId}/prebookings"
             )

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -8,7 +8,7 @@ from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalRedactorFactory
 from pcapi.core.educational.factories import EducationalYearFactory
 from pcapi.core.offers.utils import offer_app_link
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -153,12 +153,7 @@ class Returns200Test:
         adage_id = educational_year.adageId
         institution_id = educational_institution.institutionId
 
-        n_queries = 0
-        n_queries += 1  # Check for educational institution
-        n_queries += 1  # Get needed data
-        n_queries += 1  # Get deposit
-
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             client.with_eac_token().get(f"/adage/v1/years/{adage_id}/educational_institution/{institution_id}")
 
     def test_get_educational_institution_without_deposit(self, client: Any) -> None:

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
 
@@ -32,7 +32,7 @@ class Returns200Test:
         client.auth_header = {"Authorization": f"Bearer {adage_jwt_fake_valid_token}"}
 
         # When
-        with assert_num_queries(1):
+        with assert_no_duplicated_queries():
             response = client.get(f"/adage-iframe/collective/offers-template/{offer_id}")
 
         # Then

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
 
@@ -37,7 +37,7 @@ class Returns200Test:
         offer_id = stock.collectiveOffer.id
 
         # When
-        with assert_num_queries(1):
+        with assert_no_duplicated_queries():
             response = client.get(f"/adage-iframe/collective/offers/{offer_id}")
 
         # Then

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -11,7 +11,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions.models import Permissions
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
@@ -35,20 +35,15 @@ class GetOffererUsersTest:
         )
         uo3 = offerers_factories.NotValidatedUserOffererFactory(offerer=offerer1, user=users_factories.ProFactory())
 
-        offerer1_id = offerer1.id  # request from offerer outside assert_num_queries
-
         offerer2 = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer2, user=users_factories.ProFactory())
 
         auth_token = generate_token(users_factories.UserFactory(), [Permissions.READ_PRO_ENTITY])
 
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
-                url_for("backoffice_blueprint.get_offerer_users", offerer_id=offerer1_id)
+                url_for("backoffice_blueprint.get_offerer_users", offerer_id=offerer1.id)
             )
 
         # then
@@ -136,15 +131,10 @@ class GetOffererBasicInfoTest:
         admin = users_factories.UserFactory()
         auth_token = generate_token(admin, [Permissions.READ_PRO_ENTITY])
 
-        offerer_id = offerer.id  # request id from offerer outside assert_num_queries
-
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
-                url_for("backoffice_blueprint.get_offerer_basic_info", offerer_id=offerer_id)
+                url_for("backoffice_blueprint.get_offerer_basic_info", offerer_id=offerer.id)
             )
 
         # then
@@ -304,15 +294,10 @@ class GetOffererTotalRevenueTest:
         admin = users_factories.UserFactory()
         auth_token = generate_token(admin, [Permissions.READ_PRO_ENTITY])
 
-        offerer_id = offerer.id  # request id from offerer outside assert_num_queries
-
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
-                url_for("backoffice_blueprint.get_offerer_total_revenue", offerer_id=offerer_id)
+                url_for("backoffice_blueprint.get_offerer_total_revenue", offerer_id=offerer.id)
             )
 
         # then
@@ -436,15 +421,10 @@ class GetOffererOffersStatsTest:
         admin = users_factories.UserFactory()
         auth_token = generate_token(admin, [Permissions.READ_PRO_ENTITY])
 
-        offerer_id = offerer.id  # request id from offerer outside assert_num_queries
-
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
-                url_for("backoffice_blueprint.get_offerer_offers_stats", offerer_id=offerer_id)
+                url_for("backoffice_blueprint.get_offerer_offers_stats", offerer_id=offerer.id)
             )
 
         # then
@@ -628,12 +608,8 @@ class GetOffererHistoryTest:
 
         offerer_id = user_offerer.offerer.id
 
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-        n_queries += 1  # count() for pagination
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.get_offerer_history", offerer_id=offerer_id)
             )
@@ -1060,11 +1036,8 @@ class GetOfferersTagsTest:
         tag2 = offerers_factories.OffererTagFactory(name="test-type-ei", label="Entreprise individuelle")
         auth_token = generate_token(users_factories.UserFactory(), [Permissions.MANAGE_PRO_ENTITY])
 
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.get_offerers_tags_list")
             )
@@ -1323,11 +1296,8 @@ class OfferersStatsTest:
         )
         auth_token = generate_token(users_factories.UserFactory(), [Permissions.VALIDATE_OFFERER])
 
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(url_for("backoffice_blueprint.get_offerers_stats"))
 
         # then
@@ -1340,11 +1310,8 @@ class OfferersStatsTest:
         # given
         auth_token = generate_token(users_factories.UserFactory(), [Permissions.VALIDATE_OFFERER])
 
-        n_queries = 2  # permission_required: features (ENABLE_BACKOFFICE_API) + user
-        n_queries += 1  # query should load all data in a single query
-
         # when
-        with assert_num_queries(n_queries):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(url_for("backoffice_blueprint.get_offerers_stats"))
 
         # then
@@ -1377,11 +1344,6 @@ class OfferersStatsTest:
 
 
 class ListOfferersToBeValidatedTest:
-    # 2: permission_required: features (ENABLE_BACKOFFICE_API) + user
-    # +1: query should load all data in a single query
-    # +1: count() for pagination
-    N_QUERIES = 4
-
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_list_only_offerers_to_be_validated(self, client):
         # given
@@ -1402,7 +1364,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated")
             )
@@ -1463,7 +1425,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated")
             )
@@ -1532,7 +1494,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated")
             )
@@ -1559,7 +1521,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated")
             )
@@ -1705,7 +1667,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for(
                     "backoffice_blueprint.list_offerers_to_be_validated",
@@ -1778,7 +1740,7 @@ class ListOfferersToBeValidatedTest:
         offerers_factories.UserNotValidatedOffererFactory(offerer__dateCreated=datetime.datetime(2022, 11, 10, 7))
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for(
                     "backoffice_blueprint.list_offerers_to_be_validated",
@@ -1828,7 +1790,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated", q="123004004")
             )
@@ -1880,7 +1842,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_to_be_validated", q=search_filter)
             )
@@ -1911,7 +1873,7 @@ class ListOfferersToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListOfferersToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for(
                     "backoffice_blueprint.list_offerers_to_be_validated",
@@ -2381,11 +2343,6 @@ class ToggleTopActorTagTest:
 
 
 class ListUserOffererToBeValidatedTest:
-    # 2: permission_required: features (ENABLE_BACKOFFICE_API) + user
-    # +1: query should load all data in a single query
-    # +1: count() for pagination
-    N_QUERIES = 4
-
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_list_only_user_offerer_to_be_validated(self, client):
         # given
@@ -2414,7 +2371,7 @@ class ListUserOffererToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListUserOffererToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_attachments_to_be_validated")
             )
@@ -2470,7 +2427,7 @@ class ListUserOffererToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListUserOffererToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_attachments_to_be_validated")
             )
@@ -2508,7 +2465,7 @@ class ListUserOffererToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListUserOffererToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for("backoffice_blueprint.list_offerers_attachments_to_be_validated")
             )
@@ -2590,7 +2547,7 @@ class ListUserOffererToBeValidatedTest:
         auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
 
         # when
-        with assert_num_queries(ListUserOffererToBeValidatedTest.N_QUERIES):
+        with assert_no_duplicated_queries():
             response = client.with_explicit_token(auth_token).get(
                 url_for(
                     "backoffice_blueprint.list_offerers_attachments_to_be_validated",

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -337,12 +337,7 @@ class AccountTest:
         assert response.status_code == 200
         client.with_token(user.email)
 
-        n_queries = 1  # get user
-        n_queries += 1  # get bookings for deposit remaining amount
-        n_queries += 1  # get bookings for booked offers info
-        n_queries += 1  # get feature enable_native_cultural_survey
-
-        with testing.assert_num_queries(n_queries):
+        with testing.assert_no_duplicated_queries():
             response = client.get("/native/v1/me")
 
 

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -18,7 +18,7 @@ from pcapi.core.offers.factories import MediationFactory
 from pcapi.core.offers.factories import StockFactory
 from pcapi.core.offers.factories import StockWithActivationCodesFactory
 from pcapi.core.offers.models import WithdrawalTypeEnum
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import override_features
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
@@ -166,10 +166,7 @@ class GetBookingsTest:
         test_client = TestClient(app.test_client())
         test_client.auth_header = {"Authorization": f"Bearer {access_token}"}
 
-        # 1: get the user
-        # 1: get the bookings
-        # 1: rollback
-        with assert_num_queries(3):
+        with assert_no_duplicated_queries():
             response = test_client.get("/native/v1/bookings")
 
         assert response.status_code == 200

--- a/api/tests/routes/pro/get_all_bookings_test.py
+++ b/api/tests/routes/pro/get_all_bookings_test.py
@@ -5,13 +5,12 @@ from unittest.mock import patch
 from dateutil.tz import tz
 import pytest
 
-from pcapi.core import testing
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.bookings.models as bookings_models
 from pcapi.core.external_bookings.factories import ExternalBookingFactory
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 import pcapi.core.users.factories as users_factories
 from pcapi.utils.date import format_into_timezoned_date
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -118,7 +117,7 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
         client = TestClient(app.test_client()).with_session_auth(pro_user.email)
-        with assert_num_queries(testing.AUTHENTICATION_QUERIES + 2):
+        with assert_no_duplicated_queries():
             response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
 
         expected_bookings_recap = [
@@ -177,7 +176,7 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
         client = TestClient(app.test_client()).with_session_auth(pro_user.email)
-        with assert_num_queries(testing.AUTHENTICATION_QUERIES + 2):
+        with assert_no_duplicated_queries():
             response = client.get(
                 f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&eventDate={requested_date_iso_format}"
             )
@@ -199,7 +198,7 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro_user, offerer=booking.offerer)
 
         client = TestClient(app.test_client()).with_session_auth(pro_user.email)
-        with assert_num_queries(testing.AUTHENTICATION_QUERIES + 2):
+        with assert_no_duplicated_queries():
             response = client.get(
                 "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s&bookingStatusFilter=booked"
                 % (booking_period_beginning_date_iso, booking_period_ending_date_iso)

--- a/api/tests/routes/pro/get_available_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_available_reimbursement_points_test.py
@@ -26,17 +26,11 @@ class Returns200Test:
             publicName="Association des démons",
         )
         finance_factories.BankInformationFactory(venue=venue_without_siret, status=BankInformationStatus.ACCEPTED)
-        _venue_without_bank_info_nor_siret = offerers_factories.VenueFactory(
-            siret=None, comment="Pas de SIRET", managingOfferer=offerer
-        )
+        offerers_factories.VenueFactory(siret=None, comment="Pas de SIRET", managingOfferer=offerer)
 
         client = client.with_session_auth("user.pro@example.com")
-        n_queries = (
-            testing.AUTHENTICATION_QUERIES
-            + 1  # check_user_has_access_to_offerer
-            + 1  # eligible Venues with their eagerly loaded BankInformation
-        )
-        with testing.assert_num_queries(n_queries):
+
+        with testing.assert_no_duplicated_queries():
             response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
 
         assert response.status_code == 200

--- a/api/tests/routes/pro/get_business_units_test.py
+++ b/api/tests/routes/pro/get_business_units_test.py
@@ -36,9 +36,8 @@ def test_get_business_units_by_pro(client):
     offerers_factories.UserOffererFactory(offerer=venue1.managingOfferer, user=pro)
 
     client = client.with_session_auth(pro.email)
-    n_queries = testing.AUTHENTICATION_QUERIES
-    n_queries += 1  # select business units
-    with testing.assert_num_queries(n_queries):
+
+    with testing.assert_no_duplicated_queries():
         response = client.get("finance/business-units")
 
     assert response.status_code == 200

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -43,9 +43,7 @@ class Returns200Test:
         client.with_session_auth(email="user@example.com")
         humanized_offer_id = humanize(offer.id)
 
-        num_queries = 3  # select collective offer template
-
-        with testing.assert_num_queries(testing.AUTHENTICATION_QUERIES + num_queries):
+        with testing.assert_no_duplicated_queries():
             client.get(f"/collective/offers-template/{humanized_offer_id}")
 
 

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -98,14 +98,7 @@ class Returns200Test:
         client = client.with_session_auth(email="user@example.com")
         humanized_offer_id = humanize(offer.id)
 
-        NUM_QUERIES = 0
-        NUM_QUERIES += 1  # get user_session
-        NUM_QUERIES += 1  # get user information
-        NUM_QUERIES += 1  # get offerer from offer
-        NUM_QUERIES += 1  # check user has access to offerer
-        NUM_QUERIES += 1  # get offer
-
-        with testing.assert_num_queries(NUM_QUERIES):
+        with testing.assert_no_duplicated_queries():
             client.get(f"/collective/offers/{humanized_offer_id}")
 
 

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -78,11 +78,7 @@ class Returns200Test:
         client.with_session_auth(email=user_offerer.user.email)
         humanized_offer_id = humanize(offer.id)
 
-        num_queries = testing.AUTHENTICATION_QUERIES
-        num_queries += 1  # check user access to offerer
-        num_queries += 1  # Get offer by id
-
-        with testing.assert_num_queries(num_queries):
+        with testing.assert_no_duplicated_queries():
             client.get(f"/offers/{humanized_offer_id}")
 
     def test_access_even_if_offerer_has_no_siren(self, app):

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -44,18 +44,8 @@ def test_basics(client):
     offerer_id = offerer.id
     client = client.with_session_auth(pro.email)
     db.session.commit()
-    n_queries = (
-        testing.AUTHENTICATION_QUERIES
-        + 1  # check_user_has_access_to_offerer
-        + 1  # Offerer
-        + 1  # Offerer api_key prefix
-        + 1  # venues (manual with joinedload)
-        + 1  # Offerer hasDigitalVenueAtLeastOneOffer
-        + 1  # Offerer BankInformation
-        + 1  # Offerer hasMissingBankInformation
-        + 1  # Offerer.managedVenues (automatic by Pydantic)
-    )
-    with testing.assert_num_queries(n_queries):
+
+    with testing.assert_no_duplicated_queries():
         response = client.get(f"/offerers/{humanize(offerer_id)}")
 
     expected_serialized_offerer = {

--- a/api/tests/routes/pro/get_offerers_test.py
+++ b/api/tests/routes/pro/get_offerers_test.py
@@ -35,12 +35,8 @@ def test_access_by_pro(client):
     offerers_factories.OffererFactory(name="not returned")
 
     client = client.with_session_auth(pro.email)
-    n_queries = testing.AUTHENTICATION_QUERIES
-    n_queries += 1  # select offerers
-    n_queries += 1  # select count of offerers
-    n_queries_per_offerer = 3  # select count of offers, collective and template for all venues of one offerer
-    n_queries += n_queries_per_offerer * 2  # 2 offerers
-    with testing.assert_num_queries(n_queries):
+
+    with testing.assert_no_duplicated_queries():
         response = client.get("/offerers")
 
     assert response.status_code == 200

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -1,9 +1,8 @@
 from unittest.mock import patch
 
-from pcapi.core import testing
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 import pcapi.core.users.factories as users_factories
 from pcapi.utils.human_ids import humanize
 
@@ -33,11 +32,9 @@ class Returns200Test:
         stock = offers_factories.StockFactory(offer=offer_on_requested_venue)
         client = TestClient(app.test_client()).with_session_auth(email=admin.email)
         path = f"/offers?venueId={humanize(requested_venue.id)}"
-        select_offers_nb_queries = 1  # FeatureFlag query
-        select_offers_nb_queries += 1  # Offer query
 
         # when
-        with assert_num_queries(testing.AUTHENTICATION_QUERIES + select_offers_nb_queries):
+        with assert_no_duplicated_queries():
             response = client.get(path)
 
         # then

--- a/api/tests/routes/pro/get_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_reimbursement_points_test.py
@@ -48,9 +48,7 @@ def test_get_reimbursement_points_by_pro(client):
     offerers_factories.UserOffererFactory(offerer=pro_reimbursement_point_1.managingOfferer, user=pro)
 
     client = client.with_session_auth(pro.email)
-    n_queries = testing.AUTHENTICATION_QUERIES
-    n_queries += 1  # select reimbursement points
-    with testing.assert_num_queries(n_queries):
+    with testing.assert_no_duplicated_queries():
         response = client.get("/finance/reimbursement-points")
 
     assert response.status_code == 200

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -142,12 +142,8 @@ class Returns200Test:
 
         auth_request = client.with_session_auth(email=user_offerer.user.email)
         db.session.commit()  # clear SQLA cached objects
-        n_queries = (
-            testing.AUTHENTICATION_QUERIES  # 2
-            + 1  # Venue and eager loading of relations
-            + 1  # check_user_has_access_to_offerer()
-        )
-        with testing.assert_num_queries(n_queries):
+
+        with testing.assert_no_duplicated_queries():
             response = auth_request.get("/venues/%s" % humanize(venue_id))
 
         assert response.status_code == 200

--- a/api/tests/routes/pro/get_venues_educational_status_test.py
+++ b/api/tests/routes/pro/get_venues_educational_status_test.py
@@ -27,10 +27,8 @@ class Returns200Test:
         offerers_factories.VenueEducationalStatusFactory(id=4, name="Établissement privé")
         offerers_factories.VenueEducationalStatusFactory(id=5, name="micro-entreprise, auto-entrepreneur")
 
-        n_queries = testing.AUTHENTICATION_QUERIES
-        n_queries += 1  # query to retrieve all the venues educational status
         auth_client = client.with_session_auth(pro.email)
-        with testing.assert_num_queries(n_queries):
+        with testing.assert_no_duplicated_queries():
             response = auth_client.get("/venues-educational-statuses")
 
         expected_serialized_offerer = {

--- a/api/tests/routes/pro/get_venues_test.py
+++ b/api/tests/routes/pro/get_venues_test.py
@@ -2,9 +2,8 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.core import testing
 import pcapi.core.offerers.factories as offerers_factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 import pcapi.core.users.factories as users_factories
 from pcapi.utils.human_ids import humanize
 
@@ -101,9 +100,7 @@ def test_admin_call_num_queries(app):
     client = TestClient(app.test_client()).with_session_auth(admin_user.email)
 
     # when
-    n_queries = testing.AUTHENTICATION_QUERIES
-    n_queries += 1  # get venues + offerers
-    with assert_num_queries(n_queries):
+    with assert_no_duplicated_queries():
         response = client.get("/venues")
 
     # then

--- a/api/tests/routes/pro/patch_collective_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_active_status_test.py
@@ -36,12 +36,10 @@ class Returns204Test:
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
 
-        collective_offers_update_queries = 3  # collective + release savepoint
-
         # When
         client = client.with_session_auth("pro@example.com")
         data = {"ids": [humanize(offer1.id), humanize(offer2.id)], "isActive": False}
-        with testing.assert_num_queries(testing.AUTHENTICATION_QUERIES + collective_offers_update_queries):
+        with testing.assert_no_duplicated_queries():
             response = client.patch("/collective/offers/active-status", json=data)
 
         # Then

--- a/api/tests/routes/pro/patch_collective_offers_template_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_template_active_status_test.py
@@ -36,12 +36,10 @@ class Returns204Test:
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
 
-        collective_offers_update_queries = 3  # collective + release savepoint
-
         # When
         client = client.with_session_auth("pro@example.com")
         data = {"ids": [humanize(offer1.id), humanize(offer2.id)], "isActive": False}
-        with testing.assert_num_queries(testing.AUTHENTICATION_QUERIES + collective_offers_update_queries):
+        with testing.assert_no_duplicated_queries():
             response = client.patch("/collective/offers-template/active-status", json=data)
 
         # Then

--- a/api/tests/routes/pro/patch_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_offers_active_status_test.py
@@ -38,15 +38,10 @@ class Returns204Test:
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
 
-        offers_update_queries = 3
-        collective_offers_update_queries = 2  # collective + template
-
         # When
         client = TestClient(app.test_client()).with_session_auth("pro@example.com")
         data = {"ids": [humanize(offer1.id), humanize(offer2.id)], "isActive": False}
-        with testing.assert_num_queries(
-            testing.AUTHENTICATION_QUERIES + offers_update_queries + collective_offers_update_queries
-        ):
+        with testing.assert_no_duplicated_queries():
             response = client.patch("/offers/active-status", json=data)
 
         # Then

--- a/api/tests/scheduled_tasks/commands_test.py
+++ b/api/tests/scheduled_tasks/commands_test.py
@@ -12,7 +12,7 @@ from pcapi.core.mails.transactional.bookings.booking_event_reminder_to_beneficia
     get_booking_event_reminder_to_beneficiary_email_data,
 )
 import pcapi.core.offers.factories as offers_factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import override_settings
 import pcapi.notifications.push.testing as notifications_testing
 from pcapi.scheduled_tasks.commands import _send_notification_favorites_not_booked
@@ -90,7 +90,7 @@ class SendEmailReminderTomorrowEventToBeneficiariesTest:
         stock = offers_factories.EventStockFactory(beginningDatetime=tomorrow)
         bookings_factories.IndividualBookingFactory.create_batch(3, stock=stock)
 
-        with assert_num_queries(1):
+        with assert_no_duplicated_queries():
             send_email_reminder_tomorrow_event_to_beneficiaries()
 
             assert len(mails_testing.outbox) == 3

--- a/api/tests/scripts/bulk_mark_incompatible_via_isbns_test.py
+++ b/api/tests/scripts/bulk_mark_incompatible_via_isbns_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.factories import ProductFactory
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import assert_num_queries
 from pcapi.scripts.bulk_mark_incompatible_via_isbns import bulk_update_is_gcu_compatible_via_isbns
 
@@ -57,9 +58,7 @@ class BulkUpdateIsGcuCompatibleViaIsbnsTest:
 
         isbns_list = ["ABCDEFG", "HIJKLMN", "OPQRSTU", "HFGDS"]
 
-        queries = 2  # update; commit
-
-        with assert_num_queries(queries):
+        with assert_no_duplicated_queries():
             bulk_update_is_gcu_compatible_via_isbns(isbns_list, 4, is_compatible=True)
 
         assert product.isGcuCompatible

--- a/api/tests/scripts/bulk_update_is_synchronization_compatible_product_via_isbns_test.py
+++ b/api/tests/scripts/bulk_update_is_synchronization_compatible_product_via_isbns_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pcapi.core.offers.factories import ProductFactory
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.scripts.bulk_update_is_synchronization_compatible_product_via_isbns import (
     bulk_update_is_synchronization_compatible_via_isbns,
 )
@@ -16,9 +16,7 @@ def test_should_mark_synchronized_offers_and_products_as_not_synchronization_com
 
     isbns_list = ["5555555555555", "6666666666666", "8888888888888", "7777777777777"]
 
-    queries = 1  # update product
-    queries += 1  # commit
-    with assert_num_queries(queries):
+    with assert_no_duplicated_queries():
         bulk_update_is_synchronization_compatible_via_isbns(
             isbns_list, is_synchronization_compatible=False, batch_size=4
         )

--- a/api/tests/scripts/offer/tag_many_test.py
+++ b/api/tests/scripts/offer/tag_many_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from pcapi.core.criteria import factories as criteria_factories
 from pcapi.core.offers import factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.scripts.offer.tag_many import create_missing_mappings
 
 
@@ -16,11 +16,7 @@ def test_create_missing_mappings():
     criterion_names = {criterion.name for criterion in criteria}
     offer_ids = {offer.id for offer in offers}
 
-    # 1. load offers
-    # 2. load criteria (OfferCriterion)
-    # 3. insert mappings (OfferCriterionMapping)
-    # 4. commit
-    with assert_num_queries(4):
+    with assert_no_duplicated_queries():
         create_missing_mappings(offer_ids, criterion_names, dry_run=False)
 
     assert all(len(offer.criteria) == 2 for offer in offers)
@@ -39,11 +35,7 @@ def test_create_missing_mappings_when_some_criteria_exists():
     criterion_names = {criterion.name for criterion in criteria}
     offer_ids = {offer.id for offer in offers}
 
-    # 1. load offers
-    # 2. load criteria (Criterion)
-    # 3. insert mappings (OfferCriterion)
-    # 4. commit
-    with assert_num_queries(4):
+    with assert_no_duplicated_queries():
         create_missing_mappings(offer_ids, criterion_names, dry_run=False)
 
     assert all(len(offer.criteria) == 2 for offer in offers)
@@ -60,10 +52,7 @@ def test_create_missing_mappings_dry_run():
     criterion_names = {criterion.name for criterion in criteria}
     offer_ids = {offer.id for offer in offers}
 
-    # 1. load offers
-    # 2. load criteria (OfferCriterion)
-    # 3. rollback
-    with assert_num_queries(3):
+    with assert_no_duplicated_queries():
         create_missing_mappings(offer_ids, criterion_names, dry_run=True)
 
     assert all(not offer.criteria for offer in offers)

--- a/api/tests/scripts/offerer/tag_many_test.py
+++ b/api/tests/scripts/offerer/tag_many_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pcapi.core.offerers import factories
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.scripts.offerer.tag_many import create_missing_mappings
 
 
@@ -15,11 +15,7 @@ def test_create_missing_mappings():
     tag_names = {tag.name for tag in tags}
     offerer_ids = {offerer.id for offerer in offerers}
 
-    # 1. load offerers
-    # 2. load tags (OfferTag)
-    # 3. insert mappings (OfferTagMapping)
-    # 4. commit
-    with assert_num_queries(4):
+    with assert_no_duplicated_queries():
         create_missing_mappings(offerer_ids, tag_names, dry_run=False)
 
     assert all(len(offerer.tags) == 2 for offerer in offerers)
@@ -38,11 +34,7 @@ def test_create_missing_mappings_when_some_tags_exists():
     tag_names = {tag.name for tag in tags}
     offerer_ids = {offerer.id for offerer in offerers}
 
-    # 1. load offerers
-    # 2. load tags (OfferTag)
-    # 3. insert mappings (OfferTagMapping)
-    # 4. commit
-    with assert_num_queries(4):
+    with assert_no_duplicated_queries():
         create_missing_mappings(offerer_ids, tag_names, dry_run=False)
 
     assert all(len(offerer.tags) == 2 for offerer in offerers)
@@ -59,10 +51,7 @@ def test_create_missing_mappings_dry_run():
     tag_names = {tag.name for tag in tags}
     offerer_ids = {offerer.id for offerer in offerers}
 
-    # 1. load offerers
-    # 2. load tags (OfferTag)
-    # 3. rollback
-    with assert_num_queries(3):
+    with assert_no_duplicated_queries():
         create_missing_mappings(offerer_ids, tag_names, dry_run=True)
 
     assert all(not offerer.tags for offerer in offerers)

--- a/api/tests/utils/rest_test.py
+++ b/api/tests/utils/rest_test.py
@@ -2,7 +2,7 @@ import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offerers.models import Venue
-from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import assert_no_duplicated_queries
 import pcapi.core.users.factories as users_factories
 from pcapi.models.api_errors import ApiErrors
 from pcapi.utils.human_ids import humanize
@@ -18,14 +18,8 @@ class CheckUserHasAccessToOffererTest:
         pro = users_factories.UserFactory()
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
-        # fmt: off
-        n_queries = (
-            1  # select Offerer
-            + 1  # select User
-            + 1  # select UserOfferer
-        )
-        # fmt: on
-        with assert_num_queries(n_queries):
+
+        with assert_no_duplicated_queries():
             check_user_has_access_to_offerer(pro, offerer.id)
 
     def test_raises_if_user_cannot_access_offerer(self, app):


### PR DESCRIPTION
## But de la pull request

Ajoute un utilitaire `assert_no_duplicated_queries` pour vérifier dans les tests qu'il n'y a pas de problème de N+1 lié à un bout de code
C'est sémantiquement plus proche de ce qu'on veut vraiment tester que lorsqu'on utilise `assert_num_queries`

![image](https://user-images.githubusercontent.com/6317823/199537344-63327f19-3065-438f-ab95-89f9537fafed.png)
