### PR TITLE
(PC-18390)[BO] feat: offerer attachments validation

### DIFF
--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -57,10 +57,6 @@ class OffererAlreadyRejectedException(Exception):
     pass
 
 
-class UserOffererNotFoundException(Exception):
-    pass
-
-
 class UserOffererAlreadyValidatedException(Exception):
     pass
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -862,6 +862,17 @@ class UserOfferer(PcObject, Base, Model, NeedsValidationMixin, ValidationStatusM
             cls.validationStatus == ValidationStatus.PENDING,
         ).is_(True)
 
+    @property
+    def requestDate(self) -> datetime | None:
+        # Added here for PC-18390 but will be removed soon in upcoming PC-18820
+        action_dates = [
+            action.actionDate
+            for action in self.offerer.action_history
+            if action.actionType in (history_models.ActionType.OFFERER_NEW, history_models.ActionType.USER_OFFERER_NEW)
+            and action.userId == self.userId
+        ]
+        return max(action_dates) if action_dates else None
+
 
 class ApiKey(PcObject, Base, Model):
     offererId: int = Column(BigInteger, ForeignKey("offerer.id"), index=True, nullable=False)

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -41,6 +41,21 @@ class OffererValidationListForm(FlaskForm):
         return q
 
 
+class UserOffererValidationListForm(FlaskForm):
+    class Meta:
+        csrf = False
+
+    status = fields.PCSelectMultipleField("États", choices=utils.choices_from_enum(offerers_models.ValidationStatus))
+
+    page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
+    per_page = fields.PCSelectField(
+        "Par page",
+        choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
+        default="10",
+        validators=(wtforms.validators.Optional(),),
+    )
+
+
 class CommentForm(FlaskForm):
     comment = fields.PCCommentField("Commentaire interne pour la structure")
 

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -148,26 +148,23 @@ def comment_offerer(offerer_id: int) -> utils.BackofficeResponse:
 validate_offerer_blueprint = utils.child_backoffice_blueprint(
     "validate_offerer",
     __name__,
-    url_prefix="/pro/offerer/validation",
+    url_prefix="/pro/validation",
     permission=perm_models.Permissions.VALIDATE_OFFERER,
 )
 
 
