### PR TITLE
(PC-18315) feat : Filtre de date pour la création des structures à valider

### DIFF
--- a/backoffice/src/resources/Pro/Components/MinMaxDateRangePicker.tsx
+++ b/backoffice/src/resources/Pro/Components/MinMaxDateRangePicker.tsx
@@ -1,12 +1,13 @@
 import Box from '@mui/material/Box'
 import TextField from '@mui/material/TextField'
-import { LocalizationProvider } from '@mui/x-date-pickers-pro'
+import { frFR, LocalizationProvider } from '@mui/x-date-pickers-pro'
 import { AdapterDateFns } from '@mui/x-date-pickers-pro/AdapterDateFns'
 import {
   DateRangePicker,
   DateRange,
 } from '@mui/x-date-pickers-pro/DateRangePicker'
 import { add } from 'date-fns'
+import frLocale from 'date-fns/locale/fr'
 import * as React from 'react'
 
 function getWeeksAfter(date: Date | null, amount: number) {
@@ -18,10 +19,17 @@ type Props = {
 }
 export default function MinMaxDateRangePicker({ value, setNewValue }: Props) {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider
+      dateAdapter={AdapterDateFns}
+      adapterLocale={frLocale}
+      localeText={
+        frFR.components.MuiLocalizationProvider.defaultProps.localeText
+      }
+    >
       <DateRangePicker
         value={value}
         maxDate={getWeeksAfter(value[0], 4)}
+        inputFormat={'dd/MM/yyyy'}
         onChange={newValue => {
           setNewValue(newValue)
         }}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18315

## But de la pull request

- En tant que responsable homologation 
- J'aimerais pouvoir filtrer sur la date de réception de la demande sur la liste de validation de structure
- Afin de gagner du temps sur la recherche d’une demande spécifique

## Implémentation

- Ajout d’un filtre “Date” sur l'écran de validation des structures

- Ce filtre doit permettre de sélectionner les demandes de validation par semaine (du lundi au dimanche)

- Tout comme les filtres “Tags” et “Statut”, il est possible d’en sélectionner plusieurs, afin d’afficher par exemple les demandes sur 2 ou 3 semaines différentes

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

<img width="1627" alt="Capture d’écran 2022-11-09 à 10 27 08" src="https://user-images.githubusercontent.com/9610732/200792489-e2853d20-b3e7-4b8e-93cd-c9a78e55ee11.png">
<img width="1633" alt="Capture d’écran 2022-11-09 à 10 27 17" src="https://user-images.githubusercontent.com/9610732/200792503-2f303afd-397b-44ca-89d4-79691c566a3a.png">
<img width="1632" alt="Capture d’écran 2022-11-09 à 10 27 31" src="https://user-images.githubusercontent.com/9610732/200792509-be17acc5-956c-403d-a670-b767ca0bac66.png">

