### PR TITLE
Jeremieb/bo remove csrf protection

### DIFF
--- a/api/src/pcapi/admin/base_configuration.py
+++ b/api/src/pcapi/admin/base_configuration.py
@@ -72,35 +72,13 @@ class BaseSuperAdminMixin(BaseAdminMixin):
         return authorized
 
 
-class FlaskWTFSecureForm(SecureForm):
-    """
-    To be used only if Flask-WTF is activated: it will handle all the
-    CSRF protection. Both FlaskAdmin internal configuration for CSRF
-    protection and Flask-WTF cannot work together.
-
-    The later adds some defaults (config and jinja filters) that will
-    automatically add a CSRF token and run all the related security
-    checks.
-
-    Note:
-        Flask-WTF has an `exempt()` method that deactivates CSRF
-        protection for a blueprint... which sounds great but the
-        overriden defaults stays. The result is that a FlaskAdmin view
-        with a SecureForm will have two CSRF tokens... and the form will
-        be considered invalid.
-    """
-
-    class Meta:
-        csrf = False
-
-
 class BaseAdminView(BaseAdminMixin, ModelView):
     page_size = 25
     can_set_page_size = True
     can_create = False
     can_edit = False
     can_delete = False
-    form_base_class = FlaskWTFSecureForm
+    form_base_class = SecureForm
 
     def inaccessible_callback(self, name, **kwargs):  # type: ignore [no-untyped-def]
         return werkzeug.utils.redirect(url_for("admin.index"))

--- a/api/src/pcapi/admin/base_configuration.py
+++ b/api/src/pcapi/admin/base_configuration.py
@@ -8,13 +8,12 @@ from flask_admin import expose
 from flask_admin.base import AdminIndexView as AdminIndexBaseView
 from flask_admin.base import BaseView
 from flask_admin.contrib.sqla import ModelView
-from flask_admin.form import BaseForm
+from flask_admin.form import SecureForm
 from flask_admin.helpers import get_form_data
 from flask_login import current_user
 from flask_login import login_user
 from flask_login import logout_user
 from flask_sqlalchemy import Model
-from flask_wtf.form import FlaskForm
 import werkzeug
 
 from pcapi import settings
@@ -73,15 +72,26 @@ class BaseSuperAdminMixin(BaseAdminMixin):
         return authorized
 
 
-class FlaskWTFSecureForm(BaseForm, FlaskForm):
+class FlaskWTFSecureForm(SecureForm):
     """
-    FlaskForm handles all the CSRF protection.
+    To be used only if Flask-WTF is activated: it will handle all the
+    CSRF protection. Both FlaskAdmin internal configuration for CSRF
+    protection and Flask-WTF cannot work together.
 
-    BaseForm is needed because FlaskAdmin expects forms to inherit from
-    this base class.
+    The later adds some defaults (config and jinja filters) that will
+    automatically add a CSRF token and run all the related security
+    checks.
+
+    Note:
+        Flask-WTF has an `exempt()` method that deactivates CSRF
+        protection for a blueprint... which sounds great but the
+        overriden defaults stays. The result is that a FlaskAdmin view
+        with a SecureForm will have two CSRF tokens... and the form will
+        be considered invalid.
     """
 
-    pass  # pylint: disable=unnecessary-pass
+    class Meta:
+        csrf = False
 
 
 class BaseAdminView(BaseAdminMixin, ModelView):
@@ -95,7 +105,7 @@ class BaseAdminView(BaseAdminMixin, ModelView):
     def inaccessible_callback(self, name, **kwargs):  # type: ignore [no-untyped-def]
         return werkzeug.utils.redirect(url_for("admin.index"))
 
-    def after_model_change(self, form: FlaskWTFSecureForm, model: Model, is_created: bool) -> None:
+    def after_model_change(self, form: SecureForm, model: Model, is_created: bool) -> None:
         action = "Création" if is_created else "Modification"
         model_name = str(model)
         logger.info("[ADMIN] %s du modèle %s par l'utilisateur %s", action, model_name, current_user)

--- a/api/src/pcapi/admin/custom_views/booking_view.py
+++ b/api/src/pcapi/admin/custom_views/booking_view.py
@@ -3,13 +3,13 @@ from flask import request
 from flask.helpers import flash
 from flask.helpers import url_for
 from flask_admin import expose
+from flask_admin.form import SecureForm
 from sqlalchemy.orm import joinedload
 import werkzeug
 from wtforms import StringField
 from wtforms import validators
 
 from pcapi.admin.base_configuration import BaseCustomAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 from pcapi.core.bookings import models as booking_models
 import pcapi.core.bookings.api as bookings_api
 import pcapi.core.bookings.exceptions as bookings_exceptions
@@ -28,7 +28,7 @@ def _get_error_msg(error: Exception) -> str:
     return BOOKING_ERRORS_MSG.get(type(error), str(error))
 
 
-class SearchForm(FlaskWTFSecureForm):
+class SearchForm(SecureForm):
     token = StringField(
         "Code de contremarque",
         validators=[validators.DataRequired()],
@@ -36,11 +36,11 @@ class SearchForm(FlaskWTFSecureForm):
     )
 
 
-class MarkAsUsedForm(FlaskWTFSecureForm):
+class MarkAsUsedForm(SecureForm):
     pass
 
 
-class CancelForm(FlaskWTFSecureForm):
+class CancelForm(SecureForm):
     pass
 
 

--- a/api/src/pcapi/admin/custom_views/boost_pivot_view.py
+++ b/api/src/pcapi/admin/custom_views/boost_pivot_view.py
@@ -1,6 +1,7 @@
 import typing
 
 from flask import flash
+from flask_admin.form import SecureForm
 from werkzeug.exceptions import Forbidden
 from wtforms import Form
 from wtforms import IntegerField
@@ -9,14 +10,13 @@ from wtforms.validators import DataRequired
 from wtforms.validators import URL
 
 from pcapi.admin.base_configuration import BaseAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.providers.models as providers_models
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.models import db
 
 
-class BoostPivotForm(FlaskWTFSecureForm):
+class BoostPivotForm(SecureForm):
     venue_id = IntegerField("Identifiant numérique du lieu (pass Culture)", [DataRequired()])
     cinema_id = StringField("Identifiant Cinéma (Boost)", [DataRequired()])
     username = StringField("Nom d'utilisateur (Boost)", [DataRequired()])

--- a/api/src/pcapi/admin/custom_views/cine_office_pivot_view.py
+++ b/api/src/pcapi/admin/custom_views/cine_office_pivot_view.py
@@ -1,6 +1,7 @@
 import typing
 
 from flask import flash
+from flask_admin.form import SecureForm
 from werkzeug.exceptions import Forbidden
 from wtforms import Form
 from wtforms import IntegerField
