### PR TITLE
(BSR) Improve CI workflow

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -11,6 +11,10 @@ on:
         # The docker image tag
         required: true
         type: string
+      pcapi:
+        required: false
+        type: boolean
+        default: false
       console:
         required: false
         type: boolean
@@ -58,6 +62,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
     - name: "Build and push pcapi image"
       uses: docker/build-push-action@v2
+      if: ${{ inputs.pcapi == true }}
       with:
         context: api
         push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,22 @@ on:
       teleport_kubernetes_cluster:
         type: string
         required: true
+      deploy_adage:
+        type: boolean
+        required: false
+        default: false
+      deploy_api:
+        type: boolean
+        required: false
+        default: false
+      deploy_backoffice:
+        type: boolean
+        required: false
+        default: false
+      deploy_pro:
+        type: boolean
+        required: false
+        default: false
 
 env:
   REGION: europe-west1
@@ -25,6 +41,7 @@ jobs:
   generate-pcapi-helm-secrets-file:
     name: "[pcapi] Generate helm secrets values file"
     runs-on: ubuntu-latest
+    if: ${{ inputs.deploy_api }}
     permissions:
       id-token: write
       contents: read
@@ -58,14 +75,15 @@ jobs:
         id: set-secrets-file-output
         run: echo "secrets_file_base64=$(cat ${{ github.workspace }}/helm_secrets_file_base64)" >> $GITHUB_OUTPUT
 
-  deploy-helm-release:
-    name: "[pcapi] Deploy helm release"
+  deploy-api:
+    name: Deploy api
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read
     needs: generate-pcapi-helm-secrets-file
