### PR TITLE
(PC-19430)[PRO] fix: bug information lieu banner

### DIFF
--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -95,7 +95,7 @@ describe('StockEventForm', () => {
     await userEvent.click(screen.getByText(27))
 
     expect(screen.getByLabelText('Date limite de réservation')).toHaveValue(
-      '27/12/2022'
+      '28/12/2022'
     )
   })
 

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormVenue/FormVenue.tsx
@@ -84,19 +84,22 @@ const FormVenue = ({
           />
         </FormLayout.Row>
       )}
-      {values.venueId.length === 0 && values.offererId.length !== 0 && (
-        <Banner
-          links={[
-            {
-              href: `/structures/${values.offererId}/lieux/creation`,
-              linkTitle: 'Renseigner un lieu',
-            },
-          ]}
-        >
-          Pour proposer des offres à destination d’un groupe scolaire, vous
-          devez renseigner un lieu pour pouvoir être remboursé.
-        </Banner>
-      )}
+      {isEligible &&
+        venuesOptions.length > 0 &&
+        values.venueId.length === 0 &&
+        values.offererId.length !== 0 && (
+          <Banner
+            links={[
+              {
+                href: `/structures/${values.offererId}/lieux/creation`,
+                linkTitle: 'Renseigner un lieu',
+              },
+            ]}
+          >
+            Pour proposer des offres à destination d’un groupe scolaire, vous
+            devez renseigner un lieu pour pouvoir être remboursé.
+          </Banner>
+        )}
     </FormLayout.Section>
   )
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19430

## But de la pull request

Régler un bug concernant la bannière de lieu lors de la création d'une offre, la bannière s'affichait alors que la structure n'était pas éligible mais avait déjà des lieux créer et validé. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
