### PR TITLE
(PC-18464)[API] feat: bo: edit venue details

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -76,13 +76,19 @@ def create_digital_venue(offerer: models.Offerer) -> models.Venue:
 def update_venue(
     venue: models.Venue,
     contact_data: serialize_base.VenueContactModel = None,
+    admin_update: bool = False,
     **attrs: typing.Any,
 ) -> models.Venue:
     validation.validate_coordinates(attrs.get("latitude"), attrs.get("longitude"))  # type: ignore [arg-type]
     reimbursement_point_id = attrs.pop("reimbursementPointId", None)
 
     modifications = {field: value for field, value in attrs.items() if venue.field_exists_and_has_changed(field, value)}
-    validation.check_venue_edition(modifications, venue)
+
+    if not admin_update:
+        # run validation when the venue update is triggered by a pro
+        # user. This can be bypassed when done by and admin/backoffice
+        # user.
+        validation.check_venue_edition(modifications, venue)
 
     if contact_data:
         upsert_venue_contact(venue, contact_data)

--- a/api/src/pcapi/routes/backoffice_v3/forms/account.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/account.py
@@ -2,13 +2,12 @@ from flask_wtf import FlaskForm
 
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.models as users_models
-import pcapi.utils.email as email_utils
 
 from . import fields
 from . import utils
 
 
-class EditAccountForm(FlaskForm):
+class EditAccountForm(utils.PCForm):
     first_name = fields.PCOptStringField("Prénom")
     last_name = fields.PCOptStringField("Nom")
     email = fields.PCEmailField("Email")
@@ -17,11 +16,6 @@ class EditAccountForm(FlaskForm):
     address = fields.PCOptStringField("Adresse")
     postal_code = fields.PCOptPostalCodeField("Code postal")
     city = fields.PCOptStringField("Ville")
-
-    def filter_email(self, raw_email: str | None) -> str:
-        if not raw_email:
-            return ""
-        return email_utils.sanitize_email(raw_email)
 
 
 class ManualReviewForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice_v3/forms/account.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/account.py
@@ -1,5 +1,4 @@
 from flask_wtf import FlaskForm
-from wtforms import validators
 
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.models as users_models
@@ -16,13 +15,8 @@ class EditAccountForm(FlaskForm):
     birth_date = fields.PCDateField("Date de naissance")
     id_piece_number = fields.PCOptStringField("N° pièce d'identité")
     address = fields.PCOptStringField("Adresse")
-    postal_code = fields.PCPostalCodeField("Code postal")
+    postal_code = fields.PCOptPostalCodeField("Code postal")
     city = fields.PCOptStringField("Ville")
-
-    def validate_postal_code(self, postal_code: fields.PCPostalCodeField) -> fields.PCPostalCodeField:
-        if not postal_code.data.isnumeric():
-            raise validators.ValidationError("Un code postal doit être composé de chiffres")
-        return postal_code
 
     def filter_email(self, raw_email: str | None) -> str:
         if not raw_email:

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -13,6 +13,15 @@ def widget(field: wtforms.Field, template: str, *args: typing.Any, **kwargs: typ
     return render_template(template, field=field)
 
 
+class PostalCodeValidator:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __call__(self, form: wtforms.Form, postal_code: wtforms.Field) -> None:
+        if not postal_code.data.isnumeric() or len(postal_code.data) != 5:
+            raise validators.ValidationError(self.message)
+
+
 class PCOptStringField(wtforms.StringField):
     widget = partial(widget, template="components/forms/string_field.html")
     validators = [
@@ -28,10 +37,17 @@ class PCStringField(PCOptStringField):
     ]
 
 
-class PCPostalCodeField(PCStringField):
+class PCOptPostalCodeField(PCStringField):
     validators = [
         validators.Optional(""),
-        validators.Length(min=5, max=5, message="Le code postal doit contenir %(max)d caractères"),
+        PostalCodeValidator("Le code postal doit contenir 5 caractères"),
+    ]
+
+
+class PCPostalCodeField(PCStringField):
+    validators = [
+        validators.InputRequired("Information obligatoire"),
+        PostalCodeValidator("Le code postal doit contenir 5 caractères"),
     ]
 
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/pro_user.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/pro_user.py
@@ -1,13 +1,10 @@
 from flask_wtf import FlaskForm
-from wtforms import validators
-
-import pcapi.utils.email as email_utils
-import pcapi.utils.phone_number as phone_utils
 
 from . import fields
+from . import utils
 
 
-class EditProUserForm(FlaskForm):
+class EditProUserForm(utils.PCForm):
     first_name = fields.PCOptStringField("Prénom")
     last_name = fields.PCOptStringField("Nom")
     email = fields.PCEmailField("Email")
@@ -15,11 +12,6 @@ class EditProUserForm(FlaskForm):
         "Téléphone",
     )
     postal_code = fields.PCOptPostalCodeField("Code postal")
