### PR TITLE
(PC-18618)[PRO] fix: correct quantity serialize when quantity is 0

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksThing/adapters/__specs__/serializers.spec.ts
+++ b/pro/src/screens/OfferIndividual/StocksThing/adapters/__specs__/serializers.spec.ts
@@ -68,4 +68,28 @@ describe('screens::StockThing::serializers:serializeStockThingList', () => {
     )
     expect(serializedData).toStrictEqual([expectedApiStockThing])
   })
+
+  it('should not set null when quantity value is 0', async () => {
+    const serializedData = serializeStockThingList(
+      {
+        stockId: 'STOCK_ID',
+        ...formValues,
+        quantity: '0',
+      },
+      departementCode
+    )
+    expect(serializedData[0].quantity).toStrictEqual(0)
+  })
+
+  it('should set null when quantity field is empty', async () => {
+    const serializedData = serializeStockThingList(
+      {
+        stockId: 'STOCK_ID',
+        ...formValues,
+        quantity: '',
+      },
+      departementCode
+    )
+    expect(serializedData[0].quantity).toStrictEqual(null)
+  })
 })

--- a/pro/src/screens/OfferIndividual/StocksThing/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksThing/adapters/serializers.ts
@@ -20,6 +20,7 @@ export const serializeStockThingList = (
   formValues: IStockThingFormValues,
   departementCode: string
 ): StockCreationBodyModel[] | StockEditionBodyModel[] => {
+  const parseQuantity = parseInt(formValues.quantity)
   const apiStock: StockCreationBodyModel = {
     bookingLimitDatetime: formValues.bookingLimitDatetime
       ? serializeThingBookingLimitDatetime(
@@ -28,16 +29,18 @@ export const serializeStockThingList = (
         )
       : null,
     price: parseInt(formValues.price, 10),
-    quantity: parseInt(formValues.quantity, 10) || null,
+    quantity: isNaN(parseQuantity) ? null : parseQuantity,
   }
   if (formValues.activationCodes.length > 0) {
     apiStock.activationCodes = formValues.activationCodes
-    if (formValues.activationCodesExpirationDatetime)
+    /* istanbul ignore next */
+    if (formValues.activationCodesExpirationDatetime) {
       apiStock.activationCodesExpirationDatetime =
         serializeThingBookingLimitDatetime(
           formValues.activationCodesExpirationDatetime,
           departementCode
         )
+    }
   }
   if (formValues.stockId) {
     return [


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18618

## But de la pull request

Lors de l'enregistrement du stock:
- Si je rentre 0: quantity = 0
- Si je laisse vide: quantity = null
