### PR TITLE
PC-19208/fix-pcapi-chart-backoffice-deployment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.17.0
+      - chartVersion: 0.17.1
   staging:
     values:
       - chartVersion: 0.16.3


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-9208

## But de la pull request

Upgrade de la version du chart pcapi en 0.17.1 pour testing pour fix le problème de type dans le deployment backoffice-v3