### PR TITLE
(PC-19202)[PRO] fix: css set correct fields width for stockThing and correct vertical align for stock action

### DIFF
--- a/pro/src/components/StockEventFormRow/StockEventFormRow.module.scss
+++ b/pro/src/components/StockEventFormRow/StockEventFormRow.module.scss
@@ -2,7 +2,6 @@
 
 .stock-form-row {
   display: flex;
-  align-items: center;
 
   .stock-form {
     display: flex;
@@ -20,9 +19,10 @@
   }
 
   .stock-actions {
+    display: flex;
+    align-self: flex-start;
     &.stock-first-action {
-      margin-top: rem.torem(-6px);
+      margin-top: rem.torem(40px);
     }
-    margin-top: rem.torem(-40px);
   }
 }

--- a/pro/src/components/StockThingForm/StockThingForm.module.scss
+++ b/pro/src/components/StockThingForm/StockThingForm.module.scss
@@ -1,7 +1,15 @@
 @use 'styles/mixins/_rem.scss' as rem;
 
-.input-quantity {
-  flex: 1 0 rem.torem(112px);
+.input-price, .input-quantity {
+  width: rem.torem(146px);
+}
+
+.input-booking-limit-datetime {
+  flex: 1 0 rem.torem(316px);
+}
+
+.input-activation-code {
+  flex: 1 0 rem.torem(160px);
 }
 
 .field-layout-footer {

--- a/pro/src/components/StockThingForm/StockThingForm.tsx
+++ b/pro/src/components/StockThingForm/StockThingForm.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import { useFormikContext } from 'formik'
 import React from 'react'
 
@@ -30,11 +31,13 @@ const StockThingForm = ({
   return (
     <>
       <TextInput
-        className={styles['price-field']}
         smallLabel
         name="price"
         label="Prix"
         placeholder="Ex: 20€"
+        className={cn({
+          [styles['input-price']]: !showExpirationDate,
+        })}
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('price')}
         type="number"
@@ -46,6 +49,9 @@ const StockThingForm = ({
         smallLabel
         name="bookingLimitDatetime"
         label="Date limite de réservation"
+        className={cn({
+          [styles['input-booking-limit-datetime']]: !showExpirationDate,
+        })}
         classNameFooter={styles['field-layout-footer']}
         minDateTime={today}
         maxDateTime={getMaximumBookingDatetime(maxDateTime)}
@@ -58,6 +64,7 @@ const StockThingForm = ({
           smallLabel
           name="activationCodesExpirationDatetime"
           label="Date d'expiration"
+          className={styles['input-activation-code']}
           classNameFooter={styles['field-layout-footer']}
           disabled={true}
         />
@@ -67,7 +74,9 @@ const StockThingForm = ({
         name="quantity"
         label="Quantité"
         placeholder="Illimité"
-        className={styles['input-quantity']}
+        className={cn({
+          [styles['input-quantity']]: !showExpirationDate,
+        })}
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('quantity')}
         type="number"

--- a/pro/src/components/StockThingFormRow/StockThingFormRow.module.scss
+++ b/pro/src/components/StockThingFormRow/StockThingFormRow.module.scss
@@ -2,11 +2,10 @@
 
 .stock-form-row {
   display: flex;
-  align-items: center;
 
   .stock-form {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     > *:not(:last-child) {
       margin-right: rem.torem(16px);
     }
@@ -21,6 +20,9 @@
   }
 
   .stock-actions {
-    margin-top: rem.torem(-17px);
+    display: flex;
+    align-items: flex-end;
+    height: rem.torem(66px);
+    margin-left: auto;
   }
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19202

## But de la pull request

- Mettre les champs du formulaire stock physique à la bonne taille.
- Bien placer le bouton action pour les stocks à droite de la ligne

## Implémentation

Avant:
![Screenshot from 2022-12-12 16-28-13](https://user-images.githubusercontent.com/106379750/207085103-9bb222f4-8505-4db1-a0d8-ec43eebe8585.png)

Après:
![Screenshot from 2022-12-12 16-20-22](https://user-images.githubusercontent.com/106379750/207085197-a7850da7-a9bf-43cd-86e5-f00ae733e662.png)


## Informations supplémentaires

- Correction de l'alignement pour le bouton action des stocks évènements

Avant:
![Screenshot from 2022-12-12 16-30-26](https://user-images.githubusercontent.com/106379750/207085584-04522ddd-2524-4b74-a9d4-93702d5b2790.png)

Après:
![Screenshot from 2022-12-12 16-19-36](https://user-images.githubusercontent.com/106379750/207085299-56553d95-9e9a-4eb7-918b-7f8972a522c4.png)
