### PR TITLE
[PC-19355] Use pcapi helm chart v0.17.2

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -18,19 +18,19 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.17.1
+      - chartVersion: 0.17.2
   staging:
     values:
-      - chartVersion: 0.17.1
+      - chartVersion: 0.17.2
   integration:
     values:
-      - chartVersion: 0.17.1
+      - chartVersion: 0.17.2
   production:
     values:
-      - chartVersion: 0.17.1
+      - chartVersion: 0.17.2
   ops:
     values:
-      - chartVersion: 0.17.1
+      - chartVersion: 0.17.2
   perf:
     values:
-      - chartVersion: 0.17.1
+      - chartVersion: 0.17.2


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19355

## But de la pull request

Fix le déploiement en production en utilisant la dernière version du chart de pcapi qui corrige le conflit entre `minAvailable` et `maxUnavailable` dans les `PodDisruptionBudget`.