### PR TITLE
(BSR)[PRO] offer v3 back to step 1

### DIFF
--- a/pro/src/screens/OfferIndividual/Informations/Informations.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/Informations.tsx
@@ -186,6 +186,13 @@ const Informations = ({
         setOffer && setOffer(response.payload)
       }
       notify.success('Vos modifications ont bien été prises en compte')
+      history.replace(
+        getOfferIndividualUrl({
+          offerId: payload.id,
+          step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+          mode,
+        })
+      )
       history.push(
         getOfferIndividualUrl({
           offerId: payload.id,


### PR DESCRIPTION
## But de la pull request

Lorsqu'on faisait back navigateur de stock vers informations on retournait sur la page de création.
Ici, via ce replace d'url, on retrouve bien l'édition de l'offre nouvellement créée
