### PR TITLE
(BSR)[PRO] fix old ternary-link button icon size

### DIFF
--- a/pro/src/styles/components/layout/buttons/TertiaryButton/_TertiaryButton.scss
+++ b/pro/src/styles/components/layout/buttons/TertiaryButton/_TertiaryButton.scss
@@ -20,7 +20,7 @@
     height: rem.torem(24px);
     margin-right: rem.torem(8px);
     vertical-align: bottom;
-    width: rem.torem(24px);
+    width: rem.torem(20px);
   }
 }
 
@@ -50,7 +50,7 @@
 
     img,
     svg {
-      height: rem.torem(24px);
+      height: rem.torem(20px);
       margin-right: rem.torem(4px);
     }
   }


### PR DESCRIPTION
les css global avait des icons à 24px au lieu de 20px
