### PR TITLE
(PC-18224)[API] fix: missing action when creating a pro account with an existing offerer

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -635,6 +635,16 @@ def create_pro_user_and_offerer(pro_user: ProUserCreationBodyModel) -> models.Us
             ]
         else:
             user_offerer = _generate_user_offerer_when_existing_offerer(new_pro_user, existing_offerer)
+            objects_to_save += [
+                history_api.log_action(
+                    history_models.ActionType.USER_OFFERER_NEW,
+                    new_pro_user,
+                    user=new_pro_user,
+                    offerer=existing_offerer,
+                    save=False,
+                    comment="Demande de rattachement à la création de compte pro",
+                ),
+            ]
         offerer = existing_offerer
     else:
         offerer = _generate_offerer(pro_user.dict(by_alias=True))

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -62,6 +62,7 @@ class Returns204Test:
         user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).first()
         assert user_offerer is not None
         assert user_offerer.validationToken is None
+        assert user_offerer.validationStatus == offerers_models.ValidationStatus.VALIDATED
 
         actions_list = history_models.ActionHistory.query.all()
         assert len(actions_list) == 1
@@ -116,6 +117,14 @@ class Returns204Test:
         user_offerer = UserOfferer.query.filter_by(user=pro, offerer=offerer).first()
         assert user_offerer is not None
         assert user_offerer.validationToken is not None
+        assert user_offerer.validationStatus == offerers_models.ValidationStatus.NEW
+
+        actions_list = history_models.ActionHistory.query.all()
+        assert len(actions_list) == 1
+        assert actions_list[0].actionType == history_models.ActionType.USER_OFFERER_NEW
+        assert actions_list[0].authorUser == pro
+        assert actions_list[0].user == pro
+        assert actions_list[0].offerer == offerer
 
     def when_successful_and_existing_offerer_but_no_user_offerer_does_not_signin(self, client):
         # Given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18224

## But de la pull request

En créant un compte pro avec une structure déjà existante (SIREN déjà validé), le nouveau rattachement n'apparaissait pas dans l'historique de la structure/du rattachement. Il manquait la création de l'action.

Sans cette action, on ne peut voir la date de la demande dans la liste des rattachements à valider.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