+    if: ${{ inputs.deploy_api }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
@@ -106,7 +124,12 @@ jobs:
           helmfile -e ${{ inputs.environment }} sync --set image.tag=${{ inputs.app_version }}
 
   deploy-pro:
-    needs: deploy-helm-release
+    name: Deploy pro
+    needs: deploy-api
+    if: |
+      always() &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
+      inputs.deploy_pro == true
     uses: ./.github/workflows/deploy-gcs-front.yml
     with:
       app_name: pro
@@ -118,7 +141,12 @@ jobs:
       workload_identity_provider: ${{ secrets.METIER_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
   deploy-adage-front:
-    needs: deploy-helm-release
+    name: Deploy adage
+    needs: deploy-api
+    if: |
+      always() &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
+      inputs.deploy_adage == true
     uses: ./.github/workflows/deploy-gcs-front.yml
     with:
       app_name: adage
@@ -130,8 +158,12 @@ jobs:
       workload_identity_provider: ${{ secrets.METIER_GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
   deploy-backoffice-front:
-    name: "[backoffice] Deployment"
-    if: inputs.environment != 'integration'
+    name: Deploy backoffice
+    needs: deploy-api
+    if: |
+      inputs.environment != 'integration' &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
+      inputs.deploy_backoffice == true
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     permissions:
@@ -140,7 +172,6 @@ jobs:
     defaults:
       run:
         working-directory: backoffice
-    needs: deploy-helm-release
     steps:
       - uses: actions/checkout@v3
       - id: openid-auth
@@ -176,20 +207,22 @@ jobs:
 
   apply-algolia-config:
     name: "apply Algolia settings"
-    if: inputs.environment == 'production'
+    needs: deploy-api
+    if: |
+      inputs.environment == 'production' &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped')
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: backoffice
-    needs: deploy-helm-release
     steps:
       - run: su pcapi -c "flask set_algolia_settings offers --dry-run=false"
       - run: su pcapi -c "flask set_algolia_settings collective_offers --dry-run=false"
       - run: su pcapi -c "flask set_algolia_settings venues --dry-run=false"
 
   deploy-image-resizing:
-    name: "[image-resizing] Deployment"
+    name: "Deploy image-resizing"
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -10,17 +10,9 @@ defaults:
     working-directory: api
 
 jobs:
-  check-api-folder-changes:
-    name: "Check if folder changed"
-    uses: ./.github/workflows/check-folder-changes.yml
-    with:
-      folder: api
-
   build-tests-docker-image:
-    name: "Build tests docker image"
+    name: Build tests docker image
     uses: ./.github/workflows/build-and-push-docker-images.yml
-    needs: check-api-folder-changes
-    if: needs.check-api-folder-changes.outputs.folder_changed == 'true' || github.ref == 'refs/heads/master'
     with:
       tag: ${{ github.sha }}
       tests: true
@@ -29,10 +21,7 @@ jobs:
   quality-api:
     name: "Quality check"
     runs-on: ubuntu-latest
-    needs:
-      - check-api-folder-changes
-      - build-tests-docker-image
-    if: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read
@@ -96,10 +85,7 @@ jobs:
       DATABASE_URL_TEST: postgresql://pytest:pytest@postgres:5432/pass_culture
       REDIS_URL: redis://redis:6379
     runs-on: ubuntu-latest
-    needs:
-      - check-api-folder-changes
-      - build-tests-docker-image
-    if: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read
@@ -204,10 +190,7 @@ jobs:
             "tests/routes -m 'not backoffice_v3'",
             "tests --ignore=tests/core --ignore=tests/routes",
           ]
-    needs:
-      - check-api-folder-changes
-      - build-tests-docker-image
-    if: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+    needs: build-tests-docker-image
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/tests-backoffice.yml
+++ b/.github/workflows/tests-backoffice.yml
@@ -9,16 +9,9 @@ defaults:
     working-directory: backoffice
 
 jobs:
-  check-backoffice-folder-changes:
-    name: "Check if folder changed"
-    uses: ./.github/workflows/check-folder-changes.yml
-    with:
-      folder: backoffice
-
   read-node-version:
     name: "Read node version from .nvmrc"
     runs-on: ubuntu-latest
-    needs: check-backoffice-folder-changes
     if: ${{ needs.check-backoffice-folder-changes.outputs.folder_changed == 'true' }}
     outputs:
       node_version: ${{ steps.read-node-version.outputs.node_version }}

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -8,21 +8,53 @@ on:
       - staging
 
 jobs:
+  check-adage-folder-changes:
+    name: Check adage folder changes
+    uses: ./.github/workflows/check-folder-changes.yml
+    with:
+      folder: adage
+
+  check-api-folder-changes:
+    name: Check api folder changes
+    uses: ./.github/workflows/check-folder-changes.yml
+    with:
+      folder: api
+
+  check-backoffice-folder-changes:
+    name: Check backoffice folder changes
+    uses: ./.github/workflows/check-folder-changes.yml
+    with:
+      folder: backoffice
+
+  check-pro-folder-changes:
+    name: Check pro folder changes
+    uses: ./.github/workflows/check-folder-changes.yml
+    with:
+      folder: pro
+
   test-adage:
-    name: Tests adage
+    name: Test adage
+    needs: check-adage-folder-changes
+    if: needs.check-adage-folder-changes.outputs.folder_changed == 'true'
     uses: ./.github/workflows/tests-adage.yml
 
   test-api:
-    name: Tests api
+    name: Test api
+    needs: check-api-folder-changes
+    if: needs.check-api-folder-changes.outputs.folder_changed == 'true'
     uses: ./.github/workflows/tests-api.yml
     secrets: inherit
 
   test-backoffice:
-    name: Tests backoffice
+    name: Test backoffice
+    needs: check-backoffice-folder-changes
+    if: needs.check-backoffice-folder-changes.outputs.folder_changed == 'true'
     uses: ./.github/workflows/tests-backoffice.yml
     secrets: inherit
 
   test-pro:
+    needs: check-pro-folder-changes
+    if: needs.check-pro-folder-changes.outputs.folder_changed == 'true'
     name: Tests pro
     uses: ./.github/workflows/tests-pro.yml
 
@@ -37,13 +69,24 @@ jobs:
       pcapi: true
     secrets: inherit
 
-  deploy-testing:
-    name: "[testing] Deployment"
+  deploy-to-testing:
+    name: Deploy to testing
     needs:
-      - test-pro
+      - check-adage-folder-changes
+      - check-api-folder-changes
+      - check-backoffice-folder-changes
+      - check-pro-folder-changes
       - test-adage
-      - test-api
-    if: github.ref == 'refs/heads/master'
+      - build-api
+      - test-backoffice
+      - test-pro
+    if: |
+      always() &&
+      github.ref == 'refs/heads/master' &&
+      (needs.test-adage.result == 'success' || needs.test-adage.result == 'skipped') &&
+      (needs.build-api.result == 'success' || needs.build-api.result == 'skipped') &&
+      (needs.test-backoffice.result == 'success' || needs.test-backoffice.result == 'skipped') &&
+      (needs.test-pro.result == 'success' || needs.test-pro.result == 'skipped')
     uses: ./.github/workflows/deploy.yml
     with:
       environment: testing

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -94,4 +94,8 @@ jobs:
       teleport_version: 11.1.1
       teleport_proxy: teleport.ehp.passculture.team:443
       teleport_kubernetes_cluster: passculture-metier-ehp
+      deploy_adage: ${{ needs.check-adage-folder-changes.outputs.folder_changed == 'true' }}
+      deploy_api: ${{ needs.check-api-folder-changes.outputs.folder_changed == 'true' }}
+      deploy_backoffice: ${{ needs.check-backoffice-folder-changes.outputs.folder_changed == 'true' }}
+      deploy_pro: ${{ needs.check-pro-folder-changes.outputs.folder_changed == 'true' }}
     secrets: inherit

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -26,6 +26,17 @@ jobs:
     name: Tests pro
     uses: ./.github/workflows/tests-pro.yml
 
+  build-api:
+    name: Build api docker image on master branch
+    needs:
+      - test-api
+    if: github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/build-and-push-docker-images.yml
+    with:
+      tag: ${{ github.sha }}
+      pcapi: true
+    secrets: inherit
+
   deploy-testing:
     name: "[testing] Deployment"
     needs:

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,4 +1,5 @@
-name: Tests main
+name: Test main
+run-name: Test main${{ github.ref == 'refs/heads/master' && ' and deploy to testing' || '' }}
 on:
   push:
     branches-ignore:

--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -9,17 +9,9 @@ defaults:
     working-directory: pro
 
 jobs:
-  check-pro-folder-changes:
-    name: "Check if folder changed"
-    uses: ./.github/workflows/check-folder-changes.yml
-    with:
-      folder: pro
-
   read-node-version:
     name: "Read node version from .nvmrc"
     runs-on: ubuntu-latest
-    needs: check-pro-folder-changes
-    if: ${{ needs.check-pro-folder-changes.outputs.folder_changed == 'true' }}
     outputs:
       node_version: ${{ steps.read-node-version.outputs.node_version }}
     steps:


### PR DESCRIPTION
### Benefits
- run api/pro/adage/backoffice test job only if the folder changes, which improves CI pull requests state visualization on Github
- stop deploying api (resp pro/backoffice/adage) if api (resp pro/backoffice/adage) folder did not change
- build api docker image just before deploying, which has 2 benefitss:
  - the tests-api step lasts 30 seconds less
  - the image build needed to deploy is less hidden (it was inside the tests-api job)
  - drawback: the deployment on testing lasts 2 minutes more ; this will be less if we add cache to docker image


Avant : 
<img width="1043" alt="Capture d’écran 2022-12-21 à 14 23 31" src="https://user-images.githubusercontent.com/22373097/208915421-2a50e337-8c87-4629-be97-3c7f50984353.png">

Maintenant : 
<img width="1023" alt="Capture d’écran 2022-12-21 à 14 21 52" src="https://user-images.githubusercontent.com/22373097/208915179-a17065c2-3adb-4e67-81cb-c1c3332cb730.png">
