### PR TITLE
(PC-19558)[BO] fix: new lines in comments

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
@@ -20,7 +20,7 @@
                             <p>{{ action.user.full_name | empty_string_if_null }} - {{ action.userId }}</p>
                         </a>
 
-                        <p>{{ action.comment | empty_string_if_null }}</p>
+                        <p>{{ action.comment | empty_string_if_null | replace("\n", "<br/>"|safe) }}</p>
                     {% elif action.actionType.name == "USER_INFO_MODIFIED" %}
                         <p>Informations modifées :</p>
                         {% for info_name, modified_info in action.extraData.get('modified_info', {}).items() %}
@@ -30,7 +30,7 @@
                     {% elif action.actionType.name == "USER_SUSPENDED" %}
                         <p>{{ action.extraData['reason'] | format_reason_label }}</p>
                     {% else %}
-                        <p>{{ action.comment | empty_string_if_null }}</p>
+                        <p>{{ action.comment | empty_string_if_null | replace("\n", "<br/>"|safe) }}</p>
                     {% endif %}
                 </td>
                 <td>{{ action.authorUser.full_name if action.authorUser else None | empty_string_if_null }}</td>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/edit_status_modal.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/edit_status_modal.html
@@ -10,7 +10,7 @@
             </div>
             <div class="modal-body row">
                 <div class="form-floating my-3 col">
-                    <textarea name="comment" class="form-control" id="{{ div_id }}-textarea" rows="3"></textarea>
+                    <textarea name="comment" class="form-control" id="{{ div_id }}-textarea" rows="3" style="height:100%;"></textarea>
                     <label for={{ div_id }}-textarea"><label for="comment">Raison</label></label>
                 </div>
                 <button type="button" class="btn btn-outline-secondary col-1 h-50" id="{{ div_id }}-newline">⏎</button>
@@ -29,9 +29,8 @@
         function(event) {
             if (event.keyCode === 13) {
                 event.preventDefault();
-                if (event.ctrlKey) {
-                    const textarea = document.getElementById('{{ div_id }}-textarea')
-                    textarea.value = textarea.value.slice(0, textarea.selectionStart) + "\n" + textarea.value.slice(textarea.selectionEnd)
+                if (event.ctrlKey || event.shiftKey) {
+                    document.getElementById("{{ div_id }}-newline").click()
                 } else {
                     document.getElementById("{{ div_id }}-form").submit();
                 }
@@ -43,7 +42,10 @@
         "click",
         function() {
             const textarea = document.getElementById('{{ div_id }}-textarea')
-            textarea.value = textarea.value.slice(0, textarea.selectionStart) + "\n" + textarea.value.slice(textarea.selectionEnd)
+            const start = textarea.selectionStart
+            textarea.value = textarea.value.slice(0, start) + "\n" + textarea.value.slice(textarea.selectionEnd)
+            textarea.setSelectionRange(start + 1, start + 1)
+            textarea.focus()
         }
     )
 </script>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -123,7 +123,7 @@
                             </td>
                             <td>{% include "components/offerer/user_offerer_status_badge.html" %}</td>
                             <td>{{ user_offerer.dateCreated | format_date("%d/%m/%Y") }}</td>
-                            <td>{{ get_last_comment_func(offerer, user_offerer.userId) | empty_string_if_null }}</td>
+                            <td>{{ get_last_comment_func(offerer, user_offerer.userId) | empty_string_if_null | replace("\n", "<br/>"|safe) }}</td>
                             <td>{{ user_offerer.user.phoneNumber | format_phone_number }}</td>
                             <td>
                                 <a href="{{ url_for('backoffice_v3_web.offerer.get', offerer_id=user_offerer.offererId) }}">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -153,7 +153,7 @@
                                 </div>
                             </td>
                             <td>{{ offerer.dateCreated | format_date("%d/%m/%Y") }}</td>
-                            <td>{{ get_last_comment_func(offerer) | empty_string_if_null }}</td>
+                            <td>{{ get_last_comment_func(offerer) | empty_string_if_null | replace("\n", "<br/>"|safe) }}</td>
                             <td>
                                 {% if offerer.siren %}
                                     <a href="https://www.societe.com/cgi-bin/fiche?rncs={{ offerer.siren }}"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19558

## But de la pull request

Corriger des petits bugs pour l'ajout d'une nouvelle ligne dans un commentaire

- newline button did not give focus back to textarea
- cursor was at the end when CR is entered, now at the same position
- shift+Enter submitted the form, now new line
- modal popup textarea did not show 3 rows
- comments were displayed as single lines in tables, now new line on CR

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
