### PR TITLE
(PC-18569)[API] feat: Fix keyboard navigation and conditional field reset.

### DIFF
--- a/pro/src/components/VenueForm/Address/Address.tsx
+++ b/pro/src/components/VenueForm/Address/Address.tsx
@@ -2,7 +2,7 @@ import { useField, useFormikContext } from 'formik'
 import React, { useEffect, useState } from 'react'
 
 import FormLayout from 'components/FormLayout'
-import { SelectAutocomplete } from 'ui-kit'
+import SelectAutocomplete from 'ui-kit/form/SelectAutoComplete2/SelectAutocomplete'
 import { IAutocompleteItemProps } from 'ui-kit/form/shared/AutocompleteList/type'
 
 import { IVenueFormValues } from '../types'
@@ -91,6 +91,7 @@ const Address = () => {
             placeholder="Entrez votre adresse et sélectionnez une suggestion"
             options={options}
             hideArrow={true}
+            resetOnOpen={false}
           ></SelectAutocomplete>
         </FormLayout.Row>
       </FormLayout.Section>

--- a/pro/src/components/VenueForm/Address/__specs__/Address.spec.tsx
+++ b/pro/src/components/VenueForm/Address/__specs__/Address.spec.tsx
@@ -101,7 +101,8 @@ describe('components | Address', () => {
 
     await userEvent.type(adressInput, '12 rue ')
     const suggestion = await screen.getByText(
-      '12 rue des tournesols 75003 Paris'
+      '12 rue des tournesols 75003 Paris',
+      { selector: 'span' }
     )
 
     await userEvent.click(suggestion)

--- a/pro/src/ui-kit/form/SelectAutoComplete2/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete2/SelectAutocomplete.tsx
@@ -26,6 +26,7 @@ export interface SelectAutocompleteProps {
   placeholder?: string
   pluralLabel?: string
   smallLabel?: boolean
+  resetOnOpen?: boolean
 }
 
 const SelectAutocomplete = ({
@@ -44,6 +45,7 @@ const SelectAutocomplete = ({
   placeholder,
   pluralLabel,
   smallLabel = false,
+  resetOnOpen = true,
 }: SelectAutocompleteProps): JSX.Element => {
   const { setFieldTouched, setFieldValue } = useFormikContext<any>()
 
@@ -66,7 +68,7 @@ const SelectAutocomplete = ({
   }, [options])
 
   useEffect(() => {
-    if (isOpen && searchField.value !== '')
+    if (isOpen && resetOnOpen && searchField.value !== '')
       setFieldValue(`search-${fieldName}`, '', false)
   }, [isOpen])
 
@@ -136,6 +138,7 @@ const SelectAutocomplete = ({
         break
       case 'Enter':
         if (isOpen && hoveredOptionIndex !== null) {
+          event.preventDefault()
           selectOption(filteredOptions[hoveredOptionIndex].value)
         }
         break

--- a/pro/src/ui-kit/form/SelectAutoComplete2/index.ts
+++ b/pro/src/ui-kit/form/SelectAutoComplete2/index.ts
@@ -1,1 +1,1 @@
-export { default } from './SelectAutocomplete'
+export { default as SelectAutoComplete } from './SelectAutocomplete'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18569

## But de la pull request

- Correction du composant utilisé + remise des tests.
- Ajout d'une props pour désactiver la remise à zéro au clic sur le `SelectAutoComplete`
- La touche entrer pour sélectionner un élément ne doit pas envoyer le formulaire.