### PR TITLE
(PC-19200)[PRO] fix: replace help button

### DIFF
--- a/pro/src/components/HelpLink/HelpLink.module.scss
+++ b/pro/src/components/HelpLink/HelpLink.module.scss
@@ -1,11 +1,12 @@
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_size.scss" as size;
 
 .help-link {
   display: inline-block;
   position: fixed;
-  bottom: rem.torem(32px);
+  bottom: rem.torem(calc(size.$action-bar-sticky-height + 8px));
   right: rem.torem(32px);
   text-align: center;
   max-width: rem.torem(42px);


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19200

## But de la pull request

Déplacer le bouton d'aide afin qu'il ne soit pas superposé avec la sticky bar

Avant:
<img width="1490" alt="Capture d’écran 2023-01-05 à 11 06 06" src="https://user-images.githubusercontent.com/119043808/210754573-0f56b729-105e-4a29-846d-4e9acbc582d7.png">
Après:
<img width="1490" alt="Capture d’écran 2023-01-05 à 11 05 46" src="https://user-images.githubusercontent.com/119043808/210754604-8fde4492-906a-409e-a4d1-089950f29624.png">

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
