### PR TITLE
(PC-19464)[PRO] fix: allow to delete synchronized offer in edition mode

### DIFF
--- a/pro/src/components/Notification/Notification.tsx
+++ b/pro/src/components/Notification/Notification.tsx
@@ -69,8 +69,7 @@ const Notification = (): JSX.Element | null => {
             styles['notification'],
             styles[
               //graphic variation
-              /* istanbul ignore next */
-              `is-${type || 'success'}`
+              /* istanbul ignore next */ `is-${type || 'success'}`
             ],
             /* istanbul ignore next: DEBT, TO FIX */ isVisible
               ? styles['show']

--- a/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
@@ -96,8 +96,7 @@ const StockFormList = ({ offer, onDeleteStock }: IStockFormListProps) => {
                       }
                     },
                     label: 'Supprimer le stock',
-                    disabled:
-                      !stockValues.isDeletable || isDisabled || isSynchronized,
+                    disabled: !stockValues.isDeletable || isDisabled,
                     Icon: TrashFilledIcon,
                   },
                 ]}

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -428,7 +428,7 @@ describe('screens:StocksEvent:Edition', () => {
     expect(screen.getByLabelText('Prix')).toHaveValue(10.01)
   })
 
-  it('should not allow user to delete stock from a synchronized offer', async () => {
+  it('should allow user to delete stock from a synchronized offer', async () => {
     jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
     apiOffer.lastProvider = {
       ...apiOffer.lastProvider,
@@ -444,8 +444,17 @@ describe('screens:StocksEvent:Edition', () => {
     await userEvent.click(
       screen.getAllByTestId('stock-form-actions-button-open')[1]
     )
-    const deleteButton = screen.getAllByTitle('Supprimer le stock')[0]
-    expect(deleteButton).toHaveAttribute('aria-disabled', 'true')
+    await userEvent.click(
+      screen.getAllByTestId('stock-form-actions-button-open')[0]
+    )
+    await userEvent.click(screen.getAllByText('Supprimer le stock')[0])
+    expect(
+      screen.getByText('Voulez-vous supprimer ce stock ?')
+    ).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Supprimer', { selector: 'button' }))
+    expect(screen.getByText('Le stock a été supprimé.')).toBeInTheDocument()
+    expect(api.deleteStock).toHaveBeenCalledWith('STOCK_ID')
+    expect(api.deleteStock).toHaveBeenCalledTimes(1)
   })
 
   it('should not allow user to add a date for a synchronized offer', async () => {

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -83,7 +83,6 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
   } = useModal()
   /* istanbul ignore next: DEBT, TO FIX */
   const isDisabled = offer.status ? isOfferDisabled(offer.status) : false
-  const isSynchronized = offer.lastProvider !== null
   const providerName = offer?.lastProviderName
 
   const onSubmit = async (formValues: IStockThingFormValues) => {
@@ -290,7 +289,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
     })
   }
 
-  actions[0].disabled = isDisabled || isSynchronized
+  actions[0].disabled = isDisabled
 
   if (offer.isDigital) {
     description += `

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -326,7 +326,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks')
     expect(api.upsertStocks).not.toHaveBeenCalled()
   })
-  it('should not allow user to delete stock from a synchronized offer', async () => {
+  it('should allow user to delete stock from a synchronized offer', async () => {
     apiOffer.lastProvider = {
       id: 'PROVIDER_ID',
       isActive: true,
@@ -343,11 +343,17 @@ describe('screens:StocksThing', () => {
     await userEvent.click(
       screen.getAllByTestId('stock-form-actions-button-open')[1]
     )
-    const deleteButton = screen.getAllByTitle('Supprimer le stock')[0]
-    expect(deleteButton).toHaveAttribute('aria-disabled', 'true')
-    await deleteButton.click()
-    expect(api.deleteStock).toHaveBeenCalledTimes(0)
-    expect(screen.getByLabelText('Prix')).toHaveValue(10.01)
+    await userEvent.click(
+      screen.getAllByTestId('stock-form-actions-button-open')[0]
+    )
+    await userEvent.click(screen.getAllByText('Supprimer le stock')[0])
+    expect(
+      screen.getByText('Voulez-vous supprimer ce stock ?')
+    ).toBeInTheDocument()
+    await userEvent.click(screen.getByText('Supprimer', { selector: 'button' }))
+    expect(screen.getByText('Le stock a été supprimé.')).toBeInTheDocument()
+    expect(api.deleteStock).toHaveBeenCalledWith('STOCK_ID')
+    expect(api.deleteStock).toHaveBeenCalledTimes(1)
   })
   it('should display an error message when there is an api error', async () => {
     jest.spyOn(api, 'deleteStock').mockRejectedValue(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19464

## But de la pull request

- Permettre à l'utilisateur de supprimer un stock synchronisé si possible en ne désactivant pas le bouton supprimer.

## Implémentation

![Screenshot from 2023-01-02 16-50-18](https://user-images.githubusercontent.com/106379750/210255244-ebbfdbaa-9124-4084-b3b0-05e221ea4fb8.png)
