### PR TITLE
PC-19264 send event to batch when a user activates their deposit

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -24,6 +24,7 @@ from pcapi.core.users import utils as users_utils
 from pcapi.core.users import young_status as young_status_module
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
+import pcapi.notifications.push as push_notifications
 import pcapi.repository as pcapi_repository
 import pcapi.utils.postal_code as postal_code_utils
 from pcapi.workers import apps_flyer_job
@@ -80,6 +81,7 @@ def activate_beneficiary_for_eligibility(
         logger.warning("Could not send accepted as beneficiary email to user", extra={"user": user.id})
 
     external_attributes_api.update_external_user(user)
+    push_notifications.track_deposit_activated_event(user.id, can_be_asynchronously_retried=True)
 
     if "apps_flyer" in user.externalIds:  # type: ignore [operator]
         apps_flyer_job.log_user_becomes_beneficiary_event_job.delay(user.id)

--- a/api/src/pcapi/notifications/push/__init__.py
+++ b/api/src/pcapi/notifications/push/__init__.py
@@ -31,3 +31,10 @@ def send_transactional_notification(
 def delete_user_attributes(user_id: int, can_be_asynchronously_retried: bool = False) -> None:
     backend = import_string(settings.PUSH_NOTIFICATION_BACKEND)
     backend().delete_user_attributes(user_id, can_be_asynchronously_retried=can_be_asynchronously_retried)
+
+
+def track_deposit_activated_event(user_id: int, can_be_asynchronously_retried: bool = False) -> None:
+    backend = import_string(settings.PUSH_NOTIFICATION_BACKEND)
+    backend().track_event(
+        user_id, "user_deposit_activated", can_be_asynchronously_retried=can_be_asynchronously_retried
+    )

--- a/api/src/pcapi/notifications/push/backends/batch.py
+++ b/api/src/pcapi/notifications/push/backends/batch.py
@@ -139,3 +139,22 @@ class BatchBackend:
                 api_name="delete_user_attributes",
                 can_be_asynchronously_retried=can_be_asynchronously_retried,
             )
+
+    def track_event(self, user_id: int, event_name: str, can_be_asynchronously_retried: bool = False) -> None:
+        def make_post_request(api: BatchAPI) -> None:
+            self.handle_request(
+                "POST",
+                f"{API_URL}/1.0/{api.value}/events/users/{user_id}",
+                api_name="track_event",
+                payload={
+                    "events": [
+                        {
+                            "name": f"ue.{event_name}",
+                        }
+                    ]
+                },
+                can_be_asynchronously_retried=can_be_asynchronously_retried,
+            )
+
+        make_post_request(BatchAPI.ANDROID)
+        make_post_request(BatchAPI.IOS)

--- a/api/src/pcapi/notifications/push/backends/logger.py
+++ b/api/src/pcapi/notifications/push/backends/logger.py
@@ -48,3 +48,11 @@ class LoggerBackend:
             user_id,
             extra={"can_be_asynchronously_retried": can_be_asynchronously_retried},
         )
+
+    def track_event(self, user_id: int, event_name: str, can_be_asynchronously_retried: bool = False) -> None:
+        logger.info(
+            "A request to track event=ue.%s would be sent for user with id=%d",
+            event_name,
+            user_id,
+            extra={"can_be_asynchronously_retried": can_be_asynchronously_retried},
+        )

--- a/api/src/pcapi/notifications/push/backends/testing.py
+++ b/api/src/pcapi/notifications/push/backends/testing.py
@@ -46,3 +46,13 @@ class TestingBackend(LoggerBackend):
     def delete_user_attributes(self, user_id: int, can_be_asynchronously_retried: bool = False) -> None:
         super().delete_user_attributes(user_id, can_be_asynchronously_retried=can_be_asynchronously_retried)
         testing.requests.append({"user_id": user_id, "can_be_asynchronously_retried": can_be_asynchronously_retried})
+
+    def track_event(self, user_id: int, event_name: str, can_be_asynchronously_retried: bool = False) -> None:
+        super().track_event(user_id, event_name, can_be_asynchronously_retried=can_be_asynchronously_retried)
+        testing.requests.append(
+            {
+                "user_id": user_id,
+                "event_name": event_name,
+                "can_be_asynchronously_retried": can_be_asynchronously_retried,
+            }
+        )

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -488,8 +488,12 @@ class CreateBeneficiaryTest:
         )
         subscription_api.activate_beneficiary_for_eligibility(user, "test", users_models.EligibilityType.AGE18)
 
-        assert len(batch_testing.requests) == 2
+        assert len(batch_testing.requests) == 3
         assert len(sendinblue_testing.sendinblue_requests) == 1
+
+        trigger_event_log = batch_testing.requests[2]
+        assert trigger_event_log["user_id"] == user.id
+        assert trigger_event_log["event_name"] == "user_deposit_activated"
 
 
 class FulfillBeneficiaryDataTest:

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -878,7 +878,7 @@ class UpdateProfileTest:
         assert user.lastName == "Stan"
         assert user.has_beneficiary_role
 
-        assert len(push_testing.requests) == 2
+        assert len(push_testing.requests) == 3
         notification = push_testing.requests[0]
         assert notification["user_id"] == user.id
         assert notification["attribute_values"]["u.is_beneficiary"]

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -391,7 +391,7 @@ class RunIntegrationTest:
             if fraud_check.type == fraud_models.FraudCheckType.HONOR_STATEMENT
         )
 
-        assert len(push_testing.requests) == 2
+        assert len(push_testing.requests) == 3
 
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["template"]["id_prod"] == 96  # accepted as beneficiary email
@@ -548,7 +548,7 @@ class RunIntegrationTest:
             TransactionalEmail.ACCEPTED_AS_BENEFICIARY.value
         )
 
-        assert len(push_testing.requests) == 2
+        assert len(push_testing.requests) == 3
         assert push_testing.requests[0]["attribute_values"]["u.is_beneficiary"]
 
     @patch.object(dms_connector_api.DMSGraphQLClient, "get_applications_with_details")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19264

## But de la pull request

Envoyer un évènement à Batch quand un utilisateur voit son crédit activé, pour lui envoyer une notification par la suite

## Implémentation

- Une fonction `track_event` pour batch
- Un evenement pour le cas concret

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
