### PR TITLE
(PC-18659)[API] feat: add category for OffererTag (requested for data…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-8b0574f4aa1b (pre) (head)
+8948db4edb75 (pre) (head)
 4e9a6643eeed (post) (head)

--- a/api/src/pcapi/admin/custom_views/offerer_tag_view.py
+++ b/api/src/pcapi/admin/custom_views/offerer_tag_view.py
@@ -1,3 +1,6 @@
+import typing
+
+from jinja2.runtime import Context
 from wtforms.fields import StringField
 from wtforms.form import Form
 from wtforms.validators import DataRequired
@@ -5,19 +8,31 @@ from wtforms.validators import Length
 from wtforms.validators import Regexp
 
 from pcapi.admin.base_configuration import BaseAdminView
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offerers import tag_categories
 
 
 TAG_NAME_REGEX = r"^[^\s]+$"
 
 
+def category_formatter(view: BaseAdminView, context: Context, model: offerers_models.OffererTag, name: str) -> str:
+    if model.categoryId is None:
+        return ""
+    return tag_categories.ALL_OFFERER_TAG_CATEGORIES_DICT[model.categoryId].label
+
+
 class OffererTagView(BaseAdminView):
     can_create = True
-    can_edit = False  # Nothing to edit
+    can_edit = True
     can_delete = True
-    column_list = ["id", "name", "label", "description"]
-    column_labels = {"name": "Nom", "label": "Libellé", "description": "Description"}
+    column_list = ["id", "name", "label", "description", "categoryId"]
+    column_labels = {"name": "Nom", "label": "Libellé", "description": "Description", "categoryId": "Catégorie"}
     column_searchable_list = ["name"]
     column_filters: list[str] = []
+
+    form_choices = {
+        "categoryId": [(category.id, category.label) for category in tag_categories.ALL_OFFERER_TAG_CATEGORIES]
+    }
 
     def get_create_form(self) -> Form:
         form = self.scaffold_form()
@@ -37,3 +52,9 @@ class OffererTagView(BaseAdminView):
         )
         form.description = StringField("Description")
         return form
+
+    @property
+    def column_formatters(self) -> dict[str, typing.Callable]:
+        formatters = super().column_formatters
+        formatters["categoryId"] = category_formatter
+        return formatters

