### PR TITLE
(PC-19224)[PRO] fix: blues acoustic subcategory wording

### DIFF
--- a/api/src/pcapi/domain/music_types.py
+++ b/api/src/pcapi/domain/music_types.py
@@ -46,7 +46,7 @@ music_types = [
         code=520,
         label="Blues",
         children=[
-            MusicSubType(code=521, label="Blues Accoustique", slug="BLUES-BLUES_ACCOUSTIQUE"),
+            MusicSubType(code=521, label="Blues Acoustique", slug="BLUES-BLUES_ACOUSTIQUE"),
             MusicSubType(code=522, label="Blues Contemporain", slug="BLUES-BLUES_CONTEMPORAIN"),
             MusicSubType(code=523, label="Blues Électrique", slug="BLUES-BLUES_ELECTRIQUE"),
             MusicSubType(code=524, label="Blues Rock", slug="BLUES-BLUES_ROCK"),

--- a/pro/src/core/Offers/categoriesSubTypes.ts
+++ b/pro/src/core/Offers/categoriesSubTypes.ts
@@ -31,7 +31,7 @@ export const musicOptionsTree: ICategorySubtypeItem[] = [
     code: 520,
     label: 'Blues',
     children: [
-      { code: 521, label: 'Blues Accoustique' },
+      { code: 521, label: 'Blues Acoustique' },
       { code: 522, label: 'Blues Contemporain' },
       { code: 523, label: 'Blues Électrique' },
       { code: 524, label: 'Blues Rock' },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19224

## But de la pull request

- Corriger la faute d'orthographe à "accoustique"

## Implémentation

- Changement appliqué au front (`categoriesSubTypes.ts`)  et back (`music_type.py`) .