### PR TITLE
(PC-19746)[API] fix: fix 'unlimited' quantity deserialization

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -205,7 +205,7 @@ def post_product_offer(
                 offers_api.create_stock(
                     offer=created_offer,
                     price=finance_utils.to_euros(body.stock.price),
-                    quantity=body.stock.quantity if body.stock.quantity != "unlimited" else None,
+                    quantity=serialization.deserialize_quantity(body.stock.quantity),
                     booking_limit_datetime=body.stock.booking_limit_datetime,
                     creating_provider=individual_offers_provider,
                 )
@@ -303,7 +303,7 @@ def post_event_dates(
                     offers_api.create_stock(
                         offer=offer,
                         price=finance_utils.to_euros(date.price),
-                        quantity=date.quantity if date.quantity != "unlimited" else None,
+                        quantity=serialization.deserialize_quantity(date.quantity),
                         beginning_datetime=date.beginning_datetime,
                         booking_limit_datetime=date.booking_limit_datetime,
                         creating_provider=individual_offers_provider,
@@ -547,15 +547,16 @@ def edit_product(
                         offers_api.create_stock(
                             offer=offer,
                             price=finance_utils.to_euros(body.stock.price),
-                            quantity=body.stock.quantity if body.stock.quantity != "unlimited" else None,
+                            quantity=serialization.deserialize_quantity(body.stock.quantity),
                             booking_limit_datetime=body.stock.booking_limit_datetime,
                             creating_provider=individual_offers_provider,
                         )
                     else:
                         price = update_body["stock"].get("price", offers_api.UNCHANGED)
+                        quantity = update_body["stock"].get("quantity", offers_api.UNCHANGED)
                         offers_api.edit_stock(
                             existing_stock,
-                            quantity=update_body["stock"].get("quantity", offers_api.UNCHANGED),
+                            quantity=serialization.deserialize_quantity(quantity),
                             price=finance_utils.to_euros(price)
                             if price != offers_api.UNCHANGED
                             else offers_api.UNCHANGED,
@@ -669,9 +670,10 @@ def patch_event_date(
     try:
         with repository.transaction():
             price = update_body.get("price", offers_api.UNCHANGED)
+            quantity = update_body.get("quantity", offers_api.UNCHANGED)
             edited_date, _ = offers_api.edit_stock(
                 stock_to_edit,
-                quantity=update_body.get("quantity", offers_api.UNCHANGED),
+                quantity=serialization.deserialize_quantity(quantity),
                 price=finance_utils.to_euros(price) if price != offers_api.UNCHANGED else offers_api.UNCHANGED,
                 booking_limit_datetime=update_body.get("booking_limit_datetime", offers_api.UNCHANGED),
                 beginning_datetime=update_body.get("beginning_datetime", offers_api.UNCHANGED),

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -319,10 +319,12 @@ QUANTITY_FIELD = pydantic.Field(
     example=10,
 )
 
+UNLIMITED_LITERAL = typing.Literal["unlimited"]
+
 
 class BaseStockCreation(serialization.ConfiguredBaseModel):
     price: pydantic.StrictInt = PRICE_FIELD
-    quantity: pydantic.StrictInt | typing.Literal["unlimited"] = QUANTITY_FIELD
+    quantity: pydantic.StrictInt | UNLIMITED_LITERAL = QUANTITY_FIELD
 
     @pydantic.validator("price")
     def price_must_be_positive(cls, value: int) -> int:
@@ -337,6 +339,12 @@ class BaseStockCreation(serialization.ConfiguredBaseModel):
         return quantity
 
 
+def deserialize_quantity(quantity: int | UNLIMITED_LITERAL | None) -> int | None:
+    if quantity == "unlimited":
+        return None
+    return quantity
+
+
 class StockCreation(BaseStockCreation):
     booking_limit_datetime: datetime.datetime | None = BOOKING_LIMIT_DATETIME_FIELD
 
@@ -346,7 +354,7 @@ class StockCreation(BaseStockCreation):
 class StockEdition(serialization.ConfiguredBaseModel):
     booking_limit_datetime: datetime.datetime | None = BOOKING_LIMIT_DATETIME_FIELD
     price: pydantic.StrictInt | None = PRICE_FIELD
-    quantity: pydantic.StrictInt | typing.Literal["unlimited"] | None = QUANTITY_FIELD
+    quantity: pydantic.StrictInt | UNLIMITED_LITERAL | None = QUANTITY_FIELD
 
     @pydantic.validator("price")
     def price_must_be_positive(cls, value: int | None) -> int | None:
@@ -454,7 +462,7 @@ class BaseStockResponse(serialization.ConfiguredBaseModel):
     booking_limit_datetime: datetime.datetime | None = BOOKING_LIMIT_DATETIME_FIELD
     dnBookedQuantity: int = pydantic.Field(..., description="Number of bookings.", example=0, alias="bookedQuantity")
     price: pydantic.StrictInt = PRICE_FIELD
-    quantity: pydantic.StrictInt | typing.Literal["unlimited"] = QUANTITY_FIELD
+    quantity: pydantic.StrictInt | UNLIMITED_LITERAL = QUANTITY_FIELD
 
     class Config:
         json_encoders = {datetime.datetime: date_utils.format_into_utc_date}

--- a/api/tests/routes/public/individual_offers/v1/endpoints_test.py
+++ b/api/tests/routes/public/individual_offers/v1/endpoints_test.py
@@ -1741,22 +1741,22 @@ class PatchProductTest:
             venue__managingOfferer=api_key.offerer,
             lastProvider=individual_offers_api_provider,
         )
-        stock = offers_factories.StockFactory(offer=product_offer, quantity=None, price=10)
+        stock = offers_factories.StockFactory(offer=product_offer, quantity=30, price=10)
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
             f"/public/offers/v1/products/{product_offer.id}",
-            json={"stock": {"quantity": 100}},
+            json={"stock": {"quantity": "unlimited"}},
         )
         assert response.status_code == 200
         assert response.json["stock"] == {
             "bookedQuantity": 0,
             "bookingLimitDatetime": None,
             "price": 1000,
-            "quantity": 100,
+            "quantity": "unlimited",
         }
         assert len(product_offer.activeStocks) == 1
         assert product_offer.activeStocks[0] == stock
-        assert product_offer.activeStocks[0].quantity == 100
+        assert product_offer.activeStocks[0].quantity == None
 
     def test_remove_stock_booking_limit_datetime(self, individual_offers_api_provider, client):
         api_key = offerers_factories.ApiKeyFactory()


### PR DESCRIPTION
Il y avait un bug en édition : si on mettait "unlimited" on avait une 500 car le champ n'était pas transformé en `None`.