### PR TITLE
(PC-19345)[API] feat: add hiding filters button on validation pages

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -7,44 +7,51 @@
         <div class="d-flex justify-content-between">
             <h2 class="fw-light">Rattachements à valider</h2>
         </div>
-        <form action="{{ dst }}" method="GET" class="mb-4 mt-3">
-            <div class="row">
-                <div class="col-10">
-                    {% for form_field in form %}
-                        {% if form_field.type == "HiddenField" %}
-                            {{ form_field }}
-                        {% endif %}
-                    {% endfor %}
-                    <div class="input-group mb-3">
+        <div class="col-2">
+            <div class="py-2">
+                <button id="toggle-filters-button" type="submit" class="btn btn-primary"></button>
+            </div>
+        </div>
+        <div id="filters" class="d-none">
+            <form action="{{ dst }}" method="GET" class="mb-4 mt-3">
+                <div class="row">
+                    <div class="col-10">
                         {% for form_field in form %}
-                            {% if form_field.type != "HiddenField" and form_field.type != "PCSelectMultipleField" and form_field.type != "PCQuerySelectMultipleField" %}
+                            {% if form_field.type == "HiddenField" %}
                                 {{ form_field }}
                             {% endif %}
                         {% endfor %}
-                    </div>
-                    <div class="input-group mb-1 ">
-                        {% for form_field in form %}
-                            {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
-                                <div class="col-4 p-1"> {{ form_field }}</div>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
+                        <div class="input-group mb-3">
+                            {% for form_field in form %}
+                                {% if form_field.type != "HiddenField" and form_field.type != "PCSelectMultipleField" and form_field.type != "PCQuerySelectMultipleField" %}
+                                    {{ form_field }}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        <div class="input-group mb-1 ">
+                            {% for form_field in form %}
+                                {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
+                                    <div class="col-4 p-1"> {{ form_field }}</div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
 
-                </div>
-                <div class="col-2">
-                    <div class="py-2">
-                        <button type="submit" class="btn btn-primary">Appliquer</button>
+                    </div>
+                    <div class="col-2">
+                        <div class="py-2">
+                            <button type="submit" class="btn btn-primary">Appliquer</button>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="w-100 my-4">
-                {% for form_field in form %}
-                    {% for error in form_field.errors %}
-                        <p class="text-warning lead">{{ error }}</p>
+                <div class="w-100 my-4">
+                    {% for form_field in form %}
+                        {% for error in form_field.errors %}
+                            <p class="text-warning lead">{{ error }}</p>
+                        {% endfor %}
                     {% endfor %}
-                {% endfor %}
-            </div>
-        </form>
+                </div>
+            </form>
+        </div>
         <div>
             {% if rows and rows.total > 0 %}
                 <div class="d-flex justify-content-between">
@@ -164,4 +171,30 @@
         </div>
     </div>
 
+{% endblock %}
+
+{% block scripts %}
+    <script>
+        function toggleSearchFilters(areFiltersHidden){
+            const button = document.getElementById("toggle-filters-button");
+            const filters = document.getElementById("filters");
+            if (areFiltersHidden){
+                button.textContent = "Afficher les filtres";
+                filters.classList.add("d-none");
+            } else {
+                button.textContent = "Masquer les filtres";
+                filters.classList.remove("d-none");
+            }
+        }
+        let areUserOffererFiltersHidden = localStorage.getItem("areUserOffererFiltersHidden") === "true";
+        toggleSearchFilters(areUserOffererFiltersHidden);
+        document.getElementById("toggle-filters-button").addEventListener(
+            "click",
+            function() {
+                areUserOffererFiltersHidden = !areUserOffererFiltersHidden;
+                localStorage.setItem("areUserOffererFiltersHidden", areUserOffererFiltersHidden.toString());
+                toggleSearchFilters(areUserOffererFiltersHidden);
+            }
+        )
+    </script>
 {% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -15,50 +15,56 @@
 {% block page %}
     <div class="pt-3 px-5">
         <h2 class="fw-light">Structures à valider</h2>
-        <div class="row px-1">
-            {{ stats_card(stats["NEW"], "nouvelle structure", "nouvelles structures") }}
-            {{ stats_card(stats["PENDING"], "structure en attente", "structures en attente") }}
-            {{ stats_card(stats["VALIDATED"], "structure validée", "structures validées") }}
-            {{ stats_card(stats["REJECTED"], "structure rejetée", "structures rejetées") }}
+        <div class="col-2">
+            <div class="py-2">
+                <button id="toggle-filters-button" type="submit" class="btn btn-primary"></button>
+            </div>
         </div>
-        <form action="{{ dst }}" method="GET" class="mb-4 mt-3">
-            <div class="row">
-                <div class="col-10">
-
-                    <div class="input-group mb-3">
+        <div id="filters" class="d-none">
+            <div class="row px-1">
+                {{ stats_card(stats["NEW"], "nouvelle structure", "nouvelles structures") }}
+                {{ stats_card(stats["PENDING"], "structure en attente", "structures en attente") }}
+                {{ stats_card(stats["VALIDATED"], "structure validée", "structures validées") }}
+                {{ stats_card(stats["REJECTED"], "structure rejetée", "structures rejetées") }}
+            </div>
+            <form action="{{ dst }}" method="GET" class="mb-4 mt-3">
+                <div class="row">
+                    <div class="col-10">
+                        <div class="input-group mb-3">
+                            {% for form_field in form %}
+                                {% if form_field.type != "HiddenField" and form_field.type != "PCSelectMultipleField" and form_field.type != "PCQuerySelectMultipleField" %}
+                                    {{ form_field }}
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        <div class="input-group mb-1 ">
+                            {% for form_field in form %}
+                                {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
+                                    <div class="col-6 p-1"> {{ form_field }}</div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
                         {% for form_field in form %}
-                            {% if form_field.type != "HiddenField" and form_field.type != "PCSelectMultipleField" and form_field.type != "PCQuerySelectMultipleField" %}
+                            {% if form_field.type == "HiddenField" %}
                                 {{ form_field }}
                             {% endif %}
                         {% endfor %}
                     </div>
-                    <div class="input-group mb-1 ">
-                        {% for form_field in form %}
-                            {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
-                                <div class="col-6 p-1"> {{ form_field }}</div>
-                            {% endif %}
-                        {% endfor %}
+                    <div class="col-2">
+                        <div class="py-2">
+                            <button type="submit" class="btn btn-primary">Appliquer</button>
+                        </div>
                     </div>
+                </div>
+                <div class="w-100 my-4">
                     {% for form_field in form %}
-                        {% if form_field.type == "HiddenField" %}
-                            {{ form_field }}
-                        {% endif %}
+                        {% for error in form_field.errors %}
+                            <p class="text-warning lead">{{ error }}</p>
+                        {% endfor %}
                     {% endfor %}
                 </div>
-                <div class="col-2">
-                    <div class="py-2">
-                        <button type="submit" class="btn btn-primary">Appliquer</button>
-                    </div>
-                </div>
-            </div>
-            <div class="w-100 my-4">
-                {% for form_field in form %}
-                    {% for error in form_field.errors %}
-                        <p class="text-warning lead">{{ error }}</p>
-                    {% endfor %}
-                {% endfor %}
-            </div>
-        </form>
+            </form>
+        </div>
         <div>
             {% if rows and rows.total > 0 %}
                 <div class="d-flex justify-content-between">
@@ -197,4 +203,30 @@
         </div>
     </div>
 
+{% endblock %}
+
+{% block scripts %}
+    <script>
+        function toggleSearchFilters(areFiltersHidden){
+            const button = document.getElementById("toggle-filters-button");
+            const filters = document.getElementById("filters");
+            if (areFiltersHidden){
+                button.textContent = "Afficher les filtres";
+                filters.classList.add("d-none");
+            } else {
+                button.textContent = "Masquer les filtres";
+                filters.classList.remove("d-none");
+            }
+        }
+        let areOffererFiltersHidden = localStorage.getItem("areOffererFiltersHidden") === "true";
+        toggleSearchFilters(areOffererFiltersHidden);
+        document.getElementById("toggle-filters-button").addEventListener(
+            "click",
+            function() {
+                areOffererFiltersHidden = !areOffererFiltersHidden;
+                localStorage.setItem("areOffererFiltersHidden", areOffererFiltersHidden.toString());
+                toggleSearchFilters(areOffererFiltersHidden);
+            }
+        )
+    </script>
 {% endblock %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19345

## But de la pull request

Ajout d'un bouton pour cacher les filtres sur les pages de validation de structure et de validation des rattachements de structure.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
