### PR TITLE
[API][Backoffice] PC 18493 backoffice own flask app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,12 +407,73 @@ jobs:
             alembic upgrade post@head
           working_directory: /usr/src/app
       - run:
-          name: Running tests
+          name: Running tests (without backoffice)
           command: |
             # Synchronize these globs with `python_files` in `pytest.ini`
             TEST_FILES=$(circleci tests glob "tests/**/*test.py" "tests/**/test*.py" | circleci tests split)
             mkdir -p test-results
-            pytest $TEST_FILES --durations=10 --junitxml=test-results/junit.xml
+            pytest $TEST_FILES --durations=10 --junitxml=test-results/junit.xml -m "not backoffice_v3"
+          working_directory: /usr/src/app
+      - store_test_results:
+          path: /usr/src/app/test-results
+      - store_artifacts:
+          path: /usr/src/app/test-results
+      - when:
+          condition:
+            equal: ["master", << pipeline.git.branch >>]
+          steps:
+            - notify-slack:
+                channel: shérif
+
+  tests-backoffice-v3:
+    parameters:
+      is_nightly_build:
+        type: boolean
+        default: false
+      pytest_extra_args:
+        description: "directories to include and ignore"
+        default: "tests"
+        type: string
+    working_directory: ~/pass-culture
+    docker:
+      - image: ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-tests:${CIRCLE_SHA1}
+        auth:
+          username: _json_key # default username when using a JSON key file to authenticate
+          password: $GCP_INFRA_KEY
+        environment:
+          RUN_ENV: tests
+          DATABASE_URL_TEST: postgresql://pytest:pytest@localhost:5432/pass_culture
+          REDIS_URL: redis://localhost:6379
+      - image: cimg/postgres:12.9-postgis
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          POSTGRES_USER: pytest
+          POSTGRES_PASSWORD: pytest
+          POSTGRES_DB: pass_culture
+      - image: redis
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - checkout
+      - skip_unchanged:
+          paths: api
+      - run:
+          name: Show installed Python packages
+          command: pip freeze
+      - run:
+          name: Running backoffice tests
+          command: |
+            flask install_postgres_extensions
+            alembic upgrade pre@head
+            alembic upgrade post@head
+            flask install_data
+            # Synchronize these globs with `python_files` in `pytest.ini`
+            TEST_FILES=$(circleci tests glob "tests/routes/backoffice_v3/**/*test.py" )
+            mkdir -p test-results
+            pytest $TEST_FILES --durations=10 --junitxml=test-results/junit.xml -m backoffice_v3
           working_directory: /usr/src/app
       - store_test_results:
           path: /usr/src/app/test-results
@@ -1233,6 +1294,20 @@ workflows:
          requires:
            - build-and-push-image
       - tests-api:
+         filters:
+           branches:
+             ignore:
+               - production
+               - staging
+               - integration
+               - docs
+         context:
+          - Slack
+          - GCP
+          - GCP_EHP
+         requires:
+           - build-and-push-image
+      - tests-backoffice-v3:
          filters:
            branches:
              ignore:

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -173,7 +173,7 @@ jobs:
             alembic downgrade pre@f460dc2c9f93
             alembic upgrade pre@head
             alembic upgrade post@head
-      - name: Running tests
+      - name: Running tests (without backoffice v3)
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.tests_docker_image }}
@@ -181,7 +181,7 @@ jobs:
           options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL
           run: |
             mkdir -p test-results
-            pytest --durations=10 --junitxml=test-results/junit.xml
+            pytest --durations=10 --junitxml=test-results/junit.xml -m 'not backoffice_v3'
       - name: Slack Notification
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/tests-backoffice-v3.yml
+++ b/.github/workflows/tests-backoffice-v3.yml
@@ -1,0 +1,102 @@
+on: workflow_call
+
+env:
+  region: europe-west1
+  tests_docker_image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:${{ github.sha }}
+
+defaults:
+  run:
+    working-directory: api
+
+jobs:
+  check-api-folder-changes:
+    name: "Check if folder changed"
+    uses: ./.github/workflows/check-folder-changes.yml
+    with:
+      folder: api
+
+  build-tests-docker-image:
+    name: "Build tests docker image"
+    uses: ./.github/workflows/build-and-push-docker-images.yml
+    needs: check-api-folder-changes
+    if: needs.check-api-folder-changes.outputs.folder_changed == 'true' || github.ref == 'refs/heads/master'
+    with:
+      tag: ${{ github.sha }}
+      tests: true
+    secrets: inherit
+
+  tests-api:
+    name: "Tests"
+    env:
+      RUN_ENV: tests
+      DATABASE_URL_TEST: postgresql://pytest:pytest@postgres:5432/pass_culture
+      REDIS_URL: redis://redis:6379
+    runs-on: ubuntu-latest
+    needs:
+      - check-api-folder-changes
+      - build-tests-docker-image
+    if: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+    permissions:
+      id-token: write
+      contents: read
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      postgres:
+        image: postgis/postgis:12-3.3-alpine
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          POSTGRES_USER: pytest
+          POSTGRES_PASSWORD: pytest
+          POSTGRES_DB: pass_culture
+    steps:
+      - uses: actions/checkout@v3
+      - id: openid-auth
+        name: "OpenID Connect Authentication"
+        uses: 'google-github-actions/auth@v0'
+        with:
+          create_credentials_file: false
+          token_format: 'access_token'
+          workload_identity_provider: ${{ secrets.INFRA_PROD_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - uses: docker/login-action@v2
+        with:
+          registry: '${{ env.region }}-docker.pkg.dev'
+          username: oauth2accesstoken
+          password: ${{ steps.openid-auth.outputs.access_token }}
+      - run: docker pull ${{ env.tests_docker_image }}
+      - name: Running backoffice tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.tests_docker_image }}
+          shell: bash
+          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL
+          run: |
+            flask install_postgres_extensions
+            alembic upgrade pre@head
+            alembic upgrade post@head
+            flask install_data
+            mkdir -p test-results
+            pytest --durations=10 --junitxml=test-results/junit.xml -m backoffice_v3
+      - name: Slack Notification
+        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_CHANNEL: shérif
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_USERNAME: Github Actions Bot
+

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -11,4 +11,4 @@ exec gunicorn \
     --threads $GUNICORN_THREADS \
     --timeout $GUNICORN_TIMEOUT \
     --log-level $GUNICORN_LOG_LEVEL \
