### PR TITLE
[BSR]ci: have Pytest collect all required files

### DIFF
--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -178,10 +178,8 @@ jobs:
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL
           run: |
-            # Synchronize these globs with `python_files` in `pytest.ini`
-            TEST_FILES=$(ls tests/**/*test.py tests/**/test*.py)
             mkdir -p test-results
-            pytest $TEST_FILES --durations=10 --junitxml=test-results/junit.xml
+            pytest --durations=10 --junitxml=test-results/junit.xml
       - name: Slack Notification
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## But de la pull request

Collecter tous les tests api lors du lancement de pytest via GitHub Actions

## Implémentation

Laisser Pytest découvrir tous les tests dans le dossier `tests`, définis via `testpaths` dans `pyproject.toml`

## Informations supplémentaires

Un commit jetable est ajouté, contenant  un test en échec qui n'était pas collecté avec la précédente configuration.