### PR TITLE
Pc 19897 eac fix venue displayed in collective practical informations

### DIFF
--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferDetails.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferDetails.tsx
@@ -53,7 +53,6 @@ const OfferDetails = ({
 }): JSX.Element => {
   const {
     durationMinutes,
-    venue,
     audioDisabilityCompliant,
     mentalDisabilityCompliant,
     motorDisabilityCompliant,
@@ -93,10 +92,11 @@ const OfferDetails = ({
       {educationalPriceDetail && (
         <OfferSection title="Détails">{educationalPriceDetail}</OfferSection>
       )}
-
-      <OfferSection title="Adresse où se déroulera l’évènement">
-        <OfferVenue offerVenue={offerVenue} venue={venue} />
-      </OfferSection>
+      {offerVenue && (
+        <OfferSection title="Adresse où se déroulera l’évènement">
+          <OfferVenue offerVenue={offerVenue} />
+        </OfferSection>
+      )}
 
       {interventionArea?.length > 0 && (
         <OfferSection title="Zone de Mobilité">

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/OfferVenue.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/OfferVenue.tsx
@@ -1,30 +1,24 @@
 import React from 'react'
 
-import { OfferAddressType, OfferVenueResponse } from 'apiClient'
+import { CollectiveOfferOfferVenue, OfferAddressType } from 'apiClient'
 
 interface IOfferVenue {
-  offerVenue?: {
-    addressType: OfferAddressType
-    otherAddress: string
-    venueId: string
-  }
-  venue: OfferVenueResponse
+  offerVenue: CollectiveOfferOfferVenue
 }
 
-const OfferVenue = ({ offerVenue, venue }: IOfferVenue): JSX.Element => {
-  if (offerVenue) {
-    if (offerVenue.addressType === OfferAddressType.OTHER) {
-      return <div>{offerVenue.otherAddress}</div>
-    } else if (offerVenue.addressType === OfferAddressType.SCHOOL) {
-      return <div>Dans l’établissement scolaire</div>
-    }
+const OfferVenue = ({ offerVenue }: IOfferVenue): JSX.Element => {
+  if (offerVenue.addressType === OfferAddressType.OTHER) {
+    return <div>{offerVenue.otherAddress}</div>
+  }
+  if (offerVenue.addressType === OfferAddressType.SCHOOL) {
+    return <div>Dans l’établissement scolaire</div>
   }
 
   return (
     <div>
-      <div>{venue.name ?? venue.publicName}</div>
+      <div>{offerVenue.name ?? offerVenue.publicName}</div>
       <div>
-        {venue.address}, {venue.postalCode} {venue.city}
+        {offerVenue.address}, {offerVenue.postalCode} {offerVenue.city}
       </div>
     </div>
   )

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/CollectiveOfferPracticalInformation.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/CollectiveOfferPracticalInformation.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 
 import { SummaryLayout } from 'components/SummaryLayout'
 import { CollectiveOffer, CollectiveOfferTemplate } from 'core/OfferEducational'
+import { useGetVenue } from 'core/Venue'
+import useNotification from 'hooks/useNotification'
+import Spinner from 'ui-kit/Spinner/Spinner'
 
 import { DEFAULT_RECAP_VALUE } from '../constants'
 import { formatOfferEventAddress } from '../utils/formatOfferEventAddress'
@@ -13,11 +16,25 @@ interface ICollectiveOfferPracticalInformationSectionProps {
 const CollectiveOfferPracticalInformationSection = ({
   offer,
 }: ICollectiveOfferPracticalInformationSectionProps) => {
+  const notify = useNotification()
+  const {
+    error,
+    isLoading,
+    data: venue,
+  } = useGetVenue(offer.offerVenue.venueId)
+  if (isLoading) {
+    return <Spinner />
+  }
+  if (error) {
+    notify.error(error.message)
+    return null
+  }
+
   return (
     <SummaryLayout.SubSection title="Informations pratiques">
       <SummaryLayout.Row
         title="Adresse où se déroulera l’évènement"
-        description={formatOfferEventAddress(offer.offerVenue, offer.venue)}
+        description={formatOfferEventAddress(offer.offerVenue, venue)}
       />
       {offer.isTemplate && (
         <SummaryLayout.Row

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/__specs__/CollectiveOfferPracticalInformation.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/__specs__/CollectiveOfferPracticalInformation.spec.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from '@testing-library/react'
-import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import React from 'react'
+import { Provider } from 'react-redux'
 
+import { api } from 'apiClient/api'
+import { GetVenueResponseModel } from 'apiClient/v1'
+import { configureTestStore } from 'store/testUtils'
 import {
   collectiveOfferFactory,
   collectiveOfferTemplateFactory,
@@ -10,31 +14,48 @@ import {
 
 import CollectiveOfferPracticalInformation from '..'
 
-describe('CollectiveOfferPracticalInformation', () => {
-  it('when offer is template', () => {
-    render(
-      <CollectiveOfferPracticalInformation
-        offer={collectiveOfferTemplateFactory({
-          educationalPriceDetail: 'Le détail du prix',
-        })}
-      />
-    )
+jest.mock('apiClient/api', () => ({
+  api: {
+    getVenue: jest.fn(),
+  },
+}))
 
+describe('CollectiveOfferPracticalInformation', () => {
+  it('when offer is template', async () => {
+    jest.spyOn(api, 'getVenue').mockResolvedValue({
+      id: 'AE',
+    } as GetVenueResponseModel)
+    const store = configureTestStore()
+    render(
+      <Provider store={store}>
+        <CollectiveOfferPracticalInformation
+          offer={collectiveOfferTemplateFactory({
+            educationalPriceDetail: 'Le détail du prix',
+          })}
+        />
+      </Provider>
+    )
+    await waitFor(() => {
+      expect(api.getVenue).toHaveBeenCalledTimes(1)
+    })
     const priceDetail = screen.getByText(/Informations sur le prix/)
     expect(priceDetail).toBeInTheDocument()
     expect(screen.getByText('Le détail du prix')).toBeInTheDocument()
   })
 
   it('when offer is not template', () => {
+    const store = configureTestStore()
     render(
-      <CollectiveOfferPracticalInformation
-        offer={collectiveOfferFactory(
-          {},
-          collectiveStockFactory({
-            educationalPriceDetail: 'Le détail du prix',
-          })
-        )}
-      />
+      <Provider store={store}>
+        <CollectiveOfferPracticalInformation
+          offer={collectiveOfferFactory(
+            {},
+            collectiveStockFactory({
+              educationalPriceDetail: 'Le détail du prix',
+            })
+          )}
+        />
+      </Provider>
     )
 
     const priceDetail = screen.queryByText(/Informations sur le prix/)

--- a/pro/src/components/CollectiveOfferSummary/components/utils/__specs__/formatOfferEventAddress.spec.ts
+++ b/pro/src/components/CollectiveOfferSummary/components/utils/__specs__/formatOfferEventAddress.spec.ts
@@ -1,7 +1,5 @@
-import {
-  GetCollectiveOfferVenueResponseModel,
-  OfferAddressType,
-} from 'apiClient/v1'
+import { OfferAddressType } from 'apiClient/v1'
+import { IVenue } from 'core/Venue'
 import { EVENT_ADDRESS_SCHOOL_LABEL } from 'screens/OfferEducational/constants/labels'
 
 import { formatOfferEventAddress } from '../formatOfferEventAddress'
@@ -22,7 +20,7 @@ describe('formatOfferEventAddress', () => {
           postalCode: '75000',
           city: 'Paris',
           address: '12 rue Duhesme',
-        } as GetCollectiveOfferVenueResponseModel
+        } as IVenue
       )
     ).toBe('Offerer venue, 12 rue Duhesme, 75000, Paris')
   })
@@ -42,7 +40,7 @@ describe('formatOfferEventAddress', () => {
           postalCode: '75000',
           city: 'Paris',
           address: '12 rue Duhesme',
-        } as GetCollectiveOfferVenueResponseModel
+        } as IVenue
       )
     ).toBe(EVENT_ADDRESS_SCHOOL_LABEL)
   })
@@ -62,7 +60,7 @@ describe('formatOfferEventAddress', () => {
           postalCode: '75000',
           city: 'Paris',
           address: '12 rue Duhesme',
-        } as GetCollectiveOfferVenueResponseModel
+        } as IVenue
       )
     ).toBe('A la mairie')
   })

--- a/pro/src/components/CollectiveOfferSummary/components/utils/formatOfferEventAddress.ts
+++ b/pro/src/components/CollectiveOfferSummary/components/utils/formatOfferEventAddress.ts
@@ -1,13 +1,13 @@
 import {
   CollectiveOfferOfferVenueResponseModel,
-  GetCollectiveOfferVenueResponseModel,
   OfferAddressType,
 } from 'apiClient/v1'
+import { IVenue } from 'core/Venue'
 import { EVENT_ADDRESS_SCHOOL_LABEL } from 'screens/OfferEducational/constants/labels'
 
 export const formatOfferEventAddress = (
   eventAddress: CollectiveOfferOfferVenueResponseModel,
-  venue: GetCollectiveOfferVenueResponseModel
+  venue: IVenue
 ): string => {
   if (eventAddress.addressType === OfferAddressType.SCHOOL) {
     return EVENT_ADDRESS_SCHOOL_LABEL


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19897

## But de la pull request

Fix l'affichage du lieu dans les informations pratiques d'une offre collective. Actuellement le lieu affiché était le lieu qui percevra les remboursements alors que ces deux informations sont différentes. 
