### PR TITLE
(PC-18221)[PRO] feat: add collective template offer creation page

### DIFF
--- a/pro/src/core/OfferEducational/adapters/postCollectiveOfferTemplateAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/postCollectiveOfferTemplateAdapter.ts
@@ -1,0 +1,56 @@
+import { api } from 'apiClient/api'
+import { isErrorAPIError } from 'apiClient/helpers'
+import { IOfferEducationalFormValues } from 'core/OfferEducational'
+
+import { createCollectiveOfferPayload } from '../utils/createOfferPayload'
+
+type Params = {
+  offer: IOfferEducationalFormValues
+}
+
+type IPayloadSuccess = { offerId: string }
+type IPayloadFailure = { offerId: null }
+
+type PostOfferAdapter = Adapter<Params, IPayloadSuccess, IPayloadFailure>
+
+const BAD_REQUEST_FAILING_RESPONSE: AdapterFailure<IPayloadFailure> = {
+  isOk: false,
+  message: 'Une ou plusieurs erreurs sont présentes dans le formulaire',
+  payload: {
+    offerId: null,
+  },
+}
+
+const UNKNOWN_FAILING_RESPONSE: AdapterFailure<IPayloadFailure> = {
+  isOk: false,
+  message: 'Une erreur est survenue lors de la création de votre offre',
+  payload: {
+    offerId: null,
+  },
+}
+
+const postCollectiveOfferTemplateAdapter: PostOfferAdapter = async ({
+  offer,
+}) => {
+  try {
+    const payload = createCollectiveOfferPayload(offer)
+
+    const response = await api.createCollectiveOfferTemplate(payload)
+
+    return {
+      isOk: true,
+      message: null,
+      payload: {
+        offerId: response.id,
+      },
+    }
+  } catch (error) {
+    if (isErrorAPIError(error) && error.status === 400) {
+      return BAD_REQUEST_FAILING_RESPONSE
+    }
+
+    return UNKNOWN_FAILING_RESPONSE
+  }
+}
+
+export default postCollectiveOfferTemplateAdapter

--- a/pro/src/pages/CollectiveOfferTemplateCreation/CollectiveOfferTemplateCreation.tsx
+++ b/pro/src/pages/CollectiveOfferTemplateCreation/CollectiveOfferTemplateCreation.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
+
+// @debt deprecated "Mathilde: should not import utility from legacy page"
+import { queryParamsFromOfferer } from 'components/pages/Offers/utils/queryParamsFromOfferer'
+import {
+  DEFAULT_EAC_FORM_VALUES,
+  IOfferEducationalFormValues,
+  Mode,
+  setInitialFormValues,
+} from 'core/OfferEducational'
+import canOffererCreateCollectiveOfferAdapter from 'core/OfferEducational/adapters/canOffererCreateCollectiveOfferAdapter'
+import getCollectiveOfferFormDataApdater from 'core/OfferEducational/adapters/getCollectiveOfferFormDataAdapter'
+import postCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/postCollectiveOfferTemplateAdapter'
+import useNotification from 'hooks/useNotification'
+import RouteLeavingGuardOfferCreation from 'new_components/RouteLeavingGuardOfferCreation'
+import OfferEducationalScreen from 'screens/OfferEducational'
+import { IOfferEducationalProps } from 'screens/OfferEducational/OfferEducational'
+import Spinner from 'ui-kit/Spinner/Spinner'
+
+type AsyncScreenProps = Pick<
+  IOfferEducationalProps,
+  'categories' | 'userOfferers' | 'domainsOptions'
+>
+
+const CollectiveOfferTemplateCreation = () => {
+  const history = useHistory()
+  const location = useLocation()
+
+  const [isReady, setIsReady] = useState<boolean>(false)
+  const [screenProps, setScreenProps] = useState<AsyncScreenProps | null>(null)
+  const [initialValues, setInitialValues] =
+    useState<IOfferEducationalFormValues>(DEFAULT_EAC_FORM_VALUES)
+
+  const { structure: offererId, lieu: venueId } =
+    queryParamsFromOfferer(location)
+
+  const notify = useNotification()
+
+  const createTemplateOffer = async (offer: IOfferEducationalFormValues) => {
+    const { payload, isOk, message } = await postCollectiveOfferTemplateAdapter(
+      {
+        offer,
+      }
+    )
+
+    if (!isOk) {
+      return notify.error(message)
+    }
+
+    history.push(`/offre/${payload.offerId}/collectif/stocks`)
+  }
+
+  useEffect(() => {
+    if (!isReady) {
+      const loadData = async () => {
+        const result = await getCollectiveOfferFormDataApdater({ offererId })
+
+        if (!result.isOk) {
+          notify.error(result.message)
+        }
+
+        const { categories, offerers, domains } = result.payload
+
+        setScreenProps({
+          categories: categories,
+          userOfferers: offerers,
+          domainsOptions: domains,
+        })
+
+        setInitialValues(values =>
+          setInitialFormValues(values, offerers, offererId, venueId)
+        )
+
+        setIsReady(true)
+      }
+
+      loadData()
+    }
+  }, [isReady, venueId, offererId])
+
+  return isReady && screenProps ? (
+    <>
+      <OfferEducationalScreen
+        {...screenProps}
+        getIsOffererEligible={canOffererCreateCollectiveOfferAdapter}
+        initialValues={initialValues}
+        mode={Mode.CREATION}
+        onSubmit={createTemplateOffer}
+      />
+      <RouteLeavingGuardOfferCreation />
+    </>
+  ) : (
+    <Spinner />
+  )
+}
+
+export default CollectiveOfferTemplateCreation

