### PR TITLE
(BSR)[API] fix: delete removed feature flags from database

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 2e171418aa71 (pre) (head)
-5355cbe2ebef (post) (head)
+f94795ee981a (post) (head)

--- a/api/src/pcapi/alembic/versions/20230110T082249_525089ccbb4d_remove_wip_enable_backoffice_v3_feature_flag.py
+++ b/api/src/pcapi/alembic/versions/20230110T082249_525089ccbb4d_remove_wip_enable_backoffice_v3_feature_flag.py
@@ -1,0 +1,34 @@
+"""Remove_WIP_ENABLE_BACKOFFICE_V3_feature_flag
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "525089ccbb4d"
+down_revision = "5355cbe2ebef"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type: ignore [no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="WIP_ENABLE_BACKOFFICE_V3",
+        isActive=False,
+        description="Autorise l'accès au nouveau back-office (v3)",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/alembic/versions/20230110T082449_f94795ee981a_remove_venue_form_v2_feature_flag.py
+++ b/api/src/pcapi/alembic/versions/20230110T082449_f94795ee981a_remove_venue_form_v2_feature_flag.py
@@ -1,0 +1,34 @@
+"""Remove_VENUE_FORM_V2_feature_flag
+"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f94795ee981a"
+down_revision = "525089ccbb4d"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type: ignore [no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="VENUE_FORM_V2",
+        isActive=False,
+        description="Afficher la version 2 du formulaire de lieu",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())


### PR DESCRIPTION
## But de la pull request

Supprimer de la base de données deux FF qui n'existent plus :
- WIP_ENABLE_BACKOFFICE_V3 (supprimé hier)
- VENUE_FORM_V2

Afin d'éviter l'erreur au démarrage :
`ERROR:pcapi.models.feature:The following feature flags are present in database but not present in code: {'WIP_ENABLE_BACKOFFICE_V3', 'VENUE_FORM_V2'}`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
