### PR TITLE
(PC-19192) [API] chore: remove unused param

### DIFF
--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -54,7 +54,7 @@ def get_business_units_query(
     return query
 
 
-def get_reimbursement_points_query(user: users_models.User, offerer_id: int = None) -> sqla_orm.Query:
+def get_reimbursement_points_query(user: users_models.User) -> sqla_orm.Query:
     query = offerers_models.Venue.query.join(models.BankInformation).filter(
         models.BankInformation.status == models.BankInformationStatus.ACCEPTED
     )
@@ -64,8 +64,6 @@ def get_reimbursement_points_query(user: users_models.User, offerer_id: int = No
             offerers_models.UserOfferer,
             offerers_models.Venue.managingOffererId == offerers_models.UserOfferer.offererId,
         ).filter(offerers_models.UserOfferer.user == user, offerers_models.UserOfferer.isValidated)
-    if offerer_id:
-        venue_subquery = venue_subquery.filter(offerers_models.Venue.managingOffererId == offerer_id)
     if venue_subquery.whereclause is not None:
         venue_subquery = venue_subquery.with_entities(offerers_models.Venue.id).subquery()
         query = query.filter(offerers_models.Venue.id.in_(venue_subquery))

--- a/api/src/pcapi/routes/pro/finance.py
+++ b/api/src/pcapi/routes/pro/finance.py
@@ -72,14 +72,9 @@ def get_business_units(query: finance_serialize.BusinessUnitListQueryModel) -> N
 @spectree_serialize(
     response_model=finance_serialize.ReimbursementPointListResponseModel, api=blueprint.pro_private_schema
 )
-def get_reimbursement_points(
-    query: finance_serialize.BusinessUnitListQueryModel,
-) -> finance_serialize.ReimbursementPointListResponseModel:
-    if query.offerer_id:
-        check_user_has_access_to_offerer(current_user, query.offerer_id)
+def get_reimbursement_points() -> finance_serialize.ReimbursementPointListResponseModel:
     reimbursement_points = finance_repository.get_reimbursement_points_query(
         user=current_user,
-        offerer_id=query.offerer_id,
     )
     reimbursement_points = reimbursement_points.options(
         sqla_orm.contains_eager(offerers_models.Venue.bankInformation),

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -7,6 +7,8 @@ import pcapi.serialization.utils as serialization_utils
 
 
 class BusinessUnitListQueryModel(BaseModel):
+    # FIXME (mageoffray, 2022-12-27): Business Units are not used and this should be cleaned
+    # Please do not use dehumanize anymore.
     class Config:
         alias_generator = serialization_utils.to_camel
         extra = "forbid"

--- a/api/tests/core/finance/test_repository.py
+++ b/api/tests/core/finance/test_repository.py
@@ -125,49 +125,6 @@ class GetReimbursementPointsTest:
 
         assert reimbursement_points == [reimbursement_point1]
 
-    def test_admin_and_filter_on_offerer_id(self):
-        admin = users_factories.AdminFactory()
-        offerer1 = offerers_factories.OffererFactory()
-        reimbursement_point1 = offerers_factories.VenueFactory(managingOfferer=offerer1, reimbursement_point="self")
-        factories.BankInformationFactory(venue=reimbursement_point1)
-        reimbursement_point2 = offerers_factories.VenueFactory(reimbursement_point="self")
-        factories.BankInformationFactory(venue=reimbursement_point2)
-
-        reimbursement_points = repository.get_reimbursement_points_query(user=admin, offerer_id=offerer1.id)
-        reimbursement_points = list(reimbursement_points.order_by(offerers_models.Venue.id))
-
-        assert reimbursement_points == [reimbursement_point1]
-
-    def test_pro_and_filter_on_offerer_id(self):
-        offerer1 = offerers_factories.OffererFactory()
-        reimbursement_point1 = offerers_factories.VenueFactory(managingOfferer=offerer1, reimbursement_point="self")
-        factories.BankInformationFactory(venue=reimbursement_point1)
-        offerer2 = offerers_factories.OffererFactory()
-        reimbursement_point2 = offerers_factories.VenueFactory(managingOfferer=offerer2, reimbursement_point="self")
-        factories.BankInformationFactory(venue=reimbursement_point2)
-        pro = users_factories.ProFactory()
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer1)
-
-        reimbursement_points = list(repository.get_reimbursement_points_query(pro, offerer_id=offerer1.id))
-
-        assert reimbursement_points == [reimbursement_point1]
-
-    def test_check_offerer_id_and_pro_user(self):
-        # Make sure that a pro user cannot specify an offerer id for
-        # which they don't have access.
-        offerer1 = offerers_factories.OffererFactory()
-        pro = users_factories.ProFactory()
-        offerers_factories.UserOffererFactory(user=pro, offerer=offerer1)
-        reimbursement_point1 = offerers_factories.VenueFactory(managingOfferer=offerer1, reimbursement_point="self")
-        factories.BankInformationFactory(venue=reimbursement_point1)
-        offerer2 = offerers_factories.OffererFactory()
-        reimbursement_point2 = offerers_factories.VenueFactory(managingOfferer=offerer2, reimbursement_point="self")
-        factories.BankInformationFactory(venue=reimbursement_point2)
-
-        reimbursement_points = repository.get_reimbursement_points_query(pro, offerer_id=offerer2.id)
-
-        assert reimbursement_points.count() == 0
-
     def test_return_accepted_bank_information_only(self):
         admin = users_factories.AdminFactory()
         reimbursement_point1 = offerers_factories.VenueFactory(reimbursement_point="self")

--- a/api/tests/routes/pro/get_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_reimbursement_points_test.py
@@ -4,7 +4,6 @@ from pcapi.core import testing
 import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
-from pcapi.utils import human_ids
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -59,37 +58,3 @@ def test_get_reimbursement_points_by_pro(client):
         "name": "My Reimbursement Point",
         "publicName": "My Reimbursement Point Public Name",
     }
