### PR TITLE
(PC-19903)[API] feat: have integration's user authentication work as in testing

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/auth.py
+++ b/api/src/pcapi/routes/backoffice_v3/auth.py
@@ -61,7 +61,7 @@ def authorize():  # type: ignore
     if user and not user.isActive:
         return werkzeug.exceptions.Forbidden()
 
-    if settings.IS_TESTING or settings.IS_DEV:
+    if settings.IS_TESTING or settings.IS_DEV or settings.IS_INTEGRATION:
         if not user:
             user = create_local_admin_user(
                 email=google_user["email"],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19903

## But de la pull request

En `integration`, le code actuel cherche à obtenir les groupes dans le workspace correspondant mais ne fonctionne pas. Comme ces groupes ne sont pas nécessaires à `integration`, on modifie la configuration par une similaire à `testing` pour l'authentification.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
