### PR TITLE
(PC-18348)[API] feat: order offerer validation by requestDate

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -348,6 +348,7 @@ def list_offerers_to_be_validated(
         )
     except db_utils.BadSortError as err:
         raise api_errors.ApiErrors(errors={"sort": f"unable to process provided sorting options: {err}"})
+
     paginated_offerers = sorted_offerers.paginate(
         page=query.page,
         per_page=query.perPage,

--- a/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
+++ b/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
@@ -143,7 +143,7 @@ export const OfferersToValidate = () => {
       const response = await apiProvider().listOfferersToBeValidated({
         page: page + 1,
         perPage: rowsPerPage,
-        sort: JSON.stringify([{ field: 'dateCreated', order: 'desc' }]),
+        sort: JSON.stringify([{ field: 'requestDate', order: 'desc' }]),
         filter: JSON.stringify(filters),
         q: searchParameter || undefined,
       })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18348

## But de la pull request

Ajout des tests du tri par requestDate (ajout des requestDate dans ce ticket mais déjà fait en parallèle dans https://github.com/pass-culture/pass-culture-main/pull/4208)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
