### PR TITLE
(PC-18369)[BO] feat: Show Adage id in venue details page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -85,9 +85,9 @@
                     <div class="col-lg-4">
                         <p class="mb-1">
                             <span class="fw-bold">Éligible EAC :
-                                {% if is_collective_eligible %}
-                                    <span class="mx-4 pb-1 badge rounded-pill text-bg-success">
-                                    <i class="bi bi-check-circle"></i> Oui
+                                {% if venue.adageId %}
+                                    <span class="mx-2 pb-1 badge rounded-pill text-bg-success">
+                                        <i class="bi bi-check-circle"></i> Oui
                                     </span>
                                 {% else %}
                                     <span class="mx-2 pb-1 badge rounded-pill text-bg-dark">
@@ -96,6 +96,13 @@
                                 {% endif %}
                             </span>
                         </p>
+
+                        {% if venue.adageId %}
+                            <p class="mb-1">
+                                <span class="fw-bold">ID Adage :</span>
+                                {{ venue.adageId }}
+                            </p>
+                        {% endif %}
 
                         {% if venue.venueTypeCode %}
                             <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -89,7 +89,6 @@ def get(venue_id: int) -> utils.BackofficeResponse:
         region=region,
         has_reimbursement_point=has_reimbursement_point(venue),
         dms_stats=dms_stats,
-        is_collective_eligible=venue.venueEducationalStatusId is not None,
     )
 
 

--- a/api/tests/routes/backoffice_v3/helpers/html_parser.py
+++ b/api/tests/routes/backoffice_v3/helpers/html_parser.py
@@ -7,6 +7,11 @@ def _filter_whitespaces(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
+def content_as_text(html_content: str) -> str:
+    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+    return _filter_whitespaces(soup.text)
+
+
 def extract_table_rows(html_content: str) -> list[dict[str, str]]:
     """
     Extract data from html table (thead + tbody), so that we can compare with expected data when testing routes.


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18369

## But de la pull request

Ajout de la donnée ID Adage en dessous de “Éligible EAC”
Afficher ID Adage uniquement s’il existe
Si l’ID Adage est renseigné, Eligible EAC = OUI

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
