### PR TITLE
(PC-19451)[API] fix: bov3: JS: Handle 5xx errors within turbo-frames

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -50,6 +50,20 @@
 
 <script type="module">
     import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo';
+
+    // Handle server-side errors without a turbo-frame
+    addEventListener("turbo:frame-missing", async (event) => {
+        // default behaviour since turbo 7.2 is to display a full page with the
+        // error content. For example, if nginx throws a 504 error because the
+        // flask controller did not respond in time, the the whole page will be
+        // replaced by a generic 504 error message, which is not great in terms
+        // of UX...
+        event.preventDefault();
+        console.log('Turbo frame missing');
+        console.log(`status code: ${event.detail.response.status}`);
+
+        event.target.textContent = "Une erreur est survenue";
+    })
 </script>
 </body>
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19451

## But de la pull request

Depuis la version 7.2 de turbo, les erreurs 500 (et plus) sont traitées différemment : tout le contenu de la page est remplacé par celui reçu. Par exemple, si un `turbo-frame` de la page de détails d'une offre met trop de temps à répondre, nginx renvoie une 504 pour cet élément et turbo remplace toute la page par le code html d'erreur de nginx. Donc une erreur dans un `turbo-frame` et toute la page saute :cry:

Donc en cas d'erreur, ce fix permet d'afficher un message d'erreur basique.
Cette solution ne règle pas certains problèmes de fond mais elle permet de rendre certaines pages utilisables, en attendant.
