### PR TITLE
(BSR)[API] feat: new finance command: move siret

### DIFF
--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -7,7 +7,9 @@ import sqlalchemy.orm as sqla_orm
 
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.utils as finance_utils
+import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
+from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 import pcapi.scheduled_tasks.decorators as cron_decorators
 from pcapi.utils import human_ids
@@ -124,3 +126,120 @@ def add_custom_offer_reimbursement_rule(
         end_date=valid_until_dt,
     )
     print(f"Created new rule: {rule.id}")
+
+
+class CheckError(Exception):
+    pass
+
+
+def check_can_move_siret(source_id: int, target_id: int, siret: str, override_revenue_check: bool) -> None:
+    source = offerers_models.Venue.query.get(source_id)
+    target = offerers_models.Venue.query.get(target_id)
+    if source.managingOffererId != target.managingOffererId:
+        raise CheckError(f"Source {source_id} and target {target_id} do not have the same offerer")
+    offerer = target.managingOfferer
+    if offerer.siren != siret[:9]:
+        raise CheckError(f"SIRET {siret} does not match offerer SIREN {offerer.siren}")
+    if source.siret != siret:
+        raise CheckError(f"Source venue {source.id} has SIRET {source.siret}, not requested SIRET {siret}")
+    if target.siret is not None:
+        raise CheckError(f"Target venue {target.id} already has a siret: {target.siret}")
+
+    if not override_revenue_check:
+        # Calculate yearly revenue of target venue
+        query = """
+          select sum(booking.amount * booking.quantity) as "chiffre d'affaires"
+          from booking
+          where
+            "venueId" = :target_id
+            and "dateUsed" is not null
+            -- On ajoute 1 heure pour la conversion UTC -> CET afin de récupérer
+            -- le chiffre d'affaires de l'année en cours.
+            and DATE_PART('year', "dateUsed" + interval '1 hour') = date_part('year', now() + interval '1 hour');
+        """
+        rows = db.session.execute(query, {"target_id": target_id}).fetchone()
+        revenue = rows[0]
+        if revenue and revenue > 10_000:
+            raise CheckError("Target venue has an unexpectedly high yearly revenue.")
+
+
+@blueprint.cli.command("move_siret")
+@click.option("--src-venue-id", type=int, required=True)
+@click.option("--dst-venue-id", type=int, required=True)
+@click.option("--siret", required=True)
+@click.option("--comment", required=True)
+@click.option("--apply-changes", is_flag=True, default=False, required=False)
+@click.option("--override-revenue-check", is_flag=True, default=False, required=False)
+def move_siret(
+    src_venue_id: int,
+    dst_venue_id: int,
+    siret: str,
+    comment: str,
+    apply_changes: bool = False,
+    override_revenue_check: bool = False,
+) -> None:
+    try:
+        check_can_move_siret(
+            source_id=src_venue_id,
+            target_id=dst_venue_id,
+            siret=siret,
+            override_revenue_check=override_revenue_check,
+        )
+    except CheckError as exc:
+        print(str(exc))
+        return
+
+    db.session.rollback()  # discard any previous transaction to start a fresh new one.
+    queries = [
+        """
+        update pricing
+        set "pricingPointId" = :target_id
+        where "pricingPointId" = :source_id
+        """,
+        """
+        update venue_pricing_point_link
+        set "pricingPointId" = :target_id
+        where "pricingPointId" = :source_id
+        """,
+        """
+        update venue
+        set siret = NULL, comment = :comment
+        where id = :source_id and siret = :siret
+        """,
+        """
+        update venue
+        set siret = :siret, comment = NULL
+        where id = :target_id and siret IS NULL
+        """,
+        """
+        insert into venue_pricing_point_link ("venueId", "pricingPointId", timespan)
+        values (
+          :target_id,
+          :target_id,
+          tsrange(now()::timestamp, NULL, '[)')
+        )
+        -- If the pricing point of the target venue was the source venue before our changes,
+        -- the update above will have changed the existing row. Thus the source venue
+        -- now points to itself, which means that we don't need to execute this insert
+        -- (and it would raise an integrity error). Hence the "do nothing" below.
+        on conflict do nothing
+        """,
+    ]
+
+    db.session.begin()
+    for query in queries:
+        db.session.execute(
+            query,
+            {
+                "source_id": src_venue_id,
+                "target_id": dst_venue_id,
+                "siret": siret,
+                "comment": comment,
+            },
+        )
+    if apply_changes:
+        db.session.commit()
+        print("Siret has been moved.")
+    else:
+        db.session.rollback()
+        print("DRY RUN: NO CHANGES HAVE BEEN MADE")

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -1,26 +1,30 @@
 import decimal
 
 import pcapi.core.finance.models as finance_models
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.factories as offers_factories
 from pcapi.utils import human_ids
 
 from tests.conftest import clean_database
 
 
