### PR TITLE
(BSR)[API]feat: add unique constraint in cinema pivots

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-d223c62b00b8 (pre) (head)
+2ca4b0b05bc6 (pre) (head)
 4e9a6643eeed (post) (head)

--- a/api/src/pcapi/admin/custom_views/boost_pivot_view.py
+++ b/api/src/pcapi/admin/custom_views/boost_pivot_view.py
@@ -6,19 +6,26 @@ from werkzeug.exceptions import Forbidden
 from wtforms import Form
 from wtforms import IntegerField
 from wtforms import StringField
+from wtforms import ValidationError
 from wtforms.validators import DataRequired
 from wtforms.validators import URL
 
 from pcapi.admin.base_configuration import BaseAdminView
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.providers.models as providers_models
-from pcapi.core.providers.repository import get_provider_by_local_class
+import pcapi.core.providers.repository as providers_repository
 from pcapi.models import db
+
+
+def unique_id_at_provider_check(_form: SecureForm, field: StringField) -> None:
+    cds_provider = providers_repository.get_provider_by_local_class("BoostStocks")
+    if providers_repository.id_at_provider_exists_for_provider(id_at_provider=field.data, provider_id=cds_provider.id):
+        raise ValidationError("Cet identifiant cinéma existe déjà pour un autre lieu")
 
 
 class BoostPivotForm(SecureForm):
     venue_id = IntegerField("Identifiant numérique du lieu (pass Culture)", [DataRequired()])
-    cinema_id = StringField("Identifiant Cinéma (Boost)", [DataRequired()])
+    cinema_id = StringField("Identifiant Cinéma (Boost)", [DataRequired(), unique_id_at_provider_check])
     username = StringField("Nom d'utilisateur (Boost)", [DataRequired()])
     password = StringField("Mot de passe (Boost)", [DataRequired()])
     cinema_url = StringField("Url (Boost)", [DataRequired(), URL()])
@@ -90,7 +97,7 @@ class BoostPivotView(BaseAdminView):
     def create_model(self, form: BoostPivotForm) -> providers_models.BoostCinemaDetails | None:
         if not self.can_create:
             raise Forbidden()
-        boost_provider = get_provider_by_local_class("BoostStocks")
+        boost_provider = providers_repository.get_provider_by_local_class("BoostStocks")
         if not boost_provider:
             flash("Provider Boost n'existe pas.", "error")
             return None

