### PR TITLE
(PC-18822)[API] feat: allow to submit modals by typing return

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/edit_status_modal.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/edit_status_modal.html
@@ -1,18 +1,19 @@
 {% macro build_edit_status_modal(dst, div_id, validate_btn_msg) %}
 <div class="modal fade" id="{{ div_id }}" tabindex="-1" aria-labelledby="{{ div_id }}-label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
-        <form action="{{ dst }}" method="POST" class="modal-content" data-turbo="false">
+        <form action="{{ dst }}" method="POST" class="modal-content" id="{{ div_id }}-form" data-turbo="false">
             {{ csrf_token }}
 
             <div class="modal-header">
                 <h5 class="modal-title">{{ caller() }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
-            <div class="modal-body">
-                <div class="form-floating my-3">
+            <div class="modal-body row">
+                <div class="form-floating my-3 col">
                     <textarea name="comment" class="form-control" id="{{ div_id }}-textarea" rows="3"></textarea>
                     <label for={{ div_id }}-textarea"><label for="comment">Raison</label></label>
                 </div>
+                <button type="button" class="btn btn-outline-secondary col-1 h-50" id="{{ div_id }}-newline">⏎</button>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Annuler</button>
@@ -21,4 +22,30 @@
         </form>
     </div>
 </div>
+
+<script>
+    document.getElementById("{{ div_id }}-textarea").addEventListener(
+        "keydown",
+        function(event) {
+            if (event.keyCode === 13) {
+                event.preventDefault();
+                if (event.ctrlKey) {
+                    const textarea = document.getElementById('{{ div_id }}-textarea')
+                    textarea.value = textarea.value.slice(0, textarea.selectionStart) + "\n" + textarea.value.slice(textarea.selectionEnd)
+                } else {
+                    document.getElementById("{{ div_id }}-form").submit();
+                }
+                return false;
+            }
+        }
+    )
+    document.getElementById("{{ div_id }}-newline").addEventListener(
+        "click",
+        function() {
+            const textarea = document.getElementById('{{ div_id }}-textarea')
+            textarea.value = textarea.value.slice(0, textarea.selectionStart) + "\n" + textarea.value.slice(textarea.selectionEnd)
+        }
+    )
+</script>
+
 {% endmacro %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18822

## But de la pull request

Permettre de soumettre les formulaires de validation d'une structure en appuyant sur [Enter].
+ Ajout d'un bouton pour pouvoir ajouter un saut de ligne dans le commenaire
+ Ajout d'un raccourcis clavier Ctrl+Enter aussi pour ajouter un saut de ligne dans le commentaire

## Implémentation

![image](https://user-images.githubusercontent.com/88191987/208924809-a3657147-a2e9-4bca-a7cd-1db265474637.png)

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
