### PR TITLE
(PC-18903)[PRO] fix: fix offer layout when collective image ff is not…

### DIFF
--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.scss
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.scss
@@ -26,6 +26,7 @@ $offer-image-width: rem(176px);
   }
   &-main-container {
     display: flex;
+    width: 100%;
   }
   &-image-container {
     border-radius: rem(3px);

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/Offer.tsx
@@ -76,7 +76,10 @@ export const Offer = ({
             )}
           </div>
         )}
-        <div className="offer-container">
+        <div
+          className="offer-container"
+          style={!isCollectiveImageOfferActive ? { paddingLeft: '18px' } : {}}
+        >
           {offer.isTemplate ? (
             <ContactButton
               className="offer-prebooking-button"


### PR DESCRIPTION
… active

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18903

## But de la pull request

Fixer l'affichage des offres dans l'iframe adage lorsque le feature flag WIP_IMAGE_COLLECTIVE_OFFER n'est pas activé. 

## Implémentation

- Ajout de padding à gauche des informations de l'offre
- Ajustement de la taille du container principale pour qu'il prenne toute la largeur du composant

## Screenshot

![Capture d’écran 2022-11-28 à 16 30 55](https://user-images.githubusercontent.com/71768799/204317129-c32d14af-9700-41e3-ba2a-70dae8b0497b.png)

