### PR TITLE
PC-17244 update dms instructor ko message

### DIFF
--- a/api/src/pcapi/core/subscription/dms/messages.py
+++ b/api/src/pcapi/core/subscription/dms/messages.py
@@ -153,8 +153,7 @@ def get_error_not_updatable_message(
         user_message += " Tu peux contacter le support pour mettre à jour ton dossier."
         pop_over_icon = None
     elif fraud_models.FraudReasonCode.REFUSED_BY_OPERATOR in reason_codes:
-        user_message += " : tu n'es malheureusement pas éligible au pass Culture."
-        call_to_action = None
+        user_message += ". Tu peux contacter le support pour plus d’informations."
     else:
         user_message += "."
         call_to_action = None

--- a/api/src/pcapi/core/subscription/dms/messages.py
+++ b/api/src/pcapi/core/subscription/dms/messages.py
@@ -111,31 +111,29 @@ def get_error_not_updatable_message(
 ) -> models.SubscriptionMessage:
     user_message = "Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé"
     pop_over_icon: models.PopOverIcon | None = models.PopOverIcon.ERROR
-    call_to_action = None
+    call_to_action: models.CallToActionMessage | None = subscription_messages.compute_support_call_to_action(user.id)
 
     if fraud_models.FraudReasonCode.DUPLICATE_USER in reason_codes:
         user_message = subscription_messages.build_duplicate_error_message(
             user, fraud_models.FraudReasonCode.DUPLICATE_USER, application_content
         )
-        call_to_action = subscription_messages.compute_support_call_to_action(user.id)
         pop_over_icon = None
 
     elif fraud_models.FraudReasonCode.DUPLICATE_ID_PIECE_NUMBER in reason_codes:
         user_message = subscription_messages.build_duplicate_error_message(
             user, fraud_models.FraudReasonCode.DUPLICATE_ID_PIECE_NUMBER, application_content
         )
-        call_to_action = subscription_messages.compute_support_call_to_action(user.id)
         pop_over_icon = None
 
     elif fraud_models.FraudReasonCode.NOT_ELIGIBLE in reason_codes or birth_date_error:
         user_message += " : la date de naissance indique que tu n'es pas éligible. Tu dois avoir entre 15 et 18 ans."
+        call_to_action = None
 
     elif (
         fraud_models.FraudReasonCode.EMPTY_ID_PIECE_NUMBER in reason_codes
         or fraud_models.FraudReasonCode.INVALID_ID_PIECE_NUMBER in reason_codes
     ):
         user_message += " : le format du numéro de pièce d'identité renseigné est invalide. Tu peux contacter le support pour plus d'informations."
-        call_to_action = subscription_messages.compute_support_call_to_action(user.id)
         pop_over_icon = None
 
     elif fraud_models.FraudReasonCode.ERROR_IN_DATA in reason_codes or (
@@ -153,12 +151,13 @@ def get_error_not_updatable_message(
         else:
             user_message += " : il y a une erreur dans les données de ton dossier."
         user_message += " Tu peux contacter le support pour mettre à jour ton dossier."
-        call_to_action = subscription_messages.compute_support_call_to_action(user.id)
         pop_over_icon = None
     elif fraud_models.FraudReasonCode.REFUSED_BY_OPERATOR in reason_codes:
         user_message += " : tu n'es malheureusement pas éligible au pass Culture."
+        call_to_action = None
     else:
         user_message += "."
+        call_to_action = None
 
     return models.SubscriptionMessage(
         user_message=user_message,

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -696,7 +696,7 @@ class DmsSubscriptionMessageTest:
 
     @patch("pcapi.core.subscription.dms.api.dms_connector_api.DMSGraphQLClient.send_user_message")
     def test_refused_by_operator(self, mock_send_user_message):
-        users_factories.UserFactory(email=self.user_email)
+        user = users_factories.UserFactory(email=self.user_email)
         refused_application = make_parsed_graphql_application(
             application_number=1,
             state=dms_models.GraphQLApplicationStates.refused,
@@ -708,8 +708,13 @@ class DmsSubscriptionMessageTest:
         message = dms_subscription_api.get_dms_subscription_message(fraud_check)
 
         assert message == subscription_models.SubscriptionMessage(
-            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : tu n'es malheureusement pas éligible au pass Culture.",
-            call_to_action=None,
+            user_message="Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé. Tu peux contacter le support pour plus d’informations.",
+            call_to_action=subscription_models.CallToActionMessage(
+                title="Contacter le support",
+                link=subscription_messages.MAILTO_SUPPORT
+                + subscription_messages.MAILTO_SUPPORT_PARAMS.format(id=user.id),
+                icon=subscription_models.CallToActionIcon.EMAIL,
+            ),
             pop_over_icon=subscription_models.PopOverIcon.ERROR,
             updated_at=fraud_check.updatedAt,
         )

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -394,8 +394,14 @@ class DmsWebhookApplicationTest:
         assert message.pop_over_icon == subscription_models.PopOverIcon.ERROR
         assert (
             message.user_message
-            == "Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé : tu n'es malheureusement pas éligible au pass Culture."
+            == "Ton dossier déposé sur le site demarches-simplifiees.fr a été refusé. Tu peux contacter le support pour plus d’informations."
         )
+        assert (
+            message.call_to_action.link
+            == subscription_messages.MAILTO_SUPPORT + subscription_messages.MAILTO_SUPPORT_PARAMS.format(id=user.id)
+        )
+        assert message.call_to_action.title == "Contacter le support"
+
         assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.REFUSED_BY_OPERATOR]
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17244

## But de la pull request

Update le message in app pour que l'utilisateur puisse contacter le support en 1 clic en cas de DMS KO

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
