### PR TITLE
(PC-17228)[API] feat: add pro_user profile to backoffice v3

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/pro_users.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_users.py
@@ -1,5 +1,9 @@
+from flask import flash
+from flask import redirect
 from flask import render_template
+from flask import url_for
 
+import pcapi.core.offerers.models as offerers_models
 import pcapi.core.permissions.models as perm_models
 import pcapi.core.users.models as users_models
 
@@ -9,12 +13,20 @@ from . import utils
 pro_user_blueprint = utils.child_backoffice_blueprint(
     "pro_user",
     __name__,
-    url_prefix="/pro/user/<int:user_id>",
+    url_prefix="/pro/pro_user/<int:user_id>",
     permission=perm_models.Permissions.READ_PRO_ENTITY,
 )
 
 
 @pro_user_blueprint.route("", methods=["GET"])
 def get(user_id: int) -> utils.BackofficeResponse:
-    pro_user = users_models.User.query.get_or_404(user_id)
-    return render_template("pro_user/get.html", row=pro_user)
+    # TODO (vroullier) 24-11-2022 : use User.roles once it is updated
+    # Make sure user is pro
+    user = (
+        users_models.User.query.join(offerers_models.UserOfferer).filter(users_models.User.id == user_id).one_or_none()
+    )
+    if not user:
+        flash("Cet utilisateur n'a pas de compte pro ou n'existe pas", "warning")
+        return redirect(url_for("backoffice_v3_web.search_pro"), code=303)
+
+    return render_template("pro_user/get.html", user=user)

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
@@ -20,9 +20,9 @@
         </h6>
 
         <div class="fs-6">
-            <p class="mb-1"><span class="fw-bold">email :</span> {{ row.email }} </p>
+            <p class="mb-1"><span class="fw-bold">E-mail :</span> {{ row.email }} </p>
             {% if row.phoneNumber %}
-                <p><span class="fw-bold">tél :</span> {{ row.phoneNumber | format_phone_number }} </p>
+                <p><span class="fw-bold">Tél :</span> {{ row.phoneNumber | format_phone_number }} </p>
             {% endif %}
         </div>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -1,1 +1,7 @@
-{% extends "pro/get.html" %}
+{% extends "layouts/pro.html" %}
+
+{% block pro_main_content %}
+
+    {% include "pro_user/get/general.html" %}
+
+{% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/general.html
@@ -1,0 +1,50 @@
+<div class="row row-cols-1 g-4 py-3">
+    <div class="col">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">
+                    {{ user.firstName }} {{ user.lastName | upper }}
+
+                    {% for role in user.roles %}
+                        <span class="ms-5 me-2 badge rounded-pill text-bg-primary align-middle">
+                            {{ role | format_role }}
+                        </span>
+                    {% endfor %}
+                    {% if not user.isActive %}
+                        <span class="badge rounded-pill text-bg-secondary align-middle">
+                            {{ user.isActive | format_state }}
+                        </span>
+                    {% endif %}
+                </h5>
+
+                <h6 class="card-subtitle text-muted">
+                    User ID : {{ user.id }}
+                </h6>
+                <div class="row pt-3">
+
+                    <div class="col-4">
+                        <div class="fs-6">
+                            <p class="mb-1"><span class="fw-bold">E-mail :</span> {{ user.email }} </p>
+                            <p class="mb-1"><span class="fw-bold">Tél :</span> {{ user.phoneNumber | format_phone_number }} </p>
+                        </div>
+                    </div>
+
+                    <div class="col-4">
+                        <div class="fs-6">
+                            <p class="mb-1"><span class="fw-bold">Code postal :</span> {{ user.postalCode | empty_string_if_null }} </p>
+                            <p class="mb-1"><span class="fw-bold">Département :</span> {{ user.departementCode | empty_string_if_null }} </p>
+                        </div>
+                    </div>
+
+                    <div class="col-4">
+                        <a href="{{ url_for('.get', user_id=user.id) }}" class="card-link">
+                            <button class="btn btn-outline-primary lead fw-bold mt-2">
+                                Modifier les informations
+                            </button>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -1,0 +1,54 @@
+from flask import url_for
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.permissions.models as perm_models
+from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import override_features
+import pcapi.core.users.factories as users_factories
+
+from .helpers import unauthorized as unauthorized_helpers
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class GetProUserTest:
+    endpoint = "backoffice_v3_web.pro_user.get"
+
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+        endpoint = "backoffice_v3_web.pro_user.get"
+        endpoint_kwargs = {"user_id": 1}
+        needed_permission = perm_models.Permissions.READ_PRO_ENTITY
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_get_pro_user(self, authenticated_client):  # type: ignore
+        user = offerers_factories.UserOffererFactory(user__phoneNumber="+33638656565", user__postalCode="29000").user
+        url = url_for("backoffice_v3_web.pro_user.get", user_id=user.id)
+
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        content = response.data.decode("utf-8")
+
+        assert str(user.id) in content
+        assert user.firstName in content
+        assert user.lastName.upper() in content
+        assert user.email in content
+        assert user.phoneNumber in content
+        assert user.postalCode in content
+        assert user.departementCode in content
+        assert "Pro" in content
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_get_not_pro_user(self, authenticated_client):  # type: ignore
+        user = users_factories.BeneficiaryGrant18Factory()
+        url = url_for("backoffice_v3_web.pro_user.get", user_id=user.id)
+
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url)
+        assert response.status_code == 303
+
+        expected_url = url_for("backoffice_v3_web.search_pro", _external=True)
+        assert response.location == expected_url


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17228

## But de la pull request

Ajout de la page profil d'un user pro.
Le bouton pour modifier les informations est présent mais non-fonctionnel (sujet d'un autre ticket).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
