### PR TITLE
(PC-18431)[API] feat: Add Batch attribute 'deposit_activation_date'

### DIFF
--- a/api/src/pcapi/core/users/external/batch.py
+++ b/api/src/pcapi/core/users/external/batch.py
@@ -26,6 +26,7 @@ def format_user_attributes(user_attributes: UserAttributes) -> dict:
     attributes = {
         "date(u.date_created)": _format_date(user_attributes.date_created),
         "date(u.date_of_birth)": _format_date(user_attributes.date_of_birth),
+        "date(u.deposit_activation_date)": _format_date(user_attributes.deposit_activation_date),
         "date(u.deposit_expiration_date)": _format_date(user_attributes.deposit_expiration_date),
         "date(u.last_booking_date)": _format_date(user_attributes.last_booking_date),
         "u.credit": int(user_attributes.domains_credit.all.remaining * 100) if user_attributes.domains_credit else None,

--- a/api/tests/core/users/external/batch_test.py
+++ b/api/tests/core/users/external/batch_test.py
@@ -19,6 +19,7 @@ class FormatUserAttributesTest:
         assert formatted_attributes == {
             "date(u.date_of_birth)": "2003-05-06T00:00:00",
             "date(u.date_created)": "2021-02-06T00:00:00",
+            "date(u.deposit_activation_date)": None,
             "date(u.deposit_expiration_date)": None,
             "date(u.last_booking_date)": "2021-05-06T00:00:00",
             "date(u.product_brut_x_use)": "2021-05-06T00:00:00",

--- a/api/tests/scripts/external_users/batch_update_users_attributes_test.py
+++ b/api/tests/scripts/external_users/batch_update_users_attributes_test.py
@@ -80,6 +80,7 @@ def test_format_batch_user():
     assert res[0].attributes == {
         "date(u.date_created)": user.dateCreated.strftime(BATCH_DATETIME_FORMAT),
         "date(u.date_of_birth)": user.dateOfBirth.strftime(BATCH_DATETIME_FORMAT),
+        "date(u.deposit_activation_date)": user.deposit_activation_date.strftime(BATCH_DATETIME_FORMAT),
         "date(u.deposit_expiration_date)": user.deposit_expiration_date.strftime(BATCH_DATETIME_FORMAT),
         "date(u.last_booking_date)": booking.dateCreated.strftime(BATCH_DATETIME_FORMAT),
         "u.city": "Paris",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18431

## But de la pull request

Ajout d'un attribut Batch : `deposit_activation_date`.
Identique à `DEPOSIT_ACTIVATION_DATE` déjà envoyé vers Sendinblue pour les jeunes.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
