### PR TITLE
(PC-18538) fix: Non-mise à jour du nom d'un acteur culturel sur Zendesk Sell

### DIFF
--- a/api/src/pcapi/core/users/external/zendesk_sell.py
+++ b/api/src/pcapi/core/users/external/zendesk_sell.py
@@ -148,7 +148,7 @@ def _get_venue_data(venue: offerers_models.Venue, parent_organization_id: int | 
     params: dict = {
         "data": {
             "is_organization": True,
-            "name": venue.publicName if venue.publicName else venue.name,
+            # "name" is not updated because sometimes the name in the product is not the same in Zendesk Sell,
             "parent_organization_id": parent_organization_id,  # if None, then it will send null on the request
             "last_name": "",  # leave that empty for the Zendesk api
             "description": venue.description,
@@ -190,7 +190,7 @@ def _get_offerer_data(offerer: offerers_models.Offerer, created: bool = False) -
     params: dict = {
         "data": {
             "is_organization": True,
-            "name": offerer.name if offerer.name else "N/A",
+            # "name" is not updated because sometimes the name in the product is not the same in Zendesk Sell,
             "last_name": "",
             "address": {
                 "line1": offerer.address,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18538

## But de la pull request

Lors de la mise à jour de Zendesk avec les données des acteurs culturels du portail pro, prévoir d’update tous les champs des AC à l'exception de “publicName”

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
