### PR TITLE
Pc 18717 archive unexpirable digital offers

### DIFF
--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timedelta
 import logging
 
 from sqlalchemy.orm import joinedload
@@ -198,6 +199,13 @@ def is_ended_booking(booking: Booking) -> bool:
         # consider digital bookings as special: is_used should be true anyway so
         # let's use displayAsEnded
         return booking.displayAsEnded  # type: ignore [return-value]
+
+    booking_subcategory = booking.stock.offer.subcategory
+    if booking.dateCreated < datetime.utcnow() - timedelta(days=30) and not (
+        booking_subcategory.can_expire or booking_subcategory.is_event
+    ):
+        # consider digital bookings with no expiration date as ended after 30 days
+        return True
 
     return (
         not booking.stock.offer.isPermanent

--- a/api/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -99,6 +99,7 @@ class BookingReponse(BaseModel):
     cancellationReason: bookings_models.BookingCancellationReasons | None
     confirmationDate: datetime | None
     completedUrl: str | None
+    dateCreated: datetime
     dateUsed: datetime | None
     expirationDate: datetime | None
     qrCodeData: str | None

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -323,6 +323,21 @@ class GetBookingsTest:
             {"barcode": "111111112", "seat": "A_2"},
         ]
 
+    def test_digital_bookings_are_considered_used_after_30_days(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
+        booking = booking_factories.IndividualBookingFactory(
+            dateCreated=datetime.utcnow() - timedelta(days=30, minutes=1),
+            individualBooking__user=user,
+            stock__offer__subcategoryId=subcategories.ABO_PRESSE_EN_LIGNE.id,
+        )
+
+        response = client.with_token(self.identifier).get("/native/v1/bookings")
+
+        assert response.status_code == 200
+        assert len(response.json["ongoing_bookings"]) == 0
+        assert len(response.json["ended_bookings"]) == 1
+        assert response.json["ended_bookings"][0]["id"] == booking.id
+
 
 class CancelBookingTest:
     identifier = "pascal.ture@example.com"

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -196,6 +196,7 @@ class GetBookingsTest:
             "cancellationReason": None,
             "confirmationDate": "2021-03-02T00:00:00Z",
             "completedUrl": f"https://demo.pass/some/path?token={used2.token}&email=pascal.ture@example.com&offerId={humanize(used2.stock.offer.id)}",
+            "dateCreated": used2.dateCreated.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "dateUsed": "2021-03-02T00:00:00Z",
             "expirationDate": None,
             "quantity": 1,

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -175,6 +175,7 @@ def test_public_api(client):
                             "title": "Confirmationdate",
                             "type": "string",
                         },
+                        "dateCreated": {"format": "date-time", "title": "Datecreated", "type": "string"},
                         "dateUsed": {"format": "date-time", "nullable": True, "title": "Dateused", "type": "string"},
                         "expirationDate": {
                             "format": "date-time",
@@ -195,7 +196,7 @@ def test_public_api(client):
                         "token": {"nullable": True, "title": "Token", "type": "string"},
                         "totalAmount": {"title": "Totalamount", "type": "integer"},
                     },
-                    "required": ["id", "quantity", "stock", "totalAmount"],
+                    "required": ["id", "dateCreated", "quantity", "stock", "totalAmount"],
                     "title": "BookingReponse",
                     "type": "object",
                 },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18717

## But de la pull request

- ajout des dates de réservation à la réponse du endpoint de liste des réservations
- les réservations d'offres non expirables, qui ne sont pas des évènements, et qui ont plus de 30 jours sont considérées comme terminées

## Implémentation

RAS

## Informations supplémentaires
RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
