### PR TITLE
(PC-19809)[API] fix: Fix bug in _delete_dependent_pricings with FINANCE_OVERRIDE_PRICING_ORDERING_ON_PRICING_POINTS and multiple pricing points

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -535,12 +535,16 @@ def _delete_dependent_pricings(
         sqla.func.ROW(*_PRICE_BOOKINGS_ORDER_CLAUSE) > sqla.func.ROW(*_booking_comparison_tuple(booking)),
     )
 
-    pricings = pricings.with_entities(
-        models.Pricing.id,
-        models.Pricing.bookingId,
-        models.Pricing.status,
-        bookings_models.Booking.stockId,
-    ).all()
+    pricings = (
+        pricings.with_entities(
+            models.Pricing.id,
+            models.Pricing.bookingId,
+            models.Pricing.status,
+            bookings_models.Booking.stockId,
+        )
+        .distinct()
+        .all()
+    )
     if not pricings:
         return
     pricing_ids = {p.id for p in pricings}

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -640,6 +640,7 @@ def _delete_dependent_pricings(
                         "booking_being_priced_or_cancelled": booking.id,
                         "older_pricing": pricing.id,
                         "older_pricing_status": pricing.status,
+                        "pricing_point": pricing_point_id,
                     },
                 )
                 raise exceptions.NonCancellablePricingError()


### PR DESCRIPTION
If a venue had 2 pricing points and one of them was in
FINANCE_OVERRIDE_PRICING_ORDERING_ON_PRICING_POINTS, we processed each
pricing twice, which failed the second time. Using `distinct()` solves
that.