-def _get_serialized_offerer_last_comment(offerer: offerers_models.Offerer, user_id: int | None = None) -> str | None:
+def _get_serialized_last_comment(
+    action_types: typing.Collection[history_models.ActionType],
+    offerer: offerers_models.Offerer,
+    user_id: int | None = None,
+) -> str | None:
     last = max(
         (
             action
             for action in offerer.action_history
             if bool(action.comment)
             and (user_id is None or action.userId == user_id)
-            and action.actionType
-            in (
-                history_models.ActionType.OFFERER_NEW,
-                history_models.ActionType.OFFERER_PENDING,
-                history_models.ActionType.OFFERER_VALIDATED,
-                history_models.ActionType.OFFERER_REJECTED,
-                history_models.ActionType.COMMENT,
-            )
+            and action.actionType in action_types
         ),
         key=lambda action: action.actionDate,
         default=None,
@@ -178,7 +175,21 @@ def _get_serialized_offerer_last_comment(offerer: offerers_models.Offerer, user_
     return None
 
 
-def _redirect_after_validation_action(code: int = 303) -> utils.BackofficeResponse:
+def _get_serialized_offerer_last_comment(offerer: offerers_models.Offerer, user_id: int | None = None) -> str | None:
+    return _get_serialized_last_comment(
+        (
+            history_models.ActionType.OFFERER_NEW,
+            history_models.ActionType.OFFERER_PENDING,
+            history_models.ActionType.OFFERER_VALIDATED,
+            history_models.ActionType.OFFERER_REJECTED,
+            history_models.ActionType.COMMENT,
+        ),
+        offerer,
+        user_id=user_id,
+    )
+
+
+def _redirect_after_offerer_validation_action(code: int = 303) -> utils.BackofficeResponse:
     if request.referrer:
         return redirect(request.referrer, code)
 
@@ -193,7 +204,7 @@ class OffererToBeValidatedRow:
     owner: users_models.User
 
 
-@validate_offerer_blueprint.route("", methods=["GET"])
+@validate_offerer_blueprint.route("/offerer", methods=["GET"])
 def list_offerers_to_validate() -> utils.BackofficeResponse:
     form = offerer_forms.OffererValidationListForm(request.args)
     if not form.validate():
@@ -230,10 +241,10 @@ def validate(offerer_id: int) -> utils.BackofficeResponse:
         offerers_api.validate_offerer(offerer, current_user)
     except offerers_exceptions.OffererAlreadyValidatedException:
         flash(f"La structure {offerer.name} est déjà validée", "warning")
-        return _redirect_after_validation_action(code=400)
+        return _redirect_after_offerer_validation_action(code=400)
 
     flash(f"La structure {offerer.name} a été validée", "success")
-    return _redirect_after_validation_action()
+    return _redirect_after_offerer_validation_action()
 
 
 @offerer_blueprint.route("/reject", methods=["POST"])
@@ -244,16 +255,16 @@ def reject(offerer_id: int) -> utils.BackofficeResponse:
     form = offerer_forms.OptionalCommentForm()
     if not form.validate():
         flash("Les données envoyées comportent des erreurs", "warning")
-        return _redirect_after_validation_action(code=400)
+        return _redirect_after_offerer_validation_action(code=400)
 
     try:
         offerers_api.reject_offerer(offerer, current_user, comment=form.comment.data)
     except offerers_exceptions.OffererAlreadyRejectedException:
         flash(f"La structure {offerer.name} est déjà rejetée", "warning")
-        return _redirect_after_validation_action(code=400)
+        return _redirect_after_offerer_validation_action(code=400)
 
     flash(f"La structure {offerer.name} a été rejetée", "success")
-    return _redirect_after_validation_action()
+    return _redirect_after_offerer_validation_action()
 
 
 @offerer_blueprint.route("/pending", methods=["POST"])
@@ -264,12 +275,12 @@ def set_pending(offerer_id: int) -> utils.BackofficeResponse:
     form = offerer_forms.OptionalCommentForm()
     if not form.validate():
         flash("Les données envoyées comportent des erreurs", "warning")
-        return _redirect_after_validation_action(code=400)
+        return _redirect_after_offerer_validation_action(code=400)
 
     offerers_api.set_offerer_pending(offerer, current_user, comment=form.comment.data)
 
     flash(f"La structure {offerer.name} a été mise en attente", "success")
-    return _redirect_after_validation_action()
+    return _redirect_after_offerer_validation_action()
 
 
 @offerer_blueprint.route("/top-actor", methods=["POST"])
@@ -281,12 +292,12 @@ def toggle_top_actor(offerer_id: int) -> utils.BackofficeResponse:
         tag = offerers_models.OffererTag.query.filter(offerers_models.OffererTag.name == "top-acteur").one()
     except sa.exc.NoResultFound:
         flash("Le tag top-acteur n'existe pas", "warning")
-        return _redirect_after_validation_action(code=400)
+        return _redirect_after_offerer_validation_action(code=400)
 
     form = offerer_forms.TopActorForm()
     if not form.validate():
         flash("Les données envoyées comportent des erreurs", "warning")
-        return _redirect_after_validation_action(code=400)
+        return _redirect_after_offerer_validation_action(code=400)
 
     if form.is_top_actor.data and form.is_top_actor.data == "on":
         # Associate the tag with offerer
@@ -304,4 +315,125 @@ def toggle_top_actor(offerer_id: int) -> utils.BackofficeResponse:
         ).delete()
         db.session.commit()
 
-    return _redirect_after_validation_action()
+    return _redirect_after_offerer_validation_action()
+
+
+def _get_serialized_user_offerer_last_comment(
+    offerer: offerers_models.Offerer, user_id: int | None = None
+) -> str | None:
+    return _get_serialized_last_comment(
+        (
+            history_models.ActionType.USER_OFFERER_NEW,
+            history_models.ActionType.USER_OFFERER_PENDING,
+            history_models.ActionType.USER_OFFERER_VALIDATED,
+            history_models.ActionType.USER_OFFERER_REJECTED,
+            history_models.ActionType.COMMENT,
+        ),
+        offerer,
+        user_id=user_id,
+    )
+
+
+@validate_offerer_blueprint.route("/user_offerer", methods=["GET"])
+def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
+    form = offerer_forms.UserOffererValidationListForm(request.args)
+    if not form.validate():
+        return render_template("offerer/user_offerer_validation.html", rows=[], form=form), 400
+
+    users_offerers = offerers_api.list_users_offerers_to_be_validated(**form.data)
+
+    sorted_users_offerers = users_offerers.order_by(offerers_models.UserOfferer.id.desc())
+
+    paginated_users_offerers = sorted_users_offerers.paginate(  # type: ignore [attr-defined]
+        page=int(form.data["page"]),
+        per_page=int(form.data["per_page"]),
+    )
+
+    next_page = partial(url_for, ".list_offerers_attachments_to_validate", **form.data)
+    next_pages_urls = search_utils.pagination_links(next_page, int(form.data["page"]), paginated_users_offerers.pages)
+
+    return render_template(
+        "offerer/user_offerer_validation.html",
+        rows=paginated_users_offerers,
+        form=form,
+        next_pages_urls=next_pages_urls,
+        is_top_actor_func=offerers_api.is_top_actor,
+        get_last_comment_func=_get_serialized_user_offerer_last_comment,
+    )
+
+
+def _redirect_after_user_offerer_validation_action(offerer_id: int, code: int = 303) -> utils.BackofficeResponse:
+    if request.referrer:
+        return redirect(request.referrer, code)
+
+    return redirect(url_for("backoffice_v3_web.offerer.get", offerer_id=offerer_id), code=code)
+
+
+user_offerer_blueprint = utils.child_backoffice_blueprint(
+    "user_offerer",
+    __name__,
+    url_prefix="/pro/user_offerer/<int:user_offerer_id>",
+    permission=perm_models.Permissions.VALIDATE_OFFERER,
+)
+
+
+@user_offerer_blueprint.route("/validate", methods=["POST"])
+def user_offerer_validate(user_offerer_id: int) -> utils.BackofficeResponse:
+    user_offerer = offerers_models.UserOfferer.query.filter_by(id=user_offerer_id).one_or_none()
+    if not user_offerer:
+        raise NotFound()
+
+    try:
+        offerers_api.validate_offerer_attachment(user_offerer, current_user)
+    except offerers_exceptions.UserOffererAlreadyValidatedException:
+        flash(
+            f"Le rattachement de {user_offerer.user.email} à la structure {user_offerer.offerer.name} est déjà validé",
+            "warning",
+        )
+        return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id, code=400)
+
+    flash(
+        f"Le rattachement de {user_offerer.user.email} à la structure {user_offerer.offerer.name} a été validé",
+        "success",
+    )
+    return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id)
+
+
+@user_offerer_blueprint.route("/reject", methods=["POST"])
+def user_offerer_reject(user_offerer_id: int) -> utils.BackofficeResponse:
+    user_offerer = offerers_models.UserOfferer.query.filter_by(id=user_offerer_id).one_or_none()
+    if not user_offerer:
+        raise NotFound()
+
+    form = offerer_forms.OptionalCommentForm()
+    if not form.validate():
+        flash("Les données envoyées comportent des erreurs", "warning")
+        return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id, code=400)
+
+    offerers_api.reject_offerer_attachment(user_offerer, current_user, form.comment.data)
+
+    flash(
+        f"Le rattachement de {user_offerer.user.email} à la structure {user_offerer.offerer.name} a été rejeté",
+        "success",
+    )
+    return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id)
+
+
+@user_offerer_blueprint.route("/pending", methods=["POST"])
+def user_offerer_set_pending(user_offerer_id: int) -> utils.BackofficeResponse:
+    user_offerer = offerers_models.UserOfferer.query.filter_by(id=user_offerer_id).one_or_none()
+    if not user_offerer:
+        raise NotFound()
+
+    form = offerer_forms.OptionalCommentForm()
+    if not form.validate():
+        flash("Les données envoyées comportent des erreurs", "warning")
+        return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id, code=400)
+
+    offerers_api.set_offerer_attachment_pending(user_offerer, current_user, form.comment.data)
+    flash(
+        f"Le rattachement de {user_offerer.user.email} à la structure {user_offerer.offerer.name} a été mis en attente",
+        "success",
+    )
+
+    return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id)

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/offerer/user_offerer_status_badge.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/offerer/user_offerer_status_badge.html
@@ -1,0 +1,17 @@
+{% if user_offerer.isNew %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-info">
+        Nouveau
+    </span>
+{% elif user_offerer.isPending %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-warning">
+        En attente
+    </span>
+{% elif user_offerer.isValidated %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-success">
+        Validé
+    </span>
+{% elif user_offerer.isRejected %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-danger">
+        Rejeté
+    </span>
+{% endif %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -61,6 +61,7 @@
                         {% call menu_section("Acteurs culturels") %}
                             {{ menu_section_item("Liste des acteurs culturels", "backoffice_v3_web.search_pro") }}
                             {{ menu_section_item("Structures à valider", "backoffice_v3_web.validate_offerer.list_offerers_to_validate") }}
+                            {{ menu_section_item("Rattachements à valider", "backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate") }}
                             <!--                                {{ menu_section_item("Feature flipping", "backoffice_v3_web.home") }}-->
                             <!--                                {{ menu_section_item("Catégories et sous-catégories d'offres", "backoffice_v3_web.home") }}-->
                             <!--                                {{ menu_section_item("Rechercher des offres", "backoffice_v3_web.home") }}-->

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -1,0 +1,154 @@
+{% from "offerer/edit_status_modal.html" import build_edit_status_modal with context %}
+
+{% extends "layouts/connected.html" %}
+
+{% block page %}
+<div class="pt-3 px-5">
+    <div class="d-flex justify-content-between">
+        <h2 class="fw-light">Rattachements à valider</h2>
+    </div>
+    <form action="{{ dst }}" method="GET" class="mb-4 mt-3">
+        <div class="row">
+            <div class="col-10">
+                <div class="input-group mb-3">
+                    {% for form_field in form %}
+                        {% if form_field.type != "HiddenField" %}
+                            {{ form_field }}
+                        {% endif %}
+                    {% endfor %}
+                </div>
+                {% for form_field in form %}
+                    {% if form_field.type == "HiddenField" %}
+                        {{ form_field }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <div class="col-2">
+                <div class="py-2">
+                    <button type="submit" class="btn btn-primary">Appliquer</button>
+                </div>
+            </div>
+        </div>
+        <div class="w-100 my-4">
+            {% for form_field in form %}
+                {% for error in form_field.errors %}
+                    <p class="text-warning lead">{{ error }}</p>
+                {% endfor %}
+            {% endfor %}
+        </div>
+    </form>
+    <div>
+        {% if rows and rows.total > 0 %}
+            <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
+            <table class="table mb-4">
+                <thead>
+                    <tr>
+                        <th scope="col"></th>
+                        <th scope="col">ID Compte pro</th>
+                        <th scope="col">Email Compte pro</th>
+                        <th scope="col">Nom Compte pro</th>
+                        <th scope="col">État</th>
+                        <th scope="col">Date de la demande</th>
+                        <th scope="col">Dernier commentaire</th>
+                        <th scope="col">Tél Compte pro</th>
+                        <th scope="col">Nom Structure</th>
+                        <th scope="col">Date de création Structure</th>
+                        <th scope="col">Email Responsable</th>
+                        <th scope="col">SIREN</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for user_offerer in rows.items %}
+                        {% set offerer = user_offerer.offerer %}
+                        {% set owner = offerer.UserOfferers[0].user if offerer.UserOfferers else none %}
+                        <tr>
+                            <td>
+                                <div class="dropdown">
+                                    <button type="button" data-bs-toggle="dropdown" aria-expanded="false" class="btn p-0"><i
+                                            class="bi bi-three-dots-vertical"></i></button>
+                                    <ul class="dropdown-menu">
+                                        <li class="dropdown-item">
+                                            <form
+                                                    action="{{ url_for(
+                                                    "backoffice_v3_web.user_offerer.user_offerer_validate",
+                                                    offerer_id=offerer.id,
+                                                    user_offerer_id=user_offerer.id
+                                                ) }}"
+                                                    method="POST">
+                                                <button type="submit" class="btn btn-sm">
+                                                    Valider
+                                                </button>
+                                            </form>
+                                        </li>
+                                        <li class="dropdown-item">
+                                            <button type="button"
+                                                    class="btn btn-sm"
+                                                    data-bs-toggle="modal"
+                                                    data-bs-target="#reject-modal-{{ user_offerer.id }}">
+                                                Rejeter
+                                            </button>
+                                        </li>
+                                        <li class="dropdown-item">
+                                            <button type="button"
+                                                    class="btn btn-sm"
+                                                    data-bs-toggle="modal"
+                                                    data-bs-target="#pending-modal-{{ user_offerer.id }}">
+                                                Mettre en attente
+                                            </button>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </td>
+                            <td>{{ user_offerer.user.id }}</td>
+                            <td>{{ user_offerer.user.email | empty_string_if_null }}</td>
+                            <td>
+                                <a href="{{ url_for('backoffice_v3_web.pro_user.get', user_id=user_offerer.user.id) }}">
+                                    {{ user_offerer.user.firstName | empty_string_if_null | escape }}
+                                    {{ user_offerer.user.lastName | empty_string_if_null | escape }}
+                                </a>
+                            </td>
+                            <td>{% include "components/offerer/user_offerer_status_badge.html" %}</td>
+                            <td>{{ user_offerer.requestDate | format_date("%d/%m/%Y") }}</td>
+                            <td>{{ get_last_comment_func(offerer, user_offerer.userId) | empty_string_if_null }}</td>
+                            <td>{{ user_offerer.user.phoneNumber | format_phone_number }}</td>
+                            <td>
+                                <a href="{{ url_for('backoffice_v3_web.offerer.get', offerer_id=user_offerer.offererId) }}">
+                                    {{ offerer.name | upper | escape }}
+                                </a>
+                            </td>
+                            <td>{{ offerer.requestDate | format_date("%d/%m/%Y") }}</td>
+                            <td>{{ (owner and owner.email) | empty_string_if_null }}</td>
+                            <td>
+                                {% if offerer.siren %}
+                                    <a href="https://www.societe.com/cgi-bin/fiche?rncs={{ offerer.siren }}"
+                                            target="_blank"
+                                            title="Visualiser sur societe.com">
+                                        {{ offerer.siren | empty_string_if_null }}
+                                    </a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% include 'components/search/pagination.html' %}
+
+            {% for user_offerer in rows.items %}
+                {% call build_edit_status_modal(
+                    url_for("backoffice_v3_web.user_offerer.user_offerer_reject", offerer_id=user_offerer.offererId, user_offerer_id=user_offerer.id),
+                    "reject-modal-" + user_offerer.id|string, "Rejeter le rattachement") %}
+                    Rejeter le rattachement à {{ user_offerer.offerer.name | upper }}
+                {% endcall %}
+                {% call build_edit_status_modal(
+                    url_for("backoffice_v3_web.user_offerer.user_offerer_set_pending", offerer_id=user_offerer.offererId, user_offerer_id=user_offerer.id),
+                    "pending-modal-" + user_offerer.id|string, "Mettre en attente le rattachement") %}
+                    Mettre en attente le rattachement à {{ user_offerer.offerer.name | upper }}
+                {% endcall %}
+            {% endfor %}
+        {% else %}
+            Aucun rattachement ne correspond à la requête
+        {% endif %}
+    </div>
+</div>
+
+{% endblock %}

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -721,7 +721,7 @@ class RejectOffererAttachementTest:
         user_offerer = offerers_factories.NotValidatedUserOffererFactory()
 
         # When
-        offerers_api.reject_offerer_attachment(user_offerer.id, admin)
+        offerers_api.reject_offerer_attachment(user_offerer, admin)
 
         # Then
         assert offerers_models.UserOfferer.query.count() == 0
@@ -733,7 +733,7 @@ class RejectOffererAttachementTest:
         user_offerer = offerers_factories.NotValidatedUserOffererFactory(user=user)
 
         # When
-        offerers_api.reject_offerer_attachment(user_offerer.id, admin)
+        offerers_api.reject_offerer_attachment(user_offerer, admin)
 
         # Then
         assert not user.has_pro_role
@@ -745,7 +745,7 @@ class RejectOffererAttachementTest:
         user_offerer = offerers_factories.NotValidatedUserOffererFactory(user=validated_user_offerer.user)
 
         # When
-        offerers_api.reject_offerer_attachment(user_offerer.id, admin)
+        offerers_api.reject_offerer_attachment(user_offerer, admin)
 
         # Then
         assert validated_user_offerer.user.has_pro_role
@@ -757,7 +757,7 @@ class RejectOffererAttachementTest:
         user_offerer = offerers_factories.NotValidatedUserOffererFactory()
 
         # When
-        offerers_api.reject_offerer_attachment(user_offerer.id, admin)
+        offerers_api.reject_offerer_attachment(user_offerer, admin)
 
         # Then
         send_offerer_attachment_rejection_email_to_pro.assert_called_once_with(user_offerer)
@@ -770,7 +770,7 @@ class RejectOffererAttachementTest:
         user_offerer = offerers_factories.NotValidatedUserOffererFactory(user=user, offerer=offerer)
 
         # When
-        offerers_api.reject_offerer_attachment(user_offerer.id, admin)
+        offerers_api.reject_offerer_attachment(user_offerer, admin)
 
         # Then
         action = history_models.ActionHistory.query.one()
@@ -780,19 +780,6 @@ class RejectOffererAttachementTest:
         assert action.userId == user.id
         assert action.offererId == offerer.id
         assert action.venueId is None
-
-    def test_do_not_reject_if_id_not_found(self):
-        # Given
-        admin = users_factories.AdminFactory()
-        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
-
-        # When
-        with pytest.raises(offerers_exceptions.UserOffererNotFoundException):
-            offerers_api.reject_offerer_attachment(user_offerer.id + 100, admin)
-
-        # Then
-        assert user_offerer.validationStatus == offerers_models.ValidationStatus.NEW
-        assert history_models.ActionHistory.query.count() == 0
 
 
 @freeze_time("2020-10-15 00:00:00")

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -392,7 +392,6 @@ class CommentOffererTest:
 
 class ListOfferersToValidateUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
     endpoint = "backoffice_v3_web.validate_offerer.list_offerers_to_validate"
-    endpoint_kwargs = {"offerer_id": 1}
     needed_permission = perm_models.Permissions.VALIDATE_OFFERER
 
 
@@ -1061,3 +1060,353 @@ class ToggleTopActorTest:
         )
         # then
         assert response.status_code == 404
