### PR TITLE
(PC-18791)[PRO] feat: Using `PhoneNumberInput` in the signup form.

### DIFF
--- a/pro/src/pages/Signup/SignupForm/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupForm/SignupForm.tsx
@@ -16,6 +16,7 @@ import useRedirectLoggedUser from 'hooks/useRedirectLoggedUser'
 import { Button, SubmitButton, TextInput, Checkbox } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { PasswordInput, SirenInput } from 'ui-kit/form'
+import PhoneNumberInput from 'ui-kit/form/PhoneNumberInput'
 import { removeWhitespaces } from 'utils/string'
 
 import {
@@ -198,10 +199,11 @@ const SignupForm = (): JSX.Element => {
                   />
                 </FormLayout.Row>
                 <FormLayout.Row>
-                  <TextInput
-                    label="Téléphone (utilisé uniquement par l’équipe du pass Culture)"
+                  <PhoneNumberInput
                     name="phoneNumber"
-                    placeholder="Mon numéro de téléphone"
+                    label={
+                      'Téléphone (utilisé uniquement par l’équipe du pass Culture)'
+                    }
                   />
                 </FormLayout.Row>
                 <div className="siren-field">

--- a/pro/src/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
+++ b/pro/src/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
@@ -318,7 +318,8 @@ describe('src | components | pages | Signup | SignupForm', () => {
           screen.getByRole('textbox', {
             name: /Téléphone/,
           }),
-          '0722332233'
+
+          '+33722332233'
         )
         expect(submitButton).toBeDisabled()
         await userEvent.type(
@@ -352,7 +353,7 @@ describe('src | components | pages | Signup | SignupForm', () => {
           longitude: 1.1,
           name: 'Ma Petite structure',
           password: 'user@AZERTY123',
-          phoneNumber: '0722332233',
+          phoneNumber: '+33722332233',
           postalCode: '22350',
           publicName: 'Prénom',
           siren: '881457238',

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -25,3 +25,9 @@ WithInitialValue.args = {
   name: 'phone',
   initialValues: { phone: '06 94 20 12 34' },
 }
+
+export const WithCustomLabel = Template.bind({})
+WithCustomLabel.args = {
+  name: 'phone',
+  label: 'Custom label for my field',
+}

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
@@ -12,12 +12,14 @@ import { getPhoneNumberInputAndCountryCode } from './utils/getPhoneNumberInputAn
 
 export interface PhoneNumberInputProps {
   name: string
+  label?: string
   disabled?: boolean
   isOptional?: boolean
 }
 
 const PhoneNumberInput = ({
   name,
+  label = 'Téléphone',
   disabled,
   isOptional = false,
 }: PhoneNumberInputProps) => {
@@ -79,7 +81,7 @@ const PhoneNumberInput = ({
 
   return (
     <FieldLayout
-      label="Téléphone"
+      label={label}
       name={name}
       isOptional={isOptional}
       showError={meta.touched && !!meta.error}

--- a/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
@@ -15,10 +15,10 @@ jest.mock('libphonenumber-js', () => {
   }
 })
 
-const renderPhoneNumberInput = () => {
+const renderPhoneNumberInput = (label?: string) => {
   render(
     <Formik initialValues={{}} onSubmit={() => {}}>
-      <PhoneNumberInput name="phone" />
+      <PhoneNumberInput name="phone" label={label} />
     </Formik>
   )
 }
@@ -92,6 +92,20 @@ describe('PhoneNumberInput', () => {
       expect(
         screen.queryByText('Veuillez entrer un numéro de téléphone valide')
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('label', () => {
+    it('default label', () => {
+      renderPhoneNumberInput()
+
+      expect(screen.getByLabelText('Téléphone')).toBeInTheDocument()
+    })
+
+    it('it should have a custom label when set', async () => {
+      renderPhoneNumberInput('Custom Label')
+      expect(screen.getByLabelText('Custom Label')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Téléphone')).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18791

## But de la pull request

- Utilisation du composant `PhoneNumberInput` dans le formulaire d'inscription

## Implémentation

- Ajout de la possibilité de changer le label du `PhoneNumberInput`.

## Changements visuels

### Avant
![image](https://user-images.githubusercontent.com/114910244/204324322-60954a41-43c1-4597-a590-db017ec41a75.png)

### Après
![image](https://user-images.githubusercontent.com/114910244/204324365-65607c44-9bef-4c7f-b3bc-31e59f352da3.png)

