### PR TITLE
(PC-18934)[API] feat: add educational institution name when sending j…

### DIFF
--- a/api/src/pcapi/core/mails/transactional/educational/eac_pending_booking_confirmation_limit_date_in_3_days.py
+++ b/api/src/pcapi/core/mails/transactional/educational/eac_pending_booking_confirmation_limit_date_in_3_days.py
@@ -32,5 +32,6 @@ def get_data_pending_booking_confirmation_limit_date_in_3_days(
             "USER_FIRSTNAME": booking.educationalRedactor.firstName,
             "USER_LASTNAME": booking.educationalRedactor.lastName,
             "USER_EMAIL": booking.educationalRedactor.email,
+            "EDUCATIONAL_INSTITUTION_NAME": booking.educationalInstitution.name,
         },
     )

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -834,6 +834,7 @@ class EACPendingBookingWithConfirmationLimitDate3DaysTest:
             "USER_FIRSTNAME": booking.educationalRedactor.firstName,
             "USER_LASTNAME": booking.educationalRedactor.lastName,
             "USER_EMAIL": booking.educationalRedactor.email,
+            "EDUCATIONAL_INSTITUTION_NAME": booking.educationalInstitution.name,
         }
 
     @mock.patch(


### PR DESCRIPTION
…3 mail to ac

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18934

## But de la pull request

Ajouter l'information du nom de l'établissement dans le mail indiquant à l'acteur qu'il reste seulement 3 jours pour que l'établissement confirme sa réservation.

## Implémentation

- Ajouter le paramètre transactionnel : `EDUCATIONAL_INSTITUTION_NAME`

