### PR TITLE
pc-18943-reservation_status_cancelled

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
@@ -22,7 +22,6 @@ from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_timezoned_date
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.human_ids import humanize
-from pcapi.core.educational import models as educational_models
 
 
 class CollectiveBookingRecapStatus(Enum):
@@ -111,7 +110,7 @@ class CollectiveBookingResponseModel(BaseModel):
     booking_amount: float
     booking_status_history: list[BookingStatusHistoryResponseModel]
     booking_identifier: str
-    booking_cancellation_reason: educational_models.CollectiveBookingCancellationReasons | None
+    booking_cancellation_reason: models.CollectiveBookingCancellationReasons | None
 
     class Config:
         alias_generator = to_camel
@@ -268,32 +267,6 @@ def _serialize_collective_booking_recap_status(
     return CollectiveBookingRecapStatus.booked
 
 
-class CollectiveBookingCancellationReason(Enum):
-    offerer = "offerer"
-    beneficiary = "beneficiary"
-    expired = "expired"
-    fraud = "fraud"
-    refused_by_institute = "refused_by_institute"
-    refused_by_headmaster = "refused_by_headmaster"
-
-
-def _serialize_collective_booking_cancellation_reason(
-    collective_booking: models.CollectiveBooking,
-) -> CollectiveBookingCancellationReason:
-    if collective_booking.cancellationReason == models.CollectiveBookingCancellationReasons.OFFERER:
-        return CollectiveBookingCancellationReason.offerer
-    if collective_booking.cancellationReason == models.CollectiveBookingCancellationReasons.BENEFICIARY:
-        return CollectiveBookingCancellationReason.beneficiary
-    if collective_booking.cancellationReason == models.CollectiveBookingCancellationReasons.EXPIRED:
-        return CollectiveBookingCancellationReason.expired
-    if collective_booking.cancellationReason == models.CollectiveBookingCancellationReasons.FRAUD:
-        return CollectiveBookingCancellationReason.fraud
-    if collective_booking.cancellationReason == models.CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE:
-        return CollectiveBookingCancellationReason.refused_by_institute
-
-    return CollectiveBookingCancellationReason.refused_by_headmaster
-
-
 def serialize_collective_booking(collective_booking: models.CollectiveBooking) -> CollectiveBookingResponseModel:
     return CollectiveBookingResponseModel(
         stock=serialize_collective_booking_stock(collective_booking),
@@ -345,10 +318,7 @@ def serialize_collective_booking(collective_booking: models.CollectiveBooking) -
             is_confirmed=collective_booking.isConfirmed,  # type: ignore[arg-type]
         ),
         bookingIdentifier=humanize(collective_booking.id),
-        cancellationReason=_serialize_collective_booking_cancellation_reason(collective_booking).value
-        if _serialize_collective_booking_recap_status(collective_booking).value
-        == models.CollectiveBookingStatus.CANCELLED
-        else None,
+        bookingCancellationReason=collective_booking.cancellationReason,
     )
 
 

--- a/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
@@ -22,6 +22,7 @@ from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_timezoned_date
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.human_ids import humanize
+from pcapi.core.educational import models as educational_models
 
 
 class CollectiveBookingRecapStatus(Enum):
@@ -110,7 +111,7 @@ class CollectiveBookingResponseModel(BaseModel):
     booking_amount: float
     booking_status_history: list[BookingStatusHistoryResponseModel]
     booking_identifier: str
-    cancellation_reason: str | None
+    booking_cancellation_reason: educational_models.CollectiveBookingCancellationReasons | None
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/routes/pro/get_all_collective_bookings_test.py
+++ b/api/tests/routes/pro/get_all_collective_bookings_test.py
@@ -92,7 +92,7 @@ class Returns200Test:
                 "bookingToken": None,
                 "bookingStatus": "confirmed",
                 "bookingIsDuo": False,
