### PR TITLE
(PC-19454)[API] feat: Erreur lors de la saisie des commentaires de rejet ou mise ne attente

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -26,14 +26,14 @@ class PCOptStringField(wtforms.StringField):
     widget = partial(widget, template="components/forms/string_field.html")
     validators = [
         validators.Optional(""),
-        validators.Length(min=3, max=64, message="doit contenir entre %(min)d et %(max)d caractères"),
+        validators.Length(max=64, message="doit contenir au maximum %(max)d caractères"),
     ]
 
 
 class PCStringField(PCOptStringField):
     validators = [
         validators.InputRequired("Information obligatoire"),
-        validators.Length(min=3, max=64, message="doit contenir entre %(min)d et %(max)d caractères"),
+        validators.Length(min=1, max=64, message="doit contenir entre %(min)d et %(max)d caractères"),
     ]
 
 
@@ -60,7 +60,7 @@ class PCPhoneNumberField(PCStringField):
 
 class PCCommentField(PCOptStringField):
     validators = [
-        validators.Length(min=2, max=1024, message="doit contenir entre %(min)d et %(max)d caractères"),
+        validators.Length(min=1, max=1024, message="doit contenir entre %(min)d et %(max)d caractères"),
     ]
 
 


### PR DESCRIPTION

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19454

## But de la pull request

Sur les pages “Liste des structures à valider” et “Liste des rattachements à valider”, lorsqu’on met en attente ou rejette une demande avec le commentaire “AE”, on obtient une page de redirection puis un bandeau d’erreur après clic sur le lien, qui nous impose la saisie d’un commentaire différent 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