--- a/pro/src/pages/CollectiveOfferTemplateCreation/index.ts
+++ b/pro/src/pages/CollectiveOfferTemplateCreation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CollectiveOfferTemplateCreation'

--- a/pro/src/routes/CollectiveOfferRoutes/CollectiveOfferCreationRoutes/CollectiveOfferCreationRoutes.tsx
+++ b/pro/src/routes/CollectiveOfferRoutes/CollectiveOfferCreationRoutes/CollectiveOfferCreationRoutes.tsx
@@ -5,6 +5,7 @@ import { CollectiveOffer, CollectiveOfferTemplate } from 'core/OfferEducational'
 import getCollectiveOfferAdapter from 'core/OfferEducational/adapters/getCollectiveOfferAdapter'
 import getCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
 import CollectiveOfferLayout from 'new_components/CollectiveOfferLayout'
+import CollectiveOfferTemplateCreation from 'pages/CollectiveOfferTemplateCreation'
 import CollectiveOfferConfirmation from 'routes/CollectiveOfferConfirmation'
 import CollectiveOfferStockCreation from 'routes/CollectiveOfferStockCreation'
 import CollectiveOfferSummaryCreation from 'routes/CollectiveOfferSummaryCreation'
@@ -60,7 +61,11 @@ const CollectiveOfferCreationRoutes = ({
         {offer ? <CollectiveOfferConfirmation offer={offer} /> : <Spinner />}
       </Route>
       <Route
-        path={['/offre/:offerId/collectif', '/offre/creation/collectif']}
+        path={[
+          '/offre/:offerId/collectif',
+          '/offre/creation/collectif',
+          '/offre/creation/collectif/vitrine',
+        ]}
         exact={false}
       >
         <CollectiveOfferLayout
@@ -72,6 +77,9 @@ const CollectiveOfferCreationRoutes = ({
           }}
         >
           <Switch>
+            <Route path="/offre/creation/collectif/vitrine">
+              <CollectiveOfferTemplateCreation />
+            </Route>
             <Route path="/offre/creation/collectif">
               <OfferEducationalCreation />
             </Route>

--- a/pro/src/routes/CollectiveOfferRoutes/CollectiveOfferRoutes.tsx
+++ b/pro/src/routes/CollectiveOfferRoutes/CollectiveOfferRoutes.tsx
@@ -54,6 +54,7 @@ const CollectiveOfferRoutes = (): JSX.Element => {
       <Route
         path={[
           '/offre/creation/collectif',
+          '/offre/creation/collectif/vitrine',
           '/offre/:offerId/collectif/stocks',
           '/offre/:offerId/collectif/visibilite',
           '/offre/:offerId/collectif/confirmation',

--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -35,7 +35,7 @@ const OfferType = (): JSX.Element => {
     // Offer type is EDUCATIONAL
     if (offerSubtype === OFFER_SUBTYPES.TEMPLATE && isSubtypeChosenAtCreation) {
       return history.push({
-        pathname: '/offre/collective/vitrine/creation',
+        pathname: '/offre/creation/collectif/vitrine',
         search: location.search,
       })
     }

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -147,7 +147,7 @@ describe('screens:OfferIndividual::OfferType', () => {
     )
 
     expect(mockHistoryPush).toHaveBeenCalledWith({
-      pathname: '/offre/collective/vitrine/creation',
+      pathname: '/offre/creation/collectif/vitrine',
       search: '',
     })
   })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18221

## But de la pull request

Afficher la page de création d'une offre vitrine lorsque cette option est sélectionnée au début du parcours de création d'offre collective. 
Au clic sur étape suivante, créer une offre vitrine et rediriger vers la page des stocks.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
