### PR TITLE
(BSR)[API] fix: bov3: venue details: rm unused tabs

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
@@ -43,20 +43,6 @@
                 LIEUX ASSOCIÉS
             </button>
         </li>
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3"
-                id="pills-bookings-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-bookings"
-                type="button"
-                role="tab"
-                aria-controls="pills-bookings"
-                aria-selected="false"
-            >
-                RÉSERVATIONS
-            </button>
-        </li>
     </ul>
 
     <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
@@ -88,9 +74,6 @@
             tabindex="0"
         >
         {% include "offerer/get/details/managed_venues.html" %}
-        </div>
-
-        <div class="tab-pane fade" id="pills-bookings" role="tabpanel" aria-labelledby="pills-bookings-tab" tabindex="0">
         </div>
     </div>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details.html
@@ -4,42 +4,22 @@
         <li class="nav-item" role="presentation">
             <button
                 class="nav-link active fw-bolder py-3"
-                id="pills-home-tab"
+                id="pills-history-tab"
                 data-bs-toggle="pill"
-                data-bs-target="#pills-home"
+                data-bs-target="#pills-history"
                 type="button"
                 role="tab"
-                aria-controls="pills-home"
+                aria-controls="pills-history"
                 aria-selected="true"
             >
                 HISTORIQUE DU COMPTE
             </button>
         </li>
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3"
-                id="pills-pro-users-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-pro-users"
-                type="button"
-                role="tab"
-                aria-controls="pills-pro-users"
-                aria-selected="false"
-            >
-                COMPTE(S) PRO RATTACHÉ(S)
-            </button>
-        </li>
     </ul>
 
     <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
-        <div class="tab-pane fade show active p-4" id="pills-home" role="tabpanel" aria-labelledby="pills-home-tab" tabindex="0">
+        <div class="tab-pane fade show active p-4" id="pills-history" role="tabpanel" aria-labelledby="pills-history-tab" tabindex="0">
             {% include "venue/get/details/history.html" %}
-        </div>
-        <div class="tab-pane fade" id="pills-pro-users" role="tabpanel" aria-labelledby="pills-pro-users-tab" tabindex="0">
-        </div>
-        <div class="tab-pane fade" id="pills-details" role="tabpanel" aria-labelledby="pills-details-tab" tabindex="0">
-        </div>
-        <div class="tab-pane fade" id="pills-bookings" role="tabpanel" aria-labelledby="pills-bookings-tab" tabindex="0">
         </div>
     </div>
 


### PR DESCRIPTION
## But de la pull request

Supprimer l'onglet comptes pro rattachés de la page de détails d'un lieu : il n'a aucune raison d'être là.

### Au passage

L'id de l'onglet a été renommé. `pills-history` me semblait plus logique que `pills-home`.