### PR TITLE
(PC-19028)[PRO] fix: adage deployment

### DIFF
--- a/adage-front/package.json
+++ b/adage-front/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node scripts/start.js",
-    "build": "node scripts/build.js",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider node scripts/build.js",
     "build:development": "ENV=development yarn build",
     "build:testing": "ENV=testing yarn build",
     "build:staging": "ENV=staging yarn build",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19028

Activation d'une option legacy pour avoir le comportement de Node 16 dessus : 
https://stackoverflow.com/questions/69962209/what-is-openssl-legacy-provider-in-node-js-v17

Avant :

![image](https://user-images.githubusercontent.com/6317823/205313658-4bf3a496-c742-41ee-a523-a6697ea406d5.png)

Après : 

![image](https://user-images.githubusercontent.com/6317823/205313536-f2ac1bf7-4ac3-48c2-bfb3-604579965c27.png)



Spoiler alert mais le dossier adage-front sera probablement fusionné dans pro prochainement donc le build un peu custom de adage-front disparaitra en passant sur le build de pro qui est standard