-    pcapi.app:app
+    ${GUNICORN_FLASK_APP:-pcapi.app:app}

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -181,3 +181,6 @@ python_functions = ["test_*", "when_*", "expect_*", "should_*"]
 env_files = ["local_test_env_file"]
 mocked-sessions = ["pcapi.models.db.session"]
 junit_family = "xunit1"
+markers = [
+    "backoffice_v3"
+]

--- a/api/src/pcapi/admin/base_configuration.py
+++ b/api/src/pcapi/admin/base_configuration.py
@@ -20,7 +20,6 @@ from pcapi import settings
 from pcapi.core.users import models as users_models
 from pcapi.core.users import repository as users_repository
 import pcapi.core.users.api as users_api
-from pcapi.flask_app import oauth
 
 
 logger = logging.getLogger(__name__)
@@ -124,6 +123,8 @@ class AdminIndexView(AdminIndexBaseView):
 
     @expose("/login/", methods=("GET", "POST"))
     def login_view(self) -> werkzeug.Response:
+        from pcapi.flask_app import oauth  # avoid circular imports
+
         if settings.IS_DEV:
             from pcapi.utils import login_manager
 
@@ -150,6 +151,7 @@ class AdminIndexView(AdminIndexBaseView):
 
     @expose("/authorize/")
     def authorize(self):  # type: ignore [no-untyped-def]
+        from pcapi.flask_app import oauth  # avoid circular imports
         from pcapi.utils import login_manager
 
         token = oauth.google.authorize_access_token()

--- a/api/src/pcapi/core/auth/utils.py
+++ b/api/src/pcapi/core/auth/utils.py
@@ -1,9 +1,9 @@
 import typing
 
+from flask import current_app as app
 from flask import g
 
 from pcapi.core.users import models as users_models
-from pcapi.flask_app import app
 
 
 CURRENT_USER_GLOBAL_NAME = "current_account"

--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -203,6 +203,12 @@ class JsonFormatter(logging.Formatter):
 
 
 def install_logging() -> None:
+    global _internal_logger  # pylint: disable=global-statement
+
+    # Avoid side effects of calling this function more than once.
+    if _internal_logger is not None:
+        return
+
     monkey_patch_logger_makeRecord()
     monkey_patch_logger_log()
     if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
@@ -210,12 +216,6 @@ def install_logging() -> None:
         logging.basicConfig(level=settings.LOG_LEVEL)
         _silence_noisy_loggers()
 
-        return
-
-    global _internal_logger  # pylint: disable=global-statement
-
-    # Avoid side effects of calling this function more than once.
-    if _internal_logger is not None:
         return
 
     handler = logging.StreamHandler(stream=sys.stdout)

--- a/api/src/pcapi/routes/__init__.py
+++ b/api/src/pcapi/routes/__init__.py
@@ -13,7 +13,6 @@ def install_all_routes(app: Flask) -> None:
     from pcapi.routes.apis import private_api
     from pcapi.routes.apis import public_api
     from pcapi.routes.backoffice.blueprint import backoffice_blueprint
-    from pcapi.routes.backoffice_v3.blueprint import backoffice_v3_web
     from pcapi.routes.native.v1.blueprint import native_v1 as native_v1_blueprint
     from pcapi.routes.pro.blueprint import pro_private_api as pro_private_api_blueprint
     from pcapi.routes.pro.blueprint import pro_public_api_v1 as pro_public_api_v1_blueprint
@@ -26,7 +25,6 @@ def install_all_routes(app: Flask) -> None:
     from . import adage
     from . import adage_iframe
     from . import backoffice
-    from . import backoffice_v3
     from . import error_handlers  # pylint: disable=unused-import
     from . import external
     from . import internal
@@ -52,7 +50,6 @@ def install_all_routes(app: Flask) -> None:
     pcapi.tasks.install_handlers(app)
     install_admin_template_filters(app)
     backoffice.install_routes(app)
