### PR TITLE
(PC-19781)[BO] fix: offerer validation filters hidden when no results returned

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -85,7 +85,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="col g-0 bg-light overflow-auto">
+            <div class="col g-0 bg-light overflow-auto min-vh-100">
                 <div class="navbar text-bg-primary p-3" id="pc-header-top">
                     <button class="btn" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasScrolling"
                             aria-controls="offcanvasScrolling"><i class="bi bi-list text-white h4"></i></button>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19781

## But de la pull request

Corriger l'affichage des filtres dans les écrans de validation des structures et rattachements.
Ils se retrouvaient cachés lorsqu'il n'y a pas de résultat (_body_ trop court).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
