### PR TITLE
(BSR)[PRO] chore: add SonarCloud to the project

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -30,6 +30,7 @@ jobs:
   test-pro:
     name: Tests pro
     uses: ./.github/workflows/tests-pro.yml
+    secrets: inherit
 
   deploy-testing:
     name: "[testing] Deployment"

--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -117,10 +117,15 @@ jobs:
         with:
           path: ./${{ env.folder }}/.jest_cache
           key: node-${{ needs.read-node-version.outputs.node_version }}-jest-cache
-      - if: ${{ github.ref == 'refs/heads/master' }}
-        run: yarn test:unit:ci
-      - if: ${{ github.ref != 'refs/heads/master' }}
-        run: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
+      - name: Run tests with coverage
+        run: yarn test:unit:ci --coverage
+      - name: SonarCloud scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: pro
       - if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/pro/sonar-project.properties
+++ b/pro/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=pass-culture_pass-culture-main
+sonar.organization=pass-culture
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.coverage.exclusions=**/*.spec.*
+sonar.qualitygate.wait=true


### PR DESCRIPTION
Mis en place sur le clone du repo https://github.com/pass-culture/pass-culture-main-config-sonarcloud, maintenant que nous avons une config qui marche bien on souhaite la mettre en place sur le vrai repo.