### PR TITLE
(PC-19281)[BO] fix: reset page param on new search

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -71,6 +71,8 @@ def search_public_accounts() -> utils.BackofficeResponse:
     paginated_rows = fetch_rows(search_model)
     next_pages_urls = search_utils.pagination_links(next_page, search_model.page, paginated_rows.pages)
 
+    form.page.data = 1  # Reset to first page when form is submitted ("Chercher" clicked)
+
     return render_template(
         "accounts/search_result.html",
         dst=url_for(".search_public_accounts"),

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -289,6 +289,8 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
     next_page = partial(url_for, ".list_offerers_to_validate", **form.data)
     next_pages_urls = search_utils.pagination_links(next_page, int(form.data["page"]), paginated_offerers.pages)
 
+    form.page.data = 1  # Reset to first page when form is submitted ("Appliquer" clicked)
+
     return render_template(
         "offerer/validation.html",
         rows=paginated_offerers,
@@ -424,6 +426,8 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
 
     next_page = partial(url_for, ".list_offerers_attachments_to_validate", **form.data)
     next_pages_urls = search_utils.pagination_links(next_page, int(form.data["page"]), paginated_users_offerers.pages)
+
+    form.page.data = 1  # Reset to first page when form is submitted ("Appliquer" clicked)
 
     return render_template(
         "offerer/user_offerer_validation.html",

--- a/api/src/pcapi/routes/backoffice_v3/pro.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro.py
@@ -105,6 +105,8 @@ def search_pro() -> utils.BackofficeResponse:
     paginated_rows = search_utils.fetch_paginated_rows(context.fetch_rows_func, search_model)
     next_pages_urls = search_utils.pagination_links(next_page, search_model.page, paginated_rows.pages)
 
+    form.page.data = 1  # Reset to first page when form is submitted ("Chercher" clicked)
+
     return render_template(
         "pro/search_result.html",
         form=form,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19281

## But de la pull request

Revenir à la page 1 lorsqu'on fait une nouvelle recherche dans le backoffice v3. Comme Google :)
Sinon,  on cherche un  nouveau terme, mais en affichant la 6ème page (par exemple) si on était à la 6ème de la précédente requête, ce qui n'a pas de sens.

## Informations supplémentaires

Un test auto de cela vérifierait le rendu html du formulaire, en particulier l'attribut d'un tag, ce qui n'est a priori pas souhaitable suite à des discussions d'équipe.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