-    backoffice_v3.install_routes(app)
 
     app.register_blueprint(adage_v1_blueprint, url_prefix="/adage/v1")
     app.register_blueprint(native_v1_blueprint, url_prefix="/native/v1")
@@ -66,4 +63,3 @@ def install_all_routes(app: Flask) -> None:
     app.register_blueprint(private_api)
     app.register_blueprint(public_api)
     app.register_blueprint(backoffice_blueprint, url_prefix="/backoffice")
-    app.register_blueprint(backoffice_v3_web, url_prefix="/backofficev3")

--- a/api/src/pcapi/routes/backoffice_v3/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/blueprint.py
@@ -8,6 +8,8 @@ from pcapi.models.feature import FeatureToggle
 from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
 
+from .forms import empty as empty_forms
+
 
 backoffice_v3_web = Blueprint("backoffice_v3_web", __name__, template_folder="templates")
 CORS(
@@ -46,4 +48,4 @@ def require_ff() -> None:
 
 @backoffice_v3_web.context_processor
 def add_logout_csrf_token() -> dict:
-    return {"logout_csrf_token": ""}
+    return {"logout_csrf_token": empty_forms.EmptyForm().csrf_token}

--- a/api/src/pcapi/routes/backoffice_v3/templates/errors/csrf.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/errors/csrf.html
@@ -1,0 +1,11 @@
+{% extends "layouts/error.html" %}
+
+{% block error %}
+<h1 class="display-1 fw-bold">Erreur</h1>
+
+<!-- this frame wrap errors in case the error call was made inside a turbo frame -->
+<turbo-frame id="{{ turbo_frame_id }}">
+    <p class="fs-3"> <span class="text-danger">Woops !</span> Token CSRF absent</p>
+</turbo-frame>
+
+{% endblock %}

--- a/api/src/pcapi/scripts/external_users/max_user_id.py
+++ b/api/src/pcapi/scripts/external_users/max_user_id.py
@@ -1,0 +1,8 @@
+from flask import current_app as app
+
+from pcapi.core.users.models import User
+
+
+with app.app_context():
+    last_user = User.query.order_by(User.id.desc()).first()
+    print(last_user.id)

--- a/api/src/pcapi/scripts/external_users/sendinblue_batch_update_user_attributes.py
+++ b/api/src/pcapi/scripts/external_users/sendinblue_batch_update_user_attributes.py
@@ -1,0 +1,81 @@
+"""
+Fetch users from database and update their information in Batch and Sendinblue.
+Goal: some users do not have all the expected attributes, this script should
+fix this issue.
+"""
+import sys
+
+from pcapi.core.external import batch
+from pcapi.core.external import sendinblue
+from pcapi.core.external.attributes.api import get_user_attributes
+from pcapi.core.external.attributes.api import get_user_or_pro_attributes
+from pcapi.core.external.sendinblue import SendinblueUserUpdateData
+from pcapi.core.external.sendinblue import import_contacts_in_sendinblue
+from pcapi.core.users.models import User
+from pcapi.notifications.push import update_users_attributes
+from pcapi.notifications.push.backends.batch import UserUpdateData
+
+
+def format_batch_users(users: list[User]) -> list[UserUpdateData]:
+    res = []
+    for user in users:
+        attributes = batch.format_user_attributes(get_user_attributes(user))
+        res.append(UserUpdateData(user_id=str(user.id), attributes=attributes))
+    print(f"{len(res)} users formatted for batch...")
+    return res
+
+
+def format_sendinblue_users(users: list[User]) -> list[SendinblueUserUpdateData]:
+    res = []
+    for user in users:
+        attributes = sendinblue.format_user_attributes(get_user_or_pro_attributes(user))
+        res.append(SendinblueUserUpdateData(email=user.email, attributes=attributes))
+    print(f"{len(res)} users formatted for sendinblue...")
+    return res
+
+
+def run(
+    min_user_id: int, max_user_id: int, synchronize_batch: bool = True, synchronize_sendinblue: bool = True
+) -> None:
+    if not synchronize_batch and not synchronize_sendinblue:
+        print("No user synchronized, please set synchronize_batch or synchronize_sendinblue to True")
+        return
+
+    message = (
+        "Update multiple user attributes in "
+        f"[{'Batch, ' if synchronize_batch else ''}{'Sendinblue' if synchronize_sendinblue else ''}] "
+        f"with user ids in range {min_user_id}-{max_user_id}"
+    )
+
+    user_ids = list(range(min_user_id, max_user_id + 1))
+
+    print("%s started" % message)
+    chunk = (
+        User.query.filter(User.id.in_(user_ids))
+        .filter(User.has_pro_role.is_(False))  # type: ignore [attr-defined]
+        .filter(User.has_admin_role.is_(False))  # type: ignore [attr-defined]
+        .all()
+    )
+    if synchronize_batch:
+        batch_users_data = format_batch_users(chunk)
+        update_users_attributes(batch_users_data)
+    if synchronize_sendinblue:
+        sendinblue_users_data = format_sendinblue_users(chunk)
+        import_contacts_in_sendinblue(sendinblue_users_data)
+
+    print("%s users updated" % len(chunk))
+
+
+if __name__ == "__main__":
+    from flask import current_app as app
+
+    app.app_context().push()
+
+    if len(sys.argv) != 3:
+        raise ValueError("This script requires two arguments: min and max ids")
+    user_id_bounds = [int(v) for v in sys.argv[1:3]]
+
+    arg_min_user_id = min(user_id_bounds)
+    arg_max_user_id = max(user_id_bounds)
+
+    run(arg_min_user_id, arg_max_user_id, synchronize_batch=True, synchronize_sendinblue=True)

--- a/api/src/pcapi/scripts/external_users/sendinblue_update_pro_attributes.py
+++ b/api/src/pcapi/scripts/external_users/sendinblue_update_pro_attributes.py
@@ -72,7 +72,7 @@ def sendinblue_update_all_pro_attributes(start_index: int = 0) -> None:
 
 
 if __name__ == "__main__":
-    from pcapi.flask_app import app
+    from flask import current_app as app
 
     app.app_context().push()
 

--- a/api/src/pcapi/scripts/external_users/zendesk_sell_initialization.py
+++ b/api/src/pcapi/scripts/external_users/zendesk_sell_initialization.py
@@ -217,7 +217,7 @@ def run_initialization(dry: bool = True, min_offerer_id: int = 0) -> None:
 
 
 if __name__ == "__main__":
-    from pcapi.flask_app import app
+    from flask import current_app as app
 
     parser = argparse.ArgumentParser(description="""Sync Zendesk Sell with PC production database""")
     parser.add_argument(

--- a/api/src/pcapi/scripts/fill_allocine_pivot.py
+++ b/api/src/pcapi/scripts/fill_allocine_pivot.py
@@ -3,10 +3,10 @@
 import argparse
 import csv
 
+from flask import current_app as app
 import sqlalchemy.exc
 
 from pcapi.core.providers.models import AllocinePivot
-from pcapi.flask_app import app
 from pcapi.models import db
 
 

--- a/api/src/pcapi/scripts/format_user_phone_numbers.py
+++ b/api/src/pcapi/scripts/format_user_phone_numbers.py
@@ -138,10 +138,11 @@ if __name__ == "__main__":
         os.environ["CORS_ALLOWED_ORIGINS_ADAGE_IFRAME"] = ""
         os.environ["DATABASE_URL"] = "postgresql://pass_culture:pass_culture@localhost:5434/pass_culture"
 
+    from flask import current_app as app
+
     from pcapi.core.subscription.phone_validation.exceptions import InvalidPhoneNumber
     from pcapi.core.users.models import User
-    from pcapi.flask_app import app
-    from pcapi.flask_app import db
+    from pcapi.models import db
     from pcapi.utils.phone_number import ParsedPhoneNumber
 
     main(

--- a/api/src/pcapi/scripts/import_unsubscribed_users.py
+++ b/api/src/pcapi/scripts/import_unsubscribed_users.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
+from flask import current_app as app
+
 from pcapi.core.external.sendinblue import import_contacts_in_sendinblue
 from pcapi.core.users.models import User
-from pcapi.flask_app import app
 from pcapi.repository import repository
 from pcapi.scripts.external_users.batch_update_users_attributes import format_sendinblue_users
 

--- a/api/src/pcapi/scripts/reject_cgu_incompatible_offers.py
+++ b/api/src/pcapi/scripts/reject_cgu_incompatible_offers.py
@@ -89,10 +89,11 @@ if __name__ == "__main__":
         os.environ["CORS_ALLOWED_ORIGINS_ADAGE_IFRAME"] = ""
         os.environ["DATABASE_URL"] = "postgresql://pass_culture:pass_culture@localhost:5434/pass_culture"
 
+    from flask import current_app as app
+
     from pcapi.core.offers.models import Offer
     from pcapi.core.offers.models import Product
-    from pcapi.flask_app import app
-    from pcapi.flask_app import db
+    from pcapi.models import db
     from pcapi.models.offer_mixin import OfferValidationStatus
     from pcapi.models.offer_mixin import OfferValidationType
 

--- a/api/tests/core/permissions/test_permissions_check.py
+++ b/api/tests/core/permissions/test_permissions_check.py
@@ -7,7 +7,6 @@ import pytest
 
 from pcapi.core.auth.api import generate_token
 from pcapi.core.permissions.factories import PermissionFactory
-from pcapi.core.permissions.utils import permission_required
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.core.users.factories import UserFactory
@@ -17,6 +16,9 @@ from pcapi.repository import repository
 
 @override_features(ENABLE_BACKOFFICE_API=True)
 def test_access_granted_with_right_permission(db_session, client):
+    # avoid "working outside of application context" error
+    from pcapi.core.permissions.utils import permission_required
+
     # given
     permission = PermissionFactory()
     repository.save(permission)
@@ -38,6 +40,9 @@ def test_access_granted_with_right_permission(db_session, client):
 
 @override_features(ENABLE_BACKOFFICE_API=True)
 def test_access_denied_without_right_permission(db_session, client):
+    # avoid "working outside of application context" error
+    from pcapi.core.permissions.utils import permission_required
+
     # given
     permission = PermissionFactory()
     repository.save(permission)
@@ -63,6 +68,9 @@ def test_access_denied_without_right_permission(db_session, client):
 
 @override_features(ENABLE_BACKOFFICE_API=True)
 def test_access_denied_with_expired_token(db_session, client):
+    # avoid "working outside of application context" error
+    from pcapi.core.permissions.utils import permission_required
+
     # given
     permission = PermissionFactory()
     repository.save(permission)
@@ -90,6 +98,9 @@ def test_access_denied_with_expired_token(db_session, client):
 
 @override_features(ENABLE_BACKOFFICE_API=True)
 def test_access_denied_as_anonymous(db_session, client):
+    # avoid "working outside of application context" error
+    from pcapi.core.permissions.utils import permission_required
+
     # given
     permission = PermissionFactory()
     repository.save(permission)
@@ -112,6 +123,9 @@ def test_access_denied_as_anonymous(db_session, client):
 @override_features(ENABLE_BACKOFFICE_API=True)
 @override_settings(IS_TESTING=True)
 def test_no_need_for_permissions_on_testing_environment(db_session, client):
+    # avoid "working outside of application context" error
+    from pcapi.core.permissions.utils import permission_required
+
     # given
     permission = PermissionFactory()
     repository.save(permission)
@@ -133,6 +147,9 @@ def test_no_need_for_permissions_on_testing_environment(db_session, client):
 
 @override_features(ENABLE_BACKOFFICE_API=False)
 def test_access_denied_when_backoffice_api_disabled(db_session, client):
+    # avoid "working outside of application context" error
+    from pcapi.core.permissions.utils import permission_required
+
     # given
     permission = PermissionFactory()
     repository.save(permission)

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -16,7 +16,10 @@ from .helpers import search as search_helpers
 from .helpers import unauthorized as unauthorized_helpers
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 class SearchPublicAccountsUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
@@ -28,19 +31,19 @@ class SearchPublicAccountsAuthorizedTest(search_helpers.SearchHelper):
     endpoint = "backoffice_v3_web.search_public_accounts"
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_search_result_page(self, client, legit_user):  # type: ignore
+    def test_search_result_page(self, authenticated_client, legit_user):  # type: ignore
         url = url_for(self.endpoint, terms=legit_user.email, order_by="", page=1, per_page=20)
 
-        response = client.with_session_auth(legit_user.email).get(url)
+        response = authenticated_client.get(url)
 
         assert response.status_code == 200, f"[{response.status}] {response.location}"
         assert legit_user.email in str(response.data)
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_malformed_query(self, client, legit_user):  # type: ignore
+    def test_malformed_query(self, authenticated_client, legit_user):  # type: ignore
         url = url_for(self.endpoint, terms=legit_user.email, order_by="unknown_field")
 
-        response = client.with_session_auth(legit_user.email).get(url)
+        response = authenticated_client.get(url)
 
         assert response.status_code == 400
 
@@ -71,7 +74,7 @@ class UpdatePublicAccountTest:
         form = {"first_name": "aaaaaaaaaaaaaaaaaaa"}
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_update_field(self, client, legit_user):
+    def test_update_field(self, authenticated_client):
         user_to_edit = users_factories.BeneficiaryGrant18Factory()
 
         new_email = user_to_edit.email + ".UPDATE  "
@@ -89,7 +92,7 @@ class UpdatePublicAccountTest:
             "postal_code": expected_new_postal_code,
         }
 
-        response = self.update_account(client, legit_user, user_to_edit, base_form)
+        response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 303
 
         expected_url = url_for("backoffice_v3_web.get_public_account", user_id=user_to_edit.id, _external=True)
@@ -102,18 +105,18 @@ class UpdatePublicAccountTest:
         assert user_to_edit.city == expected_city
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_unknown_field(self, client, legit_user):
+    def test_unknown_field(self, authenticated_client):
         user_to_edit = users_factories.BeneficiaryGrant18Factory()
         base_form = {
             "first_name": user_to_edit.firstName,
             "unknown": "field",
         }
 
-        response = self.update_account(client, legit_user, user_to_edit, base_form)
+        response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 400
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_email_already_exists(self, client, legit_user):
+    def test_email_already_exists(self, authenticated_client):
         user_to_edit = users_factories.BeneficiaryGrant18Factory()
         other_user = users_factories.BeneficiaryGrant18Factory()
 
@@ -123,32 +126,32 @@ class UpdatePublicAccountTest:
             "email": other_user.email,
         }
 
-        response = self.update_account(client, legit_user, user_to_edit, base_form)
+        response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 400
 
         user_to_edit = users_models.User.query.get(user_to_edit.id)
         assert user_to_edit.email != other_user.email
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_invalid_postal_code(self, client, legit_user):
+    def test_invalid_postal_code(self, authenticated_client):
         user_to_edit = users_factories.BeneficiaryGrant18Factory()
 
         base_form = {
             "postal_code": "7500",
         }
 
-        response = self.update_account(client, legit_user, user_to_edit, base_form)
+        response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 400
 
-    def update_account(self, client, legit_user, user_to_edit, form):
+    def update_account(self, authenticated_client, user_to_edit, form):
         # generate csrf token
         edit_url = url_for("backoffice_v3_web.edit_public_account", user_id=user_to_edit.id)
-        client.with_session_auth(legit_user.email).get(edit_url)
+        authenticated_client.get(edit_url)
 
         url = url_for("backoffice_v3_web.update_public_account", user_id=user_to_edit.id)
 
         form["csrf_token"] = g.get("csrf_token", "")
-        return client.with_session_auth(legit_user.email).post(url, form=form)
+        return authenticated_client.post(url, form=form)
 
 
 class ResendValidationEmailTest:
@@ -163,39 +166,39 @@ class ResendValidationEmailTest:
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_resend_validation_email(self, client, legit_user):
+    def test_resend_validation_email(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory(isEmailValidated=False)
-        response = self.send_resend_validation_email_request(client, legit_user, user)
+        response = self.send_resend_validation_email_request(authenticated_client, user)
 
         assert response.status_code == 303
         assert len(mails_testing.outbox) == 1
 
     @pytest.mark.parametrize("user_factory", [users_factories.AdminFactory, users_factories.ProFactory])
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_no_email_sent_if_admin_pro(self, client, legit_user, user_factory):
+    def test_no_email_sent_if_admin_pro(self, authenticated_client, user_factory):
         user = user_factory()
-        response = self.send_resend_validation_email_request(client, legit_user, user)
+        response = self.send_resend_validation_email_request(authenticated_client, user)
 
         assert response.status_code == 303
         assert not mails_testing.outbox
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_no_email_sent_if_already_validated(self, client, legit_user):
+    def test_no_email_sent_if_already_validated(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory(isEmailValidated=True)
-        response = self.send_resend_validation_email_request(client, legit_user, user)
+        response = self.send_resend_validation_email_request(authenticated_client, user)
 
         assert response.status_code == 303
         assert not mails_testing.outbox
 
-    def send_resend_validation_email_request(self, client, legit_user, user):
+    def send_resend_validation_email_request(self, authenticated_client, user):
         # generate csrf token
         account_detail_url = url_for("backoffice_v3_web.get_public_account", user_id=user.id)
-        client.with_session_auth(legit_user.email).get(account_detail_url)
+        authenticated_client.get(account_detail_url)
 
         url = url_for("backoffice_v3_web.resend_validation_email", user_id=user.id)
         form = {"csrf_token": g.get("csrf_token", "")}
 
-        return client.with_session_auth(legit_user.email).post(url, form=form)
+        return authenticated_client.post(url, form=form)
 
 
 class SendValidationCodeTest:
@@ -210,15 +213,15 @@ class SendValidationCodeTest:
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_send_validation_code(self, client, legit_user):
+    def test_send_validation_code(self, authenticated_client):
         user = users_factories.UserFactory(phoneNumber="+33601020304", isEmailValidated=True)
-        response = self.send_request(client, legit_user, user)
+        response = self.send_request(authenticated_client, user)
 
         assert response.status_code == 303
         assert len(sms_testing.requests) == 1
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_nothing_sent_use_cases(self, client, legit_user):
+    def test_nothing_sent_use_cases(self, authenticated_client):
         other_user = users_factories.BeneficiaryGrant18Factory(
             phoneNumber="+33601020304",
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
@@ -240,20 +243,20 @@ class SendValidationCodeTest:
         ]
 
         for idx, user in enumerate(users):
-            response = self.send_request(client, legit_user, user)
+            response = self.send_request(authenticated_client, user)
 
             assert response.status_code == 303, f"[{idx}] found: {response.status_code}, expected: 303"
             assert not sms_testing.requests, f"[{idx}] {len(sms_testing.requests)} sms sent"
 
-    def send_request(self, client, legit_user, user):
+    def send_request(self, authenticated_client, user):
         # generate csrf token
         account_detail_url = url_for("backoffice_v3_web.get_public_account", user_id=user.id)
-        client.with_session_auth(legit_user.email).get(account_detail_url)
+        authenticated_client.get(account_detail_url)
 
         url = url_for("backoffice_v3_web.send_validation_code", user_id=user.id)
         form = {"csrf_token": g.get("csrf_token", "")}
 
-        return client.with_session_auth(legit_user.email).post(url, form=form)
+        return authenticated_client.post(url, form=form)
 
 
 class EditPublicAccountReviewTest(accounts_helpers.PageRendersHelper):
@@ -277,7 +280,7 @@ class UpdatePublicAccountReviewTest:
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_add_new_fraud_review_to_account(self, client, legit_user):
+    def test_add_new_fraud_review_to_account(self, authenticated_client, legit_user):
         user = users_factories.BeneficiaryGrant18Factory()
 
         base_form = {
@@ -286,7 +289,7 @@ class UpdatePublicAccountReviewTest:
             "reason": "test",
         }
 
-        response = self.add_new_review(client, legit_user, user, base_form)
+        response = self.add_new_review(authenticated_client, user, base_form)
         assert response.status_code == 303
 
         expected_url = url_for("backoffice_v3_web.get_public_account", user_id=user.id, _external=True)
@@ -301,7 +304,7 @@ class UpdatePublicAccountReviewTest:
         assert fraud_review.reason == "test"
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_malformed_form(self, client, legit_user):
+    def test_malformed_form(self, authenticated_client):
         user = users_factories.UserFactory()
 
         base_form = {
@@ -310,14 +313,14 @@ class UpdatePublicAccountReviewTest:
             "reason": "test",
         }
 
-        response = self.add_new_review(client, legit_user, user, base_form)
+        response = self.add_new_review(authenticated_client, user, base_form)
         assert response.status_code == 400
 
         user = users_models.User.query.get(user.id)
         assert not user.deposits
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_reason_not_compulsory(self, client, legit_user):
+    def test_reason_not_compulsory(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory()
 
         base_form = {
@@ -325,7 +328,7 @@ class UpdatePublicAccountReviewTest:
             "eligibility": users_models.EligibilityType.AGE18.name,
         }
 
-        response = self.add_new_review(client, legit_user, user, base_form)
+        response = self.add_new_review(authenticated_client, user, base_form)
         assert response.status_code == 303
 
         expected_url = url_for("backoffice_v3_web.get_public_account", user_id=user.id, _external=True)
@@ -340,7 +343,7 @@ class UpdatePublicAccountReviewTest:
         assert fraud_review.reason == None
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_missing_identity_fraud_check_filled(self, client, legit_user):
+    def test_missing_identity_fraud_check_filled(self, authenticated_client):
         # not a beneficiary, does not have any identity fraud check
         # filled by default.
         user = users_factories.UserFactory()
@@ -351,18 +354,20 @@ class UpdatePublicAccountReviewTest:
             "reason": "test",
         }
 
-        response = self.add_new_review(client, legit_user, user, base_form)
+        response = self.add_new_review(authenticated_client, user, base_form)
         assert response.status_code == 303
 
         user = users_models.User.query.get(user.id)
         assert not user.deposits
 
-    def add_new_review(self, client, legit_user, user_to_edit, form):
+    def add_new_review(self, authenticated_client, user_to_edit, form):
         # generate csrf token
         edit_url = url_for("backoffice_v3_web.edit_public_account", user_id=user_to_edit.id)
-        client.with_session_auth(legit_user.email).get(edit_url)
+        response = authenticated_client.get(edit_url)
+
+        assert response.status_code == 200
 
         url = url_for("backoffice_v3_web.review_public_account", user_id=user_to_edit.id)
 
         form["csrf_token"] = g.get("csrf_token", "")
-        return client.with_session_auth(legit_user.email).post(url, form=form)
+        return authenticated_client.post(url, form=form)

--- a/api/tests/routes/backoffice_v3/admin_test.py
+++ b/api/tests/routes/backoffice_v3/admin_test.py
@@ -9,7 +9,10 @@ from pcapi.core.testing import override_features
 from .helpers import unauthorized as unauthorized_helpers
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 class GetRolesAuthorizedTest:
@@ -53,9 +56,9 @@ class UpdateRoleTest:
     def update_role(self, client, legit_user, role_to_edit, form):
         # generate csrf token
         edit_url = url_for("backoffice_v3_web.get_roles")
-        client.with_session_auth(legit_user.email).get(edit_url)
+        client.with_bo_session_auth(legit_user).get(edit_url)
 
         url = url_for("backoffice_v3_web.update_role", role_id=role_to_edit.id)
 
         form["csrf_token"] = g.get("csrf_token", "")
-        return client.with_session_auth(legit_user.email).post(url, form=form)
+        return client.with_bo_session_auth(legit_user).post(url, form=form)

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -19,7 +19,10 @@ from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
@@ -59,7 +62,7 @@ def roles_with_permissions_fixture() -> None:
     perms_in_db = {perm.name: perm for perm in perm_models.Permission.query.all()}
 
     for name, perms in ROLE_PERMISSIONS.items():
-        role = perm_models.Role(name=name, permissions=[perms_in_db[perm.name] for perm in perms])
+        role = perm_models.Role(name=name, permissions=[perms_in_db[perm.name] for perm in perms])  # type: ignore
         db.session.add(role)
 
     db.session.commit()
@@ -79,7 +82,7 @@ def legit_user_fixture(roles_with_permissions: None) -> users_models.User:
 
 @pytest.fixture(scope="function", name="authenticated_client")
 def authenticated_client_fixture(client, legit_user):  # type: ignore
-    return client.with_session_auth(legit_user.email)
+    return client.with_bo_session_auth(legit_user)
 
 
 @pytest.fixture(name="offerer")

--- a/api/tests/routes/backoffice_v3/helpers/accounts.py
+++ b/api/tests/routes/backoffice_v3/helpers/accounts.py
@@ -6,7 +6,10 @@ from pcapi.core.users import factories as users_factories
 from . import base
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 class PageRendersHelper(base.BaseHelper):
@@ -20,5 +23,5 @@ class PageRendersHelper(base.BaseHelper):
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_page_renders(self, client, legit_user):
-        response = client.with_session_auth(legit_user.email).get(self.path)
+        response = client.with_bo_session_auth(legit_user).get(self.path)
         assert response.status_code == 200

--- a/api/tests/routes/backoffice_v3/helpers/search.py
+++ b/api/tests/routes/backoffice_v3/helpers/search.py
@@ -4,7 +4,10 @@ import pytest
 from pcapi.core.testing import override_features
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 class SearchHelper:
@@ -18,17 +21,17 @@ class SearchHelper:
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_view_empty_search_page(self, client, legit_user):  # type: ignore
-        response = client.with_session_auth(legit_user.email).get(self.search_path)
+        response = client.with_bo_session_auth(legit_user).get(self.search_path)
         assert response.status_code == 200
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_invalid_search(self, client, legit_user):  # type: ignore
         url = url_for(self.endpoint, unknown="param")
-        response = client.with_session_auth(legit_user.email).get(url)
+        response = client.with_bo_session_auth(legit_user).get(url)
 
         assert response.status_code == 400
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_search(self, client, legit_user):  # type: ignore
-        response = client.with_session_auth(legit_user.email).get(self.search_path)
+        response = client.with_bo_session_auth(legit_user).get(self.search_path)
         assert response.status_code == 200

--- a/api/tests/routes/backoffice_v3/home_test.py
+++ b/api/tests/routes/backoffice_v3/home_test.py
@@ -1,6 +1,13 @@
 from flask import url_for
+import pytest
 
 from pcapi.core.testing import override_features
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 class HomePageTest:

--- a/api/tests/routes/backoffice_v3/html_parser_test.py
+++ b/api/tests/routes/backoffice_v3/html_parser_test.py
@@ -1,4 +1,9 @@
+import pytest
+
 from .helpers import html_parser
+
+
+pytestmark = pytest.mark.backoffice_v3
 
 
 HTML_TABLE_CONTENT = """

--- a/api/tests/routes/backoffice_v3/pro_test.py
+++ b/api/tests/routes/backoffice_v3/pro_test.py
@@ -9,7 +9,10 @@ from .helpers import search as search_helpers
 from .helpers import unauthorized as unauthorized_helpers
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 def build_pro_user():
@@ -41,10 +44,10 @@ class SearchProTest(search_helpers.SearchHelper):
         ],
     )
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-    def test_search_result_page(self, client, legit_user, pro_builder, pro_type):
+    def test_search_result_page(self, authenticated_client, pro_builder, pro_type):
         pro_object = pro_builder()
 
         url = url_for(self.endpoint, terms=pro_object.id, pro_type=pro_type)
-        response = client.with_session_auth(legit_user.email).get(url)
+        response = authenticated_client.get(url)
 
         assert response.status_code == 200, f"[{response.status_code}] {response.location}"

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -13,7 +13,10 @@ from pcapi.routes.backoffice_v3.filters import format_date
 from .helpers import unauthorized as unauthorized_helpers
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 class GetProUserTest:
@@ -116,7 +119,7 @@ class CommentProUserTest:
         assert not pro_user.action_history
 
     def send_comment_pro_user_request(self, client, legit_user, pro_user, comment):
-        authenticated_client = client.with_session_auth(legit_user.email)
+        authenticated_client = client.with_bo_session_auth(legit_user)
 
         # generate and fetch (inside g) csrf token
         pro_user_detail_url = url_for("backoffice_v3_web.pro_user.get", user_id=pro_user.id)

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -20,7 +20,10 @@ from .helpers import html_parser
 from .helpers import unauthorized as unauthorized_helpers
 
 
-pytestmark = pytest.mark.usefixtures("db_session")
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
 
 
 @pytest.fixture(scope="function", name="venue")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18493

## But de la pull request

Créer une application Flask à part pour le backoffice. Ceci permettra d'avoir une configuration dédiée, d'éviter de se marcher sur les pieds (protection CSRF source de conflit entre la v3 et FlaskAdmin)...

## Implémentation

Les deux nouveaux fichiers backoffice_app.py et backoffice_flask_app sont globalement des copier/coller. Des éléments de configuration inutiles au backoffice ont été retirés, d'autres adaptés.

Ensuite le gros changement se situe au niveau des tests. Malheureusement, pytest-flask s'attend à avoir une fixture app : si on ne touche rien, on se retrouve lié à l'application Flask principale... sans le backoffice. L'idée ici est d'utiliser des pytest.mark pour : 

1. instancier la bonne application Flask ;
2. exécuter ou non des tests.

Concrètement, on lancera les tests en deux temps : d'abord les tests pour l'api sans le backoffice via `pytest -m "not backoffice_v3"` et ensuite ceux pour le backoffice via `pytest -m "backoffice_v3"`. Si quelqu'un a mieux, je suis preneur !

Et pour terminer, un petit mot sur la route /signin créée dans conftest : l'authentification sur la v3 ne se fait pas via un couple identifiant - mot de passe classique, mais via un _callback_ de Google. Pour proposer un moyen d'authentifier l'utilisateur lors des tests, il m'a semblé plus simple d'ajouter une route qui l'authentifie que de commencer à ajouter des patchs sur `/authorize`.

### github actions / circle ci

Les tests du backoffice sont lancé via des workflow indépendants afin que tous les tests soient systématiquement exécutés.