### PR TITLE
(BSR)[PRO] fix: only run unit tests on diff for pull requests in CI

### DIFF
--- a/.github/workflows/tests-backoffice.yml
+++ b/.github/workflows/tests-backoffice.yml
@@ -54,9 +54,10 @@ jobs:
         with:
           path: ./${{ env.folder }}/.jest_cache
           key: node-${{ needs.read-node-version.outputs.node_version }}-jest-cache
-      - if: ${{ github.ref != 'refs/heads/master' }}
+      - if: ${{ github.ref == 'refs/heads/master' }}
         run: yarn test:unit:ci
-      - run: yarn test:unit:ci --changedSince=master
+      - if: ${{ github.ref != 'refs/heads/master' }}
+        run: yarn test:unit:ci --changedSince=master
       - if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -97,9 +97,10 @@ jobs:
         with:
           path: ./${{ env.folder }}/.jest_cache
           key: node-${{ needs.read-node-version.outputs.node_version }}-jest-cache
-      - if: ${{ github.ref != 'refs/heads/master' }}
+      - if: ${{ github.ref == 'refs/heads/master' }}
         run: yarn test:unit:ci
-      - run: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
+      - if: ${{ github.ref != 'refs/heads/master' }}
+        run: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
       - if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
## But de la pull request

Aligner le fonctionnement avec le comportement actuel de CircleCI : 

- tests complets quand sur master
- tests que sur le diff quand sur une branche