### PR TITLE
(PC-19580)[BO] fix: server error when invalid siren was not captured …

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -39,10 +39,12 @@ class OffererValidationListForm(FlaskForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
-            raise wtforms.validators.ValidationError(
-                "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
-            )
+        if q.data:
+            q.data = q.data.strip()
+            if q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
+                raise wtforms.validators.ValidationError(
+                    "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
+                )
         return q
 
 
@@ -73,8 +75,10 @@ class UserOffererValidationListForm(FlaskForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data and q.data.isnumeric() and len(q.data) != 9:
-            raise wtforms.validators.ValidationError("Le nombre de chiffres ne correspond pas à un SIREN")
+        if q.data:
+            q.data = q.data.strip()
+            if q.data.isnumeric() and len(q.data) != 9:
+                raise wtforms.validators.ValidationError("Le nombre de chiffres ne correspond pas à un SIREN")
         return q
 
 

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -724,11 +724,12 @@ class ListOfferersToValidateTest:
             assert "Date invalide" in response.data.decode("utf-8")
 
         @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-        def test_list_search_by_siren(self, authenticated_client, offerers_to_be_validated):
+        @pytest.mark.parametrize("search", ["123004004", "  123004004 ", "123004004\n"])
+        def test_list_search_by_siren(self, authenticated_client, offerers_to_be_validated, search):
             # when
             with assert_no_duplicated_queries():
                 response = authenticated_client.get(
-                    url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate", q="123004004")
+                    url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate", q=search)
                 )
 
             # then
@@ -781,11 +782,11 @@ class ListOfferersToValidateTest:
             assert html_parser.extract_pagination_info(response.data) == (1, 1, 2)
 
         @override_features(WIP_ENABLE_BACKOFFICE_V3=True)
-        @pytest.mark.parametrize("num_digits", [1, 4, 6, 7, 8, 10])
-        def test_list_search_by_invalid_number_of_digits(self, authenticated_client, num_digits):
+        @pytest.mark.parametrize("search", ["1", "1234", "123456", "1234567", "12345678", "12345678912345", "  1234"])
+        def test_list_search_by_invalid_number_of_digits(self, authenticated_client, search):
             # when
             response = authenticated_client.get(
-                url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate", q="1234567890"[:num_digits])
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_to_validate", q=search)
             )
 
             # then


### PR DESCRIPTION
…by WTForms validator

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19580

## But de la pull request

Le nombre de chiffres invalides dans la recherche de structures à valider n'était pas capturé par le validateur WTForms.
Cette PR évite donc une exception causant une erreur 500 si on a des espaces avant un SIRET dans le champ de recherche.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
