### PR TITLE
(PC-18828)[API] fix: autotag offerer when created with user

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -407,7 +407,7 @@ def _fill_in_offerer(
     offerer.dateCreated = datetime.utcnow()
 
 
-def _auto_tag_new_offerer(offerer: offerers_models.Offerer, siren_info: sirene.SirenInfo) -> None:
+def auto_tag_new_offerer(offerer: offerers_models.Offerer, siren_info: sirene.SirenInfo) -> None:
     tag_label = APE_TAG_MAPPING.get(siren_info.ape_code)
 
     if tag_label:
@@ -480,7 +480,7 @@ def create_offerer(
     if is_new:
         extra_data = {}
         if siren_info:
-            _auto_tag_new_offerer(offerer, siren_info)
+            auto_tag_new_offerer(offerer, siren_info)
             extra_data = {"sirene_info": dict(siren_info)}
 
         history_api.log_action(

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -31,6 +31,7 @@ from pcapi.routes.serialization.offerers_serialize import CreateOffererQueryMode
 from pcapi.utils.human_ids import humanize
 
 import tests
+from tests.test_utils import gen_offerer_tags
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -434,10 +435,6 @@ class ApiKeyTest:
 
 
 class CreateOffererTest:
-    def _gen_offerer_tags(self):
-        tags = [offerers_factories.OffererTagFactory(label=label) for label in ("Collectivité", "Établissement public")]
-        return tags
-
     @patch("pcapi.domain.admin_emails.maybe_send_offerer_validation_email", return_value=True)
     def test_create_new_offerer_with_validation_token_if_siren_is_not_already_registered(
         self, mock_maybe_send_offerer_validation_email
@@ -622,16 +619,16 @@ class CreateOffererTest:
         assert actions_list[0].comment == "Nouvelle demande sur un SIREN précédemment rejeté"
 
     @pytest.mark.parametrize(
-        "siren, expected_ape, expected_tag",
+        "siren, expected_tag",
         (
-            ("777084112", "84.11Z", "Collectivité"),
-            ("777084122", "84.12Z", "Établissement public"),
-            ("777091032", "91.03Z", "Établissement public"),
+            ("777084112", "Collectivité"),
+            ("777084122", "Établissement public"),
+            ("777091032", "Établissement public"),
         ),
     )
-    def test_create_offerer_auto_tagging(self, siren, expected_ape, expected_tag):
+    def test_create_offerer_auto_tagging(self, siren, expected_tag):
         # Given
-        self._gen_offerer_tags()
+        gen_offerer_tags()
         offerers_factories.VirtualVenueTypeFactory()
         user = users_factories.UserFactory()
         offerer_informations = CreateOffererQueryModel(

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -745,15 +745,7 @@ class CreateProUserTest:
 
 
 class CreateProUserAndOffererTest:
-    @pytest.mark.parametrize(
-        "siren, expected_tag",
-        (
-            ("777084112", "Collectivité"),
-            ("777084122", "Établissement public"),
-            ("777091032", "Établissement public"),
-        ),
-    )
-    def test_offerer_auto_tagging(self, siren, expected_tag):
+    def test_offerer_auto_tagging(self):
         # Given
         gen_offerer_tags()
         offerers_factories.VirtualVenueTypeFactory()
@@ -768,7 +760,7 @@ class CreateProUserAndOffererTest:
             phoneNumber="0607080910",
             postalCode="75017",
             publicName="The public name",
-            siren=siren,
+            siren=777084122,
             contactOk=True,
         )
 
@@ -778,7 +770,7 @@ class CreateProUserAndOffererTest:
         # Then
         offerer = user.UserOfferers[0].offerer
         assert offerer.name == user_info.name
-        assert expected_tag in (tag.label for tag in offerer.tags)
+        assert "Établissement public" in (tag.label for tag in offerer.tags)
 
 
 class BeneficiaryInformationUpdateTest:

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -3,6 +3,8 @@ import enum
 import operator
 import uuid
 
+from pcapi.core.offerers import factories as offerers_factories
+
 
 def json_default(data):
     conversions = {
@@ -15,3 +17,8 @@ def json_default(data):
             return func(data)
 
     return data
+
+
+def gen_offerer_tags():
+    tags = [offerers_factories.OffererTagFactory(label=label) for label in ("Collectivité", "Établissement public")]
+    return tags


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18828

## But de la pull request

implémenter l'auto tag des nouvelles structure aussi lorsqu'elles sont créées en même qu'un utilisateur pro

## Implémentation

RAS

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
