### PR TITLE
(PC-18967)[BO] feat: Link to PC Pro from offerer and venue details pages

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -7,6 +7,7 @@ from flask import Flask
 import pytz
 
 from pcapi.core.users import models as users_models
+from pcapi.utils import urls
 
 
 PARIS_TZ = pytz.timezone("Europe/Paris")
@@ -102,3 +103,5 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_bool"] = format_bool
     app.jinja_env.filters["format_string_list"] = format_string_list
     app.jinja_env.filters["parse_referrer"] = parse_referrer
+    app.jinja_env.filters["pc_pro_offerer_link"] = urls.build_pc_pro_offerer_link
+    app.jinja_env.filters["pc_pro_venue_link"] = urls.build_pc_pro_venue_link

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -19,7 +19,10 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="card-title mb-3">
-                    {{ offerer.name }}
+                    <a href="{{ offerer | pc_pro_offerer_link }}" target="_blank"
+                       class="text-decoration-none hover-text-underline">
+                        {{ offerer.name | escape }}
+                    </a>
 
                     <span class="fs-5 ps-4 mb-3 align-middle">
                         {{ build_offerer_badges(offerer) }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -8,7 +8,10 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="card-title mb-3">
-                    {{ venue.name }}
+                    <a href="{{ venue | pc_pro_venue_link }}" target="_blank"
+                       class="text-decoration-none hover-text-underline">
+                        {{ venue.name | escape }}
+                    </a>
 
                     <span class="fs-5 ps-4 mb-3 align-middle">
                         {{ build_venue_badges(venue) }}

--- a/api/src/pcapi/static/backoffice/css/base.css
+++ b/api/src/pcapi/static/backoffice/css/base.css
@@ -19,3 +19,7 @@ select.dropdown-menu option.dropdown-item:checked {
     background-color: rgb(var(--bs-primary-rgb));
     color: white;
 }
+
+a.hover-text-underline:hover {
+    text-decoration: underline !important;
+}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Sur le profil d’un acteur culturel, rendre le nom d’une structure ou d’un lieu cliquable (le nom est souligné au passage de la souris) afin de rediriger l’utilisateur vers la fiche correspondante de l’AC sur le portail pro

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
