### PR TITLE
(PC-18412)[PRO] fix: create offer v3 form category behavior

### DIFF
--- a/pro/src/components/OfferIndividualForm/Categories/Categories.tsx
+++ b/pro/src/components/OfferIndividualForm/Categories/Categories.tsx
@@ -31,12 +31,18 @@ const Categories = ({
   const {
     values: formValues,
     setFieldValue,
+    setFieldTouched,
     touched,
   } = useFormikContext<IOfferIndividualFormValues>()
   useEffect(() => {
     if (touched.subcategoryId) {
+      if (formValues.subcategoryId !== '') {
+        setFieldTouched('subcategoryId', false)
+      }
       setFieldValue('subcategoryId', FORM_DEFAULT_VALUES.subcategoryId)
       setFieldValue('subCategoryFields', FORM_DEFAULT_VALUES.subCategoryFields)
+    } else {
+      setFieldTouched('subcategoryId', true)
     }
   }, [formValues.categoryId])
 

--- a/pro/src/components/OfferIndividualForm/Categories/Categories.tsx
+++ b/pro/src/components/OfferIndividualForm/Categories/Categories.tsx
@@ -34,11 +34,21 @@ const Categories = ({
     setFieldTouched,
   } = useFormikContext<IOfferIndividualFormValues>()
   useEffect(() => {
-    if (formValues.subcategoryId !== '') {
+    const currentSubcategories = subCategories.filter(
+      e => e.categoryId === formValues.categoryId
+    )
+    const containsSubcategory = currentSubcategories.some(
+      e => e.id === formValues.subcategoryId
+    )
+    if (
+      formValues.subcategoryId === '' ||
+      formValues.categoryId === '' ||
+      (currentSubcategories.length > 1 && !containsSubcategory)
+    ) {
+      setFieldValue('subcategoryId', FORM_DEFAULT_VALUES.subcategoryId)
+      setFieldValue('subCategoryFields', FORM_DEFAULT_VALUES.subCategoryFields)
       setFieldTouched('subcategoryId', false)
     }
-    setFieldValue('subcategoryId', FORM_DEFAULT_VALUES.subcategoryId)
-    setFieldValue('subCategoryFields', FORM_DEFAULT_VALUES.subCategoryFields)
   }, [formValues.categoryId])
 
   const categoryOptions: SelectOptions = categories

--- a/pro/src/components/OfferIndividualForm/Categories/Categories.tsx
+++ b/pro/src/components/OfferIndividualForm/Categories/Categories.tsx
@@ -32,18 +32,13 @@ const Categories = ({
     values: formValues,
     setFieldValue,
     setFieldTouched,
-    touched,
   } = useFormikContext<IOfferIndividualFormValues>()
   useEffect(() => {
-    if (touched.subcategoryId) {
-      if (formValues.subcategoryId !== '') {
-        setFieldTouched('subcategoryId', false)
-      }
-      setFieldValue('subcategoryId', FORM_DEFAULT_VALUES.subcategoryId)
-      setFieldValue('subCategoryFields', FORM_DEFAULT_VALUES.subCategoryFields)
-    } else {
-      setFieldTouched('subcategoryId', true)
+    if (formValues.subcategoryId !== '') {
+      setFieldTouched('subcategoryId', false)
     }
+    setFieldValue('subcategoryId', FORM_DEFAULT_VALUES.subcategoryId)
+    setFieldValue('subCategoryFields', FORM_DEFAULT_VALUES.subCategoryFields)
   }, [formValues.categoryId])
 
   const categoryOptions: SelectOptions = categories

--- a/pro/src/components/OfferIndividualForm/Categories/hooks/useSubCategoryUpdates/useSubCategoryUpdates.ts
+++ b/pro/src/components/OfferIndividualForm/Categories/hooks/useSubCategoryUpdates/useSubCategoryUpdates.ts
@@ -5,8 +5,6 @@ import { IOfferIndividualFormValues } from 'components/OfferIndividualForm/types
 import { setSubCategoryFields } from 'components/OfferIndividualForm/utils'
 import { IOfferSubCategory } from 'core/Offers/types'
 
-import { SUBCATEGORIES_FIELDS_DEFAULT_VALUES } from '../../constants'
-
 interface IUseSubCategoryUpdatesArgs {
   subCategories: IOfferSubCategory[]
 }
@@ -16,18 +14,10 @@ const useSubCategoryUpdates = ({
 }: IUseSubCategoryUpdatesArgs) => {
   const {
     dirty,
-    values: { subcategoryId, subCategoryFields },
+    values: { subcategoryId },
     setFieldValue,
+    setTouched,
   } = useFormikContext<IOfferIndividualFormValues>()
-
-  const resetSubCategoryFieldValues = (): void => {
-    Object.entries(SUBCATEGORIES_FIELDS_DEFAULT_VALUES).forEach(
-      ([field, value]: [string, string | undefined]) => {
-        setFieldValue(field, value)
-      }
-    )
-  }
-
   const setFormSubCategoryFields = (): void => {
     const { subCategoryFields, isEvent } = setSubCategoryFields(
       subcategoryId,
@@ -44,11 +34,12 @@ const useSubCategoryUpdates = ({
   useEffect(
     function onSubCategoryChange() {
       if (dirty) {
-        const previousSubCategoryFields = subCategoryFields
         setFormSubCategoryFields()
-
-        if (previousSubCategoryFields !== subCategoryFields) {
-          resetSubCategoryFieldValues()
+        if (subcategoryId !== '') {
+          setTouched({
+            categoryId: true,
+            subcategoryId: true,
+          })
         }
       }
     },

--- a/pro/src/components/OfferIndividualForm/Categories/validationSchema.ts
+++ b/pro/src/components/OfferIndividualForm/Categories/validationSchema.ts
@@ -7,7 +7,9 @@ const validationSchema = {
   subcategoryId: yup.string().when('categoryId', {
     is: (categoryId: string) => categoryId !== undefined,
     then: yup.string().required('Veuillez sélectionner une sous-catégorie'),
-    otherwise: yup.string(),
+    otherwise: yup
+      .string()
+      .required('Veuillez sélectionner une sous-catégorie'),
   }),
   musicType: yup.string().when('subCategoryFields', {
     is: (subCategoryFields: string[]) =>

--- a/pro/src/components/OfferIndividualForm/Categories/validationSchema.ts
+++ b/pro/src/components/OfferIndividualForm/Categories/validationSchema.ts
@@ -4,13 +4,9 @@ import { CATEGORIES_DEFAULT_VALUES } from './constants'
 
 const validationSchema = {
   categoryId: yup.string().required('Veuillez sélectionner une catégorie'),
-  subcategoryId: yup.string().when('categoryId', {
-    is: (categoryId: string) => categoryId !== undefined,
-    then: yup.string().required('Veuillez sélectionner une sous-catégorie'),
-    otherwise: yup
-      .string()
-      .required('Veuillez sélectionner une sous-catégorie'),
-  }),
+  subcategoryId: yup
+    .string()
+    .required('Veuillez sélectionner une sous-catégorie'),
   musicType: yup.string().when('subCategoryFields', {
     is: (subCategoryFields: string[]) =>
       subCategoryFields.includes('musicType'),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18412

## But de la pull request

- Ne pas afficher le formulaire lorsque l'utilisateur n'a pas sélectionné de sous catégorie.
- Bien afficher la bonne sous catégorie lorsqu'on retourne sur le détail d'une offre.
- Ne pas pouvoir passer à l'étape suivante tant qu'il n'y a pas de sous catégorie séléctionnée.

## Implémentation

- Correction de l'affichage du style des sous catégories.
- N'affiche plus les erreurs lorsqu'on change de sous catégorie.

## Informations supplémentaires

- Lorsque le formulaire n'est pas visible, la page n'affiche plus les erreurs du formulaire lorsqu'on clique sur l'étape suivante, puis qu'on séléctionne une sous catégorie.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
