### PR TITLE
(PC-19044)fix: allow user to delete stockThing limit datetime

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -76,7 +76,14 @@ def edit_collective_stock(
 
     updatable_fields = _extract_updatable_fields_from_stock_data(stock, stock_data, beginning, booking_limit_datetime)
 
-    offer_validation.check_booking_limit_datetime(stock, beginning, booking_limit_datetime)
+    check_beginning = beginning
+    check_booking_limit_datetime = booking_limit_datetime
+    if beginning is None:
+        check_beginning = stock.beginningDatetime
+    if booking_limit_datetime is None:
+        check_booking_limit_datetime = stock.bookingLimitDatetime
+
+    offer_validation.check_booking_limit_datetime(stock, check_beginning, check_booking_limit_datetime)
 
     # due to check_booking_limit_datetime the only reason beginning < booking_limit_dt is when they are on the same day
     # in the venue timezone

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -560,6 +560,11 @@ def edit_stock(
         errors.status_code = 403
         raise errors
 
+    if beginning is None:
+        beginning = stock.beginningDatetime
+    if booking_limit_datetime is None:
+        booking_limit_datetime = stock.bookingLimitDatetime
+
     validation.check_booking_limit_datetime(stock, beginning_datetime, booking_limit_datetime)
 
     new_booking_limit_datetime = booking_limit_datetime or stock.bookingLimitDatetime

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -376,11 +376,6 @@ def check_booking_limit_datetime(
     booking_limit_datetime: datetime | None,
 ) -> None:
     if stock:
-        if beginning is None:
-            beginning = stock.beginningDatetime
-        if booking_limit_datetime is None:
-            booking_limit_datetime = stock.bookingLimitDatetime
-
         if isinstance(stock, CollectiveStock):
             offer = stock.collectiveOffer
         else:

--- a/api/tests/routes/pro/post_stocks_test.py
+++ b/api/tests/routes/pro/post_stocks_test.py
@@ -325,6 +325,63 @@ class Returns201Test:
         assert updated_booking.status is bookings_models.BookingStatus.USED
         assert updated_booking.dateUsed == date_used_in_48_hours
 
+    def test_update_thing_stock_without_booking_limit_date(self, app):
+        # We allow nullable bookingLimitDate for thing Stock.
+        offer = offers_factories.ThingOfferFactory(isActive=False, validation=OfferValidationStatus.DRAFT)
+        booking_limit = datetime(2019, 2, 14)
+        existing_stock = offers_factories.StockFactory(offer=offer, price=10, bookingLimitDatetime=booking_limit)
+        offerers_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+        # When
+        stock_data = {
+            "humanizedOfferId": humanize(offer.id),
+            "stocks": [{"price": 20, "humanizedId": humanize(existing_stock.id)}],
+        }
+
+        response = (
+            TestClient(app.test_client()).with_session_auth("user@example.com").post("/stocks/bulk/", json=stock_data)
+        )
+
+        created_stock = Stock.query.get(dehumanize(response.json["stocks"][0]["id"]))
+        assert offer.id == created_stock.offerId
+        assert created_stock.price == 20
+        assert created_stock.bookingLimitDatetime == None
+
+    def test_update_event_stock_without_booking_limit_date(self, app):
+        # If no bookingLimitDatetime is provided for event Stock, it should not change.
+        offer = offers_factories.EventOfferFactory(isActive=False, validation=OfferValidationStatus.DRAFT)
+        beginning = datetime(2019, 2, 14)
+        booking_limit = datetime(2019, 2, 1)
+        existing_stock = offers_factories.StockFactory(
+            offer=offer, price=10, bookingLimitDatetime=booking_limit, beginningDatetime=beginning
+        )
+        offerers_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+        # When
+        stock_data = {
+            "humanizedOfferId": humanize(offer.id),
+            "stocks": [
+                {
+                    "price": 20,
+                    "humanizedId": humanize(existing_stock.id),
+                    "beginningDatetime": serialize(beginning),
+                }
+            ],
+        }
+
+        response = (
+            TestClient(app.test_client()).with_session_auth("user@example.com").post("/stocks/bulk/", json=stock_data)
+        )
+
+        created_stock = Stock.query.get(dehumanize(response.json["stocks"][0]["id"]))
+        assert offer.id == created_stock.offerId
+        assert created_stock.price == 20
+        assert created_stock.bookingLimitDatetime == booking_limit
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19044
Il est possible de créer un stock Thing sans date limite de reservation mais impossible de la supprimer une fois qu'elle a été ajoutée.  Il est impossible de supprimer la date limite de reservation pour les stocks Event