--- a/api/src/pcapi/alembic/versions/20221123T164521_8948db4edb75_add_offerertag_category.py
+++ b/api/src/pcapi/alembic/versions/20221123T164521_8948db4edb75_add_offerertag_category.py
@@ -1,0 +1,22 @@
+"""Add_OffererTag_category
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8948db4edb75"
+down_revision = "8b0574f4aa1b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("offerer_tag", sa.Column("categoryId", sa.Text(), nullable=True))
+    op.create_index(op.f("ix_offerer_tag_categoryId"), "offerer_tag", ["categoryId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_offerer_tag_categoryId"), table_name="offerer_tag")
+    op.drop_column("offerer_tag", "categoryId")

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -65,6 +65,7 @@ from pcapi.utils.human_ids import humanize
 import pcapi.utils.postal_code as postal_code_utils
 
 from . import constants
+from . import tag_categories
 
 
 if typing.TYPE_CHECKING:
@@ -888,9 +889,18 @@ class OffererTag(PcObject, Base, Model):
     name: str = Column(String(140), nullable=False, unique=True)
     label: str = Column(String(140))
     description: str = Column(Text)
+    categoryId: str = sa.Column(sa.Text, nullable=True, index=True)
 
     def __repr__(self) -> str:
         return self.name
+
+    @property
+    def category(self) -> tag_categories.OffererTagCategory | None:
+        if not self.categoryId:
+            return None
+        if self.categoryId not in tag_categories.ALL_OFFERER_TAG_CATEGORIES_DICT:
+            raise ValueError(f"Unexpected categoryId '{self.categoryId}' for offerer tag {self.id}")
+        return tag_categories.ALL_OFFERER_TAG_CATEGORIES_DICT[self.categoryId]
 
 
 class OffererTagMapping(PcObject, Base, Model):

--- a/api/src/pcapi/core/offerers/tag_categories.py
+++ b/api/src/pcapi/core/offerers/tag_categories.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OffererTagCategory:
+    id: str
+    label: str
+
+
+# Partners counting projects, for data analytics to apply different rules on offerers
+COMPTAGE = OffererTagCategory(id="COMPTAGE", label="Comptage Partenaires")
+
+# Tags used for filtering offerers to validate
+HOMOLOGATION = OffererTagCategory(id="HOMOLOGATION", label="Homologation")
+
+ALL_OFFERER_TAG_CATEGORIES = (
+    COMPTAGE,
+    HOMOLOGATION,
+)
+
+ALL_OFFERER_TAG_CATEGORIES_DICT = {subcategory.id: subcategory for subcategory in ALL_OFFERER_TAG_CATEGORIES}

--- a/api/tests/admin/custom_views/offerer_tag_view_test.py
+++ b/api/tests/admin/custom_views/offerer_tag_view_test.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.core.offerers import tag_categories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.users.factories as users_factories
@@ -18,11 +19,16 @@ class OffererTagViewTest:
 
         api_client = client.with_session_auth("admin@example.com")
 
-        response = api_client.post("/pc/back-office/offerertag/new/", form={"name": name})
+        response = api_client.post(
+            "/pc/back-office/offerertag/new/", form={"name": name, "categoryId": tag_categories.HOMOLOGATION.id}
+        )
 
         assert response.status_code == 302
         assert offerers_models.OffererTag.query.count() == 1
-        assert offerers_models.OffererTag.query.first().name == name
+        tag = offerers_models.OffererTag.query.first()
+        assert tag.name == name
+        assert tag.categoryId == tag_categories.HOMOLOGATION.id
+        assert tag.category == tag_categories.HOMOLOGATION
 
     @pytest.mark.parametrize(
         "name", ["tag ", " tag", "t ag", "tag\t", "\ttag", "ta\tg", "\ntag", "t\nag", "\rtag", "tag\r", "t\rag"]
@@ -52,6 +58,26 @@ class OffererTagViewTest:
         assert response.status_code == 200
         assert "Le nom ne peut excéder 140 caractères" in response.data.decode("utf8")
         assert offerers_models.OffererTag.query.count() == 0
+
+    @clean_database
+    @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
+    def test_edit_tag(self, mocked_validate_csrf_token, client):
+        users_factories.AdminFactory(email="admin@example.com")
+
+        offerer = offerers_factories.OffererFactory(tags=[offerers_factories.OffererTagFactory(name="test_edit_tag")])
+
+        api_client = client.with_session_auth("admin@example.com")
+
+        response = api_client.post(
+            f"/pc/back-office/offerertag/edit/?id={offerer.tags[0].id}",
+            form={"name": "test_edit_tag", "categoryId": tag_categories.COMPTAGE.id},
+        )
+
+        assert response.status_code == 302
+        assert len(offerer.tags) == 1
+        assert offerer.tags[0].name == "test_edit_tag"
+        assert offerer.tags[0].categoryId == tag_categories.COMPTAGE.id
+        assert offerer.tags[0].category == tag_categories.COMPTAGE
 
     @clean_database
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")


### PR DESCRIPTION
… analytics)

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18659

## But de la pull request

Catégoriser les tags des structures, en fonction des différentes équipes (différents projets) qui les utilisent :
- comptage des partenaires (Caroline/Lucille), avec un besoin d'identifier les tags concernant ce projet
- homologation, pour ne proposer le filtrage que sur leurs tags dans la validation de structures.

## Implémentation

J'ai repris les choix d'implémentation des catégories et sous-catégories utilisées pour les offres et les produits, avec le même typage, pour assurer une cohérence dans le code pour les mêmes données.

Plus d'infos en commentaire dans le ticket.
Captures d'écran dans le ticket.

Ajout de la possibilité d'éditer un tag de structure dans Flask Admin, afin de pouvoir effectivement les catégoriser sans besoin d'une console SQL.

## Modifications du schéma de la base de données

Ajout d'une colonne à la table `offerer-tag` : `categoryId`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
