### PR TITLE
(PC-18884)[PRO] feat: add edit link in offer collective summary creation

### DIFF
--- a/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -73,7 +73,15 @@ const CollectiveOfferSummaryCreation = ({
         Vous y êtes presque !<br />
         Vérifiez les informations ci-dessous avant de publier votre offre.
       </Banner>
-      <CollectiveOfferSummary offer={offer} categories={categories} />
+      <CollectiveOfferSummary
+        offer={offer}
+        categories={categories}
+        offerEditLink={`/offre/collectif${offer.isTemplate ? '/vitrine' : ''}/${
+          offer.id
+        }/creation`}
+        stockEditLink={`/offre/${offer.id}/collectif/stocks/edition`}
+        visibilityEditLink={`/offre/${offer.id}/collectif/visibilite`}
+      />
       {isOfferFormV3 ? (
         <ActionsBarSticky>
           <ActionsBarSticky.Left>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18884

## But de la pull request

Ajouter des liens dans l'écran récap de création d'offre collective (vitrine ou non) pour revenir sur une des étapes précédentes (détails, stock, visibilité)

## Screenshot

![Capture d’écran 2022-12-01 à 16 46 41](https://user-images.githubusercontent.com/71768799/205097442-570895be-fd52-432d-bec4-2e18b3e7ee2d.png)