### PR TITLE
(PC-19312)[PRO] fix: wording toaster when cancel resa expired status

### DIFF
--- a/pro/src/core/OfferEducational/adapters/__specs__/cancelCollectiveBookingsAdapter.spec.ts
+++ b/pro/src/core/OfferEducational/adapters/__specs__/cancelCollectiveBookingsAdapter.spec.ts
@@ -2,6 +2,7 @@ import { api } from 'apiClient/api'
 import { ApiError } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
+import { OfferStatus } from 'apiClient/v2'
 
 import { cancelCollectiveBookingAdapter } from '../cancelCollectiveBookingAdapter'
 
@@ -50,7 +51,24 @@ describe('cancelCollectiveBookingAdapter', () => {
     // then
     expect(response.isOk).toBeTruthy()
     expect(response.message).toBe(
-      'La réservation / préreservation sur cette offre à été annulée avec succès, votre offre sera à nouveau visible sur ADAGE.'
+      'La réservation sur cette offre a été annulée avec succès, votre offre sera à nouveau visible sur ADAGE.'
+    )
+  })
+
+  it('should return a confirmation when the booking was cancelled and status expired', async () => {
+    // given
+    jest.spyOn(api, 'cancelCollectiveOfferBooking').mockResolvedValue()
+
+    // when
+    const response = await cancelCollectiveBookingAdapter({
+      offerId: '12',
+      offerStatus: OfferStatus.EXPIRED,
+    })
+
+    // then
+    expect(response.isOk).toBeTruthy()
+    expect(response.message).toBe(
+      'La réservation sur cette offre a été annulée.'
     )
   })
 })

--- a/pro/src/core/OfferEducational/adapters/cancelCollectiveBookingAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/cancelCollectiveBookingAdapter.ts
@@ -1,16 +1,22 @@
 import { api } from 'apiClient/api'
 import { getErrorCode, isErrorAPIError } from 'apiClient/helpers'
+import { OfferStatus } from 'apiClient/v2'
 
 type IPayloadSuccess = null
 type IPayloadFailure = null
 type cancelCollectiveBookingAdapter = Adapter<
-  { offerId?: string },
+  { offerId?: string; offerStatus?: string },
   IPayloadSuccess,
   IPayloadFailure
 >
 
 export const cancelCollectiveBookingAdapter: cancelCollectiveBookingAdapter =
-  async ({ offerId }) => {
+  async ({ offerId, offerStatus }) => {
+    const message =
+      offerStatus === OfferStatus.EXPIRED
+        ? 'La réservation sur cette offre a été annulée.'
+        : 'La réservation sur cette offre a été annulée avec succès, votre offre sera à nouveau visible sur ADAGE.'
+
     try {
       // the api returns no understandable error when the id is not valid, so we deal before calling the api
       if (!offerId || offerId === '') {
@@ -19,8 +25,7 @@ export const cancelCollectiveBookingAdapter: cancelCollectiveBookingAdapter =
       await api.cancelCollectiveOfferBooking(offerId)
       return {
         isOk: true,
-        message:
-          'La réservation / préreservation sur cette offre à été annulée avec succès, votre offre sera à nouveau visible sur ADAGE.',
+        message: message,
         payload: null,
       }
     } catch (error) {

--- a/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -61,6 +61,7 @@ const CollectiveOfferSummaryEdition = ({
 
     const { isOk, message } = await cancelCollectiveBookingAdapter({
       offerId: offer.id,
+      offerStatus: offer.status,
     })
 
     if (!isOk) {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19312

## But de la pull request

Changer le wording du toaster lorsqu'on annule une réservation / offre en status expiré, pour tous les autres status enlevé le '/ pré reservation' 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