-class AddCustomOfferReimbursementRuleTest:
-    def _run_command(self, app, *args):
-        runner = app.test_cli_runner()
-        args = ("add_custom_offer_reimbursement_rule",) + args
-        return runner.invoke(args=args)
+def run_command(app, command_name, *args):
+    runner = app.test_cli_runner()
+    args = (command_name, *args)
+    return runner.invoke(args=args)
 
+
+class AddCustomOfferReimbursementRuleTest:
     @clean_database
     def test_basics(self, app):
         stock = offers_factories.StockFactory(price=24.68)
         offer = stock.offer
         offer_id = offer.id
         # fmt: off
-        result = self._run_command(
+        result = run_command(
             app,
+            "add_custom_offer_reimbursement_rule",
             "--offer-humanized-id", human_ids.humanize(offer.id),
             "--offer-original-amount", "24,68",
             "--offerer-id", str(offer.venue.managingOffererId),
@@ -40,8 +44,9 @@ class AddCustomOfferReimbursementRuleTest:
         stock = offers_factories.StockFactory(price=24.68)
         offer = stock.offer
         # fmt: off
-        result = self._run_command(
+        result = run_command(
             app,
+            "add_custom_offer_reimbursement_rule",
             "--offer-humanized-id", human_ids.humanize(offer.id),
             "--offer-original-amount", "0,34",  # wrong amount
             "--offerer-id", str(offer.venue.managingOffererId + 7),
@@ -62,8 +67,9 @@ class AddCustomOfferReimbursementRuleTest:
         offer_id = offer.id
 
         # fmt: off
-        result = self._run_command(
+        result = run_command(
             app,
+            "add_custom_offer_reimbursement_rule",
             "--offer-humanized-id", human_ids.humanize(offer.id),
             "--offer-original-amount", "0,34",  # wrong amount
             "--offerer-id", str(offer.venue.managingOffererId + 7),
@@ -77,3 +83,34 @@ class AddCustomOfferReimbursementRuleTest:
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offer.id == offer_id
         assert rule.amount == decimal.Decimal("12.34")
+
+
+@clean_database
+def test_move_siret(app):
+    offerer = offerers_factories.OffererFactory()
+    siret = offerer.siren + "00001"
+
+    src_venue_id = offerers_factories.VenueFactory(siret=siret, managingOfferer=offerer).id
+    dst_venue_id = offerers_factories.VenueFactory(siret=None, comment="no siret", managingOfferer=offerer).id
+
+    result = run_command(
+        app,
+        "move_siret",
+        "--src-venue-id",
+        src_venue_id,
+        "--dst-venue-id",
+        dst_venue_id,
+        "--siret",
+        siret,
+        "--comment",
+        "test move siret",
+        "--apply-changes",
+    )
+
+    src_venue = offerers_models.Venue.query.get(src_venue_id)
+    dst_venue = offerers_models.Venue.query.get(dst_venue_id)
+
+    assert "Siret has been moved." in result.stdout
+
+    assert not src_venue.siret
+    assert dst_venue.siret == siret


### PR DESCRIPTION
## But de la pull request

> FIXME: move this to a proper Flask command.

([source](https://github.com/pass-culture/pass-culture-main/blob/dbaty/move_siret/api/src/pcapi/scripts/move-siret.py))

C'est chose faite. Le code pour déplacer un siret a désormais sa propre commande Flask.