### PR TITLE
(PC-19147)[API] feat: add isPermanent switch on venue edition page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -19,6 +19,7 @@ class EditVenueForm(EditVirtualVenueForm):
     city = fields.PCStringField("Ville")
     postalCode = fields.PCPostalCodeField("Code postal")  # match Venue.postalCode case
     address = fields.PCStringField("Adresse")
+    isPermanent = fields.PCSwitchBooleanField("Lieu permanent")
 
     def __init__(self, venue: offerers_models.Venue, *args: typing.Any, **kwargs: typing.Any) -> None:
         """
@@ -33,6 +34,7 @@ class EditVenueForm(EditVirtualVenueForm):
         # self._fields is a collections.OrderedDict
         self._fields.move_to_end("email")
         self._fields.move_to_end("phone_number")
+        self._fields.move_to_end("isPermanent")
 
     def validate_siret(self, siret: fields.PCStringField) -> fields.PCStringField:
         if not siret.data or len(siret.data) != 14:

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -106,6 +106,7 @@ def render_venue_details(
                 address=venue.address,
                 email=venue.contact.email if venue.contact else None,
                 phone_number=venue.contact.phone_number if venue.contact else None,
+                isPermanent=venue.isPermanent,
             )
 
     return render_template(
@@ -222,7 +223,7 @@ def update(venue_id: int) -> utils.BackofficeResponse:
                     data-bs-target="#venue-edit-details">
                 Les données envoyées comportent des erreurs. Afficher
             </button>
-        """
+            """
         ).format()
         flash(msg, "warning")
         return render_venue_details(venue, form)

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -197,7 +197,6 @@ class UpdateVenueTest:
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_update_venue(self, authenticated_client, offerer):
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-
         url = url_for("backoffice_v3_web.manage_venue.update", venue_id=venue.id)
         data = {
             "siret": venue.managingOfferer.siren + "98765",
@@ -206,6 +205,7 @@ class UpdateVenueTest:
             "address": "Skolgatan 31A",
             "email": venue.contact.email + ".update",
             "phone_number": "+33102030456",
+            "isPermanent": True,
         }
 
         response = send_request(authenticated_client, venue.id, url, data)
@@ -221,6 +221,7 @@ class UpdateVenueTest:
         assert venue.address == data["address"]
         assert venue.contact.email == data["email"]
         assert venue.contact.phone_number == data["phone_number"]
+        assert venue.isPermanent == data["isPermanent"]
 
     @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
     def test_update_virtual_venue(self, authenticated_client, offerer):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19147

## But de la pull request

Ajout d'un bouton pour passer un lieu (non-virtuel) en un lieu permanent (et vice-versa).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)


[PC-19147]: https://passculture.atlassian.net/browse/PC-19147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