### PR TITLE
(PC-20049)[API] refactor: improve offer ExtraData

### DIFF
--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -15,6 +15,7 @@ from uuid import UUID
 import psycopg2.extras
 import sqlalchemy as sqla
 import sqlalchemy.dialects.postgresql as sqla_psql
+import sqlalchemy.ext.mutable as sqla_mutable
 import sqlalchemy.orm as sqla_orm
 
 from pcapi import settings
@@ -577,7 +578,9 @@ class CashflowLog(Base, Model):
     timestamp: datetime.datetime = sqla.Column(sqla.DateTime, nullable=False, server_default=sqla.func.now())
     statusBefore: CashflowStatus = sqla.Column(db_utils.MagicEnum(CashflowStatus), nullable=False)
     statusAfter: CashflowStatus = sqla.Column(db_utils.MagicEnum(CashflowStatus), nullable=False)
-    details = sqla.Column(db_utils.SafeJsonB, nullable=True, default={}, server_default="{}")
+    details: dict | None = sqla.Column(
+        sqla_mutable.MutableDict.as_mutable(sqla_psql.JSONB), nullable=True, default={}, server_default="{}"
+    )
 
 
 class CashflowPricing(Base, Model):

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -2,6 +2,8 @@ import enum
 import typing
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext import mutable as sa_mutable
 import sqlalchemy.orm as sa_orm
 
 from pcapi.core.users import models as users_models
@@ -78,7 +80,7 @@ class ActionHistory(PcObject, Base, Model):
     authorUserId: int | None = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
     authorUser: users_models.User | None = sa.orm.relationship("User", foreign_keys=[authorUserId])
 
