### PR TITLE
Fix DB squash for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
           RUN_ENV: tests
           DATABASE_URL_TEST: postgresql://pytest:pytest@localhost:5432/pass_culture
           REDIS_URL: redis://localhost:6379
-      - image: cimg/postgres:12.9-postgis
+      - image: cimg/postgres:12.12-postgis
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
@@ -430,7 +430,7 @@ jobs:
           DATABASE_URL: postgresql://pytest:pytest@localhost:5432/pass_culture
           DATABASE_URL_TEST: postgresql://pytest:pytest@localhost:5432/pass_culture
           GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp_infra_key.json
-      - image: cimg/postgres:12.9-postgis
+      - image: cimg/postgres:12.12-postgis
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -110,7 +110,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: cimg/postgres:12.9-postgis
+        image: postgis/postgis:12-3.3-alpine
         ports:
           - 5432:5432
         options: >-

--- a/api/src/pcapi/alembic/versions/sql/schema_init.sql
+++ b/api/src/pcapi/alembic/versions/sql/schema_init.sql
@@ -16,11 +16,16 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+
+-- Manually added, for Alembic
+
+CREATE TABLE IF NOT EXISTS public.alembic_version (version_num character varying(32) NOT NULL);
+
 --
 -- Name: tiger; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA tiger;
+CREATE SCHEMA IF NOT EXISTS tiger;
 
 
 
@@ -28,7 +33,7 @@ CREATE SCHEMA tiger;
 -- Name: tiger_data; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA tiger_data;
+CREATE SCHEMA IF NOT EXISTS tiger_data;
 
 
 
@@ -36,7 +41,7 @@ CREATE SCHEMA tiger_data;
 -- Name: topology; Type: SCHEMA; Schema: -; Owner: pass_culture
 --
 
-CREATE SCHEMA topology;
+CREATE SCHEMA IF NOT EXISTS topology;
 
 
 

--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -39,3 +39,5 @@ if __name__ == "__main__":
 
     set_tag("pcapi.app_type", "app")
     app.run(host="0.0.0.0", port=port, debug=True, use_reloader=True)
+
+    # welp


### PR DESCRIPTION
## But de la pull request

Corriger les erreurs de CI lors des commandes alembic

## Implémentation

- Corriger manuellement le script SQL d'initialisation

## Informations supplémentaires

- On utilise l'image [postgis-12.3.3](https://github.com/postgis/docker-postgis/tree/master/12-3.3/alpine) sur GHA, qui comporte Postgres 12.13 et Postgis 3.3
- On utilise l'image [cimg/postgres-12.12](https://github.com/CircleCI-Public/cimg-postgres/tree/main/12.9) sur CircleCI, qui qui comporte Postgres 12.12 et Postgis 3.1.4
