### PR TITLE
(BSR)[API] feat: add dms form activity value

### DIFF
--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -20,6 +20,7 @@ DMS_ACTIVITY_ENUM_MAPPING = {
     "Etudiant": users_models.ActivityEnum.STUDENT.value,
     "Employé": users_models.ActivityEnum.EMPLOYEE.value,
     "En recherche d'emploi ou chômeur": users_models.ActivityEnum.UNEMPLOYED.value,
+    "Chômeur, En recherche d'emploi": users_models.ActivityEnum.UNEMPLOYED.value,
     "Inactif (ni en emploi ni au chômage), En incapacité de travailler": users_models.ActivityEnum.INACTIVE.value,
     "Apprenti": users_models.ActivityEnum.APPRENTICE.value,
     "Alternant": users_models.ActivityEnum.APPRENTICE_STUDENT.value,


### PR DESCRIPTION
Some old dms applications still have this old form value. Cf [cet événement sur sentry](https://sentry.passculture.team/organizations/sentry/issues/382141/events/4401e9f97e8b4598b9ea4df88e9eaca1/?environment=production&project=5&query=is%3Aunresolved&statsPeriod=14d)

Il y a toujours l'erreur avec la valeur "Apprenti, Alternant, Volontaire en service civique rémunéré" mais comme on ne peut pas savoir si c'est Apprenti, Alternant ou Volontaire, je laisse comme ça.