### PR TITLE
(PC-19436)[PRO] fix: stocks forms inputs width and price input placeholder

### DIFF
--- a/adage-front/src/styles/_colors.scss
+++ b/adage-front/src/styles/_colors.scss
@@ -24,5 +24,3 @@ $input-bg-color: $white;
 
 $input-text-color: #161617;
 $input-text-color-disabled: #67686b;
-
-$placeholder-text-color: #67686b;

--- a/pro/src/components/StockEventForm/StockEventForm.module.scss
+++ b/pro/src/components/StockEventForm/StockEventForm.module.scss
@@ -18,5 +18,5 @@
 .input-quantity,
 .input-price {
   flex: 0 1 rem.torem(112px);
-  min-width: rem.torem(90px);
+  min-width: rem.torem(89px);
 }

--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -101,11 +101,8 @@ const StockEventForm = ({
         className={cn(styles['input-price'], styles['field-layout-align-self'])}
         classNameLabel={formRowStyles['field-layout-label']}
         classNameFooter={styles['field-layout-footer']}
-        placeholder="Ex: 20€"
         disabled={readOnlyFields.includes('price')}
-        rightIcon={() =>
-          stockFormValues.price.toString().length > 0 ? <IcoEuro /> : <></>
-        }
+        rightIcon={() => <IcoEuro />}
         type="number"
         hideHiddenFooter={true}
       />

--- a/pro/src/components/StockEventFormRow/StockEventFormInfo/StockEventFormInfo.module.scss
+++ b/pro/src/components/StockEventFormRow/StockEventFormInfo/StockEventFormInfo.module.scss
@@ -1,12 +1,12 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .field-info-remaining-stocks {
-  width: rem.torem(60px);
+  width: rem.torem(52px);
   margin-right: rem.torem(12px);
 }
 
 .field-info-bookings {
-  width: rem.torem(85px);
+  width: rem.torem(80px);
 }
 
 .stock-form-info {

--- a/pro/src/components/StockThingForm/StockThingForm.tsx
+++ b/pro/src/components/StockThingForm/StockThingForm.tsx
@@ -52,18 +52,13 @@ const StockThingForm = ({
         smallLabel
         name="price"
         label="Prix"
-        placeholder="Ex: 20€"
         className={cn({
           [styles['input-price']]: !showExpirationDate,
         })}
         classNameFooter={styles['field-layout-footer']}
         disabled={readOnlyFields.includes('price')}
         type="number"
-        rightIcon={
-          values.price.toString().length > 0
-            ? () => <IcoEuro tabIndex={-1} />
-            : () => <></>
-        }
+        rightIcon={() => <IcoEuro tabIndex={-1} />}
       />
       <DatePicker
         smallLabel

--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import FormLayout from 'components/FormLayout'
 import { Mode, OfferEducationalStockFormValues } from 'core/OfferEducational'
+import { IcoEuro } from 'icons'
 import { DatePicker, TextInput, TimePicker } from 'ui-kit'
 
 import {
@@ -47,10 +48,10 @@ const FormStock = ({ mode }: IFormStockProps): JSX.Element => {
         disabled={mode === Mode.READ_ONLY}
         label={TOTAL_PRICE_LABEL}
         name="totalPrice"
-        placeholder="Ex : 200€"
         smallLabel
         step={0.01} // allow user to enter a price with cents
         type="number"
+        rightIcon={() => <IcoEuro />}
       />
       <DatePicker
         disabled={mode === Mode.READ_ONLY}

--- a/pro/src/styles/mixins/_forms.scss
+++ b/pro/src/styles/mixins/_forms.scss
@@ -15,14 +15,14 @@
   border: solid size.$input-border-width forms.$input-border-color;
   border-radius: rem.torem(forms.$input-border-radius);
   background-color: forms.$input-bg-color;
-  padding: 0 rem.torem(17px);
+  padding: 0 rem.torem(16px);
   color: colors.$input-text-color;
   box-shadow: 0 0 0 0 rgb(0 0 0 / 0%);
   transition: background 150ms ease, box-shadow 150ms ease;
 
   &:focus {
     border: solid forms.$input-border-width-focus forms.$input-border-color-focus;
-    padding: 0 rem.torem(16px);
+    padding: 0 rem.torem(15px);
   }
 
   &:hover:not(:focus) {
@@ -45,6 +45,7 @@
     @include fonts.placeholder;
 
     color: forms.$placeholder-text-color;
+    opacity: 1;
   }
 
   &:-webkit-autofill,

--- a/pro/src/styles/variables/_forms.scss
+++ b/pro/src/styles/variables/_forms.scss
@@ -1,6 +1,7 @@
 @use "styles/variables/_colors.scss" as colors;
 @use "styles/mixins/_rem.scss" as rem;
 
+$input-color-grey-dark: #67686b;
 $input-border-color: colors.$grey-semi-dark;
 $input-border-color-focus: colors.$black;
 $input-border-width-focus: rem.torem(2px);
@@ -9,10 +10,10 @@ $input-border-color-disabled: colors.$grey-light;
 $input-hover-shadow: 0 rem.torem(3px) rem.torem(4px) 0 colors.$grey-medium-shadow;
 $input-bg-color: colors.$white;
 $input-bg-color-disabled: colors.$grey-light;
-$input-text-color-disabled: colors.$grey-dark;
+$input-text-color-disabled: $input-color-grey-dark;
 $input-border-radius: rem.torem(20px);
 $error-text-color: colors.$red-warning;
-$placeholder-text-color: #67686b;
+$placeholder-text-color: $input-color-grey-dark;
 $input-right-icon-padding: rem.torem(32px);
 $input-error-reserved-space: rem.torem(18px);
 $input-space-before-error: rem.torem(8px);


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19436

## But de la pull request

- Corriger l'affichage des champs du formulaire de stock (surtout en édition)
- Corriger la couleur du placeholder sur firefox
- Retirer le placeholder des champs prix, et ajouter l'icône € (même sans valeur)

## Implémentation

![image](https://user-images.githubusercontent.com/106379750/211007065-db13bea0-b9bd-4a9f-8fb5-6df138b6db3f.png)
![image](https://user-images.githubusercontent.com/106379750/211007097-bea11bc0-058a-44e1-b2bb-e70211326cd4.png)
![image](https://user-images.githubusercontent.com/106379750/211007110-fef2da80-7cb2-48d6-9fdc-c984b1503d54.png)
