### PR TITLE
[BO] PC 18505 add primary keys

### DIFF
--- a/api/src/pcapi/alembic/versions/20221109T184508_8b0574f4aa1b_add_primary_key_to_role_permission.py
+++ b/api/src/pcapi/alembic/versions/20221109T184508_8b0574f4aa1b_add_primary_key_to_role_permission.py
@@ -1,0 +1,53 @@
+"""add primary key to role_permission
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8b0574f4aa1b"
+down_revision = "ffd6d7217351"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("COMMIT")
+    op.execute("""SET SESSION statement_timeout = '900s'""")
+
+    # fill ids
+    op.execute(
+        """
+        BEGIN ;
+
+        -- add nullable id column
+        ALTER TABLE role_permission
+        ADD COLUMN IF NOT EXISTS "id" bigint NULL ;
+
+        -- fill null ids with sequence
+        CREATE SEQUENCE IF NOT EXISTS role_permission_seq ;
+
+        UPDATE role_permission
+        SET "id" = nextval('role_permission_seq') ;
+
+        -- transform id into primary key
+        ALTER TABLE role_permission
+        ALTER "id" SET NOT NULL ;
+
+        ALTER TABLE role_permission
+        ALTER "id" SET DEFAULT nextval('role_permission_seq'::regclass) ;
+
+        ALTER TABLE role_permission
+        ADD PRIMARY KEY ("id") ;
+
+        COMMIT ;
+        """
+    )
+
+    op.execute(f"""SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}""")
+
+
+def downgrade():
+    op.drop_column("role_permission", "id")

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -71,13 +71,14 @@ def sync_db_permissions(session: sa.orm.Session) -> None:
     return sync_enum_with_db_field(session, Permissions, Permission.name)
 
 
-role_permission_table = sa.Table(
-    "role_permission",
-    Base.metadata,
-    sa.Column("roleId", sa.ForeignKey("role.id", ondelete="CASCADE")),
-    sa.Column("permissionId", sa.ForeignKey("permission.id", ondelete="CASCADE")),
-    sa.UniqueConstraint("roleId", "permissionId"),
-)
+class RolePermission(PcObject, Base, Model):
+    """
+    An association table between roles and permission for their
+    many-to-many relationship
+    """
+
+    roleId: int = sa.Column(sa.BigInteger, sa.ForeignKey("role.id", ondelete="CASCADE"))
+    permissionId: int = sa.Column(sa.BigInteger, sa.ForeignKey("permission.id", ondelete="CASCADE"))
 
 
 class Permission(PcObject, Base, Model):
@@ -86,7 +87,7 @@ class Permission(PcObject, Base, Model):
     name: str = sa.Column(sa.String(length=140), nullable=False, unique=True)
     category = sa.Column(sa.String(140), nullable=True, default=None)
     roles = sa.orm.relationship(  # type: ignore [misc]
-        "Role", secondary=role_permission_table, back_populates="permissions"
+        "Role", secondary="role_permission", back_populates="permissions"
     )
 
 
@@ -121,7 +122,7 @@ class Role(PcObject, Base, Model):
 
     name: str = sa.Column(sa.String(140), nullable=False, unique=True)
     permissions = sa.orm.relationship(  # type: ignore [misc]
-        Permission, secondary=role_permission_table, back_populates="roles"
+        Permission, secondary="role_permission", back_populates="roles"
     )
     profiles = sa.orm.relationship("BackOfficeUserProfile", secondary=role_backoffice_profile_table, back_populates="roles")  # type: ignore
 

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -97,7 +97,7 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     educational_models.EducationalYear.query.delete()
     educational_models.EducationalRedactor.query.delete()
     Feature.query.delete()
-    db.session.execute(f"DELETE FROM {perm_models.role_permission_table.name};")
+    perm_models.RolePermission.query.delete()
     perm_models.Permission.query.delete()
     perm_models.Role.query.delete()
     history_models.ActionHistory.query.delete()

--- a/api/tests/core/permissions/test_permissions_sync.py
+++ b/api/tests/core/permissions/test_permissions_sync.py
@@ -2,7 +2,6 @@ import enum
 from unittest import mock
 
 from pcapi.core.permissions import models as perm_models
-from pcapi.core.permissions.models import role_permission_table
 
 
 def test_sync_first_perms(db_session):
@@ -11,7 +10,7 @@ def test_sync_first_perms(db_session):
         FOO = "foo"
         BAR = "bar"
 
-    db_session.execute(f"DELETE FROM {role_permission_table.name};")
+    perm_models.RolePermission.query.delete()
     db_session.query(perm_models.Permission).delete()
     assert db_session.query(perm_models.Permission.id).count() == 0
 
@@ -31,7 +30,7 @@ def test_sync_new_perms(db_session):
         BAR = "bar"
         BAZ = "baz"
 
-    db_session.execute(f"DELETE FROM {role_permission_table.name};")
+    perm_models.RolePermission.query.delete()
     db_session.query(perm_models.Permission).delete()
     db_session.add(perm_models.Permission(name="FOO"))
     db_session.add(perm_models.Permission(name="BAR"))
@@ -52,7 +51,7 @@ def test_sync_removed_perms(db_session):
         FOO = "foo"
         BAR = "bar"
 
-    db_session.execute(f"DELETE FROM {role_permission_table.name};")
+    perm_models.RolePermission.query.delete()
     db_session.query(perm_models.Permission).delete()
     db_session.add(perm_models.Permission(name="FOO"))
     db_session.add(perm_models.Permission(name="BAR"))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18505

## But de la pull request

Ajout d'une clé primaire (id) à `role_permission`.
Les colonnes `roleId` et `permissionId` peuvent être nulles donc je n'ai pas opté pour l'option clé primaire avec ces deux colonnes.