### PR TITLE
(PC-19892)[PRO] feat: add show all booking button when defaultBooking…

### DIFF
--- a/pro/src/screens/Bookings/Bookings.tsx
+++ b/pro/src/screens/Bookings/Bookings.tsx
@@ -92,6 +92,11 @@ const Bookings = <
     })
   }, [setWereBookingsRequested])
 
+  const resetAndApplyPreFilters = useCallback(() => {
+    resetPreFilters()
+    updateUrl(appliedPreFilters)
+  }, [appliedPreFilters])
+
   const applyPreFilters = (filters: TPreFilters) => {
     setAppliedPreFilters(filters)
     loadBookingsRecap(filters)
@@ -283,6 +288,7 @@ const Bookings = <
             locationState={locationState}
             audience={audience}
             reloadBookings={reloadBookings}
+            resetBookings={resetAndApplyPreFilters}
           />
         ) : isTableLoading ? (
           <Spinner />

--- a/pro/src/screens/Bookings/BookingsRecapTable/BookingsRecapTable.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/BookingsRecapTable.tsx
@@ -41,6 +41,7 @@ interface IBookingsRecapTableProps<
   }
   audience: Audience
   reloadBookings: () => void
+  resetBookings: () => void
 }
 interface IRowExpandedContext {
   rowToExpandId: string
@@ -60,6 +61,7 @@ const BookingsRecapTable = <
   locationState,
   audience,
   reloadBookings,
+  resetBookings,
 }: IBookingsRecapTableProps<T>) => {
   const [filteredBookings, setFilteredBookings] = useState(bookingsRecap)
   const [currentPage, setCurrentPage] = useState(FIRST_PAGE_INDEX)
@@ -191,6 +193,8 @@ const BookingsRecapTable = <
           <Header
             bookingsRecapFilteredLength={filteredBookings.length}
             isLoading={isLoading}
+            queryBookingId={defaultBookingId}
+            resetBookings={resetBookings}
           />
           <RowExpandedContext.Provider
             value={{

--- a/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
@@ -41,6 +41,14 @@ describe('components | BookingsRecapTable', () => {
   let store: Store<Partial<RootState>>
   type Props = ComponentProps<typeof BookingsRecapTable>
 
+  const defaultProps: Props = {
+    isLoading: false,
+    audience: Audience.INDIVIDUAL,
+    reloadBookings: jest.fn(),
+    resetBookings: jest.fn(),
+    bookingsRecap: [],
+  }
+
   const renderBookingRecap = (props: Props) => {
     return render(
       <MemoryRouter initialEntries={['/reservations/collectives']}>
@@ -50,7 +58,6 @@ describe('components | BookingsRecapTable', () => {
       </MemoryRouter>
     )
   }
-
   beforeEach(() => {
     store = configureTestStore({})
   })
@@ -61,10 +68,8 @@ describe('components | BookingsRecapTable', () => {
       bookingRecapFactory(),
     ]
     const props: Props = {
+      ...defaultProps,
       bookingsRecap: bookingsRecap,
-      isLoading: false,
-      audience: Audience.INDIVIDUAL,
-      reloadBookings: jest.fn(),
     }
     renderBookingRecap(props)
 
@@ -97,13 +102,11 @@ describe('components | BookingsRecapTable', () => {
   it('should filter bookings on render', () => {
     // Given
     const props: Props = {
+      ...defaultProps,
       bookingsRecap: [bookingRecapFactory()],
-      isLoading: false,
       locationState: {
         statuses: ['booked', 'cancelled'],
       },
-      audience: Audience.INDIVIDUAL,
-      reloadBookings: jest.fn(),
     }
     jest.spyOn(filterBookingsRecap, 'default').mockReturnValue([])
 
@@ -131,10 +134,8 @@ describe('components | BookingsRecapTable', () => {
     const bookingsRecap = [bookingRecapFactory(), bookingRecapFactory()]
     jest.spyOn(filterBookingsRecap, 'default').mockReturnValue(bookingsRecap)
     const props: Props = {
+      ...defaultProps,
       bookingsRecap: bookingsRecap,
-      isLoading: false,
-      audience: Audience.INDIVIDUAL,
-      reloadBookings: jest.fn(),
     }
 
     // When
@@ -160,10 +161,9 @@ describe('components | BookingsRecapTable', () => {
     const bookingRecap = bookingRecapFactory(bookingInstitutionCustom)
     jest.spyOn(filterBookingsRecap, 'default').mockReturnValue([bookingRecap])
     const props: Props = {
-      bookingsRecap: [bookingRecap],
-      isLoading: false,
+      ...defaultProps,
       audience: Audience.COLLECTIVE,
-      reloadBookings: jest.fn(),
+      bookingsRecap: [bookingRecap],
     }
 
     // When
@@ -184,10 +184,8 @@ describe('components | BookingsRecapTable', () => {
   it('should not render a Header component when there is no filtered booking', async () => {
     // given
     const props: Props = {
+      ...defaultProps,
       bookingsRecap: [],
-      audience: Audience.INDIVIDUAL,
-      isLoading: false,
-      reloadBookings: jest.fn(),
     }
 
     // When
@@ -202,10 +200,8 @@ describe('components | BookingsRecapTable', () => {
   it('should reset filters when clicking on "afficher toutes les réservations"', async () => {
     // given
     const props: Props = {
-      audience: Audience.INDIVIDUAL,
+      ...defaultProps,
       bookingsRecap: [bookingRecapFactory()],
-      isLoading: false,
-      reloadBookings: jest.fn(),
     }
 
     renderBookingRecap(props)
@@ -227,12 +223,7 @@ describe('components | BookingsRecapTable', () => {
   it('should not show pagination when applying filters with no result', async () => {
     // given
     const bookingsRecap = [bookingRecapFactory(), bookingRecapFactory()]
-    const props: Props = {
-      audience: Audience.INDIVIDUAL,
-      bookingsRecap: bookingsRecap,
-      isLoading: false,
-      reloadBookings: jest.fn(),
-    }
+    const props: Props = { ...defaultProps, bookingsRecap: bookingsRecap }
     renderBookingRecap(props)
 
     await userEvent.click(screen.getAllByRole('button')[1])
@@ -251,10 +242,8 @@ describe('components | BookingsRecapTable', () => {
     spyOnFilterBookingsRecap.mockReturnValue(bookingsRecap)
 
     const props: Props = {
-      audience: Audience.INDIVIDUAL,
+      ...defaultProps,
       bookingsRecap: bookingsRecap,
-      isLoading: false,
-      reloadBookings: jest.fn(),
     }
 
     // When

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Header/Header.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Header/Header.tsx
@@ -1,13 +1,23 @@
 import React from 'react'
 
+import { ReactComponent as ResetIcon } from 'icons/reset.svg'
+import { Button } from 'ui-kit'
+import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
 import { pluralize } from 'utils/pluralize'
 
 export interface HeaderProps {
   bookingsRecapFilteredLength: number
   isLoading: boolean
+  queryBookingId?: string
+  resetBookings: () => void
 }
 
-const Header = ({ bookingsRecapFilteredLength, isLoading }: HeaderProps) => {
+const Header = ({
+  bookingsRecapFilteredLength,
+  isLoading,
+  queryBookingId,
+  resetBookings,
+}: HeaderProps) => {
   if (isLoading) {
     return (
       <div className="bookings-header-loading">
@@ -17,9 +27,20 @@ const Header = ({ bookingsRecapFilteredLength, isLoading }: HeaderProps) => {
   } else {
     return (
       <div className="bookings-header">
-        <span className="bookings-header-number">
-          {pluralize(bookingsRecapFilteredLength, 'réservation')}
-        </span>
+        {!queryBookingId ? (
+          <span className="bookings-header-number">
+            {pluralize(bookingsRecapFilteredLength, 'réservation')}
+          </span>
+        ) : (
+          <Button
+            variant={ButtonVariant.TERNARY}
+            onClick={resetBookings}
+            Icon={ResetIcon}
+            iconPosition={IconPositionEnum.LEFT}
+          >
+            Voir toutes les réservations
+          </Button>
+        )}
       </div>
     )
   }

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Header/__specs__/Header.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Header/__specs__/Header.spec.tsx
@@ -7,16 +7,16 @@ import Header, { HeaderProps } from '../Header'
 
 const renderHeader = (props: HeaderProps) => render(<Header {...props} />)
 
+const defaultProps: HeaderProps = {
+  bookingsRecapFilteredLength: 1,
+  isLoading: false,
+  resetBookings: jest.fn(),
+}
+
 describe("bookings recap table's header", () => {
   it('should display the appropriate message when there is one booking', () => {
-    // Given
-    const props = {
-      bookingsRecapFilteredLength: 1,
-      isLoading: false,
-    }
-
     // When
-    renderHeader(props)
+    renderHeader(defaultProps)
 
     // Then
     expect(screen.queryByText('1 réservation')).toBeInTheDocument()
@@ -25,8 +25,8 @@ describe("bookings recap table's header", () => {
   it('should display the appropriate message when there is several booking', () => {
     // Given
     const props = {
+      ...defaultProps,
       bookingsRecapFilteredLength: 2,
-      isLoading: false,
     }
 
     // When
@@ -39,6 +39,7 @@ describe("bookings recap table's header", () => {
   it('should only display a specific message when data are still loading', () => {
     // Given
     const props = {
+      ...defaultProps,
       bookingsRecapFilteredLength: 0,
       isLoading: true,
     }
@@ -49,6 +50,20 @@ describe("bookings recap table's header", () => {
     // Then
     expect(
       screen.getByText('Chargement des réservations...')
+    ).toBeInTheDocument()
+  })
+
+  it('should display show all booking button when default booking id provided', () => {
+    // Given
+    const props = { ...defaultProps, queryBookingId: '1' }
+
+    // When
+    renderHeader(props)
+
+    // Then
+    expect(screen.queryByText('1 réservation')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Voir toutes les réservations' })
     ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
…Id is provided for collectiveBookings

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19892

## But de la pull request

Ajouter un bouton 'Voir toutes les réservations' quand on accède aux détails d'une réservation depuis la page offer (= bookingId présent dans l'url). 
Au clic sur ce bouton on réinitialise les filtres et on affiche les réservations par défaut.

## Screenshot 

<img width="853" alt="Capture d’écran 2023-01-18 à 10 22 44" src="https://user-images.githubusercontent.com/71768799/213152024-cf155919-5b9a-49aa-9ab5-60d159b0e203.png">


