### PR TITLE
(BSR)[API] fix: algolia: add missing field to index

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -405,6 +405,7 @@ class AlgoliaBackend(base.SearchBackend):
                 "movieGenres": extra_data.get("genres"),
                 "musicType": music_type_label,
                 "name": offer.name,
+                "nativeCategoryId": offer.subcategory.native_category_id,
                 "prices": prices_sorted,
                 # TODO(jeremieb): keep searchGroupNamev2 and remove
                 # remove searchGroupName once the search group name &

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -65,6 +65,7 @@ def test_serialize_offer():
             "movieGenres": None,
             "musicType": None,
             "name": "Titre formidable",
+            "nativeCategoryId": offer.subcategory.native_category_id,
             "prices": [decimal.Decimal("10.00")],
             "rankingWeight": 2,
             "searchGroupName": "LIVRE",


### PR DESCRIPTION
## But de la pull request

Ajout de la `native_category_id` lors de l'indexation d'une offre (Algolia).