### PR TITLE
(BSR) Fix DB checks in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,8 @@ jobs:
           name: Check for alembic multiple heads
           command: |
             LINE_COUNT=$(wc -l \<<< "$(alembic heads)")
-            if [${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
+            echo "Found "$LINE_COUNT" head(s)"
+            if [ ${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
           working_directory: /usr/src/app
       - run:
           name: Check database and model are aligned

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -142,9 +142,11 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.tests_docker_image }}
+          shell: bash
           run: |
-            LINE_COUNT=$(wc -l \<<< "$(alembic heads)")
-            if [${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
+            LINE_COUNT=$(wc -l <<< "$(alembic heads)")
+            echo "Found "$LINE_COUNT" head(s)"
+            if [ ${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
       - name: Check database and model are aligned
         uses: addnab/docker-run-action@v3
         with:

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -110,7 +110,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: postgis/postgis:12-3.3-alpine
+        image: cimg/postgres:12.9-postgis
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -95,10 +95,7 @@ jobs:
     needs:
       - check-api-folder-changes
       - build-tests-docker-image
-#  FIXME: this job fails since dbb3f7e8ec16ca66af88a0320ea83aae61d0cc8e on GitHub Action (but
-#  not on CircleCI). It blocks deployment on testing. Restore it when fixed.
-#    if: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
-    if: ${{ 1 == 2 }}
+    if: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## But de la pull request

Corriger les configurations de CI

## Implémentation

- réactiver le step tests-api dans GHA
- Corriger la syntaxe de `Check for alembic multiple heads` dans chaque CI
- Corriger l'image Docker de Postgres utilisée pour GHA

## Informations supplémentaires

- On doit utiliser `bash` pour les commandes exécutées en CI, et il ne faut pas oublier de l'utiliser en local pendant le développement (et non `zsh` sur Mac)