### PR TITLE
(PC-19791)[API] fix: rename secrets.DEV_EMAIL_ALIAS_ADDRESS to env.END_TO_END_TESTS_EMAIL

### DIFF
--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -78,19 +78,19 @@ class ToDevSendinblueBackend(SendinblueBackend):
 
     def _get_whitelisted_recipients(self, recipient_list: Iterable) -> list:
         whitelisted_recipients = set()
-        alias_recipient_arr = settings.DEV_EMAIL_ALIAS_ADDRESS.split("@")
+        end_to_end_tests_email_address_arr = settings.END_TO_END_TESTS_EMAIL_ADDRESS.split("@")
         for recipient in recipient_list:
             # Imported test users are whitelisted (Internal users, Bug Bounty, audit, etc.)
             user = find_user_by_email(recipient)
-            qatest_recipient = (
-                len(alias_recipient_arr) == 2
-                and recipient.startswith(alias_recipient_arr[0])
-                and recipient.endswith(f"@{alias_recipient_arr[1]}")
+            e2e_recipient = (
+                len(end_to_end_tests_email_address_arr) == 2
+                and recipient.startswith(end_to_end_tests_email_address_arr[0])
+                and recipient.endswith(f"@{end_to_end_tests_email_address_arr[1]}")
             )
             staging_whitelisted_email_recipients = settings.IS_STAGING and (
-                recipient.endswith("@yeswehack.ninja") or qatest_recipient
+                recipient.endswith("@yeswehack.ninja") or e2e_recipient
             )
-            testing_whitelisted_email_recipients = settings.IS_TESTING and qatest_recipient
+            testing_whitelisted_email_recipients = settings.IS_TESTING and e2e_recipient
             if (
                 (user and user.has_test_role)
                 or recipient in settings.WHITELISTED_EMAIL_RECIPIENTS

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -143,7 +143,7 @@ MAX_API_KEY_PER_OFFERER = int(os.environ.get("MAX_API_KEY_PER_OFFERER", 5))
 ADMINISTRATION_EMAIL_ADDRESS = secrets_utils.get("ADMINISTRATION_EMAIL_ADDRESS")
 COMPLIANCE_EMAIL_ADDRESS = secrets_utils.get("COMPLIANCE_EMAIL_ADDRESS", "")
 DEV_EMAIL_ADDRESS = secrets_utils.get("DEV_EMAIL_ADDRESS")
-DEV_EMAIL_ALIAS_ADDRESS = secrets_utils.get("DEV_EMAIL_ALIAS_ADDRESS")
+END_TO_END_TESTS_EMAIL_ADDRESS = os.environ.get("END_TO_END_TESTS_EMAIL_ADDRESS", "")
 
 # When load testing, override `EMAIL_BACKEND` to avoid going over SendinBlue quota:
 #     EMAIL_BACKEND="pcapi.core.mails.backends.logger.LoggerBackend"

--- a/api/tests/core/mails/tests.py
+++ b/api/tests/core/mails/tests.py
@@ -156,7 +156,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert result.successful
 
     @override_settings(IS_STAGING=True)
-    @override_settings(DEV_EMAIL_ALIAS_ADDRESS="qa-test@passculture.app")
+    @override_settings(END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail_whitelisted_qa_staging(self, mock_send_transactional_email_secondary_task):
         recipient = "qa-test+123@passculture.app"
@@ -171,7 +171,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert result.successful
 
     @override_settings(IS_TESTING=True)
-    @override_settings(DEV_EMAIL_ALIAS_ADDRESS="qa-test@passculture.app")
+    @override_settings(END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail_whitelisted_qa_testing(
         self, mock_send_transactional_email_secondary_task, recipient="qa-test+123@passculture.app"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19791

## But de la pull request

Correction: déplacement des secrets de la variable `DEV_EMAIL_ALIAS_ADDRESS`  pour les envs

## Implémentation

NA

## Informations supplémentaires

Exemples: nettoyage de code

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
