### PR TITLE
(PC-19143)[API] fix: exception in FA when a venue with allocine pivot is deleted

### DIFF
--- a/api/src/pcapi/scripts/offerer/delete_cascade_offerer_by_id.py
+++ b/api/src/pcapi/scripts/offerer/delete_cascade_offerer_by_id.py
@@ -18,6 +18,7 @@ from pcapi.core.offers.models import Mediation
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import Stock
+from pcapi.core.providers.models import AllocinePivot
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.core.providers.models import VenueProvider
@@ -84,6 +85,10 @@ def delete_cascade_offerer_by_id(offerer_id: int) -> None:
     deleted_allocine_venue_providers_count = AllocineVenueProvider.query.filter(
         AllocineVenueProvider.id == VenueProvider.id,
         VenueProvider.venueId == Venue.id,
+        Venue.managingOffererId == offerer_id,
+    ).delete(synchronize_session=False)
+    deleted_allocine_pivot_count = AllocinePivot.query.filter(
+        AllocinePivot.venueId == Venue.id,
         Venue.managingOffererId == offerer_id,
     ).delete(synchronize_session=False)
 
@@ -193,6 +198,7 @@ def delete_cascade_offerer_by_id(offerer_id: int) -> None:
         "deleted_venues_count": deleted_venues_count,
         "deleted_venue_providers_count": deleted_venue_providers_count,
         "deleted_allocine_venue_providers_count": deleted_allocine_venue_providers_count,
+        "deleted_allocine_pivot_count": deleted_allocine_pivot_count,
         "deleted_offers_count": deleted_offers_count,
         "deleted_mediations_count": deleted_mediations_count,
         "deleted_favorites_count": deleted_favorites_count,

--- a/api/src/pcapi/scripts/offerer/delete_cascade_venue_by_id.py
+++ b/api/src/pcapi/scripts/offerer/delete_cascade_venue_by_id.py
@@ -13,6 +13,7 @@ from pcapi.core.offers.models import ActivationCode
 from pcapi.core.offers.models import Mediation
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
+from pcapi.core.providers.models import AllocinePivot
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.core.providers.models import VenueProvider
@@ -83,6 +84,7 @@ def delete_cascade_venue_by_id(venue_id: int) -> None:
         VenueProvider.venueId == venue_id,
         Venue.id == venue_id,
     ).delete(synchronize_session=False)
+    deleted_allocine_pivot_count = AllocinePivot.query.filter_by(venueId=venue_id).delete(synchronize_session=False)
 
     offer_ids_to_delete = [id[0] for id in db.session.query(Offer.id).filter(Offer.venueId == venue_id).all()]
     collective_offer_ids_to_delete = [
@@ -150,6 +152,7 @@ def delete_cascade_venue_by_id(venue_id: int) -> None:
         "deleted_venues_count": deleted_venues_count,
         "deleted_venue_providers_count": deleted_venue_providers_count,
         "deleted_allocine_venue_providers_count": deleted_allocine_venue_providers_count,
+        "deleted_allocine_pivot_count": deleted_allocine_pivot_count,
         "deleted_business_unit_venue_links": deleted_business_unit_venue_links_count,
         "deleted_offers_count": deleted_offers_count,
         "deleted_collective_offers_count": deleted_collective_offers_count,

--- a/api/tests/scripts/offerer/delete_cascade_venue_by_id_test.py
+++ b/api/tests/scripts/offerer/delete_cascade_venue_by_id_test.py
@@ -19,6 +19,7 @@ from pcapi.core.offers.models import Mediation
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
 import pcapi.core.providers.factories as providers_factories
+from pcapi.core.providers.models import AllocinePivot
 from pcapi.core.providers.models import AllocineVenueProvider
 from pcapi.core.providers.models import AllocineVenueProviderPriceRule
 from pcapi.core.providers.models import Provider
@@ -248,6 +249,8 @@ def test_delete_cascade_venue_should_remove_synchronization_to_allocine_provider
     venue_to_delete = offerers_factories.VenueFactory()
     providers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider__venue=venue_to_delete)
     providers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider__venue=venue)
+    providers_factories.AllocinePivotFactory(venue=venue_to_delete)
+    providers_factories.AllocinePivotFactory(venue=venue, theaterId="ABCDEFGHIJKLMNOPQR==", internalId="PABCDE")
 
     # When
     delete_cascade_venue_by_id(venue_to_delete.id)
@@ -257,4 +260,5 @@ def test_delete_cascade_venue_should_remove_synchronization_to_allocine_provider
     assert VenueProvider.query.count() == 1
     assert AllocineVenueProvider.query.count() == 1
     assert AllocineVenueProviderPriceRule.query.count() == 1
+    assert AllocinePivot.query.count() == 1
     assert Provider.query.count() > 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19143

## But de la pull request

Corriger l'exception remontée par Sentry :
https://sentry.passculture.team/organizations/sentry/issues/401572/?project=5&referrer=slack

## Implémentation

Les objets liés à Allocine sont supprimés à la suppression d'un lieu, sauf dans `AllocinePivot`, qui gardait donc une référence sur le lieu et en empêchait la suppression. Par cohérence, on le supprime donc aussi.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
