### PR TITLE
(PC-17066)[PRO] feat: add aria label to modifications buttons in summary

### DIFF
--- a/pro/src/components/SummaryLayout/SummaryLayoutSection.tsx
+++ b/pro/src/components/SummaryLayout/SummaryLayoutSection.tsx
@@ -12,7 +12,7 @@ interface ISummaryLayoutSectionProps {
   className?: string
   editLink?: string // FIXME(MathildeDuboille - 18/10/22): make this props mandatory when we can modify collective offer during its creation
   onLinkClick?: () => void
-  ariaLabel?: string
+  'aria-label'?: string
 }
 
 const Section = ({
@@ -21,7 +21,7 @@ const Section = ({
   className,
   editLink,
   onLinkClick,
-  ariaLabel,
+  ...props
 }: ISummaryLayoutSectionProps): JSX.Element => (
   <div className={cn(style['summary-layout-section'], className)}>
     <div className={style['summary-layout-section-header']}>
@@ -34,7 +34,7 @@ const Section = ({
             link={{
               to: editLink,
               isExternal: false,
-              'aria-label': ariaLabel,
+              'aria-label': props['aria-label'],
             }}
             className={style['summary-layout-section-header-edit-link']}
             Icon={IcoPen}

--- a/pro/src/components/SummaryLayout/SummaryLayoutSection.tsx
+++ b/pro/src/components/SummaryLayout/SummaryLayoutSection.tsx
@@ -12,6 +12,7 @@ interface ISummaryLayoutSectionProps {
   className?: string
   editLink?: string // FIXME(MathildeDuboille - 18/10/22): make this props mandatory when we can modify collective offer during its creation
   onLinkClick?: () => void
+  ariaLabel?: string
 }
 
 const Section = ({
@@ -20,6 +21,7 @@ const Section = ({
   className,
   editLink,
   onLinkClick,
+  ariaLabel,
 }: ISummaryLayoutSectionProps): JSX.Element => (
   <div className={cn(style['summary-layout-section'], className)}>
     <div className={style['summary-layout-section-header']}>
@@ -29,7 +31,11 @@ const Section = ({
         </Title>
         {editLink && (
           <ButtonLink
-            link={{ to: editLink, isExternal: false }}
+            link={{
+              to: editLink,
+              isExternal: false,
+              'aria-label': ariaLabel,
+            }}
             className={style['summary-layout-section-header-edit-link']}
             Icon={IcoPen}
             onClick={onLinkClick ? onLinkClick : undefined}

--- a/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
@@ -88,7 +88,7 @@ const OfferSummary = ({
       title="Détails de l’offre"
       editLink={editLink}
       onLinkClick={logEditEvent}
-      ariaLabel="Modifier détails de l’offre"
+      aria-label="Modifier détails de l’offre"
     >
       <SummaryLayout.SubSection title="Type d’offre">
         <SummaryLayout.Row title="Catégorie" description={offer.categoryName} />

--- a/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/OfferSection/OfferSection.tsx
@@ -88,6 +88,7 @@ const OfferSummary = ({
       title="Détails de l’offre"
       editLink={editLink}
       onLinkClick={logEditEvent}
+      ariaLabel="Modifier détails de l’offre"
     >
       <SummaryLayout.SubSection title="Type d’offre">
         <SummaryLayout.Row title="Catégorie" description={offer.categoryName} />

--- a/pro/src/screens/OfferIndividual/Summary/StockSection/StockSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockSection/StockSection.tsx
@@ -66,6 +66,7 @@ const StockSection = ({
         title="Stocks et prix"
         editLink={editLink}
         onLinkClick={logEditEvent}
+        ariaLabel="Modifier stock et prix"
       >
         {stockWarningText && (
           <SummaryLayout.Row

--- a/pro/src/screens/OfferIndividual/Summary/StockSection/StockSection.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockSection/StockSection.tsx
@@ -66,7 +66,7 @@ const StockSection = ({
         title="Stocks et prix"
         editLink={editLink}
         onLinkClick={logEditEvent}
-        ariaLabel="Modifier stock et prix"
+        aria-label="Modifier stock et prix"
       >
         {stockWarningText && (
           <SummaryLayout.Row

--- a/pro/src/ui-kit/Button/ButtonLink.tsx
+++ b/pro/src/ui-kit/Button/ButtonLink.tsx
@@ -110,6 +110,7 @@ const ButtonLink = ({
       to={to}
       {...disabled}
       {...tooltipProps}
+      aria-label={linkProps['aria-label']}
     >
       {body}
     </Link>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-17066

## But de la pull request

- Ajouter des aria text aux boutons "modifier" de la page de récapitulatif.

## Implémentation

- Ajout d'aria label.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] Le lecteur d'écran lit bien les aria-label des boutons.