-
-    def filter_email(self, raw_email: str | None) -> str:
-        if not raw_email:
-            return ""
-        return email_utils.sanitize_email(raw_email)
 
 
 class CommentForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice_v3/forms/pro_user.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/pro_user.py
@@ -16,11 +16,6 @@ class EditProUserForm(FlaskForm):
     )
     postal_code = fields.PCOptPostalCodeField("Code postal")
 
-    def validate_phone_number(self, phone_number: fields.PCPhoneNumberField) -> fields.PCPhoneNumberField:
-        if not phone_utils.ParsedPhoneNumber(phone_number.data):
-            raise validators.ValidationError("Veuillez indiquer un numéro de téléphone valide.")
-        return phone_number
-
     def filter_email(self, raw_email: str | None) -> str:
         if not raw_email:
             return ""

--- a/api/src/pcapi/routes/backoffice_v3/forms/pro_user.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/pro_user.py
@@ -14,12 +14,7 @@ class EditProUserForm(FlaskForm):
     phone_number = fields.PCPhoneNumberField(
         "Téléphone",
     )
-    postal_code = fields.PCPostalCodeField("Code postal")
-
-    def validate_postal_code(self, postal_code: fields.PCPostalCodeField) -> fields.PCPostalCodeField:
-        if not postal_code.data.isnumeric() and len(postal_code.data) == 5:
-            raise validators.ValidationError("Un code postal doit être composé de 5 chiffres")
-        return postal_code
+    postal_code = fields.PCOptPostalCodeField("Code postal")
 
     def validate_phone_number(self, phone_number: fields.PCPhoneNumberField) -> fields.PCPhoneNumberField:
         if not phone_utils.ParsedPhoneNumber(phone_number.data):

--- a/api/src/pcapi/routes/backoffice_v3/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/utils.py
@@ -1,6 +1,17 @@
 import enum
 import typing
 
+from flask_wtf import FlaskForm
+
+import pcapi.utils.email as email_utils
+
+
+class PCForm(FlaskForm):
+    def filter_email(self, raw_email: str | None) -> str:
+        if not raw_email:
+            return ""
+        return email_utils.sanitize_email(raw_email)
+
 
 def choices_from_enum(enum_cls: typing.Type[enum.Enum]) -> list[tuple]:
     return [(opt.name, opt.value) for opt in enum_cls]

--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -1,22 +1,16 @@
 import typing
 
-from flask_wtf import FlaskForm
 from wtforms import validators
 
 import pcapi.core.offerers.models as offerers_models
-import pcapi.utils.email as email_utils
 
 from . import fields
+from . import utils
 
 
-class EditVirtualVenueForm(FlaskForm):
+class EditVirtualVenueForm(utils.PCForm):
     email = fields.PCEmailField("Email")
     phone_number = fields.PCPhoneNumberField("Numéro de téléphone")  # match Venue.contact.postal_code case
-
-    def filter_email(self, raw_email: str | None) -> str:
-        if not raw_email:
-            return ""
-        return email_utils.sanitize_email(raw_email)
 
 
 class EditVenueForm(EditVirtualVenueForm):

