### PR TITLE
(PC-18352)[API] fix: use same redirect link for all ubble retryable messages

### DIFF
--- a/api/src/pcapi/core/subscription/ubble/messages.py
+++ b/api/src/pcapi/core/subscription/ubble/messages.py
@@ -32,15 +32,12 @@ def get_application_pending_message(updated_at: datetime.datetime | None) -> sub
 def get_ubble_retryable_message(
     reason_codes: list[fraud_models.FraudReasonCode], updated_at: datetime.datetime | None
 ) -> subscription_models.SubscriptionMessage:
-    call_to_action = REDIRECT_TO_IDENTIFICATION
-
     if fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE in reason_codes:
         user_message = "Nous n'arrivons pas à lire ton document. Réessaye avec un passeport ou une carte d'identité française en cours de validité dans un lieu bien éclairé."
     elif fraud_models.FraudReasonCode.ID_CHECK_NOT_AUTHENTIC in reason_codes:
         user_message = "Le document que tu as présenté n’est pas accepté car il s’agit d’une photo ou d’une copie de l’original. Réessaye avec un document original en cours de validité."
     elif fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED in reason_codes:
         user_message = "Le document d'identité que tu as présenté n'est pas accepté. S’il s’agit d’une pièce d’identité étrangère ou d’un titre de séjour français, tu dois passer par le site demarches-simplifiees.fr. Si non, tu peux réessayer avec un passeport ou une carte d’identité française en cours de validité."
-        call_to_action = subscription_messages.REDIRECT_TO_IDENTIFICATION_CHOICE
     elif fraud_models.FraudReasonCode.ID_CHECK_EXPIRED in reason_codes:
         user_message = "Ton document d'identité est expiré. Réessaye avec un passeport ou une carte d'identité française en cours de validité."
     else:
@@ -48,7 +45,7 @@ def get_ubble_retryable_message(
 
     return subscription_models.SubscriptionMessage(
         user_message=user_message,
-        call_to_action=call_to_action,
+        call_to_action=subscription_messages.REDIRECT_TO_IDENTIFICATION_CHOICE,
         pop_over_icon=None,
         updated_at=updated_at,
     )

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -821,36 +821,31 @@ class SubscriptionMessageTest:
         assert ubble_subscription_api.get_ubble_subscription_message(fraud_check, False) is None
 
     @pytest.mark.parametrize(
-        "reason_codes,expected_message,link",
+        "reason_codes,expected_message",
         [
             (
                 [fraud_models.FraudReasonCode.ID_CHECK_EXPIRED],
                 "Ton document d'identité est expiré. Réessaye avec un passeport ou une carte d'identité française en cours de validité.",
-                "passculture://verification-identite/identification",
             ),
             (
                 [fraud_models.FraudReasonCode.ID_CHECK_NOT_AUTHENTIC],
                 "Le document que tu as présenté n’est pas accepté car il s’agit d’une photo ou d’une copie de l’original. Réessaye avec un document original en cours de validité.",
-                "passculture://verification-identite/identification",
             ),
             (
                 [fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED],
                 "Le document d'identité que tu as présenté n'est pas accepté. S’il s’agit d’une pièce d’identité étrangère ou d’un titre de séjour français, tu dois passer par le site demarches-simplifiees.fr. Si non, tu peux réessayer avec un passeport ou une carte d’identité française en cours de validité.",
-                "passculture://verification-identite",
             ),
             (
                 [fraud_models.FraudReasonCode.ID_CHECK_UNPROCESSABLE],
                 "Nous n'arrivons pas à lire ton document. Réessaye avec un passeport ou une carte d'identité française en cours de validité dans un lieu bien éclairé.",
-                "passculture://verification-identite/identification",
             ),
             (
                 None,
                 "La vérification de ton identité a échoué. Tu peux réessayer.",
-                "passculture://verification-identite/identification",
             ),
         ],
     )
-    def test_retryable(self, reason_codes, expected_message, link):
+    def test_retryable(self, reason_codes, expected_message):
         fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(
             type=fraud_models.FraudCheckType.UBBLE,
             status=FraudCheckStatus.SUSPICIOUS,
@@ -862,7 +857,7 @@ class SubscriptionMessageTest:
             user_message=expected_message,
             call_to_action=subscription_models.CallToActionMessage(
                 title="Réessayer la vérification de mon identité",
-                link=link,
+                link="passculture://verification-identite",
                 icon=subscription_models.CallToActionIcon.RETRY,
             ),
             pop_over_icon=None,

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -1970,7 +1970,7 @@ class UbbleWebhookTest:
             message.user_message
             == "Ton document d'identité est expiré. Réessaye avec un passeport ou une carte d'identité française en cours de validité."
         )
-        assert message.call_to_action.link == "passculture://verification-identite/identification"
+        assert message.call_to_action.link == "passculture://verification-identite"
         assert message.call_to_action.icon == subscription_models.CallToActionIcon.RETRY
         assert message.call_to_action.title == "Réessayer la vérification de mon identité"
 
@@ -2037,7 +2037,7 @@ class UbbleWebhookTest:
             message.user_message
             == "Le document que tu as présenté n’est pas accepté car il s’agit d’une photo ou d’une copie de l’original. Réessaye avec un document original en cours de validité."
         )
-        assert message.call_to_action.link == "passculture://verification-identite/identification"
+        assert message.call_to_action.link == "passculture://verification-identite"
         assert message.call_to_action.icon == subscription_models.CallToActionIcon.RETRY
         assert message.call_to_action.title == "Réessayer la vérification de mon identité"
 
@@ -2279,7 +2279,7 @@ class UbbleWebhookTest:
             message.user_message
             == "Nous n'arrivons pas à lire ton document. Réessaye avec un passeport ou une carte d'identité française en cours de validité dans un lieu bien éclairé."
         )
-        assert message.call_to_action.link == "passculture://verification-identite/identification"
+        assert message.call_to_action.link == "passculture://verification-identite"
         assert message.call_to_action.icon == subscription_models.CallToActionIcon.RETRY
         assert message.call_to_action.title == "Réessayer la vérification de mon identité"
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18352

## But de la pull request

Rediriger au bon endroit quand un utilisateur peut retry Ubble

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