@@ -8,14 +9,13 @@ from wtforms import StringField
 from wtforms.validators import DataRequired
 
 from pcapi.admin.base_configuration import BaseAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.providers.models as providers_models
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.models import db
 
 
-class CineOfficePivotForm(FlaskWTFSecureForm):
+class CineOfficePivotForm(SecureForm):
     venue_id = IntegerField("Identifiant numérique du lieu (pass Culture)", [DataRequired()])
     account_id = StringField("Nom de compte (CDS)", [DataRequired()])
     cinema_id = StringField("Identifiant cinéma (CDS)", [DataRequired()])

--- a/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -3,7 +3,6 @@ import datetime
 from decimal import Decimal
 import typing
 
-from flask_admin.form import BaseForm
 from flask_login import current_user
 from jinja2.runtime import Context
 import markupsafe
@@ -56,7 +55,7 @@ def get_offerers(offerer_ids: list) -> list[dict[str, str]]:
 
 
 class AddForm(FlaskWTFSecureForm):
-    class Meta(BaseForm.Meta):
+    class Meta(FlaskWTFSecureForm.Meta):
         # Specify locale to use the comma as the decimal separator for
         # the `rate` field.
         locales = ["fr"]

--- a/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -3,6 +3,7 @@ import datetime
 from decimal import Decimal
 import typing
 
+from flask_admin.form import SecureForm
 from flask_login import current_user
 from jinja2.runtime import Context
 import markupsafe
@@ -17,7 +18,6 @@ from pcapi.admin import fields
 from pcapi.admin import permissions
 from pcapi.admin import widgets
 from pcapi.admin.base_configuration import BaseAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 from pcapi.core.categories.categories import ALL_CATEGORIES_DICT
 from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES
 from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES_DICT
@@ -54,8 +54,8 @@ def get_offerers(offerer_ids: list) -> list[dict[str, str]]:
     ]
 
 
-class AddForm(FlaskWTFSecureForm):
-    class Meta(FlaskWTFSecureForm.Meta):
+class AddForm(SecureForm):
+    class Meta(SecureForm.Meta):
         # Specify locale to use the comma as the decimal separator for
         # the `rate` field.
         locales = ["fr"]
@@ -98,7 +98,7 @@ class AddForm(FlaskWTFSecureForm):
     )
 
 
