### PR TITLE
Stop installing local providers

### DIFF
--- a/api/src/pcapi/alembic/versions/sql/schema_init.sql
+++ b/api/src/pcapi/alembic/versions/sql/schema_init.sql
@@ -5588,6 +5588,7 @@ INSERT INTO public.provider VALUES (false, 8, 'Praxiel/Inférence', 'PraxielStoc
 INSERT INTO public.provider VALUES (false, 1, 'TiteLive Stocks (Epagine / Place des libraires.com)', 'TiteLiveStocks', false, NULL, NULL, true, false);
 INSERT INTO public.provider VALUES (true, 9, 'Ciné Office', 'CDSStocks', true, NULL, NULL, false, false);
 INSERT INTO public.provider VALUES (true, 10, 'Boost', 'BoostStocks', true, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 11, 'Pass Culture API Stocks', 'PCAPIStocks', false, NULL, NULL, false, false);
 
 
 --

--- a/api/src/pcapi/alembic/versions/sql/schema_init.sql
+++ b/api/src/pcapi/alembic/versions/sql/schema_init.sql
@@ -5578,17 +5578,14 @@ INSERT INTO public.offerer_tag VALUES (1, 'top-acteur', 'Top Acteur', 'Acteur pr
 -- Data for Name: provider; Type: TABLE DATA; Schema: public; Owner: pass_culture
 --
 
-INSERT INTO public.provider VALUES (false, 2, 'TiteLive (Epagine / Place des libraires.com)', 'TiteLiveThings', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 3, 'TiteLive (Epagine / Place des libraires.com) Descriptions', 'TiteLiveThingDescriptions', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 4, 'TiteLive (Epagine / Place des libraires.com) Thumbs', 'TiteLiveThingThumbs', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 5, 'Allociné', 'AllocineStocks', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 6, 'Leslibraires.fr', 'LibrairesStocks', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 7, 'FNAC', 'FnacStocks', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 8, 'Praxiel/Inférence', 'PraxielStocks', false, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 1, 'TiteLive Stocks (Epagine / Place des libraires.com)', 'TiteLiveStocks', false, NULL, NULL, true, false);
-INSERT INTO public.provider VALUES (true, 9, 'Ciné Office', 'CDSStocks', true, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (true, 10, 'Boost', 'BoostStocks', true, NULL, NULL, false, false);
-INSERT INTO public.provider VALUES (false, 11, 'Pass Culture API Stocks', 'PCAPIStocks', false, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 1, 'TiteLive (Epagine / Place des libraires.com)', 'TiteLiveThings', false, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 2, 'TiteLive (Epagine / Place des libraires.com) Descriptions', 'TiteLiveThingDescriptions', false, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 3, 'TiteLive (Epagine / Place des libraires.com) Thumbs', 'TiteLiveThingThumbs', false, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 4, 'Allociné', 'AllocineStocks', false, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 5, 'FNAC', 'FnacStocks', false, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (true, 6, 'Ciné Office', 'CDSStocks', true, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (true, 7, 'Boost', 'BoostStocks', true, NULL, NULL, false, false);
+INSERT INTO public.provider VALUES (false, 8, 'Pass Culture API Stocks', 'PCAPIStocks', false, NULL, NULL, false, false);
 
 
 --

--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -4,7 +4,6 @@ from sentry_sdk import set_tag
 
 from pcapi import settings
 from pcapi.flask_app import app
-from pcapi.local_providers.install import install_local_providers
 
 
 app.config["SESSION_COOKIE_HTTPONLY"] = True
@@ -27,9 +26,6 @@ with app.app_context():
     # pylint: disable=unused-import
     from pcapi.routes import install_all_routes
     import pcapi.utils.login_manager
-
-    if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
-        install_local_providers()
 
     install_all_routes(app)
 

--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -6,7 +6,6 @@ from sentry_sdk import set_tag
 
 from pcapi import settings
 from pcapi.flask_app import app
-from pcapi.local_providers.install import install_local_providers
 
 
 app.config["SESSION_COOKIE_HTTPONLY"] = True
@@ -36,9 +35,6 @@ with app.app_context():
     from pcapi.routes.backoffice_v3.blueprint import backoffice_v3_web
     import pcapi.routes.backoffice_v3.error_handlers  # pylint: disable=unused-import
     import pcapi.utils.login_manager
-
-    if settings.IS_DEV and not settings.IS_RUNNING_TESTS:
-        install_local_providers()
 
     install_routes(app)
     app.register_blueprint(backoffice_v3_web, url_prefix="/backofficev3")

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -31,7 +31,6 @@ import pcapi.core.testing
 from pcapi.core.users import testing as users_testing
 import pcapi.core.users.models as users_models
 from pcapi.install_database_extensions import install_database_extensions
-from pcapi.local_providers.install import install_local_providers
 from pcapi.models import db
 from pcapi.models.feature import install_feature_flags
 from pcapi.notifications.internal import testing as internal_notifications_testing
@@ -96,7 +95,6 @@ def build_backoffice_app():
         install_database_extensions()
         run_migrations()
         install_feature_flags()
-        install_local_providers()
 
         install_routes(app)
 
@@ -125,7 +123,6 @@ def build_main_app():
         install_database_extensions()
         run_migrations()
         install_feature_flags()
-        install_local_providers()
 
         yield app
 
@@ -204,7 +201,6 @@ def _db(app):
     install_database_extensions()
     run_migrations()
 
-    install_local_providers()
     clean_all_database()
 
     return mock_db


### PR DESCRIPTION
Avantage : 
Supprimer les `install_local_providers` qu'il faut répéter à plein d'endroits (notamment dans les tests).
En effet les local_providers sont installés dans les migrations (init)

Le seul usage qui resterait serait pour "relancer la sandbox" en env testing.

Inconvénient : 
Quand on ajoute un "local provider" il faut l'ajouter à la fois dans `install_local_providers` (pour la sandbox de testing) et dans une migration de données.