### PR TITLE
(BSR)[API] fix: lock deposit when booking offer

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -23,6 +23,7 @@ import pcapi.core.external_bookings.api as external_bookings_api
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.models as finance_models
 import pcapi.core.finance.repository as finance_repository
+from pcapi.core.finance.repository import get_and_lock_deposit
 import pcapi.core.mails.transactional as transactional_mails
 from pcapi.core.offers import repository as offers_repository
 import pcapi.core.offers.models as offers_models
@@ -64,6 +65,7 @@ def book_offer(
     # on the stock if validation issues an exception
     with transaction():
         stock = offers_repository.get_and_lock_stock(stock_id=stock_id)
+        get_and_lock_deposit(beneficiary.id)
         validation.check_offer_category_is_bookable_by_user(beneficiary, stock)
         validation.check_can_book_free_offer(beneficiary, stock)
         validation.check_offer_already_booked(beneficiary, stock.offer)

--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -501,3 +501,8 @@ def _get_legacy_payments_for_collective_bookings(
             models.Payment.collectiveBookingId.label("collective_booking_id"),
         )
     )
+
+
+def get_and_lock_deposit(userId: int) -> models.Deposit:
+    deposit = models.Deposit.query.filter_by(userId=userId).populate_existing().with_for_update().one_or_none()
+    return deposit

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -60,6 +60,14 @@ class BookOfferConcurrencyTest:
             with pytest.raises(sqlalchemy.exc.OperationalError):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
+        with engine.connect() as connection:
+            connection.execute(
+                text("""SELECT * FROM deposit WHERE "userId" = :user_id FOR UPDATE"""), user_id=beneficiary.id
+            )
+
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
+
         assert models.Booking.query.count() == 0
         assert offers_models.Stock.query.filter_by(id=stock.id, dnBookedQuantity=5).count() == 1
 


### PR DESCRIPTION
Lock la table `deposit` au moment de la réservation d'une offre pour éviter un mauvais calcul au moment de vérifier le crédit restant d'un jeune. 


