### PR TITLE
(PC-18865)[PRO] fix: save draft toaster

### DIFF
--- a/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
@@ -11,6 +11,7 @@ import {
 import { computeOffersUrl, OFFER_WIZARD_MODE } from 'core/Offers'
 import { useOfferWizardMode } from 'hooks'
 import useAnalytics from 'hooks/useAnalytics'
+import useNotification from 'hooks/useNotification'
 import { ReactComponent as IcoMiniArrowLeft } from 'icons/ico-mini-arrow-left.svg'
 import { ReactComponent as IcoMiniArrowRight } from 'icons/ico-mini-arrow-right.svg'
 import { RootState } from 'store/reducers'
@@ -45,6 +46,7 @@ const ActionBar = ({
   const mode = useOfferWizardMode()
   const backOfferUrl = computeOffersUrl(offersSearchFilters, offersPageNumber)
   const { logEvent } = useAnalytics()
+  const notify = useNotification()
 
   const logCancel = () => {
     shouldTrack &&
@@ -131,7 +133,12 @@ const ActionBar = ({
               <ButtonLink
                 link={{ to: '/offres', isExternal: false }}
                 variant={ButtonVariant.SECONDARY}
-                onClick={logDraft}
+                onClick={() => {
+                  notify.success(
+                    'Brouillon sauvegardé dans la liste des offres'
+                  )
+                  logDraft()
+                }}
               >
                 Sauvegarder le brouillon et quitter
               </ButtonLink>

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -9,6 +9,7 @@ import {
   getValidationSchema,
   buildInitialValues,
   IStockEventFormValues,
+  STOCK_EVENT_FORM_DEFAULT_VALUES,
 } from 'components/StockEventForm'
 import { useOfferIndividualContext } from 'context/OfferIndividualContext'
 import {
@@ -127,6 +128,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
     lastProviderName: offer.lastProviderName,
     offerStatus: offer.status,
   })
+
   const formik = useFormik<{ stocks: IStockEventFormValues[] }>({
     initialValues,
     onSubmit,
@@ -136,6 +138,13 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
     validationSchema: getValidationSchema(),
     enableReinitialize: true,
   })
+
+  const isFormEmpty = () => {
+    return formik.values.stocks.every(
+      val => val === STOCK_EVENT_FORM_DEFAULT_VALUES
+    )
+  }
+
   useNotifyFormError({
     isSubmitting: formik.isSubmitting,
     errors: formik.errors,
@@ -149,6 +158,12 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   const handleNextStep =
     ({ saveDraft = false } = {}) =>
     () => {
+      // When saving draft with an empty form
+      // we display a success notification even if nothing is done
+      if (saveDraft && isFormEmpty()) {
+        notify.success('Brouillon sauvegardé dans la liste des offres')
+        return
+      }
       // tested but coverage don't see it.
       /* istanbul ignore next */
       setIsSubmittingDraft(saveDraft)

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -23,7 +23,6 @@ import {
   IOfferIndividualVenue,
 } from 'core/Offers/types'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
-import { FORM_ERROR_MESSAGE } from 'core/shared'
 import { RootState } from 'store/reducers'
 import { configureTestStore } from 'store/testUtils'
 import { getToday } from 'utils/date'
@@ -286,12 +285,14 @@ describe('screens:StocksEvent', () => {
     //   screen.getByText('API bookingLimitDatetime ERROR')
     // ).toBeInTheDocument()
   })
-  it('should show a error notification if nothing has been touched', async () => {
+  it('should show a success notification if nothing has been touched', async () => {
     renderStockEventScreen({ props, storeOverride, contextValue })
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
     )
-    expect(screen.getByText(FORM_ERROR_MESSAGE)).toBeInTheDocument()
+    expect(
+      screen.getByText('Brouillon sauvegardé dans la liste des offres')
+    ).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -149,6 +149,10 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
     setShouldTrack(!formik.dirty)
   }, [formik.dirty])
 
+  const isFormEmpty = () => {
+    return formik.values === STOCK_THING_FORM_DEFAULT_VALUES
+  }
+
   useNotifyFormError({
     isSubmitting: formik.isSubmitting,
     errors: formik.errors,
@@ -157,6 +161,12 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
   const handleNextStep =
     ({ saveDraft = false } = {}) =>
     () => {
+      // When saving draft with an empty form
+      // we display a success notification even if nothing is done
+      if (saveDraft && isFormEmpty()) {
+        notify.success('Brouillon sauvegardé dans la liste des offres')
+        return
+      }
       // tested but coverage don't see it.
       /* istanbul ignore next */
       setIsSubmittingDraft(saveDraft)

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -26,7 +26,6 @@ import {
   getOfferIndividualPath,
   getOfferIndividualUrl,
 } from 'core/Offers/utils/getOfferIndividualUrl'
-import { FORM_ERROR_MESSAGE } from 'core/shared'
 import { RootState } from 'store/reducers'
 import { configureTestStore } from 'store/testUtils'
 
@@ -423,12 +422,14 @@ describe('screens:StocksThing', () => {
       expect(expirationInput).toHaveValue('15/12/2020')
     })
 
-    it('should show a error notification if nothing has been touched', async () => {
+    it('should show a success notification if nothing has been touched', async () => {
       renderStockThingScreen({ props, storeOverride, contextValue })
       await userEvent.click(
         screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
       )
-      expect(screen.getByText(FORM_ERROR_MESSAGE)).toBeInTheDocument()
+      expect(
+        screen.getByText('Brouillon sauvegardé dans la liste des offres')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
@@ -598,6 +598,25 @@ describe('Summary', () => {
       }
     )
 
+    it('should display a notification when saving as draft', async () => {
+      // when
+      renderSummary({
+        props,
+        url: generatePath(
+          getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+            mode: OFFER_WIZARD_MODE.CREATION,
+          }),
+          { offerId: 'AA' }
+        ),
+      })
+      await userEvent.click(
+        screen.getByText('Sauvegarder le brouillon et quitter')
+      )
+      expect(
+        screen.getByText('Brouillon sauvegardé dans la liste des offres')
+      ).toBeInTheDocument()
+    })
     it('should not display pre publishing banner in edition mode', () => {
       // when
       renderSummary({


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18865

- Toaster quand on sauvegarde un image en edition
- Toaster quand on sauvegarde un draft depuis la page de recap
- Toaster de success quand on sauvegarde un draft sur la page stock sans rien dans le form