### PR TITLE
(BSR)[API] chore: Pin SQLAlchemy until we have fixed deprecation warnings

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -63,7 +63,10 @@ semver==2.13.0
 sentry-sdk==1.8.0
 sib-api-v3-sdk
 spectree==0.7.2
-SQLAlchemy[mypy]==1.4.*
+# FIXME (dbaty, 2023-01-04): do not use 1.4.46 that has a new
+# deprecation warning for which we're not ready
+# (https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-e67bfa1efbe52ae40aa842124bc40c51).
+SQLAlchemy[mypy]==1.4.45
 slack-sdk==3.13.0
 types-freezegun
 types-python-dateutil


### PR DESCRIPTION
The new SQLAlchemy 1.4.46 release introduces a new behaviour:

    A new deprecation “uber warning” is now emitted at runtime the
    first time any SQLAlchemy 2.0 deprecation warning would normally
    be emitted, but the SQLALCHEMY_WARN_20 environment variable is not
    set. The warning emits only once at most, before setting a boolean
    to prevent it from emitting a second time.

See https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-1.4.46
for further details.

We're not ready for this warning, let's pin SQLAlchemy until then.