### PR TITLE
(PC-18826)[API] fix: remove user name in action history when action

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -89,6 +89,20 @@ def get_stats(offerer_id: int) -> utils.BackofficeResponse:
     )
 
 
+def _is_user_offerer_action_type(historyItem: serialization.HistoryItem) -> bool:
+    user_offerer_action_types = [
+        history_models.ActionType.USER_OFFERER_NEW,
+        history_models.ActionType.USER_OFFERER_PENDING,
+        history_models.ActionType.USER_OFFERER_VALIDATED,
+        history_models.ActionType.USER_OFFERER_REJECTED,
+    ]
+    return history_models.ActionType(historyItem.type) in user_offerer_action_types
+
+
+def _is_offerer_new_action_type(historyItem: serialization.HistoryItem) -> bool:
+    return history_models.ActionType(historyItem.type) == history_models.ActionType.OFFERER_NEW
+
+
 def get_offerer_history_data(offerer_id: int) -> typing.Sequence[serialization.HistoryItem]:
     actions = history_repository.find_all_actions_by_offerer(offerer_id)
     return [
@@ -111,7 +125,12 @@ def get_offerer_history(offerer_id: int) -> utils.BackofficeResponse:
     history = get_offerer_history_data(offerer_id)
     can_add_comment = utils.has_current_user_permission(perm_models.Permissions.MANAGE_PRO_ENTITY)
     return render_template(
-        "offerer/get/details.html", offerer=offerer, history=history, can_add_comment=can_add_comment
+        "offerer/get/details.html",
+        offerer=offerer,
+        history=history,
+        can_add_comment=can_add_comment,
+        is_user_offerer_action_type=_is_user_offerer_action_type,
+        is_offerer_new_action_type=_is_offerer_new_action_type,
     )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
@@ -26,7 +26,7 @@
                 <td>{{ event.type }}</td>
                 <td>{{ event.date | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
                 <td class="px-4 text-break">
-                    {% if event.accountName %}
+                    {% if event.accountName and is_user_offerer_action_type(event) %}
                         <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=event.accountId) }}">
                             <p>{{ event.accountName | empty_string_if_null }} - {{ event.accountId }}</p>
                         </a>
@@ -36,7 +36,15 @@
                         <p>{{ event.comment | empty_string_if_null }}</p>
                     {% endif %}
                 </td>
-                <td>{{ event.authorName | empty_string_if_null }}</td>
+                <td>
+                    {% if is_offerer_new_action_type(event) %}
+                        <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=event.authorId) }}">
+                            <p>{{ event.authorName | empty_string_if_null }} - {{ event.authorId }}</p>
+                        </a>
+                    {% else %}
+                        <p>{{ event.authorName | empty_string_if_null }}</p>
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
type is not user offerer

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18826

## But de la pull request

Ne pas avoir le nom et id de l'utilisateur concerné dans le commentaire d'une action si cette action n'est pas liée à un rattachement.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
