### PR TITLE
(PC-18673)[PRO] feat: update wording onclick collective offers active…

### DIFF
--- a/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useHistory } from 'react-router'
 
 import CollectiveOfferSummary from 'components/CollectiveOfferSummary'
@@ -37,6 +37,7 @@ const CollectiveOfferSummaryEdition = ({
   categories,
   reloadCollectiveOffer,
 }: CollectiveOfferSummaryEditionProps) => {
+  const [isActive, setIsActive] = useState(offer.isActive)
   const notify = useNotification()
   const history = useHistory()
   const isSubtypeChosenAtCreation = useActiveFeature(
@@ -81,10 +82,11 @@ const CollectiveOfferSummaryEdition = ({
 
     const response = await adapter({
       offerId: offer.id,
-      isActive: !offer.isActive,
+      isActive: !isActive,
     })
 
     if (response.isOk) {
+      setIsActive(!isActive)
       return notify.success(response.message)
     }
 
@@ -100,7 +102,7 @@ const CollectiveOfferSummaryEdition = ({
           offer.isTemplate ? false : Boolean(offer.collectiveStock?.isBooked)
         }
         isCancellable={offer.isCancellable}
-        isOfferActive={offer.isActive}
+        isOfferActive={isActive}
         setIsOfferActive={setIsOfferActive}
       />
       {offer.isTemplate && (

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -124,7 +124,7 @@ describe('CollectiveOfferSummary', () => {
     )
   })
 
-  it('should display desactive offer when clicking on activate offer', async () => {
+  it('should activate offer', async () => {
     offer = collectiveOfferTemplateFactory({
       isTemplate: true,
       isActive: false,
@@ -144,31 +144,6 @@ describe('CollectiveOfferSummary', () => {
 
     const desactivateOffer = screen.getByRole('button', {
       name: 'Désactiver l’offre',
-    })
-
-    expect(desactivateOffer).toBeInTheDocument()
-  })
-
-  it('should display activate offer when clicking on desactive offer', async () => {
-    offer = collectiveOfferTemplateFactory({
-      isTemplate: true,
-      isActive: true,
-    })
-    renderCollectiveOfferSummaryEdition(offer, categories)
-    const toggle = jest
-      .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
-      .mockResolvedValue()
-
-    const activateOffer = screen.getByRole('button', {
-      name: 'Désactiver l’offre',
-    })
-
-    await userEvent.click(activateOffer)
-
-    expect(toggle).toHaveBeenCalledTimes(1)
-
-    const desactivateOffer = screen.getByRole('button', {
-      name: 'Activer l’offre',
     })
 
     expect(desactivateOffer).toBeInTheDocument()

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
+import { api } from 'apiClient/api'
 import {
   Events,
   OFFER_FROM_TEMPLATE_ENTRIES,
@@ -121,5 +122,55 @@ describe('CollectiveOfferSummary', () => {
         from: OFFER_FROM_TEMPLATE_ENTRIES.OFFER_TEMPLATE_RECAP,
       }
     )
+  })
+
+  it('should display desactive offer when clicking on activate offer', async () => {
+    offer = collectiveOfferTemplateFactory({
+      isTemplate: true,
+      isActive: false,
+    })
+    renderCollectiveOfferSummaryEdition(offer, categories)
+    const toggle = jest
+      .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
+      .mockResolvedValue()
+
+    const activateOffer = screen.getByRole('button', {
+      name: 'Activer l’offre',
+    })
+
+    await userEvent.click(activateOffer)
+
+    expect(toggle).toHaveBeenCalledTimes(1)
+
+    const desactivateOffer = screen.getByRole('button', {
+      name: 'Désactiver l’offre',
+    })
+
+    expect(desactivateOffer).toBeInTheDocument()
+  })
+
+  it('should display activate offer when clicking on desactive offer', async () => {
+    offer = collectiveOfferTemplateFactory({
+      isTemplate: true,
+      isActive: true,
+    })
+    renderCollectiveOfferSummaryEdition(offer, categories)
+    const toggle = jest
+      .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
+      .mockResolvedValue()
+
+    const activateOffer = screen.getByRole('button', {
+      name: 'Désactiver l’offre',
+    })
+
+    await userEvent.click(activateOffer)
+
+    expect(toggle).toHaveBeenCalledTimes(1)
+
+    const desactivateOffer = screen.getByRole('button', {
+      name: 'Activer l’offre',
+    })
+
+    expect(desactivateOffer).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18673

## But de la pull request

Corriger le fait de ne pas voir apparaître le bon wording lorsqu'on cliquait sur "Activer l'offre"

## Implémentation

- Ajout d'un state isActive et changer sa valeur au clique sur le bouton
- Ajouter des tests pour vérifier le changement de wording au clic sur le bouton activer/désactiver

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x ] J'ai écrit les tests nécessaires