-
-
-def test_get_reimbursement_points_by_pro_filtered_on_offerer_id(client):
-    reimbursement_point_1 = offerers_factories.VenueFactory(
-        businessUnit=None, reimbursement_point="self", name="My Reimbursement Point"
-    )
-    finance_factories.BankInformationFactory(venue=reimbursement_point_1)
-
-    reimbursement_point_2 = offerers_factories.VenueFactory(businessUnit=None, reimbursement_point="self")
-    finance_factories.BankInformationFactory(venue=reimbursement_point_2)
-    pro = users_factories.ProFactory()
-    offerers_factories.UserOffererFactory(offerer=reimbursement_point_1.managingOfferer, user=pro)
-    offerers_factories.UserOffererFactory(offerer=reimbursement_point_2.managingOfferer, user=pro)
-
-    client = client.with_session_auth(pro.email)
-    params = {"offererId": human_ids.humanize(reimbursement_point_1.managingOffererId)}
-    response = client.get("/finance/reimbursement-points", params=params)
-
-    assert response.status_code == 200
-    reimbursement_points = response.json
-    assert len(reimbursement_points) == 1
-    assert reimbursement_points[0]["id"] == reimbursement_point_1.id
-
-
-def test_get_reimbursement_points_by_pro_unauthorized_offerer_id(client):
-    reimbursement_point = offerers_factories.VenueFactory(businessUnit=None, reimbursement_point="self")
-    finance_factories.BankInformationFactory(venue=reimbursement_point)
-    pro = users_factories.ProFactory()
-
-    client = client.with_session_auth(pro.email)
-    params = {"offererId": human_ids.humanize(reimbursement_point.managingOffererId)}
-    response = client.get("/finance/reimbursement-points", params=params)
-
-    assert response.status_code == 403

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -947,19 +947,13 @@ export class DefaultService {
 
   /**
    * get_reimbursement_points <GET>
-   * @param offererId
    * @returns ReimbursementPointListResponseModel OK
    * @throws ApiError
    */
-  public getReimbursementPoints(
-    offererId?: number | null,
-  ): CancelablePromise<ReimbursementPointListResponseModel> {
+  public getReimbursementPoints(): CancelablePromise<ReimbursementPointListResponseModel> {
     return this.httpRequest.request({
       method: 'GET',
       url: '/finance/reimbursement-points',
-      query: {
-        'offererId': offererId,
-      },
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Entity`,


### PR DESCRIPTION
This was the only place we had some dehumanization on finance endpoints. 
An other route GET business_units, that is not used anymore, should be deleted

It is not possible to filter by offerer_id from pro front

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19192