--- a/api/src/pcapi/alembic/versions/20221129T111214_2ca4b0b05bc6_add_unique_provider_id_at_provider_constraint.py
+++ b/api/src/pcapi/alembic/versions/20221129T111214_2ca4b0b05bc6_add_unique_provider_id_at_provider_constraint.py
@@ -1,0 +1,20 @@
+"""add unique_provider_id_at_provider constraint"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "2ca4b0b05bc6"
+down_revision = "d223c62b00b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "unique_provider_id_at_provider", "cinema_provider_pivot", ["providerId", "idAtProvider"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("unique_provider_id_at_provider", "cinema_provider_pivot", type_="unique")

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -6,6 +6,7 @@ import secrets
 import factory
 
 from pcapi.core.offerers.factories import VenueFactory
+import pcapi.core.providers.repository as providers_repository
 from pcapi.core.testing import BaseFactory
 
 from . import models
@@ -74,11 +75,25 @@ class CinemaProviderPivotFactory(BaseFactory):
     idAtProvider = factory.Sequence("idProvider{}".format)
 
 
+class BoostCinemaProviderPivotFactory(CinemaProviderPivotFactory):
+    class Meta:
+        sqlalchemy_get_or_create = ["provider"]
+
+    provider = factory.LazyFunction(lambda: providers_repository.get_provider_by_local_class("BoostStocks"))
+
+
+class CDSCinemaProviderPivotFactory(CinemaProviderPivotFactory):
+    class Meta:
+        sqlalchemy_get_or_create = ["provider"]
+
+    provider = factory.LazyFunction(lambda: providers_repository.get_provider_by_local_class("CDSStocks"))
+
+
 class CDSCinemaDetailsFactory(BaseFactory):
     class Meta:
         model = models.CDSCinemaDetails
 
-    cinemaProviderPivot = factory.SubFactory(CinemaProviderPivotFactory)
+    cinemaProviderPivot = factory.SubFactory(CDSCinemaProviderPivotFactory)
     cinemaApiToken = factory.LazyFunction(secrets.token_urlsafe)
     accountId = factory.Sequence("account{}".format)
 
@@ -87,7 +102,7 @@ class BoostCinemaDetailsFactory(BaseFactory):
     class Meta:
         model = models.BoostCinemaDetails
 
-    cinemaProviderPivot = factory.SubFactory(CinemaProviderPivotFactory)
+    cinemaProviderPivot = factory.SubFactory(BoostCinemaProviderPivotFactory)
     cinemaUrl = factory.Sequence("https://cinema-{}.example.com/".format)
     username = "pass_culture"
     password = "a great password"

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -169,6 +169,11 @@ class CinemaProviderPivot(PcObject, Base, Model):
             "providerId",
             name="unique_pivot_venue_provider",
         ),
+        UniqueConstraint(
+            "providerId",
+            "idAtProvider",
+            name="unique_provider_id_at_provider",
+        ),
     )
 
 

--- a/api/tests/core/external_bookings/test_api.py
+++ b/api/tests/core/external_bookings/test_api.py
@@ -51,7 +51,7 @@ class GetExternalBookingsClientApiTest:
         venue_provider = providers_factories.VenueProviderFactory(
             provider=cds_provider, venueIdAtOfferProvider="test_id"
         )
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(
+        cinema_provider_pivot = providers_factories.CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         providers_factories.CDSCinemaDetailsFactory(

--- a/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
@@ -7,7 +7,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import Stock
 from pcapi.core.providers.factories import BoostCinemaDetailsFactory
-from pcapi.core.providers.factories import CinemaProviderPivotFactory
+from pcapi.core.providers.factories import BoostCinemaProviderPivotFactory
 from pcapi.core.providers.factories import VenueProviderFactory
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.local_providers import BoostStocks
@@ -20,7 +20,7 @@ class BoostStocksTest:
     def should_return_providable_info_on_next(self, requests_mock):
         boost_provider = get_provider_by_local_class("BoostStocks")
         venue_provider = VenueProviderFactory(provider=boost_provider)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = BoostCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         BoostCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://cinema-0.example.com/")
@@ -70,7 +70,7 @@ class BoostStocksTest:
     def should_fill_offer_and_product_and_stock_informations_for_each_movie(self, requests_mock):
         boost_provider = get_provider_by_local_class("BoostStocks")
         venue_provider = VenueProviderFactory(provider=boost_provider, isDuoOffers=True)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = BoostCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         BoostCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://cinema-0.example.com/")
@@ -147,7 +147,7 @@ class BoostStocksTest:
     def should_not_create_stock_when_showtime_does_not_have_pass_culture_pricing(self, requests_mock):
         boost_provider = get_provider_by_local_class("BoostStocks")
         venue_provider = VenueProviderFactory(provider=boost_provider, isDuoOffers=True)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = BoostCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         BoostCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://cinema-0.example.com/")
@@ -174,7 +174,7 @@ class BoostStocksTest:
     def should_update_stock_with_the_correct_stock_quantity(self, requests_mock):
         boost_provider = get_provider_by_local_class("BoostStocks")
         venue_provider = VenueProviderFactory(provider=boost_provider, isDuoOffers=True)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = BoostCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         BoostCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://cinema-0.example.com/")

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -13,7 +13,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import Stock
 from pcapi.core.providers.factories import CDSCinemaDetailsFactory
-from pcapi.core.providers.factories import CinemaProviderPivotFactory
+from pcapi.core.providers.factories import CDSCinemaProviderPivotFactory
 from pcapi.core.providers.factories import VenueProviderFactory
 from pcapi.core.providers.models import Provider
 from pcapi.local_providers.cinema_providers.cds.cds_stocks import CDSStocks
@@ -32,7 +32,7 @@ class CDSStocksTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
@@ -89,7 +89,7 @@ class CDSStocksTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
@@ -175,7 +175,7 @@ class CDSStocksTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
@@ -245,7 +245,7 @@ class CDSStocksTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
@@ -326,7 +326,7 @@ class CDSStocksTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider, isDuoOffers=True)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
@@ -448,7 +448,7 @@ class CDSStocksTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider, isDuoOffers=True)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
@@ -547,7 +547,7 @@ class CDSStocksQuantityTest:
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         cds_venue_provider = VenueProviderFactory(provider=cds_provider)
-        cinema_provider_pivot = CinemaProviderPivotFactory(
+        cinema_provider_pivot = CDSCinemaProviderPivotFactory(
             venue=cds_venue_provider.venue, idAtProvider=cds_venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)


### PR DESCRIPTION
## But de la pull request

Eviter les conflits d'`idAtProvider` lors de l'ajout/édition de pivot de cinéma

## Implémentation

- Ajout de contrainte d'unicité
- Ajout d'un validateur dans le formulaire `CineOfficePivotForm` et `BoostPivotForm`


## Informations supplémentaires

- Vu le faible nombre de lignes dans la table CinemaProviderPivot, j'ai écrit une migration naïve d'ajout de contrainte en une seule fois
- Modification des _Factories_ pour utiliser les bons _Providers_
