### PR TITLE
(PC-19839)[BO] feat: Search user offerer to validate by postal code, department code or city

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -79,7 +79,7 @@ class UserOffererValidationListForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Nom de structure, SIREN, email, nom de compte pro")
+    q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
     regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags", query_factory=_get_validation_tags_query, get_pk=lambda tag: tag.id, get_label=lambda tag: tag.label
@@ -104,8 +104,10 @@ class UserOffererValidationListForm(FlaskForm):
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data:
             q.data = q.data.strip()
-            if q.data.isnumeric() and len(q.data) != 9:
-                raise wtforms.validators.ValidationError("Le nombre de chiffres ne correspond pas à un SIREN")
+            if q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
+                raise wtforms.validators.ValidationError(
+                    "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
+                )
         return q
 
 

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -420,26 +420,39 @@ def user_offerer_to_be_validated_fixture(offerer_tags):
     top_tag, collec_tag, public_tag = offerer_tags
 
     no_tag = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="a@example.com", offerer__validationStatus=ValidationStatus.NEW, offerer__postalCode="97200"
+        user__email="a@example.com",
+        offerer__validationStatus=ValidationStatus.NEW,
+        offerer__postalCode="97200",
+        offerer__city="Fort-de-France",
     )
     top = offerers_factories.NotValidatedUserOffererFactory(
         user__email="b@example.com",
         offerer__validationStatus=ValidationStatus.NEW,
         validationStatus=ValidationStatus.PENDING,
         offerer__postalCode="97100",
+        offerer__city="Basse-Terre",
     )
-    collec = offerers_factories.NotValidatedUserOffererFactory(user__email="c@example.com", offerer__postalCode="29200")
+    collec = offerers_factories.NotValidatedUserOffererFactory(
+        user__email="c@example.com", offerer__postalCode="29200", offerer__city="Brest"
+    )
     public = offerers_factories.NotValidatedUserOffererFactory(
         user__email="d@example.com",
         offerer__validationStatus=ValidationStatus.PENDING,
         validationStatus=ValidationStatus.PENDING,
         offerer__postalCode="97290",
+        offerer__city="Le Marin",
     )
     top_collec = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="e@example.com", offerer__validationStatus=ValidationStatus.PENDING, offerer__postalCode="06400"
+        user__email="e@example.com",
+        offerer__validationStatus=ValidationStatus.PENDING,
+        offerer__postalCode="06400",
+        offerer__city="Cannes",
     )
     top_public = offerers_factories.NotValidatedUserOffererFactory(
-        user__email="f@example.com", validationStatus=ValidationStatus.PENDING, offerer__postalCode="97400"
+        user__email="f@example.com",
+        validationStatus=ValidationStatus.PENDING,
+        offerer__postalCode="97400",
+        offerer__city="Saint-Denis",
     )
 
     for user_offerer in (top, top_collec, top_public):

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -1543,6 +1543,42 @@ class ListUserOffererToValidateTest:
         rows = html_parser.extract_table_rows(response.data)
         assert [int(row["ID Compte pro"]) for row in rows] == [uo.user.id for uo in (user_offerer_3, user_offerer_2)]
 
+    def test_list_search_by_postal_code(self, authenticated_client, user_offerer_to_be_validated):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate", q="97100")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert {row["Email Compte pro"] for row in rows} == {"b@example.com"}
+
+    def test_list_search_by_department_code(self, authenticated_client, user_offerer_to_be_validated):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate", q="972")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert {row["Email Compte pro"] for row in rows} == {"a@example.com", "d@example.com"}
+
+    def test_list_search_by_city(self, authenticated_client, user_offerer_to_be_validated):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for("backoffice_v3_web.validate_offerer.list_offerers_attachments_to_validate", q="Fort De France")
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert {row["Email Compte pro"] for row in rows} == {"a@example.com"}
+
     def test_list_search_by_email(self, authenticated_client, user_offerer_to_be_validated):
         # when
         with assert_no_duplicated_queries():


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19839

## But de la pull request

Permettre la recherche par code postal, code de département ou ville dans les rattachements à valider.
Cela était déjà possible pour les structures à valider.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
