### PR TITLE
[PC-19050] Upgrade pcapi chart to v0.17.0 for testing

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.16.3
+      - chartVersion: 0.17.0
   staging:
     values:
       - chartVersion: 0.16.3


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19050

## But de la pull request

Mise à jour de la version du chart pcapi en v0.17.0 pour ajouter le déploiement backofficeV3 