### PR TITLE
(PC-19290)[BO] feat: filter offerers to validate by pro user name or email

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1421,25 +1421,36 @@ def list_offerers_to_be_validated(
     )
 
     if q:
-        if q.isnumeric():
-            num_digits = len(q)
+        sanitized_q = email_utils.sanitize_email(q)
+
+        if sanitized_q.isnumeric():
+            num_digits = len(sanitized_q)
             if num_digits == 9:
-                query = query.filter(offerers_models.Offerer.siren == q)
+                query = query.filter(offerers_models.Offerer.siren == sanitized_q)
             elif num_digits == 5:
-                query = query.filter(offerers_models.Offerer.postalCode == q)
+                query = query.filter(offerers_models.Offerer.postalCode == sanitized_q)
             elif num_digits in (2, 3):
-                query = query.filter(offerers_models.Offerer.departementCode == q)
+                query = query.filter(offerers_models.Offerer.departementCode == sanitized_q)
             else:
                 raise exceptions.InvalidSiren(
                     "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
                 )
+        elif email_utils.is_valid_email(sanitized_q):
+            # Filter by attached user email address
+            query = query.join(offerers_models.UserOfferer).join(users_models.User)
+            query = query.filter(users_models.User.email == sanitized_q)
         else:
             name = q.replace(" ", "%").replace("-", "%")
             name = clean_accents(name)
+            # outerjoin so that we filter on offerer name entities which may have no user attached
+            query = query.outerjoin(offerers_models.UserOfferer).outerjoin(users_models.User)
             query = query.filter(
                 sa.or_(
                     sa.func.unaccent(offerers_models.Offerer.name).ilike(f"%{name}%"),
                     sa.func.unaccent(offerers_models.Offerer.city).ilike(f"%{name}%"),
+                    sa.func.unaccent(
+                        sa.func.concat(users_models.User.firstName, " ", users_models.User.lastName)
+                    ).ilike(f"%{name}%"),
                 )
             )
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -22,7 +22,7 @@ class OffererValidationListForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Nom de structure, SIREN, code postal ou département")
+    q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -398,6 +398,16 @@ def offerers_to_be_validated_fixture(offerer_tags):
     for offerer in (public, top_public):
         offerers_factories.OffererTagMappingFactory(tagId=public_tag.id, offererId=offerer.id)
 
+    offerers_factories.UserOffererFactory(
+        offerer=top, user__firstName="Sadi", user__lastName="Carnot", user__email="sadi@example.com"
+    )
+    offerers_factories.UserOffererFactory(
+        offerer=collec, user__firstName="Félix", user__lastName="Faure", user__email="felix@example.com"
+    )
+    offerers_factories.UserOffererFactory(
+        offerer=public, user__firstName="Émile", user__lastName="Loubet", user__email="emile@example.com"
+    )
+
     # Other statuses
     offerers_factories.OffererFactory(name="G")
     offerers_factories.NotValidatedOffererFactory(name="H", validationStatus=ValidationStatus.REJECTED)

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -768,6 +768,32 @@ class ListOfferersToValidateTest:
             )
 
         @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+        def test_list_search_by_email(self, authenticated_client, offerers_to_be_validated):
+            # when
+            with assert_no_duplicated_queries():
+                response = authenticated_client.get(
+                    url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate", q="sadi@example.com")
+                )
+
+            # then
+            assert response.status_code == 200
+            rows = html_parser.extract_table_rows(response.data)
+            assert {row["Nom de la structure"] for row in rows} == {"B"}
+
+        @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+        def test_list_search_by_user_name(self, authenticated_client, offerers_to_be_validated):
+            # when
+            with assert_no_duplicated_queries():
+                response = authenticated_client.get(
+                    url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate", q="Felix faure")
+                )
+
+            # then
+            assert response.status_code == 200
+            rows = html_parser.extract_table_rows(response.data)
+            assert {row["Nom de la structure"] for row in rows} == {"C"}
+
+        @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
         @pytest.mark.parametrize(
             "search_filter, expected_offerer_names",
             (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19290

## But de la pull request

Sur la page “Liste de structures à valider”, ajout de la possibilité de chercher par email et par prénom/nom d'un utilisateur pro.

## Informations supplémentaires

Le ticket demandait plus précisément le filtrage par nom du responsable de la structure. Compte tenu du modèle de données qui ne l'identifie pas clairement, mais oblige à chercher pour chaque structure le `first_user`, limiter au responsable risque de trop impacter les performances de la recherche. En gros le même effet que lorsqu'on avait filtré sur un champ calculé `requestDate`.
Chercher sur n'importe quel utilisateur ne devrait pas être gênant pour le métier, notamment parce que les structures pas encore validées n'ont en général qu'un seul utilisateur, celui qui a demandé l'enregistrement de la structure.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
