### PR TITLE
(PC-18224)[API] feat: backoffice: list user-offerers to validate

### DIFF
--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -83,6 +83,10 @@ class OffererToBeValidatedQuery(PaginableQuery, FilterableQuery):
     q: str | None
 
 
+class UserOffererToBeValidatedQuery(PaginableQuery, FilterableQuery):
+    pass
+
+
 class SearchQuery(PaginableQuery):
     q: str
 
@@ -453,3 +457,24 @@ class CommentRequest(BaseModel):
 
 class IsTopActorRequest(BaseModel):
     isTopActor: bool
+
+
+class UserOffererToBeValidated(BaseModel):
+    id: int
+    userId: int
+    email: str | None
+    userName: str
+    status: str
+    requestDate: datetime.datetime | None
+    lastComment: Comment | None
+    phoneNumber: str | None
+    offererId: int
+    offererName: str
+    offererCreatedDate: datetime.datetime
+    ownerId: int | None
+    ownerEmail: str | None
+    siren: str
+
+
+class ListUserOffererToBeValidatedResponseModel(PaginatedResponse):
+    data: list[UserOffererToBeValidated]

--- a/api/tests/routes/backoffice/fixtures.py
+++ b/api/tests/routes/backoffice/fixtures.py
@@ -41,6 +41,7 @@ __all__ = (
     "collective_venue_booking",
     "offerer_tags",
     "offerers_to_be_validated",
+    "user_offerer_to_be_validated",
 )
 
 
@@ -351,5 +352,35 @@ def offerers_to_be_validated(offerer_tags):
     # Other statuses
     offerers_factories.OffererFactory(name="G")
     offerers_factories.NotValidatedOffererFactory(name="H", validationStatus=offerers_models.ValidationStatus.REJECTED)
+
+    return (no_tag, top, collec, public, top_collec, top_public)
+
+
+@pytest.fixture
+def user_offerer_to_be_validated(offerer_tags):
+    top_tag, collec_tag, public_tag = offerer_tags
+
+    no_tag = offerers_factories.NotValidatedUserOffererFactory(user__email="a@example.com")
+    top = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="b@example.com", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+    collec = offerers_factories.NotValidatedUserOffererFactory(user__email="c@example.com")
+    public = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="d@example.com", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+    top_collec = offerers_factories.NotValidatedUserOffererFactory(user__email="e@example.com")
+    top_public = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="f@example.com", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+
+    for user_offerer in (top, top_collec, top_public):
+        offerers_factories.OffererTagMappingFactory(tagId=top_tag.id, offererId=user_offerer.offererId)
+    for user_offerer in (collec, top_collec):
+        offerers_factories.OffererTagMappingFactory(tagId=collec_tag.id, offererId=user_offerer.offererId)
+    for user_offerer in (public, top_public):
+        offerers_factories.OffererTagMappingFactory(tagId=public_tag.id, offererId=user_offerer.offererId)
+
+    # Other status
+    offerers_factories.UserOffererFactory(user__email="g@example.com")
 
     return (no_tag, top, collec, public, top_collec, top_public)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18224

## But de la pull request

Ajout d'un endpoint pour la liste des rattachements d'utilisateurs à des structures, à valider.
Voir détails dans le ticket.

## Informations supplémentaires

Je voulais en même temps pouvoir filtrer par tag sur la structure, comme pour la validation des structures, mais : 
- ce n'est pas explicitement demandé,
- et surtout je me fais des nœuds au cerveau avec des erreurs dans la requête SQL,
donc parons au plus urgent pour le métier, on pourra ajouter cela après en cas de besoin.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
