### PR TITLE
(PC-18634)[PRO] fix: stock event error messages and fit fields width with figma

### DIFF
--- a/pro/src/components/StockEventForm/StockEventForm.module.scss
+++ b/pro/src/components/StockEventForm/StockEventForm.module.scss
@@ -1,21 +1,22 @@
 @use "styles/mixins/_rem.scss" as rem;
 
-.field-layout-footer {
-  min-height: rem.torem(32px);
-}
-
 .field-layout-align-self {
   align-self: flex-start;
 }
 
-.input-beginning-time {
-  flex: 1 0 rem.torem(90px);
+.input-date {
+  flex: 1 1 rem.torem(168px);
+  max-width: rem.torem(168px);
 }
 
-.input-quantity {
-  flex: 1 0 rem.torem(85px);
+.input-booking-limit-datetime {
+  flex: 1 1 rem.torem(208px);
+  max-width: rem.torem(208px);
 }
 
+.input-beginning-time,
+.input-quantity,
 .input-price {
-  flex: 1 0 rem.torem(90px);
+  flex: 1 1 rem.torem(112px);
+  max-width: rem.torem(112px);
 }

--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -49,13 +49,14 @@ const StockEventForm = ({
         name={`stocks[${stockIndex}]beginningDate`}
         label="Date"
         isLabelHidden={stockIndex !== 0}
-        className={styles['field-layout-align-self']}
+        className={cn(styles['field-layout-align-self'], styles['input-date'])}
         classNameLabel={formRowStyles['field-layout-label']}
         classNameFooter={styles['field-layout-footer']}
         minDateTime={today}
         openingDateTime={today}
         disabled={readOnlyFields.includes('beginningDate')}
         onChange={onChangeBeginningDate}
+        hideHiddenFooter={true}
       />
       <TimePicker
         smallLabel
@@ -69,6 +70,7 @@ const StockEventForm = ({
         classNameFooter={styles['field-layout-footer']}
         name={`stocks[${stockIndex}]beginningTime`}
         disabled={readOnlyFields.includes('beginningTime')}
+        hideHiddenFooter={true}
       />
       <TextInput
         smallLabel
@@ -82,6 +84,7 @@ const StockEventForm = ({
         disabled={readOnlyFields.includes('price')}
         rightIcon={() => (stockFormValues.price ? <IconEuroGrey /> : <></>)}
         type="number"
+        hideHiddenFooter={true}
       />
       <DatePicker
         smallLabel
@@ -89,7 +92,7 @@ const StockEventForm = ({
         label="Date limite de réservation"
         isLabelHidden={stockIndex !== 0}
         className={cn(
-          styles['input-bookingLimitDatetime'],
+          styles['input-booking-limit-datetime'],
           styles['field-layout-align-self']
         )}
         classNameLabel={formRowStyles['field-layout-label']}
@@ -98,6 +101,7 @@ const StockEventForm = ({
         maxDateTime={beginningDate ? beginningDate : undefined}
         openingDateTime={today}
         disabled={readOnlyFields.includes('bookingLimitDatetime')}
+        hideHiddenFooter={true}
       />
       <TextInput
         smallLabel
@@ -114,6 +118,7 @@ const StockEventForm = ({
         disabled={readOnlyFields.includes('quantity')}
         type="number"
         hasDecimal={false}
+        hideHiddenFooter={true}
       />
     </>
   )

--- a/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/validationSchema.spec.tsx
@@ -73,9 +73,11 @@ describe('StockEventForm:validationSchema', () => {
       screen.queryByTestId('error-stocks[0]quantity')
     ).not.toBeInTheDocument()
 
-    expect(errorBeginningDate).toHaveTextContent('Champ obligatoire')
-    expect(errorBeginningTime).toHaveTextContent('Champ obligatoire')
-    expect(errorPrice).toHaveTextContent('Champ obligatoire')
+    expect(errorBeginningDate).toHaveTextContent('Veuillez renseigner une date')
+    expect(errorBeginningTime).toHaveTextContent(
+      'Veuillez renseigner un horaire'
+    )
+    expect(errorPrice).toHaveTextContent('Veuillez renseigner un prix')
   })
 
   const dataSetbeginningDate: Array<number> = [

--- a/pro/src/components/StockEventForm/validationSchema.ts
+++ b/pro/src/components/StockEventForm/validationSchema.ts
@@ -21,7 +21,7 @@ const getSingleValidationSchema = () => {
     beginningDate: yup
       .date()
       .nullable()
-      .required('Champ obligatoire')
+      .required('Veuillez renseigner une date')
       .when(['readOnlyFields'], (readOnlyFields, schema) => {
         /* istanbul ignore next: DEBT, TO FIX */
         if (readOnlyFields.includes('beginningDate')) {
@@ -32,16 +32,20 @@ const getSingleValidationSchema = () => {
           "L'évènement doit être à venir"
         )
       }),
-    beginningTime: yup.string().nullable().required('Champ obligatoire'),
+    beginningTime: yup
+      .string()
+      .nullable()
+      .required('Veuillez renseigner un horaire'),
     price: yup
       .number()
       .typeError('Doit être un nombre')
       .moreThan(-1, 'Doit être positif')
       .max(300, 'Veuillez renseigner un prix inférieur à 300€')
-      .required('Champ obligatoire'),
+      .required('Veuillez renseigner un prix'),
     bookingLimitDatetime: yup.date().nullable().test({
       name: 'bookingLimitDatetime-before-beginningDate',
-      message: 'Date invalide',
+      message:
+        'Veuillez renseigner une date antérieure à la date de l’évènement',
       test: isBeforeBeginningDate,
     }),
     bookingsQuantity: yup.number(),

--- a/pro/src/components/StockEventFormRow/StockEventFormRow.module.scss
+++ b/pro/src/components/StockEventFormRow/StockEventFormRow.module.scss
@@ -2,6 +2,7 @@
 
 .stock-form-row {
   display: flex;
+  padding-bottom: rem.torem(16px);
 
   .stock-form {
     display: flex;

--- a/pro/src/ui-kit/form/DatePicker/DatePicker.tsx
+++ b/pro/src/ui-kit/form/DatePicker/DatePicker.tsx
@@ -24,6 +24,8 @@ interface IDatePickerProps {
   openingDateTime?: Date
   smallLabel?: boolean
   isOptional?: boolean
+  hideFooter?: boolean
+  hideHiddenFooter?: boolean
   onChange?: (name: string, date: Date | null) => void
 }
 
@@ -41,9 +43,12 @@ const DatePicker = ({
   smallLabel,
   isOptional = false,
   onChange,
+  hideFooter = false,
+  hideHiddenFooter = false,
 }: IDatePickerProps): JSX.Element => {
   const [field, meta, helpers] = useField({ name, type: 'date' })
   const ref = createRef<HTMLInputElement>()
+  const showError = meta.touched && !!meta.error
 
   return (
     <FieldLayout
@@ -54,9 +59,10 @@ const DatePicker = ({
       label={label}
       isLabelHidden={isLabelHidden}
       name={name}
-      showError={meta.touched && !!meta.error}
+      showError={showError}
       smallLabel={smallLabel}
       isOptional={isOptional}
+      hideFooter={hideFooter || (hideHiddenFooter && !showError)}
     >
       <ReactDatePicker
         {...field}

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -28,6 +28,7 @@ export interface ITextInputProps
   inline?: boolean
   hasDecimal?: boolean
   refForInput?: ForwardedRef<HTMLInputElement>
+  hideHiddenFooter?: boolean
 }
 
 const TextInput = ({
@@ -52,6 +53,7 @@ const TextInput = ({
   step,
   hasDecimal = true,
   inline = false,
+  hideHiddenFooter = false,
   ...props
 }: ITextInputProps): JSX.Element => {
   const [field, meta] = useField({
@@ -61,6 +63,7 @@ const TextInput = ({
 
   const regexHasDecimal = /[0-9,.]|Backspace/
   const regexHasNotDecimal = /[0-9]|Backspace/
+  const showError = meta.touched && !!meta.error
 
   return (
     <FieldLayout
@@ -69,15 +72,15 @@ const TextInput = ({
       classNameFooter={classNameFooter}
       count={countCharacters ? field.value.length : undefined}
       error={meta.error}
-      hideFooter={hideFooter}
       isOptional={isOptional}
       label={label}
       isLabelHidden={isLabelHidden}
       maxLength={maxLength}
       name={name}
-      showError={meta.touched && !!meta.error}
+      showError={showError}
       smallLabel={smallLabel}
       inline={inline}
+      hideFooter={hideFooter || (hideHiddenFooter && !showError)}
     >
       {readOnly ? (
         <span

--- a/pro/src/ui-kit/form/TimePicker/TimePicker.tsx
+++ b/pro/src/ui-kit/form/TimePicker/TimePicker.tsx
@@ -19,6 +19,8 @@ export interface ITimePickerProps {
   smallLabel?: boolean
   classNameFooter?: string
   classNameLabel?: string
+  hideFooter?: boolean
+  hideHiddenFooter?: boolean
 }
 
 const TimePicker = ({
@@ -30,9 +32,12 @@ const TimePicker = ({
   label,
   isLabelHidden = false,
   smallLabel,
+  hideFooter = false,
+  hideHiddenFooter = false,
 }: ITimePickerProps): JSX.Element => {
   const [field, meta, helpers] = useField({ name, type: 'text' })
   const ref = createRef<HTMLInputElement>()
+  const showError = meta.touched && !!meta.error
 
   /* istanbul ignore next: DEBT, TO FIX */
   return (
@@ -42,10 +47,11 @@ const TimePicker = ({
       label={label}
       isLabelHidden={isLabelHidden}
       name={name}
-      showError={meta.touched && !!meta.error}
+      showError={showError}
       smallLabel={smallLabel}
       classNameLabel={classNameLabel}
       classNameFooter={classNameFooter}
+      hideFooter={hideFooter || (hideHiddenFooter && !showError)}
     >
       <ReactDatePicker
         {...field}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18634

## But de la pull request

- Mettre les bons messages d'erreur des champs du formulaire de stock event
- Corriger la taille des champs
- Enlever l'espace créé par les messages d'erreur lorsqu'ils ne sont pas visibles.

## Implémentation
![Screenshot from 2022-12-14 17-11-11](https://user-images.githubusercontent.com/106379750/207654803-39912594-03eb-4d82-87c7-78e2a203bfce.png)
![Screenshot from 2022-12-14 17-01-07](https://user-images.githubusercontent.com/106379750/207654811-eb5892fb-ba93-4672-8862-a781ec3c5729.png)
![Screenshot from 2022-12-14 17-01-02](https://user-images.githubusercontent.com/106379750/207654816-f960937d-00f2-49de-98d2-12aff36b1735.png)
![Screenshot from 2022-12-14 17-00-51](https://user-images.githubusercontent.com/106379750/207654817-3aa0aa0f-d004-4c8f-b5ff-3935966bf50d.png)
![Screenshot from 2022-12-14 16-08-26](https://user-images.githubusercontent.com/106379750/207654820-b506c7bd-2ac0-476e-a11e-7fb3d7a64c49.png)
![Screenshot from 2022-12-14 16-07-52](https://user-images.githubusercontent.com/106379750/207654822-b5c0860c-58ae-43b5-a745-2de2ccd1c31e.png)

