### PR TITLE
(PC-17618)[PRO] feat: trackers offer form v3

### DIFF
--- a/pro/src/components/OfferBreadcrumb/OfferBreadcrumb.tsx
+++ b/pro/src/components/OfferBreadcrumb/OfferBreadcrumb.tsx
@@ -145,6 +145,8 @@ const OfferBreadcrumb = ({
           to: step.id,
           used: OFFER_FORM_NAVIGATION_MEDIUM.BREADCRUMB,
           isEdition: !isCreatingOffer,
+          isDraft: isCreatingOffer || isCompletingDraft,
+          offerId: offerId,
         })
       }
     })

--- a/pro/src/components/OfferIndividualStepper/OfferIndividualStepper.tsx
+++ b/pro/src/components/OfferIndividualStepper/OfferIndividualStepper.tsx
@@ -7,8 +7,13 @@ import Breadcrumb, {
   Step,
 } from 'components/Breadcrumb'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { useOfferWizardMode } from 'hooks'
+import useAnalytics from 'hooks/useAnalytics'
 
 import { OFFER_WIZARD_STEP_IDS } from './constants'
 import { useActiveStep } from './hooks'
@@ -17,6 +22,7 @@ import styles from './OfferIndividualStepper.module.scss'
 const OfferIndividualStepper = () => {
   const { offer } = useOfferIndividualContext()
   const activeStep = useActiveStep()
+  const { logEvent } = useAnalytics()
   const mode = useOfferWizardMode()
   const hasOffer = offer !== null
   const hasStock = offer !== null && offer.stocks.length > 0
@@ -74,6 +80,16 @@ const OfferIndividualStepper = () => {
     const step: Step = {
       id: stepPattern.id,
       label: stepPattern.label,
+      onClick: () => {
+        logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+          from: activeStep,
+          to: step.id,
+          used: OFFER_FORM_NAVIGATION_MEDIUM.BREADCRUMB,
+          isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+          isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+          offerId: offer?.id,
+        })
+      },
     }
     if (stepPattern.isActive && stepPattern.path && offer) {
       step.url = generatePath(stepPattern.path, { offerId: offer.id })

--- a/pro/src/components/OfferIndividualStepper/__specs__/OfferIndividualStepper.spec.tsx
+++ b/pro/src/components/OfferIndividualStepper/__specs__/OfferIndividualStepper.spec.tsx
@@ -82,15 +82,15 @@ const renderOfferIndividualStepper = (
 
 describe('test OfferIndividualStepper', () => {
   describe('in creation', () => {
-    it('should render stepper breadcrumb in creation', async () => {
-      await renderOfferIndividualStepper()
+    it('should render stepper breadcrumb in creation', () => {
+      renderOfferIndividualStepper()
 
       expect(screen.getByTestId('stepper')).toBeInTheDocument()
     })
 
     it('should render steps when no offer is given', async () => {
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper()
+        renderOfferIndividualStepper()
 
       expect(tabInformations).toBeInTheDocument()
       expect(tabStocks).toBeInTheDocument()
@@ -118,7 +118,7 @@ describe('test OfferIndividualStepper', () => {
         offer: offer as IOfferIndividual,
       }
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(contextOverride)
+        renderOfferIndividualStepper(contextOverride)
 
       expect(tabInformations).toBeInTheDocument()
       expect(tabStocks).toBeInTheDocument()
@@ -145,7 +145,7 @@ describe('test OfferIndividualStepper', () => {
         offer: offer as IOfferIndividual,
       }
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(contextOverride)
+        renderOfferIndividualStepper(contextOverride)
 
       expect(tabInformations).toBeInTheDocument()
       expect(tabStocks).toBeInTheDocument()
@@ -162,9 +162,9 @@ describe('test OfferIndividualStepper', () => {
       expect(screen.getByText('Summary screen')).toBeInTheDocument()
     })
 
-    it('should render steps on Information', async () => {
+    it('should render steps on Information', () => {
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(
+        renderOfferIndividualStepper(
           undefined,
           '/offre/AA/v3/creation/individuelle/informations'
         )
@@ -176,9 +176,9 @@ describe('test OfferIndividualStepper', () => {
       expect(screen.getByText('Informations screen')).toBeInTheDocument()
     })
 
-    it('should render steps on Stocks', async () => {
+    it('should render steps on Stocks', () => {
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(
+        renderOfferIndividualStepper(
           undefined,
           '/offre/AA/v3/creation/individuelle/stocks'
         )
@@ -190,9 +190,9 @@ describe('test OfferIndividualStepper', () => {
       expect(screen.getByText('Stocks screen')).toBeInTheDocument()
     })
 
-    it('should render steps on Summary', async () => {
+    it('should render steps on Summary', () => {
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(
+        renderOfferIndividualStepper(
           undefined,
           '/offre/AA/v3/creation/individuelle/recapitulatif'
         )
@@ -206,7 +206,7 @@ describe('test OfferIndividualStepper', () => {
   })
 
   describe('in edition', () => {
-    it('should render default breadcrumb in edition', async () => {
+    it('should render default breadcrumb in edition', () => {
       const offer: Partial<IOfferIndividual> = {
         id: 'AA',
         stocks: [{ id: 'STOCK_ID' } as IOfferIndividualStock],
@@ -215,7 +215,7 @@ describe('test OfferIndividualStepper', () => {
       const contextOverride: Partial<IOfferIndividualContext> = {
         offer: offer as IOfferIndividual,
       }
-      await renderOfferIndividualStepper(
+      renderOfferIndividualStepper(
         contextOverride,
         '/offre/AA/v3/individuelle/informations'
       )
@@ -224,7 +224,7 @@ describe('test OfferIndividualStepper', () => {
       expect(screen.getByTestId('bc-tab')).toBeInTheDocument()
     })
 
-    it('should render steps on Information', async () => {
+    it('should render steps on Information', () => {
       const offer: Partial<IOfferIndividual> = {
         id: 'AA',
         stocks: [{ id: 'STOCK_ID' } as IOfferIndividualStock],
@@ -235,7 +235,7 @@ describe('test OfferIndividualStepper', () => {
       }
 
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(
+        renderOfferIndividualStepper(
           contextOverride,
           '/offre/AA/v3/individuelle/informations'
         )
@@ -248,7 +248,7 @@ describe('test OfferIndividualStepper', () => {
       expect(screen.getByText('Informations screen')).toBeInTheDocument()
     })
 
-    it('should render steps on Stocks', async () => {
+    it('should render steps on Stocks', () => {
       const offer: Partial<IOfferIndividual> = {
         id: 'AA',
         stocks: [{ id: 'STOCK_ID' } as IOfferIndividualStock],
@@ -259,7 +259,7 @@ describe('test OfferIndividualStepper', () => {
       }
 
       const { tabInformations, tabStocks, tabSummary, tabConfirmation } =
-        await renderOfferIndividualStepper(
+        renderOfferIndividualStepper(
           contextOverride,
           '/offre/AA/v3/individuelle/stocks'
         )

--- a/pro/src/components/OfferIndividualStepper/__specs__/OfferIndividualStepper.tracker.spec.tsx
+++ b/pro/src/components/OfferIndividualStepper/__specs__/OfferIndividualStepper.tracker.spec.tsx
@@ -1,0 +1,283 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { MemoryRouter, Route, Switch } from 'react-router'
+
+import {
+  IOfferIndividualContext,
+  OfferIndividualContext,
+} from 'context/OfferIndividualContext'
+import { Events } from 'core/FirebaseEvents/constants'
+import { IOfferIndividual, IOfferIndividualStock } from 'core/Offers/types'
+import * as useAnalytics from 'hooks/useAnalytics'
+
+import OfferIndividualStepper from '../OfferIndividualStepper'
+
+const mockLogEvent = jest.fn()
+
+const renderOfferIndividualStepper = (
+  contextOverride: Partial<IOfferIndividualContext> = {},
+  url = '/offre/AA/v3/creation/individuelle/informations'
+) => {
+  const contextValues: IOfferIndividualContext = {
+    offerId: null,
+    offer: null,
+    venueList: [],
+    offererNames: [],
+    categories: [],
+    subCategories: [],
+    setOffer: () => {},
+    ...contextOverride,
+  }
+  const rtlReturns = render(
+    <OfferIndividualContext.Provider value={contextValues}>
+      <MemoryRouter initialEntries={[url]}>
+        <OfferIndividualStepper />
+        <Switch>
+          <Route
+            path={[
+              '/offre/:offerId/v3/brouillon/individuelle/informations',
+              '/offre/:offerId/v3/creation/individuelle/informations',
+              '/offre/:offerId/v3/individuelle/informations',
+            ]}
+          >
+            <div>Informations screen</div>
+          </Route>
+          <Route
+            path={[
+              '/offre/:offerId/v3/brouillon/individuelle/stocks',
+              '/offre/:offerId/v3/creation/individuelle/stocks',
+              '/offre/:offerId/v3/individuelle/stocks',
+            ]}
+          >
+            <div>Stocks screen</div>
+          </Route>
+          <Route
+            path={[
+              '/offre/:offerId/v3/brouillon/individuelle/recapitulatif',
+              '/offre/:offerId/v3/creation/individuelle/recapitulatif',
+              '/offre/:offerId/v3/individuelle/recapitulatif',
+            ]}
+          >
+            <div>Summary screen</div>
+          </Route>
+          <Route
+            path={['/offre/:offerId/v3/creation/individuelle/confirmation']}
+          >
+            <div>Confirmation screen</div>
+          </Route>
+        </Switch>
+      </MemoryRouter>
+    </OfferIndividualContext.Provider>
+  )
+
+  const tabInformations = screen.queryByText('Informations')
+  const tabStocks = screen.queryByText('Stock & Prix')
+  const tabSummary = screen.queryByText('Récapitulatif')
+
+  return {
+    ...rtlReturns,
+    tabInformations,
+    tabStocks,
+    tabSummary,
+  }
+}
+
+describe('test tracker OfferIndividualStepper', () => {
+  let offer: Partial<IOfferIndividual>
+  let contextOverride: Partial<IOfferIndividualContext>
+  beforeEach(() => {
+    offer = {
+      id: 'AA',
+      stocks: [{ id: 'STOCK_ID' } as IOfferIndividualStock],
+    }
+
+    contextOverride = {
+      offer: offer as IOfferIndividual,
+    }
+    jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+      setLogEvent: null,
+    }))
+  })
+  describe('in creation', () => {
+    it('should track when clicking on steps on Information', async () => {
+      const { tabStocks } = renderOfferIndividualStepper(contextOverride)
+
+      tabStocks && (await userEvent.click(tabStocks))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'informations',
+          isEdition: false,
+          isDraft: true,
+          offerId: 'AA',
+          to: 'stocks',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+
+    it('should track when clicking on steps on Stocks', async () => {
+      const { tabSummary } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/creation/individuelle/stocks'
+      )
+
+      tabSummary && (await userEvent.click(tabSummary))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'stocks',
+          isEdition: false,
+          isDraft: true,
+          offerId: 'AA',
+          to: 'recapitulatif',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+
+    it('should track when clicking on steps on Summary', async () => {
+      const { tabInformations } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/creation/individuelle/recapitulatif'
+      )
+
+      tabInformations && (await userEvent.click(tabInformations))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'recapitulatif',
+          isEdition: false,
+          isDraft: true,
+          offerId: 'AA',
+          to: 'informations',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+  })
+
+  describe('in edition', () => {
+    it('should track when clicking on steps on Information', async () => {
+      const { tabStocks } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/individuelle/informations'
+      )
+
+      tabStocks && (await userEvent.click(tabStocks))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'informations',
+          isEdition: true,
+          isDraft: false,
+          offerId: 'AA',
+          to: 'stocks',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+
+    it('should track when clicking on steps on Stocks', async () => {
+      const { tabInformations } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/individuelle/stocks'
+      )
+
+      tabInformations && (await userEvent.click(tabInformations))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'stocks',
+          isEdition: true,
+          isDraft: false,
+          offerId: 'AA',
+          to: 'informations',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+  })
+
+  describe('in draft', () => {
+    it('should track when clicking on steps on Information', async () => {
+      const { tabSummary } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/brouillon/individuelle/informations'
+      )
+
+      tabSummary && (await userEvent.click(tabSummary))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'informations',
+          isEdition: true,
+          isDraft: true,
+          offerId: 'AA',
+          to: 'recapitulatif',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+
+    it('should track when clicking on steps on Stocks', async () => {
+      const { tabSummary } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/brouillon/individuelle/stocks'
+      )
+
+      tabSummary && (await userEvent.click(tabSummary))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'stocks',
+          isEdition: true,
+          isDraft: true,
+          offerId: 'AA',
+          to: 'recapitulatif',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+
+    it('should track when clicking on steps on Summary', async () => {
+      const { tabStocks } = renderOfferIndividualStepper(
+        contextOverride,
+        '/offre/AA/v3/brouillon/individuelle/recapitulatif'
+      )
+
+      tabStocks && (await userEvent.click(tabStocks))
+      expect(mockLogEvent).toHaveBeenCalledTimes(1)
+      expect(mockLogEvent).toHaveBeenNthCalledWith(
+        1,
+        Events.CLICKED_OFFER_FORM_NAVIGATION,
+        {
+          from: 'recapitulatif',
+          isEdition: true,
+          isDraft: true,
+          offerId: 'AA',
+          to: 'stocks',
+          used: 'Breadcrumb',
+        }
+      )
+    })
+  })
+})

--- a/pro/src/components/OfferIndividualStepper/__specs__/OfferIndividualStepper.tracker.spec.tsx
+++ b/pro/src/components/OfferIndividualStepper/__specs__/OfferIndividualStepper.tracker.spec.tsx
@@ -73,7 +73,7 @@ const renderOfferIndividualStepper = (
     </OfferIndividualContext.Provider>
   )
 
-  const tabInformations = screen.queryByText('Informations')
+  const tabInformations = screen.queryByText('Détails de l’offre')
   const tabStocks = screen.queryByText('Stock & Prix')
   const tabSummary = screen.queryByText('Récapitulatif')
 

--- a/pro/src/components/RouteLeavingGuard/RouteLeavingGuard.tsx
+++ b/pro/src/components/RouteLeavingGuard/RouteLeavingGuard.tsx
@@ -81,25 +81,29 @@ const RouteLeavingGuard = ({
     setIsConfirmedNavigation(true)
   }, [])
 
-  if (isConfirmedNavigation && nextLocation) {
+  const trackWhenQuit = useCallback(() => {
     tracking &&
       tracking(
         Object.keys(nextLocation).includes('pathname')
           ? nextLocation.pathname
           : nextLocation
       )
-  }
+  }, [isConfirmedNavigation, nextLocation])
 
   const rightButtonAction = () => {
     if (typeof rightButton.action === 'function') {
       return () => {
         rightButton.action && rightButton.action()
         handleConfirmNavigationClick()
+        trackWhenQuit()
       }
     } else if (rightButton.actionType === BUTTON_ACTION.CANCEL) {
       return closeModal
     }
-    return handleConfirmNavigationClick
+    return () => {
+      handleConfirmNavigationClick()
+      trackWhenQuit()
+    }
   }
 
   const leftButtonAction = () => {
@@ -107,9 +111,13 @@ const RouteLeavingGuard = ({
       return () => {
         leftButton.action && leftButton.action()
         handleConfirmNavigationClick()
+        trackWhenQuit()
       }
     } else if (leftButton.actionType === BUTTON_ACTION.QUIT_WITHOUT_SAVING) {
-      return handleConfirmNavigationClick
+      return () => {
+        handleConfirmNavigationClick()
+        trackWhenQuit()
+      }
     }
     return closeModal
   }

--- a/pro/src/components/RouteLeavingGuardOfferIndividual/RouteLeavingGuardOfferIndividual.tsx
+++ b/pro/src/components/RouteLeavingGuardOfferIndividual/RouteLeavingGuardOfferIndividual.tsx
@@ -37,6 +37,7 @@ export interface IRouteLeavingGuardOfferIndividual {
   hasOfferBeenCreated: boolean
   isFormValid: boolean
   setIsSubmittingFromRouteLeavingGuard: (p: boolean) => void
+  tracking?: (p: string) => void
 }
 
 const RouteLeavingGuardOfferIndividual = ({
@@ -45,6 +46,7 @@ const RouteLeavingGuardOfferIndividual = ({
   hasOfferBeenCreated,
   isFormValid,
   setIsSubmittingFromRouteLeavingGuard,
+  tracking,
 }: IRouteLeavingGuardOfferIndividual): JSX.Element => {
   const routeLeavingGuardTypes = {
     // form dirty and mandatory fields not ok
@@ -129,6 +131,7 @@ const RouteLeavingGuardOfferIndividual = ({
       dialogTitle={routeLeavingGuardTypes[type].dialogTitle}
       leftButton={routeLeavingGuardTypes[type].leftButton}
       rightButton={routeLeavingGuardTypes[type].rightButton}
+      tracking={tracking}
     >
       <p>{routeLeavingGuardTypes[type].description}</p>
     </RouteLeavingGuard>

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -76,6 +76,8 @@ export enum OFFER_FORM_NAVIGATION_MEDIUM {
   CONFIRMATION_BUTTON_OFFER_LIST = 'ConfirmationButtonOfferList',
   DETAILS_PREVIEW = 'DetailsPreview',
   OFFERS_TRASH_ICON = 'OffersTrashicon',
+  IMAGE_DELETE = 'ImageDelete',
+  IMAGE_CREATION = 'ImageCreation',
 }
 
 export enum OFFER_FORM_NAVIGATION_OUT {

--- a/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
@@ -3,8 +3,14 @@ import { useSelector } from 'react-redux'
 
 import ActionsBarSticky from 'components/ActionsBarSticky'
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualStepper'
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+  OFFER_FORM_NAVIGATION_OUT,
+} from 'core/FirebaseEvents/constants'
 import { computeOffersUrl, OFFER_WIZARD_MODE } from 'core/Offers'
 import { useOfferWizardMode } from 'hooks'
+import useAnalytics from 'hooks/useAnalytics'
 import { ReactComponent as IcoMiniArrowLeft } from 'icons/ico-mini-arrow-left.svg'
 import { ReactComponent as IcoMiniArrowRight } from 'icons/ico-mini-arrow-right.svg'
 import { RootState } from 'store/reducers'
@@ -17,6 +23,7 @@ export interface IActionBarProps {
   onClickSaveDraft?: () => void
   isDisabled: boolean
   step: OFFER_WIZARD_STEP_IDS
+  offerId?: string
 }
 
 const ActionBar = ({
@@ -25,6 +32,7 @@ const ActionBar = ({
   onClickSaveDraft,
   isDisabled,
   step,
+  offerId,
 }: IActionBarProps) => {
   const offersSearchFilters = useSelector(
     (state: RootState) => state.offers.searchFilters
@@ -34,6 +42,18 @@ const ActionBar = ({
   )
   const mode = useOfferWizardMode()
   const backOfferUrl = computeOffersUrl(offersSearchFilters, offersPageNumber)
+  const { logEvent } = useAnalytics()
+
+  const onCancelLog = () => {
+    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: step,
+      to: OFFER_FORM_NAVIGATION_OUT.OFFERS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+      offerId: offerId,
+    })
+  }
 
   const Left = (): JSX.Element => {
     if (mode !== OFFER_WIZARD_MODE.EDITION) {
@@ -43,6 +63,7 @@ const ActionBar = ({
             <ButtonLink
               link={{ to: '/offres', isExternal: false }}
               variant={ButtonVariant.SECONDARY}
+              onClick={onCancelLog}
             >
               Annuler et quitter
             </ButtonLink>
@@ -65,6 +86,7 @@ const ActionBar = ({
           <ButtonLink
             link={{ to: backOfferUrl, isExternal: false }}
             variant={ButtonVariant.PRIMARY}
+            onClick={onCancelLog}
           >
             Retour à la liste des offres
           </ButtonLink>
@@ -73,6 +95,7 @@ const ActionBar = ({
             <ButtonLink
               link={{ to: backOfferUrl, isExternal: false }}
               variant={ButtonVariant.SECONDARY}
+              onClick={onCancelLog}
             >
               Annuler et quitter
             </ButtonLink>
@@ -94,6 +117,7 @@ const ActionBar = ({
               <ButtonLink
                 link={{ to: '/offres', isExternal: false }}
                 variant={ButtonVariant.SECONDARY}
+                onClick={onCancelLog}
               >
                 Sauvegarder le brouillon et quitter
               </ButtonLink>

--- a/pro/src/screens/OfferIndividual/Informations/Informations.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/Informations.tsx
@@ -270,7 +270,9 @@ const Informations = ({
       logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
         from: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
         to: nextStep,
-        used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+        used: isSubmittingDraft
+          ? OFFER_FORM_NAVIGATION_MEDIUM.DRAFT_BUTTONS
+          : OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
         isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
         isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
         offerId: receivedOfferId,

--- a/pro/src/screens/OfferIndividual/Informations/Informations.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/Informations.tsx
@@ -322,6 +322,7 @@ const Informations = ({
             onClickSaveDraft={handleNextStep({ saveDraft: true })}
             step={OFFER_WIZARD_STEP_IDS.INFORMATIONS}
             isDisabled={formik.isSubmitting}
+            offerId={offer?.id}
           />
         </form>
       </FormLayout>

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
@@ -407,7 +407,7 @@ describe('screens:OfferIndividual::Informations::creation', () => {
         isEdition: false,
         offerId: 'AA',
         to: 'informations',
-        used: 'StickyButtons',
+        used: 'DraftButtons',
       }
     )
   })

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
@@ -411,4 +411,24 @@ describe('screens:OfferIndividual::Informations::creation', () => {
       }
     )
   })
+
+  it('should track when cancelling creation', async () => {
+    renderInformationsScreen(props, store, contextOverride)
+
+    await userEvent.click(await screen.findByText('Annuler et quitter'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'informations',
+        isDraft: true,
+        isEdition: false,
+        offerId: undefined,
+        to: 'Offers',
+        used: 'StickyButtons',
+      }
+    )
+  })
 })

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
@@ -365,7 +365,7 @@ describe('screens:OfferIndividual::Informations::creation', () => {
     await userEvent.selectOptions(categorySelect, 'A')
     const subCategorySelect = screen.getByLabelText('Sous-catégorie')
     await userEvent.selectOptions(subCategorySelect, 'physical')
-    const nameField = screen.getByLabelText("Titre de l'offre")
+    const nameField = screen.getByLabelText('Titre de l’offre')
     await userEvent.type(nameField, 'Le nom de mon offre')
 
     await userEvent.click(await screen.findByText('Étape suivante'))
@@ -392,7 +392,7 @@ describe('screens:OfferIndividual::Informations::creation', () => {
     await userEvent.selectOptions(categorySelect, 'A')
     const subCategorySelect = screen.getByLabelText('Sous-catégorie')
     await userEvent.selectOptions(subCategorySelect, 'physical')
-    const nameField = screen.getByLabelText("Titre de l'offre")
+    const nameField = screen.getByLabelText('Titre de l’offre')
     await userEvent.type(nameField, 'Le nom de mon offre')
 
     await userEvent.click(await screen.findByText('Sauvegarder le brouillon'))

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.creation.spec.tsx
@@ -17,13 +17,17 @@ import {
   OfferIndividualContext,
 } from 'context/OfferIndividualContext'
 import { REIMBURSEMENT_RULES } from 'core/Finances'
+import { Events } from 'core/FirebaseEvents/constants'
 import { CATEGORY_STATUS } from 'core/Offers'
 import { TOfferIndividualVenue } from 'core/Venue/types'
+import * as useAnalytics from 'hooks/useAnalytics'
 import * as pcapi from 'repository/pcapi/pcapi'
 import * as utils from 'screens/OfferIndividual/Informations/utils'
 import { configureTestStore } from 'store/testUtils'
 
 import { IInformationsProps, Informations as InformationsScreen } from '..'
+
+const mockLogEvent = jest.fn()
 
 jest.mock('screens/OfferIndividual/Informations/utils', () => {
   return {
@@ -175,6 +179,10 @@ describe('screens:OfferIndividual::Informations::creation', () => {
       .spyOn(utils, 'filterCategories')
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .mockImplementation((c, s, _v) => [c, s])
+    jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+      setLogEvent: null,
+    }))
   })
 
   it('should submit minimal physical offer', async () => {
@@ -348,5 +356,59 @@ describe('screens:OfferIndividual::Informations::creation', () => {
         'Tous les champs sont obligatoires sauf mention contraire.'
       )
     ).toBeInTheDocument()
+  })
+
+  it('should track when submitting offer', async () => {
+    renderInformationsScreen(props, store, contextOverride)
+
+    const categorySelect = await screen.findByLabelText('Catégorie')
+    await userEvent.selectOptions(categorySelect, 'A')
+    const subCategorySelect = screen.getByLabelText('Sous-catégorie')
+    await userEvent.selectOptions(subCategorySelect, 'physical')
+    const nameField = screen.getByLabelText("Titre de l'offre")
+    await userEvent.type(nameField, 'Le nom de mon offre')
+
+    await userEvent.click(await screen.findByText('Étape suivante'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'informations',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'AA',
+        to: 'stocks',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when creating draft offer', async () => {
+    renderInformationsScreen(props, store, contextOverride)
+
+    const categorySelect = await screen.findByLabelText('Catégorie')
+    await userEvent.selectOptions(categorySelect, 'A')
+    const subCategorySelect = screen.getByLabelText('Sous-catégorie')
+    await userEvent.selectOptions(subCategorySelect, 'physical')
+    const nameField = screen.getByLabelText("Titre de l'offre")
+    await userEvent.type(nameField, 'Le nom de mon offre')
+
+    await userEvent.click(await screen.findByText('Sauvegarder le brouillon'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'informations',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'AA',
+        to: 'informations',
+        used: 'StickyButtons',
+      }
+    )
   })
 })

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.draft.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.draft.spec.tsx
@@ -341,7 +341,7 @@ describe('screens:OfferIndividual::Informations:draft', () => {
         isEdition: true,
         offerId: 'AA',
         to: 'informations',
-        used: 'StickyButtons',
+        used: 'DraftButtons',
       }
     )
   })

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -468,4 +468,24 @@ describe('screens:OfferIndividual::Informations:edition', () => {
       }
     )
   })
+
+  it('should track when cancelling edition', async () => {
+    renderInformationsScreen(props, store, contextOverride)
+
+    await userEvent.click(await screen.findByText('Annuler et quitter'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'informations',
+        isDraft: false,
+        isEdition: true,
+        offerId: 'AA',
+        to: 'Offers',
+        used: 'StickyButtons',
+      }
+    )
+  })
 })

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -446,7 +446,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
 
   it('should track when submitting offer', async () => {
     renderInformationsScreen(props, store, contextOverride)
-    const nameField = screen.getByLabelText("Titre de l'offre")
+    const nameField = screen.getByLabelText('Titre de l’offre')
     await userEvent.clear(nameField)
     await userEvent.type(nameField, 'Le nom de mon offre édité')
 
@@ -463,7 +463,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
         isDraft: false,
         isEdition: true,
         offerId: 'AA',
-        to: 'stocks',
+        to: 'recapitulatif',
         used: 'StickyButtons',
       }
     )

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -11,11 +11,16 @@ import {
   IStockEventFormValues,
 } from 'components/StockEventForm'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualAdapter } from 'core/Offers/adapters'
 import { IOfferIndividual } from 'core/Offers/types'
 import { getOfferIndividualUrl } from 'core/Offers/utils/getOfferIndividualUrl'
 import { useNavigate, useOfferWizardMode } from 'hooks'
+import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 
 import { ActionBar } from '../ActionBar'
@@ -42,6 +47,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   ] = useState<boolean>(false)
   const [isClickingFromActionBar, setIsClickingFromActionBar] =
     useState<boolean>(false)
+  const { logEvent } = useAnalytics()
   const navigate = useNavigate()
   const notify = useNotification()
   const { setOffer } = useOfferIndividualContext()
@@ -120,9 +126,26 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
       })
     )
     formik.handleSubmit()
+    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OFFER_WIZARD_STEP_IDS.STOCKS,
+      to: OFFER_WIZARD_STEP_IDS.SUMMARY,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+      offerId: offer.id,
+    })
   }
 
   const handlePreviousStep = () => {
+    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OFFER_WIZARD_STEP_IDS.STOCKS,
+      to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+      offerId: offer.id,
+    })
+    /* istanbul ignore next: DEBT, TO FIX */
     navigate(
       getOfferIndividualUrl({
         offerId: offer.id,
@@ -148,6 +171,14 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
     } else {
       formik.handleSubmit()
     }
+    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OFFER_WIZARD_STEP_IDS.STOCKS,
+      to: OFFER_WIZARD_STEP_IDS.STOCKS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.DRAFT_BUTTONS,
+      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+      isDraft: true,
+      offerId: offer.id,
+    })
   }
 
   return (
@@ -167,6 +198,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
               onClickPrevious={handlePreviousStep}
               onClickSaveDraft={handleSaveDraft}
               step={OFFER_WIZARD_STEP_IDS.STOCKS}
+              offerId={offer.id}
             />
           </form>
         </FormLayout.Section>

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -14,6 +14,7 @@ import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import {
   Events,
   OFFER_FORM_NAVIGATION_MEDIUM,
+  OFFER_FORM_NAVIGATION_OUT,
 } from 'core/FirebaseEvents/constants'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualAdapter } from 'core/Offers/adapters'
@@ -24,6 +25,7 @@ import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 
 import { ActionBar } from '../ActionBar'
+import { logTo } from '../utils/logTo'
 
 import { upsertStocksEventAdapter } from './adapters'
 import { StockFormList } from './StockFormList'
@@ -137,14 +139,16 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   }
 
   const handlePreviousStep = () => {
-    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
-      from: OFFER_WIZARD_STEP_IDS.STOCKS,
-      to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
-      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
-      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
-      offerId: offer.id,
-    })
+    if (!formik.dirty) {
+      logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+        from: OFFER_WIZARD_STEP_IDS.STOCKS,
+        to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+        used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+        isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+        isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+        offerId: offer.id,
+      })
+    }
     /* istanbul ignore next: DEBT, TO FIX */
     navigate(
       getOfferIndividualUrl({
@@ -212,6 +216,16 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
           mode={mode}
           hasOfferBeenCreated
           isFormValid={formik.isValid}
+          tracking={nextLocation =>
+            logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+              from: OFFER_WIZARD_STEP_IDS.STOCKS,
+              to: logTo(nextLocation),
+              used: OFFER_FORM_NAVIGATION_OUT.ROUTE_LEAVING_GUARD,
+              isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+              isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+              offerId: offer?.id,
+            })
+          }
         />
       )}
     </FormikProvider>

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
@@ -1,0 +1,350 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route } from 'react-router'
+
+import { api } from 'apiClient/api'
+import { GetIndividualOfferResponseModel } from 'apiClient/v1'
+import Notification from 'components/Notification/Notification'
+import {
+  IOfferIndividualContext,
+  OfferIndividualContext,
+} from 'context/OfferIndividualContext'
+import { Events } from 'core/FirebaseEvents/constants'
+import { IOfferIndividual, IOfferIndividualVenue } from 'core/Offers/types'
+import * as useAnalytics from 'hooks/useAnalytics'
+import { RootState } from 'store/reducers'
+import { configureTestStore } from 'store/testUtils'
+import { getToday } from 'utils/date'
+
+import StocksEvent, { IStocksEventProps } from '../StocksEvent'
+
+const mockLogEvent = jest.fn()
+
+jest.mock('screens/OfferIndividual/Informations/utils', () => {
+  return {
+    filterCategories: jest.fn(),
+  }
+})
+
+jest.mock('repository/pcapi/pcapi', () => ({
+  postThumbnail: jest.fn(),
+}))
+
+jest.mock('utils/date', () => ({
+  ...jest.requireActual('utils/date'),
+  getToday: jest
+    .fn()
+    .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
+}))
+
+const renderStockEventScreen = ({
+  props,
+  storeOverride = {},
+  contextValue,
+  url = '/creation/stocks',
+}: {
+  props: IStocksEventProps
+  storeOverride: Partial<RootState>
+  contextValue: IOfferIndividualContext
+  url?: string
+}) => {
+  const store = configureTestStore(storeOverride)
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[url]}>
+        <Route path={['/creation/stocks', '/brouillon/stocks', '/stocks']}>
+          <OfferIndividualContext.Provider value={contextValue}>
+            <StocksEvent {...props} />
+          </OfferIndividualContext.Provider>
+        </Route>
+        <Notification />
+      </MemoryRouter>
+    </Provider>
+  )
+}
+
+const today = getToday()
+
+describe('screens:StocksEvent', () => {
+  let props: IStocksEventProps
+  let storeOverride: Partial<RootState>
+  let contextValue: IOfferIndividualContext
+  let offer: Partial<IOfferIndividual>
+
+  beforeEach(() => {
+    offer = {
+      id: 'OFFER_ID',
+      venue: {
+        departmentCode: '75',
+      } as IOfferIndividualVenue,
+      stocks: [],
+    }
+    props = {
+      offer: offer as IOfferIndividual,
+    }
+    storeOverride = {}
+    contextValue = {
+      offerId: null,
+      offer: null,
+      venueList: [],
+      offererNames: [],
+      categories: [],
+      subCategories: [],
+      setOffer: () => {},
+    }
+    jest
+      .spyOn(api, 'getOffer')
+      .mockResolvedValue({} as GetIndividualOfferResponseModel)
+
+    jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+      setLogEvent: null,
+    }))
+  })
+
+  it('should track when clicking on "Sauvegarder le brouillon" on creation', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockEventScreen({ props, storeOverride, contextValue })
+
+    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getByText(today.getDate()))
+    await userEvent.click(screen.getByLabelText('Horaire'))
+    await userEvent.click(await screen.getByText('12:00'))
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'OFFER_ID',
+        to: 'stocks',
+        used: 'DraftButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Sauvegarder le brouillon" on draft', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockEventScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/brouillon/stocks',
+    })
+
+    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getByText(today.getDate()))
+    await userEvent.click(screen.getByLabelText('Horaire'))
+    await userEvent.click(await screen.getByText('12:00'))
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'stocks',
+        used: 'DraftButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Enregistrer les modifications" on edition', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockEventScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/stocks',
+    })
+
+    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getByText(today.getDate()))
+    await userEvent.click(screen.getByLabelText('Horaire'))
+    await userEvent.click(await screen.getByText('12:00'))
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Enregistrer les modifications'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: false,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'recapitulatif',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape suivante" on creation', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockEventScreen({ props, storeOverride, contextValue })
+
+    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getByText(today.getDate()))
+    await userEvent.click(screen.getByLabelText('Horaire'))
+    await userEvent.click(await screen.getByText('12:00'))
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Étape suivante'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'OFFER_ID',
+        to: 'recapitulatif',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape suivante" on draft', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockEventScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/brouillon/stocks/',
+    })
+
+    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getByText(today.getDate()))
+    await userEvent.click(screen.getByLabelText('Horaire'))
+    await userEvent.click(await screen.getByText('12:00'))
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Étape suivante'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'recapitulatif',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape précédente" on creation', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+
+    renderStockEventScreen({ props, storeOverride, contextValue })
+
+    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getByText(today.getDate()))
+    await userEvent.click(screen.getByLabelText('Horaire'))
+    await userEvent.click(await screen.getByText('12:00'))
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Étape précédente'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'OFFER_ID',
+        to: 'informations',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape précédente" on draft', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+
+    renderStockEventScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/brouillon/stocks',
+    })
+
+    await userEvent.click(screen.getByText('Étape précédente'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'informations',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Annuler et quitter" on edition', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+
+    renderStockEventScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/stocks',
+    })
+
+    await userEvent.click(screen.getByText('Annuler et quitter'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: false,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'Offers',
+        used: 'StickyButtons',
+      }
+    )
+  })
+})

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
@@ -268,11 +268,6 @@ describe('screens:StocksEvent', () => {
 
     renderStockEventScreen({ props, storeOverride, contextValue })
 
-    await userEvent.click(screen.getByLabelText('Date', { exact: true }))
-    await userEvent.click(await screen.getByText(today.getDate()))
-    await userEvent.click(screen.getByLabelText('Horaire'))
-    await userEvent.click(await screen.getByText('12:00'))
-    await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Étape précédente'))
 
     expect(mockLogEvent).toHaveBeenCalledTimes(1)

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -14,6 +14,10 @@ import {
 } from 'components/StockThingForm'
 import { setFormReadOnlyFields } from 'components/StockThingForm/utils'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
+import {
+  Events,
+  OFFER_FORM_NAVIGATION_MEDIUM,
+} from 'core/FirebaseEvents/constants'
 import { getOfferIndividualAdapter } from 'core/Offers/adapters'
 import {
   LIVRE_PAPIER_SUBCATEGORY_ID,
@@ -22,6 +26,7 @@ import {
 import { IOfferIndividual } from 'core/Offers/types'
 import { getOfferIndividualUrl } from 'core/Offers/utils/getOfferIndividualUrl'
 import { useNavigate, useOfferWizardMode } from 'hooks'
+import useAnalytics from 'hooks/useAnalytics'
 import { useModal } from 'hooks/useModal'
 import useNotification from 'hooks/useNotification'
 import { ReactComponent as AddActivationCodeIcon } from 'icons/add-activation-code-light.svg'
@@ -52,6 +57,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
   ] = useState<boolean>(false)
   const [isClickingFromActionBar, setIsClickingFromActionBar] =
     useState<boolean>(false)
+  const { logEvent } = useAnalytics()
   const navigate = useNavigate()
   const notify = useNotification()
   const { setOffer } = useOfferIndividualContext()
@@ -122,9 +128,29 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
       } else {
         formik.handleSubmit()
       }
+      logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+        from: OFFER_WIZARD_STEP_IDS.STOCKS,
+        to: saveDraft
+          ? OFFER_WIZARD_STEP_IDS.STOCKS
+          : OFFER_WIZARD_STEP_IDS.SUMMARY,
+        used: saveDraft
+          ? OFFER_FORM_NAVIGATION_MEDIUM.DRAFT_BUTTONS
+          : OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+        isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+        isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+        offerId: offer.id,
+      })
     }
 
   const handlePreviousStep = () => {
+    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+      from: OFFER_WIZARD_STEP_IDS.STOCKS,
+      to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+      offerId: offer.id,
+    })
     /* istanbul ignore next: DEBT, TO FIX */
     navigate(
       getOfferIndividualUrl({

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -212,6 +212,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
               onClickSaveDraft={handleNextStep({ saveDraft: true })}
               step={OFFER_WIZARD_STEP_IDS.STOCKS}
               isDisabled={formik.isSubmitting}
+              offerId={offer.id}
             />
           </form>
         </FormLayout.Section>

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -17,6 +17,7 @@ import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import {
   Events,
   OFFER_FORM_NAVIGATION_MEDIUM,
+  OFFER_FORM_NAVIGATION_OUT,
 } from 'core/FirebaseEvents/constants'
 import { getOfferIndividualAdapter } from 'core/Offers/adapters'
 import {
@@ -34,6 +35,7 @@ import { getToday } from 'utils/date'
 import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 
 import { ActionBar } from '../ActionBar'
+import { logTo } from '../utils/logTo'
 
 import { ActivationCodeFormDialog } from './ActivationCodeFormDialog'
 import { upsertStocksThingAdapter } from './adapters'
@@ -141,16 +143,17 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
         offerId: offer.id,
       })
     }
-
   const handlePreviousStep = () => {
-    logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
-      from: OFFER_WIZARD_STEP_IDS.STOCKS,
-      to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-      used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
-      isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
-      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
-      offerId: offer.id,
-    })
+    if (!formik.dirty) {
+      logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+        from: OFFER_WIZARD_STEP_IDS.STOCKS,
+        to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+        used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
+        isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+        isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+        offerId: offer.id,
+      })
+    }
     /* istanbul ignore next: DEBT, TO FIX */
     navigate(
       getOfferIndividualUrl({
@@ -252,6 +255,16 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
           mode={mode}
           hasOfferBeenCreated
           isFormValid={formik.isValid}
+          tracking={nextLocation =>
+            logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+              from: OFFER_WIZARD_STEP_IDS.STOCKS,
+              to: logTo(nextLocation),
+              used: OFFER_FORM_NAVIGATION_OUT.ROUTE_LEAVING_GUARD,
+              isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+              isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+              offerId: offer?.id,
+            })
+          }
         />
       )}
     </FormikProvider>

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.tracker.spec.tsx
@@ -1,0 +1,319 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter, Route } from 'react-router'
+
+import { api } from 'apiClient/api'
+import { GetIndividualOfferResponseModel } from 'apiClient/v1'
+import {
+  IOfferIndividualContext,
+  OfferIndividualContext,
+} from 'context/OfferIndividualContext'
+import { Events } from 'core/FirebaseEvents/constants'
+import { IOfferIndividual, IOfferIndividualVenue } from 'core/Offers/types'
+import * as useAnalytics from 'hooks/useAnalytics'
+import { RootState } from 'store/reducers'
+import { configureTestStore } from 'store/testUtils'
+
+import StocksThing, { IStocksThingProps } from '../StocksThing'
+
+const mockLogEvent = jest.fn()
+
+jest.mock('screens/OfferIndividual/Informations/utils', () => {
+  return {
+    filterCategories: jest.fn(),
+  }
+})
+
+jest.mock('repository/pcapi/pcapi', () => ({
+  postThumbnail: jest.fn(),
+}))
+
+jest.mock('utils/date', () => ({
+  ...jest.requireActual('utils/date'),
+  getToday: jest
+    .fn()
+    .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
+}))
+
+const renderStockThingScreen = ({
+  props,
+  storeOverride = {},
+  contextValue,
+  url = '/creation/stocks',
+}: {
+  props: IStocksThingProps
+  storeOverride: Partial<RootState>
+  contextValue: IOfferIndividualContext
+  url?: string
+}) => {
+  const store = configureTestStore(storeOverride)
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[url]}>
+        <Route path={['/creation/stocks', '/brouillon/stocks', '/stocks']}>
+          <OfferIndividualContext.Provider value={contextValue}>
+            <StocksThing {...props} />
+          </OfferIndividualContext.Provider>
+        </Route>
+      </MemoryRouter>
+    </Provider>
+  )
+}
+
+describe('screens:StocksThing', () => {
+  let props: IStocksThingProps
+  let storeOverride: Partial<RootState>
+  let contextValue: IOfferIndividualContext
+  let offer: Partial<IOfferIndividual>
+
+  beforeEach(() => {
+    offer = {
+      id: 'OFFER_ID',
+      venue: {
+        departmentCode: '75',
+      } as IOfferIndividualVenue,
+      stocks: [],
+    }
+    props = {
+      offer: offer as IOfferIndividual,
+    }
+    storeOverride = {}
+    contextValue = {
+      offerId: null,
+      offer: null,
+      venueList: [],
+      offererNames: [],
+      categories: [],
+      subCategories: [],
+      setOffer: () => {},
+    }
+    jest
+      .spyOn(api, 'getOffer')
+      .mockResolvedValue({} as GetIndividualOfferResponseModel)
+    jest.spyOn(useAnalytics, 'default').mockImplementation(() => ({
+      logEvent: mockLogEvent,
+      setLogEvent: null,
+    }))
+  })
+
+  it('should track when clicking on "Sauvegarder le brouillon" on creation', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockThingScreen({ props, storeOverride, contextValue })
+
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'OFFER_ID',
+        to: 'stocks',
+        used: 'DraftButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Sauvegarder le brouillon" on draft', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockThingScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/brouillon/stocks',
+    })
+
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'stocks',
+        used: 'DraftButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape suivante" on creation', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockThingScreen({ props, storeOverride, contextValue })
+
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Étape suivante'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'OFFER_ID',
+        to: 'recapitulatif',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape suivante" on brouillon', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockThingScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/brouillon/stocks',
+    })
+
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Étape suivante'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'recapitulatif',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Enregistrer les modifications" on edition', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    renderStockThingScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/stocks',
+    })
+
+    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.click(screen.getByText('Enregistrer les modifications'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: false,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'recapitulatif',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape précédente" on creation', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+
+    renderStockThingScreen({ props, storeOverride, contextValue })
+
+    await userEvent.click(screen.getByText('Étape précédente'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: false,
+        offerId: 'OFFER_ID',
+        to: 'informations',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Étape précédente" on draft', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+
+    renderStockThingScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/brouillon/stocks',
+    })
+
+    await userEvent.click(screen.getByText('Étape précédente'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: true,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'informations',
+        used: 'StickyButtons',
+      }
+    )
+  })
+
+  it('should track when clicking on "Annuler et quitter" on edition', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+
+    renderStockThingScreen({
+      props,
+      storeOverride,
+      contextValue,
+      url: '/stocks',
+    })
+
+    await userEvent.click(screen.getByText('Annuler et quitter'))
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenNthCalledWith(
+      1,
+      Events.CLICKED_OFFER_FORM_NAVIGATION,
+      {
+        from: 'stocks',
+        isDraft: false,
+        isEdition: true,
+        offerId: 'OFFER_ID',
+        to: 'Offers',
+        used: 'StickyButtons',
+      }
+    )
+  })
+})

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -115,7 +115,10 @@ const Summary = (
       to: OfferBreadcrumbStep.STOCKS,
       used: OFFER_FORM_NAVIGATION_MEDIUM.STICKY_BUTTONS,
       isEdition: mode !== OFFER_WIZARD_MODE.CREATION,
+      isDraft: mode !== OFFER_WIZARD_MODE.EDITION,
+      offerId: offerId,
     })
+
     history.push(
       getOfferIndividualUrl({
         offerId,
@@ -190,7 +193,7 @@ const Summary = (
               onClickPrevious={handlePreviousStep}
               step={OFFER_WIZARD_STEP_IDS.SUMMARY}
               isDisabled={isDisabled}
-              offerId={offer.id}
+              offerId={offerId}
             />
           )}
         </SummaryLayout.Content>

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -190,6 +190,7 @@ const Summary = (
               onClickPrevious={handlePreviousStep}
               step={OFFER_WIZARD_STEP_IDS.SUMMARY}
               isDisabled={isDisabled}
+              offerId={offer.id}
             />
           )}
         </SummaryLayout.Content>

--- a/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.tracker.spec.tsx
@@ -385,11 +385,13 @@ describe('Summary trackers', () => {
             isEdition: false,
             to: 'stocks',
             used: 'StickyButtons',
+            offerId: 'AB',
+            isDraft: true,
           }
         )
       })
 
-      it('should track when clicking on return to next step button', async () => {
+      it('should track when clicking on publish button', async () => {
         // given
         renderSummary({ props })
 

--- a/pro/src/screens/OfferIndividual/utils/logTo.ts
+++ b/pro/src/screens/OfferIndividual/utils/logTo.ts
@@ -1,0 +1,12 @@
+import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualStepper'
+
+export const logTo = (nextLocation: string) => {
+  if (nextLocation.includes(OFFER_WIZARD_STEP_IDS.INFORMATIONS)) {
+    return OFFER_WIZARD_STEP_IDS.INFORMATIONS
+  } else if (nextLocation.includes(OFFER_WIZARD_STEP_IDS.STOCKS)) {
+    return OFFER_WIZARD_STEP_IDS.STOCKS
+  } else if (nextLocation.includes(OFFER_WIZARD_STEP_IDS.SUMMARY)) {
+    return OFFER_WIZARD_STEP_IDS.SUMMARY
+  }
+  return nextLocation
+}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17618

## But de la pull request

_Ajouter / adapter les trackers à OfferFormV3
_ sur page détails
_ sur page stocks event
_ sur page stocks thing
_ sur page recap
_ dans le breadcrumb
_ dans le route leaving guard
_ tests

avec ces params :

```
        Events.CLICKED_OFFER_FORM_NAVIGATION,
        {
          from: 'informations',
          isEdition: false,
          isDraft: true,
          offerId: 'AA',
          to: 'stocks',
          used: 'Breadcrumb',
```

j'ai eu pas mal de rebase à faire, parfois un peu compliqués, j'espère que je n'ai rien cassé :/
