### PR TITLE
(PC-18998)[PRO] reafactor: stock v3: fix past event validation

### DIFF
--- a/pro/src/components/StockEventForm/StockEventForm.stories.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.stories.tsx
@@ -85,6 +85,7 @@ const TemplateWithInitialValues: ComponentStory<typeof StockEventForm> =
       ),
       quantity: '10',
       isDeletable: true,
+      readOnlyFields: [],
     },
   })
 
@@ -93,14 +94,31 @@ WithInitialValues.args = {
   today,
 }
 
-export const Disabled = TemplateWithInitialValues.bind({})
+const TemplateDisabled: ComponentStory<typeof StockEventForm> =
+  renderStockEventForm({
+    initialValues: {
+      beginningDate: new Date(),
+      beginningTime: today,
+      stockId: 'STOCK_ID',
+      remainingQuantity: '7',
+      bookingsQuantity: '5',
+      price: '5',
+      bookingLimitDatetime: getLocalDepartementDateTimeFromUtc(
+        new Date().toISOString(),
+        '75'
+      ),
+      quantity: '10',
+      isDeletable: true,
+      readOnlyFields: [
+        'eventDatetime',
+        'eventTime',
+        'price',
+        'bookingLimitDatetime',
+        'quantity',
+      ],
+    },
+  })
+export const Disabled = TemplateDisabled.bind({})
 Disabled.args = {
-  readOnlyFields: [
-    'eventDatetime',
-    'eventTime',
-    'price',
-    'bookingLimitDatetime',
-    'quantity',
-  ],
   today,
 }