+
+
+class ListUserOffererToValidateUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+    endpoint = "backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate"
+    needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+
+
+class ListUserOffererToValidateTest:
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_list_only_user_offerer_to_be_validated(self, authenticated_client):
+        # given
+        to_be_validated = []
+        for _ in range(2):
+            validated_user_offerer = offerers_factories.UserOffererFactory()
+            new_user_offerer = offerers_factories.NotValidatedUserOffererFactory(offerer=validated_user_offerer.offerer)
+            to_be_validated.append(new_user_offerer)
+            pending_user_offerer = offerers_factories.NotValidatedUserOffererFactory(
+                offerer=validated_user_offerer.offerer, validationStatus=offerers_models.ValidationStatus.PENDING
+            )
+            to_be_validated.append(pending_user_offerer)
+            for action_type in (
+                history_models.ActionType.USER_OFFERER_PENDING,
+                history_models.ActionType.USER_OFFERER_PENDING,
+            ):
+                history_factories.ActionHistoryFactory(
+                    actionType=action_type,
+                    authorUser=users_factories.AdminFactory(),
+                    offerer=pending_user_offerer.offerer,
+                    user=pending_user_offerer.user,
+                    comment=None,
+                )
+
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert {int(row["ID Compte pro"]) for row in rows} == {user_offerer.user.id for user_offerer in to_be_validated}
+
+    @pytest.mark.parametrize(
+        "validation_status,expected_status",
+        [
+            (offerers_models.ValidationStatus.NEW, "Nouveau"),
+            (offerers_models.ValidationStatus.PENDING, "En attente"),
+        ],
+    )
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_payload_content(self, authenticated_client, validation_status, expected_status):
+        # given
+        owner_user_offerer = offerers_factories.UserOffererFactory(
+            offerer__dateCreated=datetime.datetime(2022, 11, 2, 11, 30)
+        )
+        new_user_offerer = offerers_factories.NotValidatedUserOffererFactory(
+            offerer=owner_user_offerer.offerer,
+            validationStatus=validation_status,
+            user__phoneNumber="+33612345678",
+        )
+        commenter = users_factories.AdminFactory(firstName="Inspecteur", lastName="Validateur")
+        history_factories.ActionHistoryFactory(
+            actionDate=datetime.datetime(2022, 11, 3, 12, 0),
+            actionType=history_models.ActionType.USER_OFFERER_NEW,
+            authorUser=commenter,
+            offerer=new_user_offerer.offerer,
+            user=new_user_offerer.user,
+            comment=None,
+        )
+        history_factories.ActionHistoryFactory(
+            actionDate=datetime.datetime(2022, 11, 4, 13, 1),
+            actionType=history_models.ActionType.COMMENT,
+            authorUser=commenter,
+            offerer=new_user_offerer.offerer,
+            user=new_user_offerer.user,
+            comment="Bla blabla" if validation_status == offerers_models.ValidationStatus.NEW else "Premier",
+        )
+        if validation_status == offerers_models.ValidationStatus.PENDING:
+            history_factories.ActionHistoryFactory(
+                actionDate=datetime.datetime(2022, 11, 5, 14, 2),
+                actionType=history_models.ActionType.USER_OFFERER_PENDING,
+                authorUser=commenter,
+                offerer=new_user_offerer.offerer,
+                user=new_user_offerer.user,
+                comment="Bla blabla",
+            )
+
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert rows[0]["ID Compte pro"] == str(new_user_offerer.user.id)
+        assert rows[0]["Email Compte pro"] == new_user_offerer.user.email
+        assert rows[0]["Nom Compte pro"] == f"{new_user_offerer.user.firstName} {new_user_offerer.user.lastName}"
+        assert rows[0]["État"] == expected_status
+        assert rows[0]["Date de la demande"] == "03/11/2022"
+        assert rows[0]["Dernier commentaire"] == "Bla blabla"
+        assert rows[0]["Tél Compte pro"] == new_user_offerer.user.phoneNumber
+        assert rows[0]["Nom Structure"] == owner_user_offerer.offerer.name.upper()
+        assert rows[0]["Date de création Structure"] == "02/11/2022"
+        assert rows[0]["Email Responsable"] == owner_user_offerer.user.email
+        assert rows[0]["SIREN"] == owner_user_offerer.offerer.siren
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_payload_content_no_action(self, authenticated_client):
+        # given
+        owner_user_offerer = offerers_factories.UserOffererFactory(offerer__dateCreated=datetime.datetime(2022, 11, 3))
+        offerers_factories.UserOffererFactory(offerer=owner_user_offerer.offerer)  # other validated, not owner
+        new_user_offerer = offerers_factories.NotValidatedUserOffererFactory(offerer=owner_user_offerer.offerer)
+
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert rows[0]["ID Compte pro"] == str(new_user_offerer.user.id)
+        assert rows[0]["Email Compte pro"] == new_user_offerer.user.email
+        assert rows[0]["Nom Compte pro"] == f"{new_user_offerer.user.firstName} {new_user_offerer.user.lastName}"
+        assert rows[0]["État"] == "Nouveau"
+        assert rows[0]["Date de la demande"] == ""
+        assert rows[0]["Dernier commentaire"] == ""
+        assert rows[0]["Tél Compte pro"] == ""
+        assert rows[0]["Nom Structure"] == owner_user_offerer.offerer.name.upper()
+        assert rows[0]["Date de création Structure"] == "03/11/2022"
+        assert rows[0]["Email Responsable"] == owner_user_offerer.user.email
+        assert rows[0]["SIREN"] == owner_user_offerer.offerer.siren
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    @pytest.mark.parametrize(
+        "total_items, pagination_config, expected_total_pages, expected_page, expected_items",
+        (
+            (31, {"per_page": 10}, 4, 1, 10),
+            (31, {"per_page": 10, "page": 1}, 4, 1, 10),
+            (31, {"per_page": 10, "page": 3}, 4, 3, 10),
+            (31, {"per_page": 10, "page": 4}, 4, 4, 1),
+            (20, {"per_page": 10, "page": 1}, 2, 1, 10),
+            (10, {"page": 1}, 1, 1, 10),
+            (10, {"per_page": 25, "page": 1}, 1, 1, 10),
+        ),
+    )
+    def test_list_pagination(
+        self, authenticated_client, total_items, pagination_config, expected_total_pages, expected_page, expected_items
+    ):
+        # given
+        for _ in range(total_items):
+            offerers_factories.NotValidatedUserOffererFactory()
+
+        # when
+        response = authenticated_client.get(
+            url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate", **pagination_config)
+        )
+
+        # then
+        assert response.status_code == 200
+        assert html_parser.count_table_rows(response.data) == expected_items
+        assert html_parser.extract_pagination_info(response.data) == (
+            expected_page,
+            expected_total_pages,
+            total_items,
+        )
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    @pytest.mark.parametrize(
+        "status_filter, expected_status, expected_users_emails",
+        (
+            ("NEW", 200, {"a@example.com", "c@example.com", "e@example.com"}),
+            ("PENDING", 200, {"b@example.com", "d@example.com", "f@example.com"}),
+            (
+                ["NEW", "PENDING"],
+                200,
+                {"a@example.com", "b@example.com", "c@example.com", "d@example.com", "e@example.com", "f@example.com"},
+            ),
+            ("VALIDATED", 200, {"g@example.com"}),
+            ("REJECTED", 200, set()),
+            (
+                None,
+                200,
+                {"a@example.com", "b@example.com", "c@example.com", "d@example.com", "e@example.com", "f@example.com"},
+            ),  # same as default
+            ("OTHER", 400, set()),  # unknown value
+        ),
+    )
+    def test_list_filtering_by_status(
+        self, authenticated_client, status_filter, expected_status, expected_users_emails, user_offerer_to_be_validated
+    ):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for(
+                    "backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate", status=status_filter
+                )
+            )
+
+        # then
+        assert response.status_code == expected_status
+        if expected_status == 200:
+            rows = html_parser.extract_table_rows(response.data)
+            assert {row["Email Compte pro"] for row in rows} == expected_users_emails
+        else:
+            assert html_parser.count_table_rows(response.data) == 0
+
+
+class ValidateOffererAttachmentUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+    method = "post"
+    endpoint = "backoffice_v3_web.user_offerer.user_offerer_validate"
+    endpoint_kwargs = {"user_offerer_id": 1}
+    needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+
+
+class ValidateOffererAttachmentTest:
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_validate_offerer_attachment(self, legit_user, authenticated_client):
+        # given
+        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
+
+        # when
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.user_offerer.user_offerer_validate", user_offerer_id=user_offerer.id)
+        )
+
+        # then
+        assert response.status_code == 303
+
+        db.session.refresh(user_offerer)
+        assert user_offerer.isValidated
+        assert user_offerer.user.has_pro_role
+
+        action = history_models.ActionHistory.query.one()
+        assert action.actionType == history_models.ActionType.USER_OFFERER_VALIDATED
+        assert action.actionDate is not None
+        assert action.authorUserId == legit_user.id
+        assert action.userId == user_offerer.user.id
+        assert action.offererId == user_offerer.offerer.id
+        assert action.venueId is None
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_validate_offerer_attachment_returns_404_if_offerer_is_not_found(self, authenticated_client):
+        # when
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.user_offerer.user_offerer_validate", user_offerer_id=42)
+        )
+
+        # then
+        assert response.status_code == 404
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_cannot_validate_offerer_attachment_already_validated(self, authenticated_client):
+        # given
+        user_offerer = offerers_factories.UserOffererFactory()
+
+        # when
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.user_offerer.user_offerer_validate", user_offerer_id=user_offerer.id)
+        )
+
+        # then
+        assert response.status_code == 400
+
+        redirected_response = authenticated_client.get(response.headers["location"])
+        assert "est déjà validé" in redirected_response.data.decode("utf8")
+
+
+class RejectOffererAttachmentUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+    method = "post"
+    endpoint = "backoffice_v3_web.user_offerer.user_offerer_reject"
+    endpoint_kwargs = {"user_offerer_id": 1}
+    needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+
+
+class RejectOffererAttachmentTest:
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_reject_offerer_attachment(self, legit_user, authenticated_client):
+        # given
+        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
+
+        # when
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.user_offerer.user_offerer_reject", user_offerer_id=user_offerer.id)
+        )
+
+        # then
+        assert response.status_code == 303
+
+        users_offerers = offerers_models.UserOfferer.query.all()
+        assert len(users_offerers) == 0
+
+        action = history_models.ActionHistory.query.one()
+        assert action.actionType == history_models.ActionType.USER_OFFERER_REJECTED
+        assert action.actionDate is not None
+        assert action.authorUserId == legit_user.id
+        assert action.userId == user_offerer.user.id
+        assert action.offererId == user_offerer.offerer.id
+        assert action.venueId is None
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_reject_offerer_returns_404_if_offerer_attachment_is_not_found(self, authenticated_client):
+        # when
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.user_offerer.user_offerer_reject", user_offerer_id=42)
+        )
+
+        # then
+        assert response.status_code == 404
+
+
+class SetOffererAttachmentPendingUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+    method = "post"
+    endpoint = "backoffice_v3_web.user_offerer.user_offerer_set_pending"
+    endpoint_kwargs = {"user_offerer_id": 1}
+    needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+
+
+class SetOffererAttachmentPendingTest:
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_set_offerer_attachment_pending(self, legit_user, authenticated_client):
+        # given
+        user_offerer = offerers_factories.NotValidatedUserOffererFactory()
+
+        # when
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.user_offerer.user_offerer_set_pending", user_offerer_id=user_offerer.id),
+            form={"comment": "En attente de documents"},
+        )
+
+        # then
+        assert response.status_code == 303
+
+        db.session.refresh(user_offerer)
+        assert not user_offerer.isValidated
+        assert user_offerer.validationStatus == offerers_models.ValidationStatus.PENDING
+        action = history_models.ActionHistory.query.one()
+        assert action.actionType == history_models.ActionType.USER_OFFERER_PENDING
+        assert action.actionDate is not None
+        assert action.authorUserId == legit_user.id
+        assert action.userId == user_offerer.user.id
+        assert action.offererId == user_offerer.offerer.id
+        assert action.venueId is None
+        assert action.comment == "En attente de documents"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18390

## But de la pull request

Écran de validation des rattachements d'utilisateurs pro à des structures dans le backoffice v3.
Iso-fonctionnel avec le backoffice v2.

## Implémentation

UX identique à celle de la validation des structures du backoffice v3.
Fonctionnalités et tests identiques à ceux des endpoints backend du backoffice v2.

## Informations supplémentaires

La barre de filtrage, avec moins de possibilités que les structures, n'a pas été soignée pour ce choix réduit car des tickets arrivent derrière pour y ajouter des filtres comme sur la validation des structures. La forme prendra avec ces tickets.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
