### PR TITLE
(BSR)[PRO] fix: update pipeline to fix GitHub Actions not checking out master

### DIFF
--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -76,6 +76,10 @@ jobs:
           cache: yarn
           cache-dependency-path: pro/yarn.lock
           node-version: ${{ needs.read-node-version.outputs.node_version }}
+      - name: "Fetch master branch so that Jest can assert changes since master"
+        run: |
+          git fetch --no-tags origin +refs/heads/master:refs/remotes/origin/master
+          git update-ref refs/heads/master refs/remotes/origin/master
       - if: ${{ env.use_cache == false }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## But de la pull request

Résoud ce problème : https://dev.to/bnb/jest-and-the-changedsince-flag-in-github-actions-ci-468i

L'option changedSince de Jest cause une erreur `fatal: bad revision 'master...HEAD'` car GitHub Actions ne fetch pas master par défaut => les tests ne se lancent pas.

Exemple de pipeline où les tests se lancent correctement avec cette nouvelle config : https://github.com/pass-culture/pass-culture-main/actions/runs/3392641957/jobs/5639077606 
(les tests de ce run sont rouges mais c'est parce que j'ai volontairement changé un fichier pour déclencher le workflow, l'important est que les tests se lancent jusqu'au bout)