### PR TITLE
(PC-18316)[API] feat: backoffice: filter offerers to validate by request dates

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1,3 +1,4 @@
+from datetime import date
 from datetime import datetime
 import logging
 import secrets
@@ -1382,6 +1383,22 @@ def list_offerers_to_be_validated(search_query: str | None, filter_: list[dict[s
         query = query.join(tagged_offerers, tagged_offerers.c.id == offerers_models.Offerer.id).filter(
             sa.and_(*(tagged_offerers.c.tags.any(tag) for tag in tags))
         )
+
+    from_date = filter_dict.get("fromDate")
+    if from_date:
+        try:
+            min_datetime = datetime.combine(date.fromisoformat(from_date), datetime.min.time())
+        except ValueError:
+            raise ApiErrors({"filter": "Le format de date est invalide"})
+        query = query.filter(offerers_models.Offerer.requestDate >= min_datetime)  # type: ignore [operator]
+
+    to_date = filter_dict.get("toDate")
+    if to_date:
+        try:
+            max_datetime = datetime.combine(date.fromisoformat(to_date), datetime.max.time())
+        except ValueError:
+            raise ApiErrors({"filter": "Le format de date est invalide"})
+        query = query.filter(offerers_models.Offerer.requestDate <= max_datetime)  # type: ignore [operator]
 
     return query
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18316

## But de la pull request

Dans la liste des structures à valider, permettre le filtrage par date de la demande (dans un intervalle de dates).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
