### PR TITLE
Pc 18564 eac sort venue alphabetically in offer creation

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -10,6 +10,7 @@ import { SelectOption } from 'custom_types/form'
 import { useScrollToFirstErrorAfterSubmit } from 'hooks'
 import useNotification from 'hooks/useNotification'
 import { Banner, SubmitButton } from 'ui-kit'
+import { sortByLabel } from 'utils/strings'
 
 import { IOfferEducationalProps } from '../OfferEducational'
 
@@ -77,6 +78,7 @@ const OfferEducationalForm = ({
         }
 
         if (!isOk) {
+          /* istanbul ignore next: TO FIX -> issue when trying to mock useNotification */
           notify.error(message)
         }
 
@@ -92,7 +94,7 @@ const OfferEducationalForm = ({
       if (venuesOptions.length > 1) {
         venuesOptions = [
           { value: '', label: 'Sélectionner un lieu' },
-          ...venuesOptions,
+          ...sortByLabel(venuesOptions),
         ]
       }
       setCurrentOfferer(selectedOfferer)

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalCreationOffererStep.spec.tsx
@@ -215,11 +215,13 @@ describe('screens | OfferEducational : creation offerer step', () => {
             managedVenues: managedVenuesFactory([
               { id: 'VENUE_1', name: 'Venue 1' },
               { id: 'VENUE_2', name: 'Venue 2' },
+              { id: 'VENUE_3', name: 'A - Venue 3' },
             ]),
           },
         ]),
       }
     })
+
     it('should require a venue selection from the user', async () => {
       renderEACOfferForm(props)
       const venueSelect = await screen.findByLabelText(
@@ -228,7 +230,7 @@ describe('screens | OfferEducational : creation offerer step', () => {
 
       expect(venueSelect).toHaveValue('')
       expect(venueSelect).toHaveDisplayValue('Sélectionner un lieu')
-      expect(venueSelect.children).toHaveLength(3)
+      expect(venueSelect.children).toHaveLength(4)
       expect(venueSelect).toBeEnabled()
       expect(screen.queryByTestId('error-venueId')).not.toBeInTheDocument()
 
@@ -258,6 +260,18 @@ describe('screens | OfferEducational : creation offerer step', () => {
           name: 'Type d’offre',
         })
       ).toBeInTheDocument()
+    })
+
+    it('should display venues by alphabeticall order', async () => {
+      renderEACOfferForm(props)
+      const venueSelect = await screen.findByLabelText(
+        'Lieu qui percevra le remboursement'
+      )
+      const venuesOptions = venueSelect.children
+      expect(venuesOptions[0].textContent).toEqual('Sélectionner un lieu')
+      expect(venuesOptions[1].textContent).toEqual('A - Venue 3')
+      expect(venuesOptions[2].textContent).toEqual('Venue 1')
+      expect(venuesOptions[3].textContent).toEqual('Venue 2')
     })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18564

## But de la pull request

Trier par ordre alphabétique la sélection d'un lieu  lors de la création d'offres collectives 
BSR : ajout d'un test si le test d'éligibilité fail

![Capture d’écran 2022-11-21 à 12 09 12](https://user-images.githubusercontent.com/71768799/203035782-4d989390-ac7c-42b0-aa45-ee4551c39896.png)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
