### PR TITLE
(BSR)[API] Contournements temporaires pour compatibilité avec mypy 0.990

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -57,6 +57,12 @@ exclude = """
 # FIXME (dbaty, 2022-11-08): this is temporary until we fix typing
 # annotations that break with the new default value (true).
 no_implicit_optional = false
+# FIXME (dbaty, 2022-11-08): this is temporary until we find a
+# solution to type hybrid_property-decorated methods. Otherwise, mypy
+# reports a "truthy-function" error on code that uses these methods.
+disable_error_code = [
+    "truthy-function",
+]
 
 
 [tool.pylint.MASTER]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -54,7 +54,9 @@ exclude = """
     | src/pcapi/alembic/.*
   )
 """
-
+# FIXME (dbaty, 2022-11-08): this is temporary until we fix typing
+# annotations that break with the new default value (true).
+no_implicit_optional = false
 
 
 [tool.pylint.MASTER]


### PR DESCRIPTION
mypy 0.990 a été publié lundi et rapporte 2 nouvelles erreurs que nous
devons désactiver temporairement, le temps de mettre à jour notre code.

2 commits à relire séparément, chaque message de commit donne des détails.

Pour le second commit, il faut trouver une façon de typer correctement
les méthodes décorées avec `hybrid_property`. J'ai vu une façon de
faire [ici](https://github.com/python/mypy/issues/4430#issuecomment-781272415), c'est en cours dans une autre pull request à venir.