### PR TITLE
(BSR)[API] feat: Dockerfile: user --chown=pcapi:pcapi

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -47,15 +47,13 @@ RUN apt-get update \
 		libxmlsec1-openssl \
 		xmlsec1
 
-COPY --from=builder /home/pcapi/.local /home/pcapi/.local
+USER pcapi
+
+COPY --chown=pcapi:pcapi --from=builder /home/pcapi/.local /home/pcapi/.local
 
 WORKDIR /usr/src/app
 
-COPY --from=sources /tmp/src .
-
-RUN chown -R pcapi:pcapi .
-
-USER pcapi
+COPY --chown=pcapi:pcapi --from=sources /tmp/src .
 
 ######### DEV ##########
 


### PR DESCRIPTION
## But de la pull request

L'étape `RUN chown -R pcapi:pcapi .` est très (très) lente. On peut remplacer cette opération en utilisation l'option `--chown` de `COPY`, ce qui est déjà fait ailleurs dans le fichier.