### PR TITLE
(BSR)[API] test: Fix date-related errors in Zendesk and Sendinblue tests

### DIFF
--- a/api/tests/core/external/external_users_test.py
+++ b/api/tests/core/external/external_users_test.py
@@ -94,12 +94,18 @@ def test_get_user_attributes_beneficiary_with_v1_deposit():
         subcategoryId=subcategories.SEANCE_CINE.id,
         extraData={"genres": ["THRILLER"]},
     )
-    b1 = IndividualBookingFactory(individualBooking__user=user, amount=10, stock__offer=offer)
+    b1 = IndividualBookingFactory(
+        individualBooking__user=user, amount=10, dateCreated=datetime(2022, 12, 6, 10), stock__offer=offer
+    )
     b2 = IndividualBookingFactory(
-        individualBooking__user=user, amount=10, dateUsed=datetime(2022, 12, 7), stock__offer=offer
+        individualBooking__user=user,
+        amount=10,
+        dateCreated=datetime(2022, 12, 6, 11),
+        dateUsed=datetime(2022, 12, 7),
+        stock__offer=offer,
     )
     IndividualBookingFactory(
-        individualBooking__user=user, amount=100, status=BookingStatus.CANCELLED
+        individualBooking__user=user, amount=100, dateCreated=datetime(2022, 12, 6, 12), status=BookingStatus.CANCELLED
     )  # should be ignored
 
     last_date_created = max(booking.dateCreated for booking in [b1, b2])
@@ -226,9 +232,15 @@ def test_get_user_attributes_beneficiary_because_of_credit():
     offer1 = OfferFactory(product__id=list(TRACKED_PRODUCT_IDS.keys())[0])
     offer2 = OfferFactory(venue=offer1.venue)
     offer3 = OfferFactory()
-    IndividualBookingFactory(individualBooking__user=user, amount=100, stock__offer=offer1)
-    IndividualBookingFactory(individualBooking__user=user, amount=120, stock__offer=offer2)
-    last_booking = IndividualBookingFactory(individualBooking__user=user, amount=80, stock__offer=offer3)
+    IndividualBookingFactory(
+        individualBooking__user=user, amount=100, dateCreated=datetime(2022, 12, 6, 11), stock__offer=offer1
+    )
+    IndividualBookingFactory(
+        individualBooking__user=user, amount=120, dateCreated=datetime(2022, 12, 6, 12), stock__offer=offer2
+    )
+    last_booking = IndividualBookingFactory(
+        individualBooking__user=user, amount=80, dateCreated=datetime(2022, 12, 6, 13), stock__offer=offer3
+    )
 
     with assert_no_duplicated_queries():
         attributes = get_user_attributes(user)

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -19,8 +19,10 @@ class ZendeskWebhookTest:
         "phone_number,postal_code", [("0612345678", 55270), ("06 12 34 56 78", None), ("+33612345678", 97600)]
     )
     def test_webhook_update_user_by_email(self, client, phone_number, postal_code):
+        birth_year = datetime.utcnow().year - user_constants.ELIGIBILITY_AGE_18
+
         user = users_factories.BeneficiaryGrant18Factory(
-            dateOfBirth=datetime(2004, 1, 2),
+            dateOfBirth=datetime(birth_year, 1, 2),
             phoneNumber=phone_number,
             postalCode=postal_code,
             phoneValidationStatus=PhoneValidationStatusType.VALIDATED,
@@ -53,7 +55,7 @@ class ZendeskWebhookTest:
                     "first_name": user.firstName,
                     "last_name": user.lastName,
                     "postal_code": user.postalCode,
-                    "date_of_birth": "2004-01-02",
+                    "date_of_birth": f"{birth_year}-01-02",
                     "suspended": "Non",
                     "email_validated": True,
                     "phone_validated": True,
@@ -113,9 +115,11 @@ class ZendeskWebhookTest:
         }
 
     def test_webhook_update_user_without_subscription_process(self, client):
+        birth_year = datetime.utcnow().year - user_constants.ELIGIBILITY_AGE_18
+
         # first name, last name and phone number unknown
         user = users_factories.UserFactory(
-            dateOfBirth=datetime(2004, 1, 2),
+            dateOfBirth=datetime(birth_year, 1, 2),
             firstName=None,
             lastName=None,
             phoneNumber=None,
@@ -149,7 +153,7 @@ class ZendeskWebhookTest:
                     "first_name": user.firstName,
                     "last_name": user.lastName,
                     "postal_code": user.postalCode,
-                    "date_of_birth": "2004-01-02",
+                    "date_of_birth": f"{birth_year}-01-02",
                     "suspended": "Non",
                     "email_validated": True,
                     "phone_validated": False,

--- a/api/tests/scripts/external_users/batch_update_users_attributes_test.py
+++ b/api/tests/scripts/external_users/batch_update_users_attributes_test.py
@@ -1,3 +1,4 @@
+import datetime
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -111,7 +112,7 @@ def test_format_batch_user():
 @freeze_time("2022-12-06 10:00:00")  # Keep time frozen in 2022 as long as we send *_2022 attributes
 def test_format_sendinblue_user():
     user = BeneficiaryGrant18Factory(departementCode="75")
-    booking = IndividualBookingFactory(individualBooking__user=user)
+    booking = IndividualBookingFactory(individualBooking__user=user, dateCreated=datetime.datetime(2022, 12, 6, 10))
 
     res = format_sendinblue_users([user])
 


### PR DESCRIPTION
## But de la pull request

Corriger les tests Zendesk et Sendinblue qui échouent à cause du passage en 2023.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
