### PR TITLE
(PC-18368)[BO] feat: Edit offerer tags from details page

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -516,11 +516,16 @@ def grant_user_offerer_access(offerer: models.Offerer, user: users_models.User) 
     return models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.VALIDATED)
 
 
+def _format_tags(tags: typing.Iterable[models.OffererTag]) -> str:
+    return ", ".join(sorted(tag.label for tag in tags))
+
+
 def update_offerer(  # type: ignore [no-untyped-def]
     offerer: models.Offerer,
     city=UNCHANGED,
     postal_code=UNCHANGED,
     address=UNCHANGED,
+    tags=UNCHANGED,
 ) -> dict[str, dict[str, str]]:
     modified_info = {}
 
@@ -536,6 +541,10 @@ def update_offerer(  # type: ignore [no-untyped-def]
         if offerer.address != address:
             modified_info["address"] = {"old_info": offerer.address, "new_info": address}
             offerer.address = address
+    if tags is not UNCHANGED:
+        if set(offerer.tags) != set(tags):
+            modified_info["tags"] = {"old_info": _format_tags(offerer.tags), "new_info": _format_tags(tags)}
+            offerer.tags = tags
 
     repository.save(offerer)
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -14,7 +14,11 @@ def _get_regions_choices() -> list[tuple]:
     return [(key, key) for key in get_all_regions()]
 
 
-def _get_tags_query() -> sa.orm.Query:
+def _get_all_tags_query() -> sa.orm.Query:
+    return offerers_models.OffererTag.query.order_by(offerers_models.OffererTag.label)
+
+
+def _get_validation_tags_query() -> sa.orm.Query:
     return (
         offerers_models.OffererTag.query.join(offerers_models.OffererTagCategoryMapping)
         .join(offerers_models.OffererTagCategory)
@@ -24,6 +28,9 @@ def _get_tags_query() -> sa.orm.Query:
 
 
 class EditOffererForm(FlaskForm):
+    tags = fields.PCQuerySelectMultipleField(
+        "Tags", query_factory=_get_all_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
+    )
     address = fields.PCOptStringField(
         "Adresse",
         validators=(wtforms.validators.Length(max=200, message="doit contenir moins de %(max)d caractères"),),
@@ -44,7 +51,7 @@ class OffererValidationListForm(FlaskForm):
     q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
     regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
-        "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
+        "Tags", query_factory=_get_validation_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )
     status = fields.PCSelectMultipleField("États", choices=utils.choices_from_enum(ValidationStatus))
     from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))
@@ -75,7 +82,7 @@ class UserOffererValidationListForm(FlaskForm):
     q = fields.PCOptSearchField("Nom de structure, SIREN, email, nom de compte pro")
     regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
-        "Tags", query_factory=_get_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
+        "Tags", query_factory=_get_validation_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
     )
     status = fields.PCSelectMultipleField(
         "États de la demande de rattachement", choices=utils.choices_from_enum(ValidationStatus)

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -73,6 +73,7 @@ def render_offerer_details(
             city=offerer.city,
             postal_code=offerer.postalCode,
             address=offerer.address,
+            tags=offerer.tags,
         )
 
     dst = url_for(".update_offerer", offerer_id=offerer.id)
@@ -194,6 +195,7 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
         city=form.city.data,
         postal_code=form.postal_code.data,
         address=form.address.data,
+        tags=form.tags.data,
     )
 
     if modified_info:

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
@@ -26,7 +26,7 @@
                         <p class="fw-bold">Informations modifiées</p>
                         {% for info_name, modified_info in action.extraData.get('modified_info', {}).items() %}
                             <p>
-                                <span class="text-decoration-underline">{{ info_name | i18n_column_name }}:</span>
+                                <span class="text-decoration-underline">{{ info_name | i18n_column_name }} :</span>
                                  {{ modified_info['old_info'] | escape }} =&gt; {{ modified_info['new_info'] | escape }}
                             </p>
                         {% endfor %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -32,7 +32,7 @@
                                         <div class="modal-header fs-5" id="edit-offerer-modal-label">
                                             Modifier les informations de la structure</div>
                                         <form action="{{ dst }}" method="POST">
-                                            <div class="modal-body">
+                                            <div class="modal-body pb-3">
                                                 <div class="form-group">
                                                     {% include "components/form_body.html" %}
                                                 </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18368

## But de la pull request

Permettre de gérer (ajouter ou retirer) les tags d'une structure depuis la page de détails d'une structure dans le backoffice v3.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
