### PR TITLE
(PC-18362)[API] fix: CDS seatmap row and col indexes should start from 0

### DIFF
--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -227,13 +227,21 @@ class SeatCDS:
 
             if screen_infos.seatmap_skip_missing_seats:
                 seat_row_array = seat_map.map[seat_location_indices[0]]
-                previous_seats = (
+                seat_col_array = [seat_map.map[i][seat_location_indices[1]] for i in range(seat_map.nb_row)]
+                previous_col_seats = (
                     seat_row_array[: seat_location_indices[1]]
                     if screen_infos.seatmap_left_to_right
                     else seat_row_array[seat_location_indices[1] :]
                 )
-                skipped_seat = sum(1 for seat_value in previous_seats if seat_value == 0)
-                self.seatCol -= skipped_seat
+                previous_row_seats = (
+                    seat_col_array[: seat_location_indices[0]]
+                    if screen_infos.seatmap_front_to_back
+                    else seat_col_array[seat_location_indices[0] :]
+                )
+                skipped_col_seats = sum(1 for seat_value in previous_col_seats if seat_value == 0)
+                skipped_row_seats = sum(1 for seat_value in previous_row_seats if seat_value == 0)
+                self.seatCol -= skipped_col_seats
+                self.seatRow -= skipped_row_seats
 
             seat_letter = chr(ord("A") + self.seatRow)
             self.seatNumber = f"{seat_letter}_{self.seatCol + 1}"

--- a/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cine_digital_service_serializers.py
@@ -213,17 +213,17 @@ class SeatCDS:
         seat_map: SeatmapCDS,
         hardcoded_seatmap: str = None,
     ):
-        self.seatRow = seat_location_indices[0] + 1
-        self.seatCol = seat_location_indices[1] + 1
+        self.seatRow = seat_location_indices[0]
+        self.seatCol = seat_location_indices[1]
         if hardcoded_seatmap:
             hardcoded_seatmap = json.loads(hardcoded_seatmap)
             assert isinstance(hardcoded_seatmap, list)
-            self.seatNumber: str = hardcoded_seatmap[self.seatRow - 1][self.seatCol - 1]
+            self.seatNumber: str = hardcoded_seatmap[self.seatRow][self.seatCol]
         else:
             if not screen_infos.seatmap_front_to_back:
-                self.seatRow = seat_map.nb_row - seat_location_indices[0]
+                self.seatRow = seat_map.nb_row - seat_location_indices[0] - 1
             if not screen_infos.seatmap_left_to_right:
-                self.seatCol = seat_map.nb_col - seat_location_indices[1]
+                self.seatCol = seat_map.nb_col - seat_location_indices[1] - 1
 
             if screen_infos.seatmap_skip_missing_seats:
                 seat_row_array = seat_map.map[seat_location_indices[0]]
@@ -235,5 +235,5 @@ class SeatCDS:
                 skipped_seat = sum(1 for seat_value in previous_seats if seat_value == 0)
                 self.seatCol -= skipped_seat
 
-            seat_letter = chr(ord("A") + self.seatRow - 1)
-            self.seatNumber = f"{seat_letter}_{self.seatCol}"
+            seat_letter = chr(ord("A") + self.seatRow)
+            self.seatNumber = f"{seat_letter}_{self.seatCol + 1}"

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -668,11 +668,12 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_hardcoded_setmap", return_value=None)
     def test_should_return_seat_infos_according_to_screen(self, mocked_gat_hardcoded_seatmap, mocked_get_resource):
         seatmap_json = [
-            [3, 3, 3, 3, 0, 3],
-            [3, 3, 3, 3, 0, 3],
-            [3, 3, 3, 3, 0, 3],
-            [3, 3, 3, 1, 0, 3],
-            [3, 3, 3, 3, 0, 3],
+            [3, 3, 3, 3, 0, 0, 3, 3],
+            [3, 3, 3, 3, 0, 0, 3, 3],
+            [3, 3, 3, 3, 0, 0, 3, 3],
+            [3, 3, 3, 1, 0, 0, 3, 3],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [3, 3, 3, 3, 0, 0, 3, 3],
         ]
 
         screen = cds_serializers.ScreenCDS(
@@ -691,8 +692,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         best_seat = cine_digital_service.get_available_seat(show, screen)
         assert len(best_seat) == 1
         assert best_seat[0].seatRow == 1
-        assert best_seat[0].seatCol == 1
-        assert best_seat[0].seatNumber == "B_2"
+        assert best_seat[0].seatCol == 2
+        assert best_seat[0].seatNumber == "B_3"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
     def test_should_return_None_if_no_seat_available(self, mocked_get_resource):

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -594,8 +594,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
         best_seat = cine_digital_service.get_available_seat(show, screen)
         assert len(best_seat) == 1
-        assert best_seat[0].seatRow == 5
-        assert best_seat[0].seatCol == 6
+        assert best_seat[0].seatRow == 4
+        assert best_seat[0].seatCol == 5
         assert best_seat[0].seatNumber == "E_6"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
@@ -628,8 +628,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
         best_seat = cine_digital_service.get_available_seat(show, screen)
         assert len(best_seat) == 1
-        assert best_seat[0].seatRow == 2
-        assert best_seat[0].seatCol == 5
+        assert best_seat[0].seatRow == 1
+        assert best_seat[0].seatCol == 4
         assert best_seat[0].seatNumber == "M_9"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
@@ -660,8 +660,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         )
         best_seat = cine_digital_service.get_available_seat(show, screen)
         assert len(best_seat) == 1
-        assert best_seat[0].seatRow == 4
-        assert best_seat[0].seatCol == 6
+        assert best_seat[0].seatRow == 3
+        assert best_seat[0].seatCol == 5
         assert best_seat[0].seatNumber == "D_6"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
@@ -690,8 +690,8 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         )
         best_seat = cine_digital_service.get_available_seat(show, screen)
         assert len(best_seat) == 1
-        assert best_seat[0].seatRow == 2
-        assert best_seat[0].seatCol == 2
+        assert best_seat[0].seatRow == 1
+        assert best_seat[0].seatCol == 1
         assert best_seat[0].seatNumber == "B_2"
 
     @patch("pcapi.core.external_bookings.cds.client.get_resource")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18362

## But de la pull request
- Les indexes sur la matrice du plan de salles doivent commencer de 0 et non pas de 1.
- Prendre en considération les rangés manquants dans le calcul du numéro siège.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
