### PR TITLE
(PC-19157)[BO] fix: offerer attachment: 'Validé' instead of 'Validée'…

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/badges.html
@@ -2,19 +2,19 @@
 
     {% if object.isNew %}
         <span class="me-1 pb-1 badge rounded-pill text-bg-info">
-            Nouvelle
+            {{ new }}
         </span>
     {% elif object.isPending %}
         <span class="me-1 pb-1 badge rounded-pill text-bg-warning">
-            En attente
+            {{ pending }}
         </span>
     {% elif object.isValidated %}
         <span class="me-1 pb-1 badge rounded-pill text-bg-success">
-            Validée
+            {{ validated }}
         </span>
     {% elif object.isRejected %}
         <span class="me-1 pb-1 badge rounded-pill text-bg-danger">
-            Rejetée
+            {{ rejected }}
         </span>
     {% endif %}
 


### PR DESCRIPTION
…, etc.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19157

## But de la pull request

Petite confusion masulin/féminin dans un badge des comptes pro rattachés, sur la page des structures (bo v3).

## Informations supplémentaires

- C'est seulement une partie du ticket PC-19157, mais cette partie est triviale.
- Je n'ai pas trouvé de tests existants sur ces comptes pro rattachés, le but de ce fix rapide n'est pas de les écrire entièrement.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
