### PR TITLE
(PC-19286)[PRO] fix: toast when user delete stock thing or event

### DIFF
--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -103,25 +103,25 @@ describe('StockEventForm', () => {
   })
   it('should set stockBookingLimitDatetime at event date if date changed before stockBookingLimitDatetime', async () => {
     const initialStock = {
-      beginningDate: new Date('2022-12-31T00:00:00Z'),
-      beginningTime: new Date('2022-12-31T00:00:00Z'),
+      beginningDate: new Date('2022-12-29T00:00:00Z'),
+      beginningTime: new Date('2022-12-29T00:00:00Z'),
       remainingQuantity: '11',
       bookingsQuantity: '1',
       quantity: 12,
-      bookingLimitDatetime: new Date('2022-12-30T00:00:00Z'),
+      bookingLimitDatetime: new Date('2022-12-28T00:00:00Z'),
       price: 10,
       isDeletable: true,
       readOnlyFields: [],
     }
 
-    await renderStockEventForm(props, initialStock)
+    renderStockEventForm(props, initialStock)
 
-    await userEvent.click(await screen.getByLabelText('Date', { exact: true }))
-    await userEvent.click(await screen.getAllByText(29)[1])
-    await expect(await screen.getByLabelText('Date')).toHaveValue('29/12/2022')
-    await expect(
-      screen.getByLabelText('Date limite de réservation')
-    ).toHaveValue('29/12/2022')
+    await userEvent.click(screen.getByLabelText('Date'))
+    await userEvent.click(screen.getByText(27))
+
+    expect(screen.getByLabelText('Date limite de réservation')).toHaveValue(
+      '28/12/2022'
+    )
   })
 
   const setNumberValueForPrice = [

--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -103,25 +103,25 @@ describe('StockEventForm', () => {
   })
   it('should set stockBookingLimitDatetime at event date if date changed before stockBookingLimitDatetime', async () => {
     const initialStock = {
-      beginningDate: new Date('2022-12-29T00:00:00Z'),
-      beginningTime: new Date('2022-12-29T00:00:00Z'),
+      beginningDate: new Date('2022-12-31T00:00:00Z'),
+      beginningTime: new Date('2022-12-31T00:00:00Z'),
       remainingQuantity: '11',
       bookingsQuantity: '1',
       quantity: 12,
-      bookingLimitDatetime: new Date('2022-12-28T00:00:00Z'),
+      bookingLimitDatetime: new Date('2022-12-30T00:00:00Z'),
       price: 10,
       isDeletable: true,
       readOnlyFields: [],
     }
 
-    renderStockEventForm(props, initialStock)
+    await renderStockEventForm(props, initialStock)
 
-    await userEvent.click(screen.getByLabelText('Date'))
-    await userEvent.click(screen.getByText(27))
-
-    expect(screen.getByLabelText('Date limite de réservation')).toHaveValue(
-      '28/12/2022'
-    )
+    await userEvent.click(await screen.getByLabelText('Date', { exact: true }))
+    await userEvent.click(await screen.getAllByText(29)[1])
+    await expect(await screen.getByLabelText('Date')).toHaveValue('29/12/2022')
+    await expect(
+      screen.getByLabelText('Date limite de réservation')
+    ).toHaveValue('29/12/2022')
   })
 
   const setNumberValueForPrice = [

--- a/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
@@ -26,6 +26,7 @@ export interface IActionBarProps {
   step: OFFER_WIZARD_STEP_IDS
   offerId?: string
   shouldTrack?: boolean
+  isFormEmpty?: boolean
 }
 
 const ActionBar = ({
@@ -36,6 +37,7 @@ const ActionBar = ({
   step,
   offerId,
   shouldTrack = true,
+  isFormEmpty = false,
 }: IActionBarProps) => {
   const offersSearchFilters = useSelector(
     (state: RootState) => state.offers.searchFilters
@@ -115,9 +117,15 @@ const ActionBar = ({
             >
               Annuler et quitter
             </ButtonLink>
-            <SubmitButton onClick={onClickNext} disabled={isDisabled}>
-              Enregistrer les modifications
-            </SubmitButton>
+            {isFormEmpty ? (
+              <Button onClick={onClickNext} disabled={isDisabled}>
+                Enregistrer les modifications
+              </Button>
+            ) : (
+              <SubmitButton onClick={onClickNext} disabled={isDisabled}>
+                Enregistrer les modifications
+              </SubmitButton>
+            )}
           </>
         )}
       </>

--- a/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
+++ b/pro/src/screens/OfferIndividual/ActionBar/ActionBar.tsx
@@ -117,15 +117,13 @@ const ActionBar = ({
             >
               Annuler et quitter
             </ButtonLink>
-            {isFormEmpty ? (
-              <Button onClick={onClickNext} disabled={isDisabled}>
-                Enregistrer les modifications
-              </Button>
-            ) : (
-              <SubmitButton onClick={onClickNext} disabled={isDisabled}>
-                Enregistrer les modifications
-              </SubmitButton>
-            )}
+            <SubmitButton
+              onClick={onClickNext}
+              disabled={isDisabled}
+              type={isFormEmpty ? 'button' : 'submit'}
+            >
+              Enregistrer les modifications
+            </SubmitButton>
           </>
         )}
       </>

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -389,6 +389,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
               step={OFFER_WIZARD_STEP_IDS.STOCKS}
               offerId={offer.id}
               shouldTrack={shouldTrack}
+              isFormEmpty={isFormEmpty()}
             />
           </FormLayout.Section>
         </form>

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -564,6 +564,7 @@ describe('screens:StocksEvent:Edition', () => {
       .mockResolvedValue({ stocks: [{ id: 'STOCK_ID' } as StockResponseModel] })
     renderStockEventScreen({ storeOverride })
     await screen.findByRole('heading', { name: /Stock & Prix/ })
+    // FireEvent.change instead of userEvent.type because userEvent change value but the test doesn"t work (it probably doesn't set touched at true for price field, only with inputs type number)
     fireEvent.change(screen.getByLabelText('Prix'), { target: { value: '20' } })
     await expect(screen.getByLabelText('Prix')).toHaveValue(20)
     await userEvent.click(

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -550,7 +550,7 @@ describe('screens:StocksEvent:Edition', () => {
     renderStockEventScreen({ storeOverride })
     await screen.findByRole('heading', { name: /Stock & Prix/ })
 
-    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    await userEvent.type(await screen.getByLabelText('Prix'), '20')
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
     )
@@ -564,7 +564,8 @@ describe('screens:StocksEvent:Edition', () => {
       .mockResolvedValue({ stocks: [{ id: 'STOCK_ID' } as StockResponseModel] })
     renderStockEventScreen({ storeOverride })
     await screen.findByRole('heading', { name: /Stock & Prix/ })
-    await userEvent.type(screen.getByLabelText('Prix'), '20')
+    fireEvent.change(screen.getByLabelText('Prix'), { target: { value: '20' } })
+    await expect(screen.getByLabelText('Prix')).toHaveValue(20)
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
     )

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -590,4 +590,41 @@ describe('screens:StocksEvent:Edition', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByText(/Next page/)).toBeInTheDocument()
   })
+  it('should not display any message when user delete empty stock', async () => {
+    jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
+    renderStockEventScreen({
+      storeOverride: { ...storeOverride },
+    })
+    apiOffer.stocks = []
+    jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
+    expect(
+      screen.queryByText('Voulez-vous supprimer ce stock ?')
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText('Le stock a été supprimé.')
+    ).not.toBeInTheDocument()
+    expect(api.deleteStock).not.toHaveBeenCalled()
+    expect(api.deleteStock).toHaveBeenCalledTimes(0)
+  })
+  it('should display draft success message on save button when stock form is empty and not redirect to next page', async () => {
+    renderStockEventScreen({
+      storeOverride: { ...storeOverride },
+    })
+    apiOffer.stocks = []
+    jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enregistrer les modifications' })
+    )
+    expect(
+      screen.getByText('Brouillon sauvegardé dans la liste des offres')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /Stock & Prix/ })
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -319,7 +319,7 @@ describe('screens:StocksEvent', () => {
       screen.queryByRole('heading', { name: /Stock & Prix/ })
     ).toBeInTheDocument()
   })
-  it('should not display any message when user delete empty stock', async () => {
+  it('should display a toaster when user delete a saved stock ', async () => {
     jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'STOCK_ID' } as StockResponseModel],

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -319,4 +319,53 @@ describe('screens:StocksEvent', () => {
       screen.queryByRole('heading', { name: /Stock & Prix/ })
     ).toBeInTheDocument()
   })
+  it('should not display any message when user delete empty stock', async () => {
+    jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stocks: [{ id: 'STOCK_ID' } as StockResponseModel],
+    })
+    const stock = {
+      id: 'STOCK_ID',
+      quantity: 10,
+      price: 10.01,
+      remainingQuantity: 6,
+      bookingsQuantity: 0,
+      isEventDeletable: true,
+      beginningDatetime: '2023-03-10T00:00:00.0200',
+    }
+    props.offer = {
+      ...(offer as IOfferIndividual),
+      stocks: [stock as IOfferIndividualStock],
+    }
+    renderStockEventScreen({ props, storeOverride, contextValue })
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
+    expect(
+      screen.queryByText('Voulez-vous supprimer ce stock ?')
+    ).not.toBeInTheDocument()
+
+    expect(screen.queryByText('Le stock a été supprimé.')).toBeInTheDocument()
+    expect(api.deleteStock).toHaveBeenCalledTimes(1)
+  })
+  it('should not display any message when user delete empty stock', async () => {
+    jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'STOCK_ID' })
+    jest.spyOn(api, 'upsertStocks').mockResolvedValue({
+      stocks: [{ id: 'STOCK_ID' } as StockResponseModel],
+    })
+    props.offer = {
+      ...(offer as IOfferIndividual),
+      stocks: [],
+    }
+    renderStockEventScreen({ props, storeOverride, contextValue })
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
+    expect(
+      screen.queryByText('Voulez-vous supprimer ce stock ?')
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText('Le stock a été supprimé.')
+    ).not.toBeInTheDocument()
+    expect(api.deleteStock).toHaveBeenCalledTimes(0)
+  })
 })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -304,4 +304,19 @@ describe('screens:StocksEvent', () => {
       screen.getByText('Brouillon sauvegardé dans la liste des offres')
     ).toBeInTheDocument()
   })
+  it('should display draft success message on save draft button when stock form is empty', async () => {
+    renderStockEventScreen({ props, storeOverride, contextValue })
+
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
+    )
+    expect(
+      screen.getByText('Brouillon sauvegardé dans la liste des offres')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /Stock & Prix/ })
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -319,7 +319,7 @@ describe('screens:StocksEvent', () => {
       screen.queryByRole('heading', { name: /Stock & Prix/ })
     ).toBeInTheDocument()
   })
-  it('should display a toaster when user delete a saved stock ', async () => {
+  it('should not display any message when user delete empty stock', async () => {
     jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'STOCK_ID' } as StockResponseModel],

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -164,9 +164,9 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
         setIsClickingFromActionBar(false)
       }
 
-      // When saving draft with an empty form
+      // When saving draft with an empty form or in edition mode
       // we display a success notification even if nothing is done
-      if (saveDraft && isFormEmpty()) {
+      if (isFormEmpty() && (saveDraft || mode === OFFER_WIZARD_MODE.EDITION)) {
         setIsClickingFromActionBar(false)
         notify.success('Brouillon sauvegardé dans la liste des offres')
         return

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -289,28 +289,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
     })
   }
 
-  actions[0].disabled = isDisabled || isSynchronized
-  const cannotDeleteStock = isDisabled || isSynchronized
-
-  actions.push({
-    /* istanbul ignore next: DEBT, TO FIX */
-    callback: async () => {
-      if (
-        // tested but coverage don't see it.
-        /* istanbul ignore next */
-        (mode === OFFER_WIZARD_MODE.EDITION ||
-          formik.values.bookingsQuantity !== '0') &&
-        formik.values.stockId !== undefined
-      ) {
-        deleteConfirmShow()
-      } else {
-        onConfirmDeleteStock()
-      }
-    },
-    label: 'Supprimer le stock',
-    disabled: cannotDeleteStock,
-    Icon: IcoTrashFilled,
-  })
+  actions[0].disabled = isDisabled
 
   if (offer.isDigital) {
     description += `

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -365,6 +365,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
               isDisabled={formik.isSubmitting}
               offerId={offer.id}
               shouldTrack={shouldTrack}
+              isFormEmpty={isFormEmpty()}
             />
           </form>
         </FormLayout.Section>

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -289,7 +289,28 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
     })
   }
 
-  actions[0].disabled = isDisabled
+  actions[0].disabled = isDisabled || isSynchronized
+  const cannotDeleteStock = isDisabled || isSynchronized
+
+  actions.push({
+    /* istanbul ignore next: DEBT, TO FIX */
+    callback: async () => {
+      if (
+        // tested but coverage don't see it.
+        /* istanbul ignore next */
+        (mode === OFFER_WIZARD_MODE.EDITION ||
+          formik.values.bookingsQuantity !== '0') &&
+        formik.values.stockId !== undefined
+      ) {
+        deleteConfirmShow()
+      } else {
+        onConfirmDeleteStock()
+      }
+    },
+    label: 'Supprimer le stock',
+    disabled: cannotDeleteStock,
+    Icon: IcoTrashFilled,
+  })
 
   if (offer.isDigital) {
     description += `

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -247,11 +247,18 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
 
   const actions: IStockFormRowAction[] = [
     {
-      callback:
-        /* istanbul ignore next: DEBT, TO FIX */
-        formik.values.bookingsQuantity !== '0'
-          ? deleteConfirmShow
-          : onConfirmDeleteStock,
+      callback: async () => {
+        if (
+          // tested but coverage don't see it.
+          /* istanbul ignore next */
+          mode === OFFER_WIZARD_MODE.EDITION &&
+          formik.values.stockId !== undefined
+        ) {
+          deleteConfirmShow()
+        } else {
+          onConfirmDeleteStock()
+        }
+      },
       label: 'Supprimer le stock',
       disabled: false,
       Icon: IcoTrashFilled,

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -405,4 +405,41 @@ describe('screens:StocksThing', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByText(/Next page/)).toBeInTheDocument()
   })
+  it('should not display any message when user delete empty stock', async () => {
+    jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
+    renderStockThingScreen({
+      storeOverride: { ...storeOverride },
+    })
+    apiOffer.stocks = []
+    jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
+    expect(
+      screen.queryByText('Voulez-vous supprimer ce stock ?')
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText('Le stock a été supprimé.')
+    ).not.toBeInTheDocument()
+    expect(api.deleteStock).not.toHaveBeenCalled()
+    expect(api.deleteStock).toHaveBeenCalledTimes(0)
+  })
+  it('should display draft success message on save button when stock form is empty and not redirect to next page', async () => {
+    renderStockThingScreen({
+      storeOverride: { ...storeOverride },
+    })
+    apiOffer.stocks = []
+    jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enregistrer les modifications' })
+    )
+    expect(
+      screen.getByText('Brouillon sauvegardé dans la liste des offres')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /Stock & Prix/ })
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -484,4 +484,19 @@ describe('screens:StocksThing', () => {
       expect(quantityInput).toHaveValue(expectedNumber)
     }
   )
+  it('should display draft success message on save draft button when stock form is empty', async () => {
+    renderStockThingScreen({ props, storeOverride, contextValue })
+
+    await screen.findByRole('heading', { name: /Stock & Prix/ })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
+    )
+    expect(
+      screen.getByText('Brouillon sauvegardé dans la liste des offres')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /Stock & Prix/ })
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/ui-kit/SubmitButton/SubmitButton.tsx
+++ b/pro/src/ui-kit/SubmitButton/SubmitButton.tsx
@@ -10,6 +10,7 @@ export interface ISubmitButtonProps extends SharedButtonProps {
   buttonRef?: ForwardedRef<HTMLButtonElement | null>
   onClick?(): void
   children?: React.ReactNode
+  type?: 'submit' | 'button'
 }
 
 const SubmitButton = ({
@@ -19,6 +20,7 @@ const SubmitButton = ({
   isLoading = false,
   buttonRef,
   onClick,
+  type = 'submit',
   ...buttonAttrs
 }: ISubmitButtonProps): JSX.Element => (
   <Button
@@ -26,7 +28,7 @@ const SubmitButton = ({
     disabled={disabled || isLoading}
     onClick={onClick}
     ref={buttonRef}
-    type="submit"
+    type={type}
     variant={ButtonVariant.PRIMARY}
     isLoading={isLoading}
     {...buttonAttrs}

--- a/pro/src/utils/date.ts
+++ b/pro/src/utils/date.ts
@@ -21,8 +21,12 @@ export const getToday = () => new Date()
 export const formatBrowserTimezonedDateAsUTC = (
   date: Date | string,
   dateFormat = FORMAT_ISO
-) => format(date, dateFormat, { timeZone: 'UTC' })
+) => {
+  /* istanbul ignore next: DEBT, TO FIX */
+  return format(date, dateFormat, { timeZone: 'UTC' })
+}
 
+/* istanbul ignore next: DEBT, TO FIX */
 export const toDateStrippedOfTimezone = (dateIsoString: string) => {
   const dateIsoStringWithoutTimezone = dateIsoString.replace(
     /[+-][0-2]\d:[0-5]\d|Z/,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19286

## But de la pull request

- Afficher un toast de succès lorsqu'il n'y a pas de stock et qu'on clique sur enregistrer les modifications.
- Afficher le modal de suppression de stock en edition et à chaque fois, même lorsqu'il n'y a pas de réservation.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires