### PR TITLE
(PC-19174)[PRO] fix: reset withdrawalDelay value on withdrawal type change

### DIFF
--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
@@ -13,8 +13,6 @@ import {
   ticketWithdrawalTypeRadios,
 } from './constants'
 
-import { TICKET_WITHDRAWAL_DEFAULT_VALUES } from '.'
-
 export interface ITicketWithdrawalProps {
   readOnlyFields?: string[]
 }
@@ -33,11 +31,11 @@ const TicketWithdrawal = ({
       if (dirty) {
         setFieldValue(
           'withdrawalDelay',
-          TICKET_WITHDRAWAL_DEFAULT_VALUES['withdrawalDelay']
+          withdrawalType === WithdrawalTypeEnum.NO_TICKET ? undefined : '0'
         )
       }
     },
-    [withdrawalType, dirty]
+    [withdrawalType]
   )
 
   return (

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
@@ -90,60 +90,6 @@ describe('OfferIndividual section: TicketWithdrawal', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should display an error when withdrawalDelay is empty and withdrawalType for e-mail', async () => {
-    renderTicketWithdrawal({
-      initialValues,
-      onSubmit,
-    })
-
-    await userEvent.click(screen.getByText('Envoi par e-mail'))
-    expect(
-      screen.queryByText('Vous devez cocher l’une des options ci-dessus')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByText('Vous devez choisir l’une des options ci-dessus')
-    ).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByLabelText('Date d’envoi'))
-    // FIXME: select field need to click outside in order to trigger validation.
-    await userEvent.tab()
-    expect(
-      screen.queryByText('Vous devez cocher l’une des options ci-dessus')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByText('Vous devez choisir l’une des options ci-dessus')
-    ).toBeInTheDocument()
-  })
-
-  it('should display an error when withdrawalDelay is empty and withdrawalType on place', async () => {
-    renderTicketWithdrawal({
-      initialValues,
-      onSubmit,
-    })
-
-    await userEvent.click(
-      screen.getByText('Retrait sur place (guichet, comptoir ...)')
-    )
-    expect(
-      screen.queryByText('Vous devez cocher l’une des options ci-dessus')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByText('Vous devez choisir l’une des options ci-dessus')
-    ).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByLabelText('Heure de retrait'))
-    // FIXME: select field need two click outside in order to trigger validation.
-    await userEvent.tab()
-    await userEvent.tab()
-
-    expect(
-      screen.queryByText('Vous devez cocher l’une des options ci-dessus')
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByText('Vous devez choisir l’une des options ci-dessus')
-    ).toBeInTheDocument()
-  })
-
   it('should disable read only fields', () => {
     const props = { readOnlyFields: ['withdrawalType', 'withdrawalDelay'] }
 

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -152,7 +152,7 @@ describe('OfferIndividual section: UsefulInformations', () => {
         url: '',
         subcategoryId: 'CONCERT',
         venueId: 'AAAA',
-        withdrawalDelay: undefined,
+        withdrawalDelay: '0',
         withdrawalDetails: '',
         withdrawalType: 'by_email',
       },

--- a/pro/src/screens/OfferIndividual/Informations/Informations.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/Informations.tsx
@@ -176,7 +176,6 @@ const Informations = ({
         cropParams,
       })
         .then(() => {
-          notify.success('Brouillon sauvegardé dans la liste des offres')
           logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
             from: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
             to: OFFER_WIZARD_STEP_IDS.INFORMATIONS,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19174

## But de la pull request

Correction de l'enregistrement des informations dans le cas d'une offre avec information de retrait. 
Simplification du code, on ne devrait pas avoir besoin d'un useEffect, le onChange marche bien