-    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa.dialects.postgresql.JSONB)
+    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
 
     userId: int | None = sa.Column(
         sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=True

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -2,11 +2,11 @@ import enum
 import typing
 
 import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
 
 from pcapi.core.users import models as users_models
 from pcapi.models import Base
 from pcapi.models import Model
-from pcapi.models.extra_data_mixin import ExtraDataMixin
 from pcapi.models.pc_object import PcObject
 
 
@@ -39,7 +39,7 @@ class ActionType(enum.Enum):
     USER_UNSUSPENDED = "Compte réactivé"
 
 
-class ActionHistory(PcObject, Base, Model, ExtraDataMixin):
+class ActionHistory(PcObject, Base, Model):
     """
     This table aims at logging all actions that should appear in a resource history for support, fraud team, etc.
 
@@ -77,6 +77,8 @@ class ActionHistory(PcObject, Base, Model, ExtraDataMixin):
     # author is removed; but the author is mandatory for any new action
     authorUserId: int | None = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
     authorUser: users_models.User | None = sa.orm.relationship("User", foreign_keys=[authorUserId])
+
+    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa.dialects.postgresql.JSONB)
 
     userId: int | None = sa.Column(
         sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=True

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -10,6 +10,7 @@ from flask_sqlalchemy import BaseQuery
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 import sqlalchemy.exc as sa_exc
+from sqlalchemy.ext import mutable as sa_mutable
 import sqlalchemy.orm as sa_orm
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.elements import BooleanClauseList
@@ -59,7 +60,7 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
     conditions = sa.Column(sa.String(120), nullable=True)
     description = sa.Column(sa.Text, nullable=True)
     durationMinutes = sa.Column(sa.Integer, nullable=True)
-    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", postgresql.JSONB)
+    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
     isGcuCompatible: bool = sa.Column(sa.Boolean, default=True, server_default=sa.true(), nullable=False)
     isNational: bool = sa.Column(sa.Boolean, server_default=sa.false(), default=False, nullable=False)
     isSynchronizationCompatible: bool = sa.Column(sa.Boolean, default=True, server_default=sa.true(), nullable=False)
@@ -328,7 +329,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     description = sa.Column(sa.Text, nullable=True)
     durationMinutes = sa.Column(sa.Integer, nullable=True)
     externalTicketOfficeUrl = sa.Column(sa.String, nullable=True)
-    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", postgresql.JSONB)
+    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
     fieldsUpdated: list[str] = sa.Column(
         postgresql.ARRAY(sa.String(100)), nullable=False, default=[], server_default="{}"
     )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -3,6 +3,7 @@ import datetime
 import decimal
 import enum
 import logging
+import typing
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -54,13 +55,53 @@ class BookFormat(enum.Enum):
 UNRELEASED_OR_UNAVAILABLE_BOOK_MARKER = "xxx"
 
 
+class OfferExtraData(typing.TypedDict, total=False):
+    author: str | None
+    ean: str | None
+    isbn: str | None
+    musicSubType: str | None
+    musicType: str | None
+    performer: str | None
+    showSubType: str | None
+    showType: str | None
+    speaker: str | None
+    stageDirector: str | None
+    visa: str | None
+
+    # allocine
+    cast: str | None
+    companies: list[dict] | None
+    countries: str | None
+    diffusionVersion: str | None
+    genres: list[str] | None
+    releaseDate: str | None
+    theater: dict | None
+    type: str | None
+
+    # titelive
+    bookFormat: str | None
+    collection: str | None
+    comic_series: str | None
+    comment: str | None
+    date_parution: str | None
+    dewey: str | None
+    distributeur: str | None
+    editeur: str | None
+    num_in_collection: str | None
+    prix_livre: str | None
+    rayon: str | None
+    top: str | None
+    schoolbook: bool | None
+    titelive_regroup: str | None
+
+
 class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
     ageMin = sa.Column(sa.Integer, nullable=True)
     ageMax = sa.Column(sa.Integer, nullable=True)
     conditions = sa.Column(sa.String(120), nullable=True)
     description = sa.Column(sa.Text, nullable=True)
     durationMinutes = sa.Column(sa.Integer, nullable=True)
-    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
+    extraData: OfferExtraData | None = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
     isGcuCompatible: bool = sa.Column(sa.Boolean, default=True, server_default=sa.true(), nullable=False)
     isNational: bool = sa.Column(sa.Boolean, server_default=sa.false(), default=False, nullable=False)
     isSynchronizationCompatible: bool = sa.Column(sa.Boolean, default=True, server_default=sa.true(), nullable=False)
@@ -329,7 +370,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     description = sa.Column(sa.Text, nullable=True)
     durationMinutes = sa.Column(sa.Integer, nullable=True)
     externalTicketOfficeUrl = sa.Column(sa.String, nullable=True)
-    extraData: sa_orm.Mapped[dict | None] = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
+    extraData: OfferExtraData | None = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
     fieldsUpdated: list[str] = sa.Column(
         postgresql.ARRAY(sa.String(100)), nullable=False, default=[], server_default="{}"
     )

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -388,9 +388,10 @@ def _get_stocks_to_upsert(
         if stock_detail.price is not None:
             book_price = stock_detail.price
         else:
-            if product.extraData is None:
-                raise AttributeError("Cannot compute book_price because product extraData is None")
-            book_price = float(product.extraData["prix_livre"])
+            extra_data_price = product.extraData.get("prix_livre") if product.extraData else None
+            if extra_data_price is None:
+                raise AttributeError("Cannot compute book_price because product extraData.prix_livre is None")
+            book_price = float(extra_data_price)
         if stock_provider_reference in stocks_by_provider_reference:
             stock = stocks_by_provider_reference[stock_provider_reference]
 

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -368,12 +368,12 @@ class AlgoliaBackend(base.SearchBackend):
         stocks_date_created = [stock.dateCreated.timestamp() for stock in offer.bookableStocks]
         tags = [criterion.name for criterion in offer.criteria]
         extra_data = offer.extraData or {}
-        artist = " ".join(extra_data.get(key, "") for key in ("author", "performer", "speaker", "stageDirector"))
+        artist = " ".join(extra_data.get(key, "") for key in ("author", "performer", "speaker", "stageDirector"))  # type: ignore[misc]
 
         # Field used by Algolia (not the frontend) to deduplicate results
         # https://www.algolia.com/doc/api-reference/api-parameters/distinct/
         distinct = extra_data.get("isbn") or extra_data.get("visa") or extra_data.get("ean") or str(offer.id)
-        distinct += extra_data.get("diffusionVersion", "")
+        distinct += extra_data.get("diffusionVersion") or ""
 
         music_type_label = None
         music_type = (extra_data.get("musicType") or "").strip()

--- a/api/src/pcapi/infrastructure/repository/pro_offers/offers_recap_domain_converter.py
+++ b/api/src/pcapi/infrastructure/repository/pro_offers/offers_recap_domain_converter.py
@@ -35,7 +35,7 @@ def _offer_recap_to_domain(offer: Offer) -> OfferRecap:
         venue_departement_code=offer.venue.departementCode,
         stocks=stocks,
         status=offer.status.name,  # type: ignore [attr-defined]
-        is_showcase=offer.extraData.get("isShowcase") if offer.extraData else None,  # type: ignore [arg-type]
+        is_showcase=False,
     )
 
 

--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -112,9 +112,9 @@ class AllocineStocks(LocalProvider):
             self.fill_stock_attributes(pc_object)
 
     def update_from_movie_information(self, obj: Offer | Product, movie_information: dict):  # type: ignore [no-untyped-def]
-        if "description" in self.movie_information:  # type: ignore [operator]
+        if self.movie_information and "description" in self.movie_information:
             obj.description = movie_information["description"]
-        if "duration" in self.movie_information:  # type: ignore [operator]
+        if self.movie_information and "duration" in self.movie_information:
             obj.durationMinutes = movie_information["duration"]
         if not obj.extraData:
             obj.extraData = {}
@@ -129,9 +129,9 @@ class AllocineStocks(LocalProvider):
             "cast",
         ):
             if field in movie_information:
-                obj.extraData[field] = movie_information[field]
+                obj.extraData[field] = movie_information[field]  # type: ignore [literal-required]
 
-    def fill_product_attributes(self, allocine_product: Product):  # type: ignore [no-untyped-def]
+    def fill_product_attributes(self, allocine_product: Product) -> None:
         allocine_product.name = self.movie_information["title"]  # type: ignore [index]
         allocine_product.subcategoryId = subcategories.SEANCE_CINE.id
         allocine_product.thumbCount = 0
@@ -158,10 +158,10 @@ class AllocineStocks(LocalProvider):
             "allocine_room_id": self.room_internal_id,
         }
 
-        if "visa" in self.movie_information:  # type: ignore [operator]
-            allocine_offer.extraData["visa"] = self.movie_information["visa"]  # type: ignore [index]
-        if "stageDirector" in self.movie_information:  # type: ignore [operator]
-            allocine_offer.extraData["stageDirector"] = self.movie_information["stageDirector"]  # type: ignore [index]
+        if self.movie_information and "visa" in self.movie_information:
+            allocine_offer.extraData["visa"] = self.movie_information["visa"]
+        if self.movie_information and "stageDirector" in self.movie_information:
+            allocine_offer.extraData["stageDirector"] = self.movie_information["stageDirector"]
 
         movie_version = (
             ORIGINAL_VERSION_SUFFIX

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -160,8 +160,6 @@ class CDSStocks(LocalProvider):
             obj.description = movie_information.description
         if self.movie_information.duration:
             obj.durationMinutes = movie_information.duration
-        if not obj.extraData:
-            obj.extraData = {}
         obj.extraData = {"visa": self.movie_information.visa}
 
     def get_object_thumb(self) -> bytes:

--- a/api/src/pcapi/models/extra_data_mixin.py
+++ b/api/src/pcapi/models/extra_data_mixin.py
@@ -1,9 +1,0 @@
-from sqlalchemy import Column
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped
-from sqlalchemy.orm import declarative_mixin
-
-
-@declarative_mixin
-class ExtraDataMixin:
-    extraData: Mapped[dict | None] = Column("jsonData", JSONB)

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -208,6 +208,7 @@ def compute_category_fields_model(
 
     model = pydantic.create_model(f"{subcategory.id}_{method.value}", **specific_fields)
     model.__doc__ = subcategory.pro_label
+    model.__config__.allow_population_by_field_name = True
     return model
 
 
@@ -223,13 +224,13 @@ def serialize_extra_data(offer: offers_models.Offer) -> CategoryRelatedFields:
     if show_sub_type:
         serialized_data["showType"] = ShowTypeEnum(show_types.SHOW_SUB_TYPES_BY_CODE[int(show_sub_type)].slug)
 
-    return category_fields_model(**serialized_data, category=offer.subcategory.id)
+    return category_fields_model(**serialized_data, subcategory_id=offer.subcategory.id)
 
 
 def deserialize_extra_data(
-    category_related_fields: CategoryRelatedFields, initial_extra_data: dict[str, str] | None = None
+    category_related_fields: CategoryRelatedFields, initial_extra_data: offers_models.OfferExtraData | None = None
 ) -> dict[str, str]:
-    extra_data = initial_extra_data or {}
+    extra_data: dict = initial_extra_data or {}  # type: ignore[assignment]
     for field_name, field_value in category_related_fields.dict(exclude_unset=True).items():
         if field_name == "subcategory_id":
             continue

--- a/api/src/pcapi/utils/db.py
+++ b/api/src/pcapi/utils/db.py
@@ -6,9 +6,7 @@ import typing
 import psycopg2.extras
 import pytz
 import sqlalchemy as sqla
-import sqlalchemy.dialects.postgresql.json as sqla_json
 import sqlalchemy.engine as sqla_engine
-import sqlalchemy.ext.mutable as sqla_mutable
 import sqlalchemy.types as sqla_types
 
 from pcapi.models import Model
@@ -103,9 +101,6 @@ class MagicEnum(sqla_types.TypeDecorator):
         if value is None:
             return None
         return self.enum_class(value)
-
-
-SafeJsonB = sqla_mutable.MutableDict.as_mutable(sqla_json.JSONB)
 
 
 def make_timerange(

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -286,7 +286,7 @@ class SynchronizeStocksTest:
             id=456,
             name="product_name",
             description="product_desc",
-            extraData="extra",
+            extraData={"extra": "data"},
             subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
         products_by_provider_reference = {"isbn_product_ref": product}
@@ -306,7 +306,7 @@ class SynchronizeStocksTest:
         new_offer = new_offers[0]
         assert new_offer.bookingEmail == "booking_email"
         assert new_offer.description == "product_desc"
-        assert new_offer.extraData == "extra"
+        assert new_offer.extraData == {"extra": "data"}
         assert new_offer.idAtProvider == "isbn_product_ref"
         assert new_offer.lastProviderId == provider.id
         assert new_offer.name == "product_name"

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1046,7 +1046,7 @@ def test_public_api(client):
                         "description": {"title": "Description", "type": "string"},
                         "title": {"title": "Title", "type": "string"},
                     },
-                    "required": ["title", "description"],
+                    "required": ["description", "title"],
                     "title": "ReasonMeta",
                     "type": "object",
                 },
@@ -1833,7 +1833,7 @@ def test_public_api(client):
                 },
                 "WithdrawalTypeEnum": {
                     "description": "An enumeration.",
-                    "enum": ["no_ticket", "by_email", "on_site"],
+                    "enum": ["by_email", "no_ticket", "on_site"],
                     "title": "WithdrawalTypeEnum",
                 },
                 "_HomepageLabelNameEnum": {

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -75,7 +75,7 @@ class Returns200Test:
                     "publicName": "My public name",
                 },
                 "venueId": humanize(requested_venue.id),
-                "isShowcase": None,
+                "isShowcase": False,
             }
         ]
 

--- a/pro/src/apiClient/v1/models/WithdrawalTypeEnum.ts
+++ b/pro/src/apiClient/v1/models/WithdrawalTypeEnum.ts
@@ -6,7 +6,7 @@
  * An enumeration.
  */
 export enum WithdrawalTypeEnum {
-  NO_TICKET = 'no_ticket',
   BY_EMAIL = 'by_email',
+  NO_TICKET = 'no_ticket',
   ON_SITE = 'on_site',
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20049

<img width="781" alt="image" src="https://user-images.githubusercontent.com/22373097/214547411-9d95d411-ad17-4658-b5ab-ebba9e2ffb10.png">

### Limitations
Malheureusement on ne peut pas : 
- utiliser une variable comme clé (cf [cette issue](https://github.com/python/mypy/issues/7178))
- typer les propriétés d'un TypedDict avec le type TypedDict (cf [cette issue](https://github.com/python/mypy/issues/5149))
- caster un TypedDict en dict (cf [cette issue](https://github.com/python/mypy/issues/4976))
- Le type de `extra_data.get("diffusionVersion", "")` est `str | None`
- pas de validation du typage quand on appelle extraData en tant que propriété de classe (ex: `offers_models.Product.extraData["isbnz"].astext`)