### PR TITLE
(PC-18594)[API] feat: auto set permanent synced venues

### DIFF
--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -50,11 +50,12 @@ def create_venue_provider(
     if (
         provider.isActive
         and provider.enabledForPro
-        and venue.venueType.label
+        and venue.venueTypeCode
         in (
-            offerers_models.VenueTypeCode.BOOKSTORE.value,
-            offerers_models.VenueTypeCode.MOVIE.value,
+            offerers_models.VenueTypeCode.BOOKSTORE,
+            offerers_models.VenueTypeCode.MOVIE,
         )
+        and not venue.isPermanent
     ):
         venue.isPermanent = True
         repository.save(venue)

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -37,11 +37,11 @@ class CreateVenueProviderTest:
         assert not providers_models.VenueProvider.query.first()
 
     @pytest.mark.parametrize(
-        "venue_type, provider_is_active, provider_enabled_for_pro, is_permanent",
+        "venue_type, is_permanent",
         (
-            (offerers_models.VenueTypeCode.BOOKSTORE, True, True, True),
-            (offerers_models.VenueTypeCode.MOVIE, True, True, True),
-            (offerers_models.VenueTypeCode.DIGITAL, True, True, False),
+            (offerers_models.VenueTypeCode.BOOKSTORE, True),
+            (offerers_models.VenueTypeCode.MOVIE, True),
+            (offerers_models.VenueTypeCode.DIGITAL, False),
         ),
     )
     @patch(
@@ -52,16 +52,14 @@ class CreateVenueProviderTest:
         self,
         _unused_mock,
         venue_type,
-        provider_is_active,
-        provider_enabled_for_pro,
         is_permanent,
         db_session,
     ):
         # Given
         venue = offerers_factories.VenueFactory(venueTypeCode=venue_type)
         provider = providers_factories.ProviderFactory(
-            enabledForPro=provider_enabled_for_pro,
-            isActive=provider_is_active,
+            enabledForPro=True,
+            isActive=True,
             apiUrl="https://example.com/api",
             localClass=None,
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18594

## But de la pull request

marquer comme permanents les lieux qui déclarent une synchro

## Implémentation

RAS

## Informations supplémentaires

la requête de rattrapage à lancer sur la prod quand la PR sera mergée:
```sql
WITH permanent_venues AS (
    SELECT
        v.id,
        v.name,
        v."isPermanent",
        p.name AS provider,
        vt.label AS type
    FROM provider AS p
        JOIN venue_provider AS vp ON p.id = vp."providerId"
        JOIN venue AS v ON v.id = vp."venueId"
        JOIN venue_type AS vt ON v."venueTypeId" = vt.id
    WHERE p."isActive" IS TRUE
        AND p."enabledForPro" IS TRUE
        AND v."isPermanent" IS FALSE
        AND vt.label in ('Librairie', 'Cinéma - Salle de projections')
    ORDER BY vt.label, p.name DESC
)
-- SELECT *
-- FROM permanent_venues
UPDATE venue
SET "isPermanent" = TRUE
WHERE id IN (SELECT id FROM permanent_venues)
;
```

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)


[PC-18594]: https://passculture.atlassian.net/browse/PC-18594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