### PR TITLE
PC-19310 rendre obligatoire le renseignement d au moins un booking em…

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -428,6 +428,17 @@ class PostCollectiveOfferBodyModel(BaseModel):
             raise ValueError("intervention_area must have at least one value")
         return values
 
+    @root_validator
+    def validate_booking_emails(cls, values: dict) -> dict:
+        booking_emails = values.get("booking_emails", [])
+        is_from_template = bool(values.get("template_id", None))
+        if not booking_emails:
+            if is_from_template:
+                values["booking_emails"] = [values["contact_email"]]
+            else:
+                raise ValueError("Un email doit etre renseigné")
+        return values
+
     class Config:
         alias_generator = to_camel
         extra = "forbid"
@@ -514,6 +525,12 @@ class PatchCollectiveOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
             raise ValueError("interventionArea must have at least one value")
 
         return intervention_area
+
+    @validator("bookingEmails")
+    def validate_booking_emails(cls, booking_emails: list[str]) -> list[str]:
+        if not booking_emails:
+            raise ValueError("Un email doit etre renseigné.")
+        return booking_emails
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/public_api_collective_offers_serialize.py
@@ -60,6 +60,8 @@ def validate_email(email: str) -> str:
 
 
 def validate_emails(emails: list[str]) -> list[str]:
+    if not emails:
+        raise ValueError("Un email doit etre renseigné.")
     for email in emails:
         if not email_utils.is_valid_email(email):
             raise ValueError(f"{email} n'est pas une adresse mail valide")


### PR DESCRIPTION
…ail dans les api publique et privees

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19310

## But de la pull request

rendre obligatoire de renseigner au moins 1 BookingEmails dans les api publiques et privées
