### PR TITLE
(PC-19241)[API] feat: set login duration to 120 minutes on BO

### DIFF
--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -15,9 +15,9 @@ app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 app.config["SESSION_COOKIE_NAME"] = "bo_session"
 app.config["REMEMBER_COOKIE_HTTPONLY"] = True
 app.config["REMEMBER_COOKIE_SECURE"] = not settings.IS_DEV
-app.config["REMEMBER_COOKIE_DURATION"] = 30 * 60
+app.config["REMEMBER_COOKIE_DURATION"] = 120 * 60
 app.config["REMEMBER_COOKIE_NAME"] = "bo_remember_me"
-app.config["PERMANENT_SESSION_LIFETIME"] = 30 * 60
+app.config["PERMANENT_SESSION_LIFETIME"] = 120 * 60
 
 
 csrf = CSRFProtect()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19241

## But de la pull request

passer l'expiration de cookie de session du BOv3 à 120 minutes

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
