### PR TITLE
(BSR)[API] feat: pc start-backoffice command

### DIFF
--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         import debugpy
 
         if not debugpy.is_client_connected():
-            debugpy.listen(("0.0.0.0", 10002))
+            debugpy.listen(("0.0.0.0", 10003))
             print("⏳ Code debugger can now be attached, press F5 in VS Code for example ⏳", flush=True)
             debugpy.wait_for_client()
             print("🎉 Code debugger attached, enjoy debugging 🎉", flush=True)

--- a/api/start-backoffice-when-database-is-ready.sh
+++ b/api/start-backoffice-when-database-is-ready.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+until psql $DATABASE_URL -c '\q'; do
+  echo >&2 -e "\033[0;33mPostgres is unavailable - sleeping"
+  sleep 1
+done
+
+echo >&2 -e "\n\033[0;32mPostgres is up - Install app\n"
+flask install_postgres_extensions
+
+echo >&2 -e "\n\033[0;32mPostgres is up - Running migration\n"
+alembic upgrade pre@head
+alembic upgrade post@head
+
+echo >&2 -e "\n\033[0;32mMigrations have run - Installing feature flags\n"
+flask install_data
+
+echo >&2 -e "\n\033[0;32mFeature flags installed - Starting the application\n"
+while true; do python src/pcapi/backoffice_app.py || continue; done

--- a/docker-compose-backoffice.yml
+++ b/docker-compose-backoffice.yml
@@ -1,0 +1,91 @@
+version: "3.7"
+
+services:
+  postgres:
+    image: cimg/postgres:12.9-postgis
+    container_name: pc-postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - env_file
+    networks:
+      - db_nw
+    ports:
+      - 5434:5432 # This port is used outside docker-compose network (E2E tests and developers launching flask api on their local machines)
+    command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
+
+  postgres-test:
+    image: cimg/postgres:12.9-postgis
+    container_name: pc-postgres-pytest
+    volumes:
+      - postgres_data_test:/var/lib/postgresql-test/data
+    environment:
+      - POSTGRES_DB=pass_culture
+      - POSTGRES_USER=pytest
+      - POSTGRES_PASSWORD=pytest
+    command: postgres -c logging_collector=on -c log_destination=stderr -c log_min_duration_statement=0 -c log_statement=all -c log_duration=on
+    ports:
+      - 5433:5432
+    networks:
+      - db_nw
+
+  flask:
+    build:
+      context: ./api
+      target: api-flask
+    working_dir: /usr/src/app
+    container_name: pc-backoffice
+    command: ["./start-backoffice-when-database-is-ready.sh"]
+    volumes:
+      - ./api:/usr/src/app
+    env_file:
+      - env_file
+    networks:
+      - db_nw
+      - web_nw
+    depends_on:
+      - postgres
+      - redis
+      - postgres-test
+    ports:
+      - 5001:5001
+      - 10003:10003 # debugger port
+    stdin_open: true
+    tty: true
+
+  redis:
+    image: scalingo/redis
+    container_name: pc-redis
+    command: redis-server
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/data
+    networks:
+      - db_nw
+
+  nginx:
+    build: nginx
+    container_name: pc-nginx-backoffice
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./certs:/etc/letsencrypt
+      - ./certs-data:/data/letsencrypt
+    networks:
+      - web_nw
+    depends_on:
+      - flask
+
+networks:
+  db_nw:
+    driver: bridge
+  web_nw:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  postgres_data_test:
+  redis_data:

--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -21,3 +21,13 @@ function rebuild_backend {
     sudo rm -rf $ROOT_PATH/api/static/object_store_data;
     docker-compose -f "$ROOT_PATH"/docker-compose-app.yml down --volumes'
 }
+
+function start_backoffice {
+    docker_compose_major=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\).*/\1/");
+    docker_compose_minor=$(docker-compose -v 2>&1 | sed "s/.*version \([0-9]\).\([0-9]*\).\([0-9]*\).*/\2/");
+    if [ "$docker_compose_major" -le "1" ] && [ "$docker_compose_minor" -le "23" ]; then
+        echo "This script requires docker-compose 1.24 or greater"
+        exit 1
+    fi
+    RUN='cd $ROOT_PATH && docker-compose -f "$ROOT_PATH"/docker-compose-backoffice.yml build && docker-compose -f "$ROOT_PATH"/docker-compose-backoffice.yml up'
+}

--- a/pc
+++ b/pc
@@ -38,6 +38,7 @@ Commands:
   set-git-config        Define a local Git configuration
   start-adage-front     Start the adage frontend on localhost
   start-backend         Start the API on localhost
+  start-backffice       Start the backoffice on localhost
   start-pro             Start the pro frontend on localhost
   symlink               Create symlink to use \"pc\" command (admin rights may be needed)
   test-backend          Run tests for the API
@@ -205,6 +206,11 @@ elif [[ "$CMD" == "restore-db-intact" ]]; then
 elif [[ "$CMD" == "start-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
   start_backend
+
+# Start API server with database and nginx server
+elif [[ "$CMD" == "start-backoffice" ]]; then
+  source "$INFRA_SCRIPTS_PATH"/start_backend.sh
+  start_backoffice
 
 # Start pro or adage application
 elif [[ "$CMD" == "start-pro" ]] || [[ "$CMD" == "start-adage-front" ]]; then


### PR DESCRIPTION
## But de la pull request

Ajouter une commande `pc start-backoffice` qui lance tout ce qu'il faut pour avoir un backoffice (v3) opérationnel, à la manière de `pc start-backend`.

Cette solution a toutefois un inconvénient : on ne peut lancer `pc start-backoffice` et `pc start-backend` en parallèle puisque les deux utilisent la même image. C'est une contrainte acceptable dans un premier temps.

Pour avoir les deux existant côte-à-côte, il faudrait sûrement regarder du côté de la configuration `nginx` et ça dépasse mes compétences.