### PR TITLE
(PC-19348)[PRO]feat: add boost to Providers constants

### DIFF
--- a/pro/src/core/Providers/constants.ts
+++ b/pro/src/core/Providers/constants.ts
@@ -1,1 +1,1 @@
-export const CINEMA_PROVIDER_NAMES = ['ciné office']
+export const CINEMA_PROVIDER_NAMES = ['ciné office', 'boost']


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19348

## But de la pull request

Permettre d'afficher les paramètres spécifiques de synchro de billetterie cinéma pour le Provider Boost
