### PR TITLE
Pc 18436 remove active label from account search result

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
@@ -1,31 +1,33 @@
 {% extends "layouts/admin.html" %}
 
 {% block roles_management %}
-  <div class="container">
-    <h2>Gestion des rôles</h2>
-    {% for form in forms %}
-      <div class="card mb-4">
-        <div class="card-header" data-bs-toggle="collapse" href="#{{ form.name }}">
-          {{ form.name }}
-        </div>
-        <div class="collapse card-collapse" id="{{ form.name }}">
-          <form action="{{ url_for(".update_role", role_id=form.id) }}" method="PATCH">
-            <div class="card-body">
-              <div class="row">
-                {% for form_field in forms[form] %}
-                  {{ form_field }}
-                {% endfor %}
-              </div>
-              <div class="row col-2">
-                <button type="submit" class="btn btn-primary">
-                  Sauvegarder les modifications
-                </button>
-              </div>
+    <div class="container">
+        <h2>Gestion des rôles</h2>
+        {% for form in forms %}
+            <div class="card mb-4">
+                <div class="card-header" data-bs-toggle="collapse" href="#{{ form.name }}">
+                    {{ form.name }}
+                </div>
+                <div class="collapse card-collapse p-3 shadow" id="{{ form.name }}">
+                    <form action="{{ url_for(".update_role", role_id=form.id) }}" method="PATCH">
+                        <div class="card-body">
+                            <div class="row">
+                                {% for form_field in forms[form] %}
+                                    {{ form_field }}
+                                {% endfor %}
+                            </div>
+                            <div class="row">
+                                <div class="my-3">
+                                    <button type="submit" class="btn btn-sm py-2 btn-primary">
+                                        Sauvegarder les modifications
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
             </div>
-          </form>
-        </div>
-      </div>
-    {% endfor %}
-  </div>
+        {% endfor %}
+    </div>
 {% endblock %}
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/switch_boolean_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/switch_boolean_field.html
@@ -1,4 +1,4 @@
-<div class="col-4 form-check form-switch">
-    <input class="form-check-input" type="checkbox" role="switch" name="{{ field.name }}" id="{{ field.name }}" {{ "checked" if field.data }}>
+<div class="col-6 form-check form-switch mb-2">
+    <input class="form-check-input " type="checkbox" role="switch" style="height: 1.7rem; width: 3rem; margin-right: .5rem" name="{{ field.name }}" id="{{ field.name }}" {{ "checked" if field.data }}>
     <label class="form-check-label" for="{{ field.name }}">{{ field.label }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
@@ -1,9 +1,12 @@
 <div class="card shadow">
     <div class="card-body">
         <h5 class="card-title mb-3">
-            <span class="badge rounded-pill text-bg-primary">
-                {{ row.isActive | format_state }}
-            </span>
+            {% if not row.isActive %}
+                <span class="badge rounded-pill text-bg-primary">
+                    {{ row.isActive | format_state }}
+                </span>
+            {% endif %}
+
             {% for role in row.roles %}
                 <span class="badge rounded-pill text-bg-secondary">
                     {{ role | format_role }}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18436

## But de la pull request

Ne plus afficher l'étiquette “Actif” dans les résultats de recherche jeune

## Implémentation


## Informations supplémentaires

- Chore : Amélioration du style de la page admin 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

<img width="1365" alt="Capture d’écran 2022-11-24 à 14 54 14" src="https://user-images.githubusercontent.com/9610732/203805605-e0e9b795-3eb5-4c4f-8474-672d58b1079b.png">