-                "cancellationReason": None,
+                "bookingCancellationReason": None,
                 "bookingStatusHistory": [
                     {
                         "status": "pending",
@@ -256,7 +256,7 @@ class Returns200Test:
             dateCreated=booking_date,
             confirmationDate=None,
             cancellationDate=booking_date + timedelta(days=5, minutes=32),
-            cancellationReason=None,
+            cancellationReason=CollectiveBookingCancellationReasons.OFFERER,
         )
 
         # When
@@ -267,6 +267,7 @@ class Returns200Test:
         assert response.status_code == 200
         booking_recap = response.json["bookingsRecap"][0]
         assert booking_recap["bookingStatus"] == "cancelled"
+        assert booking_recap["bookingCancellationReason"] == "OFFERER"
         assert booking_recap["bookingStatusHistory"] == [
             {
                 "status": "pending",
@@ -440,7 +441,7 @@ class Returns200Test:
                 "bookingToken": None,
                 "bookingStatus": "confirmed",
                 "bookingIsDuo": False,
-                "cancellationReason": None,
+                "bookingCancellationReason": None,
                 "bookingStatusHistory": [
                     {
                         "status": "pending",
@@ -529,7 +530,7 @@ class Returns200Test:
                 "bookingToken": None,
                 "bookingStatus": "confirmed",
                 "bookingIsDuo": False,
-                "cancellationReason": None,
+                "bookingCancellationReason": None,
                 "bookingStatusHistory": [
                     {
                         "status": "pending",
@@ -620,7 +621,7 @@ class Returns200Test:
                 "bookingToken": None,
                 "bookingStatus": "validated",
                 "bookingIsDuo": False,
-                "cancellationReason": None,
+                "bookingCancellationReason": None,
                 "bookingStatusHistory": [
                     {
                         "status": "pending",

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -28,6 +28,7 @@ export type { ChangePasswordBodyModel } from './models/ChangePasswordBodyModel';
 export type { ChangeProEmailBody } from './models/ChangeProEmailBody';
 export { CollectiveBookingBankInformationStatus } from './models/CollectiveBookingBankInformationStatus';
 export type { CollectiveBookingByIdResponseModel } from './models/CollectiveBookingByIdResponseModel';
+export { CollectiveBookingCancellationReasons } from './models/CollectiveBookingCancellationReasons';
 export type { CollectiveBookingCollectiveStockResponseModel } from './models/CollectiveBookingCollectiveStockResponseModel';
 export type { CollectiveBookingEducationalRedactorResponseModel } from './models/CollectiveBookingEducationalRedactorResponseModel';
 export type { CollectiveBookingResponseModel } from './models/CollectiveBookingResponseModel';

--- a/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingCancellationReasons.ts
@@ -1,0 +1,15 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * An enumeration.
+ */
+export enum CollectiveBookingCancellationReasons {
+  OFFERER = 'OFFERER',
+  BENEFICIARY = 'BENEFICIARY',
+  EXPIRED = 'EXPIRED',
+  FRAUD = 'FRAUD',
+  REFUSED_BY_INSTITUTE = 'REFUSED_BY_INSTITUTE',
+  REFUSED_BY_HEADMASTER = 'REFUSED_BY_HEADMASTER',
+}

--- a/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
@@ -20,7 +20,6 @@ export type CollectiveBookingResponseModel = {
   bookingStatus: string;
   bookingStatusHistory: Array<BookingStatusHistoryResponseModel>;
   bookingToken?: string | null;
-  cancellationReason?: string | null;
   institution: EducationalInstitutionResponseModel;
   stock: CollectiveBookingCollectiveStockResponseModel;
 };

--- a/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveBookingResponseModel.ts
@@ -3,12 +3,14 @@
 /* eslint-disable */
 
 import type { BookingStatusHistoryResponseModel } from './BookingStatusHistoryResponseModel';
+import type { CollectiveBookingCancellationReasons } from './CollectiveBookingCancellationReasons';
 import type { CollectiveBookingCollectiveStockResponseModel } from './CollectiveBookingCollectiveStockResponseModel';
 import type { EducationalInstitutionResponseModel } from './EducationalInstitutionResponseModel';
 
 export type CollectiveBookingResponseModel = {
   bookingAmount: number;
   bookingCancellationLimitDate: string;
+  bookingCancellationReason?: CollectiveBookingCancellationReasons | null;
   bookingConfirmationDate?: string | null;
   bookingConfirmationLimitDate: string;
   bookingDate: string;

--- a/pro/src/apiClient/v1/models/CropParams.ts
+++ b/pro/src/apiClient/v1/models/CropParams.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 /**
- * CropParams(x_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 0.0, y_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 0.0, height_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 1.0, width_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 1.0)
+ * CropParams(x_crop_percent: pydantic.types.ConstrainedFloatValue = 0.0, y_crop_percent: pydantic.types.ConstrainedFloatValue = 0.0, height_crop_percent: pydantic.types.ConstrainedFloatValue = 1.0, width_crop_percent: pydantic.types.ConstrainedFloatValue = 1.0)
  */
 export type CropParams = {
   height_crop_percent?: number;

--- a/pro/src/apiClient/v1/models/CropParams.ts
+++ b/pro/src/apiClient/v1/models/CropParams.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 
 /**
- * CropParams(x_crop_percent: pydantic.types.ConstrainedFloatValue = 0.0, y_crop_percent: pydantic.types.ConstrainedFloatValue = 0.0, height_crop_percent: pydantic.types.ConstrainedFloatValue = 1.0, width_crop_percent: pydantic.types.ConstrainedFloatValue = 1.0)
+ * CropParams(x_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 0.0, y_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 0.0, height_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 1.0, width_crop_percent: pcapi.utils.image_conversion.ConstrainedFloatValue = 1.0)
  */
 export type CropParams = {
   height_crop_percent?: number;

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
@@ -66,4 +66,17 @@ describe('collective timeline', () => {
     renderCollectiveTimeLine(bookingRecap)
     expect(screen.getByText('Remboursement effectué')).toBeInTheDocument()
   })
+  it('should render steps for cancelled booking', () => {
+    const bookingRecap = collectiveBookingRecapFactory({
+      bookingStatus: BOOKING_STATUS.CANCELLED,
+      bookingStatusHistory: [
+        { date: new Date().toISOString(), status: BOOKING_STATUS.PENDING },
+        { date: new Date().toISOString(), status: BOOKING_STATUS.CANCELLED },
+      ],
+    })
+    renderCollectiveTimeLine(bookingRecap)
+    expect(
+      screen.getByText('Vous avez annulé la réservation')
+    ).toBeInTheDocument()
+  })
 })

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 
 import { CollectiveBookingResponseModel } from 'apiClient/v1'
+import { CollectiveBookingCancellationReasons } from 'apiClient/v1/models/CollectiveBookingCancellationReasons'
 import { BOOKING_STATUS } from 'core/Bookings'
 import { configureTestStore } from 'store/testUtils'
 import { collectiveBookingRecapFactory } from 'utils/collectiveApiFactories'
@@ -69,6 +70,8 @@ describe('collective timeline', () => {
   it('should render steps for cancelled booking', () => {
     const bookingRecap = collectiveBookingRecapFactory({
       bookingStatus: BOOKING_STATUS.CANCELLED,
+      bookingConfirmationDate: null,
+      bookingCancellationReason: CollectiveBookingCancellationReasons.OFFERER,
       bookingStatusHistory: [
         { date: new Date().toISOString(), status: BOOKING_STATUS.PENDING },
         { date: new Date().toISOString(), status: BOOKING_STATUS.CANCELLED },

--- a/pro/src/ui-kit/Timeline/Timeline.tsx
+++ b/pro/src/ui-kit/Timeline/Timeline.tsx
@@ -13,6 +13,7 @@ export enum TimelineStepType {
   ERROR = 'ERROR',
   WAITING = 'WAITING',
   DISABLED = 'DISABLED',
+  CANCELLED = 'CANCELLED',
 }
 
 export interface ITimelineStep {
@@ -57,6 +58,13 @@ const getIconComponent = (type: TimelineStepType, hasErrorSteps: boolean) => {
         <DisabledSvg
           title="Étape non disponible"
           className={cn(styles.icon, styles['icon-disabled'])}
+        />
+      )
+    case TimelineStepType.CANCELLED:
+      return (
+        <ErrorSvg
+          title="Étape annulée"
+          className={cn(styles.icon, styles['icon-error'])}
         />
       )
     default:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18943

## But de la pull request

Adapter la timeline pour le suivi des réservations lorsque le status de la réservation est annulé en créer la timeline via le `booking_status_history `

<img width="391" alt="Capture d’écran 2023-01-10 à 16 14 53" src="https://user-images.githubusercontent.com/119043808/211589334-1d7d9938-6eec-4e75-bcd2-761baca1c9da.png">

<img width="391" alt="Capture d’écran 2023-01-10 à 16 15 19" src="https://user-images.githubusercontent.com/119043808/211589343-83741ef4-519f-4a05-84ef-ff819d6ab572.png">



## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
