### PR TITLE
(BSR)[API] fix: add composite primary key to role_backoffice_profile

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-3ad10501291a (pre) (head)
+9f7d2f05b501 (pre) (head)
 51d8855b12f6 (post) (head)

--- a/api/src/pcapi/alembic/versions/20221201T175927_9f7d2f05b501_add_primary_key_to_role_backoffice_profile.py
+++ b/api/src/pcapi/alembic/versions/20221201T175927_9f7d2f05b501_add_primary_key_to_role_backoffice_profile.py
@@ -1,0 +1,58 @@
+"""add primary key to role_backoffice_profile
+"""
+from alembic import op
+
+
+revision = "9f7d2f05b501"
+down_revision = "3ad10501291a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Replace unique constraint by a composite primary key
+    """
+
+    op.execute(
+        """
+        BEGIN;
+
+        ALTER TABLE
+            role_backoffice_profile
+        DROP CONSTRAINT IF EXISTS
+            "role_backoffice_profile_roleId_profileId_key";
+
+        ALTER TABLE
+            role_backoffice_profile
+        ADD CONSTRAINT
+            "role_backoffice_profile_pkey"
+            PRIMARY KEY ("roleId", "profileId");
+
+        COMMIT;
+        """
+    )
+
+
+def downgrade() -> None:
+    """
+    Remove composite primary key and set back the unique constraint
+    """
+    op.execute(
+        """
+        BEGIN;
+
+        ALTER TABLE
+            role_backoffice_profile
+        DROP CONSTRAINT IF EXISTS
+            "role_backoffice_profile_pkey";
+
+        ALTER TABLE
+            role_backoffice_profile
+        ADD CONSTRAINT
+            "role_backoffice_profile_roleId_profileId_key"
+            UNIQUE("roleId", "profileId");
+
+        COMMIT;
+        """
+    )

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -111,9 +111,10 @@ class Roles(enum.Enum):
 role_backoffice_profile_table = sa.Table(
     "role_backoffice_profile",
     Base.metadata,
-    sa.Column("roleId", sa.ForeignKey("role.id", ondelete="CASCADE"), nullable=False),
-    sa.Column("profileId", sa.ForeignKey("backoffice_user_profile.id", ondelete="CASCADE"), nullable=False),
-    sa.UniqueConstraint("roleId", "profileId"),
+    sa.Column("roleId", sa.ForeignKey("role.id", ondelete="CASCADE"), nullable=False, primary_key=True),
+    sa.Column(
+        "profileId", sa.ForeignKey("backoffice_user_profile.id", ondelete="CASCADE"), nullable=False, primary_key=True
+    ),
 )
 
 


### PR DESCRIPTION
## But de la pull request

Ajout d'une clé primaire (composée) sur `role_backoffice_profile` et suppression de la contrainte d'unicité.