### PR TITLE
(PC-19455)[API] feat: Zone cliquable des actions "Valider", "Mettre en attente" et "Rejeter"

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
@@ -3,73 +3,72 @@
 
 <table class="table table-hover my-4">
     <thead>
-        <tr>
-            <th scope="col"></th>
-            <th scope="col">ID</th>
-            <th scope="col">Statut</th>
-            <th scope="col">Nom</th>
-            <th scope="col">Prénom</th>
-            <th scope="col">Email</th>
-        </tr>
+    <tr>
+        <th scope="col"></th>
+        <th scope="col">ID</th>
+        <th scope="col">Statut</th>
+        <th scope="col">Nom</th>
+        <th scope="col">Prénom</th>
+        <th scope="col">Email</th>
+    </tr>
     </thead>
 
     <tbody>
-        {% for user_offerer in users_offerer %}
-            <tr>
+    {% for user_offerer in users_offerer %}
+        <tr>
 
-                <td class="fw-bolder">
+            <td class="fw-bolder">
                 <div class="dropdown">
                     <button type="button" data-bs-toggle="dropdown" aria-expanded="false" class="btn p-0">
                         <i class="bi bi-three-dots-vertical"></i>
                     </button>
                     <ul class="dropdown-menu">
-                        <li class="dropdown-item">
+                        <li class="dropdown-item p-0">
                             <form
-                                action="{{ url_for(
-                                    "backoffice_v3_web.user_offerer.user_offerer_validate",
-                                    user_offerer_id=user_offerer.id,
-                                ) }}"
-                                method="POST">
+                                    action="
+
+                                            {{ url_for("backoffice_v3_web.user_offerer.user_offerer_validate",user_offerer_id=user_offerer.id,
+                                                    ) }}"
+                                    method="POST">
                                 {{ csrf_token }}
 
-                                <button type="submit" class="btn btn-sm">
+                                <button type="submit" class="btn btn-sm d-block w-100 text-start px-3">
                                     Valider
                                 </button>
                             </form>
                         </li>
-                        <li class="dropdown-item">
-                            <button type="button"
-                                    class="btn btn-sm"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="#reject-modal-{{ user_offerer.userId }}">
+                        <li class="dropdown-item p-0">
+                            <a class="btn btn-sm d-block w-100 text-start px-3"
+                               data-bs-toggle="modal"
+                               data-bs-target="#reject-modal-{{ user_offerer.userId }}">
                                 Rejeter
-                            </button>
+                            </a>
                         </li>
-                        <li class="dropdown-item">
-                            <button type="button"
-                                    class="btn btn-sm"
+                        <li class="dropdown-item p-0">
+                            <a
+                                    class="btn btn-sm d-block w-100 text-start px-3"
                                     data-bs-toggle="modal"
                                     data-bs-target="#pending-modal-{{ user_offerer.userId }}">
                                 Mettre en attente
-                            </button>
+                            </a>
                         </li>
                     </ul>
                 </div>
-                </td>
+            </td>
 
-                <td class="fw-bolder">
-                    <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=user_offerer.userId) }}">
-                        {{ user_offerer.userId }}
-                    </a>
-                </td>
-                <td class="text-muted">
-                    {{ build_user_offerer_badges(user_offerer) }}
-                </td>
-                <td class="fw-bolder text-break">{{ user_offerer.user.lastName | empty_string_if_null }}</td>
-                <td class="text-muted">{{ user_offerer.user.firstName | empty_string_if_null }}</td>
-                <td class="fw-bolder">{{ user_offerer.user.email | empty_string_if_null }}</td>
-            </tr>
-        {% endfor %}
+            <td class="fw-bolder">
+                <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=user_offerer.userId) }}">
+                    {{ user_offerer.userId }}
+                </a>
+            </td>
+            <td class="text-muted">
+                {{ build_user_offerer_badges(user_offerer) }}
+            </td>
+            <td class="fw-bolder text-break">{{ user_offerer.user.lastName | empty_string_if_null }}</td>
+            <td class="text-muted">{{ user_offerer.user.firstName | empty_string_if_null }}</td>
+            <td class="fw-bolder">{{ user_offerer.user.email | empty_string_if_null }}</td>
+        </tr>
+    {% endfor %}
     </tbody>
 </table>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -81,7 +81,7 @@
                                             class="btn p-0"><i
                                             class="bi bi-three-dots-vertical"></i></button>
                                     <ul class="dropdown-menu">
