### PR TITLE
(PC-18408)[PRO] feat: Add stock event price limit and update tests

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -114,7 +114,7 @@ def check_stock_price(price: float, offer: Offer) -> None:
         api_errors = ApiErrors()
         api_errors.add_error("price", "Le prix doit être positif")
         raise api_errors
-    if price > 300 and not offer.isEvent:
+    if price > 300:
         api_errors = ApiErrors()
         api_errors.add_error(
             "price300",

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -58,7 +58,10 @@ class CheckPricesForStockTest:
         offer = offers_factories.EventOfferFactory()
         validation.check_stock_price(0, offer)
         validation.check_stock_price(1.5, offer)
-        validation.check_stock_price(310.5, offer)
+
+        with pytest.raises(ApiErrors) as error:
+            validation.check_stock_price(310.5, offer)
+        assert error.value.errors["price300"] == ["Le prix d’une offre ne peut excéder 300 euros."]
 
         with pytest.raises(ApiErrors) as error:
             validation.check_stock_price(-1.5, offer)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18408

## But de la pull request

- L'API ne doit pas accepter le prix d'un stockEvent supérieur à 300€. 

## Implémentation

- Suppression de la condition pour vérifier le prix maximum aussi pour les stocks de type évènement.
- Modification des tests associés.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
