### PR TITLE
(PC-18909)[PRO] fix: Fixed saving a venue with neither a siret nor a comment.

### DIFF
--- a/pro/src/screens/VenueForm/VenueFormScreen.tsx
+++ b/pro/src/screens/VenueForm/VenueFormScreen.tsx
@@ -79,7 +79,9 @@ const VenueFormScreen = ({
       : api.editVenue(
           /* istanbul ignore next: there will always be a venue id on update screen */
           venue?.id || '',
-          serializeEditVenueBodyModel(value, { hideSiret: !!venue?.comment })
+          serializeEditVenueBodyModel(value, {
+            hideSiret: venue?.siret.length === 0,
+          })
         )
 
     logEvent?.(Events.CLICKED_SAVE_VENUE, {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18909

## But de la pull request

- Corriger le problème de sauvegarde de lieu qui n'avaient ni siret ni commentaire.

## Implémentation

- Quand le lieu n'avait ni commentaire ni siret, le lieu était considéré comme ayant un siret côté validateur, mais pas côté composant (affichage). La condition est maintenant identique côté composant et côté validateur.
