### PR TITLE
(BSR)[PRO] StockThing : fix text against new wording

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -130,6 +130,7 @@ describe('screens:StocksThing', () => {
     ).toBeInTheDocument()
     expect(screen.getByLabelText('Quantité')).toBeInTheDocument()
   })
+
   it('should render digital stock thing', async () => {
     props.offer = {
       ...(offer as IOfferIndividual),
@@ -139,7 +140,7 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen({ props, storeOverride, contextValue })
     expect(
       screen.getByText(
-        'Les utilisateurs ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les utilisateurs ne peuvent pas annuler leurs réservations d’offres numériques. Toute réservation est définitive et sera immédiatement validée.'
+        /Les utilisateurs ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les utilisateurs ne peuvent pas annuler leurs réservations d’offres numériques. Toute réservation est définitive et sera immédiatement validée. Pour ajouter des codes d’activation, veuillez passer par le menu ··· et choisir l’option correspondante./
       )
     ).toBeInTheDocument()
   })


### PR DESCRIPTION
```shell
139 |     renderStockThingScreen({ props, storeOverride, contextValue })
      140 |     expect(
    > 141 |       screen.getByText(
          |              ^
      142 |         'Les utilisateurs ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les utilisateurs ne peuvent pas annuler leurs réservations d’offres numériques. Toute réservation est définitive et sera immédiatement validée.'
      143 |       )
      144 |     ).toBeInTheDocument()

      at Object.getElementError (node_modules/@testing-library/dom/dist/config.js:38:19)
      at node_modules/@testing-library/dom/dist/query-helpers.js:90:38
      at node_modules/@testing-library/dom/dist/query-helpers.js:62:17
      at getByText (node_modules/@testing-library/dom/dist/query-helpers.js:111:19)
      at Object.<anonymous> (src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx:141:14)


Test Suites: 1 failed, 354 passed, 355 total
Tests:       1 failed, 2082 passed, 2083 total
Snapshots:   2 passed, 2 total
Time:        237.719 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Exited with code exit status 1

```
