### PR TITLE
(jeremieb)[BACKOFFICE] fix: upsert roles on login

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -99,12 +99,20 @@ class Roles(enum.Enum):
     ADMIN = "admin"
     SUPPORT_N1 = "support-N1"
     SUPPORT_N2 = "support-N2"
-    SUPPORT_PRO = "support-PRO"
+    SUPPORT_PRO = "support-pro"
     FRAUDE_CONFORMITE = "fraude-conformite"
     DAF = "daf"
     BIZDEV = "bizdev"
     PROGRAMMATION = "programmation"
     PRODUCT_MANAGEMENT = "product-management"
+
+    @classmethod
+    def from_role(cls, role: "Role") -> "Roles":
+        return cls.from_role_name(role.name)
+
+    @classmethod
+    def from_role_name(cls, role_name: str) -> "Roles":
+        return cls[role_name.upper().replace("-", "_")]
 
 
 role_backoffice_profile_table = sa.Table(

--- a/api/src/pcapi/core/users/backoffice/api.py
+++ b/api/src/pcapi/core/users/backoffice/api.py
@@ -16,8 +16,11 @@ def upsert_roles(
     if not user.backoffice_profile.roles:
         user.backoffice_profile.roles = []
 
-    concrete_roles = perm_api.get_concrete_roles(roles)
-    user.backoffice_profile.roles.extend(concrete_roles)
+    current_roles = {perm_models.Roles.from_role(role) for role in user.backoffice_profile.roles}
+    new_roles = current_roles | set(roles)
+    concrete_roles = perm_api.get_concrete_roles(new_roles)
+
+    user.backoffice_profile.roles = concrete_roles
 
     return user.backoffice_profile
 

--- a/api/src/pcapi/routes/backoffice_v3/auth.py
+++ b/api/src/pcapi/routes/backoffice_v3/auth.py
@@ -100,6 +100,10 @@ def user_not_found():  # type: ignore
 def fetch_user_permissions_from_google_workspace(user: users_models.User) -> list[perm_models.Permission]:
     groups = auth_api.get_groups_from_google_workspace(user.email)
     backoffice_roles = auth_api.extract_roles_from_google_workspace_groups(groups)
+
+    roles = [perm_models.Roles.from_role_name(role_name) for role_name in backoffice_roles]
+    backoffice_api.upsert_roles(user, roles)
+
     return auth_api.get_permissions_from_roles(backoffice_roles)
 
 

--- a/api/tests/core/users/backoffice/test_api.py
+++ b/api/tests/core/users/backoffice/test_api.py
@@ -1,8 +1,12 @@
 import pytest
 
+import pcapi.core.permissions.models as perm_models
 from pcapi.core.testing import assert_num_queries
 import pcapi.core.users.backoffice.api as backoffice_api
+import pcapi.core.users.factories as users_factories
+import pcapi.core.users.models as users_models
 
+from tests.routes.backoffice_v3.conftest import ROLE_PERMISSIONS
 from tests.routes.backoffice_v3.conftest import legit_user_fixture  # pylint: disable=unused-import
 from tests.routes.backoffice_v3.conftest import roles_with_permissions_fixture  # pylint: disable=unused-import
 
@@ -16,3 +20,47 @@ def test_fetch_user_with_profile(legit_user) -> None:
     with assert_num_queries(1):
         user_with_profile = backoffice_api.fetch_user_with_profile(user_id)
         assert user_with_profile.backoffice_profile.permissions
+
+
+class UpsertRolesTest:
+    def test_add_one_role(self, roles_with_permissions) -> None:
+        user = users_factories.BeneficiaryGrant18Factory()
+        roles = [perm_models.Roles.SUPPORT_N1]
+
+        backoffice_api.upsert_roles(user, roles)
+
+        user = users_models.User.query.get(user.id)
+        assert {role.name for role in user.backoffice_profile.roles} == {"support-N1"}
+
+        user_permissions = user.backoffice_profile.permissions
+        expected_permissions = ROLE_PERMISSIONS["support-N1"]
+        assert set(user_permissions) == set(expected_permissions)
+
+    def test_two_roles(self, roles_with_permissions) -> None:
+        user = users_factories.BeneficiaryGrant18Factory()
+        roles = [perm_models.Roles.SUPPORT_N1, perm_models.Roles.SUPPORT_PRO]
+
+        backoffice_api.upsert_roles(user, roles)
+
+        user = users_models.User.query.get(user.id)
+        assert {role.name for role in user.backoffice_profile.roles} == {"support-N1", "support-pro"}
+
+        user_permissions = user.backoffice_profile.permissions
+        expected_permissions = ROLE_PERMISSIONS["support-N1"] + ROLE_PERMISSIONS["support-pro"]
+        assert set(user_permissions) == set(expected_permissions)
+
+    def test_add_role_to_existing_ones(self, roles_with_permissions) -> None:
+        user = users_factories.BeneficiaryGrant18Factory()
+
+        backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_N1])
+        backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_PRO, perm_models.Roles.ADMIN])
+
+        user = users_models.User.query.get(user.id)
+        assert {role.name for role in user.backoffice_profile.roles} == {"support-N1", "support-pro", "admin"}
+
+        user_permissions = user.backoffice_profile.permissions
+        expected_permissions = (
+            ROLE_PERMISSIONS["support-N1"] + ROLE_PERMISSIONS["support-pro"] + ROLE_PERMISSIONS["admin"]
+        )
+
+        assert set(user_permissions) == set(expected_permissions)


### PR DESCRIPTION
## But de la pull request

Fix : appeler `upsert_roles()` lors du login afin de bien mettre à jour les rôles de l'utilisateur (que l'on vient de récupérer).

## Au passage

Ajout de petites méthodes à `Roles` qui permettent de retrouver un `Roles` à partir soit d'un `Role`, soit d'un nom de rôle. Ce n'est pas idéal, ça reste du bricolage. Mais on pourra améliorer ça plus tard.