### PR TITLE
(PC-19556)[BO] fix: offerer link in venue details page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -129,8 +129,8 @@
                             <span class="fw-bold">Structure :</span>
                             <a
                                 href="{{ url_for(
-                                    "backoffice_v3_web.venue.get",
-                                    venue_id=venue.managingOffererId
+                                    "backoffice_v3_web.offerer.get",
+                                    offerer_id=venue.managingOffererId
                                 )}}"
                                 class="fw-bold text-decoration-none"
                             >


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19556

## But de la pull request

Corriger le lien vers la page de la structure, depuis la page du lieu, dans le backoffice v3.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)


[PC-19556]: https://passculture.atlassian.net/browse/PC-19556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