### PR TITLE
(PC-18365)[API] feat: young status add eligible sub status

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -732,3 +732,7 @@ def get_subscription_message(user: users_models.User) -> models.SubscriptionMess
         return subscription_messages.get_generic_ko_message(user.id)
 
     return None
+
+
+def has_subscription_issues(user: users_models.User) -> bool:
+    return get_subscription_message(user) is not None

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -122,6 +122,7 @@ class ChangeEmailTokenContent(BaseModel):
 
 class YoungStatusResponse(BaseModel):
     status_type: young_status.YoungStatusType
+    subscription_status: young_status.SubscriptionStatus | None
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -7,6 +7,7 @@ import pytest
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
 from pcapi.core.users import young_status
 
 
@@ -22,11 +23,15 @@ class UserStatusTest:
         @pytest.mark.parametrize("age", [15, 16, 17])
         def should_be_eligible_when_age_is_between_15_and_17(self, age):
             user = users_factories.UserFactory(dateOfBirth=_with_age(age))
-            assert young_status.young_status(user) == young_status.Eligible()
+            assert young_status.young_status(user) == young_status.Eligible(
+                subscription_status=young_status.SubscriptionStatus.HAS_TO_COMPLETE_SUBSCRIPTION
+            )
 
         def should_be_eligible_when_at_18yo(self):
             user = users_factories.UserFactory(dateOfBirth=_with_age(18))
-            assert young_status.young_status(user) == young_status.Eligible()
+            assert young_status.young_status(user) == young_status.Eligible(
+                subscription_status=young_status.SubscriptionStatus.HAS_TO_COMPLETE_SUBSCRIPTION
+            )
 
         def should_be_eligible_when_at_19yo_with_pending_dms_application_started_at_18yo(self):
             user = users_factories.UserFactory(dateOfBirth=_with_age(19))
@@ -37,7 +42,63 @@ class UserStatusTest:
                     registration_datetime=datetime.datetime.utcnow() - relativedelta(years=1)
                 ),
             )
-            assert young_status.young_status(user) == young_status.Eligible()
+            assert young_status.young_status(user) == young_status.Eligible(
+                subscription_status=young_status.SubscriptionStatus.HAS_SUBSCRIPTION_PENDING
+            )
+
+        @pytest.mark.parametrize(
+            "fraud_status", [fraud_models.FraudCheckStatus.STARTED, fraud_models.FraudCheckStatus.PENDING]
+        )
+        def should_be_eligible_when_subscription_is_pending(self, fraud_status):
+            user = users_factories.UserFactory(dateOfBirth=_with_age(18))
+            fraud_factories.BeneficiaryFraudCheckFactory(
+                user=user,
+                eligibilityType=users_models.EligibilityType.AGE18,
+                type=fraud_models.FraudCheckType.DMS,
+                status=fraud_status,
+            )
+
+            assert young_status.young_status(user) == young_status.Eligible(
+                subscription_status=young_status.SubscriptionStatus.HAS_SUBSCRIPTION_PENDING
+            )
+
+        @pytest.mark.parametrize(
+            "fraud_status", [fraud_models.FraudCheckStatus.STARTED, fraud_models.FraudCheckStatus.PENDING]
+        )
+        @pytest.mark.parametrize("age", [15, 16, 17])
+        def should_be_eligible_when_subscription_is_pending_for_an_underage_user(self, fraud_status, age):
+            user = users_factories.UserFactory(dateOfBirth=_with_age(age))
+            fraud_factories.BeneficiaryFraudCheckFactory(
+                user=user,
+                eligibilityType=users_models.EligibilityType.UNDERAGE,
+                type=fraud_models.FraudCheckType.DMS,
+                status=fraud_status,
+            )
+
+            assert young_status.young_status(user) == young_status.Eligible(
+                subscription_status=young_status.SubscriptionStatus.HAS_SUBSCRIPTION_PENDING
+            )
+
+        def test_be_eligible_when_has_subscription_issues(self):
+            user = users_factories.UserFactory(
+                dateOfBirth=_with_age(18),
+                phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            )
+            fraud_factories.BeneficiaryFraudCheckFactory(
+                type=fraud_models.FraudCheckType.PROFILE_COMPLETION,
+                user=user,
+                status=fraud_models.FraudCheckStatus.OK,
+            )
+            fraud_factories.BeneficiaryFraudCheckFactory(
+                type=fraud_models.FraudCheckType.UBBLE,
+                user=user,
+                status=fraud_models.FraudCheckStatus.SUSPICIOUS,
+                reasonCodes=[fraud_models.FraudReasonCode.ID_CHECK_EXPIRED],
+            )
+
+            assert young_status.young_status(user) == young_status.Eligible(
+                subscription_status=young_status.SubscriptionStatus.HAS_SUBSCRIPTION_ISSUES
+            )
 
     def should_be_non_eligible_when_too_young(self):
         user = users_factories.UserFactory(dateOfBirth=_with_age(15) + relativedelta(days=1))

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -19,9 +19,13 @@ def _with_age(age):
 
 class UserStatusTest:
     class EligibleTest:
-        @pytest.mark.parametrize("age", [15, 16, 17, 18])
-        def test_eligible_when_age_is_between_15_and_18(self, age):
+        @pytest.mark.parametrize("age", [15, 16, 17])
+        def test_eligible_when_age_is_between_15_and_17(self, age):
             user = users_factories.UserFactory(dateOfBirth=_with_age(age))
