### PR TITLE
Fix entrypoint

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -80,7 +80,7 @@ RUN pip install \
 		--no-cache-dir \
 		--editable .
 
-ENTRYPOINT exec ./entrypoint.sh
+ENTRYPOINT ./entrypoint.sh
 
 ######### CONSOLE #########
 

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variabilize "bind" when we will merge dockerfiles. "127.0.0.1 for devs and 0.0.0.0 for kubernetes"
-gunicorn \
+exec gunicorn \
     --preload \
     --bind 0.0.0.0:$GUNICORN_PORT \
     --worker-class gthread \


### PR DESCRIPTION
Actuellement l'entrypoint n'est pas bon. 

Les pods ont pour PID 1 /bin/entrypoint soit bash :

```
k exec -it testing-pcapi-signin-api-579b8875fb-zrbtn cat /proc/1/cmdline
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
/bin/bash./entrypoint.sh
```
Cela entraîne que le **sigterm** envoyé au pod n'est pas géré. Et du coup les pods ne s'arrêtent pas proprement et prennent un **sigkill** au bout de 30s :

```
❯ date; k delete po testing-pcapi-signin-api-579b8875fb-jzmb2 && date
Tue Nov 29 10:34:44 AM CET 2022
pod "testing-pcapi-signin-api-579b8875fb-jzmb2" deleted
Tue Nov 29 10:35:15 AM CET 2022
```

L'bjectif de ce commit est de faire en sorte que gunicorn soit le pid 1 du pod :

```
k exec -it testing-pcapi-signin-api-65d94d4b45-66btv /bin/bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
pcapi@testing-pcapi-signin-api-65d94d4b45-66btv:/usr/src/app$ cat /proc/1/cmdline
gunicorn: master [pcapi.app:app]pcapi@testing-pcapi-signin-api-65d94d4b45-66btv:/usr/src/app$
```

Et que les pods puissent s'éteindre proprement : 
```
❯ date; k delete po testing-pcapi-signin-api-65d94d4b45-hxnxq && date
Tue Nov 29 10:29:22 AM CET 2022
pod "testing-pcapi-signin-api-65d94d4b45-hxnxq" deleted
Tue Nov 29 10:29:27 AM CET 2022
```

J'espère que cela nous permettra de réduire les erreurs 502 que nous observons en production (probablement à cause des scale-up / scale-down régulier).

