### PR TITLE
(BSR)[BO] fix: first user for an offerer

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -614,7 +614,9 @@ class Offerer(
     name: str = Column(String(140), nullable=False)
     sa.Index("idx_offerer_trgm_name", name, postgresql_using="gin")
 
-    UserOfferers: list["UserOfferer"] = sa.orm.relationship("UserOfferer", back_populates="offerer")
+    UserOfferers: list["UserOfferer"] = sa.orm.relationship(
+        "UserOfferer", order_by="UserOfferer.id", back_populates="offerer"
+    )
 
     siren = Column(
         String(9), nullable=True, unique=True
@@ -680,6 +682,14 @@ class Offerer(
         else:
             code = label = "Donnée indisponible"
         return {"code": code, "label": label}
+
+    @property
+    def first_user(self) -> "users_models.User | None":
+        # Currently there is no way to mark a UserOfferer as the owner/creator, so we consider that this first user
+        # is the oldest entry in the table. When creator leaves the offerer, next registered user becomes the "first".
+        if not self.UserOfferers:
+            return None
+        return self.UserOfferers[0].user
 
     @hybrid_property
     def isValidated(self) -> bool:

--- a/api/src/pcapi/routes/backoffice/offerers.py
+++ b/api/src/pcapi/routes/backoffice/offerers.py
@@ -391,13 +391,13 @@ def list_offerers_to_be_validated(
                     postalCode=offerer.postalCode,
                     city=offerer.city,
                     owner=(
-                        f"{offerer.UserOfferers[0].user.firstName} {offerer.UserOfferers[0].user.lastName}"
+                        f"{offerer.first_user.firstName} {offerer.first_user.lastName}"
                         if offerer.UserOfferers
                         else None
                     ),
-                    ownerId=offerer.UserOfferers[0].userId if offerer.UserOfferers else None,
-                    phoneNumber=(offerer.UserOfferers[0].user.phoneNumber if offerer.UserOfferers else None),
-                    email=(offerer.UserOfferers[0].user.email if offerer.UserOfferers else None),
+                    ownerId=offerer.first_user.id if offerer.UserOfferers else None,
+                    phoneNumber=(offerer.first_user.phoneNumber if offerer.UserOfferers else None),
+                    email=(offerer.first_user.email if offerer.UserOfferers else None),
                     lastComment=_get_serialized_offerer_last_comment(offerer),
                     isTopActor=offerers_api.is_top_actor(offerer),
                 )
@@ -484,10 +484,8 @@ def list_offerers_attachments_to_be_validated(
                     offererId=user_offerer.offerer.id,
                     offererName=user_offerer.offerer.name,
                     offererCreatedDate=format_into_utc_date(user_offerer.offerer.dateCreated),
-                    ownerId=user_offerer.offerer.UserOfferers[0].userId if user_offerer.offerer.UserOfferers else None,
-                    ownerEmail=(
-                        user_offerer.offerer.UserOfferers[0].user.email if user_offerer.offerer.UserOfferers else None
-                    ),
+                    ownerId=user_offerer.offerer.first_user.id if user_offerer.offerer.UserOfferers else None,
+                    ownerEmail=(user_offerer.offerer.first_user.email if user_offerer.offerer.UserOfferers else None),
                     siren=user_offerer.offerer.siren,
                 )
                 for user_offerer in paginated_users_offerers.items

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -65,7 +65,7 @@
                 <tbody>
                     {% for user_offerer in rows.items %}
                         {% set offerer = user_offerer.offerer %}
-                        {% set owner = offerer.UserOfferers[0].user if offerer.UserOfferers else none %}
+                        {% set owner = offerer.first_user %}
                         <tr>
                             <td>
                                 <div class="dropdown">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -78,7 +78,7 @@
                 </thead>
                 <tbody>
                     {% for offerer in rows.items %}
-                        {% set owner = offerer.UserOfferers[0].user if offerer.UserOfferers else none %}
+                        {% set owner = offerer.first_user %}
                         <tr>
                             <td>
                                 <div class="dropdown">

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -283,3 +283,23 @@ class HasPendingBankInformationApplicationTest:
         )
 
         assert venue.hasPendingBankInformationApplication is False
+
+
+class OffererFirstUserPropertyTest:
+    def test_first_user_when_none(self):
+        offerer = factories.OffererFactory()
+
+        assert offerer.first_user is None
+
+    def test_first_user_when_only_one(self):
+        offerer = factories.OffererFactory()
+        user_offerer = factories.UserOffererFactory(offerer=offerer)
+
+        assert offerer.first_user == user_offerer.user
+
+    def test_first_user_when_multiple(self):
+        offerer = factories.OffererFactory()
+        first = factories.UserOffererFactory(offerer=offerer)
+        factories.UserOffererFactory.create_batch(3, offerer=offerer)
+
+        assert offerer.first_user == first.user

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -1444,13 +1444,13 @@ class ListOfferersToBeValidatedTest:
         assert payload["city"] == user_offerer.offerer.city
         assert payload["owner"] == " ".join(
             (
-                user_offerer.offerer.UserOfferers[0].user.firstName,
-                user_offerer.offerer.UserOfferers[0].user.lastName,
+                user_offerer.offerer.first_user.firstName,
+                user_offerer.offerer.first_user.lastName,
             )
         )
-        assert payload["ownerId"] == user_offerer.offerer.UserOfferers[0].user.id
-        assert payload["phoneNumber"] == user_offerer.offerer.UserOfferers[0].user.phoneNumber
-        assert payload["email"] == user_offerer.offerer.UserOfferers[0].user.email
+        assert payload["ownerId"] == user_offerer.offerer.first_user.id
+        assert payload["phoneNumber"] == user_offerer.offerer.first_user.phoneNumber
+        assert payload["email"] == user_offerer.offerer.first_user.email
         assert payload["lastComment"] == {
             "author": "Inspecteur Validateur",
             "content": "Houlala",

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -522,13 +522,13 @@ class ListOfferersToValidateTest:
             assert rows[0]["Date de la demande"] == "03/10/2022"
             assert rows[0]["Dernier commentaire"] == "Houlala"
             assert rows[0]["SIREN"] == user_offerer.offerer.siren
-            assert rows[0]["Email"] == user_offerer.offerer.UserOfferers[0].user.email
+            assert rows[0]["Email"] == user_offerer.offerer.first_user.email
             assert (
-                rows[0]["Responsable Structure"] == f"{user_offerer.offerer.UserOfferers[0].user.firstName} "
-                f"{user_offerer.offerer.UserOfferers[0].user.lastName}"
+                rows[0]["Responsable Structure"] == f"{user_offerer.offerer.first_user.firstName} "
+                f"{user_offerer.offerer.first_user.lastName}"
             )
             assert rows[0]["Ville"] == user_offerer.offerer.city
-            assert rows[0]["Téléphone"] == user_offerer.offerer.UserOfferers[0].user.phoneNumber
+            assert rows[0]["Téléphone"] == user_offerer.offerer.first_user.phoneNumber
 
         @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
         def test_payload_content_no_action(self, authenticated_client):


### PR DESCRIPTION
## But de la pull request

`offerer.UserOfferer[0]` est utilisé pour récupérer la plus ancienne entrée, mais on ne pouvait pas s'en assurer.
Cela faisait échouer certains tests (aléatoirement ?).

## Implémentation

Tri de `offerer.UserOfferer` et ajout d'une propriété `offerer.first_user` pour plus de clarté.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
