### PR TITLE
(PC-18523)[API] fix: Reset `dateUsed` when cancelling a booking (+ bonus BSR)

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -204,7 +204,7 @@ def _cancel_booking(
         db.session.refresh(booking)
         old_status = booking.status
         try:
-            booking.cancel_booking(cancel_even_if_used)
+            booking.cancel_booking(reason, cancel_even_if_used)
             _cancel_external_booking(booking, stock)
         except (BookingIsAlreadyUsed, BookingIsAlreadyCancelled) as e:
             if raise_if_error:
@@ -221,7 +221,6 @@ def _cancel_booking(
             return False
         if old_status is BookingStatus.USED:
             finance_api.cancel_pricing(booking, finance_models.PricingLogReason.MARK_AS_UNUSED)
-        booking.cancellationReason = reason
         stock.dnBookedQuantity -= booking.quantity
         repository.save(booking, stock)
 

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -174,7 +174,11 @@ class Booking(PcObject, Base, Model):
         self.dateUsed = None
         self.status = BookingStatus.CONFIRMED
 
-    def cancel_booking(self, cancel_even_if_used: bool = False) -> None:
+    def cancel_booking(
+        self,
+        reason: BookingCancellationReasons,
+        cancel_even_if_used: bool = False,
+    ) -> None:
         if self.status is BookingStatus.CANCELLED:
             raise exceptions.BookingIsAlreadyCancelled()
         if self.status is BookingStatus.REIMBURSED:
@@ -183,6 +187,7 @@ class Booking(PcObject, Base, Model):
             raise exceptions.BookingIsAlreadyUsed()
         self.status = BookingStatus.CANCELLED
         self.cancellationDate = datetime.utcnow()
+        self.cancellationReason = reason
         self.dateUsed = None
 
     def uncancel_booking_set_used(self) -> None:

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -183,6 +183,7 @@ class Booking(PcObject, Base, Model):
             raise exceptions.BookingIsAlreadyUsed()
         self.status = BookingStatus.CANCELLED
         self.cancellationDate = datetime.utcnow()
+        self.dateUsed = None
 
     def uncancel_booking_set_used(self) -> None:
         if not (self.status is BookingStatus.CANCELLED):

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -348,11 +348,10 @@ def _cancel_collective_booking(
         db.session.refresh(collective_booking)
 
         try:
-            collective_booking.cancel_booking()
+            collective_booking.cancel_booking(reason)
         except (exceptions.CollectiveBookingAlreadyCancelled):
             return
 
-        collective_booking.cancellationReason = reason
         db.session.commit()
 
     logger.info(

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -744,7 +744,11 @@ class CollectiveBooking(PcObject, Base, Model):
         self.dateUsed = None
         self.status = CollectiveBookingStatus.CONFIRMED
 
-    def cancel_booking(self, cancel_even_if_used: bool = False) -> None:
+    def cancel_booking(
+        self,
+        reason: CollectiveBookingCancellationReasons,
+        cancel_even_if_used: bool = False,
+    ) -> None:
         from pcapi.core.educational import exceptions
 
         if self.status is CollectiveBookingStatus.CANCELLED:
@@ -755,6 +759,7 @@ class CollectiveBooking(PcObject, Base, Model):
             raise exceptions.CollectiveBookingIsAlreadyUsed
         self.status = CollectiveBookingStatus.CANCELLED
         self.cancellationDate = datetime.utcnow()
+        self.cancellationReason = reason
         self.dateUsed = None
 
     def uncancel_booking_set_used(self) -> None:
@@ -802,8 +807,7 @@ class CollectiveBooking(PcObject, Base, Model):
             raise exceptions.EducationalBookingNotRefusable()
 
         try:
-            self.cancel_booking()
-            self.cancellationReason = CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE
+            self.cancel_booking(CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE)
         except exceptions.CollectiveBookingIsAlreadyUsed:
             raise exceptions.EducationalBookingNotRefusable()
 

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -755,6 +755,7 @@ class CollectiveBooking(PcObject, Base, Model):
             raise exceptions.CollectiveBookingIsAlreadyUsed
         self.status = CollectiveBookingStatus.CANCELLED
         self.cancellationDate = datetime.utcnow()
+        self.dateUsed = None
 
     def uncancel_booking_set_used(self) -> None:
         if not (self.status is CollectiveBookingStatus.CANCELLED):

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -721,6 +721,18 @@ class CancelForFraudTest:
 
 
 @pytest.mark.usefixtures("db_session")
+def test_mark_as_cancelled():
+    booking = booking_factories.UsedBookingFactory()
+
+    api.mark_as_cancelled(booking)
+
+    assert booking.dateUsed is None
+    assert booking.cancellationDate is not None
+    assert booking.cancellationReason == BookingCancellationReasons.BENEFICIARY
+    assert booking.status == BookingStatus.CANCELLED
+
+
+@pytest.mark.usefixtures("db_session")
 class MarkAsUsedTest:
     def test_mark_as_used(self):
         booking = booking_factories.IndividualBookingFactory()


### PR DESCRIPTION
2 commits à relire séparément. J'en ai profité pour améliorer
`Booking.cancel_booking()`.

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18523