### PR TITLE
Jeremieb/fix backoffice v3 217 0 5

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -106,6 +106,7 @@ class Roles(enum.Enum):
     BIZDEV = "bizdev"
     PROGRAMMATION = "programmation"
     PRODUCT_MANAGEMENT = "product-management"
+    HOMOLOGATION = "homologation"
 
 
 role_backoffice_profile_table = sa.Table(

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
@@ -26,7 +26,7 @@
                 <td>{{ event.type }}</td>
                 <td>{{ event.date | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
                 <td class="px-4 text-break">
-                    {% if event.accountName and is_user_offerer_action_type(event) %}
+                    {% if event.accountName and event.accountId is not none and is_user_offerer_action_type(event) %}
                         <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=event.accountId) }}">
                             <p>{{ event.accountName | empty_string_if_null }} - {{ event.accountId }}</p>
                         </a>
@@ -37,7 +37,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {% if is_offerer_new_action_type(event) %}
+                    {% if is_offerer_new_action_type(event) and event.authorId is not none %}
                         <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=event.authorId) }}">
                             <p>{{ event.authorName | empty_string_if_null }} - {{ event.authorId }}</p>
                         </a>

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -258,6 +258,35 @@ class GetOffererDetailsTest:
         assert user_offerer.user.email in content
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_get_history_with_missing_authorId(self, authenticated_client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        offerer = user_offerer.offerer
+        action = history_factories.ActionHistoryFactory(
+            offerer=offerer, actionType=history_models.ActionType.OFFERER_NEW, authorUser=None
+        )
+
+        url = url_for("backoffice_v3_web.offerer.get_details", offerer_id=offerer.id)
+
+        # if offerer is not removed from the current session, any get
+        # query won't be executed because of this specific testing
+        # environment. This would tamper the real database queries
+        # count.
+        db.session.expire(offerer)
+
+        # get session (1 query)
+        # get user with profile and permissions (1 query)
+        # get FF (1 query)
+        # get offerer and its users and history (1 query)
+        with assert_num_queries(4):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        content = response.data.decode("utf-8")
+
+        assert action.comment in content
+        assert user_offerer.user.email in content
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_no_details_data(self, authenticated_client, offerer):
         url = url_for("backoffice_v3_web.offerer.get_details", offerer_id=offerer.id)
 


### PR DESCRIPTION
## But de la pull request

1. Ajout d'un rôle (backoffice) manquant.
2. Ne pas construire le lien le profil du compte pro dans l'historique d'une structure si l'évènement à l'origine du commentaire n'a pas d'auteur.