### PR TITLE
(PC-15370) retrieve movie posters from Boost API

### DIFF
--- a/api/src/pcapi/connectors/boost.py
+++ b/api/src/pcapi/connectors/boost.py
@@ -144,6 +144,15 @@ def post_resource(cinema_str_id: str, resource: ResourceBoost, body: BaseModel) 
     return None
 
 
+def get_movie_poster_from_api(image_url: str) -> bytes:
+    api_response = requests.get(image_url)
+    if api_response.status_code != 200:
+        raise BoostAPIException(
+            f"Error getting Boost API movie poster {image_url} with code {api_response.status_code}"
+        )
+    return api_response.content
+
+
 def _check_response_is_ok(response: requests.Response, cinema_api_token: str | None, request_detail: str) -> None:
     if response.status_code >= 400:
         reason = _extract_reason_from_response(response)

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -135,3 +135,6 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         )
         showtime_details = parse_obj_as(boost_serializers.ShowTimeDetails, json_data)
         return showtime_details.data
+
+    def get_movie_poster(self, image_url: str) -> bytes:
+        return boost.get_movie_poster_from_api(image_url)

--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -136,7 +136,8 @@ class BoostStocks(LocalProvider):
         obj.extraData = {"visa": movie_information.visa}
 
     def get_object_thumb(self) -> bytes:
-        return bytes()
+        image_url = self.showtime_details.film.posterUrl
+        return self._get_boost_movie_poster(image_url) if image_url else bytes()
 
     def shall_synchronize_thumbs(self) -> bool:
         return True
@@ -151,6 +152,10 @@ class BoostStocks(LocalProvider):
     def _get_showtime_details(self, showtime_id: int) -> boost_serializers.ShowTime:
         client_boost = BoostClientAPI(self.cinema_id)
         return client_boost.get_showtime(showtime_id)
+
+    def _get_boost_movie_poster(self, image_url: str) -> bytes:
+        client_boost = BoostClientAPI(self.cinema_id)
+        return client_boost.get_movie_poster(image_url)
 
 
 def get_next_product_id_from_database() -> int:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-15370

## But de la pull request

Récupération des affiches de films synchronisés avec Boost

## Implémentation

Edition de` boost_stocks.py` et du client Boost.