### PR TITLE
(PC-18423)[API] feat: add logg to track possible extra data pass to p…

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -351,6 +351,9 @@ def patch_collective_offers_template_active_status(
 def patch_collective_offers_educational_institution(
     offer_id: str, body: collective_offers_serialize.PatchCollectiveOfferEducationalInstitution
 ) -> collective_offers_serialize.GetCollectiveOfferResponseModel:
+    # it seems that sometimes we send extra data that we shouldnt send
+    if len(body.__dict__) > 1:
+        logger.error("Extra data unexcepted in request body", extra={"request body": body})
     dehumanized_id = dehumanize_or_raise(offer_id)
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_id(dehumanized_id)

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -533,4 +533,4 @@ class PatchCollectiveOfferEducationalInstitution(BaseModel):
 
     class Config:
         alias_generator = to_camel
-        extra = "forbid"
+        extra = "allow"


### PR DESCRIPTION
…atch_collective_offers_educational_institution body

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18423

## But de la pull request

Tracker les possibles données ajoutées en trop à la requête lorsqu'on essaie de modifier les données de visibilité d'une offre collective 
