### PR TITLE
(PC-18837)[PRO] Fix: DurationInput minutes serialization

### DIFF
--- a/pro/src/components/OfferIndividualForm/utils/setInitialFormValues.ts
+++ b/pro/src/components/OfferIndividualForm/utils/setInitialFormValues.ts
@@ -8,7 +8,7 @@ import buildSubCategoryFields from './buildSubCategoryFields'
 
 const serializeDurationHour = (durationMinute: number): string => {
   const hours = Math.floor(durationMinute / 60)
-  const minutes = durationMinute - hours * 60
+  const minutes = (durationMinute % 60).toString().padStart(2, '0')
   return `${hours}:${minutes}`
 }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18837

## But de la pull request

- Remplir le champ durée au chargement de la page avec une valeur correcte (1:00 par exemple au lieu de 1:0)

## Implémentation

- Modification dans la méthode de serialisation des minutes.
