### PR TITLE
(jeremieb)[ADMIN] fix: use FlaskForm

### DIFF
--- a/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -3,6 +3,7 @@ import datetime
 from decimal import Decimal
 import typing
 
+from flask_admin.form import BaseForm
 from flask_login import current_user
 from jinja2.runtime import Context
 import markupsafe
@@ -55,7 +56,7 @@ def get_offerers(offerer_ids: list) -> list[dict[str, str]]:
 
 
 class AddForm(FlaskWTFSecureForm):
-    class Meta(FlaskWTFSecureForm.Meta):
+    class Meta(BaseForm.Meta):
         # Specify locale to use the comma as the decimal separator for
         # the `rate` field.
         locales = ["fr"]

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -18,7 +18,7 @@ from tests.conftest import clean_database
 
 class AdminUserViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_admin_user_creation(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -54,7 +54,7 @@ class AdminUserViewTest:
         assert token.expirationDate > datetime.utcnow() + timedelta(hours=20)
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_admin_user_receive_a_reset_password_token(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -82,7 +82,7 @@ class AdminUserViewTest:
         assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.EMAIL_VALIDATION_TO_PRO.value)
 
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_admin_user_creation_is_restricted_in_prod(self, mocked_validate_csrf_token, app, db_session):
         users_factories.AdminFactory(email="user@example.com")
 
@@ -104,7 +104,7 @@ class AdminUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_super_admin_can_suspend_then_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         admin = users_factories.AdminFactory(email="admin@example.com")
@@ -128,7 +128,7 @@ class AdminUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True)
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_simple_admin_can_not_suspend_admin(self, mocked_validate_csrf_token, app):
         admin_1 = users_factories.AdminFactory(email="admin1@example.com")
         admin_2 = users_factories.AdminFactory(email="admin2@example.com")
@@ -143,7 +143,7 @@ class AdminUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_simple_admin_can_not_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         admin_1 = users_factories.AdminFactory(email="admin1@example.com")

