### PR TITLE
(BSR) fix: remove workflow concurrency on master

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -8,7 +8,8 @@ on:
       - staging
 
 concurrency:
-  group: tests-main-${{ github.ref }}
+  # cancel previous workflow of the same branch except on master
+  group: ${{ github.ref == 'refs/heads/master' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Sur master, budget illimité.
Pour éviter que le déploiement suite au merge d'une PR soit annulé par le merge d'une autre PR, ce qui met helm en pls et retarde la livraison des tickets