-class EditForm(FlaskWTFSecureForm):
+class EditForm(SecureForm):
     end_date = wtf_fields.DateField(
         "Date de fin d'application",
         validators=[wtf_validators.DataRequired()],

--- a/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
+++ b/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
@@ -6,13 +6,13 @@ from flask.helpers import flash
 from flask.helpers import url_for
 from flask_admin import expose
 from flask_admin.contrib.sqla.fields import QuerySelectMultipleField
+from flask_admin.form import SecureForm
 from sqlalchemy.orm import joinedload
 from werkzeug.wrappers import Response
 from wtforms import StringField
 from wtforms import validators
 
 from pcapi.admin.base_configuration import BaseCustomAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 from pcapi.core.categories import categories
 from pcapi.core.criteria.models import Criterion
 from pcapi.core.offers.api import add_criteria_to_offers
@@ -22,7 +22,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
-class SearchForm(FlaskWTFSecureForm):
+class SearchForm(SecureForm):
     isbn = StringField(
         "ISBN",
     )
@@ -43,7 +43,7 @@ def _is_isbn_valid(isbn: str) -> bool:
     return len(_format_isbn(isbn)) == 13
 
 
-class OfferCriteriaForm(FlaskWTFSecureForm):
+class OfferCriteriaForm(SecureForm):
     criteria = QuerySelectMultipleField(
         query_factory=_select_criteria,
         allow_blank=True,

--- a/api/src/pcapi/admin/custom_views/mixins/resend_validation_email_mixin.py
+++ b/api/src/pcapi/admin/custom_views/mixins/resend_validation_email_mixin.py
@@ -3,14 +3,14 @@ from flask import redirect
 from flask import request
 from flask import url_for
 from flask_admin import expose
+from flask_admin.form import SecureForm
 from markupsafe import Markup
 
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 import pcapi.core.users.api as users_api
 from pcapi.core.users.models import User
 
 
-class ResendValidationEmailForm(FlaskWTFSecureForm):
+class ResendValidationEmailForm(SecureForm):
     pass  # empty form, only has the CSRF token field
 
 

--- a/api/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
+++ b/api/src/pcapi/admin/custom_views/mixins/suspension_mixin.py
@@ -4,6 +4,7 @@ from flask import request
 from flask import url_for
 from flask_admin import expose
 from flask_admin.actions import action
+from flask_admin.form import SecureForm
 from flask_login import current_user
 from markupsafe import Markup
 from werkzeug.exceptions import Conflict
@@ -11,14 +12,13 @@ from werkzeug.exceptions import Forbidden
 import wtforms.validators
 
 from pcapi import settings
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 import pcapi.core.bookings.exceptions as bookings_exceptions
 import pcapi.core.users.api as users_api
 import pcapi.core.users.constants as users_constants
 from pcapi.core.users.models import User
 
 
-class SuspensionForm(FlaskWTFSecureForm):
+class SuspensionForm(SecureForm):
     reason = wtforms.SelectField(
         "Raison de la suspension",
         choices=(("", "---"),) + users_constants.SUSPENSION_REASON_CHOICES,
@@ -26,7 +26,7 @@ class SuspensionForm(FlaskWTFSecureForm):
     )
 
 
-class UnsuspensionForm(FlaskWTFSecureForm):
+class UnsuspensionForm(SecureForm):
     pass  # empty form, only has the CSRF token field
 
 

--- a/api/src/pcapi/admin/custom_views/offer_view.py
+++ b/api/src/pcapi/admin/custom_views/offer_view.py
@@ -11,6 +11,7 @@ from flask_admin.actions import action
 from flask_admin.base import expose
 from flask_admin.contrib.sqla import fields
 from flask_admin.contrib.sqla import filters
+from flask_admin.form import SecureForm
 from flask_admin.helpers import get_form_data
 from flask_admin.helpers import get_redirect_target
 from flask_admin.helpers import is_form_submitted
@@ -32,7 +33,6 @@ import yaml
 
 from pcapi.admin.base_configuration import BaseAdminView
 from pcapi.admin.base_configuration import BaseSuperAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 from pcapi.core import search
 from pcapi.core.bookings.api import cancel_bookings_from_rejected_offer
 from pcapi.core.categories import categories
@@ -397,7 +397,7 @@ def _venue_link(view: BaseAdminView, context: Context, model: models.Offer, name
     return link.format(url=escape(url), name=escape(model.venue.publicName or model.venue.name))
 
 
-class OfferValidationForm(FlaskWTFSecureForm):
+class OfferValidationForm(SecureForm):
     validation = wtforms.SelectField(
         "validation",
         choices=[(choice.name, choice.value) for choice in models.OfferValidationStatus if choice.name != "DRAFT"],
@@ -650,7 +650,7 @@ def date_formatter(view, context, model, name) -> datetime:  # type: ignore [no-
     return config_date.strftime("%Y-%m-%d %H:%M:%S")
 
 
-class OfferValidationConfigForm(FlaskWTFSecureForm):
+class OfferValidationConfigForm(SecureForm):
     specs = wtforms.TextAreaField("Configuration", [InputRequired()])
 
 

--- a/api/src/pcapi/admin/custom_views/suspend_fraudulent_users_by_email_providers.py
+++ b/api/src/pcapi/admin/custom_views/suspend_fraudulent_users_by_email_providers.py
@@ -1,17 +1,17 @@
 from flask import flash
 from flask import request
 from flask_admin.base import expose
+from flask_admin.form import SecureForm
 from flask_login import current_user
 from werkzeug import Response
 from wtforms import StringField
 from wtforms.validators import DataRequired
 
 from pcapi.admin.base_configuration import BaseCustomSuperAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 from pcapi.scripts.suspend_fraudulent_beneficiary_users import suspend_fraudulent_beneficiary_users_by_email_providers
 
 
-class EmailDomainsForm(FlaskWTFSecureForm):
+class EmailDomainsForm(SecureForm):
     domains = StringField(
         "Noms de domaine",
         [

--- a/api/src/pcapi/admin/custom_views/suspend_fraudulent_users_by_ids.py
+++ b/api/src/pcapi/admin/custom_views/suspend_fraudulent_users_by_ids.py
@@ -7,12 +7,12 @@ from flask import redirect
 from flask import request
 from flask import url_for
 from flask_admin import expose
+from flask_admin.form import SecureForm
 from flask_login import current_user
 from werkzeug import Response
 from wtforms import FileField
 
 from pcapi.admin.base_configuration import BaseCustomSuperAdminView
-from pcapi.admin.base_configuration import FlaskWTFSecureForm
 from pcapi.workers.suspend_fraudulent_beneficiary_users_by_ids_job import (
     suspend_fraudulent_beneficiary_users_by_ids_job,
 )
@@ -25,7 +25,7 @@ def allowed_file(filename):  # type: ignore [no-untyped-def]
     return pathlib.Path(filename).suffix.lower() in ALLOWED_EXTENSIONS
 
 
-class SuspendFraudulentUsersByIdsForm(FlaskWTFSecureForm):
+class SuspendFraudulentUsersByIdsForm(SecureForm):
     user_ids_csv = FileField("Importer un fichier CSV contenant une seule colonne des utilisateurs à suspendre")
 
 

--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -43,8 +43,8 @@ def log_action(
         actionType=action_type,
         authorUser=author,
         user=user,
-        offerer=offerer,
-        venue=venue,
+        offerer=offerer,  # type: ignore
+        venue=venue,  # type: ignore
         comment=comment,
         extraData=extra_data,
     )

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -1,13 +1,17 @@
 import enum
+import typing
 
 import sqlalchemy as sa
 
-from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import models as users_models
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models.extra_data_mixin import ExtraDataMixin
 from pcapi.models.pc_object import PcObject
+
+
+if typing.TYPE_CHECKING:
+    from pcapi.core.offerers import models as offerers_models
 
 
 class ActionType(enum.Enum):
@@ -80,7 +84,7 @@ class ActionHistory(PcObject, Base, Model, ExtraDataMixin):
     offererId: int | None = sa.Column(
         sa.BigInteger, sa.ForeignKey("offerer.id", ondelete="CASCADE"), index=True, nullable=True
     )
-    offerer: offerers_models.Offerer | None = sa.orm.relationship(
+    offerer: sa.orm.Mapped["offerers_models.Offerer | None"] = sa.orm.relationship(
         "Offerer",
         foreign_keys=[offererId],
         backref=sa.orm.backref(
@@ -91,7 +95,7 @@ class ActionHistory(PcObject, Base, Model, ExtraDataMixin):
     venueId: int | None = sa.Column(
         sa.BigInteger, sa.ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=True
     )
-    venue: offerers_models.Venue | None = sa.orm.relationship(
+    venue: sa.orm.Mapped["offerers_models.Venue | None"] = sa.orm.relationship(
         "Venue",
         foreign_keys=[venueId],
         backref=sa.orm.backref(

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -11,7 +11,6 @@ import flask.wrappers
 from flask_jwt_extended import JWTManager
 from flask_login import LoginManager
 from flask_login import current_user
-from flask_wtf.csrf import CSRFProtect
 import redis
 import sentry_sdk
 from sqlalchemy import orm
@@ -141,6 +140,7 @@ app.config["JWT_ACCESS_TOKEN_EXPIRES"] = settings.JWT_ACCESS_TOKEN_EXPIRES
 app.config["RATELIMIT_STORAGE_URL"] = settings.REDIS_URL
 app.config["GOOGLE_CLIENT_ID"] = settings.GOOGLE_CLIENT_ID
 app.config["GOOGLE_CLIENT_SECRET"] = settings.GOOGLE_CLIENT_SECRET
+app.config["WTF_CSRF_ENABLED"] = False
 
 oauth = OAuth(app)
 oauth.register(
@@ -152,8 +152,6 @@ oauth.register(
 jwt = JWTManager(app)
 
 rate_limiter.init_app(app)
-
-csrf = CSRFProtect(app)
 
 
 @app.teardown_request  # type: ignore [arg-type]

--- a/api/src/pcapi/routes/__init__.py
+++ b/api/src/pcapi/routes/__init__.py
@@ -1,7 +1,6 @@
 from flask import Flask
 
 from pcapi import settings
-from pcapi.flask_app import csrf
 
 
 def install_all_routes(app: Flask) -> None:
@@ -64,29 +63,3 @@ def install_all_routes(app: Flask) -> None:
     app.register_blueprint(public_api)
     app.register_blueprint(backoffice_blueprint, url_prefix="/backoffice")
     app.register_blueprint(backoffice_v3_web, url_prefix="/backofficev3")
-
-    if settings.IS_RUNNING_TESTS:
-        # When running tests, FlaskAdmin already uses mocks to ignore
-        # CSRF protection. Therefore the only blueprint that needs it
-        # are the backoffice ones.
-        for name, blueprint in app.blueprints.items():
-            if not name.startswith(backoffice_v3_web.name):
-                csrf.exempt(blueprint)
-    else:
-        # Only backoffice_v3_web blueprint needs CSRF protection.
-        # It seems the only way is to exempt blueprints instead of
-        # enabling this protection for one blueprint only.
-        # And since FlaskAdmin dynamically creates its blueprints, it
-        # is very difficult to find out which one is a FlaskAdmin one
-        # and therefore should not be exempted
-        csrf.exempt(adage_v1_blueprint)
-        csrf.exempt(native_v1_blueprint)
-        csrf.exempt(pro_public_api_v1_blueprint)
-        csrf.exempt(pro_public_api_v2_blueprint)
-        csrf.exempt(pro_private_api_blueprint)
-        csrf.exempt(adage_iframe_blueprint)
-        csrf.exempt(saml_blueprint_blueprint)
-        csrf.exempt(cloud_task_api)
-        csrf.exempt(private_api)
-        csrf.exempt(public_api)
-        csrf.exempt(backoffice_blueprint)

--- a/api/src/pcapi/routes/backoffice_v3/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/blueprint.py
@@ -8,8 +8,6 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
 
-from .forms import empty as empty_forms
-
 
 backoffice_v3_web = Blueprint("backoffice_v3_web", __name__, template_folder="templates")
 CORS(
@@ -48,4 +46,4 @@ def require_ff() -> None:
 
 @backoffice_v3_web.context_processor
 def add_logout_csrf_token() -> dict:
-    return {"logout_csrf_token": empty_forms.EmptyForm().csrf_token}
+    return {"logout_csrf_token": ""}

--- a/api/tests/admin/custom_views/admin_user_view_test.py
+++ b/api/tests/admin/custom_views/admin_user_view_test.py
@@ -18,7 +18,7 @@ from tests.conftest import clean_database
 
 class AdminUserViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_admin_user_creation(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -54,7 +54,7 @@ class AdminUserViewTest:
         assert token.expirationDate > datetime.utcnow() + timedelta(hours=20)
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_admin_user_receive_a_reset_password_token(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -82,7 +82,7 @@ class AdminUserViewTest:
         assert mails_testing.outbox[0].sent_data["template"] == asdict(TransactionalEmail.EMAIL_VALIDATION_TO_PRO.value)
 
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=[])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_admin_user_creation_is_restricted_in_prod(self, mocked_validate_csrf_token, app, db_session):
         users_factories.AdminFactory(email="user@example.com")
 
@@ -104,7 +104,7 @@ class AdminUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_super_admin_can_suspend_then_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         admin = users_factories.AdminFactory(email="admin@example.com")
@@ -128,7 +128,7 @@ class AdminUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True)
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_simple_admin_can_not_suspend_admin(self, mocked_validate_csrf_token, app):
         admin_1 = users_factories.AdminFactory(email="admin1@example.com")
         admin_2 = users_factories.AdminFactory(email="admin2@example.com")
@@ -143,7 +143,7 @@ class AdminUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_simple_admin_can_not_unsuspend_simple_admin(self, mocked_validate_csrf_token, app):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         admin_1 = users_factories.AdminFactory(email="admin1@example.com")

--- a/api/tests/admin/custom_views/api_key_view_test.py
+++ b/api/tests/admin/custom_views/api_key_view_test.py
@@ -10,7 +10,7 @@ from tests.conftest import clean_database
 
 class ApiKeyViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_api_key_creation(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
         offerer = offerers_factories.OffererFactory(siren=123456789)
@@ -29,7 +29,7 @@ class ApiKeyViewTest:
         assert api_key.secret is not None
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_api_key_creation_with_wrong_siren(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/beneficiary_user_view_test.py
+++ b/api/tests/admin/custom_views/beneficiary_user_view_test.py
@@ -27,7 +27,7 @@ class BeneficiaryUserViewTest:
     AGE18_ELIGIBLE_BIRTH_DATE = date.today() - relativedelta(years=18, months=4)
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_list_beneficiaries(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
         users_factories.BeneficiaryGrant18Factory.create_batch(3)
@@ -42,7 +42,7 @@ class BeneficiaryUserViewTest:
         assert response.status_code == 200
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_beneficiary_user_creation_for_deposit_v2(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="user@example.com")
 
@@ -145,7 +145,7 @@ class BeneficiaryUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     #  generate a valid CSRF token in tests. This should be fixed.
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_suspend_beneficiary(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         booking = bookings_factories.IndividualBookingFactory()
@@ -166,7 +166,7 @@ class BeneficiaryUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     #  generate a valid CSRF token in tests. This should be fixed.
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_unsuspend_beneficiary(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="user15@example.com", isActive=False)
@@ -209,7 +209,7 @@ class BeneficiaryUserViewTest:
         assert _allow_suspension_and_unsuspension(super_admin)
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_beneficiary_user_edition_does_not_send_email(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="user@example.com")
         user_to_edit = users_factories.BeneficiaryGrant18Factory(email="not_yet_edited@email.com")
@@ -237,7 +237,7 @@ class BeneficiaryUserViewTest:
         assert len(sendinblue_testing.sendinblue_requests) == 1
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
     def test_resend_validation_email_to_beneficiary(
         self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
@@ -255,7 +255,7 @@ class BeneficiaryUserViewTest:
 @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
 @pytest.mark.usefixtures("db_session")
 class BeneficiaryUserUpdateTest:
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_idpiecenumber(self, token, client):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         client.with_session_auth(super_admin.email)
@@ -277,7 +277,7 @@ class BeneficiaryUserUpdateTest:
 
         assert user_to_update.idPieceNumber == "123123123"
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_clear_idpiecenumber(self, token, client):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         client.with_session_auth(super_admin.email)
@@ -300,7 +300,7 @@ class BeneficiaryUserUpdateTest:
 
         assert user_to_update.idPieceNumber is None
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_idpiecenumber_not_updated(self, token, client):
         admin = users_factories.AdminFactory()  # not superadmin
 
@@ -321,7 +321,7 @@ class BeneficiaryUserUpdateTest:
 
         assert user_to_update.idPieceNumber != "123123123"
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_clear_ine_hash(self, token, client):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         client.with_session_auth(super_admin.email)

--- a/api/tests/admin/custom_views/booking_view_test.py
+++ b/api/tests/admin/custom_views/booking_view_test.py
@@ -12,7 +12,7 @@ from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-@mock.patch("flask_wtf.csrf.validate_csrf", lambda *args, **kwargs: True)
+@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token", lambda *args, **kwargs: True)
 class BookingViewTest:
     def test_search_booking(self, app):
         users_factories.AdminFactory(email="admin@example.com")

--- a/api/tests/admin/custom_views/boost_pivot_view_test.py
+++ b/api/tests/admin/custom_views/boost_pivot_view_test.py
@@ -11,7 +11,7 @@ from tests.conftest import clean_database
 
 class CreateBoostPivotTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_boost_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         providers_factories.ProviderFactory(
@@ -44,7 +44,7 @@ class CreateBoostPivotTest:
 
 class EditBoostPivotTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_boost_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         boost_provider = providers_factories.ProviderFactory(
@@ -81,7 +81,7 @@ class EditBoostPivotTest:
 
 class DeleteBoostPivotTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_boost_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         boost_provider = providers_factories.ProviderFactory(
@@ -106,7 +106,7 @@ class DeleteBoostPivotTest:
         assert providers_models.CinemaProviderPivot.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_should_not_delete_boost_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         boost_provider = providers_factories.ProviderFactory(

--- a/api/tests/admin/custom_views/cine_office_pivot_view_test.py
+++ b/api/tests/admin/custom_views/cine_office_pivot_view_test.py
@@ -12,7 +12,7 @@ from tests.conftest import clean_database
 
 class CreateCineOfficePivotTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_cine_office_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -40,7 +40,7 @@ class CreateCineOfficePivotTest:
 
 class EditCineOfficePivotTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_cine_office_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -70,7 +70,7 @@ class EditCineOfficePivotTest:
 
 class DeleteCineOfficePivotTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_cine_office_information(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         cds_provider = get_provider_by_local_class("CDSStocks")
@@ -90,7 +90,7 @@ class DeleteCineOfficePivotTest:
         assert providers_models.CinemaProviderPivot.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_should_not_delete_cine_office_pivot_when_venue_provider_exist(self, _mocked_validate_csrf_token, app):
         AdminFactory(email="admin@example.fr")
         cds_provider = get_provider_by_local_class("CDSStocks")

--- a/api/tests/admin/custom_views/criteria_view_test.py
+++ b/api/tests/admin/custom_views/criteria_view_test.py
@@ -13,7 +13,7 @@ from tests.conftest import clean_database
 class CriteriaViewTest:
     @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_criterion(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -34,7 +34,7 @@ class CriteriaViewTest:
         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
     )
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_criterion_with_whitespace(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -50,7 +50,7 @@ class CriteriaViewTest:
         assert criteria_models.Criterion.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_criterion_too_long(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -66,7 +66,7 @@ class CriteriaViewTest:
         assert criteria_models.Criterion.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_criterion(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
+++ b/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
@@ -11,7 +11,7 @@ from tests.conftest import clean_database
 
 
 @clean_database
-@mock.patch("flask_wtf.csrf.validate_csrf")
+@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
 def test_create_rule(mocked_validate_csrf_token, client, app):
     admin = users_factories.AdminFactory()
     offerer = offerers_factories.OffererFactory()
@@ -36,7 +36,7 @@ def test_create_rule(mocked_validate_csrf_token, client, app):
 
 
 @clean_database
-@mock.patch("flask_wtf.csrf.validate_csrf")
+@mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
 def test_edit_rule(mocked_validate_csrf_token, client, app):
     admin = users_factories.AdminFactory()
     timespan = (datetime.datetime.today() - datetime.timedelta(days=10), None)

--- a/api/tests/admin/custom_views/feature_view_test.py
+++ b/api/tests/admin/custom_views/feature_view_test.py
@@ -9,7 +9,7 @@ from tests.conftest import clean_database
 
 class FeatureViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_feature_edition(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
         inactive_feature = Feature.query.filter_by(isActive=False).first()

--- a/api/tests/admin/custom_views/many_offers_operations_view_test.py
+++ b/api/tests/admin/custom_views/many_offers_operations_view_test.py
@@ -21,7 +21,7 @@ from tests.conftest import TestClient
 
 @pytest.mark.usefixtures("db_session")
 class ManyOffersOperationsViewTest:
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_search_product_from_isbn(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -45,7 +45,7 @@ class ManyOffersOperationsViewTest:
         get_response = client.get(response.headers["location"])
         assert get_response.status_code == 200
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_search_product_from_visa(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -60,7 +60,7 @@ class ManyOffersOperationsViewTest:
         assert response.status_code == 302
         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/edit?visa=978148"
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_search_product_from_isbn_with_invalid_isbn(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -76,7 +76,7 @@ class ManyOffersOperationsViewTest:
         # Then
         assert response.status_code == 200
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_search_product_with_no_isbn_nor_visa(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -89,7 +89,7 @@ class ManyOffersOperationsViewTest:
         assert response.status_code == 200
 
     @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_product_offers_criteria_from_isbn(
         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
     ):
@@ -125,7 +125,7 @@ class ManyOffersOperationsViewTest:
         mocked_async_index_offer_ids.assert_called_once_with([offer1.id, offer2.id])
 
     @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_product_offers_criteria_from_visa(
         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
     ):
@@ -160,7 +160,7 @@ class ManyOffersOperationsViewTest:
         assert not unmatched_offer.criteria
         mocked_async_index_offer_ids.called_once_with([offer1.id, offer2.id])
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_product_offers_criteria_from_isbn_without_offers(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -173,7 +173,7 @@ class ManyOffersOperationsViewTest:
         assert response.status_code == 302
         assert response.headers["location"] == "http://localhost/pc/back-office/many_offers_operations/"
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_product_offers_criteria_from_visa_without_offers(self, mocked_validate_csrf_token, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
@@ -215,7 +215,7 @@ class ManyOffersOperationsViewTest:
         ],
     )
     @patch("pcapi.core.search.async_index_offer_ids")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_product_gcu_compatibility(
         self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app, db_session, validation_status
     ):

--- a/api/tests/admin/custom_views/offer_view_test.py
+++ b/api/tests/admin/custom_views/offer_view_test.py
@@ -131,7 +131,7 @@ class OfferValidationViewTest:
         # then
         assert url_for(view_name) in response.data.decode("utf-8")
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_approve_offer_and_go_to_next_offer(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -171,7 +171,7 @@ class OfferValidationViewTest:
         assert response.status_code == 302
         assert url_for("validation.edit", id=oldest_offer.id) in response.location
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_approve_last_pending_offer_and_go_to_the_next_offer_redirect_to_validation_page(
         self, mocked_validate_csrf_token, client
     ):
@@ -198,7 +198,7 @@ class OfferValidationViewTest:
         assert response.status_code == 302
         assert url_for("validation.index_view") in response.location
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     def test_approve_virtual_offer_and_send_mail_to_managing_offerer(
         self,
@@ -226,7 +226,7 @@ class OfferValidationViewTest:
             offer, OfferValidationStatus.APPROVED, ["pro@example.com"]
         )
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     def test_approve_physical_offer_and_send_mail_to_venue_booking_email(
         self,
@@ -251,7 +251,7 @@ class OfferValidationViewTest:
             offer, OfferValidationStatus.APPROVED, ["venue@example.com"]
         )
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
     def test_import_validation_config(self, mocked_validate_csrf_token, client):
         # Given
@@ -317,7 +317,7 @@ class OfferValidationViewTest:
             ],
         }
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
     def test_import_validation_config_fail_with_wrong_value(self, mocked_validate_csrf_token, client):
         # Given
@@ -351,7 +351,7 @@ class OfferValidationViewTest:
         # Then
         assert response.status_code == 400
 
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @testing.override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["super_admin@example.com"])
     def test_import_validation_config_inaccessible_when_user_is_not_super_admin(
         self, mocked_validate_csrf_token, client
@@ -390,7 +390,7 @@ class OfferValidationViewTest:
         assert url_for("admin.index") in response.location
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_offer_and_send_mail_to_administration(
         self,
@@ -432,7 +432,7 @@ class OfferValidationViewTest:
         assert offer.lastValidationType == OfferValidationType.MANUAL
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_offer_and_send_mail_to_administration(
         self,
@@ -551,7 +551,7 @@ class OfferValidationViewTest:
     @pytest.mark.parametrize(
         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
     )
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_batch_approve_offers(self, mocked_validate_csrf_token, action, expected, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -586,7 +586,7 @@ class OfferValidationViewTest:
         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
 
     @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.offers.api.update_pending_offer_validation")
     def test_batch_approve_reject_offers_not_updated(
         self,
@@ -627,7 +627,7 @@ class OfferValidationViewTest:
         )
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_collective_offer_template_and_send_mail_to_administration(
         self,
@@ -671,7 +671,7 @@ class OfferValidationViewTest:
         assert offer.lastValidationType == OfferValidationType.MANUAL
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_collective_offer_template_and_send_mail_to_administration(
         self,
@@ -759,7 +759,7 @@ class OfferValidationViewTest:
     @pytest.mark.parametrize(
         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
     )
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_batch_approve_collective_offers_template(self, mocked_validate_csrf_token, action, expected, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -794,7 +794,7 @@ class OfferValidationViewTest:
         assert "2 offres ont été modifiées avec succès" in get_response.data.decode("utf8")
 
     @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.offers.api.update_pending_offer_validation")
     def test_batch_approve_reject_collective_offers_template_not_updated(
         self,
@@ -838,7 +838,7 @@ class OfferValidationViewTest:
 
     @freeze_time("2020-11-17 15:00:00")
     @override_settings(ADAGE_API_URL="https://adage_base_url")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_collective_offer_and_send_mail_to_administration_and_notify_adage(
         self,
@@ -889,7 +889,7 @@ class OfferValidationViewTest:
         assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
 
     @freeze_time("2020-11-17 15:00:00")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_collective_offer_and_send_mail_to_administration(
         self,
@@ -1013,7 +1013,7 @@ class OfferValidationViewTest:
         "action,expected", [("approve", OfferValidationStatus.APPROVED), ("reject", OfferValidationStatus.REJECTED)]
     )
     @override_settings(ADAGE_API_URL="https://adage_base_url")
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_batch_approve_collective_offers(self, mocked_validate_csrf_token, action, expected, client):
         users_factories.AdminFactory(email="admin@example.com")
         venue = offerers_factories.VenueFactory()
@@ -1055,7 +1055,7 @@ class OfferValidationViewTest:
         assert adage_api_testing.adage_requests[0]["url"] == "https://adage_base_url/v1/offre-assoc"
 
     @pytest.mark.parametrize("action", ["approve", "reject"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.offers.api.update_pending_offer_validation")
     def test_batch_approve_reject_collective_offers_not_updated(
         self,
@@ -1098,7 +1098,7 @@ class OfferValidationViewTest:
 
 class OfferViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_reject_approved_offer(
@@ -1132,7 +1132,7 @@ class OfferViewTest:
         )
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     def test_approve_rejected_offer(
@@ -1162,7 +1162,7 @@ class OfferViewTest:
         assert mocked_send_offer_validation_status_update_email.call_count == 1
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.mails.transactional.send_offer_validation_status_update_email")
     @patch("pcapi.domain.admin_emails.send_offer_validation_notification_to_administration")
     @patch("pcapi.workers.push_notification_job.send_cancel_booking_notification.delay")
@@ -1196,7 +1196,7 @@ class OfferViewTest:
         mocked_send_cancel_booking_notification.assert_called_once_with([unused_booking.id])
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_change_to_draft_approved_offer(self, mocked_validate_csrf_token, app):
         users_factories.AdminFactory(email="admin@example.com")
         offer = offers_factories.OfferFactory(validation=OfferValidationStatus.APPROVED, isActive=True)
@@ -1210,7 +1210,7 @@ class OfferViewTest:
         assert offer.lastValidationType == OfferValidationType.AUTO  # unchanged
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.reindex_offer_ids")
     def test_reindex_when_tags_updated(
         self,
@@ -1234,7 +1234,7 @@ class OfferViewTest:
 
 class OfferForVenueSubviewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory(email="user@example.com")
         client = client.with_session_auth(admin.email)

--- a/api/tests/admin/custom_views/offerer_tag_view_test.py
+++ b/api/tests/admin/custom_views/offerer_tag_view_test.py
@@ -12,7 +12,7 @@ from tests.conftest import clean_database
 class OffererTagViewTest:
     @pytest.mark.parametrize("name", ["tag", "tag_with_underscores", "[tag]!", "tag_140ch_" * 14])
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_tag(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -28,7 +28,7 @@ class OffererTagViewTest:
         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
     )
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_tag_with_whitespace(self, mocked_validate_csrf_token, client, name):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -41,7 +41,7 @@ class OffererTagViewTest:
         assert offerers_models.OffererTag.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_create_tag_too_long(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -54,7 +54,7 @@ class OffererTagViewTest:
         assert offerers_models.OffererTag.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_tag(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/offerer_view_test.py
+++ b/api/tests/admin/custom_views/offerer_view_test.py
@@ -16,7 +16,7 @@ from tests.conftest import clean_database
 
 class OffererViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_offerer_add_tags(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -49,7 +49,7 @@ class OffererViewTest:
         assert history_models.ActionHistory.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_edit_offerer_remove_tags(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 
@@ -87,7 +87,7 @@ class OffererViewTest:
         "booking_status", [None, BookingStatus.USED, BookingStatus.CANCELLED, BookingStatus.REIMBURSED]
     )
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_deactivate_offerer(self, mocked_validate_csrf_token, client, booking_status):
         admin = users_factories.AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -130,7 +130,7 @@ class OffererViewTest:
 
     @pytest.mark.parametrize("booking_status", [BookingStatus.PENDING, BookingStatus.CONFIRMED])
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_deactivate_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
         admin = users_factories.AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -165,7 +165,7 @@ class OffererViewTest:
         assert history_models.ActionHistory.query.count() == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_reactivate_offerer(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory(email="user@example.com")
         offerer = offerers_factories.OffererFactory(isActive=False)
@@ -205,7 +205,7 @@ class OffererViewTest:
         assert actions_list[0].offerer == offerer
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_offerer(self, mocked_validate_csrf_token, client):
         # Can delete offerer because there is no booking
         admin = users_factories.AdminFactory(email="user@example.com")
@@ -237,7 +237,7 @@ class OffererViewTest:
         ],
     )
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_offerer_rejected(self, mocked_validate_csrf_token, client, booking_status):
         admin = users_factories.AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -261,7 +261,7 @@ class OffererViewTest:
         assert len(external_testing.sendinblue_requests) == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_offerer_rejected_because_of_princing_point(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory()
         venue = offerers_factories.VenueFactory(pricing_point="self")

--- a/api/tests/admin/custom_views/partner_user_view_test.py
+++ b/api/tests/admin/custom_views/partner_user_view_test.py
@@ -94,7 +94,7 @@ class PartnerUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_super_admin_can_suspend_then_unsuspend_partner(self, mocked_validate_csrf_token, app):
         super_admin = users_factories.AdminFactory(email="superadmin@example.com")
         partner = users_factories.UserFactory(email="partner@example.com")
@@ -113,7 +113,7 @@ class PartnerUserViewTest:
         assert partner.isActive
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.admin.custom_views.mixins.resend_validation_email_mixin.users_api.request_email_confirmation")
     def test_resend_validation_email_to_partner(
         self, mocked_request_email_confirmation, mocked_validate_csrf_token, app
@@ -129,7 +129,7 @@ class PartnerUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_clear_profile(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory()
         user = users_factories.UserFactory(
@@ -181,7 +181,7 @@ class PartnerUserViewTest:
 
     @clean_database
     @override_settings(IS_PROD=True, SUPER_ADMIN_EMAIL_ADDRESSES=["superadmin@example.com"])
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_clear_idpiecenumber(self, mocked_validate_csrf_token, client):
         admin = users_factories.AdminFactory(email="superadmin@example.com")
         user = users_factories.UserFactory(

--- a/api/tests/admin/custom_views/pro_user_view_test.py
+++ b/api/tests/admin/custom_views/pro_user_view_test.py
@@ -20,7 +20,7 @@ from tests.conftest import clean_database
 
 class ProUserViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_pro_user_creation(self, mocked_validate_csrf_token, app):
         # Given
         bo_user = users_factories.AdminFactory(email="USER@example.com")
@@ -89,7 +89,7 @@ class ProUserViewTest:
         assert actions_list[0].offerer == offerer_created
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_pro_user_edition(self, mocked_validate_csrf_token, app):
         # Given
         admin_user = users_factories.AdminFactory()
@@ -123,7 +123,7 @@ class ProUserViewTest:
         assert updated_user.phoneNumber == "+33601020304"
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_pro_user_edition_phone_number_error(self, mocked_validate_csrf_token, app):
         # Given
         admin_user = users_factories.AdminFactory()
@@ -201,7 +201,7 @@ class ProUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     # generate a valid CSRF token in tests. This should be fixed.
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_suspend_pro(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         pro = users_factories.ProFactory(email="user15@example.com")
@@ -220,7 +220,7 @@ class ProUserViewTest:
     @clean_database
     # FIXME (dbaty, 2020-12-16): I could not find a quick way to
     # generate a valid CSRF token in tests. This should be fixed.
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_unsuspend_pro(self, mocked_validate_csrf_token, app):
         admin = users_factories.AdminFactory(email="admin15@example.com")
         pro = users_factories.ProFactory(email="user15@example.com", isActive=False)

--- a/api/tests/admin/custom_views/user_offerer_view_test.py
+++ b/api/tests/admin/custom_views/user_offerer_view_test.py
@@ -10,7 +10,7 @@ from tests.conftest import clean_database
 
 class UserOffererViewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_user_offerer(self, mocked_validate_csrf_token, client):
         users_factories.AdminFactory(email="admin@example.com")
 

--- a/api/tests/admin/custom_views/venue_provider_view_test.py
+++ b/api/tests/admin/custom_views/venue_provider_view_test.py
@@ -38,7 +38,7 @@ class VenueProviderViewTest:
 
 class EditModelTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.workers.venue_provider_job.synchronize_venue_provider")
     @patch("pcapi.core.providers.api._siret_can_be_synchronized")
     def test_edit_venue_provider(
@@ -86,7 +86,7 @@ class EditModelTest:
         mock_synchronize_venue_provider.assert_called_once_with(venue_provider)
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.providers.api._siret_can_be_synchronized")
     def test_provider_not_synchronizable(self, mock_siret_can_be_synchronized, validate_csrf_token, client):
         # Given
@@ -112,7 +112,7 @@ class EditModelTest:
         assert venue_provider.venueIdAtOfferProvider == "old-siret"
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.workers.venue_provider_job.synchronize_venue_provider")
     def test_allocine_provider(self, synchronize_venue_provider, validate_csrf_token, client):
         # Given

--- a/api/tests/admin/custom_views/venue_view_test.py
+++ b/api/tests/admin/custom_views/venue_view_test.py
@@ -40,7 +40,7 @@ def base_form_data(venue: Venue) -> dict:
 
 class EditVenueTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_update_adage_id(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -56,7 +56,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_add_siret_to_venue_without_pricing_point(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
@@ -84,7 +84,7 @@ class EditVenueTest:
         }
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_edit_siret_with_self_pricing_point(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, caplog, app
@@ -114,7 +114,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.SireneApiException)
     def test_unavailable_sirene_api_warning(
@@ -146,7 +146,7 @@ class EditVenueTest:
         }
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_remove_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -165,7 +165,7 @@ class EditVenueTest:
         assert len(external_testing.zendesk_sell_requests) == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_set_not_all_digits_siret(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
@@ -186,7 +186,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_use_inactive_siret(self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -206,7 +206,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_set_already_used_siret(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
@@ -232,7 +232,7 @@ class EditVenueTest:
         mocked_async_index_offers_of_venue_ids.assert_not_called()
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_cannot_add_siret_if_exisiting_pricing_point(
         self, mocked_async_index_offers_of_venue_ids, _mocked_validate_csrf_token, app
@@ -258,7 +258,7 @@ class EditVenueTest:
         assert len(external_testing.zendesk_sell_requests) == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_venue_other_offer_id_at_provider(self, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         business_unit = finance_factories.BusinessUnitFactory(siret="11111111111111")
@@ -295,7 +295,7 @@ class EditVenueTest:
         assert offer.idAtProvider == "id_at_provider_ne_contenant_pas_le_siret"
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_update_venue_without_siret(self, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
         business_unit = finance_factories.BusinessUnitFactory(siret="11111111111111")
@@ -324,7 +324,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     def test_update_venue_reindex_all(self, mocked_async_index_offers_of_venue_ids, mocked_validate_csrf_token, app):
         AdminFactory(email="user@example.com")
@@ -358,7 +358,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     @patch("pcapi.core.search.async_index_venue_ids")
     def test_update_venue_reindex_venue_only(
@@ -394,7 +394,7 @@ class EditVenueTest:
         assert external_testing.zendesk_sell_requests == [{"action": "update", "type": "Venue", "id": venue.id}]
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     @patch("pcapi.core.search.async_index_offers_of_venue_ids")
     @patch("pcapi.core.search.async_index_venue_ids")
     @patch("pcapi.core.search.reindex_venue_ids")
@@ -435,7 +435,7 @@ class EditVenueTest:
 
 class DeleteVenueTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_venue(self, mocked_validate_csrf_token, client):
         admin = AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory(bookingEmail="booking@example.com")
@@ -467,7 +467,7 @@ class DeleteVenueTest:
         ],
     )
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_venue_rejected(self, mocked_validate_csrf_token, client, booking_status):
         admin = AdminFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -490,7 +490,7 @@ class DeleteVenueTest:
         assert len(external_testing.sendinblue_requests) == 0
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_delete_venue_rejected_because_of_princing_point(self, mocked_validate_csrf_token, client):
         admin = AdminFactory()
         venue = offerers_factories.VenueFactory(pricing_point="self")
@@ -540,7 +540,7 @@ class GetVenueProviderLinkTest:
 
 class VenueForOffererSubviewTest:
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_list_venues_for_offerer(self, mocked_validate_csrf_token, client):
         admin = AdminFactory(email="user@example.com")
         offerer = offerers_factories.OffererFactory()
@@ -560,7 +560,7 @@ class VenueForOffererSubviewTest:
         assert sorted(venue_ids) == sorted([str(venue1.id), str(venue2.id)])
 
     @clean_database
-    @patch("flask_wtf.csrf.validate_csrf")
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
     def test_list_venues_for_offerer_not_found(self, mocked_validate_csrf_token, client):
         admin = AdminFactory(email="user@example.com")
 

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -127,7 +127,7 @@ class UpdatePublicAccountTest:
 
         url = url_for("backoffice_v3_web.update_public_account", user_id=user_to_edit.id)
 
-        form["csrf_token"] = g.csrf_token
+        form["csrf_token"] = g.get("csrf_token", "")
         return client.with_session_auth(legit_user.email).patch(url, form=form)
 
 
@@ -173,7 +173,7 @@ class ResendValidationEmailTest:
         client.with_session_auth(legit_user.email).get(account_detail_url)
 
         url = url_for("backoffice_v3_web.resend_validation_email", user_id=user.id)
-        form = {"csrf_token": g.csrf_token}
+        form = {"csrf_token": g.get("csrf_token", "")}
 
         return client.with_session_auth(legit_user.email).post(url, form=form)
 
@@ -231,7 +231,7 @@ class SendValidationCodeTest:
         client.with_session_auth(legit_user.email).get(account_detail_url)
 
         url = url_for("backoffice_v3_web.send_validation_code", user_id=user.id)
-        form = {"csrf_token": g.csrf_token}
+        form = {"csrf_token": g.get("csrf_token", "")}
 
         return client.with_session_auth(legit_user.email).post(url, form=form)
 
@@ -344,5 +344,5 @@ class UpdatePublicAccountReviewTest:
 
         url = url_for("backoffice_v3_web.review_public_account", user_id=user_to_edit.id)
 
-        form["csrf_token"] = g.csrf_token
+        form["csrf_token"] = g.get("csrf_token", "")
         return client.with_session_auth(legit_user.email).post(url, form=form)

--- a/api/tests/routes/backoffice_v3/auth_test.py
+++ b/api/tests/routes/backoffice_v3/auth_test.py
@@ -114,11 +114,12 @@ class LogoutTest:
         client.get(url_for("backoffice_v3_web.home"))
 
         url = url_for("backoffice_v3_web.logout")
-        response = client.with_session_auth(user.email).post(url, form={"csrf_token": g.csrf_token})
+        response = client.with_session_auth(user.email).post(url, form={"csrf_token": g.get("csrf_token", "")})
 
         assert response.status_code == 302
         assert response.location == url_for("backoffice_v3_web.home", _external=True)
 
+    @pytest.mark.skip(reason="csrf temporarily deactivated")
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_no_csrf_token(self, client):  # type: ignore
         response = client.post(url_for("backoffice_v3_web.logout"))

--- a/api/tests/routes/backoffice_v3/helpers/unauthorized.py
+++ b/api/tests/routes/backoffice_v3/helpers/unauthorized.py
@@ -79,6 +79,7 @@ class UnauthorizedHelper(UnauthorizedHelperBase):
         assert response.status_code == 400
 
 
+@pytest.mark.skip(reason="csrf temporarily deactivated")
 class UnauthorizedHelperWithCsrf(UnauthorizedHelperBase):
     @property
     def method(self) -> str:
@@ -135,6 +136,7 @@ class UnauthorizedHelperWithCsrf(UnauthorizedHelperBase):
         client.get(url_for("backoffice_v3_web.home"))
 
 
+@pytest.mark.skip(reason="csrf temporarily deactivated")
 class MissingCSRFHelper(base.BaseHelper):
     @property
     def method(self) -> str:


### PR DESCRIPTION
## But de la pull request

Les deux fix précédents ont réglé des problèmes mais pas tous : certaines pages FlaskAdmin devraient avoir une protection csrf (via un jeton) mais n'en ont pas. Et avec l'ajout de Flask-WTF on a des erreurs sur ces pages : certaines actions deviennent impossible.

Pour débloquer la situation, cette PR vient retirer la protection CSRF apportée par Flask-WTF puisque seul le backoffice (v3) s'en sert activement et qu'il n'est pas activé en production. Donc on retrouve l'ancien comportement de FlaskAdmin.

La protection CSRF sera remise sur le backoffice (v3) plus tard, d'une manière à ne plus avoir de conflits avec FlaskAdmin.

## Au passage

Il y avait des erreurs liées à des imports circulaires puis de typage (côté `history` dans les modules `models` et `api`) pour lesquels je n'ai pas d'explication mais j'ai ajouté des fix quand même.