### PR TITLE
(BSR)[PRO] style: replace ts-ignore by ts-expect-error

### DIFF
--- a/backoffice/src/libs/environment/tests/parser.test.ts
+++ b/backoffice/src/libs/environment/tests/parser.test.ts
@@ -21,12 +21,12 @@ describe('parseEnvVariables', () => {
 
   it('convert "true" in string to true in boolean', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore TODO: replace with useful boolean when available
+    // @ts-expect-error TODO: replace with useful boolean when available
     expect(convertedConfig.TEST_BOOLEAN).toBe(true)
   })
   it('convert "false" in string to false in boolean', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore TODO: replace with useful boolean when available
+    // @ts-expect-error TODO: replace with useful boolean when available
     const { TEST_BOOLEAN } = parseEnvVariables({
       ...mockedConfig,
       TEST_BOOLEAN: 'false',

--- a/backoffice/src/providers/authProvider.ts
+++ b/backoffice/src/providers/authProvider.ts
@@ -80,7 +80,7 @@ export const authProvider: AuthProvider = {
     const now = new Date()
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore 12356
+    // @ts-expect-error 12356
     if (now.getTime() > jwt.exp * 1000) {
       throw new Error(getErrorMessage('errors.token.expired'))
     }

--- a/backoffice/src/providers/dataProvider.ts
+++ b/backoffice/src/providers/dataProvider.ts
@@ -53,7 +53,7 @@ export const dataProvider: DataProvider = {
   },
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore TODO: (akarki) - reformat ${response} when API is ready for it
+  //@ts-expect-error TODO: (akarki) - reformat ${response} when API is ready for it
   async getOne(resource, params) {
     switch (resource) {
       case 'public_accounts': {

--- a/pro/.eslintrc.js
+++ b/pro/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/prefer-ts-expect-error': 'error',
     'no-console': 1,
     'import/order': [
       'warn',

--- a/pro/scripts/customRequestv1.ts
+++ b/pro/scripts/customRequestv1.ts
@@ -46,7 +46,6 @@ const base64 = (str: string): string => {
   try {
     return btoa(str)
   } catch (err) {
-    // @ts-ignore
     return Buffer.from(str).toString('base64')
   }
 }

--- a/pro/scripts/customRequestv2.ts
+++ b/pro/scripts/customRequestv2.ts
@@ -46,7 +46,6 @@ const base64 = (str: string): string => {
   try {
     return btoa(str)
   } catch (err) {
-    // @ts-ignore
     return Buffer.from(str).toString('base64')
   }
 }

--- a/pro/src/apiClient/v1/core/request.ts
+++ b/pro/src/apiClient/v1/core/request.ts
@@ -46,7 +46,6 @@ const base64 = (str: string): string => {
   try {
     return btoa(str)
   } catch (err) {
-    // @ts-ignore
     return Buffer.from(str).toString('base64')
   }
 }

--- a/pro/src/apiClient/v2/core/request.ts
+++ b/pro/src/apiClient/v2/core/request.ts
@@ -46,7 +46,6 @@ const base64 = (str: string): string => {
   try {
     return btoa(str)
   } catch (err) {
-    // @ts-ignore
     return Buffer.from(str).toString('base64')
   }
 }

--- a/pro/src/components/RouteLeavingGuard/RouteLeavingGuard.tsx
+++ b/pro/src/components/RouteLeavingGuard/RouteLeavingGuard.tsx
@@ -56,7 +56,7 @@ const RouteLeavingGuard = ({
   leftButton = { text: 'Annuler' },
 }: IRouteLeavingGuardProps): JSX.Element => {
   const [isModalVisible, setIsModalVisible] = useState(false)
-  // @ts-ignore next FIX ME no any
+  // FIX ME no any
   const [nextLocation, setNextLocation] = useState<any>('')
   const [isConfirmedNavigation, setIsConfirmedNavigation] = useState(false)
   const history = useHistory()

--- a/pro/src/core/OfferEducational/adapters/patchIsCollectiveOfferActiveAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/patchIsCollectiveOfferActiveAdapter.ts
@@ -32,7 +32,7 @@ export const patchIsCollectiveOfferActiveAdapter: PatchIsOfferActiveAdapter =
         message: `Une erreur est survenue lors de ${
           isActive ? 'l’activation' : 'la désactivation'
         } de votre offre. ${
-          // @ts-ignore
+          // @ts-expect-error
           error?.message ?? ''
         }`,
         payload: null,

--- a/pro/src/core/OfferEducational/adapters/patchIsTemplateOfferActiveAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/patchIsTemplateOfferActiveAdapter.ts
@@ -34,7 +34,7 @@ export const patchIsTemplateOfferActiveAdapter: PatchIsOfferActiveAdapter =
         message: `Une erreur est survenue lors de ${
           isActive ? 'l’activation' : 'la désactivation'
         } de votre offre. ${
-          // @ts-ignore
+          // @ts-expect-error
           error?.message ?? ''
         }`,
         payload: null,

--- a/pro/src/core/Offers/utils/computeOffersUrl.ts
+++ b/pro/src/core/Offers/utils/computeOffersUrl.ts
@@ -39,7 +39,7 @@ const computeOffersUrlForGivenAudience = (
   const newFilters: Partial<TSearchFilters> = {}
   keys.forEach(key => {
     if (searchFiltersParams[key] !== DEFAULT_SEARCH_FILTERS[key]) {
-      // @ts-ignore next FIX ME: newFilters['status'] is not string...
+      // @ts-expect-error next FIX ME: newFilters['status'] is not string...
       newFilters[key] = searchFiltersParams[key]
     }
   })

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -727,17 +727,17 @@ describe('components | BookingsRecap | Pro user', () => {
     const bookingsRecap = { pages: 6, bookingsRecap: [] }
     jest
       .spyOn(api, 'getBookingsPro')
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 1 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 2 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 3 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 4 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 5 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 6 })
     await renderBookingsRecap(store)
 
@@ -758,15 +758,15 @@ describe('components | BookingsRecap | Pro user', () => {
     const bookingsRecap = { pages: 5, bookingsRecap: [] }
     jest
       .spyOn(api, 'getBookingsPro')
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 1 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 2 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 3 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 4 })
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValueOnce({ ...bookingsRecap, page: 5 })
     await renderBookingsRecap(store)
 

--- a/pro/src/pages/CollectiveOfferEdition/adapters/patchCollectiveOfferTemplateAdapter.ts
+++ b/pro/src/pages/CollectiveOfferEdition/adapters/patchCollectiveOfferTemplateAdapter.ts
@@ -43,7 +43,7 @@ export const patchCollectiveOfferTemplateAdapter: patchCollectiveOfferTemplateAd
       return {
         isOk: false,
         message: `Une erreur est survenue lors de la modification de votre offre.${
-          // @ts-ignore
+          // @ts-expect-error
           error?.message ? ` ${error?.message}` : ''
         }`,
         payload: null,

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -148,7 +148,7 @@ describe('route CollectiveOffers', () => {
     offersRecap = [collectiveOfferFactory({ venue: proVenues[0] })]
     jest
       .spyOn(api, 'getCollectiveOffers')
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       .mockResolvedValue(offersRecap)
   })
 
@@ -199,7 +199,7 @@ describe('route CollectiveOffers', () => {
           // Given
           jest
             .spyOn(api, 'getCollectiveOffers')
-            // @ts-ignore FIX ME
+            // @ts-expect-error FIX ME
             .mockResolvedValueOnce(offersRecap)
             .mockResolvedValueOnce([])
           await renderOffers(store)
@@ -309,7 +309,7 @@ describe('route CollectiveOffers', () => {
           it('should reset and disable status filter when offerer filter is removed', async () => {
             // Given
             const offerer = { name: 'La structure', id: 'EF' }
-            // @ts-ignore FIX ME
+            // @ts-expect-error FIX ME
             jest.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
             const filters = {
               offererId: offerer.id,
@@ -342,7 +342,7 @@ describe('route CollectiveOffers', () => {
             // Given
             const { id: venueId } = proVenues[0]
             const offerer = { name: 'La structure', id: 'EF' }
-            // @ts-ignore FIX ME
+            // @ts-expect-error FIX ME
             jest.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
             const filters = {
               venueId: venueId,
@@ -553,7 +553,7 @@ describe('route CollectiveOffers', () => {
       )
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
       const { history } = await renderOffers(store)
       const nextPageIcon = screen.getByAltText('page suivante')
@@ -639,7 +639,7 @@ describe('route CollectiveOffers', () => {
       // Given
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
       jest.spyOn(api, 'getCategories').mockResolvedValue({
         categories: [
@@ -651,14 +651,14 @@ describe('route CollectiveOffers', () => {
           },
         ],
         subcategories: [
-          // @ts-ignore FIX ME
+          // @ts-expect-error FIX ME
           {
             id: 'test_sub_id_1',
             categoryId: 'test_id_1',
             isSelectable: true,
             canBeEducational: true,
           },
-          // @ts-ignore FIX ME
+          // @ts-expect-error FIX ME
           {
             id: 'test_sub_id_2',
             categoryId: 'test_id_2',
@@ -688,7 +688,7 @@ describe('route CollectiveOffers', () => {
     it('should have status value when user filters by status', async () => {
       // Given
       jest.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce([
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         collectiveOfferFactory(
           {
             id: 'KE',
@@ -716,7 +716,7 @@ describe('route CollectiveOffers', () => {
     it('should have status value be removed when user ask for all status', async () => {
       // Given
       jest.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce([
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         collectiveOfferFactory(
           {
             id: 'KE',
@@ -742,7 +742,7 @@ describe('route CollectiveOffers', () => {
     it('should have offerer filter when user filters by offerer', async () => {
       // Given
       const filters = { offererId: 'A4' }
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'getOfferer').mockResolvedValueOnce({
         name: 'La structure',
       })
@@ -756,7 +756,7 @@ describe('route CollectiveOffers', () => {
     it('should have offerer value be removed when user removes offerer filter', async () => {
       // Given
       const filters = { offererId: 'A4' }
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'getOfferer').mockResolvedValueOnce({
         name: 'La structure',
       })
@@ -775,7 +775,7 @@ describe('route CollectiveOffers', () => {
       // Given
 
       jest.spyOn(api, 'getCollectiveOffers').mockResolvedValue(
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         offersRecap
       )
       const { history } = await renderOffers(store)
@@ -808,7 +808,7 @@ describe('route CollectiveOffers', () => {
       const offers = Array.from({ length: 11 }, () => collectiveOfferFactory())
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offers)
       await renderOffers(store)
       const nextIcon = screen.getByAltText('page suivante')
@@ -825,7 +825,7 @@ describe('route CollectiveOffers', () => {
       const offers = Array.from({ length: 11 }, () => collectiveOfferFactory())
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offers)
       await renderOffers(store)
       const nextIcon = screen.getByAltText('page suivante')
@@ -853,7 +853,7 @@ describe('route CollectiveOffers', () => {
       // Given
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
       // When
       await renderOffers(store)
@@ -873,7 +873,7 @@ describe('route CollectiveOffers', () => {
         // Given
         jest
           .spyOn(api, 'getCollectiveOffers')
-          // @ts-ignore FIX ME
+          // @ts-expect-error FIX ME
           .mockResolvedValueOnce(offersRecap)
         // When
         await renderOffers(store)
@@ -885,7 +885,7 @@ describe('route CollectiveOffers', () => {
         // Given
         jest
           .spyOn(api, 'getCollectiveOffers')
-          // @ts-ignore FIX ME
+          // @ts-expect-error FIX ME
           .mockResolvedValueOnce(offersRecap)
         await renderOffers(store)
         const nextIcon = screen.getByAltText('page suivante')
@@ -906,7 +906,7 @@ describe('route CollectiveOffers', () => {
     it('when clicking on "afficher toutes les offres" when no offers are displayed', async () => {
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
         .mockResolvedValueOnce([])
       await renderOffers(store)
@@ -973,7 +973,7 @@ describe('route CollectiveOffers', () => {
     it('when clicking on "Réinitialiser les filtres"', async () => {
       jest
         .spyOn(api, 'getCollectiveOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
         .mockResolvedValueOnce([])
 

--- a/pro/src/pages/OffererStats/__specs__/OffererStats.spec.tsx
+++ b/pro/src/pages/OffererStats/__specs__/OffererStats.spec.tsx
@@ -99,7 +99,7 @@ describe('OffererStatsScreen', () => {
 
   it('should display error message if api call fail', async () => {
     const notifyError = jest.fn()
-    // @ts-ignore
+    // @ts-expect-error
     jest.spyOn(useNotification, 'default').mockImplementation(() => ({
       error: notifyError,
     }))

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderParamaters/AllocineProviderParameters.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderParamaters/AllocineProviderParameters.tsx
@@ -106,7 +106,7 @@ const AllocineProviderParameters = ({
       </Button>
       {isOpenedFormDialog && (
         <AllocineProviderFormDialog
-          // @ts-ignore
+          // @ts-expect-error
           initialValues={initialValues}
           onCancel={closeFormDialog}
           onConfirm={onConfirmDialog}

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/CinemaProviderForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/CinemaProviderForm.tsx
@@ -64,7 +64,7 @@ export const CinemaProviderForm = ({
                   className="cpf-is-duo"
                   label="Accepter les réservations DUO"
                   name="isDuo"
-                  // @ts-ignore
+                  // @ts-expect-error
                   value={formik.values.isDuo}
                 />
                 <span

--- a/pro/src/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateAllCollectiveOffersActiveStatusAdapter.spec.ts
+++ b/pro/src/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateAllCollectiveOffersActiveStatusAdapter.spec.ts
@@ -44,7 +44,6 @@ describe('updateAllCollectiveOffersActiveStatusAdapter', () => {
 
   it('should return an error when the update has failed', async () => {
     // given
-    // @ts-ignore
     jest
       .spyOn(api, 'patchAllCollectiveOffersActiveStatus')
       .mockRejectedValueOnce(

--- a/pro/src/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateCollectiveOffersActiveStatusAdapter.spec.ts
+++ b/pro/src/pages/Offers/Offers/ActionsBar/adapters/__specs__/updateCollectiveOffersActiveStatusAdapter.spec.ts
@@ -7,11 +7,11 @@ describe('updateCollectiveOffersActiveStatusAdapter', () => {
     // given
     jest
       .spyOn(api, 'patchCollectiveOffersActiveStatus')
-      // @ts-ignore
+      // @ts-expect-error
       .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
     jest
       .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
-      // @ts-ignore
+      // @ts-expect-error
       .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
 
     const response = await updateCollectiveOffersActiveStatusAdapter({
@@ -36,11 +36,11 @@ describe('updateCollectiveOffersActiveStatusAdapter', () => {
     // given
     jest
       .spyOn(api, 'patchCollectiveOffersActiveStatus')
-      // @ts-ignore
+      // @ts-expect-error
       .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
     jest
       .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
-      // @ts-ignore
+      // @ts-expect-error
       .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
 
     const response = await updateCollectiveOffersActiveStatusAdapter({
@@ -68,7 +68,7 @@ describe('updateCollectiveOffersActiveStatusAdapter', () => {
     })
     jest
       .spyOn(api, 'patchCollectiveOffersTemplateActiveStatus')
-      // @ts-ignore
+      // @ts-expect-error
       .mockResolvedValueOnce(new Response(new Blob(), { status: 204 }))
 
     // when

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -134,7 +134,7 @@ describe('route Offers', () => {
       },
     })
     offersRecap = [offerFactory({ venue: proVenues[0] })]
-    // @ts-ignore FIX ME
+    // @ts-expect-error FIX ME
     jest.spyOn(api, 'listOffers').mockResolvedValue(offersRecap)
   })
 
@@ -207,7 +207,7 @@ describe('route Offers', () => {
           // Given
           jest
             .spyOn(api, 'listOffers')
-            // @ts-ignore FIX ME
+            // @ts-expect-error FIX ME
             .mockResolvedValueOnce(offersRecap)
             .mockResolvedValueOnce([])
           await renderOffers(store)
@@ -315,7 +315,7 @@ describe('route Offers', () => {
           it('should reset and disable status filter when offerer filter is removed', async () => {
             // Given
             const offerer = { name: 'La structure', id: 'EF' }
-            // @ts-ignore FIX ME
+            // @ts-expect-error FIX ME
             jest.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
             const filters = {
               offererId: offerer.id,
@@ -347,7 +347,7 @@ describe('route Offers', () => {
             // Given
             const { id: venueId } = proVenues[0]
             const offerer = { name: 'La structure', id: 'EF' }
-            // @ts-ignore FIX ME
+            // @ts-expect-error FIX ME
             jest.spyOn(api, 'getOfferer').mockResolvedValue(offerer)
             const filters = {
               venueId: venueId,
@@ -548,7 +548,7 @@ describe('route Offers', () => {
     it('should have page value when page value is not first page', async () => {
       // Given
       const offersRecap = Array.from({ length: 11 }, () => offerFactory())
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
       const { history } = await renderOffers(store)
       const nextPageIcon = screen.getByAltText('page suivante')
@@ -663,7 +663,7 @@ describe('route Offers', () => {
       // Given
 
       jest.spyOn(api, 'listOffers').mockResolvedValueOnce([
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         offerFactory(
           {
             id: 'KE',
@@ -691,7 +691,7 @@ describe('route Offers', () => {
     it('should have status value be removed when user ask for all status', async () => {
       // Given
       jest.spyOn(api, 'listOffers').mockResolvedValueOnce([
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         offerFactory(
           {
             id: 'KE',
@@ -717,7 +717,7 @@ describe('route Offers', () => {
     it('should have offerer filter when user filters by offerer', async () => {
       // Given
       const filters = { offererId: 'A4' }
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'getOfferer').mockResolvedValueOnce({
         name: 'La structure',
       })
@@ -731,7 +731,7 @@ describe('route Offers', () => {
     it('should have offerer value be removed when user removes offerer filter', async () => {
       // Given
       const filters = { offererId: 'A4' }
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'getOfferer').mockResolvedValueOnce({
         name: 'La structure',
       })
@@ -778,7 +778,7 @@ describe('route Offers', () => {
   describe('page navigation', () => {
     it('should redirect to collective offers when user click on collective offer link', async () => {
       // Given
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'listOffers').mockResolvedValue(offersRecap)
       const { history } = await renderOffers(store)
       screen.getByText('Lancer la recherche')
@@ -796,7 +796,7 @@ describe('route Offers', () => {
     it('should display next page when clicking on right arrow', async () => {
       // Given
       const offers = Array.from({ length: 11 }, () => offerFactory())
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'listOffers').mockResolvedValueOnce(offers)
       await renderOffers(store)
       const nextIcon = screen.getByAltText('page suivante')
@@ -811,7 +811,7 @@ describe('route Offers', () => {
     it('should display previous page when clicking on left arrow', async () => {
       // Given
       const offers = Array.from({ length: 11 }, () => offerFactory())
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'listOffers').mockResolvedValueOnce(offers)
       await renderOffers(store)
       const nextIcon = screen.getByAltText('page suivante')
@@ -837,7 +837,7 @@ describe('route Offers', () => {
 
     it('should not be able to click on next arrow when being on the last page', async () => {
       // Given
-      // @ts-ignore FIX ME
+      // @ts-expect-error FIX ME
       jest.spyOn(api, 'listOffers').mockResolvedValueOnce(offersRecap)
       // When
       await renderOffers(store)
@@ -855,7 +855,7 @@ describe('route Offers', () => {
         // Given
         jest
           .spyOn(api, 'listOffers')
-          // @ts-ignore FIX ME
+          // @ts-expect-error FIX ME
           .mockResolvedValueOnce(offersRecap)
         // When
         await renderOffers(store)
@@ -867,7 +867,7 @@ describe('route Offers', () => {
         // Given
         jest
           .spyOn(api, 'listOffers')
-          // @ts-ignore FIX ME
+          // @ts-expect-error FIX ME
           .mockResolvedValueOnce(offersRecap)
         await renderOffers(store)
         const nextIcon = screen.getByAltText('page suivante')
@@ -888,7 +888,7 @@ describe('route Offers', () => {
     it('when clicking on "afficher toutes les offres" when no offers are displayed', async () => {
       jest
         .spyOn(api, 'listOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
         .mockResolvedValueOnce([])
       await renderOffers(store)
@@ -952,7 +952,7 @@ describe('route Offers', () => {
     it('when clicking on "Réinitialiser les filtres"', async () => {
       jest
         .spyOn(api, 'listOffers')
-        // @ts-ignore FIX ME
+        // @ts-expect-error FIX ME
         .mockResolvedValueOnce(offersRecap)
         .mockResolvedValueOnce([])
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
@@ -125,7 +125,7 @@ describe('components | BookingsRecapTable', () => {
 
   it('should render the expected table with max given number of hits per page', () => {
     // Given
-    // @ts-ignore
+    // @ts-expect-error
     // eslint-disable-next-line
     constants.NB_BOOKINGS_PER_PAGE = 1
     const bookingsRecap = [bookingRecapFactory(), bookingRecapFactory()]
@@ -154,7 +154,7 @@ describe('components | BookingsRecapTable', () => {
 
   it('should render the expected table for collective audience', () => {
     // Given
-    // @ts-ignore
+    // @ts-expect-error
     // eslint-disable-next-line
     constants.NB_BOOKINGS_PER_PAGE = 1
     const bookingRecap = bookingRecapFactory(bookingInstitutionCustom)

--- a/pro/src/screens/Bookings/PreFilters/PreFilters.tsx
+++ b/pro/src/screens/Bookings/PreFilters/PreFilters.tsx
@@ -79,9 +79,9 @@ const PreFilters = ({
         DEFAULT_PRE_FILTERS[key] instanceof Date
       ) {
         if (
-          // @ts-ignore
+          // @ts-expect-error
           selectedPreFilters[key].getTime() !==
-          // @ts-ignore
+          // @ts-expect-error
           DEFAULT_PRE_FILTERS[key].getTime()
         ) {
           hasFilters = true

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -164,7 +164,7 @@ describe('CollectiveOfferVisibility', () => {
       .fn()
       .mockResolvedValue({ isOk: false, message: 'Ooops' })
     const notifyError = jest.fn()
-    // @ts-ignore
+    // @ts-expect-error
     jest.spyOn(useNotification, 'default').mockImplementation(() => ({
       error: notifyError,
     }))

--- a/pro/src/screens/OfferIndividual/StocksThing/ActivationCodeFormDialog/ActivationCodeFormDialog.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/ActivationCodeFormDialog/ActivationCodeFormDialog.tsx
@@ -37,7 +37,7 @@ const ActivationCodeFormDialog = ({
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       setIsFileInputDisabled(true)
 
-      // @ts-ignore next-line
+      // @ts-expect-error next-line
       const currentFile = e.currentTarget.files[0]
       if (currentFile == null) {
         setIsFileInputDisabled(false)

--- a/pro/src/screens/OfferIndividual/Summary/StockSection/StockSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockSection/StockSection.tsx
@@ -54,7 +54,7 @@ const StockSection = ({
 
   const stockWarningText = hasNoStock
     ? 'Vous n’avez aucun stock renseigné.'
-    : // @ts-ignore Other OfferStatus make stockWarningText be undefined wich is expected
+    : // @ts-expect-error Other OfferStatus make stockWarningText be undefined wich is expected
       {
         [OfferStatus.SOLD_OUT]: 'Votre stock est épuisé.',
         [OfferStatus.EXPIRED]: 'Votre stock est expiré.',


### PR DESCRIPTION
`ts-expect-error` est meilleur que `ts-ignore` car si l'erreur TS originale disparait, `ts-expect-error` causera une erreur alors que `ts-ignore` restera indéfiniment (et prend le risque de masquer une 2nde erreur TS qui surviendrait au même endroit)