### PR TITLE
(PC-17966)[API] feat: Send an email after a venue is set to permanent.

### DIFF
--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -32,6 +32,7 @@ import pcapi.core.criteria.api as criteria_api
 import pcapi.core.criteria.models as criteria_models
 import pcapi.core.finance.exceptions as finance_exceptions
 import pcapi.core.finance.validation as finance_validation
+from pcapi.core.mails.transactional.pro.permanent_venue_needs_picture import send_permanent_venue_needs_picture
 import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.exceptions as offerers_exception
 from pcapi.core.offerers.models import Offerer
@@ -404,6 +405,12 @@ class VenueView(BaseAdminView):
         self._template_args["modal_title"] = f"Éditer des Lieux - {len(ids)} lieu(x) sélectionné(s)"
 
         return self.index_view()
+
+    def on_model_change(self, form: Form, venue: Venue, is_created: bool = False) -> None:
+        previous_value = form._fields["isPermanent"].object_data
+        new_value = venue.isPermanent
+        if venue.bookingEmail and new_value and previous_value != new_value:
+            send_permanent_venue_needs_picture(venue.bookingEmail, venue)
 
     @expose("/update/", methods=["POST"])
     def update_view(self) -> Response:

--- a/api/src/pcapi/core/mails/transactional/pro/permanent_venue_needs_picture.py
+++ b/api/src/pcapi/core/mails/transactional/pro/permanent_venue_needs_picture.py
@@ -1,0 +1,20 @@
+from pcapi.core import mails
+from pcapi.core.mails import models
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offerers.models import Venue
+from pcapi.utils.urls import build_pc_pro_venue_link
+
+
+def get_permanent_venue_needs_picture_data(venue: Venue) -> models.TransactionalEmailData:
+    return models.TransactionalEmailData(
+        template=TransactionalEmail.VENUE_NEEDS_PICTURE.value,
+        params={
+            "VENUE_NAME": venue.publicName or venue.name,
+            "VENUE_FORM_URL": build_pc_pro_venue_link(venue),
+        },
+    )
+
+
+def send_permanent_venue_needs_picture(recipient: str, venue: Venue) -> bool:
+    data = get_permanent_venue_needs_picture_data(venue)
+    return mails.send(recipients=[recipient], data=data)

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -165,3 +165,4 @@ class TransactionalEmail(Enum):
         id_prod=754, id_not_prod=99, tags=["pro_reinit_mdp_when_connected"]
     )
     WELCOME_TO_PRO = models.TemplatePro(id_prod=481, id_not_prod=57, tags=["pro-bienvenue-pass"])
+    VENUE_NEEDS_PICTURE = models.TemplatePro(id_prod=782, id_not_prod=113, tags=["pro_lieu_permanent"])


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17966

## But de la pull request

- Envoyer un mail d'incitation à ajouter un visuel pour lieu permanent, quand un lieu est sauvegardé sur FlaskAdmin comme étant permanent.