### PR TITLE
(PC-19144)[BO] fix: update public account

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -137,7 +137,7 @@ def edit_public_account(user_id: int) -> utils.BackofficeResponse:
     return render_template("accounts/edit.html", form=form, dst=dst, user=user)
 
 
-@blueprint.backoffice_v3_web.route("/public_accounts/<int:user_id>", methods=["PATCH"])
+@blueprint.backoffice_v3_web.route("/public_accounts/<int:user_id>", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
 def update_public_account(user_id: int) -> utils.BackofficeResponse:
     user = users_models.User.query.get_or_404(user_id)

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/edit.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/edit.html
@@ -9,7 +9,7 @@
             <h5 class="lead fs-1 my-4">Éditer les informations</h5>
 
             <div class="mt-5 text-center">
-                <form action="{{ dst }}" method="PATCH">
+                <form action="{{ dst }}" method="POST">
                     {% for form_field in form %}
                         <div class="w-100 my-4">
                             {% for error in form_field.errors %}

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -67,7 +67,7 @@ class UpdatePublicAccountTest:
     class UnauthorizedTest(unauthorized_helpers.MissingCSRFHelper):
         endpoint = "backoffice_v3_web.update_public_account"
         endpoint_kwargs = {"user_id": 1}
-        method = "patch"
+        method = "post"
         form = {"first_name": "aaaaaaaaaaaaaaaaaaa"}
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
@@ -148,7 +148,7 @@ class UpdatePublicAccountTest:
         url = url_for("backoffice_v3_web.update_public_account", user_id=user_to_edit.id)
 
         form["csrf_token"] = g.get("csrf_token", "")
-        return client.with_session_auth(legit_user.email).patch(url, form=form)
+        return client.with_session_auth(legit_user.email).post(url, form=form)
 
 
 class ResendValidationEmailTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19144

## But de la pull request

La modification des informations d'un compte jeune ou grand public dans le backoffice v3 ne fonctionnait pas.

## Informations supplémentaires

Les `<form>` html ne peuvent être envoyés par les navigateurs qu'avec l'action `GET` ou `POST`, donc `PATCH` envoyait en fait en `GET`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
