### PR TITLE
(PC-19075)[PRO] fix: change border color when focus visible

### DIFF
--- a/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
+++ b/pro/src/ui-kit/RadioButtonWithImage/RadioButtonWithImage.module.scss
@@ -45,7 +45,7 @@
     background-color: rgba(colors.$tertiary, 0.05);
 
     &:has(:focus-visible) {
-      border-color: colors.$black;
+      border: 2px solid colors.$tertiary;
       outline: rem.torem(1px) solid colors.$black;
       outline-offset: rem.torem(3px);
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19075

## But de la pull request

Changer la couleur de la bordure et sa taille lorsqu'on focus via tabulation 

Avant : 
<img width="257" alt="Capture d’écran 2022-12-28 à 17 08 15" src="https://user-images.githubusercontent.com/119043808/209840226-5195de8d-d910-408a-9528-f363ef0bb926.png">
Après : 
<img width="257" alt="Capture d’écran 2022-12-28 à 17 09 00" src="https://user-images.githubusercontent.com/119043808/209840261-da173cba-372c-45ba-bcd6-dbfc80f00f49.png">

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
