### PR TITLE
(PC-18804)[PRO] fix: fix sanbox to generate correct values for collec…

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_educational_bookings.py
@@ -256,7 +256,7 @@ PASSED_STOCK_DATA: list[StockData] = [
     ),
 ]
 
-MAINLAND_INTERVENTION_AREA = [str(i) for i in chain(range(1, 95), ["2A", "2B", "mainland"]) if i != 20]
+MAINLAND_INTERVENTION_AREA = [str(i).zfill(2) for i in chain(range(1, 95), ["2A", "2B", "mainland"]) if i != 20]
 ALL_INTERVENTION_AREA = [
     *MAINLAND_INTERVENTION_AREA,
     "971",


### PR DESCRIPTION
…tive intervention areas

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18804

## But de la pull request

Le nombre d'options sélectionnés est invalide pour le composant 'Zone de mobilé' des offres collectives et des informations EAC d'un lieu 
## Implémentation

- Données erronées au moment de générer la sandbox

## Screenshot

![Capture d’écran 2022-11-25 à 11 33 35](https://user-images.githubusercontent.com/71768799/204258615-b897f9e2-95d7-4db4-986a-02b21fa47bc6.png)
