### PR TITLE
(PC-18326)[PRO] fix: Add provider banner to stockEvent, stockThing an…

### DIFF
--- a/pro/src/components/Notification/Notification.tsx
+++ b/pro/src/components/Notification/Notification.tsx
@@ -67,9 +67,8 @@ const Notification = (): JSX.Element | null => {
           /* istanbul ignore next */
           cn(
             styles['notification'],
-            /* istanbul ignore next: DEBT, TO FIX */ styles[
-              `is-${type || 'success'}`
-            ],
+            /* istanbul ignore next: DEBT, TO FIX */
+            styles[`is-${type || 'success'}`],
             /* istanbul ignore next: DEBT, TO FIX */ isVisible
               ? styles['show']
               : styles['hide'],

--- a/pro/src/components/OfferIndividualForm/OfferIndividualForm.tsx
+++ b/pro/src/components/OfferIndividualForm/OfferIndividualForm.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import FormLayout from 'components/FormLayout'
 import { IOnImageUploadArgs } from 'components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { IOfferIndividualFormValues } from 'components/OfferIndividualForm'
+import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import { TOffererName } from 'core/Offerers/types'
 import { CATEGORY_STATUS } from 'core/Offers'
 import {
@@ -14,6 +15,7 @@ import {
 import { TOfferIndividualVenue } from 'core/Venue/types'
 import { useScrollToFirstErrorAfterSubmit } from 'hooks'
 import useCurrentUser from 'hooks/useCurrentUser'
+import { SynchronizedProviderInformation } from 'screens/OfferIndividual/SynchronisedProviderInfos'
 
 import { Accessibility } from './Accessibility'
 import { Categories } from './Categories'
@@ -77,8 +79,13 @@ const OfferIndividualForm = ({
     offerSubCategory.onlineOfflinePlatform === CATEGORY_STATUS.OFFLINE &&
     areAllVenuesVirtual
 
+  const { offer } = useOfferIndividualContext()
+  const providerName = offer?.lastProviderName
   return (
     <>
+      {providerName && (
+        <SynchronizedProviderInformation providerName={providerName} />
+      )}
       <FormLayout.MandatoryInfo />
       <Categories
         categories={categories}

--- a/pro/src/components/OfferIndividualForm/__specs__/OfferIndividualForm.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/__specs__/OfferIndividualForm.spec.tsx
@@ -186,6 +186,33 @@ describe('OfferIndividualForm', () => {
     expect(await screen.findByText('Type d’offre')).toBeInTheDocument()
   })
 
+  it('should render synchronized banner when lastProviderName is set', async () => {
+    const offer = {
+      nonHumanizedId: 12,
+      venueId: 'VID physical',
+      venue: {
+        offerer: {
+          id: 'OFID',
+          name: 'Offerer name',
+        },
+      },
+      lastProviderName: 'Ciné Office',
+    } as IOfferIndividual
+    const contextOverride: Partial<IOfferIndividualContext> = {
+      offer: offer,
+    }
+
+    renderOfferIndividualForm({
+      initialValues,
+      onSubmit,
+      props,
+      contextOverride,
+    })
+    expect(
+      screen.getByText('Offre synchronisée avec Ciné Office')
+    ).toBeInTheDocument()
+  })
+
   const imageSectionDataset: (Partial<IOfferIndividual> | undefined)[] = [
     {
       id: 'AA',

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -25,6 +25,7 @@ import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
 
 import { ActionBar } from '../ActionBar'
+import { SynchronizedProviderInformation } from '../SynchronisedProviderInfos'
 import { logTo } from '../utils/logTo'
 
 import { upsertStocksEventAdapter } from './adapters'
@@ -53,6 +54,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   const navigate = useNavigate()
   const notify = useNotification()
   const { setOffer } = useOfferIndividualContext()
+  const providerName = offer?.lastProviderName
 
   const onSubmit = async (formValues: { stocks: IStockEventFormValues[] }) => {
     const { isOk, payload } = await upsertStocksEventAdapter({
@@ -187,6 +189,9 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
 
   return (
     <FormikProvider value={formik}>
+      {providerName && (
+        <SynchronizedProviderInformation providerName={providerName} />
+      )}
       <FormLayout>
         <FormLayout.Section
           title="Stock & Prix"

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -109,10 +109,14 @@ describe('screens:StocksEvent', () => {
   it('should render stock event', async () => {
     props.offer = {
       ...(offer as IOfferIndividual),
+      lastProviderName: 'Ciné Office',
       isDigital: false,
     }
 
     renderStockEventScreen({ props, storeOverride, contextValue })
+    expect(
+      screen.getByText('Offre synchronisée avec Ciné Office')
+    ).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: /Stock & Prix/ })
     ).toBeInTheDocument()

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -79,6 +79,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
     showModal: deleteConfirmShow,
     hideModal: deleteConfirmHide,
   } = useModal()
+  /* istanbul ignore next: DEBT, TO FIX */
   const isDisabled = offer.status ? isOfferDisabled(offer.status) : false
   const isSynchronized = offer.lastProvider !== null
   const providerName = offer?.lastProviderName

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -40,6 +40,7 @@ import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 
 import { ActionBar } from '../ActionBar'
 import { DialogStockDeleteConfirm } from '../DialogStockDeleteConfirm'
+import { SynchronizedProviderInformation } from '../SynchronisedProviderInfos'
 import { logTo } from '../utils/logTo'
 
 import { ActivationCodeFormDialog } from './ActivationCodeFormDialog'
@@ -80,6 +81,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
   } = useModal()
   const isDisabled = offer.status ? isOfferDisabled(offer.status) : false
   const isSynchronized = offer.lastProvider !== null
+  const providerName = offer?.lastProviderName
 
   const onSubmit = async (formValues: IStockThingFormValues) => {
     const { isOk, payload, message } = await upsertStocksThingAdapter({
@@ -275,6 +277,10 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
           today={today}
           minExpirationDate={formik.values.bookingLimitDatetime}
         />
+      )}
+
+      {providerName && (
+        <SynchronizedProviderInformation providerName={providerName} />
       )}
       <FormLayout>
         <FormLayout.Section title="Stock & Prix" description={description}>

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -89,6 +89,7 @@ describe('screens:StocksThing', () => {
         departmentCode: '75',
       } as IOfferIndividualVenue,
       stocks: [],
+      lastProviderName: 'Ciné Office',
     }
     props = {
       offer: offer as IOfferIndividual,
@@ -109,12 +110,16 @@ describe('screens:StocksThing', () => {
   })
 
   it('should render physical stock thing', async () => {
+    offer.lastProviderName = 'Ciné Office'
     props.offer = {
       ...(offer as IOfferIndividual),
       isDigital: false,
     }
 
     renderStockThingScreen({ props, storeOverride, contextValue })
+    expect(
+      screen.getByText('Offre synchronisée avec Ciné Office')
+    ).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: /Stock & Prix/ })
     ).toBeInTheDocument()
@@ -138,6 +143,9 @@ describe('screens:StocksThing', () => {
       isDigital: true,
     }
     renderStockThingScreen({ props, storeOverride, contextValue })
+    expect(
+      screen.getByText('Offre synchronisée avec Ciné Office')
+    ).toBeInTheDocument()
     expect(
       screen.getByText(
         /Les utilisateurs ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les utilisateurs ne peuvent pas annuler leurs réservations d’offres numériques. Toute réservation est définitive et sera immédiatement validée. Pour ajouter des codes d’activation, veuillez passer par le menu ··· et choisir l’option correspondante./

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -171,6 +171,9 @@ const Summary = (
           }
         </div>
       )}
+      {providerName && (
+        <SynchronizedProviderInformation providerName={providerName} />
+      )}
       <SummaryLayout>
         <SummaryLayout.Content>
           <OfferSection conditionalFields={conditionalFields} offer={offer} />

--- a/pro/src/screens/OfferIndividual/Summary/Summary.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/Summary.tsx
@@ -161,18 +161,12 @@ const Summary = (
               </div>
             )
           }
-          {
-            /* istanbul ignore next: DEBT, TO FIX */
-            providerName !== null && (
-              <div className={styles['offer-preview-banner']}>
-                <SynchronizedProviderInformation providerName={providerName} />
-              </div>
-            )
-          }
+          {providerName !== null && (
+            <div className={styles['offer-preview-banner']}>
+              <SynchronizedProviderInformation providerName={providerName} />
+            </div>
+          )}
         </div>
-      )}
-      {providerName && (
-        <SynchronizedProviderInformation providerName={providerName} />
       )}
       <SummaryLayout>
         <SummaryLayout.Content>

--- a/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
@@ -171,7 +171,7 @@ describe('Summary', () => {
 
     props = {
       offerId: offer.id,
-      providerName: null,
+      providerName: 'Ciné Office',
       offer: offer,
       stockThing: stock,
       stockEventList: undefined,
@@ -192,6 +192,9 @@ describe('Summary', () => {
       renderSummary({ props })
 
       // then
+      expect(
+        screen.getByText('Offre synchronisée avec Ciné Office')
+      ).toBeInTheDocument()
       expect(screen.getAllByText('Modifier')).toHaveLength(2)
       expect(screen.getByText('Détails de l’offre')).toBeInTheDocument()
       expect(screen.getByText('Type d’offre')).toBeInTheDocument()

--- a/pro/src/screens/OfferIndividual/SynchronisedProviderInfos/SynchronizedProviderInformation.module.scss
+++ b/pro/src/screens/OfferIndividual/SynchronisedProviderInfos/SynchronizedProviderInformation.module.scss
@@ -1,5 +1,5 @@
 @use 'styles/mixins/_rem.scss' as rem;
 .banner-provider {
-    width: 100%;
-    padding: rem.torem(16px) 0;
+	width: 100%;
+	padding: rem.torem(16px) 0;
 }

--- a/pro/src/screens/OfferIndividual/SynchronisedProviderInfos/SynchronizedProviderInformation.tsx
+++ b/pro/src/screens/OfferIndividual/SynchronisedProviderInfos/SynchronizedProviderInformation.tsx
@@ -30,7 +30,11 @@ const SynchronizedProviderInformation = ({
         className={styles['banner-provider']}
         isProvider
       >
-        <Icon alt={providerInfo.name} svg={providerInfo.icon} />
+        <Icon
+          alt={providerInfo.name}
+          svg={providerInfo.icon}
+          className="provider-logo"
+        />
         <span>{providerInfo.synchronizedOfferMessage}</span>
       </Banner>
     </div>

--- a/pro/src/screens/OfferIndividual/SynchronisedProviderInfos/SynchronizedProviderInformation.tsx
+++ b/pro/src/screens/OfferIndividual/SynchronisedProviderInfos/SynchronizedProviderInformation.tsx
@@ -15,7 +15,6 @@ const SynchronizedProviderInformation = ({
   providerName,
 }: ISynchronizedProviderInformation): JSX.Element | null => {
   const providerInfo = getProviderInfo(providerName)
-
   if (providerInfo === undefined) {
     return null
   }

--- a/pro/src/ui-kit/Banners/BannerLayout/NewBannerLayout.module.scss
+++ b/pro/src/ui-kit/Banners/BannerLayout/NewBannerLayout.module.scss
@@ -37,6 +37,10 @@
       &.provider {
         display: flex;
         align-items: center;
+        & > img {
+          max-width: rem.torem(102px);
+          margin: 0 rem.torem(16px);
+        }
       }
     }
     .bi-link {

--- a/pro/src/ui-kit/Banners/BannerLayout/NewBannerLayout.module.scss
+++ b/pro/src/ui-kit/Banners/BannerLayout/NewBannerLayout.module.scss
@@ -37,7 +37,7 @@
       &.provider {
         display: flex;
         align-items: center;
-        & > img {
+        & > img.provider-logo {
           max-width: rem.torem(102px);
           margin: 0 rem.torem(16px);
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18326

## But de la pull request

- Ajouter la bannière des offres synchros en édition, sur les détails de l'offre et les stocks.
- Ajouter une taille maximale pour les images.


![Screenshot from 2022-11-28 11-32-40](https://user-images.githubusercontent.com/106379750/204256384-37d88272-242d-4f3f-acae-22ebbf07bf64.png)
![Screenshot from 2022-11-28 11-33-07](https://user-imag
![Screenshot from 2022-11-28 11-32-55](https://user-images.githubusercontent.com/106379750/204256765-8398f816-6a99-4101-865e-3076474431f2.png)
es.githubusercontent.com/106379750/204256606-4337fc1e-8861-4815-bf1c-f23c8457ccce.png)



