### PR TITLE
(PC-19424)[PRO] fix: prevent patch collective offer to try serialize …

### DIFF
--- a/pro/src/pages/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
+++ b/pro/src/pages/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
@@ -126,10 +126,13 @@ export const createPatchOfferPayload = (
   offerKeys.forEach(key => {
     if (
       !isEqual(offer[key], initialValues[key]) &&
-      !key.startsWith('search-')
+      !key.startsWith('search-') &&
+      key !== 'imageUrl' &&
+      key !== 'imageCredit'
     ) {
       // This is because startsWith eliminates the two keys that are not defined in the collectiveOfferSerializer
       // @ts-expect-error (7053) Element implicitly has an 'any' type because expression of type 'keyof IOfferEducationalFormValues' can't be used to index type
+
       changedValues = offerSerializer[key](changedValues, offer)
     }
   })


### PR DESCRIPTION
…imageUrl and imageCredit

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19424

## But de la pull request

Fix le patch des collectives offer (template ou non) pour ne pas envoyer les champs `imageUrl` et `imageCredit` dans le payload de  la route patch. En effet la mise à jour de l'image se fait via une autre route

