### PR TITLE
(PC-18551)[API] feat: better handles issues with identity check

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -735,4 +735,7 @@ def get_subscription_message(user: users_models.User) -> models.SubscriptionMess
 
 
 def has_subscription_issues(user: users_models.User) -> bool:
-    return get_subscription_message(user) is not None
+    return get_identity_check_subscription_status(user, user.eligibility) in [
+        models.SubscriptionItemStatus.SUSPICIOUS,
+        models.SubscriptionItemStatus.KO,
+    ]

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -109,14 +109,19 @@ class YoungStatusTest:
                 phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
-                status=fraud_models.FraudCheckStatus.OK,
                 type=fraud_models.FraudCheckType.PROFILE_COMPLETION,
+                status=fraud_models.FraudCheckStatus.OK,
                 user=user,
             )
             fraud_factories.BeneficiaryFraudCheckFactory(
-                reasonCodes=[fraud_models.FraudReasonCode.ID_CHECK_EXPIRED],
-                status=fraud_models.FraudCheckStatus.SUSPICIOUS,
+                status=fraud_models.FraudCheckStatus.KO,
+                reasonCodes=[fraud_models.FraudReasonCode.INVALID_ID_PIECE_NUMBER],
                 type=fraud_models.FraudCheckType.UBBLE,
+                user=user,
+            )
+            fraud_factories.BeneficiaryFraudCheckFactory(
+                status=fraud_models.FraudCheckStatus.OK,
+                type=fraud_models.FraudCheckType.HONOR_STATEMENT,
                 user=user,
             )
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -337,11 +337,10 @@ class AccountTest:
         n_queries += 1  # get feature enable_ubble
         n_queries += 1  # get feature enable_subscription_limitatin
         n_queries += 1  # has beneficiary_fraud_review (from get_subscription_message)
-        n_queries += 1  # get feature enable_native_cultural_survey
         n_queries += 1  # check pending status get_identity_check_subscription_status
         n_queries += 1  # check issues has_subscription_issues
-        n_queries += 1  # check issues has_subscription_issues
         n_queries += 1  # check has to complete step get_next_subscription_step
+        n_queries += 1  # get feature enable_native_cultural_survey
 
         with testing.assert_num_queries(n_queries):
             response = client.get("/native/v1/me")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18551

## But de la pull request

on a améliorer la détection des erreurs liés à identity check qui permet de détecter le sous statut `has_subscription_issues` du statut `Eligible`

On améliorera les problèmes liés au numéro de téléphone avec cette US https://passculture.atlassian.net/browse/PC-18598

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
