### PR TITLE
(PC-18745)[PRO] refactor: add hotjar to bundle

### DIFF
--- a/pro/public/index.html
+++ b/pro/public/index.html
@@ -9,33 +9,10 @@
     <meta name="version" content="%VERSION%">
     <% if (process.env.NODE_ENV === 'development') { %>
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com 'unsafe-inline'; connect-src 'self' data: https: http: ws://*:3001 wss://*:3001;">
+          content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com; connect-src 'self' data: https: http: ws://*:3001 wss://*:3001; style-src 'unsafe-inline">
     <% } else { %>
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com 'unsafe-inline';">
-    <% } %>
-    <% if (process.env.REACT_APP_ENVIRONMENT_NAME === 'production') { %>
-    <script>
-      (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:2925982,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-    </script>
-    <% } else { %>
-    <script>
-    (function(h,o,t,j,a,r){
-      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-      h._hjSettings={hjid:2968316,hjsv:6};
-      a=o.getElementsByTagName('head')[0];
-      r=o.createElement('script');r.async=1;
-      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-      a.appendChild(r);
-      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-    </script>
+          content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com; style-src 'unsafe-inline">
     <% } %>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/icon/app-icon-iphone.png">

--- a/pro/src/index.jsx
+++ b/pro/src/index.jsx
@@ -28,6 +28,26 @@ if (SENTRY_SERVER_URL) {
   })
 }
 
+// load and initialise hotjar library
+// included in the bundle instead of <script> tag in index.html
+// to avoid the need of 'insafe-inline' in Content Security Policy
+;(function (h, o, t, j, a, r) {
+  h.hj =
+    h.hj ||
+    function () {
+      ;(h.hj.q = h.hj.q || []).push(arguments)
+    }
+  h._hjSettings = {
+    hjid: ENVIRONMENT_NAME === 'production' ? 2925982 : 2968316,
+    hjsv: 6,
+  }
+  a = o.getElementsByTagName('head')[0]
+  r = o.createElement('script')
+  r.async = 1
+  r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv
+  a.appendChild(r)
+})(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=')
+
 smoothscroll.polyfill()
 
 // Start app


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18745

## But de la pull request

Permettre l'utilisation de hotjar sans avoir besoin de `unsafe-inline` dans la Content Security Policy pour l'exécuter (car cela constitue une faille de sécurité)

## Implémentation

- l'appel à hotjar se fait depuis le bundle
- `unsafe-inline` est conservé pour les styles uniquement (et non plus pour les scripts), ce sera un problème à régler dans un second temps

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
