### PR TITLE
(PC-18478)[API] feat: add user offerer tab on pro user page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -90,7 +90,7 @@
             </div>
         </div>
         <div class="mt-4">
-            <turbo-frame id="pro_user_history_frame" src="{{ url_for("backoffice_v3_web.pro_user.get_user_history", user_id=user.id) }}">
+            <turbo-frame id="pro_user_details_frame" src="{{ url_for("backoffice_v3_web.pro_user.get_details", user_id=user.id, active_tab=request.args.get("active_tab", "history")) }}">
                 <p class="text-center">
                     <span class="spinner-grow spinner-grow-sm" role="status">
                         <span class="visually-hidden">Chargement...</span>

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details.html
@@ -1,9 +1,9 @@
-<turbo-frame id="pro_user_history_frame">
+<turbo-frame id="pro_user_details_frame">
 
     <ul class="nav nav-tabs nav-fill" id="pills-tab" role="tablist">
         <li class="nav-item" role="presentation">
             <button
-                class="nav-link active fw-bolder py-3"
+                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'history' else '' }}"
                 id="pills-home-tab"
                 data-bs-toggle="pill"
                 data-bs-target="#pills-home"
@@ -17,7 +17,7 @@
         </li>
         <li class="nav-item" role="presentation">
             <button
-                class="nav-link fw-bolder py-3"
+                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'user_offerers' else '' }}"
                 id="pills-offerers-tab"
                 data-bs-toggle="pill"
                 data-bs-target="#pills-offerers"
@@ -32,10 +32,22 @@
     </ul>
 
     <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
-        <div class="tab-pane fade show active p-4" id="pills-home" role="tabpanel" aria-labelledby="pills-home-tab" tabindex="0">
+        <div 
+            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'history' else '' }}"
+            id="pills-home"
+            role="tabpanel"
+            aria-labelledby="pills-home-tab"
+            tabindex="0"
+        >
             {% include "pro_user/get/details/history.html" %}
         </div>
-        <div class="tab-pane fade" id="pills-offerers" role="tabpanel" aria-labelledby="pills-offerers-tab" tabindex="0">
+        <div
+            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'user_offerers' else '' }}"
+            id="pills-offerers"
+            role="tabpanel"
+            aria-labelledby="pills-offerers-tab"
+            tabindex="0">
+            {% include "pro_user/get/details/user_offerer.html" %}
         </div>
     </div>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details/user_offerer.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details/user_offerer.html
@@ -1,0 +1,37 @@
+{% from "components/badges.html" import build_user_offerer_badges %}
+
+<table class="table table-hover my-4">
+    <thead>
+        <tr>
+            <th scope="col"></th>
+            <th scope="col">ID de la structure</th>
+            <th scope="col">Statut du rattachement</th>
+            <th scope="col">Nom</th>
+            <th scope="col">SIREN</th>
+        </tr>
+    </thead>
+    <tbody class="table-group-divider">
+        {% for user_offerer in user_offerers %}
+            <tr>
+                <th scope="row"></th>
+                <td>{{ user_offerer.offererId}}</td>
+                <td>{{ build_user_offerer_badges(user_offerer) }}</td>
+                <td class="text-break">
+                    <a href="{{ url_for("backoffice_v3_web.offerer.get", offerer_id=user_offerer.offererId) }}">
+                        {{ user_offerer.offerer.name }}
+                    </a>
+                </td>
+                <td>
+                    {% if user_offerer.offerer.siren %}
+                        <a href="https://www.societe.com/cgi-bin/fiche?rncs={{ user_offerer.offerer.siren }}"
+                           target="_blank"
+                           title="Visualiser sur societe.com"
+                        >
+                            {{ user_offerer.offerer.siren }}
+                        </a>
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18478

## But de la pull request

Ajout de l'onglet rattachement aux structures dans la page d'un compte pro.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)


[PC-18478]: https://passculture.atlassian.net/browse/PC-18478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