### PR TITLE
(BSR)[PRO] improve SonarCloud config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,7 +769,7 @@ jobs:
           steps:
             - run:
                 name: Coverage Unit Test PRO
-                command: yarn test:unit:ci --coverage --changedSince=master --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}'
+                command: yarn test:unit:ci --coverage --changedSince=master
                 working_directory: pro
       - unless:
           condition:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -55,7 +55,7 @@ then
         echo "✅ tests passing"
     fi
 
-    yarn test:unit:ci -- --coverage --findRelatedTests --coverageThreshold='{"global":{"statements":"100","branches":"100","functions":"100","lines":"100"}}' $STAGED_FILES
+    yarn test:unit:ci -- --coverage --findRelatedTests $STAGED_FILES
     JEST_EXIT_CODE=$?
 
     # check jest exit code

--- a/.github/workflows/check-folder-changes.yml
+++ b/.github/workflows/check-folder-changes.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: folder-check-changed-files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             ${{ inputs.folder }}/**

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check adage folder changes
     uses: ./.github/workflows/check-folder-changes.yml
     with:
-      folder: adage
+      folder: adage-front
 
   check-api-folder-changes:
     name: Check api folder changes

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -2,11 +2,12 @@ name: Test main
 run-name: Test main${{ github.ref == 'refs/heads/master' && ' and deploy to testing' || '' }}
 on:
   push:
+    branches:
+      - master
+      - "maint/**"
+  pull_request:
     branches-ignore:
       - docs
-      - integration
-      - production
-      - staging
 
 concurrency:
   # cancel previous workflow of the same branch except on master

--- a/pro/sonar-project.properties
+++ b/pro/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=pass-culture_pass-culture-main
 sonar.organization=pass-culture
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.coverage.exclusions=**/*.spec.*
+sonar.coverage.exclusions=**/*.spec.*,**/*.stories.*,**/apiClient/v1/**/*,**/apiClient/v2/**/*
+sonar.cpd.exclusions=**/apiClient/v1/**/*,**/apiClient/v2/**/*
 sonar.qualitygate.wait=true


### PR DESCRIPTION
Dans cette PR plusieurs améliorations : 

- lancement des pipelines sur l'event `pull_request` plutôt que `push`. [Pourquoi et les implications](https://passcultureteam.slack.com/archives/C01CTV65S3A/p1673617655110439)
- affichage du commentaire SonarCloud sur les PRs
- ignore du API client généré automatiquement dans le coverage/duplications
- suppression des checks coverage de Jest pour laisser la main à Sonar