### PR TITLE
(PC-19049)[API] feat: add offerer status filter on user offerer list

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1374,8 +1374,6 @@ def _apply_query_filters(
 ) -> sa.orm.Query:
     if status:
         query = query.filter(cls.validationStatus.in_(status))  # type: ignore [union-attr]
-    else:
-        query = query.filter(cls.isWaitingForValidation)
 
     if tags:
         tagged_offerers = (
@@ -1476,6 +1474,7 @@ def list_users_offerers_to_be_validated_legacy(filter_: list[dict[str, typing.An
 def list_users_offerers_to_be_validated(
     tags: list[offerers_models.OffererTag] | None = None,
     status: list[ValidationStatus] | None = None,
+    offerer_status: list[ValidationStatus] | None = None,
     from_datetime: datetime | None = None,
     to_datetime: datetime | None = None,
 ) -> sa.orm.Query:
@@ -1488,6 +1487,11 @@ def list_users_offerers_to_be_validated(
         .joinedload(offerers_models.Offerer.UserOfferers)
         .joinedload(offerers_models.UserOfferer.user),
     )
+    if offerer_status:
+        query = query.join(
+            offerers_models.Offerer,
+            offerers_models.Offerer.id == offerers_models.UserOfferer.offererId,
+        ).filter(offerers_models.Offerer.validationStatus.in_(offerer_status))
 
     return _apply_query_filters(
         query,

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -53,7 +53,12 @@ class UserOffererValidationListForm(FlaskForm):
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )
-    status = fields.PCSelectMultipleField("États", choices=utils.choices_from_enum(ValidationStatus))
+    status = fields.PCSelectMultipleField(
+        "États de la demande de rattachement", choices=utils.choices_from_enum(ValidationStatus)
+    )
+    offerer_status = fields.PCSelectMultipleField(
+        "États de la structure", choices=utils.choices_from_enum(ValidationStatus)
+    )
     from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Demande jusqu'au", validators=(wtforms.validators.Optional(),))
 

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -20,6 +20,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.models.validation_status_mixin import ValidationStatus
 import pcapi.utils.regions as regions_utils
 
 from . import search_utils
@@ -271,6 +272,10 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
     if not form.validate():
         return render_template("offerer/validation.html", rows=[], form=form, stats=stats), 400
 
+    # new and pending attachements by default
+    if not form.status.data:
+        form.status.data = [ValidationStatus.NEW.value, ValidationStatus.PENDING.value]
+
     offerers = offerers_api.list_offerers_to_be_validated(
         form.q.data,
         form.tags.data,
@@ -410,9 +415,14 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
     if not form.validate():
         return render_template("offerer/user_offerer_validation.html", rows=[], form=form), 400
 
+    # new and pending attachements by default
+    if not form.status.data:
+        form.status.data = [ValidationStatus.NEW.value, ValidationStatus.PENDING.value]
+
     users_offerers = offerers_api.list_users_offerers_to_be_validated(
         form.tags.data,
         form.status.data,
+        form.offerer_status.data,
         _date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
         _date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
     )

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -25,7 +25,7 @@
                     <div class="input-group mb-1 ">
                         {% for form_field in form %}
                             {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
-                                <div class="col-6 p-1"> {{ form_field }}</div>
+                                <div class="col-4 p-1"> {{ form_field }}</div>
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -409,15 +409,23 @@ def offerers_to_be_validated_fixture(offerer_tags):
 def user_offerer_to_be_validated_fixture(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
-    no_tag = offerers_factories.NotValidatedUserOffererFactory(user__email="a@example.com")
+    no_tag = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="a@example.com", offerer__validationStatus=ValidationStatus.NEW
+    )
     top = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="b@example.com", validationStatus=ValidationStatus.PENDING
+        user__email="b@example.com",
+        offerer__validationStatus=ValidationStatus.NEW,
+        validationStatus=ValidationStatus.PENDING,
     )
     collec = offerers_factories.NotValidatedUserOffererFactory(user__email="c@example.com")
     public = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="d@example.com", validationStatus=ValidationStatus.PENDING
+        user__email="d@example.com",
+        offerer__validationStatus=ValidationStatus.PENDING,
+        validationStatus=ValidationStatus.PENDING,
     )
-    top_collec = offerers_factories.NotValidatedUserOffererFactory(user__email="e@example.com")
+    top_collec = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="e@example.com", offerer__validationStatus=ValidationStatus.PENDING
+    )
     top_public = offerers_factories.NotValidatedUserOffererFactory(
         user__email="f@example.com", validationStatus=ValidationStatus.PENDING
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19049

## But de la pull request

Ajout d'un filtre sur le statut de la structure à la liste des rattachements

## Informations supplémentaires

Le filtrage par défaut (NEW et PENDING) pour les rattachements est clairement affiché.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
