### PR TITLE
(PC-18057)[API] fix: add last30DaysBookings to offers index settings

### DIFF
--- a/api/src/pcapi/algolia_settings_offers.json
+++ b/api/src/pcapi/algolia_settings_offers.json
@@ -40,6 +40,7 @@
         "filterOnly(offer.isEvent)",
         "filterOnly(offer.isForbiddenToUnderage)",
         "filterOnly(offer.isThing)",
+        "filterOnly(offer.last30DaysBookings)",
         "filterOnly(offer.movieGenres)",
         "filterOnly(offer.musicType)",
         "filterOnly(offer.prices)",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18057

## But de la pull request

ajout de l'attribut `offer.last30DaysBookings` to `attributesForFaceting` setting for offers index

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
