### PR TITLE
(PC-19831)[API] fix: Use the right pricing point in `_delete_dependent_pricings()`

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -529,22 +529,21 @@ def _delete_dependent_pricings(
     )
 
     pricings = pricings.join(offerers_models.Venue.pricing_point_links)
+    pricings = pricings.filter(
+        offerers_models.VenuePricingPointLink.timespan.contains(bookings_models.Booking.dateUsed)
+    )
 
     pricings = pricings.filter(
         models.Pricing.valueDate.between(revenue_period_start, revenue_period_end),
         sqla.func.ROW(*_PRICE_BOOKINGS_ORDER_CLAUSE) > sqla.func.ROW(*_booking_comparison_tuple(booking)),
     )
 
-    pricings = (
-        pricings.with_entities(
-            models.Pricing.id,
-            models.Pricing.bookingId,
-            models.Pricing.status,
-            bookings_models.Booking.stockId,
-        )
-        .distinct()
-        .all()
-    )
+    pricings = pricings.with_entities(
+        models.Pricing.id,
+        models.Pricing.bookingId,
+        models.Pricing.status,
+        bookings_models.Booking.stockId,
+    ).all()
     if not pricings:
         return
     pricing_ids = {p.id for p in pricings}


### PR DESCRIPTION
When a venue was linked to more than one pricing point,
`_delete_dependent_pricings()` used an incorrect order to sort
bookings and their pricings, and ended up deleting pricings that it
should not have. We would then price another booking, delete the one
priced before, and do it again for each booking, effectively blocking
the pricing of all bookings of a pricing point.

With 2 pricing points, we selected the same booking twice: once with
the right VenuePricingPointLink row (the one for the right pricing
point that correspond to the used date of the booking), and another
row for the next pricing point, even though it was not the one to be
used to price the booking. The second row could wrongly match the
filter predicate that was supposed to look for *later* pricings. We
ended up wrongly deleting an _earlier_ pricing.

By filtering on the right pricing point (the one with which we want to
price the booking), we're sure to get a single row for each booking.
As a consequence, we don't need to call `distinct()` (which was added
in 5c79b3aee4d955412b83410cd6846c65c37ab203).

---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19831