### PR TITLE
(PC-18655)[PRO] chore: move OfferTypeButton to ui-kit

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -10,11 +10,11 @@ import { ReactComponent as TemplateOfferIcon } from 'icons/ico-template-offer.sv
 import { ReactComponent as PhoneIcon } from 'icons/info-phone.svg'
 import { ReactComponent as LibraryIcon } from 'icons/library.svg'
 import { ReactComponent as UserIcon } from 'icons/user.svg'
+import RadioButtonWithImage from 'ui-kit/RadioButtonWithImage'
 
 import ActionsBar from './ActionsBar/ActionsBar'
 import ActionsBarLegacy from './ActionsBar/ActionsBarLegacy'
 import styles from './OfferType.module.scss'
-import OfferTypeButton from './OfferTypeButton'
 import OldOfferTypeButton from './OldOfferTypeButton'
 
 const OfferType = (): JSX.Element => {
@@ -29,6 +29,7 @@ const OfferType = (): JSX.Element => {
 
   const getNextPageHref = () => {
     if (offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO) {
+      /* istanbul ignore next: condition will be removed when FF active in prod */
       return history.push({
         pathname: isOfferFormV3
           ? '/offre/v3/creation/individuelle/informations'
@@ -72,19 +73,19 @@ const OfferType = (): JSX.Element => {
           <FormLayout.Row inline>
             {isSubtypeChosenAtCreation ? (
               <>
-                <OfferTypeButton
+                <RadioButtonWithImage
                   name="offer-type"
                   Icon={PhoneIcon}
-                  isSelected={offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO}
+                  isChecked={offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO}
                   label="Au grand public"
                   onChange={handleOfferTypeChange}
                   value={OFFER_TYPES.INDIVIDUAL_OR_DUO}
                   className={styles['offer-type-button']}
                 />
-                <OfferTypeButton
+                <RadioButtonWithImage
                   name="offer-type"
                   Icon={CaseIcon}
-                  isSelected={offerType === OFFER_TYPES.EDUCATIONAL}
+                  isChecked={offerType === OFFER_TYPES.EDUCATIONAL}
                   label="À un groupe scolaire"
                   onChange={handleOfferTypeChange}
                   value={OFFER_TYPES.EDUCATIONAL}
@@ -115,10 +116,10 @@ const OfferType = (): JSX.Element => {
         {offerType === OFFER_TYPES.EDUCATIONAL && isSubtypeChosenAtCreation && (
           <FormLayout.Section title="Quel est le type de l'offre ?">
             <FormLayout.Row inline>
-              <OfferTypeButton
+              <RadioButtonWithImage
                 name="offer-subtype"
                 Icon={CalendarCheckIcon}
-                isSelected={offerSubtype === OFFER_SUBTYPES.COLLECTIVE}
+                isChecked={offerSubtype === OFFER_SUBTYPES.COLLECTIVE}
                 label="Une offre réservable"
                 description="Cette offre a une date et un prix. Vous pouvez choisir de la rendre visible par tous les établissements scolaires ou par un seul."
                 onChange={handleOfferSubtypeChange}
@@ -126,10 +127,10 @@ const OfferType = (): JSX.Element => {
               />
             </FormLayout.Row>
             <FormLayout.Row inline>
-              <OfferTypeButton
+              <RadioButtonWithImage
                 name="offer-subtype"
                 Icon={TemplateOfferIcon}
-                isSelected={offerSubtype === OFFER_SUBTYPES.TEMPLATE}
+                isChecked={offerSubtype === OFFER_SUBTYPES.TEMPLATE}
                 label="Une offre vitrine"
                 description="Cette offre n’est pas réservable. Elle n’a ni date, ni prix et permet aux enseignants de vous contacter pour co-construire une offre adaptée. "
                 onChange={handleOfferSubtypeChange}

--- a/pro/src/screens/OfferType/OfferTypeButton/index.ts
+++ b/pro/src/screens/OfferType/OfferTypeButton/index.ts
@@ -1,1 +1,0 @@
-export { default } from './OfferTypeButton'

--- a/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
+++ b/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
@@ -1,6 +1,7 @@
 @use 'styles/variables/_colors.scss' as colors;
 @use 'styles/mixins/_fonts.scss' as fonts;
 @use 'styles/mixins/_rem.scss' as rem;
+@use 'styles/mixins/_a11y.scss' as a11y;
 
 .button {
   background-color: transparent;
@@ -10,11 +11,11 @@
   font-size: rem.torem(15px);
 
   &-radio {
-    position: absolute;
-    z-index: -1;
+    @include a11y.visuallyHidden();
   }
 
-  &-radio-on, &-radio-off {
+  &-radio-on,
+  &-radio-off {
     position: absolute;
     top: rem.torem(16px);
     right: rem.torem(16px);
@@ -29,7 +30,6 @@
     width: rem.torem(40px);
     height: rem.torem(40px);
   }
-
 
   &.is-selected {
     border-color: colors.$tertiary;
@@ -91,4 +91,3 @@
     margin-right: rem.torem(12px);
   }
 }
-

--- a/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.stories.tsx
+++ b/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.stories.tsx
@@ -1,0 +1,42 @@
+import type { Story } from '@storybook/react'
+import React, { useState } from 'react'
+
+import { ReactComponent as CaseIcon } from 'icons/ico-case.svg'
+import { ReactComponent as PhoneIcon } from 'icons/info-phone.svg'
+
+import RadioButtonWithImage, {
+  IRadioButtonWithImage,
+} from './RadioButtonWithImage'
+
+export default {
+  title: 'ui-kit/RadioButtonWithImage',
+  component: RadioButtonWithImage,
+}
+
+const Template: Story<IRadioButtonWithImage> = () => {
+  const [offerType, setOfferType] = useState('indiv')
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setOfferType(e.target.value)
+  return (
+    <div style={{ maxWidth: '240px' }}>
+      <RadioButtonWithImage
+        name="offer"
+        label="Offre Individuelle"
+        isChecked={offerType == 'indiv'}
+        onChange={handleChange}
+        Icon={PhoneIcon}
+        value="indiv"
+      />
+      <RadioButtonWithImage
+        name="collectiveOffer"
+        label="Offre Collective"
+        isChecked={offerType == 'collective'}
+        onChange={handleChange}
+        Icon={CaseIcon}
+        value="collective"
+      />
+    </div>
+  )
+}
+
+export const Default = Template.bind({})

--- a/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.tsx
+++ b/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.tsx
@@ -1,15 +1,14 @@
 import cn from 'classnames'
 import React, { FunctionComponent, SVGProps } from 'react'
 
-import { OFFER_SUBTYPES, OFFER_TYPES } from 'core/Offers'
 import { ReactComponent as RadioOffIcon } from 'icons/ico-radio-off.svg'
 import { ReactComponent as RadioOnIcon } from 'icons/ico-radio-on.svg'
 
-import styles from './OfferTypeButton.module.scss'
+import styles from './RadioButtonWithImage.module.scss'
 
-interface IOfferTypeButton {
+export interface IRadioButtonWithImage {
   name: string
-  isSelected: boolean
+  isChecked: boolean
   Icon: FunctionComponent<
     SVGProps<SVGSVGElement> & { title?: string | undefined }
   >
@@ -18,12 +17,12 @@ interface IOfferTypeButton {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
   className?: string
   disabled?: boolean
-  value: OFFER_TYPES | OFFER_SUBTYPES
+  value: string
 }
 
-const OfferTypeButton = ({
+const RadioButtonWithImage = ({
   name,
-  isSelected,
+  isChecked,
   Icon,
   label,
   description,
@@ -31,7 +30,7 @@ const OfferTypeButton = ({
   className,
   disabled = false,
   value,
-}: IOfferTypeButton): JSX.Element => (
+}: IRadioButtonWithImage): JSX.Element => (
   <label
     className={cn(
       styles.button,
@@ -39,20 +38,20 @@ const OfferTypeButton = ({
         ? styles['layout-column']
         : styles['layout-row'],
       {
-        [styles['is-selected']]: isSelected,
+        [styles['is-selected']]: isChecked,
         [styles['is-disabled']]: disabled,
       },
       className
     )}
   >
-    {isSelected ? (
+    {isChecked ? (
       <RadioOnIcon className={styles['button-radio-on']} />
     ) : (
       <RadioOffIcon className={styles['button-radio-off']} />
     )}
     <Icon className={styles['button-icon']} />
     <input
-      checked={isSelected}
+      checked={isChecked}
       className={styles['button-radio']}
       disabled={disabled}
       name={name}
@@ -69,4 +68,4 @@ const OfferTypeButton = ({
   </label>
 )
 
-export default OfferTypeButton
+export default RadioButtonWithImage

--- a/pro/src/ui-kit/RadioButtonWithImage/index.ts
+++ b/pro/src/ui-kit/RadioButtonWithImage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RadioButtonWithImage'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18655

## But de la pull request

- Déplacer le composant `OfferTypeButton` dans ui-kit et le rendre réutilisable
- Utiliser ce nouveau composant (RadioButtonWithImage) dans OfferTypes

## Screenshot

![Capture d’écran 2022-11-17 à 11 30 58](https://user-images.githubusercontent.com/71768799/202423194-800601d8-fc72-412e-a296-ffee40931aa3.png)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