+            assert young_status.young_status(user) == young_status.Eligible()
+
+        def test_eligible_when_age_is_18(self):
+            user = users_factories.UserFactory(dateOfBirth=_with_age(18))
             assert young_status.young_status(user) == young_status.Eligible()
 
         def test_eligible_when_19yo_with_pending_dms_application(self):

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -20,52 +20,52 @@ def _with_age(age):
 class UserStatusTest:
     class EligibleTest:
         @pytest.mark.parametrize("age", [15, 16, 17])
-        def test_eligible_when_age_is_between_15_and_17(self, age):
+        def should_be_eligible_when_age_is_between_15_and_17(self, age):
             user = users_factories.UserFactory(dateOfBirth=_with_age(age))
             assert young_status.young_status(user) == young_status.Eligible()
 
-        def test_eligible_when_age_is_18(self):
+        def should_be_eligible_when_at_18yo(self):
             user = users_factories.UserFactory(dateOfBirth=_with_age(18))
             assert young_status.young_status(user) == young_status.Eligible()
 
-        def test_eligible_when_19yo_with_pending_dms_application(self):
+        def should_be_eligible_when_at_19yo_with_pending_dms_application_started_at_18yo(self):
             user = users_factories.UserFactory(dateOfBirth=_with_age(19))
             fraud_factories.BeneficiaryFraudCheckFactory(
                 user=user,
                 type=fraud_models.FraudCheckType.DMS,
                 resultContent=fraud_factories.DMSContentFactory(
-                    registration_datetime=(datetime.datetime.utcnow() - relativedelta(years=1))
+                    registration_datetime=datetime.datetime.utcnow() - relativedelta(years=1)
                 ),
             )
             assert young_status.young_status(user) == young_status.Eligible()
 
-    def test_non_eligible_when_too_young(self):
+    def should_be_non_eligible_when_too_young(self):
         user = users_factories.UserFactory(dateOfBirth=_with_age(15) + relativedelta(days=1))
         assert young_status.young_status(user) == young_status.NonEligible()
 
-    def test_non_eligible_when_too_old(self):
+    def should_be_non_eligible_when_too_old(self):
         user = users_factories.UserFactory(dateOfBirth=_with_age(19) - relativedelta(days=1))
         assert young_status.young_status(user) == young_status.NonEligible()
 
-    def test_beneficiary_when_18yo_and_have_deposit(self):
+    def should_be_beneficiary_when_18yo_and_have_deposit(self):
         user = users_factories.BeneficiaryGrant18Factory()
         assert young_status.young_status(user) == young_status.Beneficiary()
 
-    def test_beneficiary_when_underage_and_have_deposit(self):
+    def should_be_beneficiary_when_underage_and_have_deposit(self):
         user = users_factories.UnderageBeneficiaryFactory()
         assert young_status.young_status(user) == young_status.Beneficiary()
 
-    def test_ex_beneficiary_when_beneficiary_have_his_deposit_expired(self):
+    def should_be_ex_beneficiary_when_beneficiary_have_his_deposit_expired(self):
         user = users_factories.BeneficiaryGrant18Factory(
             deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(days=1)
         )
         assert young_status.young_status(user) == young_status.ExBeneficiary()
 
-    def test_suspended_when_account_is_not_active(self):
+    def should_be_suspended_when_account_is_not_active(self):
         user = users_factories.BeneficiaryGrant18Factory(isActive=False)
         assert young_status.young_status(user) == young_status.Suspended()
 
-    def test_can_not_mutate(self):
+    def test_is_not_mutable(self):
         status = young_status.Suspended()
         with pytest.raises(attrs.exceptions.FrozenInstanceError):
             status.status_type = young_status.YoungStatusType.BENEFICIARY

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -324,6 +324,10 @@ class AccountTest:
         n_queries += 1  # get feature enable_subscription_limitatin
         n_queries += 1  # has beneficiary_fraud_review (from get_subscription_message)
         n_queries += 1  # get feature enable_native_cultural_survey
+        n_queries += 1  # check pending status get_identity_check_subscription_status
+        n_queries += 1  # check issues has_subscription_issues
+        n_queries += 1  # check issues has_subscription_issues
+        n_queries += 1  # check has to complete step get_next_subscription_step
 
         with testing.assert_num_queries(n_queries):
             response = client.get("/native/v1/me")

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1553,7 +1553,13 @@ def test_public_api(client):
                     "title": "UserRole",
                 },
                 "YoungStatusResponse": {
-                    "properties": {"statusType": {"$ref": "#/components/schemas/YoungStatusType"}},
+                    "properties": {
+                        "statusType": {"$ref": "#/components/schemas/YoungStatusType"},
+                        "subscriptionStatus": {
+                            "anyOf": [{"$ref": "#/components/schemas/SubscriptionStatus"}],
+                            "nullable": True,
+                        },
+                    },
                     "required": ["statusType"],
                     "title": "YoungStatusResponse",
                     "type": "object",
@@ -1568,6 +1574,11 @@ def test_public_api(client):
                         "suspended",
                     ],
                     "title": "YoungStatusType",
+                },
+                "SubscriptionStatus": {
+                    "description": "An enumeration.",
+                    "enum": ["has_to_complete_subscription", "has_subscription_pending", "has_subscription_issues"],
+                    "title": "SubscriptionStatus",
                 },
                 "UserSuspensionDateResponse": {
                     "properties": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18365

## But de la pull request

Ajout des sous statuts des users éligibles

[Diagramme d'états](https://github.com/pass-culture/pass-culture-app-native/blob/master/doc/user_status.mmd)

## Implémentation

- On a ajouté `has_subscription_issues` qui pourrait etre améliorée / affinée plus tard

## Informations supplémentaires

- est-ce qu'il faudrait faire un truc en particulier pour le cas commenté `should never happen` ?

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
