### PR TITLE
(PC-18703)[BACKOFFICE] fix: performance for offerers validation list

### DIFF
--- a/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
+++ b/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
@@ -159,7 +159,7 @@ export const OfferersToValidate = () => {
       const response = await apiProvider().listOfferersToBeValidated({
         page: page + 1,
         perPage: rowsPerPage,
-        sort: JSON.stringify([{ field: 'requestDate', order: 'desc' }]),
+        sort: JSON.stringify([{ field: 'dateCreated', order: 'desc' }]),
         filter: JSON.stringify(filters),
         q: searchParameter || undefined,
       })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18703

## But de la pull request

Corriger la page de validation des structures, beaucoup trop lente : tri par `dateCreated` au lieu de `requestDate`

Détails dans le ticket

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
