### PR TITLE
(BSR)[API] fix: tests: do not install local provider too soon

### DIFF
--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -28,7 +28,7 @@ with app.app_context():
     from pcapi.routes import install_all_routes
     import pcapi.utils.login_manager
 
-    if settings.IS_DEV:
+    if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
         install_local_providers()
 
     install_all_routes(app)

--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -36,7 +36,7 @@ with app.app_context():
     from pcapi.routes.backoffice_v3.blueprint import backoffice_v3_web
     import pcapi.utils.login_manager
 
-    if settings.IS_DEV:
+    if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
         install_local_providers()
 
     install_routes(app)


### PR DESCRIPTION
## But de la pull request

Fix : ne pas appeler `install_local_providers()` dans _app.py_ et _backoffice.py_ lors des tests. Car à ce moment-là, les migrations n'ont pas nécessairement été exécutées.

Par exemple, si la base de données de test est réinitialisée. Lors du lancement du moindre test, la fonction plante parce que la table `provider` n'existe pas. Il faut donc s'assurer que les migrations ont bien été exécutées avant de l'appeler.

Cette fonction sera appelée dans les fonctions `build_main_app`/`build_backoffice_app` de _conftest.py_ : à ce moment-là, tout aura été correctement initialisé et la fonction s'exécutera sans problème.