### PR TITLE
(PC-17242)[API] fix: change ine column format to correctly handle empty form

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -192,7 +192,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
     hasSeenProTutorials: bool = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     hasSeenProRgs: bool = sa.Column(sa.Boolean, nullable=False, server_default=expression.false())
     idPieceNumber = sa.Column(sa.String, nullable=True, unique=True)
-    ineHash = sa.Column(sa.Text, nullable=True, unique=True)
+    ineHash = sa.Column(sa.String, nullable=True, unique=True)
     isEmailValidated = sa.Column(sa.Boolean, nullable=True, server_default=expression.false())
     lastConnectionDate = sa.Column(sa.DateTime, nullable=True)
     lastName = sa.Column(sa.String(128), nullable=True)

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -320,3 +320,26 @@ class BeneficiaryUserUpdateTest:
         )
 
         assert user_to_update.idPieceNumber != "123123123"
+
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_clear_ine_hash(self, token, client):
+        super_admin = users_factories.AdminFactory(email="superadmin@example.com")
+        client.with_session_auth(super_admin.email)
+
+        user_to_update = users_factories.BeneficiaryGrant18Factory(
+            departementCode="92", postalCode="92700", ineHash="123123123"
+        )
+
+        client.post(
+            f"/pc/back-office/beneficiary_users/edit/?id={user_to_update.id}",
+            form={
+                "id": user_to_update.id,
+                "ineHash": "",
+                "departementCode": user_to_update.departementCode,
+                "csrf_token": "token",
+                "email": user_to_update.email,
+                "postalCode": user_to_update.postalCode,
+            },
+        )
+
+        assert user_to_update.ineHash is None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17242

## But de la pull request

Fix un bug qui enregistrait les ine vides comme des `""` au lieu de `NULL` 
Impact du bug: a partir de la 2nde soumission, on a une erreur de duplication

## Implémentation

- Comme idPieceNumber, utiliser sa.String 

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
