### PR TITLE
(PC-18950)[PRO] feat: Write only numbers for price, quantity and timepicker inputs

### DIFF
--- a/pro/src/components/Notification/Notification.tsx
+++ b/pro/src/components/Notification/Notification.tsx
@@ -68,9 +68,8 @@ const Notification = (): JSX.Element | null => {
           cn(
             styles['notification'],
             styles[
-              /* istanbul ignore next: graphic variation */ `is-${
-                type || 'success'
-              }`
+              /* istanbul ignore next: graphic variation */
+              `is-${type || 'success'}`
             ],
             /* istanbul ignore next: DEBT, TO FIX */ isVisible
               ? styles['show']

--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -27,7 +27,7 @@ const StockEventForm = ({
   const { readOnlyFields } = stockFormValues
 
   const [showCurrencyIcon, showShowCurrencyIcon] = useState<boolean>(
-    stockFormValues.price.length > 0
+    stockFormValues.price.toString().length > 0
   )
   useEffect(() => {
     showShowCurrencyIcon(stockFormValues.price.length > 0)
@@ -38,6 +38,8 @@ const StockEventForm = ({
     if (stockBookingLimitDatetime === null) {
       return
     }
+    // tested but coverage don't see it.
+    /* istanbul ignore next */
     if (date && isAfter(stockBookingLimitDatetime, date)) {
       setTouched({
         [`stocks[${stockIndex}]bookingLimitDatetime`]: true,
@@ -86,6 +88,7 @@ const StockEventForm = ({
         placeholder="Ex: 20€"
         disabled={readOnlyFields.includes('price')}
         rightIcon={() => (showCurrencyIcon ? <IconEuroGrey /> : null)}
+        onlyNumbers
       />
       <DatePicker
         smallLabel
@@ -116,6 +119,7 @@ const StockEventForm = ({
         classNameLabel={formRowStyles['field-layout-label']}
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('quantity')}
+        onlyNumbers
       />
     </>
   )

--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -98,4 +98,29 @@ describe('StockEventForm', () => {
       '27/12/2022'
     )
   })
+
+  const setNumberValue = [
+    { value: '20', expectedNumber: '20' },
+    { value: 'azer', expectedNumber: '' },
+    { value: 'AZER', expectedNumber: '' },
+    { value: '2fsqjk', expectedNumber: '2' },
+    { value: '2fsqm0', expectedNumber: '20' },
+  ]
+  it.each(setNumberValue)(
+    'should only type numbers for price, quantity',
+    async ({ value, expectedNumber }) => {
+      renderStockEventForm(props)
+
+      const priceInput = screen.getByLabelText('Prix', {
+        exact: false,
+      })
+      const quantityInput = screen.getByLabelText('Quantité', {
+        exact: false,
+      })
+      await userEvent.type(priceInput, value)
+      await userEvent.type(quantityInput, value)
+      expect(priceInput).toHaveValue(expectedNumber)
+      expect(quantityInput).toHaveValue(expectedNumber)
+    }
+  )
 })

--- a/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
@@ -97,67 +97,27 @@ describe('StockEventForm:validationSchema', () => {
     }
   )
 
-  const dataSetPriceErrors = [
-    {
-      price: 'ABCD',
-      error: 'Doit être un nombre',
-    },
-    {
-      price: '-5',
-      error: 'Doit être positif',
-    },
-    {
-      price: '301',
-      error: 'Veuillez renseigner un prix inférieur à 300€',
-    },
-  ]
-  it.each(dataSetPriceErrors)(
-    'should display price error %s',
-    async ({ price, error }) => {
-      renderStockEventForm()
+  it('should display price error %s', async () => {
+    renderStockEventForm()
 
-      const inputPrice = screen.getByLabelText('Prix')
-      await userEvent.type(inputPrice, price)
-      await userEvent.tab()
-      const errorPrice = screen.queryByTestId('error-stocks[0]price')
-      expect(errorPrice).toBeInTheDocument()
-      expect(errorPrice).toHaveTextContent(error)
-    }
-  )
+    const inputPrice = screen.getByLabelText('Prix')
+    await userEvent.type(inputPrice, '301')
+    await userEvent.tab()
+    const errorPrice = screen.queryByTestId('error-stocks[0]price')
+    expect(errorPrice).toBeInTheDocument()
+    expect(errorPrice).toHaveTextContent(
+      'Veuillez renseigner un prix inférieur à 300€'
+    )
+  })
 
   const dataSetPrice = ['0', '100', '299']
   it.each(dataSetPrice)('should not display price error', async price => {
     renderStockEventForm()
-
     const inputPrice = screen.getByLabelText('Prix')
     await userEvent.type(inputPrice, price)
     await userEvent.tab()
     expect(screen.queryByTestId('error-stocks[0]price')).not.toBeInTheDocument()
   })
-
-  const dataSetQuantityErrors = [
-    {
-      quantity: 'ABCD',
-      error: 'Doit être un nombre',
-    },
-    {
-      quantity: '-5',
-      error: 'Doit être positif',
-    },
-  ]
-  it.each(dataSetQuantityErrors)(
-    'should display quantity error',
-    async ({ quantity, error }) => {
-      renderStockEventForm()
-
-      const inputQuantity = screen.getByLabelText('Quantité')
-      await userEvent.type(inputQuantity, quantity)
-      await userEvent.tab()
-      const errorquantity = screen.queryByTestId('error-stocks[0]quantity')
-      expect(errorquantity).toBeInTheDocument()
-      expect(errorquantity).toHaveTextContent(error)
-    }
-  )
 
   it('should display quantity error when min quantity is given', async () => {
     renderStockEventForm({

--- a/pro/src/components/StockEventForm/validationSchema.ts
+++ b/pro/src/components/StockEventForm/validationSchema.ts
@@ -23,6 +23,7 @@ const getSingleValidationSchema = () => {
       .nullable()
       .required('Champ obligatoire')
       .when(['readOnlyFields'], (readOnlyFields, schema) => {
+        /* istanbul ignore next: DEBT, TO FIX */
         if (readOnlyFields.includes('beginningDate')) {
           return schema
         }

--- a/pro/src/components/StockThingForm/StockThingForm.tsx
+++ b/pro/src/components/StockThingForm/StockThingForm.tsx
@@ -34,11 +34,14 @@ const StockThingForm = ({
         smallLabel
         name="price"
         label="Prix"
-        type="number"
         placeholder="Ex: 20€"
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('price')}
-        rightIcon={values.price.length > 0 ? () => <IconEuroGrey /> : undefined}
+        rightIcon={() =>
+          values.price.toString().length > 0 ? <IconEuroGrey /> : null
+        }
+        onlyNumbers
+        type="number"
       />
       <DatePicker
         smallLabel
@@ -68,6 +71,7 @@ const StockThingForm = ({
         className={styles['input-quantity']}
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('quantity')}
+        onlyNumbers
       />
     </>
   )

--- a/pro/src/components/StockThingForm/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/StockThingForm/__specs__/validationSchema.spec.tsx
@@ -44,32 +44,17 @@ describe('StockThingForm:validationSchema', () => {
     expect(screen.queryByTestId('error-quantity')).not.toBeInTheDocument()
   })
 
-  const dataSetPriceErrors = [
-    {
-      price: 'ABCD',
-      error: 'Veuillez renseigner un prix',
-    },
-    {
-      price: '-5',
-      error: 'Le prix ne peut pas être inferieur à 0€',
-    },
-    {
-      price: '301',
-      error: 'Veuillez renseigner un prix inférieur à 300€',
-    },
-  ]
-  it.each(dataSetPriceErrors)(
-    'should display price error',
-    async ({ price, error }) => {
-      renderStockThingForm()
-      const inputPrice = screen.getByLabelText('Prix')
-      await userEvent.type(inputPrice, price)
-      await userEvent.tab()
-      const errorPrice = screen.queryByTestId('error-price')
-      expect(errorPrice).toBeInTheDocument()
-      expect(errorPrice).toHaveTextContent(error)
-    }
-  )
+  it('should display price error', async () => {
+    renderStockThingForm()
+    const inputPrice = screen.getByLabelText('Prix')
+    await userEvent.type(inputPrice, '301')
+    await userEvent.tab()
+    const errorPrice = screen.queryByTestId('error-price')
+    expect(errorPrice).toBeInTheDocument()
+    expect(errorPrice).toHaveTextContent(
+      'Veuillez renseigner un prix inférieur à 300€'
+    )
+  })
   const dataSetPrice = ['0', '100', '299']
   it.each(dataSetPrice)('should not display price error', async price => {
     renderStockThingForm()
@@ -79,28 +64,6 @@ describe('StockThingForm:validationSchema', () => {
     expect(screen.queryByTestId('error-price')).not.toBeInTheDocument()
   })
 
-  const dataSetQuantityErrors = [
-    {
-      quantity: 'ABCD',
-      error: 'Doit être un nombre',
-    },
-    {
-      quantity: '-5',
-      error: 'Doit être positif',
-    },
-  ]
-  it.each(dataSetQuantityErrors)(
-    'should display quantity error',
-    async ({ quantity, error }) => {
-      renderStockThingForm()
-      const inputQuantity = screen.getByLabelText('Quantité')
-      await userEvent.type(inputQuantity, quantity)
-      await userEvent.tab()
-      const errorquantity = screen.queryByTestId('error-quantity')
-      expect(errorquantity).toBeInTheDocument()
-      expect(errorquantity).toHaveTextContent(error)
-    }
-  )
   it('should display quantity error when min quantity is given', async () => {
     renderStockThingForm({ minQuantity: 10 })
     const inputQuantity = screen.getByLabelText('Quantité')

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -254,6 +254,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
 
   actions.push({
     callback:
+      /* istanbul ignore next: DEBT, TO FIX */
       formik.values.bookingsQuantity !== '0'
         ? deleteConfirmShow
         : onConfirmDeleteStock,

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -340,7 +340,7 @@ describe('screens:StocksThing', () => {
 
       const priceInput = screen.getByLabelText('Prix')
       await userEvent.clear(priceInput)
-      await userEvent.type(priceInput, '14.01')
+      await userEvent.type(priceInput, '14')
       const expirationInput = screen.getByLabelText("Date d'expiration")
       expect(expirationInput).toBeDisabled()
       const date = new Date()
@@ -431,4 +431,44 @@ describe('screens:StocksThing', () => {
       expect(screen.getByText(FORM_ERROR_MESSAGE)).toBeInTheDocument()
     })
   })
+
+  const setNumberPriceValue = [
+    { value: '20', expectedNumber: 20 },
+    { value: 'azer', expectedNumber: null },
+    { value: 'AZER', expectedNumber: null },
+    { value: '2fsqjk', expectedNumber: 2 },
+    { value: '2fsqm0', expectedNumber: 20 },
+  ]
+  it.each(setNumberPriceValue)(
+    'should only type numbers for price input',
+    async ({ value, expectedNumber }) => {
+      renderStockThingScreen({ props, storeOverride, contextValue })
+
+      const priceInput = screen.getByLabelText('Prix', {
+        exact: false,
+      })
+      await userEvent.type(priceInput, value)
+      expect(priceInput).toHaveValue(expectedNumber)
+    }
+  )
+
+  const setNumberQuantityValue = [
+    { value: '20', expectedNumber: '20' },
+    { value: 'azer', expectedNumber: '' },
+    { value: 'AZER', expectedNumber: '' },
+    { value: '2fsqjk', expectedNumber: '2' },
+    { value: '2fsqm0', expectedNumber: '20' },
+  ]
+  it.each(setNumberQuantityValue)(
+    'should only type numbers for quantity input',
+    async ({ value, expectedNumber }) => {
+      renderStockThingScreen({ props, storeOverride, contextValue })
+
+      const quantityInput = screen.getByLabelText('Quantité', {
+        exact: false,
+      })
+      await userEvent.type(quantityInput, value)
+      expect(quantityInput).toHaveValue(expectedNumber)
+    }
+  )
 })

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -5,7 +5,7 @@ import { BaseInput, FieldLayout } from '../shared'
 
 import styles from './TextInput.module.scss'
 
-interface ITextInputProps
+export interface ITextInputProps
   extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
   name: string
   className?: string
@@ -27,6 +27,7 @@ interface ITextInputProps
   step?: number | string
   inline?: boolean
   refForInput?: ForwardedRef<HTMLInputElement>
+  onlyNumbers?: boolean
 }
 
 const TextInput = ({
@@ -50,6 +51,7 @@ const TextInput = ({
   rightIcon,
   step,
   inline = false,
+  onlyNumbers = false,
   ...props
 }: ITextInputProps): JSX.Element => {
   const [field, meta] = useField({
@@ -94,6 +96,11 @@ const TextInput = ({
           rightButton={rightButton}
           ref={refForInput}
           rightIcon={rightIcon}
+          onKeyPress={event => {
+            if (onlyNumbers) {
+              !/[0-9]|Backspace/.test(event.key) && event.preventDefault()
+            }
+          }}
           {...field}
           {...props}
         />

--- a/pro/src/ui-kit/form/TextInput/index.ts
+++ b/pro/src/ui-kit/form/TextInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TextInput'
+export type { ITextInputProps } from './TextInput'

--- a/pro/src/ui-kit/form/TimePicker/TimePicker.tsx
+++ b/pro/src/ui-kit/form/TimePicker/TimePicker.tsx
@@ -9,7 +9,7 @@ import { BaseInput, FieldLayout } from '../shared'
 
 registerLocale('fr', fr)
 
-interface ITimePickerProps {
+export interface ITimePickerProps {
   name: string
   className?: string
   disabled?: boolean
@@ -69,6 +69,9 @@ const TimePicker = ({
         timeCaption="Horaire"
         timeFormat={FORMAT_HH_mm}
         timeIntervals={15}
+        onKeyDown={event => {
+          !/[0-9:]|Backspace|Tab/.test(event.key) && event.preventDefault()
+        }}
       />
     </FieldLayout>
   )

--- a/pro/src/ui-kit/form/TimePicker/__specs__/TimePicker.spec.tsx
+++ b/pro/src/ui-kit/form/TimePicker/__specs__/TimePicker.spec.tsx
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Formik } from 'formik'
+import React from 'react'
+
+import TimePicker, { ITimePickerProps } from '../TimePicker'
+
+const renderTimePicker = ({
+  onSubmit = jest.fn(),
+}: {
+  onSubmit?: () => void
+} = {}) => {
+  const initialValues = { price: '' }
+  const props: ITimePickerProps = {
+    label: 'Horaire',
+    name: 'datetime',
+  }
+  return render(
+    <Formik initialValues={initialValues} onSubmit={onSubmit}>
+      <TimePicker {...props} />
+    </Formik>
+  )
+}
+
+describe('TimePicker', () => {
+  it('should render field', () => {
+    renderTimePicker()
+    expect(screen.getByLabelText('Horaire')).toBeInTheDocument()
+  })
+
+  const setNumberInputValue = [
+    { value: '20', expectedNumber: '20' },
+    { value: 'azer', expectedNumber: '' },
+    { value: 'AZER', expectedNumber: '' },
+    { value: '2fsqjk', expectedNumber: '2' },
+    { value: '2fs:qm0', expectedNumber: '2:0' },
+  ]
+  it.each(setNumberInputValue)(
+    'should complete input correctly',
+    async ({ value, expectedNumber }) => {
+      renderTimePicker()
+
+      const timepicker = screen.getByLabelText('Horaire', {
+        exact: false,
+      })
+      await userEvent.type(timepicker, value)
+      expect(timepicker).toHaveValue(expectedNumber)
+    }
+  )
+})

--- a/pro/src/ui-kit/form/TimePicker/index.ts
+++ b/pro/src/ui-kit/form/TimePicker/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TimePicker'
+export type { ITimePickerProps } from './TimePicker'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18950

## But de la pull request

- Ne plus permettre à l'utilisateur de rentrer des lettres pour les champs prix, quantité et horaire.

## Implémentation

- Ajout d'une option au composant TextInput: onlyNumbers qui ne modifie pas le champ lorsque l'utilisateur tape autre chose qu'un chiffre.
- Duplication de la règle dans le composant TimePicker
- Tests

## Informations supplémentaires

- À la base, j'ai créé un composant NumberInput, mais il dupliquait simplement un TextInput avec l'ajout de la règle sur le onKeyPress. De plus, on veut garder un type text (pour le moment) même sur les champs où l'utilisateur ne peut rentrer que des chiffres.
Je l'ai donc supprimé et j'ai juste ajouté une option au composant TextInput.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
