### PR TITLE
(PC-18820)[BO] fix: use dateCreated instead of computed requestDate for performance reasons

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-8948db4edb75 (pre) (head)
+c14229719483 (pre) (head)
 4e9a6643eeed (post) (head)

--- a/api/src/pcapi/alembic/versions/20221125T153444_c14229719483_add_userofferer_datecreated.py
+++ b/api/src/pcapi/alembic/versions/20221125T153444_c14229719483_add_userofferer_datecreated.py
@@ -1,0 +1,20 @@
+"""Add_UserOfferer_dateCreated
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "c14229719483"
+down_revision = "8948db4edb75"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("user_offerer", sa.Column("dateCreated", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_offerer", "dateCreated")

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -404,6 +404,7 @@ def _fill_in_offerer(
     offerer.siren = offerer_informations.siren
     offerer.generate_validation_token()
     offerer.validationStatus = models.ValidationStatus.NEW
+    offerer.dateCreated = datetime.utcnow()
 
 
 def _auto_tag_new_offerer(offerer: offerers_models.Offerer, siren_info: sirene.SirenInfo) -> None:
@@ -1374,7 +1375,7 @@ def list_offerers_to_be_validated_legacy(
             min_datetime = datetime.combine(date.fromisoformat(from_date), datetime.min.time())
         except ValueError:
             raise ApiErrors({"filter": "Le format de date est invalide"})
-        query = query.filter(offerers_models.Offerer.requestDate >= min_datetime)  # type: ignore [operator]
+        query = query.filter(offerers_models.Offerer.dateCreated >= min_datetime)
 
     to_date = filter_dict.get("toDate")
     if to_date:
@@ -1382,7 +1383,7 @@ def list_offerers_to_be_validated_legacy(
             max_datetime = datetime.combine(date.fromisoformat(to_date), datetime.max.time())
         except ValueError:
             raise ApiErrors({"filter": "Le format de date est invalide"})
-        query = query.filter(offerers_models.Offerer.requestDate <= max_datetime)  # type: ignore [operator]
+        query = query.filter(offerers_models.Offerer.dateCreated <= max_datetime)
 
     return query
 
@@ -1439,11 +1440,11 @@ def list_offerers_to_be_validated(
 
     if from_date:
         min_datetime = datetime.combine(from_date, datetime.min.time())
-        query = query.filter(offerers_models.Offerer.requestDate >= min_datetime)  # type: ignore [operator]
+        query = query.filter(offerers_models.Offerer.dateCreated >= min_datetime)
 
     if to_date:
         max_datetime = datetime.combine(to_date, datetime.max.time())
-        query = query.filter(offerers_models.Offerer.requestDate <= max_datetime)  # type: ignore [operator]
+        query = query.filter(offerers_models.Offerer.dateCreated <= max_datetime)
 
     return query
 
@@ -1475,6 +1476,8 @@ def list_users_offerers_to_be_validated_legacy(filter_: list[dict[str, typing.An
 
 def list_users_offerers_to_be_validated(
     status: list[offerers_models.ValidationStatus] | None = None,
+    from_date: datetime | None = None,
+    to_date: datetime | None = None,
     **_: typing.Any,
 ) -> sa.orm.Query:
     query = offerers_models.UserOfferer.query.options(
@@ -1491,6 +1494,14 @@ def list_users_offerers_to_be_validated(
         query = query.filter(offerers_models.UserOfferer.validationStatus.in_(status))
     else:
         query = query.filter(offerers_models.UserOfferer.isWaitingForValidation)
+
+    if from_date:
+        min_datetime = datetime.combine(from_date, datetime.min.time())
+        query = query.filter(offerers_models.UserOfferer.dateCreated >= min_datetime)
+
+    if to_date:
+        max_datetime = datetime.combine(to_date, datetime.max.time())
+        query = query.filter(offerers_models.UserOfferer.dateCreated <= max_datetime)
 
     return query
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -41,7 +41,6 @@ from werkzeug.utils import cached_property
 from pcapi.connectors import sirene
 from pcapi.core.educational import models as educational_models
 import pcapi.core.finance.models as finance_models
-from pcapi.core.history import models as history_models
 from pcapi.domain.ts_vector import create_ts_vector_and_table_args
 from pcapi.models import Base
 from pcapi.models import Model
@@ -747,30 +746,6 @@ class Offerer(
             cls.validationStatus == ValidationStatus.PENDING,
         ).is_(True)
 
-    @hybrid_property
-    def requestDate(self) -> datetime:
-        # Offerer may have been registered, rejected, then registered again, get the last 'NEW' date
-        return max(
-            (
-                action.actionDate
-                for action in self.action_history
-                if action.actionType == history_models.ActionType.OFFERER_NEW
-            ),
-            default=self.dateCreated,
-        )
-
-    @requestDate.expression  # type: ignore [no-redef]
-    def requestDate(cls) -> datetime:  # pylint: disable=no-self-argument
-        return sa.select(
-            sa.func.coalesce(
-                sa.func.max(history_models.ActionHistory.actionDate).filter(
-                    history_models.ActionHistory.actionType == history_models.ActionType.OFFERER_NEW,
-                    history_models.ActionHistory.offererId == cls.id,
-                ),
-                cls.dateCreated,
-            )
-        ).scalar_subquery()
-
 
 offerer_ts_indexes = [
     ("idx_offerer_fts_name", Offerer.name),
@@ -797,6 +772,9 @@ class UserOfferer(PcObject, Base, Model, NeedsValidationMixin, ValidationStatusM
             name="unique_user_offerer",
         ),
     )
+
+    # dateCreated will remain null for all rows already in this table before this field was added
+    dateCreated: datetime = Column(DateTime, nullable=True, default=datetime.utcnow)
 
     @hybrid_property
     def isValidated(self) -> bool:
@@ -861,17 +839,6 @@ class UserOfferer(PcObject, Base, Model, NeedsValidationMixin, ValidationStatusM
             sa.and_(cls.validationStatus.is_(None), cls.validationToken.is_not(None)),
             cls.validationStatus == ValidationStatus.PENDING,
         ).is_(True)
-
-    @property
-    def requestDate(self) -> datetime | None:
-        # Added here for PC-18390 but will be removed soon in upcoming PC-18820
-        action_dates = [
-            action.actionDate
-            for action in self.offerer.action_history
-            if action.actionType in (history_models.ActionType.OFFERER_NEW, history_models.ActionType.USER_OFFERER_NEW)
-            and action.userId == self.userId
-        ]
-        return max(action_dates) if action_dates else None
 
 
 class ApiKey(PcObject, Base, Model):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -710,6 +710,11 @@ def _generate_offerer(data: dict, existing_offerer: offerers_models.Offerer | No
         offerer = offerers_models.Offerer()
     offerer.populate_from_dict(data)
 
+    # If offerer was rejected, it appears as deleted from the view. When registering again with the same SIREN, it
+    # should look like it was created again, with up-to-date data, and start a new validation process.
+    # So in any case, creation date is now:
+    offerer.dateCreated = datetime.datetime.utcnow()
+
     if not settings.IS_INTEGRATION:
         offerer.generate_validation_token()
         offerer.validationStatus = offerers_models.ValidationStatus.NEW

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -385,7 +385,7 @@ def list_offerers_to_be_validated(
                 serialization.OffererToBeValidated(
                     id=offerer.id,
                     name=offerer.name,
-                    requestDate=format_into_utc_date(offerer.requestDate),
+                    dateCreated=format_into_utc_date(offerer.dateCreated),
                     status=_get_validation_status(offerer),
                     step=None,  # TODO
                     siren=offerer.siren,
@@ -480,12 +480,12 @@ def list_offerers_attachments_to_be_validated(
                     email=user_offerer.user.email,
                     userName=f"{user_offerer.user.firstName} {user_offerer.user.lastName}",
                     status=_get_validation_status(user_offerer),
-                    requestDate=format_into_utc_date(user_offerer.requestDate) if user_offerer.requestDate else None,
+                    dateCreated=format_into_utc_date(user_offerer.dateCreated) if user_offerer.dateCreated else None,
                     lastComment=_get_serialized_offerer_last_comment(user_offerer.offerer, user_id=user_offerer.userId),
                     phoneNumber=user_offerer.user.phoneNumber,
                     offererId=user_offerer.offerer.id,
                     offererName=user_offerer.offerer.name,
-                    offererCreatedDate=format_into_utc_date(user_offerer.offerer.requestDate),
+                    offererCreatedDate=format_into_utc_date(user_offerer.offerer.dateCreated),
                     ownerId=user_offerer.offerer.UserOfferers[0].userId if user_offerer.offerer.UserOfferers else None,
                     ownerEmail=(
                         user_offerer.offerer.UserOfferers[0].user.email if user_offerer.offerer.UserOfferers else None

--- a/api/src/pcapi/routes/backoffice/serialization.py
+++ b/api/src/pcapi/routes/backoffice/serialization.py
@@ -428,7 +428,7 @@ class OfferersStatsResponseModel(BaseModel):
 class OffererToBeValidated(BaseModel):
     id: int
     name: str
-    requestDate: datetime.datetime
+    dateCreated: datetime.datetime
     status: str
     step: str | None
     siren: str | None
@@ -465,7 +465,7 @@ class UserOffererToBeValidated(BaseModel):
     email: str | None
     userName: str
     status: str
-    requestDate: datetime.datetime | None
+    dateCreated: datetime.datetime | None
     lastComment: Comment | None
     phoneNumber: str | None
     offererId: int

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -46,6 +46,8 @@ class UserOffererValidationListForm(FlaskForm):
         csrf = False
 
     status = fields.PCSelectMultipleField("États", choices=utils.choices_from_enum(offerers_models.ValidationStatus))
+    from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))
+    to_date = fields.PCDateField("Demande jusqu'au", validators=(wtforms.validators.Optional(),))
 
     page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
     per_page = fields.PCSelectField(

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -108,7 +108,7 @@
                                 </a>
                             </td>
                             <td>{% include "components/offerer/user_offerer_status_badge.html" %}</td>
-                            <td>{{ user_offerer.requestDate | format_date("%d/%m/%Y") }}</td>
+                            <td>{{ user_offerer.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ get_last_comment_func(offerer, user_offerer.userId) | empty_string_if_null }}</td>
                             <td>{{ user_offerer.user.phoneNumber | format_phone_number }}</td>
                             <td>
@@ -116,7 +116,7 @@
                                     {{ offerer.name | upper | escape }}
                                 </a>
                             </td>
-                            <td>{{ offerer.requestDate | format_date("%d/%m/%Y") }}</td>
+                            <td>{{ offerer.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ (owner and owner.email) | empty_string_if_null }}</td>
                             <td>
                                 {% if offerer.siren %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -122,7 +122,7 @@
                                     </form>
                                 </div>
                             </td>
-                            <td>{{ offerer.requestDate | format_date("%d/%m/%Y") }}</td>
+                            <td>{{ offerer.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ get_last_comment_func(offerer) | empty_string_if_null }}</td>
                             <td>
                                 {% if offerer.siren %}

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -464,6 +464,7 @@ class CreateOffererTest:
         assert created_user_offerer.userId == user.id
         assert created_user_offerer.validationToken is None
         assert created_user_offerer.validationStatus == offerers_models.ValidationStatus.VALIDATED
+        assert created_user_offerer.dateCreated is not None
 
         assert not created_user_offerer.user.has_pro_role
 
@@ -521,6 +522,7 @@ class CreateOffererTest:
         assert created_user_offerer.userId == user.id
         assert created_user_offerer.validationToken is not None
         assert created_user_offerer.validationStatus == offerers_models.ValidationStatus.NEW
+        assert created_user_offerer.dateCreated is not None
 
         assert not created_user_offerer.user.has_pro_role
 
@@ -564,6 +566,7 @@ class CreateOffererTest:
         assert created_user_offerer.userId == user.id
         assert created_user_offerer.validationToken is not None
         assert created_user_offerer.validationStatus == offerers_models.ValidationStatus.NEW
+        assert created_user_offerer.dateCreated is not None
 
     @patch("pcapi.domain.admin_emails.maybe_send_offerer_validation_email", return_value=True)
     def test_create_new_offerer_with_validation_token_if_siren_was_previously_rejected(
@@ -580,6 +583,7 @@ class CreateOffererTest:
             siren=offerer_informations.siren,
             validationStatus=offerers_models.ValidationStatus.REJECTED,
         )
+        first_creation_date = offerer.dateCreated
 
         # When
         created_user_offerer = offerers_api.create_offerer(user, offerer_informations)
@@ -594,10 +598,12 @@ class CreateOffererTest:
         assert created_offerer.city == offerer_informations.city
         assert created_offerer.validationToken is not None
         assert created_offerer.validationStatus == offerers_models.ValidationStatus.NEW
+        assert created_offerer.dateCreated > first_creation_date
 
         assert created_user_offerer.userId == user.id
         assert created_user_offerer.validationToken is None
         assert created_user_offerer.validationStatus == offerers_models.ValidationStatus.VALIDATED
+        assert created_user_offerer.dateCreated is not None
 
         assert not created_user_offerer.user.has_pro_role
 

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -63,6 +63,7 @@ class Returns204Test:
         assert user_offerer is not None
         assert user_offerer.validationToken is None
         assert user_offerer.validationStatus == offerers_models.ValidationStatus.VALIDATED
+        assert user_offerer.dateCreated is not None
 
         actions_list = history_models.ActionHistory.query.all()
         assert len(actions_list) == 1
@@ -162,11 +163,13 @@ class Returns204Test:
 
     def test_when_offerer_was_previously_rejected(self, client):
         # Given
-        offerers_factories.OffererFactory(
+        offerer = offerers_factories.OffererFactory(
             name="Rejected Offerer",
             siren=BASE_DATA_PRO["siren"],
             validationStatus=offerers_models.ValidationStatus.REJECTED,
         )
+
+        first_creation_date = offerer.dateCreated
 
         data = BASE_DATA_PRO.copy()
 
@@ -182,8 +185,10 @@ class Returns204Test:
         assert offerer.name == BASE_DATA_PRO["name"]
         assert offerer.validationToken is not None
         assert offerer.validationStatus == offerers_models.ValidationStatus.NEW
+        assert offerer.dateCreated > first_creation_date
         user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).one()
         assert user_offerer.validationToken is None
+        assert user_offerer.dateCreated is not None
 
         actions_list = history_models.ActionHistory.query.all()
         assert len(actions_list) == 1

--- a/backoffice/src/TypesFromApi/models/OffererToBeValidated.ts
+++ b/backoffice/src/TypesFromApi/models/OffererToBeValidated.ts
@@ -97,7 +97,7 @@ export interface OffererToBeValidated {
    * @type {Date}
    * @memberof OffererToBeValidated
    */
-  requestDate: Date
+  dateCreated: Date
   /**
    *
    * @type {string}
@@ -143,7 +143,7 @@ export function OffererToBeValidatedFromJSONTyped(
     ownerId: !exists(json, 'ownerId') ? undefined : json['ownerId'],
     phoneNumber: !exists(json, 'phoneNumber') ? undefined : json['phoneNumber'],
     postalCode: json['postalCode'],
-    requestDate: new Date(json['requestDate']),
+    dateCreated: new Date(json['dateCreated']),
     siren: !exists(json, 'siren') ? undefined : json['siren'],
     status: json['status'],
     step: !exists(json, 'step') ? undefined : json['step'],
@@ -171,7 +171,7 @@ export function OffererToBeValidatedToJSON(
     ownerId: value.ownerId,
     phoneNumber: value.phoneNumber,
     postalCode: value.postalCode,
-    requestDate: value.requestDate.toISOString(),
+    dateCreated: value.dateCreated.toISOString(),
     siren: value.siren,
     status: value.status,
     step: value.step,

--- a/backoffice/src/TypesFromApi/models/UserOffererToBeValidated.ts
+++ b/backoffice/src/TypesFromApi/models/UserOffererToBeValidated.ts
@@ -85,7 +85,7 @@ export interface UserOffererToBeValidated {
    * @type {Date}
    * @memberof UserOffererToBeValidated
    */
-  requestDate?: Date | null
+  dateCreated?: Date | null
   /**
    *
    * @type {string}
@@ -137,11 +137,11 @@ export function UserOffererToBeValidatedFromJSONTyped(
     ownerEmail: !exists(json, 'ownerEmail') ? undefined : json['ownerEmail'],
     ownerId: !exists(json, 'ownerId') ? undefined : json['ownerId'],
     phoneNumber: !exists(json, 'phoneNumber') ? undefined : json['phoneNumber'],
-    requestDate: !exists(json, 'requestDate')
+    dateCreated: !exists(json, 'dateCreated')
       ? undefined
-      : json['requestDate'] === null
+      : json['dateCreated'] === null
       ? null
-      : new Date(json['requestDate']),
+      : new Date(json['dateCreated']),
     siren: json['siren'],
     status: json['status'],
     userId: json['userId'],
@@ -168,12 +168,12 @@ export function UserOffererToBeValidatedToJSON(
     ownerEmail: value.ownerEmail,
     ownerId: value.ownerId,
     phoneNumber: value.phoneNumber,
-    requestDate:
-      value.requestDate === undefined
+    dateCreated:
+      value.dateCreated === undefined
         ? undefined
-        : value.requestDate === null
+        : value.dateCreated === null
         ? null
-        : value.requestDate.toISOString(),
+        : value.dateCreated.toISOString(),
     siren: value.siren,
     status: value.status,
     userId: value.userId,

--- a/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
+++ b/backoffice/src/resources/Pro/Offerers/OfferersToValidate.tsx
@@ -452,7 +452,7 @@ export const OfferersToValidate = () => {
                           />
                         </TableCell>
                         <TableCell>
-                          {format(offerer.requestDate, 'dd/MM/yyyy')}
+                          {format(offerer.dateCreated, 'dd/MM/yyyy')}
                         </TableCell>
                         <TableCell>
                           {offerer.lastComment && offerer.lastComment.content}

--- a/backoffice/src/resources/Pro/Offerers/UserOfferersToValidate.tsx
+++ b/backoffice/src/resources/Pro/Offerers/UserOfferersToValidate.tsx
@@ -264,8 +264,8 @@ export const UserOfferersToValidate = () => {
                           />
                         </TableCell>
                         <TableCell>
-                          {userOfferer.requestDate &&
-                            format(userOfferer.requestDate, 'dd/MM/yyyy')}
+                          {userOfferer.dateCreated &&
+                            format(userOfferer.dateCreated, 'dd/MM/yyyy')}
                         </TableCell>
                         <TableCell>
                           {userOfferer.lastComment &&


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18820

## But de la pull request

Le temps de réponse est trop long lorsque l'on filtre les structures à valider sur la « Date de la demande ». Il s'agit donc ici d'améliorer les performances avec un filtre sur une colonne de la table `offerer`, plutôt que sur un calcul à partir de la table d'historique (juste dans le calcul, mais trop long).

On revient donc à `dateCreated` qui contient la date de la demande. La seule différence est sur les structures rejetées puis à nouveau inscrites. Dans ce cas, on décide finalement de modifier `dateCreated` pour la date de la nouvelle demande. Ça reste cohérent car :
- avant, l'homologation supprimait les structures dans FA, donc une nouvelle était créée, avec la nouvelle date ;
- c'est la dernière demande qui est effectivement considérée comme l'inscription, les précédentes ne faisant partie que d'un historique pour référence.

Je n'ai pas trouvé d'impact ailleurs dans le code qui bloque cette solution, dateCreated n'est pas utilisée dans la logique ailleurs.

Pour les rattachements, on n'avait pas de colonne `dateCreated`, mais seulement le calcul depuis le calcul ; on ajoute donc cette colonne.

## Modifications du schéma de la base de données

Ajout d'une colonne `dateCreated` dans la table `user_offerer`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
