### PR TITLE
(PC-19250)[API] fix: fix edit account bug on empty idPieceNumber

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -208,7 +208,10 @@ def update_user_information(
     if civility is not None:
         user.civility = civility
     if id_piece_number is not None:
-        user.idPieceNumber = fraud_api.format_id_piece_number(id_piece_number)
+        if id_piece_number.strip() == "":
+            user.idPieceNumber = None
+        else:
+            user.idPieceNumber = fraud_api.format_id_piece_number(id_piece_number)
     if ine_hash is not None:
         user.ineHash = ine_hash
     if married_name is not None:

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -137,11 +137,32 @@ class UpdatePublicAccountTest:
         user_to_edit = users_factories.BeneficiaryGrant18Factory()
 
         base_form = {
+            "first_name": user_to_edit.firstName,
+            "last_name": user_to_edit.lastName,
+            "email": user_to_edit.email,
             "postal_code": "7500",
         }
 
         response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 400
+
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_empty_id_piece_number(self, authenticated_client):
+        user_to_edit = users_factories.BeneficiaryGrant18Factory()
+
+        base_form = {
+            "first_name": user_to_edit.firstName,
+            "last_name": user_to_edit.lastName,
+            "email": user_to_edit.email,
+            "id_piece_number": "",
+        }
+
+        response = self.update_account(authenticated_client, user_to_edit, base_form)
+        print(response)
+        assert response.status_code == 303
+
+        user_to_edit = users_models.User.query.get(user_to_edit.id)
+        assert user_to_edit.idPieceNumber is None
 
     def update_account(self, authenticated_client, user_to_edit, form):
         # generate csrf token


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19250

## But de la pull request

Remplir un formulaire avec un numéro de pièce d'identité vide ne fonctionnait pas.

## Implémentation

Le numéro de pièce d'identité étant le seul nullable et unique du formulaire, il faut s'assurer que ne pas remplir sa ligne dans le formulaire passe bien la valeur à `None` et pas à `""`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
