### PR TITLE
Pc 18319 backoffice offerer minor fixes

### DIFF
--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -336,7 +336,7 @@ class OffererBasicInfo(BaseModel):
     name: str
     validationStatus: offerers_models.ValidationStatus
     isActive: bool
-    siren: str
+    siren: str | None
     region: str
     bankInformationStatus: OffererBankInformationStatus
     isCollectiveEligible: bool
@@ -427,7 +427,7 @@ class OffererToBeValidated(BaseModel):
     requestDate: datetime.datetime
     status: str
     step: str | None
-    siren: str
+    siren: str | None
     address: str | None  # nullable in HasAddressMixin
     postalCode: str
     city: str

--- a/backoffice/src/resources/Pro/Offerers/OffererDetail.tsx
+++ b/backoffice/src/resources/Pro/Offerers/OffererDetail.tsx
@@ -371,11 +371,17 @@ export const OffererDetail = () => {
                           <TableCell>
                             {format(item.date, 'dd/MM/yyyy à HH:mm:ss')}
                           </TableCell>
-                          <TableCell align="left">{item.authorName}</TableCell>
                           <TableCell align="left">
-                            <p>{`${item.accountName} - ${item.accountId}`}</p>
-                            <span>{`Commentaire :
-                              ${item.comment}`}</span>
+                            {item.authorName && item.authorName}
+                          </TableCell>
+                          <TableCell align="left">
+                            {!!item.accountId && (
+                              <p>{`${item.accountName} - ${item.accountId}`}</p>
+                            )}
+                            {!!item.comment && (
+                              <span>{`Commentaire :
+                                ${item.comment}`}</span>
+                            )}
                           </TableCell>
                         </TableRow>
                       ))}

--- a/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
+++ b/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
@@ -131,7 +131,7 @@ export const OfferersToValidate = () => {
       const response = await apiProvider().listOfferersToBeValidated({
         page: page + 1,
         perPage: rowsPerPage,
-        sort: JSON.stringify([{ field: 'name', order: 'asc' }]),
+        sort: JSON.stringify([{ field: 'dateCreated', order: 'desc' }]),
         filter: JSON.stringify(filters),
       })
       if (response && response.data && response.data.length > 0) {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18319

## But de la pull request

Trois petites corrections dans le backoffice pour la validation et l'historique des structures : 

- Si aucun commentaire n’a été saisi lors du changement de statut, que ce soit sur la structure ou sur un compte pro de la structure, on affiche pas “Commentaire : undefined” dans la colonne commentaire.  Cette seconde sous ligne doit disparaître dans ce cas. On affiche uniquement le commentaire lorsqu’il y a eu une saisie. De même pour la colonne “Auteur”, s’il n’y a aucune valeur, on affiche rien plutôt que “undefined”

- Trier par défaut la liste des structures à valider de la date de création la plus récente à la plus ancienne

- En cas de SIREN vide, l’accès au profil de la structure doit fonctionner malgré tout 


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
