### PR TITLE
Don't cancel a pytest matrix job when another fails

### DIFF
--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -222,6 +222,7 @@ jobs:
       REDIS_URL: redis://redis:6379
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         pytest_args:
           [


### PR DESCRIPTION
4 pytest instances are run in parallel through a matrix job. When one
of these instance fails, the default behaviour in GitHub Actions is to
cancel the other running ones [1]. As such, some tests are not run and
we just don't know whether they would have failed.

Now all pytest instances are run until their end, even if one them
already failed.

[1] https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures