### PR TITLE
(PC-19022)[BO] fix: date filters not consistent with request date because of timezones

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1394,8 +1394,8 @@ def _apply_query_filters(
     query: sa.orm.Query,
     tags: list[offerers_models.OffererTag] | None,
     status: list[offerers_models.ValidationStatus] | None,
-    from_date: datetime | None,
-    to_date: datetime | None,
+    from_datetime: datetime | None,
+    to_datetime: datetime | None,
     cls: typing.Type[offerers_models.Offerer | offerers_models.UserOfferer],
     offerer_id_column: sa.orm.InstrumentedAttribute,
 ) -> sa.orm.Query:
@@ -1425,13 +1425,11 @@ def _apply_query_filters(
             sa.and_(*(tagged_offerers.c.tags.any(tag.id) for tag in tags))
         )
 
-    if from_date:
-        min_datetime = datetime.combine(from_date, datetime.min.time())
-        query = query.filter(cls.dateCreated >= min_datetime)
+    if from_datetime:
+        query = query.filter(cls.dateCreated >= from_datetime)
 
-    if to_date:
-        max_datetime = datetime.combine(to_date, datetime.max.time())
-        query = query.filter(cls.dateCreated <= max_datetime)
+    if to_datetime:
+        query = query.filter(cls.dateCreated <= to_datetime)
 
     return query
 
@@ -1440,9 +1438,8 @@ def list_offerers_to_be_validated(
     q: str | None,  # search query
     tags: list[offerers_models.OffererTag] | None = None,
     status: list[offerers_models.ValidationStatus] | None = None,
-    from_date: datetime | None = None,
-    to_date: datetime | None = None,
-    **_: typing.Any,
+    from_datetime: datetime | None = None,
+    to_datetime: datetime | None = None,
 ) -> sa.orm.Query:
     query = offerers_models.Offerer.query.options(
         sa.orm.joinedload(offerers_models.Offerer.UserOfferers).joinedload(offerers_models.UserOfferer.user),
@@ -1461,7 +1458,7 @@ def list_offerers_to_be_validated(
             query = query.filter(sa.func.unaccent(offerers_models.Offerer.name).ilike(f"%{name}%"))
 
     return _apply_query_filters(
-        query, tags, status, from_date, to_date, offerers_models.Offerer, offerers_models.Offerer.id
+        query, tags, status, from_datetime, to_datetime, offerers_models.Offerer, offerers_models.Offerer.id
     )
 
 
@@ -1493,9 +1490,8 @@ def list_users_offerers_to_be_validated_legacy(filter_: list[dict[str, typing.An
 def list_users_offerers_to_be_validated(
     tags: list[offerers_models.OffererTag] | None = None,
     status: list[offerers_models.ValidationStatus] | None = None,
-    from_date: datetime | None = None,
-    to_date: datetime | None = None,
-    **_: typing.Any,
+    from_datetime: datetime | None = None,
+    to_datetime: datetime | None = None,
 ) -> sa.orm.Query:
     query = offerers_models.UserOfferer.query.options(
         sa.orm.joinedload(offerers_models.UserOfferer.user),
@@ -1508,7 +1504,13 @@ def list_users_offerers_to_be_validated(
     )
 
     return _apply_query_filters(
-        query, tags, status, from_date, to_date, offerers_models.UserOfferer, offerers_models.UserOfferer.offererId
+        query,
+        tags,
+        status,
+        from_datetime,
+        to_datetime,
+        offerers_models.UserOfferer,
+        offerers_models.UserOfferer.offererId,
     )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import datetime
 from functools import partial
 import typing
 
@@ -8,6 +9,7 @@ from flask import render_template
 from flask import request
 from flask import url_for
 from flask_login import current_user
+import pytz
 import sqlalchemy as sa
 from werkzeug.exceptions import NotFound
 
@@ -25,6 +27,18 @@ from . import search_utils
 from . import utils
 from .forms import offerer as offerer_forms
 from .serialization import offerers as serialization
+
+
+PARIS_TZ = pytz.timezone("Europe/Paris")
+
+
+def _date_to_localized_datetime(date_: datetime.date | None, time_: datetime.time) -> datetime.datetime | None:
+    # When min/max date filters are used in requests, backoffice user expect Metroplitan French time (CET),
+    # since date and time in the backoffice are formatted to show CET times.
+    if not date_:
+        return None
+    naive_utc_datetime = datetime.datetime.combine(date_, time_)
+    return PARIS_TZ.localize(naive_utc_datetime).astimezone(pytz.utc)
 
 
 offerer_blueprint = utils.child_backoffice_blueprint(
@@ -231,7 +245,13 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
     if not form.validate():
         return render_template("offerer/validation.html", rows=[], form=form, stats=stats), 400
 
-    offerers = offerers_api.list_offerers_to_be_validated(**form.data)
+    offerers = offerers_api.list_offerers_to_be_validated(
+        form.q.data,
+        form.tags.data,
+        form.status.data,
+        _date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
+        _date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
+    )
 
     sorted_offerers = offerers.order_by(offerers_models.Offerer.dateCreated.desc())
 
@@ -362,7 +382,12 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
     if not form.validate():
         return render_template("offerer/user_offerer_validation.html", rows=[], form=form), 400
 
-    users_offerers = offerers_api.list_users_offerers_to_be_validated(**form.data)
+    users_offerers = offerers_api.list_users_offerers_to_be_validated(
+        form.tags.data,
+        form.status.data,
+        _date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
+        _date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
+    )
 
     sorted_users_offerers = users_offerers.order_by(offerers_models.UserOfferer.id.desc())
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19022

## But de la pull request

Corriger les filtres de date dans la validation des structures et des rattachements (backoffice v3).
En effet les filtres étaient appliqués par rapport à `dateCreated` en UTC alors que la date de la demande, dans les écran du backoffice est affichée en heure française métropolitaine (CET). Cela pouvait amener des résultats affichés hors de la plage demandée pour des structures créées entre 23h et minuit.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
