### PR TITLE
(PC-18772)[BO] feat: search offerers to validate by postal code, department, city

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-aca83eb30235 (pre) (head)
+7b3320f4bd9a (pre) (head)
 c4d0c538e763 (post) (head)

--- a/api/src/pcapi/alembic/versions/20221215T153133_f35df0030ca5_add_offerer_index_postal_code.py
+++ b/api/src/pcapi/alembic/versions/20221215T153133_f35df0030ca5_add_offerer_index_postal_code.py
@@ -1,0 +1,19 @@
+"""Add_Offerer_index_postal_code
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "f35df0030ca5"
+down_revision = "aca83eb30235"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(op.f("ix_offerer_postalCode"), "offerer", ["postalCode"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_offerer_postalCode"), table_name="offerer")

--- a/api/src/pcapi/alembic/versions/20221215T153243_7b3320f4bd9a_add_offerer_index_city.py
+++ b/api/src/pcapi/alembic/versions/20221215T153243_7b3320f4bd9a_add_offerer_index_city.py
@@ -1,0 +1,35 @@
+"""Add_Offerer_index_city
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "7b3320f4bd9a"
+down_revision = "f35df0030ca5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("""SET SESSION statement_timeout = '900s'""")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_offerer_city
+        ON offerer
+        USING gin ("city" public.gin_trgm_ops)
+        """
+    )
+    op.execute(f"""SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}""")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "ix_offerer_city"
+        """
+    )

--- a/api/src/pcapi/models/has_address_mixin.py
+++ b/api/src/pcapi/models/has_address_mixin.py
@@ -9,6 +9,6 @@ from sqlalchemy.orm import declarative_mixin
 class HasAddressMixin:
     address = Column(String(200), nullable=True)
 
-    postalCode: str = Column(String(6), nullable=False)
+    postalCode: str = Column(String(6), nullable=False, index=True)
 
-    city: str = Column(String(50), nullable=False)
+    city: str = Column(String(50), nullable=False, index=True)

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -22,7 +22,7 @@ class OffererValidationListForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Nom de structure ou SIREN")
+    q = fields.PCOptSearchField("Nom de structure, SIREN, code postal ou département")
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )
@@ -39,8 +39,10 @@ class OffererValidationListForm(FlaskForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data and q.data.isnumeric() and len(q.data) != 9:
-            raise wtforms.validators.ValidationError("Le SIREN doit faire 9 caractères")
+        if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
+            raise wtforms.validators.ValidationError(
+                "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
+            )
         return q
 
 

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -372,17 +372,23 @@ def offerer_tags_fixture():
 def offerers_to_be_validated_fixture(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
-    no_tag = offerers_factories.NotValidatedOffererFactory(name="A", siren="123001001", address=None)
+    no_tag = offerers_factories.NotValidatedOffererFactory(
+        name="A", siren="123001001", address=None, postalCode="35000", city="Rennes"
+    )
     top = offerers_factories.NotValidatedOffererFactory(
-        name="B", siren="123002002", validationStatus=ValidationStatus.PENDING
+        name="B", siren="123002002", validationStatus=ValidationStatus.PENDING, postalCode="29000", city="Quimper"
     )
-    collec = offerers_factories.NotValidatedOffererFactory(name="C", siren="123003003")
+    collec = offerers_factories.NotValidatedOffererFactory(
+        name="C", siren="123003003", postalCode="29200", city="Brest"
+    )
     public = offerers_factories.NotValidatedOffererFactory(
-        name="D", siren="123004004", validationStatus=ValidationStatus.PENDING
+        name="D", siren="123004004", validationStatus=ValidationStatus.PENDING, postalCode="29300", city="Quimperlé"
     )
-    top_collec = offerers_factories.NotValidatedOffererFactory(name="E", siren="123005005")
+    top_collec = offerers_factories.NotValidatedOffererFactory(
+        name="E", siren="123005005", postalCode="35400", city="Saint-Malo"
+    )
     top_public = offerers_factories.NotValidatedOffererFactory(
-        name="F", siren="123006006", validationStatus=ValidationStatus.PENDING
+        name="F", siren="123006006", validationStatus=ValidationStatus.PENDING, postalCode="29200", city="Brest"
     )
 
     for offerer in (top, top_collec, top_public):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18772

## But de la pull request

Dans la recherche de structures à valider du backoffice v3, permettre de rechercher les structures par code postal, code de département et ville.

## Modifications du schéma de la base de données

Ajout d'index sur le code postal et la ville, afin de viser une recherche performante.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
