### PR TITLE
(PC-18563)[PRO] feat: add info box for eac offer participants

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import FormLayout from 'components/FormLayout'
 import { IOfferEducationalFormValues } from 'core/OfferEducational'
-import { CheckboxGroup } from 'ui-kit'
+import { CheckboxGroup, InfoBox } from 'ui-kit'
 
 import { participantsOptions } from './participantsOptions'
 import useParicipantUpdates from './useParticipantUpdates'
@@ -24,7 +24,14 @@ const FormParticipants = ({
 
   return (
     <FormLayout.Section title="Participants">
-      <FormLayout.Row>
+      <FormLayout.Row
+        sideComponent={
+          <InfoBox
+            type="info"
+            text="Le Pass Culture à destination du public scolaire s’adresse aux élèves de la quatrième à la terminale des établissements publics et privés sous contrat."
+          />
+        }
+      >
         <CheckboxGroup
           group={participantsOptions}
           groupName="participants"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18563

## But de la pull request

Ajouter une info box au niveau de la section `Participants` lors de la création d'une offre collective

## Screenshot 

![Capture d’écran 2022-11-21 à 13 21 15](https://user-images.githubusercontent.com/71768799/203054280-467b3805-4de1-4314-8794-3a1ede05e7e7.png)
