### PR TITLE
(PC-18396)[API] feat: Add OFFER_TAGS in booking event reminder email

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -793,6 +793,7 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Individual
             Offer.venue,
         )
         .outerjoin(Booking.activationCode)
+        .outerjoin(Offer.criteria)
         .filter(Stock.beginningDatetime >= tomorrow_min, Stock.beginningDatetime <= tomorrow_max)
         .filter(Offer.isEvent)
         .filter(not_(Offer.isDigital))
@@ -803,7 +804,10 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[Individual
             contains_eager(IndividualBooking.booking)
             .contains_eager(Booking.stock)
             .contains_eager(Stock.offer)
-            .contains_eager(Offer.venue)
+            .options(
+                contains_eager(Offer.venue),
+                contains_eager(Offer.criteria),
+            )
         )
         .all()
     )

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
@@ -57,6 +57,7 @@ def get_booking_event_reminder_to_beneficiary_email_data(
             "EVENT_HOUR": formatted_event_beginning_time,
             "IS_DUO_EVENT": individual_booking.booking.quantity == 2,
             "OFFER_NAME": individual_booking.booking.stock.offer.name,
+            "OFFER_TAGS": ",".join([criterion.name for criterion in individual_booking.booking.stock.offer.criteria]),
             "OFFER_TOKEN": booking_token,
             "OFFER_WITHDRAWAL_DELAY": offer_withdrawal_delay_in_days,
             "OFFER_WITHDRAWAL_DETAILS": individual_booking.booking.stock.offer.withdrawalDetails or None,

--- a/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 import pytest
 
 from pcapi.core.bookings.factories import IndividualBookingFactory
+import pcapi.core.criteria.factories as criteria_factories
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.bookings.booking_event_reminder_to_beneficiary import (
     get_booking_event_reminder_to_beneficiary_email_data,
@@ -62,6 +63,7 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
             "EVENT_HOUR": "14h48",
             "IS_DUO_EVENT": False,
             "OFFER_NAME": "Product",
+            "OFFER_TAGS": "",
             "OFFER_TOKEN": "N2XPV5",
             "OFFER_WITHDRAWAL_DELAY": None,
             "OFFER_WITHDRAWAL_DETAILS": None,
@@ -94,6 +96,17 @@ class GetBookingEventReminderToBeneficiaryEmailDataTest:
         email_data = get_booking_event_reminder_to_beneficiary_email_data(booking.individualBooking)
 
         assert email_data.params["OFFER_WITHDRAWAL_DETAILS"] == withdrawal_details
+
+    def test_should_return_offer_tags(self):
+        booking = IndividualBookingFactory(
+            stock=offers_factories.EventStockFactory(
+                offer__criteria=[criteria_factories.CriterionFactory(name="Tagged_offer")]
+            )
+        )
+
+        email_data = get_booking_event_reminder_to_beneficiary_email_data(booking.individualBooking)
+
+        assert email_data.params["OFFER_TAGS"] == "Tagged_offer"
 
     def should_use_venue_public_name_when_available(self):
         booking = IndividualBookingFactory(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18396

## But de la pull request

Le marketing a besoin du champ OFFER_TAGS dans le template 665 (id en prod).
La même chose que pour le template 725 où c'est déjà implémenté.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
