### PR TITLE
(PC-19464)[PRO] fix: remove synchronized stocks returns

### DIFF
--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 
 import formRowStyles from 'components/StockEventFormRow/SharedStockEventFormRow.module.scss'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
-import { useOfferWizardMode } from 'hooks'
 import { IcoEuro } from 'icons'
 import { DatePicker, TextInput, TimePicker } from 'ui-kit'
 
@@ -17,14 +16,15 @@ export interface IStockEventFormProps {
   today: Date
   stockIndex: number
   isSynchronized?: boolean
+  mode?: OFFER_WIZARD_MODE
 }
 
 const StockEventForm = ({
   today,
   stockIndex,
   isSynchronized = false,
+  mode,
 }: IStockEventFormProps): JSX.Element => {
-  const mode = useOfferWizardMode()
   const { values, setFieldValue, setTouched } = useFormikContext<{
     stocks: IStockEventFormValues[]
   }>()

--- a/pro/src/components/StockEventForm/StockEventForm.tsx
+++ b/pro/src/components/StockEventForm/StockEventForm.tsx
@@ -4,26 +4,41 @@ import { useFormikContext } from 'formik'
 import React from 'react'
 
 import formRowStyles from 'components/StockEventFormRow/SharedStockEventFormRow.module.scss'
+import { OFFER_WIZARD_MODE } from 'core/Offers'
+import { useOfferWizardMode } from 'hooks'
 import { IcoEuro } from 'icons'
 import { DatePicker, TextInput, TimePicker } from 'ui-kit'
 
+import { STOCK_EVENT_EDITION_EMPTY_SYNCHRONIZED_READ_ONLY_FIELDS } from './constants'
 import styles from './StockEventForm.module.scss'
 import { IStockEventFormValues } from './types'
 
 export interface IStockEventFormProps {
   today: Date
   stockIndex: number
+  isSynchronized?: boolean
 }
 
 const StockEventForm = ({
   today,
   stockIndex,
+  isSynchronized = false,
 }: IStockEventFormProps): JSX.Element => {
+  const mode = useOfferWizardMode()
   const { values, setFieldValue, setTouched } = useFormikContext<{
     stocks: IStockEventFormValues[]
   }>()
 
   const stockFormValues = values.stocks[stockIndex]
+
+  if (
+    isSynchronized &&
+    mode === OFFER_WIZARD_MODE.EDITION &&
+    !stockFormValues.stockId
+  ) {
+    stockFormValues.readOnlyFields =
+      STOCK_EVENT_EDITION_EMPTY_SYNCHRONIZED_READ_ONLY_FIELDS
+  }
   const { readOnlyFields } = stockFormValues
 
   const onChangeBeginningDate = (_name: string, date: Date | null) => {

--- a/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
+++ b/pro/src/components/StockEventForm/__specs__/StockEventForm.spec.tsx
@@ -5,6 +5,8 @@ import userEvent from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
 
+import { OFFER_WIZARD_MODE } from 'core/Offers'
+
 import { STOCK_EVENT_FORM_DEFAULT_VALUES } from '../constants'
 import StockEventForm, { IStockEventFormProps } from '../StockEventForm'
 
@@ -49,6 +51,33 @@ describe('StockEventForm', () => {
     ).toBeInTheDocument()
     expect(screen.getByLabelText('Quantité')).toBeInTheDocument()
 
+    expect(screen.getByLabelText('Date', { exact: true })).not.toBeDisabled()
+    expect(screen.getByLabelText('Horaire')).not.toBeDisabled()
+    expect(screen.getByLabelText('Prix')).not.toBeDisabled()
+    expect(
+      screen.getByLabelText('Date limite de réservation')
+    ).not.toBeDisabled()
+    expect(screen.getByLabelText('Quantité')).not.toBeDisabled()
+  })
+
+  it('should render disabled fields for empty form with synchronized offer in edition mode', () => {
+    props.isSynchronized = true
+    props.mode = OFFER_WIZARD_MODE.EDITION
+    renderStockEventForm(props, {
+      ...STOCK_EVENT_FORM_DEFAULT_VALUES,
+    })
+    expect(screen.getByLabelText('Date', { exact: true })).toBeDisabled()
+    expect(screen.getByLabelText('Horaire')).toBeDisabled()
+    expect(screen.getByLabelText('Prix')).toBeDisabled()
+    expect(screen.getByLabelText('Date limite de réservation')).toBeDisabled()
+    expect(screen.getByLabelText('Quantité')).toBeDisabled()
+  })
+
+  it('should not render disabled fields for empty form in edition mode for not synchronized offer', () => {
+    props.mode = OFFER_WIZARD_MODE.EDITION
+    renderStockEventForm(props, {
+      ...STOCK_EVENT_FORM_DEFAULT_VALUES,
+    })
     expect(screen.getByLabelText('Date', { exact: true })).not.toBeDisabled()
     expect(screen.getByLabelText('Horaire')).not.toBeDisabled()
     expect(screen.getByLabelText('Prix')).not.toBeDisabled()

--- a/pro/src/components/StockEventForm/constants.ts
+++ b/pro/src/components/StockEventForm/constants.ts
@@ -18,14 +18,18 @@ export const STOCK_EVENT_FORM_DEFAULT_VALUES: IStockEventFormValues = {
 }
 
 // 'price','quantity','bookingLimitDatetime', are editable
-export const STOCK_EVENT_ALLOCINE_READ_ONLY_FIELDS = [
-  'beginningDate',
-  'beginningTime',
-]
+export const STOCK_EVENT_ALLOCINE_READ_ONLY_FIELDS: (keyof IStockEventFormValues)[] =
+  ['beginningDate', 'beginningTime']
 
 // 'quantity','bookingLimitDatetime' are editable
-export const STOCK_EVENT_CINEMA_PROVIDER_READ_ONLY_FIELDS = [
-  'beginningDate',
-  'beginningTime',
-  'price',
-]
+export const STOCK_EVENT_CINEMA_PROVIDER_READ_ONLY_FIELDS: (keyof IStockEventFormValues)[] =
+  ['beginningDate', 'beginningTime', 'price']
+
+export const STOCK_EVENT_EDITION_EMPTY_SYNCHRONIZED_READ_ONLY_FIELDS: (keyof IStockEventFormValues)[] =
+  [
+    'beginningDate',
+    'beginningTime',
+    'price',
+    'quantity',
+    'bookingLimitDatetime',
+  ]

--- a/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
@@ -71,7 +71,13 @@ const StockFormList = ({ offer, onDeleteStock }: IStockFormListProps) => {
               <StockEventFormRow
                 key={`${stockValues.stockId}-${index}`}
                 stockIndex={index}
-                Form={<StockEventForm today={today} stockIndex={index} />}
+                Form={
+                  <StockEventForm
+                    today={today}
+                    stockIndex={index}
+                    isSynchronized={isSynchronized}
+                  />
+                }
                 actions={[
                   {
                     callback: async () => {

--- a/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.tsx
@@ -76,6 +76,7 @@ const StockFormList = ({ offer, onDeleteStock }: IStockFormListProps) => {
                     today={today}
                     stockIndex={index}
                     isSynchronized={isSynchronized}
+                    mode={mode}
                   />
                 }
                 actions={[


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19464

## But de la pull request

- Désactiver les champs du formulaire de stock pour les offres synchronisées en édtition.

## Implémentation

![image](https://user-images.githubusercontent.com/106379750/211544282-91f49f05-fd88-428f-a179-168752cac753.png)
