### PR TITLE
(PC-18904)[API] refactor: duplicate individual_booking.depositid in b…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-2ca4b0b05bc6 (pre) (head)
+dfea3ac0b326 (pre) (head)
 4e9a6643eeed (post) (head)

--- a/api/src/pcapi/alembic/versions/20221129T153754_dfea3ac0b326_add_deposit_in_booking.py
+++ b/api/src/pcapi/alembic/versions/20221129T153754_dfea3ac0b326_add_deposit_in_booking.py
@@ -1,0 +1,24 @@
+"""Add deposit in booking.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "dfea3ac0b326"
+down_revision = "2ca4b0b05bc6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("booking", sa.Column("depositId", sa.BigInteger(), nullable=True))
+    op.create_index(op.f("ix_booking_depositId"), "booking", ["depositId"], unique=False)
+    op.create_foreign_key("booking_depositId_fkey", "booking", "deposit", ["depositId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("booking_depositId_fkey", "booking", type_="foreignkey")
+    op.drop_index(op.f("ix_booking_depositId"), table_name="booking")
+    op.drop_column("booking", "depositId")

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -106,6 +106,7 @@ def book_offer(
             venueId=stock.offer.venueId,
             offererId=stock.offer.venue.managingOffererId,
             status=BookingStatus.CONFIRMED,
+            depositId=beneficiary.deposit.id if beneficiary.has_active_deposit else None,  # type: ignore [union-attr]
         )
 
         booking.dateCreated = datetime.datetime.utcnow()

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 import enum
+from typing import TYPE_CHECKING
 
 from sqlalchemy import BigInteger
 from sqlalchemy import Boolean
@@ -20,6 +21,7 @@ from sqlalchemy import exists
 from sqlalchemy import select
 import sqlalchemy.exc as sa_exc
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.elements import BooleanClauseList
 from sqlalchemy.sql.elements import Label
@@ -32,6 +34,10 @@ from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 from pcapi.utils.human_ids import humanize
+
+
+if TYPE_CHECKING:
+    from pcapi.core.finance.models import Deposit
 
 
 class BookingCancellationReasons(enum.Enum):
@@ -159,6 +165,10 @@ class Booking(PcObject, Base, Model):
         back_populates="booking",
         uselist=False,
     )
+
+    depositId = Column(BigInteger, ForeignKey("deposit.id"), index=True, nullable=True)
+
+    deposit: Mapped["Deposit | None"] = relationship("Deposit", foreign_keys=[depositId], backref="bookings")
 
     def mark_as_used(self) -> None:
         if self.is_used_or_reimbursed:


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18904

modifie tout les endroit ou l'on écrit booking.depositId pour ecrire dans booking.depositid en plus dans le cadre de la destruction d'individual_booking

