### PR TITLE
(PC-19110)[BO] feat: add pro user to offerer

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -516,7 +516,9 @@ def grant_user_offerer_access(offerer: models.Offerer, user: users_models.User) 
     return models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.VALIDATED)
 
 
-def validate_offerer_attachment(user_offerer: offerers_models.UserOfferer, author_user: users_models.User) -> None:
+def validate_offerer_attachment(
+    user_offerer: offerers_models.UserOfferer, author_user: users_models.User, comment: str | None = None
+) -> None:
     if user_offerer.isValidated:
         raise exceptions.UserOffererAlreadyValidatedException()
 
@@ -528,6 +530,7 @@ def validate_offerer_attachment(user_offerer: offerers_models.UserOfferer, autho
         author=author_user,
         user=user_offerer.user,
         offerer=user_offerer.offerer,
+        comment=comment,
         save=False,
     )
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -30,7 +30,8 @@ class PCOptStringField(wtforms.StringField):
     ]
 
 
-class PCStringField(PCOptStringField):
+class PCStringField(wtforms.StringField):
+    widget = partial(widget, template="components/forms/string_field.html")
     validators = [
         validators.InputRequired("Information obligatoire"),
         validators.Length(min=1, max=64, message="doit contenir entre %(min)d et %(max)d caractères"),
@@ -65,8 +66,9 @@ class PCOptCommentField(PCOptStringField):
     ]
 
 
-class PCCommentField(PCOptStringField):
+class PCCommentField(PCStringField):
     validators = [
+        validators.InputRequired("Information obligatoire"),
         validators.Length(min=1, max=1024, message="doit contenir entre %(min)d et %(max)d caractères"),
     ]
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -99,3 +99,14 @@ class OptionalCommentForm(FlaskForm):
 class TopActorForm(FlaskForm):
     # Optional because the request is sent with an empty value when disabled, "on" when enabled
     is_top_actor = wtforms.HiddenField("Top acteur", validators=(wtforms.validators.Optional(),))
+
+
+class AddProUserForm(FlaskForm):
+    pro_user_id = fields.PCSelectField("Compte pro", coerce=int)
+    comment = fields.PCCommentField("Commentaire interne")
+
+    # Empty choice is proposed to avoid select first user by default, but empty choice is not allowed
+    def validate_pro_user_id(self, pro_user_id: fields.PCSelectField) -> fields.PCSelectField:
+        if not pro_user_id.data:
+            raise wtforms.validators.ValidationError("Aucun compte pro n'est sélectionné")
+        return pro_user_id

--- a/api/src/pcapi/routes/backoffice_v3/forms/search.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/search.py
@@ -38,4 +38,6 @@ class SearchForm(FlaskForm):
 
 
 class ProSearchForm(SearchForm):
-    pro_type = fields.PCSelectField("Type", choices=utils.values_from_enum(TypeOptions))
+    pro_type = fields.PCSelectField(
+        "Type", choices=utils.values_from_enum(TypeOptions), default=TypeOptions.OFFERER.value
+    )

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_field.html
@@ -1,6 +1,9 @@
 <div class="form-floating dropdown">
     <select class="form-select form-control" id="{{ field.name }}" name="{{ field.name }}"
-            aria-label="{{ field.name }}" style="flex-grow: 1!important;">
+            aria-label="{{ field.name }}" style="flex-grow: 1!important;" {% if field.flags.required %}required{% endif %}>
+        {% if not field.default %}
+            <option value=""></option>
+        {% endif %}
         {% for choice_value, choice_label in field.choices %}
             <option value="{{ choice_value }}" {{ 'selected' if field.data==choice_value else '' }}>
                 {{ choice_label | i18n_public_account }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
@@ -1,4 +1,7 @@
 <div class="form-floating my-3">
-    <input type="text" id="{{ field.name }}" name="{{ field.name }}" class="form-control" value="{{ field.data | empty_string_if_null }}">
+    <input type="text" id="{{ field.name }}" name="{{ field.name }}" class="form-control" value="{{ field.data | empty_string_if_null }}"
+        {% if field.flags.required %}required{% endif %}
+        {% if field.flags.minlength %}minlength="{{ minlength }}"{% endif %}
+        {% if field.flags.maxlength %}maxlength="{{ maxlength }}"{% endif %}/>
     <label for="floatingInput">{{ field.label }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -44,6 +44,15 @@
         };
         new TomSelect(el, settings);
     });
