### PR TITLE
(PC-19047)[API] fix: list index out of range at offer rejection

### DIFF
--- a/api/src/pcapi/templates/mails/offer_creation_notification_email.html
+++ b/api/src/pcapi/templates/mails/offer_creation_notification_email.html
@@ -27,15 +27,19 @@
         Adresse du lieu : {{ venue.city }} {{ venue.postalCode }}
     </p>
     <p id="pro_user_information">
-        Information de l'utilisateur pro ayant créé l'offre
-        <br>
-        Nom : {{ author.lastName }}
-        <br>
-        Prénom : {{ author.firstName }}
-        <br>
-        Téléphone : {{ author.phoneNumber }}
-        <br>
-        Email : {{ author.email }}
+        {% if author %}
+            Information de l'utilisateur pro ayant créé l'offre
+            <br>
+            Nom : {{ author.lastName }}
+            <br>
+            Prénom : {{ author.firstName }}
+            <br>
+            Téléphone : {{ author.phoneNumber }}
+            <br>
+            Email : {{ author.email }}
+        {% else %}
+            Aucun utilisateur pro n'est rattaché à la structure
+        {% endif %}
     </p>
 </body>
 

--- a/api/src/pcapi/templates/mails/offer_creation_refusal_notification_email.html
+++ b/api/src/pcapi/templates/mails/offer_creation_refusal_notification_email.html
@@ -27,15 +27,19 @@
         Adresse du lieu : {{ venue.city }} {{ venue.postalCode }}
     </p>
     <p id="pro_user_information">
-        Information de l'utilisateur pro ayant créé l'offre
-        <br>
-        Nom : {{ author.lastName }}
-        <br>
-        Prénom : {{ author.firstName }}
-        <br>
-        Téléphone : {{ author.phoneNumber }}
-        <br>
-        Email : {{ author.email }}
+        {% if author %}
+            Information de l'utilisateur pro ayant créé l'offre
+            <br>
+            Nom : {{ author.lastName }}
+            <br>
+            Prénom : {{ author.firstName }}
+            <br>
+            Téléphone : {{ author.phoneNumber }}
+            <br>
+            Email : {{ author.email }}
+        {% else %}
+            Aucun utilisateur pro n'est rattaché à la structure
+        {% endif %}
     </p>
 </body>
 

--- a/api/src/pcapi/utils/mailing.py
+++ b/api/src/pcapi/utils/mailing.py
@@ -85,7 +85,7 @@ def make_offerer_internal_validation_email(
 def make_offer_creation_notification_email(
     offer: Offer | CollectiveOffer | CollectiveOfferTemplate,
 ) -> mails_models.TransactionalWithoutTemplateEmailData:
-    author = getattr(offer, "author", None) or offer.venue.managingOfferer.UserOfferers[0].user
+    author = getattr(offer, "author", None) or offer.venue.managingOfferer.first_user
     venue = offer.venue
     pro_link_to_offer = urls.build_pc_pro_offer_link(offer)
     pro_venue_link = f"{settings.PRO_URL}/structures/{humanize(venue.managingOffererId)}/lieux/{humanize(venue.id)}"
@@ -112,7 +112,7 @@ def make_offer_creation_notification_email(
 def make_offer_rejection_notification_email(
     offer: Offer | CollectiveOfferTemplate | CollectiveOffer,
 ) -> mails_models.TransactionalWithoutTemplateEmailData:
-    author = getattr(offer, "author", None) or offer.venue.managingOfferer.UserOfferers[0].user
+    author = getattr(offer, "author", None) or offer.venue.managingOfferer.first_user
     pro_link_to_offer = urls.build_pc_pro_offer_link(offer)
     venue = offer.venue
     pro_venue_link = f"{settings.PRO_URL}/structures/{humanize(venue.managingOffererId)}/lieux/{humanize(venue.id)}"

--- a/api/tests/emails/offer_creation_test.py
+++ b/api/tests/emails/offer_creation_test.py
@@ -195,3 +195,17 @@ class MakeOfferRejectionNotificationEmailTest:
 
         # Then
         assert email.subject == "[Création d’offre : refus - numérique] Les lièvres pas malins"
+
+    def test_with_no_user_offerer(self):
+        # Given
+        offer = offers_factories.EventOfferFactory(
+            author=None,
+            product=offers_factories.DigitalProductFactory(name="Les lièvres pas malins"),
+            venue=offerers_factories.VirtualVenueFactory(),
+        )
+
+        # When
+        email = make_offer_rejection_notification_email(offer)
+
+        # Then
+        assert "Aucun utilisateur pro n'est rattaché à la structure" in email.html_content


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19047

## But de la pull request

Corriger une exception remontée par Sentry : 
`IndexError('list index out of range')`
lorsqu'une offre et rejetée, si la structure parente du lieu n'a plus aucun utilisateur rattaché.

C'est un cas à la marge, mais qui peut arrivée si on rejette la structure, puis qu'on rejette ses offres.

## Implémentation

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
