### PR TITLE
(jeremieb)[API] fix: override isValidated/etc methods

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -797,6 +797,70 @@ class UserOfferer(PcObject, Base, Model, NeedsValidationMixin, ValidationStatusM
         ),
     )
 
+    @hybrid_property
+    def isValidated(self) -> bool:
+        # Keep compatibility with validation by token until production data has been migrated
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        return (
+            self.validationStatus is None and self.validationToken is None
+        ) or self.validationStatus == ValidationStatus.VALIDATED
+
+    @isValidated.expression  # type: ignore [no-redef]
+    def isValidated(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+        # Keep compatibility with validation by token until production data has been migrated
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        return sa.or_(
+            sa.and_(cls.validationStatus.is_(None), cls.validationToken.is_(None)),
+            cls.validationStatus == ValidationStatus.VALIDATED,
+        ).is_(True)
+
+    @hybrid_property
+    def isWaitingForValidation(self) -> bool:
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        return (self.validationStatus is None and self.validationToken is not None) or self.validationStatus in (
+            ValidationStatus.NEW,
+            ValidationStatus.PENDING,
+        )
+
+    @isWaitingForValidation.expression  # type: ignore [no-redef]
+    def isWaitingForValidation(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        return sa.or_(
+            sa.and_(cls.validationStatus.is_(None), cls.validationToken.is_not(None)),
+            cls.validationStatus == ValidationStatus.NEW,
+            cls.validationStatus == ValidationStatus.PENDING,
+        ).is_(True)
+
+    @hybrid_property
+    def isNew(self) -> bool:
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        if self.validationStatus is None and self.validationToken is not None:
+            return True
+        return self.validationStatus == ValidationStatus.NEW
+
+    @isNew.expression  # type: ignore [no-redef]
+    def isNew(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        return sa.or_(
+            sa.and_(cls.validationStatus.is_(None), cls.validationToken.is_not(None)),
+            cls.validationStatus == ValidationStatus.NEW,
+        ).is_(True)
+
+    @hybrid_property
+    def isPending(self) -> bool:
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        if self.validationStatus is None and self.validationToken is not None:
+            return True
+        return self.validationStatus == ValidationStatus.PENDING
+
+    @isPending.expression  # type: ignore [no-redef]
+    def isPending(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+        # TODO (prouzet): remove this overriden property when validation token is no longer used and data is migrated
+        return sa.or_(
+            sa.and_(cls.validationStatus.is_(None), cls.validationToken.is_not(None)),
+            cls.validationStatus == ValidationStatus.PENDING,
+        ).is_(True)
+
 
 class ApiKey(PcObject, Base, Model):
     offererId: int = Column(BigInteger, ForeignKey("offerer.id"), index=True, nullable=False)


### PR DESCRIPTION
Same thing as for Offerer. Without this, a user_offerer could behave like:
  * user_offerer.validationStatus => 'REJECTED'
  * user_offerer.isValidated => True

because of the inherited isValidated method which relies on the validationToken.