### PR TITLE
(PC-17618)[PRO] fix: edit booked offer popup design

### DIFF
--- a/pro/src/screens/OfferIndividual/DialogStocksEventEditConfirm/DialogStocksEventEditConfirm.tsx
+++ b/pro/src/screens/OfferIndividual/DialogStocksEventEditConfirm/DialogStocksEventEditConfirm.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import ConfirmDialog from 'components/Dialog/ConfirmDialog'
-import { ReactComponent as Trash } from 'icons/ico-trash.svg'
 
 interface IDialogStocksEventEditConfirmProps {
   onConfirm: () => void
@@ -19,14 +18,16 @@ const DialogStocksEventEditConfirm = ({
       title="Des réservations sont en cours pour cette offre"
       confirmText="Confirmer les modifications"
       cancelText="Annuler"
-      icon={Trash}
     >
       <p>
         Si vous avez changé la date ou l'heure de l'évènement, les bénéficiaires
-        ayant déjà réservé en seront automatiquement informés par e-mail. Ils
-        disposeront alors à nouveau de 48h pour annuler leur réservation (sauf
-        si ce report a lieu dans moins de 48h).
+        ayant déjà réservé en seront automatiquement informés par e-mail.
       </p>
+      <p>
+        Ils disposeront alors à nouveau de 48h pour annuler leur réservation
+        (sauf si ce report a lieu dans moins de 48h).
+      </p>
+      <br />
       <p>
         Si vous avez changé le tarif de cette offre, celui-ci ne s'appliquera
         que pour les prochaines réservations.


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17618

Fix du design de la popup avertissant les utilisateurs : 
Avant : 
<img width="697" alt="image-20221202-113630" src="https://user-images.githubusercontent.com/95358853/205939382-3f40f1dd-9462-49e0-9dd8-4cd335f21df2.png">
Après : 
![Screenshot 2022-12-06 at 15 31 58](https://user-images.githubusercontent.com/95358853/205939533-81edbb68-f076-459a-bd31-60b0f21d63aa.png)
