### PR TITLE
(PC-18964)[API] feat: Recherche sur la page "Rattachements à valider"

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -50,6 +50,8 @@ class UserOffererValidationListForm(FlaskForm):
     class Meta:
         csrf = False
 
+    q = fields.PCOptSearchField("Nom de structure, SIREN, email, nom de compte pro")
+
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )
@@ -69,6 +71,11 @@ class UserOffererValidationListForm(FlaskForm):
         default="100",
         validators=(wtforms.validators.Optional(),),
     )
+
+    def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
+        if q.data and q.data.isnumeric() and len(q.data) != 9:
+            raise wtforms.validators.ValidationError("Le nombre de chiffres ne correspond pas à un SIREN")
+        return q
 
 
 class CommentForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -399,6 +399,7 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
         form.status.data = [ValidationStatus.NEW.value, ValidationStatus.PENDING.value]
 
     users_offerers = offerers_api.list_users_offerers_to_be_validated(
+        form.q.data,
         form.tags.data,
         form.status.data,
         form.offerer_status.data,

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -1431,6 +1431,19 @@ class ListUserOffererToValidateTest:
         rows = html_parser.extract_table_rows(response.data)
         assert [int(row["ID Compte pro"]) for row in rows] == [uo.user.id for uo in (user_offerer_3, user_offerer_2)]
 
+    @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
+    def test_list_search_by_email(self, authenticated_client, user_offerer_to_be_validated):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate", q="b@example.com")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert {row["Email Compte pro"] for row in rows} == {"b@example.com"}
+
 
 class ValidateOffererAttachmentUnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
     method = "post"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18964

## But de la pull request

En tant que responsable homologation ou chargé de développement
J'aimerais rechercher une demande de rattachement via le nom du compte pro
Afin de gagner du temps

## Implémentation

- Ajout d’un champ de recherche sur la page “Rattachements à valider”, à positionner en haut de page tout à gauche (de la même façon que ce qu’on propose sur la page “Structures à valider”

- Il doit être possible de rechercher une demande de rattachement via : 

    - Le nom du compte pro 

    - l’email du compte pro

    - Le nom de la structure 

    - Le Siren de la structure 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

<img width="1714" alt="Capture d’écran 2022-12-28 à 14 15 00" src="https://user-images.githubusercontent.com/9610732/209817911-27bf55b3-ff69-4b82-bc22-085142019e4d.png">
