### PR TITLE
(PC-18394)[API] feat: add item collection details to product creation payload

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -144,6 +144,7 @@ def post_product_offer(body: serialization.ProductOfferCreationBody) -> serializ
                 url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
                 venue=venue,
                 visual_disability_compliant=body.disability_compliance.visual_disability_compliant,
+                withdrawal_details=body.item_collection.details if body.item_collection else None,
             )
 
             if body.stock:

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -183,8 +183,17 @@ class StockBody(serialization.BaseModel):
         alias_generator = to_camel
 
 
+class ItemCollection(serialization.BaseModel):
+    details: str | None = pydantic.Field(
+        None,
+        description="Further information that will be provided to the beneficiary to ease the offer collection.",
+        example="Opening hours, specific office, collection period, access code, email annoucement...",
+    )
+
+
 class ProductOfferCreationBody(OfferCreationBase):
     category_related_fields: category_related_fields
+    item_collection: ItemCollection | None
     stock: StockBody | None
 
 

--- a/api/tests/routes/public/individual_offers/v0/endpoints_test.py
+++ b/api/tests/routes/public/individual_offers/v0/endpoints_test.py
@@ -88,6 +88,7 @@ class PostProductTest:
                     "credit": "Jean-Crédit Photo",
                     "file": image_data.GOOD_IMAGE,
                 },
+                "itemCollection": {"details": "A retirer au 6ème sous-sol du parking de la gare entre minuit et 2"},
                 "location": {"type": "physical", "venueId": venue.id},
                 "name": "Le champ des possibles",
                 "stock": {
@@ -118,6 +119,7 @@ class PostProductTest:
         assert created_offer.description == "Enregistrement pour la nuit des temps"
         assert created_offer.externalTicketOfficeUrl == "https://maposaic.com"
         assert created_offer.status == offer_mixin.OfferStatus.EXPIRED
+        assert created_offer.withdrawalDetails == "A retirer au 6ème sous-sol du parking de la gare entre minuit et 2"
 
         created_stock = offers_models.Stock.query.one()
         assert created_stock.price == decimal.Decimal("12.34")


### PR DESCRIPTION
J'ai choisi de mettre ça dans une payload nestée :
```
itemCollection: {
   details: str | None
}
```
car pour les événements je prévois d'avoir :
```
itemCollection: {
   details: str | None
   ticketCollectionWay: "sur place" | "à emporter" | "par email"
   ticketSendingDelay : "30 minutes avant l'événement"
}
```