### PR TITLE
[BO] PC 18305 offerer profile history

### DIFF
--- a/api/src/pcapi/core/history/repository.py
+++ b/api/src/pcapi/core/history/repository.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import joinedload
+
 from pcapi.core.history import models
 from pcapi.core.users import models as users_models
 
@@ -7,5 +9,7 @@ def find_all_actions_by_offerer(offerer_id: int) -> list[models.ActionHistory]:
         models.ActionHistory.query.filter(models.ActionHistory.offererId == offerer_id)
         .outerjoin(users_models.User, models.ActionHistory.userId == users_models.User.id)
         .order_by(models.ActionHistory.actionDate.desc())
+        .options(joinedload(models.ActionHistory.user))
+        .options(joinedload(models.ActionHistory.authorUser))
         .all()
     )

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -32,6 +32,13 @@ class PCPostalCodeField(PCStringField):
     ]
 
 
+class PCCommentField(PCOptStringField):
+    validators = [
+        validators.InputRequired("Information obligatoire"),
+        validators.Length(min=2, max=1024, message="doit contenir entre %(min)d et %(max)d caractères"),
+    ]
+
+
 class PCEmailField(wtforms.EmailField):
     widget = partial(widget, template="components/forms/string_field.html")
     validators = [

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -1,0 +1,7 @@
+from flask_wtf import FlaskForm
+
+from . import fields
+
+
+class CommentForm(FlaskForm):
+    comment = fields.PCCommentField("Commentaire interne pour la structure")

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -1,14 +1,22 @@
+import typing
+
+from flask import flash
+from flask import redirect
 from flask import render_template
+from flask import url_for
+from flask_login import current_user
 from werkzeug.exceptions import NotFound
 
 from pcapi.core.history import repository as history_repository
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
+from pcapi.utils.date import format_into_utc_date
 import pcapi.utils.regions as regions_utils
 
 from . import utils
-from .serialization import offerers as offerers_serialization
+from .forms import offerer as offerer_forms
+from .serialization import offerers as serialization
 
 
 offerer_blueprint = utils.child_backoffice_blueprint(
@@ -31,7 +39,7 @@ def get(offerer_id: int) -> utils.BackofficeResponse:
     bank_informations_ok = bank_informations.get("ok", 0)
     bank_informations_ko = bank_informations.get("ko", 0)
 
-    bank_information_status = offerers_serialization.OffererBankInformationStatus(
+    bank_information_status = serialization.OffererBankInformationStatus(
         ok=bank_informations_ok, ko=bank_informations_ko
     )
 
@@ -44,31 +52,86 @@ def get(offerer_id: int) -> utils.BackofficeResponse:
     )
 
 
-@offerer_blueprint.route("/stats", methods=["GET"])
-def get_offerer_stats(offerer_id: int) -> utils.BackofficeResponse:
-    total_revenue = offerers_api.get_offerer_total_revenue(offerer_id)
+def get_stats_data(offerer_id: int) -> serialization.OfferersStats:
     offers_stats = offerers_api.get_offerer_offers_stats(offerer_id)
-
-    stats = offerers_serialization.OffersStats(
-        active=offerers_serialization.BaseOffersStats(
+    stats = serialization.OffersStats(
+        active=serialization.BaseOffersStats(
             individual=offers_stats.individual_offers.get("active", 0) if offers_stats.individual_offers else 0,
             collective=offers_stats.collective_offers.get("active", 0) if offers_stats.collective_offers else 0,
         ),
-        inactive=offerers_serialization.BaseOffersStats(
+        inactive=serialization.BaseOffersStats(
             individual=offers_stats.individual_offers.get("inactive", 0) if offers_stats.individual_offers else 0,
             collective=offers_stats.collective_offers.get("inactive", 0) if offers_stats.collective_offers else 0,
         ),
     )
 
+    total_revenue = offerers_api.get_offerer_total_revenue(offerer_id)
+
+    return serialization.OfferersStats(stats=stats, total_revenue=total_revenue)
+
+
+@offerer_blueprint.route("/stats", methods=["GET"])
+def get_stats(offerer_id: int) -> utils.BackofficeResponse:
+    offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
+    data = get_stats_data(offerer.id)
     return render_template(
         "offerer/get/stats.html",
-        total_revenue=total_revenue,
-        stats=stats,
+        stats=data.stats,
+        total_revenue=data.total_revenue,
     )
+
+
+def get_offerer_history_data(offerer_id: int) -> typing.Sequence[serialization.HistoryItem]:
+    actions = history_repository.find_all_actions_by_offerer(offerer_id)
+    return [
+        serialization.HistoryItem(
+            type=action.actionType.value,
+            date=format_into_utc_date(action.actionDate) if action.actionDate else None,
+            authorId=action.authorUserId,
+            authorName=action.authorUser.publicName if action.authorUser else None,
+            comment=action.comment,
+            accountId=action.userId,
+            accountName=action.user.publicName if action.user else None,
+        )
+        for action in actions
+    ]
 
 
 @offerer_blueprint.route("/history", methods=["GET"])
 def get_offerer_history(offerer_id: int) -> utils.BackofficeResponse:
-    actions = history_repository.find_all_actions_by_offerer(offerer_id)
+    offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
+    history = get_offerer_history_data(offerer_id)
+    can_add_comment = utils.has_current_user_permission(perm_models.Permissions.MANAGE_PRO_ENTITY)
+    return render_template(
+        "offerer/get/details.html", offerer=offerer, history=history, can_add_comment=can_add_comment
+    )
 
-    return render_template("offerer/get/history.html", history={"actions": actions})
+
+offerer_comment_blueprint = utils.child_backoffice_blueprint(
+    "offerer_comment",
+    __name__,
+    url_prefix="/pro/offerer/<int:offerer_id>/comment",
+    permission=perm_models.Permissions.MANAGE_PRO_ENTITY,
+)
+
+
+@offerer_comment_blueprint.route("", methods=["GET"])
+def new_comment(offerer_id: int) -> utils.BackofficeResponse:
+    offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
+    form = offerer_forms.CommentForm()
+    return render_template("offerer/comment.html", form=form, offerer=offerer)
+
+
+@offerer_comment_blueprint.route("", methods=["POST"])
+def comment_offerer(offerer_id: int) -> utils.BackofficeResponse:
+    offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
+
+    form = offerer_forms.CommentForm()
+    if not form.validate():
+        flash("Les données envoyées comportent des erreurs", "warning")
+        return render_template("offerer/comment.html", form=form, offerer=offerer), 400
+
+    offerers_api.add_comment_to_offerer(offerer_id, current_user, comment=form.comment.data)
+    flash("Commentaire enregistré", "success")
+
+    return redirect(url_for("backoffice_v3_web.offerer.get", offerer_id=offerer_id), code=303)

--- a/api/src/pcapi/routes/backoffice_v3/serialization/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/serialization/offerers.py
@@ -1,3 +1,6 @@
+import datetime
+
+import pcapi.core.history.models as history_models
 import pcapi.core.offerers.models as offerers_models
 from pcapi.routes.serialization import BaseModel
 
@@ -33,3 +36,21 @@ class BaseOffersStats(BaseModel):
 class OffersStats(BaseModel):
     active: BaseOffersStats
     inactive: BaseOffersStats
+
+
+class OfferersStats(BaseModel):
+    stats: OffersStats
+    total_revenue: float
+
+
+class HistoryItem(BaseModel):
+    class Config:
+        use_enum_values = True
+
+    type: history_models.ActionType
+    date: datetime.datetime
+    authorId: int | None  # backoffice user OR pro user who made the action
+    authorName: str | None
+    comment: str | None
+    accountId: int | None  # pro user attached to the offerer
+    accountName: str | None

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/comment.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/comment.html
@@ -1,0 +1,37 @@
+{% extends "layouts/pro.html" %}
+
+{% block pro_main_content %}
+    <div class="row">
+        <div class="col-3">
+        </div>
+
+        <div class="col-6 mt-5">
+            <h5 class="lead fs-1 my-4">{{ offerer.name }}</h5>
+
+            <div class="mt-5 text-center">
+                <form action="{{ url_for('.comment_offerer', offerer_id=offerer.id) }}" method="POST">
+                    {% for form_field in form %}
+                        <div class="w-100 my-4">
+                            {% for error in form_field.errors %}
+                                <p class="text-warning lead">{{ error }}</p>
+                            {% endfor %}
+                        </div>
+
+                        {{ form_field }}
+                    {% endfor %}
+
+                    <div class="col-12 text-start py-4">
+                        <button type="submit" class="btn btn-primary">
+                            Commenter
+                        </button>
+                    </div>
+
+                </form>
+            </div>
+        </div>
+
+        <div class="col-3">
+        </div>
+    </div>
+
+{% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -84,7 +84,7 @@
         </div>
 
         <div class="mt-4">
-            <turbo-frame id="total_revenue_frame" src="{{ url_for(".get_offerer_stats", offerer_id=offerer.id) }}">
+            <turbo-frame id="total_revenue_frame" src="{{ url_for("backoffice_v3_web.offerer.get_stats", offerer_id=offerer.id) }}">
                 <p class="text-center">
                     <span class="spinner-grow spinner-grow-sm" role="status">
                         <span class="visually-hidden">Chargement...</span>
@@ -95,7 +95,7 @@
         </div>
 
         <div class="mt-4">
-            <turbo-frame id="offerer_history_frame" src="{{ url_for(".get_offerer_history", offerer_id=offerer.id) }}">
+            <turbo-frame id="offerer_history_frame" src="{{ url_for("backoffice_v3_web.offerer.get_offerer_history", offerer_id=offerer.id) }}">
                 <p class="text-center">
                     <span class="spinner-grow spinner-grow-sm" role="status">
                         <span class="visually-hidden">Chargement...</span>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
@@ -1,0 +1,74 @@
+<turbo-frame id="offerer_history_frame">
+
+    <ul class="nav nav-tabs nav-fill" id="pills-tab" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button
+                class="nav-link active fw-bolder py-3"
+                id="pills-home-tab"
+                data-bs-toggle="pill"
+                data-bs-target="#pills-home"
+                type="button"
+                role="tab"
+                aria-controls="pills-home"
+                aria-selected="true"
+            >
+                HISTORIQUE DU COMPTE
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button
+                class="nav-link fw-bolder py-3"
+                id="pills-pro-users-tab"
+                data-bs-toggle="pill"
+                data-bs-target="#pills-pro-users"
+                type="button"
+                role="tab"
+                aria-controls="pills-pro-users"
+                aria-selected="false"
+            >
+                COMPTE(S) PRO RATTACHÉ(S)
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button
+                class="nav-link fw-bolder py-3"
+                id="pills-details-tab"
+                data-bs-toggle="pill"
+                data-bs-target="#pills-details"
+                type="button"
+                role="tab"
+                aria-controls="pills-details"
+                aria-selected="false"
+            >
+             DÉTAILS STRUCTURE / LIEUX
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button
+                class="nav-link fw-bolder py-3"
+                id="pills-bookings-tab"
+                data-bs-toggle="pill"
+                data-bs-target="#pills-bookings"
+                type="button"
+                role="tab"
+                aria-controls="pills-bookings"
+                aria-selected="false"
+            >
+                RÉSERVATIONS
+            </button>
+        </li>
+    </ul>
+
+    <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
+        <div class="tab-pane fade show active p-4" id="pills-home" role="tabpanel" aria-labelledby="pills-home-tab" tabindex="0">
+            {% include "offerer/get/details/history.html" %}
+        </div>
+        <div class="tab-pane fade" id="pills-pro-users" role="tabpanel" aria-labelledby="pills-pro-users-tab" tabindex="0">
+        </div>
+        <div class="tab-pane fade" id="pills-details" role="tabpanel" aria-labelledby="pills-details-tab" tabindex="0">
+        </div>
+        <div class="tab-pane fade" id="pills-bookings" role="tabpanel" aria-labelledby="pills-bookings-tab" tabindex="0">
+        </div>
+    </div>
+
+</turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
@@ -1,0 +1,43 @@
+{% if can_add_comment %}
+    <a
+        href="{{ url_for('backoffice_v3_web.offerer_comment.new_comment', offerer_id=offerer.id) }}"
+        class="card-link"
+        >
+        <button class="btn btn-outline-primary fw-bolder">
+            Ajouter un commentaire
+        </button>
+    </a>
+{% endif %}
+
+<table class="table table-hover my-4">
+    <thead>
+        <tr>
+            <th scope="col"></th>
+            <th scope="col">Type</th>
+            <th scope="col">Date/Heure</th>
+            <th scope="col">Commentaire</th>
+            <th scope="col" class="px-4">Auteur</th>
+        </tr>
+    </thead>
+    <tbody class="table-group-divider">
+        {% for event in history %}
+            <tr>
+                <th scope="row"></th>
+                <td>{{ event.type }}</td>
+                <td>{{ event.date | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
+                <td class="px-4 text-break">
+                    {% if event.accountName %}
+                        <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=event.accountId) }}">
+                            <p>{{ event.accountName | empty_string_if_null }} - {{ event.accountId }}</p>
+                        </a>
+
+                        <p>{{ event.comment | empty_string_if_null }}</p>
+                    {% else %}
+                        <p>{{ event.comment | empty_string_if_null }}</p>
+                    {% endif %}
+                </td>
+                <td>{{ event.authorName | empty_string_if_null }}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/history.html
@@ -1,9 +1,0 @@
-<turbo-frame id="offerer_history_frame">
-    <div>
-        {% if not history.actions %}
-            <div>Pas d'historique à afficher</div>
-        {% else %}
-            <div>Chargement...</div>
-        {% endif %}
-    </div>
-</turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 BackofficeResponse = typing.Union[str, typing.Tuple[str, int], WerkzeugResponse]
 
 
+def has_current_user_permission(permission: perm_models.Permissions) -> bool:
+    return permission in current_user.backoffice_profile.permissions or settings.IS_TESTING
+
+
 def _check_permission(permission: perm_models.Permissions) -> None:
     if not current_user.is_authenticated:
         raise ApiErrors({"global": ["l'utilisateur n'est pas authentifié"]}, status_code=403)
@@ -31,7 +35,7 @@ def _check_permission(permission: perm_models.Permissions) -> None:
     if not current_user.backoffice_profile:
         raise ApiErrors({"global": ["utilisateur inconnu"]}, status_code=403)
 
-    if permission not in current_user.backoffice_profile.permissions and not settings.IS_TESTING:
+    if not has_current_user_permission(permission):
         logger.warning(
             "user %s missed permission %s while trying to access %s",
             current_user.email,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -15,7 +15,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT,
     ],
-    "support-pro": [
+    "support-PRO": [
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.MANAGE_PRO_ENTITY,

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -35,7 +35,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT,
     ],
-    "support-pro": [
+    "support-PRO": [
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.MANAGE_PRO_ENTITY,

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -1,6 +1,18 @@
+import datetime
+
 import pytest
 
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.educational import factories as educational_factories
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.finance import models as finance_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
+from pcapi.core.providers import factories as providers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users.backoffice import api as backoffice_api
@@ -68,3 +80,336 @@ def legit_user_fixture(roles_with_permissions: None) -> users_models.User:
 @pytest.fixture(scope="function", name="authenticated_client")
 def authenticated_client_fixture(client, legit_user):  # type: ignore
     return client.with_session_auth(legit_user.email)
+
+
+@pytest.fixture(name="offerer")
+def offerer_fixture():
+    offerer = offerers_factories.OffererFactory(
+        postalCode="46150", validationStatus=offerers_models.ValidationStatus.VALIDATED
+    )
+    return offerer
+
+
+@pytest.fixture(name="venue_with_accepted_bank_info")
+def venue_with_accepted_bank_info_fixture(offerer):
+    venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+    finance_factories.BankInformationFactory(
+        venue=venue,
+        status=finance_models.BankInformationStatus.ACCEPTED,
+    )
+    return venue
+
+
+@pytest.fixture(name="venue_with_draft_bank_info")
+def venue_with_draft_bank_info_fixture(offerer):
+    venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+    finance_factories.BankInformationFactory(
+        venue=venue,
+        status=finance_models.BankInformationStatus.DRAFT,
+        applicationId=77,
+    )
+    return venue
+
+
+@pytest.fixture(name="venue_with_rejected_bank_info")
+def venue_with_rejected_bank_info_fixture(offerer):
+    venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+    finance_factories.BankInformationFactory(
+        venue=venue,
+        status=finance_models.BankInformationStatus.REJECTED,
+    )
+    return venue
+
+
+@pytest.fixture(name="venue_with_no_bank_info")
+def venue_with_no_bank_info_fixture(offerer):
+    venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+    return venue
+
+
+@pytest.fixture(name="venue_with_accepted_self_reimbursement_point")
+def venue_with_accepted_self_reimbursement_point_fixture(venue_with_accepted_bank_info):
+    offerers_factories.VenueReimbursementPointLinkFactory(
+        venue=venue_with_accepted_bank_info,
+        reimbursementPoint=venue_with_accepted_bank_info,
+    )
+    return venue_with_accepted_bank_info
+
+
+@pytest.fixture(name="venue_with_accepted_reimbursement_point")
+def venue_with_accepted_reimbursement_point_fixture(
+    venue_with_accepted_bank_info,
+    venue_with_no_bank_info,
+):
+    offerers_factories.VenueReimbursementPointLinkFactory(
+        venue=venue_with_no_bank_info,
+        reimbursementPoint=venue_with_accepted_bank_info,
+    )
+    return venue_with_no_bank_info
+
+
+@pytest.fixture(name="venue_with_expired_reimbursement_point")
+def venue_with_expired_reimbursement_point_fixture(
+    offerer,
+    venue_with_accepted_bank_info,
+):
+    venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+    offerers_factories.VenueReimbursementPointLinkFactory(
+        venue=venue,
+        reimbursementPoint=venue_with_accepted_bank_info,
+        timespan=[
+            datetime.datetime.utcnow() - datetime.timedelta(days=365),
+            datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        ],
+    )
+    return venue
+
+
+@pytest.fixture(name="venue_with_educational_status")
+def venue_with_educational_status_fixture(offerer):
+    educational_status = offerers_factories.VenueEducationalStatusFactory()
+    venue = offerers_factories.VenueFactory(
+        managingOfferer=offerer,
+        venueEducationalStatusId=educational_status.id,
+    )
+    return venue
+
+
+@pytest.fixture(name="venue_with_no_contact")
+def venue_with_no_contact_fixture():
+    venue = offerers_factories.VenueFactory(contact=None)
+    return venue
+
+
+@pytest.fixture(name="venue_with_nor_contact_or_booking_email")
+def venue_with_nor_contact_or_booking_email_fixture():
+    venue = offerers_factories.VenueFactory(contact=None, bookingEmail=None)
+    return venue
+
+
+@pytest.fixture(name="venue_provider_with_last_sync")
+def venue_provider_with_last_sync_fixture(venue_with_accepted_bank_info):
+    venue_provider = providers_factories.VenueProviderFactory(
+        venue=venue_with_accepted_bank_info,
+        lastSyncDate=datetime.datetime.utcnow(),
+    )
+    return venue_provider
+
+
+@pytest.fixture(name="random_venue")
+def random_venue_fixture():
+    venue = offerers_factories.VenueFactory(postalCode="46150")
+    finance_factories.BankInformationFactory(venue=venue)
+    return venue
+
+
+@pytest.fixture(name="offerer_bank_info_with_application_id")
+def offerer_bank_info_with_application_id_fixture(offerer):
+    bank_info = finance_factories.BankInformationFactory(offerer=offerer, applicationId="42")
+    return bank_info
+
+
+@pytest.fixture(name="offerer_bank_info_with_no_application_id")
+def offerer_bank_info_with_no_application_id_fixture(offerer):
+    bank_info = finance_factories.BankInformationFactory(offerer=offerer, applicationId=None)
+    return bank_info
+
+
+@pytest.fixture(name="offerer_active_individual_offers")
+def offerer_active_individual_offers_fixture(offerer, venue_with_accepted_bank_info):
+    approved_offers = offers_factories.OfferFactory.create_batch(
+        2,
+        venue=venue_with_accepted_bank_info,
+        isActive=True,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+
+    rejected_offer = offers_factories.OfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=True,
+        validation=offers_models.OfferValidationStatus.REJECTED.value,
+    )
+
+    return approved_offers + [rejected_offer]
+
+
+@pytest.fixture(name="offerer_inactive_individual_offers")
+def offerer_inactive_individual_offers_fixture(offerer, venue_with_accepted_bank_info):
+    approved_offers = offers_factories.OfferFactory.create_batch(
+        3,
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+
+    rejected_offer = offers_factories.OfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.REJECTED.value,
+    )
+
+    return approved_offers + [rejected_offer]
+
+
+@pytest.fixture(name="offerer_active_collective_offers")
+def offerer_active_collective_offers_fixture(offerer, venue_with_accepted_bank_info):
+    approved_offers = educational_factories.CollectiveOfferFactory.create_batch(
+        4,
+        venue=venue_with_accepted_bank_info,
+        isActive=True,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+
+    rejected_offer = educational_factories.CollectiveOfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=True,
+        validation=offers_models.OfferValidationStatus.REJECTED.value,
+    )
+
+    return approved_offers + [rejected_offer]
+
+
+@pytest.fixture(name="offerer_inactive_collective_offers")
+def offerer_inactive_collective_offers_fixture(offerer, venue_with_accepted_bank_info):
+    approved_offers = educational_factories.CollectiveOfferFactory.create_batch(
+        5,
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+
+    rejected_offer = educational_factories.CollectiveOfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.REJECTED.value,
+    )
+
+    return approved_offers + [rejected_offer]
+
+
+@pytest.fixture(name="offerer_stocks")
+def offerer_stocks_fixture(offerer_active_individual_offers):
+    stocks = [offers_factories.StockFactory(offer=offer) for offer in offerer_active_individual_offers]
+    return stocks
+
+
+@pytest.fixture(name="individual_offerer_bookings")
+def individual_offerer_bookings_fixture(offerer_stocks, venue_with_accepted_bank_info):
+    used_simple = bookings_factories.BookingFactory(
+        status=bookings_models.BookingStatus.USED,
+        quantity=1,
+        amount=10,
+        stock=offerer_stocks[0],
+    )
+    confirmed_duo = bookings_factories.BookingFactory(
+        status=bookings_models.BookingStatus.CONFIRMED,
+        quantity=2,
+        amount=10,
+        stock=offerer_stocks[1],
+    )
+    cancelled = bookings_factories.BookingFactory(
+        status=bookings_models.BookingStatus.CANCELLED,
+        venue=venue_with_accepted_bank_info,
+        stock=offerer_stocks[2],
+    )
+    return [used_simple, confirmed_duo, cancelled]
+
+
+@pytest.fixture(name="collective_offerer_booking")
+def collective_offerer_booking_fixture(venue_with_educational_status):
+    stock = educational_factories.CollectiveStockFactory(price=1664)
+    used = educational_factories.UsedCollectiveBookingFactory(
+        collectiveStock=stock,
+        offerer=venue_with_educational_status.managingOfferer,
+    )
+    cancelled = educational_factories.CancelledCollectiveBookingFactory(
+        collectiveStock=stock,
+        offerer=venue_with_educational_status.managingOfferer,
+    )
+    return used, cancelled
+
+
+@pytest.fixture(name="collective_venue_booking")
+def collective_venue_booking_fixture(venue_with_accepted_bank_info):
+    educational_status = offerers_factories.VenueEducationalStatusFactory()
+    venue_with_accepted_bank_info.venueEducationalStatusId = educational_status.id
+    stock = educational_factories.CollectiveStockFactory(price=42)
+    used = educational_factories.UsedCollectiveBookingFactory(
+        collectiveStock=stock,
+        venue=venue_with_accepted_bank_info,
+    )
+    cancelled = educational_factories.CancelledCollectiveBookingFactory(
+        collectiveStock=stock,
+        venue=venue_with_accepted_bank_info,
+    )
+    return used, cancelled
+
+
+@pytest.fixture(name="offerer_tags")
+def offerer_tags_fixture():
+    tags = tuple(
+        offerers_factories.OffererTagFactory(label=label)
+        for label in ("Top acteur", "Collectivité", "Établissement public")
+    )
+    return tags
+
+
+@pytest.fixture(name="offerers_to_be_validated")
+def offerers_to_be_validated_fixture(offerer_tags):
+    top_tag, collec_tag, public_tag = offerer_tags
+
+    no_tag = offerers_factories.NotValidatedOffererFactory(name="A", siren="123001001", address=None)
+    top = offerers_factories.NotValidatedOffererFactory(
+        name="B", siren="123002002", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+    collec = offerers_factories.NotValidatedOffererFactory(name="C", siren="123003003")
+    public = offerers_factories.NotValidatedOffererFactory(
+        name="D", siren="123004004", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+    top_collec = offerers_factories.NotValidatedOffererFactory(name="E", siren="123005005")
+    top_public = offerers_factories.NotValidatedOffererFactory(
+        name="F", siren="123006006", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+
+    for offerer in (top, top_collec, top_public):
+        offerers_factories.OffererTagMappingFactory(tagId=top_tag.id, offererId=offerer.id)
+    for offerer in (collec, top_collec):
+        offerers_factories.OffererTagMappingFactory(tagId=collec_tag.id, offererId=offerer.id)
+    for offerer in (public, top_public):
+        offerers_factories.OffererTagMappingFactory(tagId=public_tag.id, offererId=offerer.id)
+
+    # Other statuses
+    offerers_factories.OffererFactory(name="G")
+    offerers_factories.NotValidatedOffererFactory(name="H", validationStatus=offerers_models.ValidationStatus.REJECTED)
+
+    return (no_tag, top, collec, public, top_collec, top_public)
+
+
+@pytest.fixture(name="user_offerer_to_be_validated")
+def user_offerer_to_be_validated_fixture(offerer_tags):
+    top_tag, collec_tag, public_tag = offerer_tags
+
+    no_tag = offerers_factories.NotValidatedUserOffererFactory(user__email="a@example.com")
+    top = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="b@example.com", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+    collec = offerers_factories.NotValidatedUserOffererFactory(user__email="c@example.com")
+    public = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="d@example.com", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+    top_collec = offerers_factories.NotValidatedUserOffererFactory(user__email="e@example.com")
+    top_public = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="f@example.com", validationStatus=offerers_models.ValidationStatus.PENDING
+    )
+
+    for user_offerer in (top, top_collec, top_public):
+        offerers_factories.OffererTagMappingFactory(tagId=top_tag.id, offererId=user_offerer.offererId)
+    for user_offerer in (collec, top_collec):
+        offerers_factories.OffererTagMappingFactory(tagId=collec_tag.id, offererId=user_offerer.offererId)
+    for user_offerer in (public, top_public):
+        offerers_factories.OffererTagMappingFactory(tagId=public_tag.id, offererId=user_offerer.offererId)
+
+    # Other status
+    offerers_factories.UserOffererFactory(user__email="g@example.com")
+
+    return (no_tag, top, collec, public, top_collec, top_public)

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -1,3 +1,6 @@
+import datetime
+
+from flask import g
 from flask import url_for
 import pytest
 
@@ -5,13 +8,16 @@ from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import models as finance_models
-from pcapi.core.offerers import models as offerers_models
+from pcapi.core.history import models as history_models
+import pcapi.core.history.factories as history_factories
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 import pcapi.core.permissions.models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
+from pcapi.models import db
+from pcapi.routes.backoffice_v3 import offerers
 
 from .helpers import unauthorized as unauthorized_helpers
 
@@ -19,16 +25,8 @@ from .helpers import unauthorized as unauthorized_helpers
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@pytest.fixture(scope="function", name="offerer")
-def offerer_fixture():  # type: ignore
-    offerer = offerers_factories.OffererFactory(
-        postalCode="46150", validationStatus=offerers_models.ValidationStatus.VALIDATED
-    )
-    return offerer
-
-
-@pytest.fixture(scope="function", name="venue_with_accepted_bank_info")
-def venue_with_accepted_bank_info_fixture(offerer):  # type: ignore
+@pytest.fixture(scope="function", name="venue")
+def venue_fixture(offerer):  # type: ignore
     venue = offerers_factories.VenueFactory(managingOfferer=offerer)
     finance_factories.BankInformationFactory(
         venue=venue,
@@ -37,18 +35,18 @@ def venue_with_accepted_bank_info_fixture(offerer):  # type: ignore
     return venue
 
 
-@pytest.fixture(scope="function", name="offerer_active_individual_offer")
-def offerer_active_individual_offer_fixture(venue_with_accepted_bank_info):  # type: ignore
+@pytest.fixture(scope="function", name="offer")
+def offer_fixture(venue):  # type: ignore
     return offers_factories.OfferFactory(
-        venue=venue_with_accepted_bank_info,
+        venue=venue,
         isActive=True,
         validation=offers_models.OfferValidationStatus.APPROVED.value,
     )
 
 
-@pytest.fixture(scope="function", name="individual_offerer_booking")
-def individual_offerer_booking_fixture(offerer_active_individual_offer):  # type: ignore
-    stock = offers_factories.StockFactory(offer=offerer_active_individual_offer)
+@pytest.fixture(scope="function", name="booking")
+def booking_fixture(offer):  # type: ignore
+    stock = offers_factories.StockFactory(offer=offer)
     return bookings_factories.BookingFactory(
         status=bookings_models.BookingStatus.USED,
         quantity=1,
@@ -57,23 +55,29 @@ def individual_offerer_booking_fixture(offerer_active_individual_offer):  # type
     )
 
 
-class GetOffererUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
-    endpoint = "backoffice_v3_web.offerer.get"
-    endpoint_kwargs = {"offerer_id": 1}
-    needed_permission = perm_models.Permissions.READ_PRO_ENTITY
-
-
 class GetOffererTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+        endpoint = "backoffice_v3_web.offerer.get"
+        endpoint_kwargs = {"offerer_id": 1}
+        needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_get_offerer(self, authenticated_client):  # type: ignore
         offerer = offerers_factories.UserOffererFactory().offerer
         url = url_for("backoffice_v3_web.offerer.get", offerer_id=offerer.id)
 
+        # if offerer is not removed from the current session, any get
+        # query won't be executed because of this specific testing
+        # environment. This would tamper the real database queries
+        # count.
+        db.session.expire(offerer)
+
         # get session (1 query)
         # get user with profile and permissions (1 query)
         # get FF (1 query)
-        # get pro user/ offerer / venue (1 query)
-        with assert_num_queries(4):
+        # get offerer (1 query)
+        # get offerer basic info (1 query)
+        with assert_num_queries(5):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -85,18 +89,15 @@ class GetOffererTest:
         assert "Structure" in content
 
 
-class GetOffererStatsUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
-    endpoint = "backoffice_v3_web.offerer.get_offerer_stats"
-    endpoint_kwargs = {"offerer_id": 1}
-    needed_permission = perm_models.Permissions.READ_PRO_ENTITY
-
-
 class GetOffererStatsTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+        endpoint = "backoffice_v3_web.offerer.get_stats"
+        endpoint_kwargs = {"offerer_id": 1}
+        needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_get_stats(  # type: ignore
-        self, authenticated_client, offerer, offerer_active_individual_offer, individual_offerer_booking
-    ):
-        url = url_for("backoffice_v3_web.offerer.get_offerer_stats", offerer_id=offerer.id)
+    def test_get_stats(self, authenticated_client, offerer, offer, booking):  # type: ignore
+        url = url_for("backoffice_v3_web.offerer.get_stats", offerer_id=offerer.id)
 
         # get session (1 query)
         # get user with profile and permissions (1 query)
@@ -110,5 +111,275 @@ class GetOffererStatsTest:
         content = response.data.decode("utf-8")
 
         # cast to integer to avoid errors due to amount formatting
-        assert str(int(individual_offerer_booking.amount)) in content
+        assert str(int(booking.amount)) in content
         assert "1 IND" in content  # one active individual offer
+
+
+class GetOffererStatsDataTest:
+    def test_get_data(
+        self,
+        offerer,
+        offerer_active_individual_offers,
+        offerer_inactive_individual_offers,
+        offerer_active_collective_offers,
+        offerer_inactive_collective_offers,
+        individual_offerer_bookings,
+        collective_offerer_booking,
+    ):
+        offerer_id = offerer.id
+
+        # get active/inactive stats (1 query)
+        # get total revenue (1 query)
+        with assert_num_queries(2):
+            data = offerers.get_stats_data(offerer_id)
+
+        stats = data.stats
+
+        assert stats.active.individual == 2
+        assert stats.active.collective == 4
+        assert stats.inactive.individual == 3
+        assert stats.inactive.collective == 5
+
+        total_revenue = data.total_revenue
+
+        assert total_revenue == 1694.0
+
+    def test_individual_offers_only(
+        self,
+        offerer,
+        offerer_active_individual_offers,
+        offerer_inactive_individual_offers,
+        individual_offerer_bookings,
+    ):
+        offerer_id = offerer.id
+
+        # get active/inactive stats (1 query)
+        # get total revenue (1 query)
+        with assert_num_queries(2):
+            data = offerers.get_stats_data(offerer_id)
+
+        stats = data.stats
+
+        assert stats.active.individual == 2
+        assert stats.active.collective == 0
+        assert stats.inactive.individual == 3
+        assert stats.inactive.collective == 0
+
+        total_revenue = data.total_revenue
+
+        assert total_revenue == 30.0
+
+    def test_collective_offers_only(
+        self,
+        offerer,
+        offerer_active_collective_offers,
+        offerer_inactive_collective_offers,
+        collective_offerer_booking,
+    ):
+        offerer_id = offerer.id
+
+        # get active/inactive stats (1 query)
+        # get total revenue (1 query)
+        with assert_num_queries(2):
+            data = offerers.get_stats_data(offerer_id)
+
+        stats = data.stats
+
+        assert stats.active.individual == 0
+        assert stats.active.collective == 4
+        assert stats.inactive.individual == 0
+        assert stats.inactive.collective == 5
+
+        total_revenue = data.total_revenue
+
+        assert total_revenue == 1664.0
+
+    def test_no_bookings(self, offerer):
+        offerer_id = offerer.id
+
+        # get active/inactive stats (1 query)
+        # get total revenue (1 query)
+        with assert_num_queries(2):
+            data = offerers.get_stats_data(offerer_id)
+
+        stats = data.stats
+
+        assert stats.active.individual == 0
+        assert stats.active.collective == 0
+        assert stats.inactive.individual == 0
+        assert stats.inactive.collective == 0
+
+        total_revenue = data.total_revenue
+
+        assert total_revenue == 0.0
+
+
+class GetOffererHistoryTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+        endpoint = "backoffice_v3_web.offerer.get_offerer_history"
+        endpoint_kwargs = {"offerer_id": 1}
+        needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_get_history(self, authenticated_client, offerer):
+        action = history_factories.ActionHistoryFactory(offerer=offerer)
+        url = url_for("backoffice_v3_web.offerer.get_offerer_history", offerer_id=offerer.id)
+
+        # if offerer is not removed from the current session, any get
+        # query won't be executed because of this specific testing
+        # environment. This would tamper the real database queries
+        # count.
+        db.session.expire(offerer)
+
+        # get session (1 query)
+        # get user with profile and permissions (1 query)
+        # get FF (1 query)
+        # get offerer (1 query)
+        # get history (1 query)
+        with assert_num_queries(5):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        content = response.data.decode("utf-8")
+
+        assert action.comment in content
+        assert action.authorUser.publicName in content
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_no_history(self, authenticated_client, offerer):
+        url = url_for("backoffice_v3_web.offerer.get_offerer_history", offerer_id=offerer.id)
+
+        # if offerer is not removed from the current session, any get
+        # query won't be executed because of this specific testing
+        # environment. This would tamper the real database queries
+        # count.
+        db.session.expire(offerer)
+
+        # get session (1 query)
+        # get user with profile and permissions (1 query)
+        # get FF (1 query)
+        # get offerer (1 query)
+        # get history (1 query)
+        with assert_num_queries(5):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+
+class GetOffererHistoryDataTest:
+    def test_one_action(self):
+        user_offerer = offerers_factories.UserOffererFactory()
+        action = history_factories.ActionHistoryFactory(
+            actionDate=datetime.datetime(2022, 10, 3, 13, 1),
+            actionType=history_models.ActionType.OFFERER_NEW,
+            authorUser=user_offerer.user,
+            user=user_offerer.user,
+            offerer=user_offerer.offerer,
+            comment=None,
+        )
+
+        offerer_id = user_offerer.offerer.id
+
+        # get history (1 query)
+        with assert_num_queries(1):
+            history = offerers.get_offerer_history_data(offerer_id)
+
+        assert len(history) == 1
+
+        found_action = history[0]
+
+        assert found_action.type == action.actionType.value
+        assert found_action.date.astimezone() == action.actionDate.astimezone()
+        assert found_action.authorName == action.authorUser.publicName
+
+    def test_no_action(self, offerer):
+        offerer_id = offerer.id
+
+        # get history (1 query)
+        with assert_num_queries(1):
+            assert not offerers.get_offerer_history_data(offerer_id)
+
+    def test_many_actions(self):
+        user_offerer = offerers_factories.UserOffererFactory()
+        actions = history_factories.ActionHistoryFactory.create_batch(
+            3,
+            authorUser=user_offerer.user,
+            user=user_offerer.user,
+            offerer=user_offerer.offerer,
+        )
+
+        offerer_id = user_offerer.offerer.id
+
+        # get history (1 query)
+        with assert_num_queries(1):
+            history = offerers.get_offerer_history_data(offerer_id)
+
+        assert len(history) == len(actions)
+
+        found_comments = {event.comment for event in history}
+        expected_comments = {event.comment for event in actions}
+
+        assert found_comments == expected_comments
+
+
+class NewCommentTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+        endpoint = "backoffice_v3_web.offerer_comment.new_comment"
+        endpoint_kwargs = {"offerer_id": 1}
+        needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_new_comment(self, authenticated_client, offerer):
+        url = url_for("backoffice_v3_web.offerer_comment.new_comment", offerer_id=offerer.id)
+
+        # if offerer is not removed from the current session, any get
+        # query won't be executed because of this specific testing
+        # environment. This would tamper the real database queries
+        # count.
+        db.session.expire(offerer)
+
+        # get session (1 query)
+        # get user with profile and permissions (1 query)
+        # get FF (1 query)
+        # get offerer (1 query)
+        with assert_num_queries(4):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+
+class CommentOffererTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf, unauthorized_helpers.MissingCSRFHelper):
+        endpoint = "backoffice_v3_web.offerer_comment.comment_offerer"
+        endpoint_kwargs = {"offerer_id": 1}
+        needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_add_comment(self, client, legit_user, offerer):
+        comment = "some comment"
+        response = self.send_comment_offerer_request(client, legit_user, offerer, comment)
+
+        assert response.status_code == 303
+
+        expected_url = url_for("backoffice_v3_web.offerer.get", offerer_id=offerer.id, _external=True)
+        assert response.location == expected_url
+
+        assert len(offerer.action_history) == 1
+        assert offerer.action_history[0].comment == comment
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_add_invalid_comment(self, client, legit_user, offerer):
+        response = self.send_comment_offerer_request(client, legit_user, offerer, "")
+
+        assert response.status_code == 400
+        assert not offerer.action_history
+
+    def send_comment_offerer_request(self, client, legit_user, offerer, comment):
+        authenticated_client = client.with_session_auth(legit_user.email)
+
+        # generate and fetch (inside g) csrf token
+        offerer_detail_url = url_for("backoffice_v3_web.offerer.get", offerer_id=offerer.id)
+        authenticated_client.get(offerer_detail_url)
+
+        url = url_for("backoffice_v3_web.offerer_comment.comment_offerer", offerer_id=offerer.id)
+        form = {"comment": comment, "csrf_token": g.get("csrf_token", "")}
+
+        return authenticated_client.post(url, form=form)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18305

## But de la pull request

Ajout de l'onglet historique de compte de la page de profil d'une structure

## Au passage

1. Ajout de deux `joinedload` manquant à `find_all_actions_by_offerer`.
2. Ajout de tests pour la partie statistiques de la page de profil d'une structure.
3. Import des _fixtures_ de la v2 dans le fichier `conftest` des tests des routes de la v3.