### PR TITLE
(PC-18342)[PRO] feat: adjust stock screen depending on collective off…

### DIFF
--- a/pro/src/pages/CollectiveOfferTemplateCreation/CollectiveOfferTemplateCreation.tsx
+++ b/pro/src/pages/CollectiveOfferTemplateCreation/CollectiveOfferTemplateCreation.tsx
@@ -48,7 +48,7 @@ const CollectiveOfferTemplateCreation = () => {
       return notify.error(message)
     }
 
-    history.push(`/offre/${payload.offerId}/collectif/stocks`)
+    history.push(`offre/collective/vitrine/${payload.offerId}/recapitulatif`)
   }
 
   useEffect(() => {

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -97,8 +97,10 @@ const OfferEducationalStock = <
     resetForm({ values: initialValues })
   }, [initialValues, resetForm])
 
-  const shouldDisplayShowcaseScreen =
-    !isCreatingFromTemplate && mode == Mode.CREATION
+  const shouldDisplayShowcaseOfferRadios =
+    !isCreatingFromTemplate &&
+    mode == Mode.CREATION &&
+    !isSubtypeChosenAtCreation
 
   const displayElementsForShowcaseOption =
     formik.values.educationalOfferType === EducationalOfferType.SHOWCASE
@@ -122,7 +124,7 @@ const OfferEducationalStock = <
           <FormLayout className={styles['offer-educational-stock-form-layout']}>
             <FormLayout.MandatoryInfo />
             <FormLayout.Section title="Date et prix">
-              {shouldDisplayShowcaseScreen && (
+              {shouldDisplayShowcaseOfferRadios && (
                 <FormLayout.Row>
                   <RadioGroup
                     group={showcaseOfferRadios}


### PR DESCRIPTION
…er type

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18342

## But de la pull request

Afficher la page de stock sans radio bouton lors de la création d'une offre collective réservable
Ne plus afficher cette page pour une offre vitrine

## Screenshot

![Capture d’écran 2022-11-08 à 17 05 21](https://user-images.githubusercontent.com/71768799/200615687-36f95a3e-e1d5-4bd7-b0a1-0970ee2e01b6.png)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