--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -1,0 +1,55 @@
+import typing
+
+from flask_wtf import FlaskForm
+from wtforms import validators
+
+import pcapi.core.offerers.models as offerers_models
+import pcapi.utils.email as email_utils
+
+from . import fields
+
+
+class EditVirtualVenueForm(FlaskForm):
+    email = fields.PCEmailField("Email")
+    phone_number = fields.PCPhoneNumberField("Numéro de téléphone")  # match Venue.contact.postal_code case
+
+    def filter_email(self, raw_email: str | None) -> str:
+        if not raw_email:
+            return ""
+        return email_utils.sanitize_email(raw_email)
+
+
+class EditVenueForm(EditVirtualVenueForm):
+    siret = fields.PCStringField("siret")
+    city = fields.PCStringField("Ville")
+    postalCode = fields.PCPostalCodeField("Code postal")  # match Venue.postalCode case
+    address = fields.PCStringField("Adresse")
+
+    def __init__(self, venue: offerers_models.Venue, *args: typing.Any, **kwargs: typing.Any) -> None:
+        """
+        Change the fields order to avoid having the email and phone
+        number (inherited from EditVirtualVenueForm) at the top.
+        """
+        super().__init__(*args, **kwargs)
+
+        # save venue in order to validate the siret field
+        self.venue = venue
+
+        # self._fields is a collections.OrderedDict
+        self._fields.move_to_end("email")
+        self._fields.move_to_end("phone_number")
+
+    def validate_siret(self, siret: fields.PCStringField) -> fields.PCStringField:
+        if not siret.data or len(siret.data) != 14:
+            raise validators.ValidationError("Un siret doit comporter 14 chiffres")
+
+        try:
+            int(siret.data)
+        except (ValueError, TypeError):
+            raise validators.ValidationError("Un siret doit comporter 14 chiffres")
+
+        if siret.data[:9] != self.venue.managingOfferer.siren:
+            raise validators.ValidationError(
+                "Les 9 premiers caractères du SIRET doivent correspondre au SIREN de la structure"
+            )
+        return siret

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/form_body.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/form_body.html
@@ -1,0 +1,9 @@
+{% for form_field in form %}
+    <div class="w-100 my-4">
+        {% for error in form_field.errors %}
+            <p class="text-warning lead">{{ error }}</p>
+        {% endfor %}
+    </div>
+
+    {{ form_field }}
+{% endfor %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -108,16 +108,18 @@
 
                 {% with messages = get_flashed_messages(with_categories=True) %}
                     {% if messages %}
-                        {% for category, message in messages %}
-                            <div
-                                    class="alert alert-{{ category }} alert-dismissible fade show mb-3 px-5 rounded-0"
+                        <div class="mb-3">
+                            {% for category, message in messages %}
+                                <div
+                                    class="alert alert-{{ category }} alert-dismissible fade show mb-0 px-5 rounded-0"
                                     role="alert">
-                                <p class="mx-3 mb-0">{{ message }}
-                                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
-                                    </button>
-                                </p>
-                            </div>
-                        {% endfor %}
+                                    <p class="mx-3 mb-0">{{ message }}
+                                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+                                        </button>
+                                    </p>
+                                </div>
+                            {% endfor %}
+                        </div>
                     {% endif %}
                 {% endwith %}
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -7,15 +7,26 @@
     <div class="col">
         <div class="card">
             <div class="card-body">
-                <h2 class="card-title mb-3">
-                    <a href="{{ venue | pc_pro_venue_link }}" target="_blank"
-                       class="text-decoration-none hover-text-underline">
-                        {{ venue.name | escape }}
-                    </a>
+                <h2 class="card-title mb-3 d-flex justify-content-between align-items-start">
+                    <div>
+                        <a href="{{ venue | pc_pro_venue_link }}" target="_blank"
+                                                                  class="text-decoration-none hover-text-underline">
+                            {{ venue.name | escape }}
+                        </a>
 
-                    <span class="fs-5 ps-4 mb-3 align-middle">
-                        {{ build_venue_badges(venue) }}
-                    </span>
+                        <span class="fs-5 ps-4 mb-3 align-middle">
+                            {{ build_venue_badges(venue) }}
+                        </span>
+                    </div>
+
+                    <div>
+                        <button type="button"
+                                class="btn btn-outline-primary fw-bold"
+                                data-bs-toggle="modal"
+                                data-bs-target="#venue-edit-details">
+                            Modifier les informations
+                        </button>
+                    </div>
                 </h2>
 
                 <p class="card-subtitle text-muted mb-3 h5">
@@ -183,6 +194,29 @@
             </turbo-frame>
         </div>
 
+    </div>
+</div>
+
+<div class="modal fade" id="venue-edit-details" tabindex="-1" aria-labelledby="venue-edit-details-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <form action="{{ url_for("backoffice_v3_web.manage_venue.update", venue_id=venue.id) }}" method="POST" class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Modifier les informations du lieu</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+
+            <div class="modal-body">
+                <div class="form-floating my-3">
+                    {% include "components/form_body.html" %}
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Annuler</button>
+                <button type="submit" class="btn btn-primary">Enregistrer</button>
+            </div>
+
+        </form>
     </div>
 </div>
 

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -158,7 +158,6 @@ class UpdatePublicAccountTest:
         }
 
         response = self.update_account(authenticated_client, user_to_edit, base_form)
-        print(response)
         assert response.status_code == 303
 
         user_to_edit = users_models.User.query.get(user_to_edit.id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18464

## But de la pull request

Backoffice : permettre la modification des détails d'un lieu.

## Implémentation

Note : la nouvelle option `admin_update` est utilisée dans `update_venue` pour ne pas appeler `check_venue_edition` qui s'assure, entre autre, qu'on ne modifie pas le siret (action interdire pour les PRO mais qu'on veut permettre depuis le backoffice). Je ne sais pas s'il est plus pertinent de déplacer cette logique au coeur de `check_venue_edition` afin de mieux cibler les vérifications à ignorer.