### PR TITLE
(BSR)[API] fix: add health check routes to backoffice (v3)

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -7,6 +7,7 @@ def install_routes(app: Flask) -> None:
     from . import admin
     from . import auth
     from . import filters
+    from . import health_check
     from . import home
     from . import i18n
     from . import offerers

--- a/api/src/pcapi/routes/backoffice_v3/health_check.py
+++ b/api/src/pcapi/routes/backoffice_v3/health_check.py
@@ -1,0 +1,18 @@
+from flask import current_app
+
+from pcapi.utils.health_checker import check_database_connection
+from pcapi.utils.health_checker import read_version_from_file
+
+
+@current_app.route("/health/api", methods=["GET"])
+def health_api():  # type: ignore [no-untyped-def]
+    output = read_version_from_file()
+    return output, 200
+
+
+@current_app.route("/health/database", methods=["GET"])
+def health_database():  # type: ignore [no-untyped-def]
+    database_working = check_database_connection()
+    return_code = 200 if database_working else 500
+    output = read_version_from_file()
+    return output, return_code

--- a/api/tests/routes/backoffice_v3/health_check_test.py
+++ b/api/tests/routes/backoffice_v3/health_check_test.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+
+class Returns200Test:
+    @patch("pcapi.routes.internal.health_check.read_version_from_file")
+    def when_api_is_available(self, mock_read_version_from_file, client):
+        # Given
+        mock_read_version_from_file.return_value = "v69.0.0"
+
+        # When
+        response = client.get("/health/api")
+
+        # Then
+        assert response.status_code == 200
+        assert str(response.data, "utf-8") == "v69.0.0"
+
+    @patch("pcapi.routes.internal.health_check.read_version_from_file")
+    @patch("pcapi.routes.internal.health_check.check_database_connection")
+    def when_database_is_available(self, mock_check_database_connection, mock_read_version_from_file, client):
+        # Given
+        mock_check_database_connection.return_value = True
+        mock_read_version_from_file.return_value = "v69.0.0"
+
+        # When
+        response = client.get("/health/database")
+
+        # Then
+        assert response.status_code == 200
+        assert str(response.data, "utf-8") == "v69.0.0"
+
+
+class Returns500Test:
+    @patch("pcapi.routes.internal.health_check.read_version_from_file")
+    @patch("pcapi.routes.internal.health_check.check_database_connection")
+    def when_database_is_not_available(self, mock_check_database_connection, mock_read_version_from_file, client):
+        # Given
+        mock_check_database_connection.return_value = False
+        mock_read_version_from_file.return_value = "v69.0.0"
+
+        # when
+        response = client.get("/health/database")
+
+        # then
+        assert response.status_code == 500
+        assert str(response.data, "utf-8") == "v69.0.0"


### PR DESCRIPTION
## But de la pull request

Ajout des routes `/health/api` et `/health/database` au backoffice v3.
Elles ne sont pas liées au _blueprint_ afin d'avoir exactement les mêmes que sur l'application Flask principale.