### PR TITLE
(BSR)ci: dont use Docker layer caching for venv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -856,6 +856,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 19.03.13
+          docker_layer_caching: true
       - authenticate-gcp:
           gcp-key-name: GCP_INFRA_KEY
       - authenticate_gcp_docker_registry:
@@ -868,7 +869,8 @@ jobs:
               docker build ./api \
                 -f ./api/Dockerfile \
                 --target pcapi \
-                -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi:${CIRCLE_SHA1}
+                -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi:${CIRCLE_SHA1} \
+                --build-arg CACHE_DATE="$(date +%Y-%m-%d:%H:%M:%S)"
               docker push ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi:${CIRCLE_SHA1}
       - when:
           condition:
@@ -881,7 +883,8 @@ jobs:
                   docker build ./api \
                     -f ./api/Dockerfile \
                     --target pcapi-console \
-                    -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-console:${CIRCLE_SHA1}
+                    -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-console:${CIRCLE_SHA1} \
+                    --build-arg CACHE_DATE=$(date +%Y-%m-%d:%H:%M:%S)
                   docker push ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-console:${CIRCLE_SHA1}
       - when:
           condition:
@@ -894,7 +897,8 @@ jobs:
                   docker build ./api \
                     -f ./api/Dockerfile \
                     --target pcapi-tests \
-                    -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-tests:${CIRCLE_SHA1}
+                    -t ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-tests:${CIRCLE_SHA1} \
+                    --build-arg CACHE_DATE=$(date +%Y-%m-%d:%H:%M:%S)
                   docker push ${GCP_REGION}-docker.pkg.dev/${GCP_INFRA_PROJECT}/${GCP_REGISTRY_NAME}/pcapi-tests:${CIRCLE_SHA1}
       - run:
           name: Send failure notification

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -63,6 +63,10 @@ jobs:
         push: true
         target: pcapi
         tags: ${{ env.DOCKER_REPO }}/pcapi:${{ inputs.tag }}
+        build-args: |
+          CACHE_DATE="$(date +%Y-%m-%d:%H:%M:%S)"
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: "Build and push pcapi-console image"
       uses: docker/build-push-action@v2
       if: ${{ inputs.console == true }}
@@ -71,6 +75,10 @@ jobs:
         push: true
         target: pcapi-console
         tags: ${{ env.DOCKER_REPO }}/pcapi-console:${{ inputs.tag }}
+        build-args: |
+          CACHE_DATE="$(date +%Y-%m-%d:%H:%M:%S)"
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: "Build and push pcapi-tests image"
       uses: docker/build-push-action@v2
       if: ${{ inputs.tests == true }}
@@ -79,3 +87,7 @@ jobs:
         push: true
         target: pcapi-tests
         tags: ${{ env.DOCKER_REPO }}/pcapi-tests:${{ inputs.tag }}
+        build-args: |
+          CACHE_DATE="$(date +%Y-%m-%d:%H:%M:%S)"
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -15,6 +15,8 @@ ENV PYTHONUNBUFFERED 1
 
 COPY ./requirements.txt ./
 
+ARG CACHE_DATE=2022-12-07:11:11:00
+
 RUN pip install --user \
 	--requirement ./requirements.txt
 


### PR DESCRIPTION
Unpinned Python dependencies might change between two builds, so we add a build variable that will change at each run in order to invalidate the subsequent build steps

## But de la pull request

Utiliser du cache pour construire les images Docker, sauf pour la construction de l'environnement virtuel Python, afin d'éviter les soucis de dépendances implicites

## Implémentation

- Dans le Dockerfile, ajout d'une variable qui change à chaque build et qui invalide le cache des étapes suivantes (`pip install`)
