### PR TITLE
(BSR)[API] fix: backoffice: cookies: samesite: Lax not Strict

### DIFF
--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -11,7 +11,7 @@ from pcapi.local_providers.install import install_local_providers
 
 app.config["SESSION_COOKIE_HTTPONLY"] = True
 app.config["SESSION_COOKIE_SECURE"] = not settings.IS_DEV
-app.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 app.config["SESSION_COOKIE_NAME"] = "bo_session"
 app.config["REMEMBER_COOKIE_HTTPONLY"] = True
 app.config["REMEMBER_COOKIE_SECURE"] = not settings.IS_DEV


### PR DESCRIPTION
## But de la pull request

`SESSION_COOKIE_SAMESITE` : **Strict** devient **Lax**.
Il semblerait qu'avec **Strict**, on ait des soucis avec l'authentification Google. **Lax** est l'option par défaut et celle utilisée par l'application principale.