### PR TITLE
(PC-19798)[PRO] fix: doesn't display offer creation button for user without roles

### DIFF
--- a/pro/src/pages/Home/Offerers/VenueCreationLinks.jsx
+++ b/pro/src/pages/Home/Offerers/VenueCreationLinks.jsx
@@ -10,6 +10,7 @@ import {
 } from 'core/FirebaseEvents/constants'
 import useActiveFeature from 'hooks/useActiveFeature'
 import useAnalytics from 'hooks/useAnalytics'
+import useCurrentUser from 'hooks/useCurrentUser'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { UNAVAILABLE_ERROR_PAGE } from 'utils/routes'
@@ -19,10 +20,12 @@ const VenueCreationLinks = ({
   hasVirtualOffers,
   offererId,
 }) => {
+  const { currentUser } = useCurrentUser()
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
   const { logEvent } = useAnalytics()
   const location = useLocation()
 
+  /* istanbul ignore next: DEBT, TO FIX */
   const venueCreationUrl = isVenueCreationAvailable
     ? `/structures/${offererId}/lieux/creation`
     : UNAVAILABLE_ERROR_PAGE
@@ -45,23 +48,25 @@ const VenueCreationLinks = ({
         >
           {!hasPhysicalVenue ? 'Créer un lieu' : 'Ajouter un lieu'}
         </ButtonLink>
-        <ButtonLink
-          variant={ButtonVariant.SECONDARY}
-          link={{
-            to: `/offre/creation?structure=${offererId}`,
-            isExternal: false,
-          }}
-          onClick={() =>
-            logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
-              from: OFFER_FORM_NAVIGATION_IN.HOME,
-              to: OFFER_FORM_HOMEPAGE,
-              used: OFFER_FORM_NAVIGATION_MEDIUM.HOME_BUTTON,
-              isEdition: false,
-            })
-          }
-        >
-          Créer une offre
-        </ButtonLink>
+        {(currentUser.isAdmin || currentUser?.roles?.length) && (
+          <ButtonLink
+            variant={ButtonVariant.SECONDARY}
+            link={{
+              to: `/offre/creation?structure=${offererId}`,
+              isExternal: false,
+            }}
+            onClick={() =>
+              logEvent?.(Events.CLICKED_OFFER_FORM_NAVIGATION, {
+                from: OFFER_FORM_NAVIGATION_IN.HOME,
+                to: OFFER_FORM_HOMEPAGE,
+                used: OFFER_FORM_NAVIGATION_MEDIUM.HOME_BUTTON,
+                isEdition: false,
+              })
+            }
+          >
+            Créer une offre
+          </ButtonLink>
+        )}
       </div>
     )
   }

--- a/pro/src/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
+++ b/pro/src/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
@@ -35,6 +35,7 @@ const renderHomePage = () => {
         lastName: 'Do',
         email: 'john.do@dummy.xyz',
         phoneNumber: '01 00 00 00 00',
+        roles: ['PRO'],
       },
       initialized: true,
     },

--- a/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
+++ b/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
@@ -98,6 +98,7 @@ describe('offererDetailsLegacy', () => {
           lastName: 'Do',
           email: 'john.do@dummy.xyz',
           phoneNumber: '01 00 00 00 00',
+          roles: ['PRO'],
         },
         initialized: true,
       },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19798

## But de la pull request

- Ne plus afficher le bouton "Créer une offre" pour les utilisateurs non validés (sans rôle). Comme sur la page Offres.

## Implémentation

- Ajout de la règle. Le bouton s'affiche quand même pour les admin, contrairement à la page offres.
- Tests

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
