### PR TITLE
(BSR) Boost code cleanup

### DIFF
--- a/api/src/pcapi/connectors/serialization/boost_serializers.py
+++ b/api/src/pcapi/connectors/serialization/boost_serializers.py
@@ -48,10 +48,6 @@ class Collection(BaseModel):
     totalCount: int
 
 
-class FilmCollection(Collection):
-    data: list[Film2]
-
-
 def _convert_to_utc_datetime(datetime_with_tz_offset: datetime.datetime) -> datetime.datetime:
     return datetime_with_tz_offset.astimezone(tz=datetime.timezone.utc)
 

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -113,14 +113,6 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
 
         return items
 
-    def get_venue_movies(self, per_page: int = 30) -> list[external_bookings_models.Movie]:
-        films = self.get_collection_items(
-            resource=boost.ResourceBoost.FILMS,
-            collection_class=boost_serializers.FilmCollection,
-            per_page=per_page,
-        )
-        return [film.to_generic_movie() for film in films]
-
     def get_showtimes(
         self,
         per_page: int = 30,

--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -91,9 +91,6 @@ class BoostStocks(LocalProvider):
 
         self.update_from_movie_information(offer, self.showtime_details.film.to_generic_movie())
 
-        if self.showtime_details.film.numVisa:
-            offer.extraData = {"visa": self.showtime_details.film.numVisa}
-
         offer.name = self.showtime_details.film.titleCnc
         offer.subcategoryId = subcategories.SEANCE_CINE.id
         offer.productId = self.last_product_id
@@ -130,9 +127,6 @@ class BoostStocks(LocalProvider):
             obj.description = movie_information.description
         if movie_information.duration:
             obj.durationMinutes = movie_information.duration
-
-        if not obj.extraData:
-            obj.extraData = {}
         obj.extraData = {"visa": movie_information.visa}
 
     def get_object_thumb(self) -> bytes:

--- a/api/tests/core/external_bookings/boost/test_client.py
+++ b/api/tests/core/external_bookings/boost/test_client.py
@@ -13,49 +13,6 @@ from tests.local_providers.cinema_providers.boost import fixtures
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-class GetVenueMoviesTest:
-    def test_should_return_movies_information(self, requests_mock):
-        cinema_details = providers_factories.BoostCinemaDetailsFactory(cinemaUrl="https://cinema-0.example.com/")
-        cinema_str_id = cinema_details.cinemaProviderPivot.idAtProvider
-        requests_mock.get(
-            "https://cinema-0.example.com/api/films?page=1&per_page=2",
-            json=fixtures.FilmsEndpointResponse.PAGE_1_JSON_DATA,
-        )
-        requests_mock.get(
-            "https://cinema-0.example.com/api/films?page=2&per_page=2",
-            json=fixtures.FilmsEndpointResponse.PAGE_2_JSON_DATA,
-        )
-        boost = BoostClientAPI(cinema_str_id)
-        movies = boost.get_venue_movies(per_page=2)
-
-        assert movies == [
-            external_bookings_models.Movie(
-                id="207",
-                title="BLACK PANTHER : WAKANDA FOREVER",
-                duration=162,
-                description="",
-                posterpath="http://example.com/images/158026.jpg",
-                visa="158026",
-            ),
-            external_bookings_models.Movie(
-                id="210",
-                title="CHARLOTTE",
-                duration=92,
-                description="",
-                posterpath="http://example.com/images/149489.jpg",
-                visa="149489",
-            ),
-            external_bookings_models.Movie(
-                id="147",
-                title="CASSE NOISETTE ROH 2021",
-                duration=100,
-                description="",
-                posterpath="http://example.com/images/2021001414.jpg",
-                visa="2021001414",
-            ),
-        ]
-
-
 class GetShowtimesTest:
     def test_should_return_showtimes(self, requests_mock):
         cinema_details = providers_factories.BoostCinemaDetailsFactory(cinemaUrl="https://cinema-0.example.com/")

--- a/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
@@ -117,6 +117,7 @@ class BoostStocksTest:
         assert created_offers[0].durationMinutes == 162
         assert created_offers[0].isDuo
         assert created_offers[0].subcategoryId == subcategories.SEANCE_CINE.id
+        assert created_offers[0].extraData == {"visa": "158026"}
 
         assert created_products[0].name == "BLACK PANTHER : WAKANDA FOREVER"
         assert not created_products[0].description  # FIXME
@@ -137,6 +138,7 @@ class BoostStocksTest:
         assert created_offers[1].durationMinutes == 92
         assert created_offers[1].isDuo
         assert created_offers[1].subcategoryId == subcategories.SEANCE_CINE.id
+        assert created_offers[1].extraData == {"visa": "149489"}
 
         assert created_products[1].name == "CHARLOTTE"
         assert not created_products[1].description  # FIXME


### PR DESCRIPTION
## But de la pull request

- Supprimer du code inutilisé: `get_venue_movies()` du client Boost
- Simplifier et tester l'ajout du visa d'exploitation dans les offres et produits