### PR TITLE
(BSR)[PRO] fix: offer V3 unable to update offer with wthdrawalDelay

### DIFF
--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
@@ -25,16 +25,19 @@ const TicketWithdrawal = ({
   const {
     values: { withdrawalType },
     setFieldValue,
+    dirty,
   } = useFormikContext<IOfferIndividualFormValues>()
 
   useEffect(
     function onWithdrawalTypeChange() {
-      setFieldValue(
-        'withdrawalDelay',
-        TICKET_WITHDRAWAL_DEFAULT_VALUES['withdrawalDelay']
-      )
+      if (dirty) {
+        setFieldValue(
+          'withdrawalDelay',
+          TICKET_WITHDRAWAL_DEFAULT_VALUES['withdrawalDelay']
+        )
+      }
     },
-    [withdrawalType]
+    [withdrawalType, dirty]
   )
 
   return (

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -6,6 +6,7 @@ import { Form, Formik } from 'formik'
 import React from 'react'
 import * as yup from 'yup'
 
+import { WithdrawalTypeEnum } from 'apiClient/v1'
 import { IOfferIndividualFormValues } from 'components/OfferIndividualForm'
 import { REIMBURSEMENT_RULES } from 'core/Finances'
 import { TOffererName } from 'core/Offerers/types'
@@ -27,7 +28,7 @@ const renderUsefulInformations = async ({
   onSubmit: () => void
   props: IUsefulInformationsProps
 }) => {
-  render(
+  return render(
     <Formik
       initialValues={initialValues}
       onSubmit={onSubmit}
@@ -154,6 +155,42 @@ describe('OfferIndividual section: UsefulInformations', () => {
         withdrawalDelay: undefined,
         withdrawalDetails: '',
         withdrawalType: 'by_email',
+      },
+      expect.anything()
+    )
+  })
+
+  it('should submit valid form if initialValues has been given', async () => {
+    initialValues = {
+      ...initialValues,
+      name: 'Set offer',
+      venueId: 'AAAA',
+      offererId: 'AA',
+      subcategoryId: 'CONCERT',
+      subCategoryFields: ['withdrawalType'],
+      withdrawalDelay: 7200,
+      withdrawalType: WithdrawalTypeEnum.ON_SITE,
+    }
+
+    await renderUsefulInformations({
+      initialValues,
+      onSubmit,
+      props,
+    })
+
+    await userEvent.click(await screen.findByText('Submit'))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      {
+        name: 'Set offer',
+        offererId: 'AA',
+        subCategoryFields: ['withdrawalType'],
+        url: '',
+        subcategoryId: 'CONCERT',
+        venueId: 'AAAA',
+        withdrawalDelay: 7200,
+        withdrawalDetails: '',
+        withdrawalType: WithdrawalTypeEnum.ON_SITE,
       },
       expect.anything()
     )

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -49,8 +49,8 @@ export const serializePatchOffer = (
   name: formValues.name,
   venueId: formValues.venueId,
   visualDisabilityCompliant: formValues.accessibility[AccessiblityEnum.VISUAL],
-  withdrawalDelay: formValues.withdrawalDelay,
-  withdrawalDetails: formValues.withdrawalDetails,
+  withdrawalDelay: formValues.withdrawalDelay || null,
+  withdrawalDetails: formValues.withdrawalDetails || null,
   withdrawalType: formValues.withdrawalType,
   durationMinutes: serializeDurationMinutes(formValues.durationMinutes || ''),
   bookingEmail: formValues.receiveNotificationEmails

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -391,7 +391,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
       venueId: 'VID virtual',
       visualDisabilityCompliant: true,
       withdrawalDetails: 'Offer withdrawalDetails',
-      withdrawalDelay: undefined,
+      withdrawalDelay: null,
       withdrawalType: undefined,
     })
     expect(api.getOffer).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Lien vers le ticket Jira : pas de jira

## But de la pull request

* Créer une offre avec `wthdrawalDelay`, par example spéctacle vivant -> spectacle / representation
* poster un formulaire valide
* revenir à l'étape 1
* reposter le formulaire

Avant: erreur
Apres: pas d'erreur
