### PR TITLE
(BSR)[API] fix: native: send genre_type within native category

### DIFF
--- a/api/src/pcapi/core/categories/subcategories_v2.py
+++ b/api/src/pcapi/core/categories/subcategories_v2.py
@@ -60,6 +60,34 @@ class ReimbursementRuleChoices(Enum):
     BOOK = "BOOK"
 
 
+class GenreType(Enum):
+    BOOK = "BOOK"
+    MUSIC = "MUSIC"
+    SHOW = "SHOW"
+    MOVIE = "MOVIE"
+
+    @property
+    def values(self) -> list[str]:
+        return {
+            type(self).BOOK.name: self.book_values(),
+            type(self).MUSIC.name: self.music_values(),
+            type(self).SHOW.name: self.show_values(),
+            type(self).MOVIE.name: self.movie_values(),
+        }[self.value]
+
+    def book_values(self) -> list[str]:
+        return sorted(BOOK_MACRO_SECTIONS)
+
+    def music_values(self) -> list[str]:
+        return sorted(MUSIC_TYPES_LABEL_BY_CODE.values())
+
+    def show_values(self) -> list[str]:
+        return sorted(SHOW_TYPES_LABEL_BY_CODE.values())
+
+    def movie_values(self) -> list[str]:
+        return sorted(MOVIE_TYPES)
+
+
 class NativeCategory(Enum):
     LIVRES_PAPIER = "Livres papier"
     LIVRES_NUMERIQUE_ET_AUDIO = "Livres numérique & audio"
@@ -106,33 +134,12 @@ class NativeCategory(Enum):
     PRATIQUE_ARTISTIQUE_EN_LIGNE = "Pratique artistique en ligne"
     DEPRECIEE = "Dépréciée"
 
-
-class GenreType(Enum):
-    BOOK = "BOOK"
-    MUSIC = "MUSIC"
-    SHOW = "SHOW"
-    MOVIE = "MOVIE"
-
     @property
-    def values(self) -> list[str]:
-        return {
-            type(self).BOOK.name: self.book_values(),
-            type(self).MUSIC.name: self.music_values(),
-            type(self).SHOW.name: self.show_values(),
-            type(self).MOVIE.name: self.movie_values(),
-        }[self.value]
-
-    def book_values(self) -> list[str]:
-        return sorted(BOOK_MACRO_SECTIONS)
-
-    def music_values(self) -> list[str]:
-        return sorted(MUSIC_TYPES_LABEL_BY_CODE.values())
-
-    def show_values(self) -> list[str]:
-        return sorted(SHOW_TYPES_LABEL_BY_CODE.values())
-
-    def movie_values(self) -> list[str]:
-        return sorted(MOVIE_TYPES)
+    def genre_type(self) -> GenreType | None:
+        try:
+            return NATIVE_CATEGORY_GENRES_TYPES_MAPPING[self]
+        except KeyError:
+            return None
 
 
 NATIVE_CATEGORY_GENRES_TYPES_MAPPING = {
@@ -200,13 +207,6 @@ class Subcategory:
     @property
     def is_online_only(self) -> bool:
         return self.online_offline_platform == OnlineOfflinePlatformChoices.ONLINE.value
-
-    @property
-    def genre_type(self) -> GenreType | None:
-        try:
-            return NATIVE_CATEGORY_GENRES_TYPES_MAPPING[self.native_category]
-        except KeyError:
-            return None
 
 
 # region Subcategories declarations

--- a/api/src/pcapi/routes/native/v1/serialization/subcategories_v2.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subcategories_v2.py
@@ -15,7 +15,6 @@ class SubcategoryResponseModelv2(BaseModel):
     homepage_label_name: subcategories_v2.HomepageLabelNameEnumv2
     is_event: bool
     online_offline_platform: subcategories_v2.OnlineOfflinePlatformChoicesEnumv2
-    genre_type: subcategories_v2.GenreType | None
 
     class Config:
         alias_generator = to_camel
@@ -46,6 +45,7 @@ class HomepageLabelResponseModelv2(BaseModel):
 class NativeCategoryResponseModelv2(BaseModel):
     name: subcategories_v2.NativeCategoryIdEnumv2
     value: Optional[str]
+    genre_type: subcategories_v2.GenreType | None
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -691,6 +691,7 @@ def test_public_api(client):
                     "properties": {
                         "name": {"$ref": "#/components/schemas/NativeCategoryIdEnumv2"},
                         "value": {"nullable": True, "title": "Value", "type": "string"},
+                        "genreType": {"anyOf": [{"$ref": "#/components/schemas/GenreType"}], "nullable": True},
                     },
                     "required": ["name"],
                     "title": "NativeCategoryResponseModelv2",
@@ -1461,7 +1462,6 @@ def test_public_api(client):
                         "onlineOfflinePlatform": {"$ref": "#/components/schemas/OnlineOfflinePlatformChoicesEnumv2"},
                         "searchGroupName": {"$ref": "#/components/schemas/SearchGroupNameEnumv2"},
                         "nativeCategoryId": {"$ref": "#/components/schemas/NativeCategoryIdEnumv2"},
-                        "genreType": {"anyOf": [{"$ref": "#/components/schemas/GenreType"}], "nullable": True},
                     },
                     "required": [
                         "id",


### PR DESCRIPTION
## But de la pull request

Correction : on a besoin du `genre_type` au même niveau que la `native_category` dans la réponse de l'API. Pas parmi toutes les informations d'une sous-catégorie.
