### PR TITLE
(PC-19406)[PRO] fix: button focus after modal

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useHistory } from 'react-router'
 
 import {
@@ -25,6 +25,7 @@ const DuplicateOfferCell = ({
 }) => {
   const history = useHistory()
   const notify = useNotification()
+  const buttonRef = useRef<HTMLButtonElement>(null)
   const { logEvent } = useAnalytics()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const shouldDisplayModal =
@@ -47,6 +48,7 @@ const DuplicateOfferCell = ({
       })
       createOfferFromTemplate(history, notify, templateOfferId)
     }
+    buttonRef.current?.blur()
     setIsModalOpen(true)
   }
 
@@ -59,9 +61,10 @@ const DuplicateOfferCell = ({
           onClick={handleCreateOfferClick}
           Icon={PlusIcon}
           iconPosition={IconPositionEnum.CENTER}
+          innerRef={buttonRef}
           hasTooltip
         >
-          Créer une offre réservable pour un établissement
+          Créer une offre réservable pour un établissement scolaire
         </Button>
         {isModalOpen && shouldDisplayModal && (
           <DuplicateOfferDialog

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -52,7 +52,7 @@ describe('DuplicateOfferCell', () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
     const button = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement',
+      name: 'Créer une offre réservable pour un établissement scolaire',
     })
 
     await userEvent.click(button)
@@ -68,7 +68,7 @@ describe('DuplicateOfferCell', () => {
       createFromTemplateUtils.createOfferFromTemplate
     ).not.toHaveBeenCalled()
     expect(
-      screen.queryByText(
+      screen.queryByLabelText(
         'Créer une offre réservable pour un établissement scolaire'
       )
     ).not.toBeInTheDocument()
@@ -78,7 +78,7 @@ describe('DuplicateOfferCell', () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
     const button = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement',
+      name: 'Créer une offre réservable pour un établissement scolaire',
     })
 
     await userEvent.click(button)
@@ -105,7 +105,7 @@ describe('DuplicateOfferCell', () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
     const button = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement',
+      name: 'Créer une offre réservable pour un établissement scolaire',
     })
     await userEvent.click(button)
 
@@ -126,7 +126,7 @@ describe('DuplicateOfferCell', () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'true')
     renderDuplicateOfferCell()
     const button = screen.getByRole('button', {
-      name: 'Créer une offre réservable pour un établissement',
+      name: 'Créer une offre réservable pour un établissement scolaire',
     })
 
     jest.spyOn(createFromTemplateUtils, 'createOfferFromTemplate')

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
@@ -534,7 +534,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         renderOfferItem(props, store)
 
         const duplicateButton = screen.queryByRole('button', {
-          name: 'Créer une offre réservable pour un établissement',
+          name: 'Créer une offre réservable pour un établissement scolaire',
         })
 
         expect(duplicateButton).not.toBeInTheDocument()
@@ -547,14 +547,14 @@ describe('src | components | pages | Offers | OfferItem', () => {
         renderOfferItem(props, store)
 
         const duplicateButton = screen.getByRole('button', {
-          name: 'Créer une offre réservable pour un établissement',
+          name: 'Créer une offre réservable pour un établissement scolaire',
         })
         await userEvent.click(duplicateButton)
 
-        const modalTitle = screen.getByText(
+        const modalTitle = screen.getAllByText(
           'Créer une offre réservable pour un établissement scolaire'
         )
-        expect(modalTitle).toBeInTheDocument()
+        expect(modalTitle.length > 1).toBeTruthy()
       })
 
       it('should not display confirm dialog when clicking on duplicate button when user did see the modal', async () => {
@@ -565,11 +565,11 @@ describe('src | components | pages | Offers | OfferItem', () => {
         renderOfferItem(props, store)
 
         const duplicateButton = screen.getByRole('button', {
-          name: 'Créer une offre réservable pour un établissement',
+          name: 'Créer une offre réservable pour un établissement scolaire',
         })
         await userEvent.click(duplicateButton)
 
-        const modalTitle = screen.queryByText(
+        const modalTitle = screen.queryByLabelText(
           'Créer une offre réservable pour un établissement scolaire'
         )
         expect(modalTitle).not.toBeInTheDocument()

--- a/pro/src/ui-kit/Button/Button.stories.tsx
+++ b/pro/src/ui-kit/Button/Button.stories.tsx
@@ -98,7 +98,7 @@ LinkButtonWithIcon.args = {
 export const WithTooltip = Template.bind({})
 WithTooltip.args = {
   ...DefaultButton.args,
-  children: 'Créer une offre réservable pour un établissement',
+  children: 'Créer une offre réservable pour un établissement scolaire',
   Icon: PenIcon,
   iconPosition: IconPositionEnum.CENTER,
   variant: ButtonLink.variant.SECONDARY,

--- a/pro/src/ui-kit/Tooltip/Tooltip.module.scss
+++ b/pro/src/ui-kit/Tooltip/Tooltip.module.scss
@@ -12,7 +12,7 @@ $arrow-triangle-height: rem.torem(8px);
   align-self: start;
   color: white;
   padding: rem.torem(4px);
-  max-width: rem.torem(170px);
+  max-width: rem.torem(200px);
   border-radius: rem.torem(3px);
   position: absolute;
   text-align: center;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19406

## But de la pull request

Ne plus avoir le bouton focus lorsqu'on ferme la modal concernant la duplication d'une offre vitrine, changer le wording du tooltip

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`