--- a/api/tests/admin/custom_views/api_key_view_test.py
+++ b/api/tests/admin/custom_views/api_key_view_test.py
@@ -10,7 +10,7 @@ from tests.conftest import clean_database
 
 class ApiKeyViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_api_key_creation(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
         offerer = offerers_factories.OffererFactory(siren=123456789)
@@ -29,7 +29,7 @@ class ApiKeyViewTest:
         assert api_key.secret is not None
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_api_key_creation_with_wrong_siren(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -27,7 +27,7 @@ class BeneficiaryUserViewTest:
     AGE18_ELIGIBLE_BIRTH_DATE = date.today() - relativedelta(years=18, months=4)
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_list_beneficiaries(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
         users_factories.BeneficiaryGrant18Factory.create_batch(3)
@@ -42,7 +42,7 @@ class BeneficiaryUserViewTest:
         assert response.status_code == 200
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_beneficiary_user_creation_for_deposit_v2(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="user@example.com")
 
@@ -145,7 +145,7 @@ class BeneficiaryUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     #  generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_suspend_beneficiary(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         booking = bookings_factories.IndividualBookingFactory()
@@ -166,7 +166,7 @@ class BeneficiaryUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     #  generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_unsuspend_beneficiary(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="user15@example.com", isActive=False)
@@ -209,7 +209,7 @@ class BeneficiaryUserViewTest:
         assert _allow_suspension_and_unsuspension(super_admin)
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_beneficiary_user_edition_does_not_send_email(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="user@example.com")
         user_to_edit = users_factories.BeneficiaryGrant18Factory(email="not_yet_edited@email.com")
@@ -237,7 +237,7 @@ class BeneficiaryUserViewTest:
         assert len(sendinblue_testing.sendinblue_requests) == 1
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
     def test_resend_validation_email_to_beneficiary(
         self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
@@ -255,7 +255,7 @@ class BeneficiaryUserViewTest:
 @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
 @pytest.mark.usefixtures("db_session")
 class BeneficiaryUserUpdateTest:
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_update_idpiecenumber(self, token, client):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         client.with_session_auth(super_admin.email)
@@ -277,7 +277,7 @@ class BeneficiaryUserUpdateTest:
 
         assert user_to_update.idPieceNumber == "123123123"
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_clear_idpiecenumber(self, token, client):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         client.with_session_auth(super_admin.email)
@@ -300,7 +300,7 @@ class BeneficiaryUserUpdateTest:
 
         assert user_to_update.idPieceNumber is None
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_update_idpiecenumber_not_updated(self, token, client):
         admin = users_factories.AdminFactory()  # not superadmin
 
@@ -321,7 +321,7 @@ class BeneficiaryUserUpdateTest:
 
         assert user_to_update.idPieceNumber != "123123123"
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_clear_ine_hash(self, token, client):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         client.with_session_auth(super_admin.email)

--- a/api/tests/admin/custom_views/booking_view_test.py
+++ b/api/tests/admin/custom_views/booking_view_test.py
@@ -12,7 +12,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
+@mock.patch("flask_wtf.csrf.validate_csrf", lambda *args, **kwargs: True)
 class BookingViewTest:
     def test_search_booking(self, app):
         users_factories.AdminFactory(email="admin@example.com")

--- a/api/tests/admin/custom_views/boost_pivot_view_test.py
+++ b/api/tests/admin/custom_views/boost_pivot_view_test.py
@@ -11,7 +11,7 @@ from tests.conftest import clean_database
 
 class CreateBoostPivotTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_boost_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         providers_factories.ProviderFactory(
@@ -44,7 +44,7 @@ class CreateBoostPivotTest:
 
 class EditBoostPivotTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_update_boost_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         boost_provider = providers_factories.ProviderFactory(
@@ -81,7 +81,7 @@ class EditBoostPivotTest:
 
 class DeleteBoostPivotTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_boost_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         boost_provider = providers_factories.ProviderFactory(
@@ -106,7 +106,7 @@ class DeleteBoostPivotTest:
         assert providers_models.CinemaProviderPivot.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_should_not_delete_boost_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         boost_provider = providers_factories.ProviderFactory(

--- a/api/tests/admin/custom_views/cine_office_pivot_view_test.py
+++ b/api/tests/admin/custom_views/cine_office_pivot_view_test.py
@@ -12,7 +12,7 @@ from tests.conftest import clean_database
 
 class CreateCineOfficePivotTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_cine_office_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -40,7 +40,7 @@ class CreateCineOfficePivotTest:
 
 class EditCineOfficePivotTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_update_cine_office_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -70,7 +70,7 @@ class EditCineOfficePivotTest:
 
 class DeleteCineOfficePivotTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_cine_office_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         cds_provider = get_provider_by_local_class("CDSStocks")
@@ -90,7 +90,7 @@ class DeleteCineOfficePivotTest:
         assert providers_models.CinemaProviderPivot.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_should_not_delete_cine_office_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         cds_provider = get_provider_by_local_class("CDSStocks")

--- a/api/tests/admin/custom_views/criteria_view_test.py
+++ b/api/tests/admin/custom_views/criteria_view_test.py
@@ -13,7 +13,7 @@ from tests.conftest import clean_database
 class CriteriaViewTest:
     @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_criterion(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -34,7 +34,7 @@ class CriteriaViewTest:
         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
     )
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_criterion_with_whitespace(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -50,7 +50,7 @@ class CriteriaViewTest:
         assert criteria_models.Criterion.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_criterion_too_long(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -66,7 +66,7 @@ class CriteriaViewTest:
         assert criteria_models.Criterion.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_criterion(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
+++ b/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
@@ -11,7 +11,7 @@ from tests.conftest import clean_database
 
 
 @clean_database
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+@mock.patch("flask_wtf.csrf.validate_csrf")
 def test_create_rule(mocked_validate_csrf_token, client, app):
     admin = users_factories.AdminFactory()
     offerer = offerers_factories.OffererFactory()
@@ -36,7 +36,7 @@ def test_create_rule(mocked_validate_csrf_token, client, app):
 
 
 @clean_database
-@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+@mock.patch("flask_wtf.csrf.validate_csrf")
 def test_edit_rule(mocked_validate_csrf_token, client, app):
     admin = users_factories.AdminFactory()
     timespan = (datetime.datetime.today() - datetime.timedelta(days=10), None)

--- a/api/tests/admin/custom_views/feature_view_test.py
+++ b/api/tests/admin/custom_views/feature_view_test.py
@@ -9,7 +9,7 @@ from tests.conftest import clean_database
 
 class FeatureViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_feature_edition(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
         inactive_feature = Feature.query.filter_by(isActive=False).first()

--- a/api/tests/admin/custom_views/many_offers_operations_view_test.py
+++ b/api/tests/admin/custom_views/many_offers_operations_view_test.py
@@ -21,7 +21,7 @@ from tests.conftest import TestClient
 
 @pytest.mark.usefixtures("db_session")
 class ManyOffersOperationsViewTest:
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_search_product_from_isbn(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -45,7 +45,7 @@ class ManyOffersOperationsViewTest:
         get_response = client.get(response.headers["location"])
         assert get_response.status_code == 200
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_search_product_from_visa(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -60,7 +60,7 @@ class ManyOffersOperationsViewTest:
         assert response.status_code == 302
         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/edit?visa=978148"
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_search_product_from_isbn_with_invalid_isbn(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -76,7 +76,7 @@ class ManyOffersOperationsViewTest:
         # Then
         assert response.status_code == 200
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_search_product_with_no_isbn_nor_visa(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -89,7 +89,7 @@ class ManyOffersOperationsViewTest:
         assert response.status_code == 200
 
     @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_product_offers_criteria_from_isbn(
         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
     ):
@@ -125,7 +125,7 @@ class ManyOffersOperationsViewTest:
         mocked_async_index_offer_ids.assert_called_once_with([offer1.id, offer2.id])
 
     @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_product_offers_criteria_from_visa(
         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
     ):
@@ -160,7 +160,7 @@ class ManyOffersOperationsViewTest:
         assert not unmatched_offer.criteria
         mocked_async_index_offer_ids.called_once_with([offer1.id, offer2.id])
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_product_offers_criteria_from_isbn_without_offers(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -173,7 +173,7 @@ class ManyOffersOperationsViewTest:
         assert response.status_code == 302
         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_product_offers_criteria_from_visa_without_offers(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -215,7 +215,7 @@ class ManyOffersOperationsViewTest:
         ],
     )
     @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_product_gcu_compatibility(
         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app, db_session, validation_status
     ):

--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -131,7 +131,7 @@ class OfferValidationViewTest:
         # then
         assert url_for(view_name) in response.data.decode("utf-8")
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_approve_offer_and_go_to_next_offer(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -171,7 +171,7 @@ class OfferValidationViewTest:
         assert response.status_code == 302
         assert url_for("validation.edit", id=oldest_offer.id) in response.location
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_approve_last_pending_offer_and_go_to_the_next_offer_redirect_to_validation_page(
         self, mocked_validate_csrf_token, client
     ):
@@ -198,7 +198,7 @@ class OfferValidationViewTest:
         assert response.status_code == 302
         assert url_for("validation.index_view") in response.location
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     def test_approve_virtual_offer_and_send_mail_to_managing_offerer(
         self,
@@ -226,7 +226,7 @@ class OfferValidationViewTest:
             offer, OfferValidationStatus.APPROVED, ["pro@example.com"]
         )
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     def test_approve_physical_offer_and_send_mail_to_venue_booking_email(
         self,
@@ -251,7 +251,7 @@ class OfferValidationViewTest:
             offer, OfferValidationStatus.APPROVED, ["venue@example.com"]
         )
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
     def test_import_validation_config(self, mocked_validate_csrf_token, client):
         # Given
@@ -317,7 +317,7 @@ class OfferValidationViewTest:
             ],
         }
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
     def test_import_validation_config_fail_with_wrong_value(self, mocked_validate_csrf_token, client):
         # Given
@@ -351,7 +351,7 @@ class OfferValidationViewTest:
         # Then
         assert response.status_code == 400
 
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
     def test_import_validation_config_inaccessible_when_user_is_not_super_admin(
         self, mocked_validate_csrf_token, client
@@ -390,7 +390,7 @@ class OfferValidationViewTest:
         assert url_for("admin.index") in response.location
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_offer_and_send_mail_to_administration(
         self,
@@ -432,7 +432,7 @@ class OfferValidationViewTest:
         assert offer.lastValidationType == OfferValidationType.MANUAL
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_offer_and_send_mail_to_administration(
         self,
@@ -551,7 +551,7 @@ class OfferValidationViewTest:
     @pytest.mark.parametrize(
         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
     )
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_batch_approve_offers(self, mocked_validate_csrf_token, action, expected, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -586,7 +586,7 @@ class OfferValidationViewTest:
         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
 
     @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.offers.api.update_pending_offer_validation")
     def test_batch_approve_reject_offers_not_updated(
         self,
@@ -627,7 +627,7 @@ class OfferValidationViewTest:
         )
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_collective_offer_template_and_send_mail_to_administration(
         self,
@@ -671,7 +671,7 @@ class OfferValidationViewTest:
         assert offer.lastValidationType == OfferValidationType.MANUAL
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_collective_offer_template_and_send_mail_to_administration(
         self,
@@ -759,7 +759,7 @@ class OfferValidationViewTest:
     @pytest.mark.parametrize(
         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
     )
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_batch_approve_collective_offers_template(self, mocked_validate_csrf_token, action, expected, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -794,7 +794,7 @@ class OfferValidationViewTest:
         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
 
     @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.offers.api.update_pending_offer_validation")
     def test_batch_approve_reject_collective_offers_template_not_updated(
         self,
@@ -838,7 +838,7 @@ class OfferValidationViewTest:
 
     @freeze_time("2020-11-17 15:00:00")
     @override_settings(ADAGE_API_URL="https://adage_base_url")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_collective_offer_and_send_mail_to_administration_and_notify_adage(
         self,
@@ -889,7 +889,7 @@ class OfferValidationViewTest:
         assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_collective_offer_and_send_mail_to_administration(
         self,
@@ -1013,7 +1013,7 @@ class OfferValidationViewTest:
         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
     )
     @override_settings(ADAGE_API_URL="https://adage_base_url")
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_batch_approve_collective_offers(self, mocked_validate_csrf_token, action, expected, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -1055,7 +1055,7 @@ class OfferValidationViewTest:
         assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
 
     @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.offers.api.update_pending_offer_validation")
     def test_batch_approve_reject_collective_offers_not_updated(
         self,
@@ -1098,7 +1098,7 @@ class OfferValidationViewTest:
 
 class OfferViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_approved_offer(
@@ -1132,7 +1132,7 @@ class OfferViewTest:
         )
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_rejected_offer(
@@ -1162,7 +1162,7 @@ class OfferViewTest:
         assert mocked_send_offer_validation_status_update_email.call_count == 1
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     @patch("pcapi.workers.push_notification_job.send_cancel_booking_notification.delay")
@@ -1196,7 +1196,7 @@ class OfferViewTest:
         mocked_send_cancel_booking_notification.assert_called_once_with([unused_booking.id])
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_change_to_draft_approved_offer(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.APPROVED, isActive=True)
@@ -1210,7 +1210,7 @@ class OfferViewTest:
         assert offer.lastValidationType == OfferValidationType.AUTO  # unchanged
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.reindex_offer_ids")
     def test_reindex_when_tags_updated(
         self,
@@ -1234,7 +1234,7 @@ class OfferViewTest:
 
 class OfferForVenueSubviewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory(email="user@example.com")
         client = client.with_session_auth(admin.email)

--- a/api/tests/admin/custom_views/offerer_tag_view_test.py
+++ b/api/tests/admin/custom_views/offerer_tag_view_test.py
@@ -12,7 +12,7 @@ from tests.conftest import clean_database
 class OffererTagViewTest:
     @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_tag(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -28,7 +28,7 @@ class OffererTagViewTest:
         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
     )
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_tag_with_whitespace(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -41,7 +41,7 @@ class OffererTagViewTest:
         assert offerers_models.OffererTag.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_create_tag_too_long(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -54,7 +54,7 @@ class OffererTagViewTest:
         assert offerers_models.OffererTag.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_tag(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/offerer_view_test.py
+++ b/api/tests/admin/custom_views/offerer_view_test.py
@@ -16,7 +16,7 @@ from tests.conftest import clean_database
 
 class OffererViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_offerer_add_tags(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -49,7 +49,7 @@ class OffererViewTest:
         assert history_models.ActionHistory.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_edit_offerer_remove_tags(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -87,7 +87,7 @@ class OffererViewTest:
         "booking_status", [None, BookingStatus.USED, BookingStatus.CANCELLED, BookingStatus.REIMBURSED]
     )
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_deactivate_offerer(self, mocked_validate_csrf_token, client, booking_status):
         admin = users_factories.AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -130,7 +130,7 @@ class OffererViewTest:
 
     @pytest.mark.parametrize("booking_status", [BookingStatus.PENDING, BookingStatus.CONFIRMED])
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_deactivate_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
         admin = users_factories.AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -165,7 +165,7 @@ class OffererViewTest:
         assert history_models.ActionHistory.query.count() == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_reactivate_offerer(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory(email="user@example.com")
         offerer = offerers_factories.OffererFactory(isActive=False)
@@ -205,7 +205,7 @@ class OffererViewTest:
         assert actions_list[0].offerer == offerer
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_offerer(self, mocked_validate_csrf_token, client):
         # Can delete offerer because there is no booking
         admin = users_factories.AdminFactory(email="user@example.com")
@@ -237,7 +237,7 @@ class OffererViewTest:
         ],
     )
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
         admin = users_factories.AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -261,7 +261,7 @@ class OffererViewTest:
         assert len(external_testing.sendinblue_requests) == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_offerer_rejected_because_of_princing_point(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory()
         venue = offerers_factories.VenueFactory(pricing_point="self")

--- a/api/tests/admin/custom_views/partner_user_view_test.py
+++ b/api/tests/admin/custom_views/partner_user_view_test.py
@@ -94,7 +94,7 @@ class PartnerUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_super_admin_can_suspend_then_unsuspend_partner(self, mocked_validate_csrf_token, app):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         partner = users_factories.UserFactory(email="partner@example.com")
@@ -113,7 +113,7 @@ class PartnerUserViewTest:
         assert partner.isActive
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
     def test_resend_validation_email_to_partner(
         self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
@@ -129,7 +129,7 @@ class PartnerUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_clear_profile(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory()
         user = users_factories.UserFactory(
@@ -181,7 +181,7 @@ class PartnerUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_clear_idpiecenumber(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory(email="superadmin@example.com")
         user = users_factories.UserFactory(

--- a/api/tests/admin/custom_views/pro_user_view_test.py
+++ b/api/tests/admin/custom_views/pro_user_view_test.py
@@ -20,7 +20,7 @@ from tests.conftest import clean_database
 
 class ProUserViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_pro_user_creation(self, mocked_validate_csrf_token, app):
         # Given
         bo_user = users_factories.AdminFactory(email="USER@example.com")
@@ -89,7 +89,7 @@ class ProUserViewTest:
         assert actions_list[0].offerer == offerer_created
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_pro_user_edition(self, mocked_validate_csrf_token, app):
         # Given
         admin_user = users_factories.AdminFactory()
@@ -123,7 +123,7 @@ class ProUserViewTest:
         assert updated_user.phoneNumber == "+33601020304"
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_pro_user_edition_phone_number_error(self, mocked_validate_csrf_token, app):
         # Given
         admin_user = users_factories.AdminFactory()
@@ -201,7 +201,7 @@ class ProUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     # generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_suspend_pro(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         pro = users_factories.ProFactory(email="user15@example.com")
@@ -220,7 +220,7 @@ class ProUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     # generate a valid CSRF token in tests. This should be fixed.
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_unsuspend_pro(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         pro = users_factories.ProFactory(email="user15@example.com", isActive=False)

--- a/api/tests/admin/custom_views/user_offerer_view_test.py
+++ b/api/tests/admin/custom_views/user_offerer_view_test.py
@@ -10,7 +10,7 @@ from tests.conftest import clean_database
 
 class UserOffererViewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_user_offerer(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/venue_provider_view_test.py
+++ b/api/tests/admin/custom_views/venue_provider_view_test.py
@@ -38,7 +38,7 @@ class VenueProviderViewTest:
 
 class EditModelTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.workers.venue_provider_job.synchronize_venue_provider")
     @patch("pcapi.core.providers.api._siret_can_be_synchronized")
     def test_edit_venue_provider(
@@ -86,7 +86,7 @@ class EditModelTest:
         mock_synchronize_venue_provider.assert_called_once_with(venue_provider)
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.providers.api._siret_can_be_synchronized")
     def test_provider_not_synchronizable(self, mock_siret_can_be_synchronized, validate_csrf_token, client):
         # Given
@@ -112,7 +112,7 @@ class EditModelTest:
         assert venue_provider.venueIdAtOfferProvider == "old-siret"
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.workers.venue_provider_job.synchronize_venue_provider")
     def test_allocine_provider(self, synchronize_venue_provider, validate_csrf_token, client):
         # Given

--- a/api/tests/admin/custom_views/venue_view_test.py
+++ b/api/tests/admin/custom_views/venue_view_test.py
@@ -40,7 +40,7 @@ def base_form_data(venue: Venue) -> dict:
 
 class EditVenueTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_update_adage_id(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -56,7 +56,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_add_siret_to_venue_without_pricing_point(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
@@ -84,7 +84,7 @@ class EditVenueTest:
         }
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_edit_siret_with_self_pricing_point(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
@@ -114,7 +114,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.SireneApiException)
     def test_unavailable_sirene_api_warning(
@@ -146,7 +146,7 @@ class EditVenueTest:
         }
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_remove_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -165,7 +165,7 @@ class EditVenueTest:
         assert len(external_testing.zendesk_sell_requests) == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_set_not_all_digits_siret(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
@@ -186,7 +186,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_use_inactive_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -206,7 +206,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_set_already_used_siret(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
@@ -232,7 +232,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_add_siret_if_exisiting_pricing_point(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
@@ -258,7 +258,7 @@ class EditVenueTest:
         assert len(external_testing.zendesk_sell_requests) == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_update_venue_other_offer_id_at_provider(self, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         business_unit = finance_factories.BusinessUnitFactory(siret="11111111111111")
@@ -295,7 +295,7 @@ class EditVenueTest:
         assert offer.idAtProvider == "id_at_provider_ne_contenant_pas_le_siret"
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_update_venue_without_siret(self, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         business_unit = finance_factories.BusinessUnitFactory(siret="11111111111111")
@@ -324,7 +324,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_update_venue_reindex_all(self, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -358,7 +358,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     @patch("pcapi.core.search.async_index_venue_ids")
     def test_update_venue_reindex_venue_only(
@@ -394,7 +394,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     @patch("pcapi.core.search.async_index_venue_ids")
     @patch("pcapi.core.search.reindex_venue_ids")
@@ -435,7 +435,7 @@ class EditVenueTest:
 
 class DeleteVenueTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_venue(self, mocked_validate_csrf_token, client):
         admin = AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory(bookingEmail="booking@example.com")
@@ -467,7 +467,7 @@ class DeleteVenueTest:
         ],
     )
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_venue_rejected(self, mocked_validate_csrf_token, client, booking_status):
         admin = AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -490,7 +490,7 @@ class DeleteVenueTest:
         assert len(external_testing.sendinblue_requests) == 0
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_delete_venue_rejected_because_of_princing_point(self, mocked_validate_csrf_token, client):
         admin = AdminFactory()
         venue = offerers_factories.VenueFactory(pricing_point="self")
@@ -540,7 +540,7 @@ class GetVenueProviderLinkTest:
 
 class VenueForOffererSubviewTest:
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
         admin = AdminFactory(email="user@example.com")
         offerer = offerers_factories.OffererFactory()
@@ -560,7 +560,7 @@ class VenueForOffererSubviewTest:
         assert sorted(venue_ids) == sorted([str(venue1.id), str(venue2.id)])
 
     @clean_database
-    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    @patch("flask_wtf.csrf.validate_csrf")
     def test_list_venues_for_offerer_not_found(self, mocked_validate_csrf_token, client):
         admin = AdminFactory(email="user@example.com")
 


### PR DESCRIPTION
## But de la pull request

Fix : certaines formulaires de `FlaskAdmin` n'avaient plus de _csrf_token_, ce qui bloquait certaines opérations. Faire hériter la nouvelle classe `FlaskWTFSecureForm` de `FlaskForm` et supprimer la sous-classe `Meta` permet de régler ce problème.

En revanche, avec l'arrivée de `FlaskForm` (qui provient de **flask-wtf** contrairement à `SecureForm` qui provient de **flask-admin**), on se retrouvait avec des erreurs de validation inexplicables. La seule différence que j'ai trouvé par rapport à master est que les formulaires n'ont plus de champ `_obj` (défini par `BaseForm` de **flask-admin**, dont `SecureForm` hérite), ce qui génère des erreurs qui n'apparaissaient pas avant.

Le champ `_obj` est créé [ici](https://github.com/flask-admin/flask-admin/blob/master/flask_admin/form/__init__.py#L14). Et le validateur `Unique` de **flask-admin** s'attend à le retrouver à [cet endroit](https://github.com/flask-admin/flask-admin/blob/master/flask_admin/contrib/sqla/validators.py#L42).

Et avec l'arrivée de FlaskForm, il fallait aussi corriger tous les patchs de `wtforms.csrf.session.SessionCSRF.validate_csrf_token`.

Le bug a été introduit par cette PR : https://github.com/pass-culture/pass-culture-main/pull/4203