### PR TITLE
(BSR)ci: disable Docker layer caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -858,7 +858,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 19.03.13
-          docker_layer_caching: true
       - authenticate-gcp:
           gcp-key-name: GCP_INFRA_KEY
       - authenticate_gcp_docker_registry:

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -63,8 +63,6 @@ jobs:
         push: true
         target: pcapi
         tags: ${{ env.DOCKER_REPO }}/pcapi:${{ inputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
     - name: "Build and push pcapi-console image"
       uses: docker/build-push-action@v2
       if: ${{ inputs.console == true }}
@@ -73,8 +71,6 @@ jobs:
         push: true
         target: pcapi-console
         tags: ${{ env.DOCKER_REPO }}/pcapi-console:${{ inputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
     - name: "Build and push pcapi-tests image"
       uses: docker/build-push-action@v2
       if: ${{ inputs.tests == true }}
@@ -83,5 +79,3 @@ jobs:
         push: true
         target: pcapi-tests
         tags: ${{ env.DOCKER_REPO }}/pcapi-tests:${{ inputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max


### PR DESCRIPTION
## But de la pull request

Ne pas utiliser les fonctionnalités de caches des layers Docker lors de la construction d'image.
En effet, les dépendances Python tirés par `pip` peuvent changer sans que le fichier `requirements.txt` change.

## Implémentation

- Suppression de l'option `docker_layer_caching` pour CircleCI
- Suppression des arguments `cache-from` et `cache-to` dans Github Action

## Informations supplémentaires

- Ceci est un contournement temporaire en attendant d'utiliser une solution permettant d'utiliser du cache sur certaines étapes, sans effet de bord côté dépendances Python 
