### PR TITLE
(PC-17934)[PRO] fix: draft stock submit

### DIFF
--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -1,8 +1,9 @@
 import cn from 'classnames'
 import { isAfter } from 'date-fns'
 import { useFormikContext } from 'formik'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
+import { IconEuroGrey } from 'icons'
 import { DatePicker, TextInput, TimePicker } from 'ui-kit'
 
 import styles from './StockEventForm.module.scss'
@@ -11,28 +12,25 @@ import { IStockEventFormValues } from './types'
 export interface IStockEventFormProps {
   today: Date
   readOnlyFields?: string[]
-  fieldPrefix?: string
-}
-
-const phoneNumberRegex = (name: string): number => {
-  const rx = /\[(.*)\]/g
-  const match = rx.exec(name)
-  if (match === null) {
-    throw Error(`Unable to found stock for field name: ${name}`)
-  }
-  return parseInt(match[1], 10)
+  stockIndex: number
 }
 
 const StockEventForm = ({
   today,
   readOnlyFields = [],
-  fieldPrefix = '',
+  stockIndex,
 }: IStockEventFormProps): JSX.Element => {
   const { values, setFieldValue, setTouched } = useFormikContext<{
     stocks: IStockEventFormValues[]
   }>()
-  const onChangeBeginningDate = (name: string, date: Date | null) => {
-    const stockIndex = phoneNumberRegex(name)
+  const [showCurrencyIcon, showShowCurrencyIcon] = useState<boolean>(
+    values.stocks[stockIndex].price.length > 0
+  )
+  useEffect(() => {
+    showShowCurrencyIcon(values.stocks[stockIndex].price.length > 0)
+  }, [values.stocks[stockIndex].price])
+
+  const onChangeBeginningDate = (_name: string, date: Date | null) => {
     const stockBookingLimitDatetime =
       values.stocks[stockIndex].bookingLimitDatetime
     if (
@@ -51,7 +49,7 @@ const StockEventForm = ({
     <>
       <DatePicker
         smallLabel
-        name={`${fieldPrefix}beginningDate`}
+        name={`stocks[${stockIndex}]beginningDate`}
         label="Date"
         className={styles['field-layout-align-self']}
         classNameFooter={styles['field-layout-footer']}
@@ -67,22 +65,23 @@ const StockEventForm = ({
           styles['input-beginning-time'],
           styles['field-layout-align-self']
         )}
-        name={`${fieldPrefix}beginningTime`}
+        name={`stocks[${stockIndex}]beginningTime`}
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('beginningTime')}
       />
       <TextInput
         smallLabel
-        name={`${fieldPrefix}price`}
+        name={`stocks[${stockIndex}]price`}
         label="Prix"
         className={cn(styles['input-price'], styles['field-layout-align-self'])}
         placeholder="Ex: 20€"
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('price')}
+        rightIcon={() => (showCurrencyIcon ? <IconEuroGrey /> : null)}
       />
       <DatePicker
         smallLabel
-        name={`${fieldPrefix}bookingLimitDatetime`}
+        name={`stocks[${stockIndex}]bookingLimitDatetime`}
         label="Date limite de réservation"
         className={cn(
           styles['input-bookingLimitDatetime'],
@@ -95,7 +94,7 @@ const StockEventForm = ({
       />
       <TextInput
         smallLabel
-        name={`${fieldPrefix}quantity`}
+        name={`stocks[${stockIndex}]quantity`}
         label="Quantité"
         placeholder="Illimité"
         className={cn(

--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -9,7 +9,10 @@ import StockEventForm, { IStockEventFormProps } from '../StockEventForm'
 
 const renderStockEventForm = (props: IStockEventFormProps) => {
   return render(
-    <Formik initialValues={STOCK_EVENT_FORM_DEFAULT_VALUES} onSubmit={() => {}}>
+    <Formik
+      initialValues={{ stocks: [STOCK_EVENT_FORM_DEFAULT_VALUES] }}
+      onSubmit={() => {}}
+    >
       <Form>
         <StockEventForm {...props} />
       </Form>
@@ -23,6 +26,7 @@ describe('StockEventForm', () => {
   beforeEach(() => {
     props = {
       today: new Date(),
+      stockIndex: 0,
     }
   })
 

--- a/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
@@ -35,7 +35,7 @@ const renderStockEventForm = ({
   minQuantity?: number | null
   onSubmit?: () => void
 } = {}) => {
-  const props: IStockEventFormProps = { today, fieldPrefix: 'stocks[0]' }
+  const props: IStockEventFormProps = { today, stockIndex: 0 }
   return render(
     <Formik
       initialValues={{
@@ -117,7 +117,7 @@ describe('StockEventForm:validationSchema', () => {
     },
   ]
   it.each(dataSetPriceErrors)(
-    'should display price error',
+    'should display price error %s',
     async ({ price, error }) => {
       renderStockEventForm()
 

--- a/pro/src/components/StockFormRow/StockFormRow.stories.tsx
+++ b/pro/src/components/StockFormRow/StockFormRow.stories.tsx
@@ -177,7 +177,7 @@ WithoutActions.args = {
 
 export const CreateEvent = TemplateEvent.bind({})
 CreateEvent.args = {
-  Form: <StockEventForm today={today} />,
+  Form: <StockEventForm today={today} stockIndex={0} />,
   actions: [
     {
       callback: actionsCallBack('one'),

--- a/pro/src/components/StockThingForm/StockThingForm.tsx
+++ b/pro/src/components/StockThingForm/StockThingForm.tsx
@@ -1,6 +1,7 @@
 import { useFormikContext } from 'formik'
 import React from 'react'
 
+import { IconEuroGrey } from 'icons'
 import { DatePicker, TextInput } from 'ui-kit'
 
 import styles from './StockThingForm.module.scss'
@@ -37,6 +38,7 @@ const StockThingForm = ({
         placeholder="Ex: 20€"
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('price')}
+        rightIcon={values.price.length > 0 ? () => <IconEuroGrey /> : undefined}
       />
       <DatePicker
         smallLabel

--- a/pro/src/icons/index.ts
+++ b/pro/src/icons/index.ts
@@ -1,1 +1,2 @@
 export { ReactComponent as IconPlusCircle } from './ico-plus-circle.svg'
+export { ReactComponent as IconEuroGrey } from './ico-euro-grey.svg'

--- a/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
@@ -67,7 +67,7 @@ const StockFormList = ({ offer, onDeleteStock }: IStockFormListProps) => {
                       stockValues.beginningDate || null,
                       today
                     )}
-                    fieldPrefix={`stocks[${index}].`}
+                    stockIndex={index}
                   />
                 }
                 actions={

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -103,19 +103,22 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
     minQuantity = offer.stocks[0].bookingsQuantity
   }
   const initialValues = buildInitialValues(offer)
-  const { ...formik } = useFormik<{ stocks: IStockEventFormValues[] }>({
+  const formik = useFormik<{ stocks: IStockEventFormValues[] }>({
     initialValues,
     onSubmit,
     validationSchema: getValidationSchema(minQuantity),
+    enableReinitialize: true,
   })
 
   const handleNextStep = () => {
     setIsClickingFromActionBar(true)
-    getOfferIndividualUrl({
-      offerId: offer.id,
-      step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-      mode,
-    })
+    setAfterSubmitUrl(
+      getOfferIndividualUrl({
+        offerId: offer.id,
+        step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+        mode,
+      })
+    )
     formik.handleSubmit()
   }
 
@@ -132,12 +135,6 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   const handleSaveDraft = () => {
     setIsClickingFromActionBar(true)
     /* istanbul ignore next: DEBT, TO FIX */
-    if (!Object.keys(formik.touched).length) {
-      notify.success('Brouillon sauvegardé dans la liste des offres')
-    } else {
-      formik.handleSubmit()
-    }
-    /* istanbul ignore next: DEBT, TO FIX */
     setAfterSubmitUrl(
       getOfferIndividualUrl({
         offerId: offer.id,
@@ -145,6 +142,12 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         mode,
       })
     )
+    /* istanbul ignore next: DEBT, TO FIX */
+    if (!Object.keys(formik.touched).length) {
+      notify.success('Brouillon sauvegardé dans la liste des offres')
+    } else {
+      formik.handleSubmit()
+    }
   }
 
   return (

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -21,6 +21,7 @@ interface ITextInputProps
   isOptional?: boolean
   smallLabel?: boolean
   rightButton?: () => JSX.Element
+  rightIcon?: () => JSX.Element | null
   step?: number | string
   inline?: boolean
   refForInput?: ForwardedRef<HTMLInputElement>
@@ -42,6 +43,7 @@ const TextInput = ({
   isOptional = false,
   refForInput,
   rightButton,
+  rightIcon,
   step,
   inline = false,
   ...props
@@ -85,6 +87,7 @@ const TextInput = ({
           type={type}
           rightButton={rightButton}
           ref={refForInput}
+          rightIcon={rightIcon}
           {...field}
           {...props}
         />

--- a/pro/src/ui-kit/form/shared/BaseInput/BaseInput.tsx
+++ b/pro/src/ui-kit/form/shared/BaseInput/BaseInput.tsx
@@ -7,7 +7,7 @@ interface IBaseInputProps
   extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
   className?: string
   hasError?: boolean
-  rightIcon?: () => JSX.Element
+  rightIcon?: () => JSX.Element | null
   rightButton?: () => JSX.Element
 }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17934

## But de la pull request

retour de la [PR](https://github.com/pass-culture/pass-culture-main/pull/4385) qui à été revert.

changements: 
- utilisation d'index de stock au lieu de fieldsPrefix
- possiblité d'avoir un composant icone retournant null, le calcule de l'affichage de l'icon € faisait que userEvent.type() s'arretait apres le 1er charactère.