### PR TITLE
(PC-18821)[BO] feat: 100 results per page by default and pagination on top

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -31,7 +31,7 @@ class OffererValidationListForm(FlaskForm):
     per_page = fields.PCSelectField(
         "Par page",
         choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
-        default="10",
+        default="100",
         validators=(wtforms.validators.Optional(),),
     )
 
@@ -53,7 +53,7 @@ class UserOffererValidationListForm(FlaskForm):
     per_page = fields.PCSelectField(
         "Par page",
         choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
-        default="10",
+        default="100",
         validators=(wtforms.validators.Optional(),),
     )
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/search.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/search.py
@@ -12,7 +12,7 @@ class SearchForm(FlaskForm):
     class Meta:
         csrf = False
 
-    terms = fields.PCSearchField()
+    terms = fields.PCSearchField(label="")
     order_by = wtforms.HiddenField("order_by", validators=[validators.Optional(strip_whitespace=True)])
     page = wtforms.HiddenField("page", validators=[validators.Optional()])
     per_page = wtforms.HiddenField("per_page", validators=[validators.Optional()])

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/search_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/search_field.html
@@ -1,3 +1,4 @@
- <span class="input-group-text bg-white" id="searchIcon"><i class="bi bi-search"></i></span>
+<span class="input-group-text bg-white" id="searchIcon"><i class="bi bi-search"></i></span>
 <input type="text" class="form-control col-8 border-start-0" id="{{ field.id }}" name="{{ field.name }}"
-          value="{{ field.data | empty_string_if_null }}" style="flex-grow:3!important;" aria-describedby="searchIcon"/>
+        value="{{ field.data | empty_string_if_null }}" style="flex-grow:3!important;" aria-describedby="searchIcon"
+        placeholder="{{ field.label.text }}"/>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
@@ -1,8 +1,10 @@
+<div class="form-floating">
 <select multiple class="form-select" id="{{ field.name }}" name="{{ field.name }}" size="2">
     {% for value, label, selected in field.iter_choices() %}
         <option value="{{ value }}" {{ "selected" if selected else "" }}>
             {{ label | i18n_public_account }}
         </option>
     {% endfor %}
-    <label for="{{ field.name }}">{{ field.label }}</label>
 </select>
+<label for="{{ field.name }}">{{ field.label }}</label>
+</div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/pagination.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/pagination.html
@@ -1,5 +1,5 @@
 {% if rows.pages > 1 %}
-    <nav aria-label="Page navigation" class="my-5">
+    <nav aria-label="Page navigation">
         <ul class="pagination">
             {% for page_idx, next_page_url in next_pages_urls %}
                 <li class="page-item">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
@@ -23,5 +23,7 @@
         </div>
     </div>
 
-    {% include 'components/search/pagination.html' %}
+    <div class="my-5">
+        {% include 'components/search/pagination.html' %}
+    </div>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -39,7 +39,12 @@
     </form>
     <div>
         {% if rows and rows.total > 0 %}
-            <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
+            <div class="d-flex justify-content-between">
+                <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
+                <div>
+                    {% include 'components/search/pagination.html' %}
+                </div>
+            </div>
             <table class="table mb-4">
                 <thead>
                     <tr>
@@ -131,7 +136,6 @@
                     {% endfor %}
                 </tbody>
             </table>
-            {% include 'components/search/pagination.html' %}
 
             {% for user_offerer in rows.items %}
                 {% call build_edit_status_modal(

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -39,7 +39,12 @@
     </form>
     <div>
         {% if rows and rows.total > 0 %}
-            <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
+            <div class="d-flex justify-content-between">
+                <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
+                <div>
+                    {% include 'components/search/pagination.html' %}
+                </div>
+            </div>
             <table class="table mb-4">
                 <thead>
                     <tr>
@@ -148,7 +153,6 @@
                     {% endfor %}
                 </tbody>
             </table>
-            {% include 'components/search/pagination.html' %}
 
             {% for offerer in rows.items %}
                 {% call build_edit_status_modal(

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -532,7 +532,7 @@ class ListOfferersToValidateTest:
                 (31, {"per_page": 10, "page": 3}, 4, 3, 10),
                 (31, {"per_page": 10, "page": 4}, 4, 4, 1),
                 (20, {"per_page": 10, "page": 1}, 2, 1, 10),
-                (10, {"page": 1}, 1, 1, 10),
+                (27, {"page": 1}, 1, 1, 27),
                 (10, {"per_page": 25, "page": 1}, 1, 1, 10),
             ),
         )
@@ -1142,7 +1142,7 @@ class ListUserOffererToValidateTest:
             (31, {"per_page": 10, "page": 3}, 4, 3, 10),
             (31, {"per_page": 10, "page": 4}, 4, 4, 1),
             (20, {"per_page": 10, "page": 1}, 2, 1, 10),
-            (10, {"page": 1}, 1, 1, 10),
+            (27, {"page": 1}, 1, 1, 27),
             (10, {"per_page": 25, "page": 1}, 1, 1, 10),
         ),
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18821

## But de la pull request

Afficher 100 résultats par page par défaut (au lieu de 10) dans les listes des structures et rattachements à valider.
Afficher la pagination en haut à droite plutôt qu'en bas.

## Informations supplémentaires

Modifications faites dans le backoffice v3 uniquement.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
