### PR TITLE
(BSR)[API] fix: Fix send_reminder_venue_creation_to_pro when offerer has no user

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/reminder_venue_creation.py
+++ b/api/src/pcapi/core/mails/transactional/pro/reminder_venue_creation.py
@@ -1,13 +1,14 @@
 from pcapi.core import mails
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
-from pcapi.core.offerers.models import Offerer
-from pcapi.core.offerers.repository import find_new_offerer_user_email
+import pcapi.core.offerers.exceptions as offerers_exceptions
+import pcapi.core.offerers.models as offerers_models
+import pcapi.core.offerers.repository as offerers_repository
 from pcapi.settings import PRO_URL
 from pcapi.utils.human_ids import humanize
 
 
-def get_reminder_venue_creation_email_data(offerer: Offerer) -> models.TransactionalEmailData:
+def get_reminder_venue_creation_email_data(offerer: offerers_models.Offerer) -> models.TransactionalEmailData:
     return models.TransactionalEmailData(
         template=TransactionalEmail.REMINDER_VENUE_CREATION_TO_PRO.value,
         params={
@@ -17,9 +18,10 @@ def get_reminder_venue_creation_email_data(offerer: Offerer) -> models.Transacti
     )
 
 
-def send_reminder_venue_creation_to_pro(offerer: Offerer) -> bool:
-    recipient = find_new_offerer_user_email(offerer.id)
-    if not recipient:
+def send_reminder_venue_creation_to_pro(offerer: offerers_models.Offerer) -> bool:
+    try:
+        recipient = offerers_repository.find_new_offerer_user_email(offerer.id)
+    except offerers_exceptions.CannotFindOffererUserEmail:
         return True
     data = get_reminder_venue_creation_email_data(offerer)
     return mails.send(recipients=[recipient], data=data)


### PR DESCRIPTION
If an offerer does not have any user, `find_new_offerer_user_email()`
raises an exception that we should catch.