### PR TITLE
(PC-18848)[BO] feat: Show website in venue details page

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -240,7 +240,7 @@ class VenueContactFactory(BaseFactory):
 
     venue = factory.SubFactory(VenueFactory)
     email = "contact@venue.com"
-    website = "https://my@website.com"
+    website = "https://my.website.com"
     phone_number = "+33102030405"
     social_medias = {"instagram": "http://instagram.com/@venue"}
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -131,6 +131,16 @@
                             <span class="fw-bold">Présence de CB :</span>
                             {{ has_reimbursement_point | format_bool }}
                         </p>
+
+                        {% if venue.contact and venue.contact.website %}
+                            <p class="mb-1">
+                                <span class="fw-bold">Site web :</span>
+                                <a href="{{ venue.contact.website | escape }}" target="_blank"
+                                   class="text-decoration-none">
+                                    {{ venue.contact.website | escape }}
+                                </a>
+                            </p>
+                        {% endif %}
                     </div>
 
                     <div class="col-lg-4">

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -69,10 +69,11 @@ class GetVenueTest:
         response_text = html_parser.content_as_text(response.data)
         assert "Éligible EAC : Non" in response_text
         assert "ID Adage" not in response_text
+        assert f"Site web : {venue.contact.website}" in response_text
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_get_venue_with_adage_id(self, authenticated_client):
-        venue = offerers_factories.VenueFactory(adageId="7122022")
+        venue = offerers_factories.VenueFactory(adageId="7122022", contact=None)
 
         with assert_no_duplicated_queries():
             response = authenticated_client.get(url_for("backoffice_v3_web.venue.get", venue_id=venue.id))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18848

## But de la pull request

Si un URL de site web est déclaré sur PC pro pour un lieu, alors l’URL doit s’afficher sur le profil du lieu concerné dans le back office
- afficher la donnée “Site web : xxxxxxx” uniquement s’il existe une valeur
- Cette donnée doit être présente dans le bloc d’informations générales sur le profil lieu
- l’URL doit être cliquable et redirige l’utilisateur vers le site correspondant (sur un nouvel onglet de préférence)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