--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -12,29 +12,29 @@ import { IStockEventFormValues } from './types'
 
 export interface IStockEventFormProps {
   today: Date
-  readOnlyFields?: string[]
   stockIndex: number
 }
 
 const StockEventForm = ({
   today,
-  readOnlyFields = [],
   stockIndex,
 }: IStockEventFormProps): JSX.Element => {
   const { values, setFieldValue, setTouched } = useFormikContext<{
     stocks: IStockEventFormValues[]
   }>()
 
+  const stockFormValues = values.stocks[stockIndex]
+  const { readOnlyFields } = stockFormValues
+
   const [showCurrencyIcon, showShowCurrencyIcon] = useState<boolean>(
-    values.stocks[stockIndex].price.length > 0
+    stockFormValues.price.length > 0
   )
   useEffect(() => {
-    showShowCurrencyIcon(values.stocks[stockIndex].price.length > 0)
-  }, [values.stocks[stockIndex].price])
+    showShowCurrencyIcon(stockFormValues.price.length > 0)
+  }, [stockFormValues.price])
 
   const onChangeBeginningDate = (_name: string, date: Date | null) => {
-    const stockBookingLimitDatetime =
-      values.stocks[stockIndex].bookingLimitDatetime
+    const stockBookingLimitDatetime = stockFormValues.bookingLimitDatetime
     if (stockBookingLimitDatetime === null) {
       return
     }
@@ -45,7 +45,7 @@ const StockEventForm = ({
       setFieldValue(`stocks[${stockIndex}]bookingLimitDatetime`, date)
     }
   }
-  const beginningDate = values.stocks[stockIndex].beginningDate
+  const beginningDate = stockFormValues.beginningDate
 
   return (
     <>

--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -59,14 +59,16 @@ describe('StockEventForm', () => {
   })
 
   it('render disabled field in list', () => {
-    props.readOnlyFields = [
-      'beginningDate',
-      'beginningTime',
-      'bookingLimitDatetime',
-      'price',
-      'quantity',
-    ]
-    renderStockEventForm(props)
+    renderStockEventForm(props, {
+      ...STOCK_EVENT_FORM_DEFAULT_VALUES,
+      readOnlyFields: [
+        'beginningDate',
+        'beginningTime',
+        'bookingLimitDatetime',
+        'price',
+        'quantity',
+      ],
+    })
 
     expect(screen.getByLabelText('Date', { exact: true })).toBeDisabled()
     expect(screen.getByLabelText('Horaire')).toBeDisabled()
@@ -84,6 +86,7 @@ describe('StockEventForm', () => {
       bookingLimitDatetime: new Date('2022-12-28T00:00:00Z'),
       price: '10',
       isDeletable: true,
+      readOnlyFields: [],
     }
 
     renderStockEventForm(props, initialStock)

--- a/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
@@ -10,6 +10,7 @@ import { getToday } from 'utils/date'
 
 import { STOCK_EVENT_FORM_DEFAULT_VALUES } from '../constants'
 import StockEventForm, { IStockEventFormProps } from '../StockEventForm'
+import { IStockEventFormValues } from '../types'
 import { getValidationSchema } from '../validationSchema'
 
 jest.mock('utils/date', () => ({
@@ -28,20 +29,20 @@ yesterday.setDate(yesterday.getDate() - 1)
 oneWeekLater.setDate(oneWeekLater.getDate() + 7)
 
 const renderStockEventForm = ({
-  minQuantity,
+  initialValues = STOCK_EVENT_FORM_DEFAULT_VALUES,
   onSubmit = jest.fn(),
 }: {
-  minQuantity?: number | null
+  initialValues?: IStockEventFormValues
   onSubmit?: () => void
 } = {}) => {
   const props: IStockEventFormProps = { today, stockIndex: 0 }
   return render(
     <Formik
       initialValues={{
-        stocks: [STOCK_EVENT_FORM_DEFAULT_VALUES],
+        stocks: [initialValues],
       }}
       onSubmit={onSubmit}
-      validationSchema={getValidationSchema(minQuantity)}
+      validationSchema={getValidationSchema()}
     >
       {({ handleSubmit }) => (
         <form onSubmit={handleSubmit}>
@@ -159,7 +160,12 @@ describe('StockEventForm:validationSchema', () => {
   )
 
   it('should display quantity error when min quantity is given', async () => {
-    renderStockEventForm({ minQuantity: 10 })
+    renderStockEventForm({
+      initialValues: {
+        ...STOCK_EVENT_FORM_DEFAULT_VALUES,
+        bookingsQuantity: '10',
+      },
+    })
 
     const inputQuantity = screen.getByLabelText('Quantité')
     await userEvent.type(inputQuantity, '9')

--- a/pro/src/components/StockEventForm/constants.ts
+++ b/pro/src/components/StockEventForm/constants.ts
@@ -1,7 +1,12 @@
-import { IStockEventFormValues } from './types'
+import { IStockEventFormValues, IStockEventFormHiddenValues } from './types'
+
+const STOCK_EVENT_FORM_DEFAULT_HIDDEN_VALUES: IStockEventFormHiddenValues = {
+  stockId: undefined,
+  isDeletable: true,
+  readOnlyFields: [],
+}
 
 export const STOCK_EVENT_FORM_DEFAULT_VALUES: IStockEventFormValues = {
-  stockId: undefined,
   beginningDate: null,
   beginningTime: null,
   remainingQuantity: '',
@@ -9,7 +14,7 @@ export const STOCK_EVENT_FORM_DEFAULT_VALUES: IStockEventFormValues = {
   quantity: '',
   bookingLimitDatetime: null,
   price: '',
-  isDeletable: true,
+  ...STOCK_EVENT_FORM_DEFAULT_HIDDEN_VALUES,
 }
 
 // 'price','quantity','bookingLimitDatetime', are editable

--- a/pro/src/components/StockEventForm/types.ts
+++ b/pro/src/components/StockEventForm/types.ts
@@ -1,5 +1,10 @@
-export interface IStockEventFormValues {
+export interface IStockEventFormHiddenValues {
   stockId?: string
+  isDeletable: boolean
+  readOnlyFields: string[]
+}
+
+export interface IStockEventFormValues extends IStockEventFormHiddenValues {
   remainingQuantity: string
   bookingsQuantity: string
   quantity: string
@@ -7,5 +12,4 @@ export interface IStockEventFormValues {
   price: string
   beginningDate: Date | '' | null
   beginningTime: Date | '' | null
-  isDeletable: boolean
 }

--- a/pro/src/components/StockEventForm/utils/setFormReadOnlyFields.ts
+++ b/pro/src/components/StockEventForm/utils/setFormReadOnlyFields.ts
@@ -1,8 +1,8 @@
 import { isBefore } from 'date-fns'
 
+import { OfferStatus } from 'apiClient/v1'
 import { OFFER_STATUS_PENDING, OFFER_STATUS_REJECTED } from 'core/Offers'
-import { IOfferIndividual } from 'core/Offers/types'
-import { isAllocineProvider } from 'core/Providers'
+import { isAllocineProviderName } from 'core/Providers'
 import { removeTime } from 'utils/date'
 
 import {
@@ -10,17 +10,25 @@ import {
   STOCK_EVENT_FORM_DEFAULT_VALUES,
 } from '../constants'
 
-const setFormReadOnlyFields = (
-  offer: IOfferIndividual,
-  beginningDate: Date | null,
+interface ISetReadOnlyFieldsArgs {
+  beginningDate: Date | null
   today: Date
-) => {
-  const isDisabledStatus = offer.status
-    ? [OFFER_STATUS_REJECTED, OFFER_STATUS_PENDING].includes(offer.status)
+  lastProviderName: string | null
+  offerStatus: OfferStatus
+}
+
+const setFormReadOnlyFields = ({
+  beginningDate,
+  today,
+  lastProviderName,
+  offerStatus,
+}: ISetReadOnlyFieldsArgs) => {
+  const isDisabledStatus = offerStatus
+    ? [OFFER_STATUS_REJECTED, OFFER_STATUS_PENDING].includes(offerStatus)
     : false
-  const isOfferSynchronized = !!offer.lastProvider
-  const isOfferSynchronizedAllocine =
-    offer.lastProvider && isAllocineProvider(offer.lastProvider)
+
+  const isOfferSynchronized = lastProviderName !== null
+  const isOfferSynchronizedAllocine = isAllocineProviderName(lastProviderName)
 
   if (
     isDisabledStatus ||
@@ -31,6 +39,7 @@ const setFormReadOnlyFields = (
   } else if (isOfferSynchronizedAllocine) {
     return STOCK_EVENT_ALLOCINE_READ_ONLY_FIELDS
   }
+
   return []
 }
 

--- a/pro/src/core/Providers/utils/index.ts
+++ b/pro/src/core/Providers/utils/index.ts
@@ -1,2 +1,6 @@
-export { isAllocineProvider, isCinemaProvider } from './utils'
+export {
+  isAllocineProvider,
+  isAllocineProviderName,
+  isCinemaProvider,
+} from './utils'
 export { getProviderInfo } from './getProviderInfo'

--- a/pro/src/core/Providers/utils/utils.ts
+++ b/pro/src/core/Providers/utils/utils.ts
@@ -3,13 +3,23 @@ import { IOfferIndividualVenueProvider } from 'core/Offers/types'
 import { CINEMA_PROVIDER_NAMES } from '../constants'
 
 /* istanbul ignore next: DEBT, TO FIX */
+export const isAllocineProviderName = (
+  providerName: string | null
+): boolean => {
+  if (providerName === null) {
+    return false
+  }
+  return providerName.toLowerCase() === 'allociné'
+}
+
+/* istanbul ignore next: DEBT, TO FIX */
 export const isAllocineProvider = (
   provider?: IOfferIndividualVenueProvider | null
 ): boolean => {
   if (!provider) {
     return false
   }
-  return provider.name.toLowerCase() === 'allociné'
+  return isAllocineProviderName(provider.name)
 }
 
 /* istanbul ignore next: DEBT, TO FIX */

--- a/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react'
 
 import {
   StockEventForm,
-  setFormReadOnlyFields,
   IStockEventFormValues,
   STOCK_EVENT_FORM_DEFAULT_VALUES,
 } from 'components/StockEventForm'
@@ -67,17 +66,7 @@ const StockFormList = ({ offer, onDeleteStock }: IStockFormListProps) => {
               <StockEventFormRow
                 key={index}
                 stockIndex={index}
-                Form={
-                  <StockEventForm
-                    today={today}
-                    readOnlyFields={setFormReadOnlyFields(
-                      offer,
-                      stockValues.beginningDate || null,
-                      today
-                    )}
-                    stockIndex={index}
-                  />
-                }
+                Form={<StockEventForm today={today} stockIndex={index} />}
                 actions={[
                   {
                     callback: async () => {

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -24,6 +24,8 @@ import { useNavigate, useOfferWizardMode } from 'hooks'
 import useAnalytics from 'hooks/useAnalytics'
 import { useModal } from 'hooks/useModal'
 import useNotification from 'hooks/useNotification'
+import { getToday } from 'utils/date'
+import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 
 import { ActionBar } from '../ActionBar'
 import DialogStocksEventEditConfirm from '../DialogStocksEventEditConfirm/DialogStocksEventEditConfirm'
@@ -108,24 +110,26 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         )
   }
 
-  let minQuantity = null
-  // validation is test in getValidationSchema
-  // and it's not possible as is to test it here
-  /* istanbul ignore next: DEBT, TO FIX */
-  if (offer.stocks.length > 0) {
-    minQuantity = offer.stocks[0].bookingsQuantity
-  }
-  const initialValues = buildInitialValues(offer)
+  const today = getLocalDepartementDateTimeFromUtc(
+    getToday(),
+    offer.venue.departmentCode
+  )
+  const initialValues = buildInitialValues({
+    departmentCode: offer.venue.departmentCode,
+    offerStocks: offer.stocks,
+    today,
+    lastProviderName: offer.lastProviderName,
+    offerStatus: offer.status,
+  })
   const formik = useFormik<{ stocks: IStockEventFormValues[] }>({
     initialValues,
     onSubmit,
-    validationSchema: getValidationSchema(minQuantity),
     // enableReinitialize is needed to reset dirty after submit (and not block after saving a draft)
     // mostly needed to reinitialize the form after initialValue update and so not submiting duplicated stocks
     // when clicking multiple times on "Save draft"
+    validationSchema: getValidationSchema(),
     enableReinitialize: true,
   })
-
   const handleNextStep =
     ({ saveDraft = false } = {}) =>
     () => {

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -107,6 +107,7 @@ describe('screens:StocksEvent:Edition', () => {
     offer = {
       id: 'OFFER_ID',
       lastProvider: null,
+      lastProviderName: null,
       venue: {
         departmentCode: '75',
       } as IOfferIndividualVenue,

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -113,6 +113,7 @@ describe('screens:StocksEvent', () => {
         departmentCode: '75',
       } as IOfferIndividualVenue,
       stocks: [],
+      lastProviderName: null,
     }
     props = {
       offer: offer as IOfferIndividual,

--- a/pro/src/screens/OfferIndividual/StocksEvent/adapters/__specs__/serializers.spec.ts
+++ b/pro/src/screens/OfferIndividual/StocksEvent/adapters/__specs__/serializers.spec.ts
@@ -28,6 +28,7 @@ describe('screens::StockEvent::serializers:serializeStockEventList', () => {
         bookingLimitDatetime: new Date('2022-10-26T23:00:00+0200'),
         price: '10',
         isDeletable: true,
+        readOnlyFields: [],
       },
     ]
     departementCode = '75'

--- a/pro/src/screens/OfferIndividual/StocksEvent/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksEvent/adapters/serializers.ts
@@ -20,15 +20,21 @@ const serializeBookingLimitDatetime = (
   )
 }
 
+const buildDateTime = (date: Date, time: Date) =>
+  set(date, {
+    hours: time.getHours(),
+    minutes: time.getMinutes(),
+  })
+
 export const serializeBeginningDateTime = (
   beginningDate: Date,
   beginningTime: Date,
   departementCode: string
 ): string => {
-  const beginningDateTimeInDepartementTimezone = set(beginningDate, {
-    hours: beginningTime.getHours(),
-    minutes: beginningTime.getMinutes(),
-  })
+  const beginningDateTimeInDepartementTimezone = buildDateTime(
+    beginningDate,
+    beginningTime
+  )
   const beginningDateTimeInUTCTimezone = getUtcDateTimeFromLocalDepartement(
     beginningDateTimeInDepartementTimezone,
     departementCode
@@ -78,10 +84,16 @@ export const serializeStockEventList = (
 ): StockCreationBodyModel[] | StockEditionBodyModel[] => {
   const today = getToday()
   return formValuesList
-    .filter(
-      stockFormValues =>
-        !stockFormValues.beginningDate || stockFormValues.beginningDate >= today
-    )
+    .filter(stockFormValues => {
+      const beginingDatetime =
+        stockFormValues.beginningDate && stockFormValues.beginningTime
+          ? buildDateTime(
+              stockFormValues.beginningDate,
+              stockFormValues.beginningTime
+            )
+          : null
+      return beginingDatetime === null || beginingDatetime >= today
+    })
     .map((formValues: IStockEventFormValues) =>
       serializeStockEvent(formValues, departementCode)
     )


### PR DESCRIPTION
..past event validation

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18998

## But de la pull request

* sur une offre avec 2 stock ayant des ‘bookingQuantity’ differentes
* je veux que la quantité minimum soit le `bookingQuantity’ de chaque stock.
* sur une offre ayant une stock dans le passé
* je ne veux pas avoir l’erreur “L'évènement doit être à venir” au submit.

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
