### PR TITLE
(PC-19161)[BO] feat: filter offerer validation on regions

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -4,9 +4,14 @@ import wtforms
 
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils.regions import get_all_regions
 
 from . import fields
 from . import utils
+
+
+def _get_regions_choices() -> list[tuple]:
+    return [(key, key) for key in get_all_regions()]
 
 
 def _get_tags_query() -> sa.orm.Query:
@@ -23,6 +28,7 @@ class OffererValidationListForm(FlaskForm):
         csrf = False
 
     q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
+    regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )
@@ -53,7 +59,7 @@ class UserOffererValidationListForm(FlaskForm):
         csrf = False
 
     q = fields.PCOptSearchField("Nom de structure, SIREN, email, nom de compte pro")
-
+    regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )

--- a/api/src/pcapi/routes/backoffice_v3/i18n.py
+++ b/api/src/pcapi/routes/backoffice_v3/i18n.py
@@ -26,7 +26,7 @@ def i18n_public_account(term: str) -> str:
         case "rejected":  # pro
             return "Rejeté"
         case _:
-            return term.replace("_", " ").capitalize()
+            return term.replace("_", " ")
 
 
 def i18n_subscription_type(term: str) -> str:

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -257,6 +257,7 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
 
     offerers = offerers_api.list_offerers_to_be_validated(
         form.q.data,
+        form.regions.data,
         form.tags.data,
         form.status.data,
         _date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
@@ -400,6 +401,7 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
 
     users_offerers = offerers_api.list_users_offerers_to_be_validated(
         form.q.data,
+        form.regions.data,
         form.tags.data,
         form.status.data,
         form.offerer_status.data,

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -31,7 +31,7 @@
                         <div class="input-group mb-1 ">
                             {% for form_field in form %}
                                 {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
-                                    <div class="col-4 p-1"> {{ form_field }}</div>
+                                    <div class="col-3 p-1"> {{ form_field }}</div>
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -40,7 +40,7 @@
                         <div class="input-group mb-1 ">
                             {% for form_field in form %}
                                 {% if form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
-                                    <div class="col-6 p-1"> {{ form_field }}</div>
+                                    <div class="col-4 p-1"> {{ form_field }}</div>
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/api/src/pcapi/utils/regions.py
+++ b/api/src/pcapi/utils/regions.py
@@ -1,3 +1,8 @@
+import typing
+
+from pcapi.utils.clean_accents import clean_accents
+
+
 REGION_DEPARTMENT_CODES = {
     "Auvergne-Rhône-Alpes": ("01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"),
     "Bourgogne-Franche-Comté": ("21", "25", "39", "58", "70", "71", "89", "90"),
@@ -49,3 +54,12 @@ def get_region_name_from_postal_code(postal_code: str) -> str:
     department_code = get_department_code_from_postal_code(postal_code)
     region = get_region_name_from_department(department_code)
     return region
+
+
+def get_all_regions() -> list[str]:
+    # sort without accents to avoid "Île-de-France" at the end
+    return sorted(REGION_DEPARTMENT_CODES.keys(), key=clean_accents)
+
+
+def get_department_codes_for_region(region: str) -> typing.Iterable[str]:
+    return REGION_DEPARTMENT_CODES.get(region, ())

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -379,7 +379,7 @@ def offerers_to_be_validated_fixture(offerer_tags):
         name="B", siren="123002002", validationStatus=ValidationStatus.PENDING, postalCode="29000", city="Quimper"
     )
     collec = offerers_factories.NotValidatedOffererFactory(
-        name="C", siren="123003003", postalCode="29200", city="Brest"
+        name="C", siren="123003003", postalCode="50170", city="Le Mont-Saint-Michel"
     )
     public = offerers_factories.NotValidatedOffererFactory(
         name="D", siren="123004004", validationStatus=ValidationStatus.PENDING, postalCode="29300", city="Quimperlé"
@@ -388,7 +388,7 @@ def offerers_to_be_validated_fixture(offerer_tags):
         name="E", siren="123005005", postalCode="35400", city="Saint-Malo"
     )
     top_public = offerers_factories.NotValidatedOffererFactory(
-        name="F", siren="123006006", validationStatus=ValidationStatus.PENDING, postalCode="29200", city="Brest"
+        name="F", siren="123006006", validationStatus=ValidationStatus.PENDING, postalCode="44000", city="Nantes"
     )
 
     for offerer in (top, top_collec, top_public):
@@ -420,24 +420,26 @@ def user_offerer_to_be_validated_fixture(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
     no_tag = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="a@example.com", offerer__validationStatus=ValidationStatus.NEW
+        user__email="a@example.com", offerer__validationStatus=ValidationStatus.NEW, offerer__postalCode="97200"
     )
     top = offerers_factories.NotValidatedUserOffererFactory(
         user__email="b@example.com",
         offerer__validationStatus=ValidationStatus.NEW,
         validationStatus=ValidationStatus.PENDING,
+        offerer__postalCode="97100",
     )
-    collec = offerers_factories.NotValidatedUserOffererFactory(user__email="c@example.com")
+    collec = offerers_factories.NotValidatedUserOffererFactory(user__email="c@example.com", offerer__postalCode="29200")
     public = offerers_factories.NotValidatedUserOffererFactory(
         user__email="d@example.com",
         offerer__validationStatus=ValidationStatus.PENDING,
         validationStatus=ValidationStatus.PENDING,
+        offerer__postalCode="97290",
     )
     top_collec = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="e@example.com", offerer__validationStatus=ValidationStatus.PENDING
+        user__email="e@example.com", offerer__validationStatus=ValidationStatus.PENDING, offerer__postalCode="06400"
     )
     top_public = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="f@example.com", validationStatus=ValidationStatus.PENDING
+        user__email="f@example.com", validationStatus=ValidationStatus.PENDING, offerer__postalCode="97400"
     )
 
     for user_offerer in (top, top_collec, top_public):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19161

## But de la pull request

Filtrage de la liste des structures à valider et de la liste des rattachements par région, en fonction du code postal de la structure.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
