### PR TITLE
(BSR)[API] Improve navigation on backoffice

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -19,17 +19,15 @@
     <!-- Useful for local script and styles modification per-view -->
     {% block head %}{% endblock %}
 
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
+            crossorigin="anonymous"></script>
 </head>
 
-{#  Navigation with turbolink is disabled because bootstrap is not reloaded and so is not working after navigation  #}
-<body data-turbo="false">
+<body>
 
 {% block content %}{% endblock %}
-
-<!-- Bootstrap JS -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
-        crossorigin="anonymous"></script>
 
 <!-- Useful for local script modification per-view -->
 {% block scripts %}{% endblock %}


### PR DESCRIPTION
## But de la pull request

Lors de cette PR https://github.com/pass-culture/pass-culture-main/pull/4404, nous avions désactiver turbo drive parce qu'il cassait bootstrap, sans corriger le problème.
Cette PR vient corriger le pb et réactiver turbo drive.

## Informations supplémentaires

L'incompatibilité de bootstrap avec turbo drive semble apparaitre lors que le script de bootstrap est chargé une deuxième fois.
Cela vient à priori du fait que, lors d'une navigation, turbo drive recharge les scripts qui sont dans la balise body, par ceux dans le head. (ref https://turbo.hotwired.dev/handbook/building#working-with-script-elements)
Bootstrap étant dans notre balise body, il était re chargé lors d'une navigation.

Ce correctif semble bien corriger le problème.

A noter : bootstrap indique de placer sa balise script dans le body (c'est pourquoi elle était là jusqu'à présent), sans en donner la raison. (ref https://getbootstrap.com/docs/5.0/getting-started/introduction/#js)
Il semble bien fonctionner dans la balise head pourtant.
Cette réponse SO (https://stackoverflow.com/a/20794372) semble indiquer qu'il n'y a pas de différence dans le rendu final, seulement un impact sur le chargement de la page, ce qui est minime dans notre cas puisqu'il n'y aura plus qu'un seul chargement : lors de l'ouverture du backoffice.
=> à surveiller

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
