### PR TITLE
(PC-19823)[PRO] fix: warning when modifying booked event

### DIFF
--- a/pro/src/components/StockEventForm/stockEventFactory.ts
+++ b/pro/src/components/StockEventForm/stockEventFactory.ts
@@ -1,0 +1,14 @@
+import { IStockEventFormValues } from './types'
+
+export const stockEventFactory = (): IStockEventFormValues => ({
+  stockId: 'AA',
+  remainingQuantity: '10',
+  bookingsQuantity: '1',
+  quantity: 11,
+  bookingLimitDatetime: new Date('2022-12-29T00:00:00Z'),
+  price: 66.6,
+  beginningDate: new Date('2022-12-29T00:00:00Z'),
+  beginningTime: new Date('2022-12-29T00:00:00Z'),
+  isDeletable: true,
+  readOnlyFields: [],
+})

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -480,7 +480,7 @@ describe('screens:StocksEvent:Edition', () => {
     expect(screen.queryByText('Ajouter une date')).toBeDisabled()
   })
 
-  it('should allow user to edit quantity and booking limit date for a cinema synchronized offer', async () => {
+  it('should allow user to edit quantity for a cinema synchronized offer', async () => {
     jest
       .spyOn(api, 'upsertStocks')
       .mockResolvedValue({ stocks: [{ id: 'STOCK_ID' } as StockResponseModel] })
@@ -498,10 +498,6 @@ describe('screens:StocksEvent:Edition', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
     )
-    expect(
-      await screen.getByText('Des réservations sont en cours pour cette offre')
-    ).toBeInTheDocument()
-    await userEvent.click(screen.getByText('Confirmer les modifications'))
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/hasChangesOnStockWithBookings.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/hasChangesOnStockWithBookings.spec.tsx
@@ -1,0 +1,110 @@
+import '@testing-library/jest-dom'
+
+import { IStockEventFormValues } from 'components/StockEventForm'
+import { stockEventFactory } from 'components/StockEventForm/stockEventFactory'
+
+import { hasChangesOnStockWithBookings } from '../StocksEvent'
+
+describe('hasChangesOnStockWithBookings', () => {
+  it('should return false when no booking quantity', () => {
+    const values = { stocks: [] }
+    const initialValues = { stocks: [] }
+
+    const result = hasChangesOnStockWithBookings(values, initialValues)
+    expect(result).toBe(false)
+  })
+
+  it('should return false when booking quantity is 0', () => {
+    const values = {
+      stocks: [
+        { stockId: 'AA', bookingQuantity: 0 },
+      ] as unknown as IStockEventFormValues[],
+    }
+    const initialValues = { stocks: [] }
+
+    const result = hasChangesOnStockWithBookings(values, initialValues)
+    expect(result).toBe(false)
+  })
+
+  it('should return true when detecting change on price', () => {
+    const values = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+        },
+      ],
+    }
+    const initialValues = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+          price: 42,
+        },
+      ],
+    }
+
+    const result = hasChangesOnStockWithBookings(values, initialValues)
+    expect(result).toBe(true)
+  })
+
+  it('should return true when detecting change on beginningDate', () => {
+    const values = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+        },
+      ],
+    }
+    const initialValues = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+          beginningDate: new Date(),
+        },
+      ],
+    }
+
+    const result = hasChangesOnStockWithBookings(values, initialValues)
+    expect(result).toBe(true)
+  })
+
+  it('should return true when detecting change on beginningTime', () => {
+    const values = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+        },
+      ],
+    }
+    const initialValues = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+          beginningTime: new Date(),
+        },
+      ],
+    }
+    const result = hasChangesOnStockWithBookings(values, initialValues)
+    expect(result).toBe(true)
+  })
+
+  it('should return false when detecting change on other field', () => {
+    const values = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+        },
+      ],
+    }
+    const initialValues = {
+      stocks: [
+        {
+          ...stockEventFactory(),
+          bookingQuantity: 42,
+        },
+      ],
+    }
+    const result = hasChangesOnStockWithBookings(values, initialValues)
+    expect(result).toBe(true)
+  })
+})

--- a/pro/src/ui-kit/Button/Button.tsx
+++ b/pro/src/ui-kit/Button/Button.tsx
@@ -48,7 +48,7 @@ const Button = ({
       ref={innerRef}
       type={type}
       data-testid={testId}
-      {...(hasTooltip ? { 'aria-describedBy': tooltipId } : {})}
+      {...(hasTooltip ? { 'aria-describedby': tooltipId } : {})}
       {...buttonAttrs}
     >
       {Icon && iconPosition !== IconPositionEnum.RIGHT && (

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -90,7 +90,7 @@ const ButtonLink = ({
     : {}
 
   const tooltipId = uniqId()
-  const tooltipProps = hasTooltip ? { 'aria-describedBy': tooltipId } : {}
+  const tooltipProps = hasTooltip ? { 'aria-describedby': tooltipId } : {}
 
   body = isExternal ? (
     <a


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19823

## But de la pull request

_La modale attention stock déjà réservé lors d'une modif de stock ne s'affichait pas au bon moment
2 pb : 
- un mauvais rebase a dupliqué du code qu'il ne fallait pas
- on utilisait touched de formik mais en le mettant dans le submit tous les champs sont automatiquement passé à true (on regarde maintenant si nos champs sont différents) 


