### PR TITLE
(PC-18985)[PRO] feat: Add banner with link in edition mode

### DIFF
--- a/pro/src/components/FormLayout/FormLayoutSection.tsx
+++ b/pro/src/components/FormLayout/FormLayoutSection.tsx
@@ -1,7 +1,8 @@
 import cn from 'classnames'
 import React from 'react'
 
-import { Title } from 'ui-kit'
+import { Title, Banner } from 'ui-kit'
+import { Link } from 'ui-kit/Banners/Banner'
 
 import style from './FormLayout.module.scss'
 
@@ -10,6 +11,8 @@ interface IFormLayoutSectionProps {
   description?: string
   children: React.ReactNode | React.ReactNode[]
   className?: string
+  descriptionAsBanner?: boolean
+  links?: Link[]
 }
 
 const Section = ({
@@ -17,16 +20,27 @@ const Section = ({
   description,
   children,
   className,
+  descriptionAsBanner = false,
+  links,
 }: IFormLayoutSectionProps): JSX.Element => (
   <div className={cn(style['form-layout-section'], className)}>
     <div className={style['form-layout-section-header']}>
       <Title as="h2" level={3}>
         {title}
       </Title>
-      {description && (
+      {description && !descriptionAsBanner && (
         <p className={style['form-layout-section-description']}>
           {description}
         </p>
+      )}
+      {description && descriptionAsBanner && (
+        <Banner
+          type="notification-info"
+          className={style['form-layout-section-description']}
+          links={links}
+        >
+          {description}
+        </Banner>
       )}
     </div>
     {children}

--- a/pro/src/components/Notification/Notification.tsx
+++ b/pro/src/components/Notification/Notification.tsx
@@ -69,8 +69,7 @@ const Notification = (): JSX.Element | null => {
             styles['notification'],
             styles[
               //graphic variation
-              /* istanbul ignore next */
-              `is-${type || 'success'}`
+              /* istanbul ignore next */ `is-${type || 'success'}`
             ],
             /* istanbul ignore next: DEBT, TO FIX */ isVisible
               ? styles['show']

--- a/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
@@ -77,7 +77,7 @@ describe('screens:Stocks', () => {
     renderStocksScreen({ storeOverride, contextOverride })
     expect(
       screen.getByText(
-        'Les utilisateurs ont 30 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
+        'Les bénéficiaires ont 30 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
       )
     ).toBeInTheDocument()
   })
@@ -89,7 +89,7 @@ describe('screens:Stocks', () => {
     renderStocksScreen({ storeOverride, contextOverride })
     expect(
       screen.getByText(
-        'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’événement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente.'
+        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
       )
     ).toBeInTheDocument()
   })

--- a/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
@@ -89,7 +89,7 @@ describe('screens:Stocks', () => {
     renderStocksScreen({ storeOverride, contextOverride })
     expect(
       screen.getByText(
-        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
+        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. Vous pouvez annuler un événement en supprimant la ligne de stock associée. Cette action est irréversible.'
       )
     ).toBeInTheDocument()
   })

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -318,12 +318,12 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         <FormLayout.Section
           title="Stock & Prix"
           description={
-            'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. \n Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
+            'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. \n Vous pouvez annuler un événement en supprimant la ligne de stock associée. Cette action est irréversible.'
           }
           links={[
             {
               href: 'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-',
-              linkTitle: 'Comment reporter ou annuler un évènement ?',
+              linkTitle: 'Comment reporter ou annuler un événement ?',
             },
           ]}
           descriptionAsBanner={mode === OFFER_WIZARD_MODE.EDITION}

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -116,12 +116,14 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
     stockIndex: number
   ) => {
     const { isDeletable, stockId } = stockValues
+    /* istanbul ignore next: DEBT to fix */
     if (stockId === undefined || !isDeletable) {
       return
     }
     try {
       await api.deleteStock(stockId)
       const response = await getOfferIndividualAdapter(offer.id)
+      /* istanbul ignore next: DEBT to fix */
       if (response.isOk) {
         setOffer && setOffer(response.payload)
       }
@@ -138,6 +140,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
 
       // Set back possible user change.
       formStocks.splice(stockIndex, 1)
+      /* istanbul ignore next: DEBT to fix */
       formStocks.length
         ? formik.setValues({ stocks: formStocks })
         : formik.resetForm({
@@ -223,6 +226,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
               return false
             }
             const stockTouched = formik.touched.stocks[index]
+            /* istanbul ignore next: DEBT to fix */
             if (stockTouched === undefined) {
               return false
             }
@@ -252,7 +256,9 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
 
       if (hasSavedStock && !formik.dirty) {
         setIsClickingFromActionBar(false)
+        /* istanbul ignore next: DEBT to fix */
         notify.success(getSuccessMessage(mode))
+        /* istanbul ignore next: DEBT to fix */
         if (!saveDraft) {
           navigate(
             getOfferIndividualUrl({
@@ -312,8 +318,15 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         <FormLayout.Section
           title="Stock & Prix"
           description={
-            'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’événement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente.'
+            'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. \n Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
           }
+          links={[
+            {
+              href: 'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-',
+              linkTitle: 'Comment reporter ou annuler un évènement ?',
+            },
+          ]}
+          descriptionAsBanner={mode === OFFER_WIZARD_MODE.EDITION}
         >
           <form onSubmit={formik.handleSubmit}>
             <StockFormList offer={offer} onDeleteStock={onDeleteStock} />

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -157,7 +157,7 @@ describe('screens:StocksEvent', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’événement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente.'
+        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
       )
     ).toBeInTheDocument()
 

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -157,7 +157,7 @@ describe('screens:StocksEvent', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
+        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’événement. Vous pouvez annuler un événement en supprimant la ligne de stock associée. Cette action est irréversible.'
       )
     ).toBeInTheDocument()
 

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -270,13 +270,16 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
   ]
 
   let description
+  let links
   if (!offer.isDigital) {
-    description = `Les utilisateurs ont ${
+    description = `Les bénéficiaires ont ${
       offer.subcategoryId === LIVRE_PAPIER_SUBCATEGORY_ID ? '10' : '30'
     } jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.`
   } else {
-    description =
-      'Les utilisateurs ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les utilisateurs ne peuvent pas annuler leurs réservations d’offres numériques. Toute réservation est définitive et sera immédiatement validée.'
+    description = `Les bénéficiaires ont 30 jours pour annuler leurs réservations d’offres numériques. 
+
+    Dans le cas d’offres avec codes d’activation, les bénéficiaires ne peuvent pas annuler leurs réservations. Toute réservation est définitive et sera immédiatement validée.`
+
     let isDisabled = false
     if (offer.stocks.length > 0 && offer.stocks[0].hasActivationCode) {
       isDisabled = true
@@ -294,8 +297,14 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
 
   if (offer.isDigital) {
     description += `
-
     Pour ajouter des codes d’activation, veuillez passer par le menu ··· et choisir l’option correspondante.`
+
+    links = [
+      {
+        href: 'https://aide.passculture.app/hc/fr/articles/4411991970705--Acteurs-culturels-Comment-cr%C3%A9er-une-offre-num%C3%A9rique-avec-des-codes-d-activation-',
+        linkTitle: 'Comment gérer les codes d’activation ?',
+      },
+    ]
   }
 
   const submitActivationCodes = useCallback(
@@ -329,7 +338,12 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
         <SynchronizedProviderInformation providerName={providerName} />
       )}
       <FormLayout>
-        <FormLayout.Section title="Stock & Prix" description={description}>
+        <FormLayout.Section
+          title="Stock & Prix"
+          description={description}
+          links={links}
+          descriptionAsBanner={mode === OFFER_WIZARD_MODE.EDITION}
+        >
           <form onSubmit={formik.handleSubmit}>
             <StockThingFormRow
               Form={renderStockForm()}

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -166,7 +166,7 @@ describe('screens:StocksThing', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Les utilisateurs ont 30 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
+        'Les bénéficiaires ont 30 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
       )
     ).toBeInTheDocument()
 
@@ -189,9 +189,12 @@ describe('screens:StocksThing', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        /Les utilisateurs ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les utilisateurs ne peuvent pas annuler leurs réservations d’offres numériques. Toute réservation est définitive et sera immédiatement validée. Pour ajouter des codes d’activation, veuillez passer par le menu ··· et choisir l’option correspondante./
+        /Les bénéficiaires ont 30 jours pour annuler leurs réservations d’offres numériques. Dans le cas d’offres avec codes d’activation, les bénéficiaires ne peuvent pas annuler leurs réservations. Toute réservation est définitive et sera immédiatement validée. Pour ajouter des codes d’activation, veuillez passer par le menu ··· et choisir l’option correspondante./
       )
     ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Comment gérer les codes d’activation')
+    ).not.toBeInTheDocument()
   })
   it('should render digital book', async () => {
     props.offer = {
@@ -202,9 +205,12 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen({ props, storeOverride, contextValue })
     expect(
       screen.getByText(
-        'Les utilisateurs ont 10 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
+        'Les bénéficiaires ont 10 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
       )
     ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Comment gérer les codes d’activation')
+    ).not.toBeInTheDocument()
   })
 
   it('should submit stock and stay in creation mode when click on "Sauvegarder le brouillon"', async () => {

--- a/pro/src/ui-kit/Banners/Banner/Banner.tsx
+++ b/pro/src/ui-kit/Banners/Banner/Banner.tsx
@@ -42,8 +42,10 @@ const Banner = ({
         target: link.targetLink || '_blank',
         rel: 'noopener noreferrer',
       }}
-      /* istanbul ignore next: DEBT to fix */
-      Icon={link.hideLinkIcon ? undefined : link.Icon || ExternalSiteIcon}
+      Icon={
+        /* istanbul ignore next: DEBT to fix */
+        link.hideLinkIcon ? undefined : link.Icon || ExternalSiteIcon
+      }
       className={styles['bi-link']}
     >
       {link.linkTitle}

--- a/pro/src/ui-kit/Banners/Banner/Banner.tsx
+++ b/pro/src/ui-kit/Banners/Banner/Banner.tsx
@@ -8,7 +8,7 @@ import { ButtonLink } from 'ui-kit/Button'
 import BannerLayout from '../BannerLayout'
 import { IBannerLayoutProps } from '../BannerLayout/BannerLayout'
 
-type Link = {
+export type Link = {
   Icon?: FunctionComponent<
     SVGProps<SVGSVGElement> & {
       title?: string | undefined
@@ -31,8 +31,10 @@ const Banner = ({
   ...bannerLayoutProps
 }: IBannerProps): JSX.Element => {
   const isNewStyles = true
+  /* istanbul ignore next: DEBT to fix */
   const styles = isNewStyles ? newStyles : oldStyles
   const getLinkNode = (link: Link) => (
+    /* istanbul ignore next: DEBT to fix */
     <ButtonLink
       link={{
         isExternal: link.isExternal === undefined ? true : link.isExternal,
@@ -40,6 +42,7 @@ const Banner = ({
         target: link.targetLink || '_blank',
         rel: 'noopener noreferrer',
       }}
+      /* istanbul ignore next: DEBT to fix */
       Icon={link.hideLinkIcon ? undefined : link.Icon || ExternalSiteIcon}
       className={styles['bi-link']}
     >

--- a/pro/src/ui-kit/Banners/Banner/index.ts
+++ b/pro/src/ui-kit/Banners/Banner/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Banner'
+export type { Link } from './Banner'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18985

## But de la pull request

Sur la page édition:
- Ajouter une bannière d'information pour les stocks événements et physique.
- Ajouter un lien FAQ pour les stocks de type événement et numériques.
- Changer les descriptions.

## Implémentation

Numérique:
![image](https://user-images.githubusercontent.com/106379750/210603591-5dc9d321-5abe-4457-9559-7e9b23ccfabc.png)

physique:
![image](https://user-images.githubusercontent.com/106379750/210603661-84d19670-5b30-4781-b96b-756be846bdac.png)

événement:
![image](https://user-images.githubusercontent.com/106379750/210603866-e309725e-7093-4b95-93fb-a4ae349277cf.png)


[PC-18985]: https://passculture.atlassian.net/browse/PC-18985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