### PR TITLE
(PC-18883)[PRO] fix: create offer important bubble venue

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
@@ -32,7 +32,8 @@ const FormVenue = ({
     ]
   }
 
-  const { values } = useFormikContext<IOfferEducationalFormValues>()
+  const { values, setFieldValue } =
+    useFormikContext<IOfferEducationalFormValues>()
 
   return (
     <FormLayout.Section
@@ -41,6 +42,7 @@ const FormVenue = ({
     >
       <FormLayout.Row>
         <Select
+          onChange={() => setFieldValue('venueId', '')}
           disabled={offerersOptions.length === 1 || disableForm}
           label={OFFERER_LABEL}
           name="offererId"
@@ -66,20 +68,6 @@ const FormVenue = ({
           du ministère de la Culture.
         </Banner>
       )}
-
-      {venuesOptions.length === 0 && offerersOptions.length !== 0 && (
-        <Banner
-          links={[
-            {
-              href: `/structures/${values.offererId}/lieux/creation`,
-              linkTitle: 'Renseigner un lieu',
-            },
-          ]}
-        >
-          Pour proposer des offres à destination d’un groupe scolaire, vous
-          devez renseigner un lieu pour pouvoir être remboursé.
-        </Banner>
-      )}
       {offerersOptions.length === 0 && (
         <Banner>
           Vous ne pouvez pas créer d’offre collective tant que votre structure
@@ -95,6 +83,19 @@ const FormVenue = ({
             options={venuesOptions}
           />
         </FormLayout.Row>
+      )}
+      {values.venueId.length === 0 && values.offererId.length !== 0 && (
+        <Banner
+          links={[
+            {
+              href: `/structures/${values.offererId}/lieux/creation`,
+              linkTitle: 'Renseigner un lieu',
+            },
+          ]}
+        >
+          Pour proposer des offres à destination d’un groupe scolaire, vous
+          devez renseigner un lieu pour pouvoir être remboursé.
+        </Banner>
       )}
     </FormLayout.Section>
   )

--- a/pro/src/ui-kit/form/Select/Select.tsx
+++ b/pro/src/ui-kit/form/Select/Select.tsx
@@ -1,5 +1,5 @@
 import { useField } from 'formik'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { SelectOption } from 'custom_types/form'
 
@@ -33,6 +33,7 @@ const Select = ({
   hideFooter,
   description,
   inline,
+  onChange,
   ...selectAttributes
 }: ISelectProps): JSX.Element => {
   const [field, meta, helpers] = useField({ name, type: 'select' })
@@ -46,6 +47,16 @@ const Select = ({
       helpers.setValue(options[0].value)
     }
   }, [options, helpers, field, isOptional])
+
+  const onCustomChange = useCallback(
+    async (e: React.ChangeEvent<HTMLSelectElement>) => {
+      field.onChange(e)
+      if (onChange) {
+        onChange(e)
+      }
+    },
+    [field, onChange]
+  )
 
   return (
     <FieldLayout
@@ -65,8 +76,9 @@ const Select = ({
         hasDescription={description !== undefined}
         options={options}
         defaultOption={defaultOption}
-        {...selectAttributes}
         {...field}
+        {...selectAttributes}
+        onChange={e => onCustomChange(e)}
       />
 
       {description && <span>{description}</span>}

--- a/pro/src/ui-kit/form/Select/SelectInput.tsx
+++ b/pro/src/ui-kit/form/Select/SelectInput.tsx
@@ -1,16 +1,15 @@
 import cn from 'classnames'
-import React from 'react'
+import React, { ComponentProps } from 'react'
 
 import { SelectOption } from 'custom_types/form'
 
 import { ReactComponent as Down } from './assets/down.svg'
 import styles from './Select.module.scss'
 
-interface ISelectInputProps {
+interface ISelectInputProps extends ComponentProps<'select'> {
   name: string
   defaultOption?: SelectOption | null
   options: SelectOption[]
-  disabled?: boolean
   hasError?: boolean
   hasDescription?: boolean
   value: string


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18883

## But de la pull request

Ne plus afficher la bulle importante pour le lieu quand aucune structure est sélectionnée.
Régler un bug lorsqu'on passait d'une structure non validé avec 1 lieu à une structure validé avec deux lieux, le formulaire était accessible sans renseigner de lieu 

## Implémentation

Changer la condition d'affichage de la bulle importante pour les lieux, pouvoir utiliser un onChange dans notre composant Select qui permet de mettre à jour la valeur du lieu dans le formulaire pour pouvoir le réinitialiser à chaque changement de structure.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
