### PR TITLE
(PC-18840)[API] feat: add pro user status tag

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -29,6 +29,7 @@ from pcapi.models import db
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.needs_validation_mixin import NeedsValidationMixin
 from pcapi.models.pc_object import PcObject
+from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.utils import crypto
 from pcapi.utils.phone_number import ParsedPhoneNumber
 
@@ -461,6 +462,14 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
     @property
     def is_account_suspended_upon_user_request(self) -> bool:
         return self.account_state == AccountState.SUSPENDED_UPON_USER_REQUEST
+
+    @property
+    def proValidationStatus(self) -> ValidationStatus | None:
+        validation_statuses = [user_offerer.validationStatus for user_offerer in self.UserOfferers]
+        for status in (ValidationStatus.VALIDATED, ValidationStatus.PENDING, ValidationStatus.NEW):  # by priority
+            if status in validation_statuses:
+                return status
+        return None
 
     @hybrid_property
     def is_beneficiary(self) -> bool:

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/badges.html
@@ -48,3 +48,19 @@
 {% macro build_user_offerer_badges(user_offerer) %}
     {{  build_badges(user_offerer, "Nouveau", "En attente", "Validé", "Rejeté") }}
 {% endmacro %}
+
+{% macro build_pro_user_badges(pro_user) %}
+    {% if pro_user.proValidationStatus.value == "VALIDATED" %}
+        <span class="badge rounded-pill text-bg-success align-middle">
+            Validé
+        </span>
+    {% elif pro_user.proValidationStatus.value == "PENDING" %}
+        <span class="badge rounded-pill text-bg-warning align-middle">
+            En attente
+        </span>
+    {% elif pro_user.proValidationStatus.value == "NEW" %}
+        <span class="badge rounded-pill text-bg-info align-middle">
+            Nouveau
+        </span>
+    {% endif %}
+{% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
@@ -1,3 +1,5 @@
+{% from "components/badges.html" import build_pro_user_badges %}
+
 <div class="card shadow">
     <div class="card-body">
         <h5 class="card-title mb-3">
@@ -12,6 +14,7 @@
                     {{ role | format_role }}
                 </span>
             {% endfor %}
+            {{ build_pro_user_badges(row) }}
         </h5>
 
         <h5 class="card-title">

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -1,5 +1,7 @@
 {% extends "layouts/pro.html" %}
 
+{% from "components/badges.html" import build_pro_user_badges %}
+
 {% block pro_main_content %}
 <div class="row row-cols-1 g-4 py-3">
     <div class="col">
@@ -18,6 +20,7 @@
                             {{ user.isActive | format_state }}
                         </span>
                     {% endif %}
+                    {{ build_pro_user_badges(user) }}
                 </h5>
 
                 <h6 class="card-subtitle text-muted">

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -20,6 +20,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as user_models
 from pcapi.core.users.exceptions import InvalidUserRoleException
 from pcapi.models import db
+from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.repository import repository
 
 
@@ -285,6 +286,23 @@ class UserTest:
 
         no_name_user = users_factories.UserFactory(firstName="", lastName="")
         assert no_name_user.full_name == ""
+
+    def test_pro_validation_status(self):
+        user = users_factories.UserFactory()
+        assert user.proValidationStatus is None
+
+        offerers_factories.UserOffererFactory(user=user, validationStatus=ValidationStatus.NEW)
+        assert user.proValidationStatus == ValidationStatus.NEW
+
+        offerers_factories.UserOffererFactory(user=user, validationStatus=ValidationStatus.PENDING)
+        assert user.proValidationStatus == ValidationStatus.PENDING
+
+        offerers_factories.UserOffererFactory(user=user, validationStatus=ValidationStatus.VALIDATED)
+        assert user.proValidationStatus == ValidationStatus.VALIDATED
+
+        offerers_factories.UserOffererFactory(user=user, validationStatus=ValidationStatus.NEW)
+        offerers_factories.UserOffererFactory(user=user, validationStatus=ValidationStatus.PENDING)
+        assert user.proValidationStatus == ValidationStatus.VALIDATED
 
 
 class HasAccessTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18840

## But de la pull request

Ajout d'une vignette explicitant le statut de validation d'un compte pro.
Si un utilisateur pro a au moins un rattachement validé, il est considéré comme validé.
Sinon, et s'il a au moins un rattachement en attente, il est considéré comme en attente.
Sinon, et s'il a au moins une nouvelle demande de rattachement, il est considéré comme nouveau.
Enfin, il y n'a aucun statut sinon.

## Implémentation

Ajout d'une propriété au modèle des Users.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
