### PR TITLE
(PC-18087)[API] feat: add cilumns to handle images in eac offer and e…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-77555a4c81c0 (pre) (head)
+a108c3bf5e27 (pre) (head)
 d08bfa402042 (post) (head)

--- a/api/src/pcapi/alembic/versions/20221109T155216_a108c3bf5e27_eac_image_columns.py
+++ b/api/src/pcapi/alembic/versions/20221109T155216_a108c3bf5e27_eac_image_columns.py
@@ -1,0 +1,33 @@
+"""eac_image_columns
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "a108c3bf5e27"
+down_revision = "92484e2002ee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("collective_offer", sa.Column("imageCrop", postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column("collective_offer", sa.Column("imageCredit", sa.Text(), nullable=True))
+    op.add_column("collective_offer", sa.Column("imageHasOriginal", sa.Boolean(), nullable=True))
+    op.add_column(
+        "collective_offer_template", sa.Column("imageCrop", postgresql.JSONB(astext_type=sa.Text()), nullable=True)
+    )
+    op.add_column("collective_offer_template", sa.Column("imageCredit", sa.Text(), nullable=True))
+    op.add_column("collective_offer_template", sa.Column("imageHasOriginal", sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("collective_offer_template", "imageHasOriginal")
+    op.drop_column("collective_offer_template", "imageCredit")
+    op.drop_column("collective_offer_template", "imageCrop")
+    op.drop_column("collective_offer", "imageHasOriginal")
+    op.drop_column("collective_offer", "imageCredit")
+    op.drop_column("collective_offer", "imageCrop")

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -163,7 +163,9 @@ class HasImageMixin:
         self.imageHasOriginal = None
 
 
-class CollectiveOffer(PcObject, Base, offer_mixin.ValidationMixin, AccessibilityMixin, offer_mixin.StatusMixin, Model):
+class CollectiveOffer(
+    PcObject, Base, offer_mixin.ValidationMixin, AccessibilityMixin, offer_mixin.StatusMixin, HasImageMixin, Model
+):
     __tablename__ = "collective_offer"
 
     offerId = sa.Column(sa.BigInteger, nullable=True)
@@ -325,7 +327,7 @@ class CollectiveOffer(PcObject, Base, offer_mixin.ValidationMixin, Accessibility
 
 
 class CollectiveOfferTemplate(
-    PcObject, offer_mixin.ValidationMixin, AccessibilityMixin, offer_mixin.StatusMixin, Base, Model
+    PcObject, offer_mixin.ValidationMixin, AccessibilityMixin, offer_mixin.StatusMixin, HasImageMixin, Base, Model
 ):
     __tablename__ = "collective_offer_template"
 


### PR DESCRIPTION
…ac templates

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18087
## Modifications du schéma de la base de données

* ajoute les collonnes suivantes aux modeles de CollectiveOffer et CollectiveOfferTemplate
    * imageCredit (str)
    * imageCrop (json)
    * imageHasOriginal(bool) 

Ces nouvelles colonnes permettent de gérer l'ajout future d'image pour les offres collective et les offres vitrines.