### PR TITLE
(BSR)[API] fix: migration: add default value to educational_instituti…

### DIFF
--- a/api/src/pcapi/alembic/versions/20221208T155913_aca83eb30235_add_is_active_educational_institution.py
+++ b/api/src/pcapi/alembic/versions/20221208T155913_aca83eb30235_add_is_active_educational_institution.py
@@ -13,7 +13,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("educational_institution", sa.Column("isActive", sa.Boolean(), nullable=False))
+    op.add_column(
+        "educational_institution",
+        sa.Column("isActive", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+    )
 
 
 def downgrade() -> None:

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -603,7 +603,7 @@ class EducationalInstitution(PcObject, Base, Model):
 
     collectiveOffers: list["CollectiveOffer"] = relationship("CollectiveOffer", back_populates="institution")
 
-    isActive: bool = sa.Column(sa.Boolean, nullable=False, default=True)
+    isActive: bool = sa.Column(sa.Boolean, nullable=False, server_default=sa.sql.expression.true(), default=True)
 
 
 class EducationalYear(PcObject, Base, Model):


### PR DESCRIPTION
…on."isActive"

SQLA model has a default value, but not the migration (don't know why).