### PR TITLE
(PC-16737)[API] perf: Optimize generation of wallets CSV file

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1206,21 +1206,60 @@ def _payment_details_row_formatter(sql_row: typing.Any) -> tuple:
 
 def _generate_wallets_file() -> pathlib.Path:
     header = ["ID de l'utilisateur", "Solde théorique", "Solde réel"]
-    # Warning: this query ignores the expiration date of deposits.
-    query = (
-        db.session.query(
-            users_models.User.id.label("user_id"),
-            sqla.func.get_wallet_balance(users_models.User.id, False).label("current_balance"),
-            sqla.func.get_wallet_balance(users_models.User.id, True).label("real_balance"),
+    query = """
+        WITH user_with_latest_deposit AS (
+          SELECT
+            DISTINCT ON ("user".id)
+            "user".id AS user_id,
+            deposit.id AS deposit_id,
+            deposit."expirationDate" AS deposit_expiration_date,
+            deposit.amount AS deposit_amount
+          FROM "user"
+          JOIN deposit ON deposit."userId" = "user".id
+          ORDER BY "user".id, deposit."expirationDate" DESC
         )
-        .filter(users_models.User.deposits != None)
-        .order_by(users_models.User.id)
-    )
+        SELECT
+          user_id,
+          CASE
+            WHEN deposit_expiration_date > now()
+            THEN deposit_amount - coalesce(
+              SUM(booking.amount * booking.quantity) FILTER (WHERE booking.status != 'CANCELLED'),
+              0
+            )
+            ELSE 0
+          END AS current_balance,
+          CASE
+            WHEN deposit_expiration_date > now()
+            THEN deposit_amount - coalesce(
+              SUM(booking.amount * booking.quantity) FILTER (WHERE booking.status in ('USED', 'REIMBURSED')),
+              0
+            )
+            ELSE 0
+          END AS real_balance
+        FROM user_with_latest_deposit
+        LEFT OUTER JOIN individual_booking ON individual_booking."depositId" = user_with_latest_deposit.deposit_id
+        LEFT OUTER JOIN booking ON booking."individualBookingId" = individual_booking.id
+        GROUP BY
+          user_with_latest_deposit.user_id,
+          user_with_latest_deposit.deposit_expiration_date,
+          user_with_latest_deposit.deposit_amount
+        ORDER BY user_with_latest_deposit.user_id
+    """
+    result = db.session.execute(query)
+
+    # Avoid loading all rows in memory.
+    def get_rows() -> typing.Generator[typing.Iterator, None, None]:
+        while 1:
+            rows = result.fetchmany(100_000)
+            if not rows:
+                break
+            yield rows
+
     row_formatter = lambda row: (row.user_id, row.current_balance, row.real_balance)
     return _write_csv(
         "soldes_des_utilisateurs",
         header,
-        rows=query,
+        rows=itertools.chain.from_iterable(get_rows()),
         row_formatter=row_formatter,
         compress=True,
     )

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -399,14 +399,6 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return _get_latest_birthday(self.birth_date)
 
     @property
-    def real_wallet_balance(self):  # type: ignore [no-untyped-def]
-        balance = db.session.query(sa.func.get_wallet_balance(self.id, True)).scalar()
-        # Balance can be negative if the user has booked in the past
-        # but their deposit has expired. We don't want to expose a
-        # negative number.
-        return max(0, balance)
-
-    @property
     def wallet_balance(self):  # type: ignore [no-untyped-def]
         balance = db.session.query(sa.func.get_wallet_balance(self.id, False)).scalar()
         return max(0, balance)

--- a/api/tests/core/users/external/user_automations_test.py
+++ b/api/tests/core/users/external/user_automations_test.py
@@ -102,7 +102,6 @@ class UserAutomationsTest:
             )
             assert user2.deposit.expirationDate == datetime(2034, 11, 1, 22, 59, 59, 999999)
             bookings_factories.UsedIndividualBookingFactory(individualBooking__user=user2, quantity=1, amount=10)
-            assert user2.real_wallet_balance > 0
 
         with freeze_time("2032-12-01 15:00:00"):
             user3 = users_factories.BeneficiaryGrant18Factory(
@@ -134,10 +133,7 @@ class UserAutomationsTest:
 
         with freeze_time("2033-05-01 17:00:00"):
             # user6 becomes ex-beneficiary
-            bookings_factories.UsedIndividualBookingFactory(
-                individualBooking__user=user6, quantity=1, amount=int(user6.real_wallet_balance)
-            )
-            assert user6.real_wallet_balance == 0
+            bookings_factories.UsedIndividualBookingFactory(individualBooking__user=user6, quantity=1, amount=300)
 
         return [user0, user1, user2, user3, user4, user5, user6]
 

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -334,13 +334,11 @@ class UserWalletBalanceTest:
         user = users_factories.UserFactory()
 
         assert user.wallet_balance == 0
-        assert user.real_wallet_balance == 0
 
     def test_balance_ignores_expired_deposits(self):
         user = users_factories.BeneficiaryGrant18Factory(deposit__expirationDate=datetime(2000, 1, 1))
 
         assert user.wallet_balance == 0
-        assert user.real_wallet_balance == 0
 
     def test_balance(self):
         user = users_factories.BeneficiaryGrant18Factory()
@@ -350,14 +348,12 @@ class UserWalletBalanceTest:
         bookings_factories.CancelledIndividualBookingFactory(individualBooking__user=user, quantity=4, amount=40)
 
         assert user.wallet_balance == 300 - (10 + 2 * 20 + 3 * 30)
-        assert user.real_wallet_balance == 300 - (10 + 2 * 20)
 
     def test_real_balance_with_only_used_bookings(self):
         user = users_factories.BeneficiaryGrant18Factory()
         bookings_factories.IndividualBookingFactory(individualBooking__user=user, quantity=1, amount=30)
 
         assert user.wallet_balance == 300 - 30
-        assert user.real_wallet_balance == 300
 
     def test_balance_when_expired(self):
         user = users_factories.BeneficiaryGrant18Factory()
@@ -366,7 +362,6 @@ class UserWalletBalanceTest:
         deposit.expirationDate = datetime(2000, 1, 1)
 
         assert user.wallet_balance == 0
-        assert user.real_wallet_balance == 0
 
 
 class SQLFunctionsTest:


### PR DESCRIPTION
+1 commit de suppression d'une fonction qui n'est plus utilisée. Donc 2 commits à relire séparément. Ci-dessous, message du commit principal :

---

The generation of this CSV took between 10 and 15 minutes on
production. This is because we were calling the `get_wallet_balance()`
SQL function for each user (thus selecting the deposit and then
selecting related bookings for each user): that takes time.

And on staging the process was even OOMKilled, most probably because
it loaded all rows in memory (and our staging pods have less memory).

The calculation of the wallet balance is now done by a single query
that can join everything for all users. The SQL query is long but the
whole generation takes around 2 minutes on production. And we don't
keep all rows in memory anymore (making it work on staging).


---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-16737