### PR TITLE
(PC-19181)[PRO] fix: add venue withdrawdetails when user create an offer

### DIFF
--- a/pro/src/components/OfferIndividualForm/UsefulInformations/Venue/hooks/useVenueUpdates.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/Venue/hooks/useVenueUpdates.tsx
@@ -22,6 +22,7 @@ const useVenueUpdates = (venueList: TOfferIndividualVenue[]): void => {
           setFieldValue('accessibility', venue.accessibility)
 
         setFieldValue('isVenueVirtual', venue.isVirtual)
+        setFieldValue('withdrawalDetails', venue?.withdrawalDetails || '')
       }
       setPrevValue(venueId)
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19181

## But de la pull request

- Afficher la modalité de retrait du lieu s'il y en a une lors de la création d'une offre.

## Informations supplémentaires

bouton “créer une offre” de la page accueil :heavy_check_mark: 

bouton “créer une offre” de la page lieu :heavy_check_mark: : 

bouton “créer une offre” de la page offres :heavy_check_mark: : 

bouton “créer une nouvelle offre” sur la page de confirmation de création d’une offre :heavy_check_mark: 
