### PR TITLE
(BSR)[API] fix: disable pylint parallel execution in git hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -180,7 +180,8 @@ then
   if [[ ! ",${DISABLED_API_PRE_COMMIT_CHECKS}," =~ ",pylint," ]]
   then
       echo -e "\033[0;96mRunning pylint for code linting...\033[0m"
-      pylint $LINTED_FILES --output-format="colorized" --score=no --jobs=0
+      # parallel execution breaks plugins, use one single job !
+      pylint $LINTED_FILES --output-format="colorized" --score=no --jobs=1
       if [[ "$?" != 0 ]]; then
           counter=$((counter + 1))
       fi


### PR DESCRIPTION
## But de la pull request

Désactiver l'exécution parallèle de Pylint dans le `pre-commit` hook

## Implémentation

Forcer l'option `--jobs=1` avec un commentaire

## Informations supplémentaires

- La CI (CircleCI ou GHA) utilise encore ce parallélisme.
  La probabilité que le souci apparaisse avec seulement 2 jobs est faible, mais existe -> à discuter dans une autre PR.
- Au passage, résolution d'un FIXME du mois d'août dans la config pylint