### PR TITLE
(PC-19036)[API] feat: fix venue name serialization for prebooking sen…

### DIFF
--- a/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
+++ b/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
@@ -175,7 +175,7 @@ def serialize_collective_booking(collective_booking: CollectiveBooking) -> Educa
         expirationDate=None,
         id=collective_booking.id,
         isDigital=False,
-        venueName=venue.name,
+        venueName=venue.publicName or venue.name,
         name=offer.name,
         numberOfTickets=stock.numberOfTickets,
         participants=[student.value for student in offer.students],


### PR DESCRIPTION
…d to adage

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19036

## But de la pull request

Modifier la sérialisation des prébookings envoyé à adage pour envoyer le publicName d'un lieu quand cette donnée est valorisée (venue.name sinon)
