### PR TITLE
(PC-19486)[API] fix: add provider info for stock creation

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -259,7 +259,10 @@ def post_event_offer(
 @blueprint.v1_blueprint.route("/events/<int:event_id>/dates", methods=["POST"])
 @spectree_serialize(api=blueprint.v1_schema, tags=[EVENT_OFFERS_TAG], response_model=serialization.PostDatesResponse)
 @api_key_required
-def post_event_dates(event_id: int, body: serialization.DatesCreation) -> serialization.PostDatesResponse:
+@public_utils.individual_offers_api_provider
+def post_event_dates(
+    individual_offers_provider: providers_models.Provider, event_id: int, body: serialization.DatesCreation
+) -> serialization.PostDatesResponse:
     """
     Add dates to an event offer.
     """
@@ -278,6 +281,7 @@ def post_event_dates(event_id: int, body: serialization.DatesCreation) -> serial
                         quantity=date.quantity if date.quantity != "unlimited" else None,
                         beginning_datetime=date.beginning_datetime,
                         booking_limit_datetime=date.booking_limit_datetime,
+                        creating_provider=individual_offers_provider,
                     )
                 )
     except offers_exceptions.OfferCreationBaseException as error:

--- a/api/tests/routes/public/individual_offers/v1/endpoints_test.py
+++ b/api/tests/routes/public/individual_offers/v1/endpoints_test.py
@@ -14,6 +14,8 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
+from pcapi.core.providers import constants as providers_constants
+from pcapi.core.providers import repository as providers_repository
 from pcapi.models import offer_mixin
 from pcapi.utils import human_ids
 
@@ -893,7 +895,12 @@ class PostDatesTest:
     @pytest.mark.usefixtures("db_session")
     def test_new_dates_are_added(self, client):
         api_key = offerers_factories.ApiKeyFactory()
-        event_offer = offers_factories.EventOfferFactory(venue__managingOfferer=api_key.offerer)
+        individual_offers_provider = providers_repository.get_provider_by_local_class(
+            providers_constants.INDIVIDUAL_OFFERS_API_FAKE_CLASS_NAME
+        )
+        event_offer = offers_factories.EventOfferFactory(
+            venue__managingOfferer=api_key.offerer, lastProvider=individual_offers_provider
+        )
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).post(
             f"/public/offers/v1/events/{event_offer.id}/dates",


### PR DESCRIPTION
otherwise the check_provider_can_create_stock validation could reject it if the offer was created via the individual offer api

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19486