-                                        <li class="dropdown-item">
+                                        <li class="dropdown-item p-0">
                                             <form
                                                     action="{{ url_for(
                                                     "backoffice_v3_web.user_offerer.user_offerer_validate",
@@ -90,26 +90,25 @@
                                                 ) }}"
                                                     method="POST">
                                                 {{ csrf_token }}
-                                                <button type="submit" class="btn btn-sm">
+                                                <button type="submit" class="btn btn-sm d-block w-100 text-start px-3">
                                                     Valider
                                                 </button>
                                             </form>
                                         </li>
-                                        <li class="dropdown-item">
-                                            <button type="button"
-                                                    class="btn btn-sm"
+                                        <li class="dropdown-item p-0">
+                                            <a class="btn btn-sm d-block w-100 text-start px-3"
                                                     data-bs-toggle="modal"
                                                     data-bs-target="#reject-modal-{{ user_offerer.id }}">
                                                 Rejeter
-                                            </button>
+                                            </a>
                                         </li>
-                                        <li class="dropdown-item">
-                                            <button type="button"
-                                                    class="btn btn-sm"
+                                        <li class="dropdown-item p-0">
+                                            <a
+                                                    class="btn btn-sm d-block w-100 text-start px-3"
                                                     data-bs-toggle="modal"
                                                     data-bs-target="#pending-modal-{{ user_offerer.id }}">
                                                 Mettre en attente
-                                            </button>
+                                            </a>
                                         </li>
                                     </ul>
                                 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -32,7 +32,7 @@
                             {% endif %}
                         {% endfor %}
                     </div>
-                  <div class="input-group mb-1 ">
+                    <div class="input-group mb-1 ">
                         {% for form_field in form %}
                             {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
                                 <div class="col-6 p-1"> {{ form_field }}</div>
@@ -94,7 +94,7 @@
                                             class="btn p-0"><i
                                             class="bi bi-three-dots-vertical"></i></button>
                                     <ul class="dropdown-menu">
-                                        <li class="dropdown-item">
+                                        <li class="dropdown-item p-0">
                                             <form
                                                     action="{{ url_for(
                                                     "backoffice_v3_web.offerer.validate",
@@ -102,26 +102,25 @@
                                                 ) }}"
                                                     method="POST">
                                                 {{ csrf_token }}
-                                                <button type="submit" class="btn btn-sm">
+                                                <button type="submit" class="btn btn-sm d-block w-100 text-start px-3">
                                                     Valider
                                                 </button>
                                             </form>
                                         </li>
-                                        <li class="dropdown-item">
-                                            <button type="button"
-                                                    class="btn btn-sm"
-                                                    data-bs-toggle="modal"
-                                                    data-bs-target="#reject-modal-{{ offerer.id }}">
+                                        <li class="dropdown-item p-0">
+                                            <a class="btn btn-sm d-block w-100 text-start px-3"
+                                               data-bs-toggle="modal"
+                                               data-bs-target="#reject-modal-{{ offerer.id }}">
                                                 Rejeter
-                                            </button>
+                                            </a>
                                         </li>
-                                        <li class="dropdown-item">
-                                            <button type="button"
-                                                    class="btn btn-sm"
+                                        <li class="dropdown-item p-0">
+                                            <a
+                                                    class="btn btn-sm d-block w-100 text-start px-3"
                                                     data-bs-toggle="modal"
                                                     data-bs-target="#pending-modal-{{ offerer.id }}">
                                                 Mettre en attente
-                                            </button>
+                                            </a>
                                         </li>
                                     </ul>
                                 </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19455

## But de la pull request

Comportement observé (+ screenshot ou vidéo)

La zone cliquable des actions “Valider”, “Rejeter” et “Mettre en attente” sur les pages “Liste des structures à valider” et “Liste des rattachements à valider” est trop restreinte, puisqu’il est nécessaire de cliquer précisément sur le libellé pour que l’action se réalise. Sinon il faut ré-ouvrir la pop-in et recliquer sur l’action.

Si on clique sur la ligne mais pas correctement sur le libellé, cela ne fonctionne pas.


## Implémentation

Elargissement de la zone cliquable sur les boutons à toute la largeur. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`