### PR TITLE
(PC-18134)[BACKOFFICE] feat: search by name or siren in offerer validation screen

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -347,7 +347,11 @@ def list_offerers_to_be_validated(
     filters = []
     if query.filter:
         filters = json.loads(urllib.parse.unquote_plus(query.filter))
-    offerers = offerers_api.list_offerers_to_be_validated(query.q, filters)
+
+    try:
+        offerers = offerers_api.list_offerers_to_be_validated(query.q, filters)
+    except offerers_exceptions.InvalidSiren as err:
+        raise api_errors.ApiErrors(errors={"q": str(err)})
 
     sorts = urllib.parse.unquote_plus(query.sort or "[]")
     try:

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1691,6 +1691,23 @@ class ListOfferersToBeValidatedTest:
         assert data[0]["name"] == "D"
 
     @override_features(ENABLE_BACKOFFICE_API=True)
+    @pytest.mark.parametrize("siren", ["12345678", "1234567890"])
+    @override_features(ENABLE_BACKOFFICE_API=True)
+    def test_list_search_by_invalid_siren(self, client, siren):
+        # given
+        admin = users_factories.UserFactory()
+        auth_token = generate_token(admin, [Permissions.VALIDATE_OFFERER])
+
+        # when
+        response = client.with_explicit_token(auth_token).get(
+            url_for("backoffice_blueprint.list_offerers_to_be_validated", q=siren)
+        )
+
+        # then
+        assert response.status_code == 400
+        assert response.json["q"] == "Le SIREN doit faire 9 caractères"
+
+    @override_features(ENABLE_BACKOFFICE_API=True)
     @pytest.mark.parametrize(
         "search_filter, expected_offerer_names",
         (

--- a/backoffice/src/layout/CustomMenu.tsx
+++ b/backoffice/src/layout/CustomMenu.tsx
@@ -52,7 +52,7 @@ export const Menu = ({ dense = false }: MenuProps) => {
       {/*<DashboardMenuItem/>*/}
       <SubMenu
         handleToggle={() => handleToggle('menuJeunes')}
-        isOpen={true} // {state.menuJeunes}
+        isOpen={state.menuJeunes || true}
         name="menu.usersTitle"
         dense={dense}
         icon={<AccountBoxIcon />}
@@ -100,7 +100,7 @@ export const Menu = ({ dense = false }: MenuProps) => {
       ) && (
         <SubMenu
           handleToggle={() => handleToggle('menuPros')}
-          isOpen={true} // {state.menuPros}
+          isOpen={state.menuPros || true}
           name="menu.prosTitle"
           dense={dense}
           icon={<AccountBoxIcon />}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18134

## But de la pull request

En tant que CT ou responsable homologation
J'aimerais effectuer une recherche par SIREN ou nom sur l'écran de validation de structure
Afin de filtrer les résultats et de valider plus rapidement les structures dont j’ai la charge

- Si on saisit un nom (par exemple “SIRENE”), alors toutes les structures qui inclue ce nom dans leur nom complet apparaissent dans les résultats
- Si on saisit un SIREN incomplet (moins de 8 caractères), on affiche un message d’erreur de type snackbar “Le SIREN doit faire 9 caractères)
- Au clic sur le bouton “Chercher”, la liste de résultats s’actualise en conséquence

Inclut une petite correction backend pour le SIREN invalide.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
