### PR TITLE
(PC-18136)[BO] feat: Add offerers stats on top of validation screen

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1292,8 +1292,8 @@ def get_venue_offers_stats(venue_id: int) -> sa.engine.Row:
     return db.session.execute(offers_stats_query).one_or_none()
 
 
-def get_offerers_stats() -> dict[offerers_models.ValidationStatus, int]:
-    stats = (
+def count_offerers_by_validation_status() -> dict[str, int]:
+    stats = dict(
         offerers_models.Offerer.query.with_entities(
             offerers_models.Offerer.validationStatus,
             sa.func.count(offerers_models.Offerer.validationStatus).label("count"),
@@ -1302,7 +1302,8 @@ def get_offerers_stats() -> dict[offerers_models.ValidationStatus, int]:
         .all()
     )
 
-    return dict(stats)
+    # Ensure that the result includes every status, even if no offerer has this status
+    return {status.name: stats.get(status, 0) for status in offerers_models.ValidationStatus}
 
 
 def _filter_on_validation_status(

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -306,11 +306,9 @@ def remove_tag_from_offerer(offerer_id: int, tag_name: str) -> None:
 @spectree_serialize(response_model=serialization.OfferersStatsResponseModel, on_success_status=200, api=blueprint.api)
 @perm_utils.permission_required(perm_models.Permissions.VALIDATE_OFFERER)
 def get_offerers_stats() -> serialization.OfferersStatsResponseModel:
-    stats = offerers_api.get_offerers_stats()
+    stats = offerers_api.count_offerers_by_validation_status()
 
-    return serialization.OfferersStatsResponseModel(
-        data={status.name: stats.get(status, 0) for status in offerers_models.ValidationStatus}
-    )
+    return serialization.OfferersStatsResponseModel(data=stats)
 
 
 def _get_serialized_offerer_last_comment(

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -206,9 +206,11 @@ class OffererToBeValidatedRow:
 
 @validate_offerer_blueprint.route("/offerer", methods=["GET"])
 def list_offerers_to_validate() -> utils.BackofficeResponse:
+    stats = offerers_api.count_offerers_by_validation_status()
+
     form = offerer_forms.OffererValidationListForm(request.args)
     if not form.validate():
-        return render_template("offerer/validation.html", rows=[], form=form), 400
+        return render_template("offerer/validation.html", rows=[], form=form, stats=stats), 400
 
     offerers = offerers_api.list_offerers_to_be_validated(**form.data)
 
@@ -229,6 +231,7 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
         next_pages_urls=next_pages_urls,
         is_top_actor_func=offerers_api.is_top_actor,
         get_last_comment_func=_get_serialized_offerer_last_comment,
+        stats=stats,
     )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -1,11 +1,25 @@
 {% from "offerer/edit_status_modal.html" import build_edit_status_modal with context %}
+{% macro stats_card(value, text_one, text_many) %}
+    <div class="col-3 p-2">
+        <div class="card shadow">
+            <div class="card-body">
+                <div class="fs-2">{{ value }}</div>
+                <div class="text-muted">{{ text_many if value > 1 else text_one }}</div>
+            </div>
+        </div>
+    </div>
+{% endmacro %}
 
 {% extends "layouts/connected.html" %}
 
 {% block page %}
 <div class="pt-3 px-5">
-    <div class="d-flex justify-content-between">
-        <h2 class="fw-light">Structures à valider</h2>
+    <h2 class="fw-light">Structures à valider</h2>
+    <div class="row px-1">
+        {{ stats_card(stats["NEW"], "nouvelle structure", "nouvelles structures") }}
+        {{ stats_card(stats["PENDING"], "structure en attente", "structures en attente") }}
+        {{ stats_card(stats["VALIDATED"], "structure validée", "structures validées") }}
+        {{ stats_card(stats["REJECTED"], "structure rejetée", "structures rejetées") }}
     </div>
     <form action="{{ dst }}" method="GET" class="mb-4 mt-3">
         <div class="row">

--- a/api/tests/routes/backoffice_v3/helpers/html_parser.py
+++ b/api/tests/routes/backoffice_v3/helpers/html_parser.py
@@ -3,6 +3,10 @@ import re
 from bs4 import BeautifulSoup
 
 
+def _filter_whitespaces(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
 def extract_table_rows(html_content: str) -> list[dict[str, str]]:
     """
     Extract data from html table (thead + tbody), so that we can compare with expected data when testing routes.
@@ -34,8 +38,7 @@ def extract_table_rows(html_content: str) -> list[dict[str, str]]:
         assert len(td_list) == len(headers)
         for idx, td in enumerate(td_list):
             if headers[idx]:
-                td_text = re.sub(r"\s+", " ", td.text.strip())
-                row_data[headers[idx]] = td_text
+                row_data[headers[idx]] = _filter_whitespaces(td.text)
         rows.append(row_data)
 
     return rows
@@ -75,3 +78,13 @@ def extract_pagination_info(html_content: str) -> tuple[int, int, int]:
     assert active_page_link
 
     return int(active_page_link.text), len(page_links), total_results
+
+
+def extract_cards_text(html_content: str) -> list[str]:
+    """
+    Extract text from all cards in the page, as strings
+    """
+    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+
+    cards = soup.find_all("div", class_="card")
+    return [_filter_whitespaces(card.text) for card in cards]

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -748,6 +748,19 @@ class ListOfferersToValidateTest:
             else:
                 assert html_parser.count_table_rows(response.data) == 0
 
+        @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+        def test_offerers_stats_are_displayed(self, authenticated_client, offerers_to_be_validated):
+            # when
+            response = authenticated_client.get(url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate"))
+
+            # then
+            assert response.status_code == 200
+            cards = html_parser.extract_cards_text(response.data)
+            assert "3 nouvelles structures" in cards
+            assert "3 structures en attente" in cards
+            assert "1 structure validée" in cards
+            assert "1 structure rejetée" in cards
+
 
 class ValidateOffererUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
     method = "post"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18136

## But de la pull request

Sur l'écran de validation de structures, Ajout de 4 blocs en haut de pages permettant d’afficher de gauche à droite : 
- Le nombre de structures à l'état “Nouveau”
- Le nombre de structures à l'état “En attente”
- Le nombre de structures à l'état “Validé”
- Le nombre de structures à l'état “Rejetée”

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