+    document.getElementsByName("form").forEach((el) => {
+        el.addEventListener("submit", (event) => {
+            event.preventDefault();
+            const form = event.target;
+            if (form.checkValidity()) {
+                form.submit();
+            }
+        }, false);
+    })
 </script>
 <!-- Useful for local script modification per-view -->
 {% block scripts %}{% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
@@ -1,6 +1,46 @@
 {% from "offerer/edit_status_modal.html" import build_edit_status_modal with context %}
 {% from "components/badges.html" import build_user_offerer_badges %}
 
+{% if add_user_form %}
+    {% if add_user_form.pro_user_id.choices | length > 0 %}
+        <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
+            data-bs-target="#add-pro-user-modal" type="button">
+            Ajouter un compte pro
+        </button>
+        <div class="modal modal-lg fade" id="add-pro-user-modal" tabindex="-1"
+            aria-describedby="add-pro-user-modal-label" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header fs-5" id="add-pro-user-modal-label">Ajouter un compte pro</div>
+                    <div class="mx-4 mt-4">Veuillez sélectionner le compte pro à rattacher à cette structure</div>
+                    <form action="{{ add_user_dst }}" method="POST">
+                        <div class="modal-body">
+                            <div class="form-group">
+                                {% for form_field in add_user_form %}
+                                    <div class="w-100 my-4">
+                                        {% for error in form_field.errors %}
+                                            <p class="text-warning lead">{{ error }}</p>
+                                        {% endfor %}
+                                    </div>
+                                    {{ form_field }}
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Annuler</button>
+                            <button type="submit" class="btn btn-primary">Valider le rattachement</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    {% else %}
+        <button class="btn lead fw-bold mt-2" type="button" disabled>
+            Ajouter un compte pro
+        </button>
+    {% endif %}
+{% endif %}
+
 <table class="table table-hover my-4">
     <thead>
     <tr>

--- a/api/tests/routes/backoffice_v3/helpers/html_parser.py
+++ b/api/tests/routes/backoffice_v3/helpers/html_parser.py
@@ -7,8 +7,12 @@ def _filter_whitespaces(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
+def get_soup(html_content: str) -> BeautifulSoup:
+    return BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+
+
 def content_as_text(html_content: str) -> str:
-    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+    soup = get_soup(html_content)
     return _filter_whitespaces(soup.text)
 
 
@@ -20,7 +24,7 @@ def extract_table_rows(html_content: str, parent_id: str | None = None) -> list[
 
     Use `parent_id` parameter to filter inside a html tag id when several tables may be printed in the page.
     """
-    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+    soup = get_soup(html_content)
 
     if parent_id:
         soup = soup.find(id=parent_id)
@@ -57,7 +61,7 @@ def extract_table_rows(html_content: str, parent_id: str | None = None) -> list[
 
 
 def count_table_rows(html_content: str) -> int:
-    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+    soup = get_soup(html_content)
 
     tbody = soup.find("tbody")
     if tbody is None:
@@ -70,7 +74,7 @@ def extract_pagination_info(html_content: str) -> tuple[int, int, int]:
     """
     Returns current and total pages in pagination block, and total number of results on all pages
     """
-    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+    soup = get_soup(html_content)
 
     num_results = soup.find("p", class_="num-results")
     if num_results is None:
@@ -96,7 +100,16 @@ def extract_cards_text(html_content: str) -> list[str]:
     """
     Extract text from all cards in the page, as strings
     """
-    soup = BeautifulSoup(html_content, features="html5lib", from_encoding="utf-8")
+    soup = get_soup(html_content)
 
     cards = soup.find_all("div", class_="card")
     return [_filter_whitespaces(card.text) for card in cards]
+
+
+def extract_alert(html_content: str) -> str:
+    soup = get_soup(html_content)
+
+    alert = soup.find("div", class_="alert")
+    assert alert is not None
+
+    return _filter_whitespaces(alert.text)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19110

## But de la pull request

Dans le backoffice v3, permettre d'ajouter un compte pro dans les rattachements d'une structure ; automatiquement validé.

Le compte ne peut être que parmi ceux ayant déjà eu un lien avec la structure (lien rejeté et/ou supprimé), à partir de l'historique que l'on construit désormais. Voir les conditions dans le ticket.

## Informations supplémentaires

Le ticket suggérait un bouton grisé lorsque le formulaire de la popup n'est pas encore rempli, puis actif. Cela n'est pas cohérent avec le reste du backoffice v3, et demanderait à exécuter du JS natif à chaque touche appuyée.
La solution retenue est plutôt d'utiliser les attributs `required`, `minlength` et `maxlength` dans les champs du formulaire, associés à `checkValidity()` lors du clic sur le bouton de validation, afin de faire une pré-validation côté client. Cette amélioration profite directement à tous les formulaires du BO v3.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
