### PR TITLE
(BSR) feat: improve CI failure notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   tests-api:
     parameters:
@@ -423,7 +423,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   tests-backoffice-v3:
     parameters:
@@ -484,7 +484,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   test-rebuild-staging:
     working_directory: ~/pass-culture
@@ -563,7 +563,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   quality-adage-front:
     docker:
@@ -604,7 +604,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   tests-adage-front:
     docker:
@@ -643,7 +643,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   type-checking-pro:
     docker:
@@ -682,7 +682,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   quality-pro:
     docker:
@@ -725,7 +725,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   tests-pro-unit-tests:
     docker:
@@ -790,7 +790,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
   tests-pro-e2e-tests:
     machine:
       image: ubuntu-2004:202101-01
@@ -857,7 +857,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   tests-backoffice-front-unit-tests:
     docker:
@@ -912,7 +912,7 @@ jobs:
             equal: ["master", << pipeline.git.branch >>]
           steps:
             - notify-slack:
-                channel: shérif
+                channel: dev
 
   build-and-push-image:
     executor: gcp-sdk-alpine

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -82,9 +82,12 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
-          SLACK_CHANNEL: shérif
+          SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_MESSAGE: "Les tests quality-api échouent sur master. Détails sur <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Github>"
+          MSG_MINIMAL: true
 
   tests-database:
     name: "Tests database schema"
@@ -178,9 +181,12 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
-          SLACK_CHANNEL: shérif
+          SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_MESSAGE: "Les tests database échouent sur master. Détails sur <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Github>"
+          MSG_MINIMAL: true
 
   pytest:
     name: "Pytest"
@@ -270,6 +276,9 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
-          SLACK_CHANNEL: shérif
+          SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_MESSAGE: "Les tests pytest échouent sur master. Détails sur <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Github>"
+          MSG_MINIMAL: true

--- a/.github/workflows/tests-backoffice-v3.yml
+++ b/.github/workflows/tests-backoffice-v3.yml
@@ -96,7 +96,10 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
-          SLACK_CHANNEL: shérif
+          SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_MESSAGE: "Les tests de backoffice-v3 échouent sur master. Détails sur <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Github>"
+          MSG_MINIMAL: true
 

--- a/.github/workflows/tests-backoffice.yml
+++ b/.github/workflows/tests-backoffice.yml
@@ -63,6 +63,9 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
-          SLACK_CHANNEL: shérif
+          SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_MESSAGE: "Les tests de backoffice-front échouent sur master. Détails sur <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Github>"
+          MSG_MINIMAL: true

--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -125,9 +125,9 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
-          SLACK_CHANNEL: shérif
+          SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
-#
-#  tests-pro-e2e-tests:
-#    runs-on: ubuntu-latest
+          SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+          SLACK_MESSAGE: "Les tests unitaires de pro échouent sur master. Détails sur <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Github>"
+          MSG_MINIMAL: true


### PR DESCRIPTION
J'ai repris ce que j'avais configuré pour [l'action build-and-tag](https://github.com/pass-culture/pass-culture-main/blob/master/.github/workflows/reusable--build-and-tag.yml#L142)