### PR TITLE
(PC-17273)[PRO] feat: Screen reader need to spell-out the dms identifier.

### DIFF
--- a/pro/src/screens/VenueForm/VenueFormScreen.module.scss
+++ b/pro/src/screens/VenueForm/VenueFormScreen.module.scss
@@ -9,4 +9,16 @@
 }
 .identifier {
   margin-top: rem.torem(8px);
+
+  &-hidden {
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    white-space: nowrap;
+    border: 0;
+  }
 }

--- a/pro/src/screens/VenueForm/VenueFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueFormScreen.tsx
@@ -185,13 +185,22 @@ const VenueFormScreen = ({
             ? `${offerer.name} (Offre numérique)`
             : publicName || initialName}
         </Title>
-        {!isCreatingVenue && isNewBankInformationCreation && (
-          <p className={style['identifier']}>
-            {venue && venue.dmsToken
-              ? `N° d'identifiant du lieu : ${venue.dmsToken}`
-              : ''}
-          </p>
-        )}
+        {!isCreatingVenue &&
+          isNewBankInformationCreation &&
+          venue &&
+          venue.dmsToken && (
+            <>
+              {/* For the screen reader to spell-out the id, we add a
+                visually hidden span with a space between each character.
+                The other span will be hidden from the screen reader. */}
+              <span className={style['identifier-hidden']}>
+                N° d'identifiant du lieu : {venue.dmsToken.split('').join(' ')}
+              </span>
+              <span aria-hidden={true}>
+                N° d'identifiant du lieu : {venue.dmsToken}
+              </span>
+            </>
+          )}
       </div>
       <FormikProvider value={formik}>
         <form onSubmit={formik.handleSubmit}>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17273

## But de la pull request

- Faire en sorte que le lecteur d'écran épelle l'identifiant dms. 

## Implémentation

- Le span ne permet pas d'ajouter un `aria-label`.
- J'ai tenté le code plus bas (qui me semble plus propre), mais VoiceOver considère le label comme étant "vide". Après avoir bien énoncé le label, il dit "Groupe vide" (comme quoi le label est vide). Vu avec Marion, ça reste dérangeant.

```
       {!isCreatingVenue && isNewBankInformationCreation && venue && venue.dmsToken &&(
          <>
            <label
              aria-label={`N° d'identifiant du lieu : ${venue.dmsToken.split('').join(' ')}`}
            >
                <span aria-hidden={true}>N° d'identifiant du lieu : ${venue.dmsToken}</span>
            </label>
          </>
        )}
```
