### PR TITLE
(PC-19773)[PRO] fix: when bookingLimitDatetime is same day as event begining

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksEvent/adapters/__specs__/serializers.spec.ts
+++ b/pro/src/screens/OfferIndividual/StocksEvent/adapters/__specs__/serializers.spec.ts
@@ -25,7 +25,7 @@ describe('screens::StockEvent::serializers:serializeStockEventList', () => {
         remainingQuantity: STOCK_EVENT_FORM_DEFAULT_VALUES.remainingQuantity,
         bookingsQuantity: STOCK_EVENT_FORM_DEFAULT_VALUES.bookingsQuantity,
         quantity: 12,
-        bookingLimitDatetime: new Date('2022-10-26T23:00:00+0200'),
+        bookingLimitDatetime: new Date('2022-10-26T00:00:00'),
         price: 10,
         isDeletable: true,
         readOnlyFields: [],
@@ -37,7 +37,7 @@ describe('screens::StockEvent::serializers:serializeStockEventList', () => {
   it('should serialize data for stock event creation', async () => {
     const expectedApiStockEvent: StockCreationBodyModel = {
       beginningDatetime: '2022-10-26T13:00:00Z',
-      bookingLimitDatetime: '2022-10-26T00:00:00Z',
+      bookingLimitDatetime: '2022-10-26T13:00:00Z',
       price: 10,
       quantity: 12,
     }
@@ -72,8 +72,8 @@ describe('screens::StockEvent::serializers:serializeStockEventList', () => {
   it('should serialize data for stock event edition', async () => {
     const expectedApiStockEvent: StockEditionBodyModel = {
       humanizedId: 'STOCK_ID',
-      beginningDatetime: '2022-10-26T13:00:00Z',
-      bookingLimitDatetime: '2022-10-26T00:00:00Z',
+      beginningDatetime: '2022-10-11T13:00:00Z',
+      bookingLimitDatetime: '2022-10-10T21:59:59Z',
       price: 10,
       quantity: 12,
     }
@@ -83,6 +83,9 @@ describe('screens::StockEvent::serializers:serializeStockEventList', () => {
         ...formValuesList.map((formValues: IStockEventFormValues) => ({
           ...formValues,
           stockId: 'STOCK_ID',
+          beginningDate: new Date('2022-10-11T00:00:00.0200'),
+          beginningTime: new Date('2022-10-11T15:00:00.0200'),
+          bookingLimitDatetime: new Date('2022-10-10T00:00:00'),
         })),
       ],
       departementCode

--- a/pro/src/screens/OfferIndividual/StocksEvent/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksEvent/adapters/serializers.ts
@@ -1,6 +1,5 @@
 import { set } from 'date-fns'
 import endOfDay from 'date-fns/endOfDay'
-import startOfDay from 'date-fns/startOfDay'
 
 import { StockCreationBodyModel, StockEditionBodyModel } from 'apiClient/v1'
 import { IStockEventFormValues } from 'components/StockEventForm'
@@ -8,16 +7,26 @@ import { getToday, toISOStringWithoutMilliseconds } from 'utils/date'
 import { getUtcDateTimeFromLocalDepartement } from 'utils/timezone'
 
 const serializeBookingLimitDatetime = (
+  beginningDate: Date,
+  beginningTime: Date,
   bookingLimitDatetime: Date,
   departementCode: string
 ) => {
+  // If the bookingLimitDatetime is the same day as the start of the event
+  // the bookingLimitDatetime should be set to beginningDate and beginningTime
+  // ie : bookable until the event
+  if (beginningDate.toDateString() === bookingLimitDatetime.toDateString()) {
+    return serializeBeginningDateTime(
+      beginningDate,
+      beginningTime,
+      departementCode
+    )
+  }
   const endOfBookingLimitDayUtcDatetime = getUtcDateTimeFromLocalDepartement(
     endOfDay(bookingLimitDatetime),
     departementCode
   )
-  return toISOStringWithoutMilliseconds(
-    startOfDay(endOfBookingLimitDayUtcDatetime)
-  )
+  return toISOStringWithoutMilliseconds(endOfBookingLimitDayUtcDatetime)
 }
 
 const buildDateTime = (date: Date, time: Date) =>
@@ -62,6 +71,8 @@ export const serializeStockEvent = (
     beginningDatetime: serializedbeginningDatetime,
     bookingLimitDatetime: formValues.bookingLimitDatetime
       ? serializeBookingLimitDatetime(
+          formValues.beginningDate,
+          formValues.beginningTime,
           formValues.bookingLimitDatetime,
           departementCode
         )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19773

2 cas : 
- La date limite de reservation est le jour de l'évenement -> L'heure et la date de reservation sont mis à celle de l'évenement
- La date limite de reservation n'est pas le même jour que l'évt -> On set l'heure à 23:59:59s (fin de la journée de la date de limite de reservation)