### PR TITLE
(BSR)[BO] fix: offerer_validationToken_key and user_offerer_validatio…

### DIFF
--- a/api/src/pcapi/alembic/versions/20221208T130319_3e01ce2e72df_remove_offerer_validationtoken.py
+++ b/api/src/pcapi/alembic/versions/20221208T130319_3e01ce2e72df_remove_offerer_validationtoken.py
@@ -13,7 +13,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint("offerer_validationToken_key", "offerer", type_="unique")
+    # constraint offerer_validationToken_key is dropped with column
     op.drop_column("offerer", "validationToken")
 
 

--- a/api/src/pcapi/alembic/versions/20221208T130521_47bf17f0d7e9_remove_userofferer_validationtoken.py
+++ b/api/src/pcapi/alembic/versions/20221208T130521_47bf17f0d7e9_remove_userofferer_validationtoken.py
@@ -13,7 +13,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_constraint("user_offerer_validationToken_key", "user_offerer", type_="unique")
+    # constraint user_offerer_validationToken_key is dropped with column
     op.drop_column("user_offerer", "validationToken")
 
 


### PR DESCRIPTION
…nToken_key constraints are missing in prod

## But de la pull request

Débloquer les migrations sur staging.

Les contraintes `offerer_validationToken_key` et `user_offerer_validationToken_key` n'existent pas en production, ni donc sur staging, bien qu'elles soient présentes dans `schema_init.sql` ; la migration les supprimant échoue.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
