### PR TITLE
(PC-17935)[PRO] feat: New popin to warn user about event stock edition

### DIFF
--- a/pro/src/screens/OfferIndividual/DialogStocksEventEditConfirm/DialogStocksEventEditConfirm.tsx
+++ b/pro/src/screens/OfferIndividual/DialogStocksEventEditConfirm/DialogStocksEventEditConfirm.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import ConfirmDialog from 'components/Dialog/ConfirmDialog'
+import { ReactComponent as Trash } from 'icons/ico-trash.svg'
+
+interface IDialogStocksEventEditConfirmProps {
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const DialogStocksEventEditConfirm = ({
+  onConfirm,
+  onCancel,
+}: IDialogStocksEventEditConfirmProps) => {
+  return (
+    <ConfirmDialog
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      title="Des réservations sont en cours pour cette offre"
+      confirmText="Confirmer les modifications"
+      cancelText="Annuler"
+      icon={Trash}
+    >
+      <p>
+        Si vous avez changé la date ou l'heure de l'évènement, les bénéficiaires
+        ayant déjà réservé en seront automatiquement informés par e-mail. Ils
+        disposeront alors à nouveau de 48h pour annuler leur réservation (sauf
+        si ce report a lieu dans moins de 48h).
+      </p>
+      <p>
+        Si vous avez changé le tarif de cette offre, celui-ci ne s'appliquera
+        que pour les prochaines réservations.
+      </p>
+    </ConfirmDialog>
+  )
+}
+
+export default DialogStocksEventEditConfirm

--- a/pro/src/screens/OfferIndividual/DialogStocksEventEditConfirm/intex.ts
+++ b/pro/src/screens/OfferIndividual/DialogStocksEventEditConfirm/intex.ts
@@ -1,0 +1,1 @@
+export { default as DialogStocksEventEditConfirm } from './DialogStocksEventEditConfirm'

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -129,17 +129,6 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   const handleNextStep =
     ({ saveDraft = false } = {}) =>
     () => {
-      if (mode === OFFER_WIZARD_MODE.EDITION) {
-        const offerHasBookings = formik.values.stocks.some(
-          stock => stock.bookingsQuantity !== '0'
-        )
-        if (!visible && offerHasBookings && formik.dirty) {
-          showModal()
-          return
-        } else {
-          hideModal()
-        }
-      }
       // tested but coverage don't see it.
       /* istanbul ignore next */
       setIsClickingFromActionBar(true)
@@ -152,9 +141,32 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
           mode,
         })
       )
+      if (mode === OFFER_WIZARD_MODE.EDITION) {
+        const offerHasBookings = formik.values.stocks.some(
+          stock => stock.bookingsQuantity !== '0'
+        )
+        if (!visible && offerHasBookings && formik.dirty) {
+          showModal()
+          return
+        } else {
+          hideModal()
+        }
+      }
+
       if (!Object.keys(formik.touched).length) {
         setIsClickingFromActionBar(false)
         notify.success('Brouillon sauvegardé dans la liste des offres')
+        if (!saveDraft) {
+          navigate(
+            getOfferIndividualUrl({
+              offerId: offer.id,
+              step: saveDraft
+                ? OFFER_WIZARD_STEP_IDS.STOCKS
+                : OFFER_WIZARD_STEP_IDS.SUMMARY,
+              mode,
+            })
+          )
+        }
       } else {
         formik.handleSubmit()
       }

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -17,7 +17,11 @@ import {
   OfferIndividualContext,
 } from 'context/OfferIndividualContext'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
-import { IOfferIndividual, IOfferIndividualVenue } from 'core/Offers/types'
+import {
+  IOfferIndividual,
+  IOfferIndividualStock,
+  IOfferIndividualVenue,
+} from 'core/Offers/types'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
 import { RootState } from 'store/reducers'
 import { configureTestStore } from 'store/testUtils'
@@ -182,6 +186,34 @@ describe('screens:StocksEvent', () => {
   })
 
   it('should submit stock form when click on "Étape suivante""', async () => {
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stockIds: [{ id: 'CREATED_STOCK_ID' }],
+    })
+    const stock = {
+      id: 'STOCK_ID',
+      quantity: 10,
+      price: 10.01,
+      remainingQuantity: 6,
+      bookingsQuantity: 4,
+      isEventDeletable: true,
+      beginningDatetime: '2023-03-10T00:00:00.0200',
+    }
+    props.offer = {
+      ...(offer as IOfferIndividual),
+      stocks: [stock as IOfferIndividualStock],
+    }
+    renderStockEventScreen({ props, storeOverride, contextValue })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Étape suivante' })
+    )
+    expect(api.upsertStocks).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Brouillon sauvegardé dans la liste des offres')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Next page')).toBeInTheDocument()
+  })
+  it('should not submit stock if nothing has changed when click on "Étape suivante" and redirect to summary', async () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stockIds: [{ id: 'CREATED_STOCK_ID' }],
     })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
@@ -184,7 +184,9 @@ describe('screens:StocksEvent', () => {
     await userEvent.click(await screen.getByText('12:00'))
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Enregistrer les modifications'))
-
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Confirmer les modifications' })
+    )
     expect(mockLogEvent).toHaveBeenCalledTimes(1)
     expect(mockLogEvent).toHaveBeenNthCalledWith(
       1,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17935

## But de la pull request

Ajout d'une popin pour avertir l'utilisateur si des reservations ont été faites sur l'offre lors de la modification d'un évènement

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
