### PR TITLE
(PC-20020)[PRO] fix: stocks ux UI

### DIFF
--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -24,12 +24,18 @@ $info-box-margin-left: rem.torem(24px);
     margin-bottom: rem.torem(24px);
 
     &-header {
-      margin-bottom: rem.torem(32px);
+      margin-bottom: rem.torem(24px);
     }
 
     &-description {
-      white-space: pre-line;
-      margin-top: rem.torem(8px);
+      &-container {
+        margin-top: rem.torem(45px);
+        margin-bottom: rem.torem(32px);
+      }
+      &-content {
+        white-space: pre-line;
+        margin-top: rem.torem(8px);
+      }
     }
   }
 

--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -32,6 +32,7 @@ $info-box-margin-left: rem.torem(24px);
         margin-top: rem.torem(45px);
         margin-bottom: rem.torem(32px);
       }
+      
       &-content {
         white-space: pre-line;
         margin-top: rem.torem(8px);

--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -24,7 +24,7 @@ $info-box-margin-left: rem.torem(24px);
     margin-bottom: rem.torem(24px);
 
     &-header {
-      margin-bottom: rem.torem(24px);
+      margin-bottom: rem.torem(32px);
     }
 
     &-description {

--- a/pro/src/components/FormLayout/FormLayoutDescription.tsx
+++ b/pro/src/components/FormLayout/FormLayoutDescription.tsx
@@ -5,17 +5,17 @@ import { Link } from 'ui-kit/Banners/Banner'
 
 import style from './FormLayout.module.scss'
 
-interface IFormLayoutSectionProps {
+interface IFormLayoutDescriptionProps {
   description?: string
   className?: string
   isBanner?: boolean
   links?: Link[]
 }
-const FormLayoutDescription = ({
+const Description = ({
   description,
   isBanner = false,
   links,
-}: IFormLayoutSectionProps): JSX.Element => (
+}: IFormLayoutDescriptionProps): JSX.Element => (
   <>
     {description && !isBanner && (
       <p className={style['form-layout-section-description-content']}>
@@ -36,4 +36,4 @@ const FormLayoutDescription = ({
   </>
 )
 
-export default FormLayoutDescription
+export default Description

--- a/pro/src/components/FormLayout/FormLayoutDescription.tsx
+++ b/pro/src/components/FormLayout/FormLayoutDescription.tsx
@@ -5,9 +5,8 @@ import { Link } from 'ui-kit/Banners/Banner'
 
 import style from './FormLayout.module.scss'
 
-interface IFormLayoutDescriptionProps {
+export interface IFormLayoutDescriptionProps {
   description?: string
-  className?: string
   isBanner?: boolean
   links?: Link[]
 }

--- a/pro/src/components/FormLayout/FormLayoutDescription.tsx
+++ b/pro/src/components/FormLayout/FormLayoutDescription.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { Banner } from 'ui-kit'
+import { Link } from 'ui-kit/Banners/Banner'
+
+import style from './FormLayout.module.scss'
+
+interface IFormLayoutSectionProps {
+  description?: string
+  className?: string
+  isBanner?: boolean
+  links?: Link[]
+}
+const FormLayoutDescription = ({
+  description,
+  isBanner = false,
+  links,
+}: IFormLayoutSectionProps): JSX.Element => (
+  <>
+    {description && !isBanner && (
+      <p className={style['form-layout-section-description-content']}>
+        {description}
+      </p>
+    )}
+    {description && isBanner && (
+      <div className={style['form-layout-section-description-container']}>
+        <Banner
+          type="notification-info"
+          className={style['form-layout-section-description-content']}
+          links={links}
+        >
+          {description}
+        </Banner>
+      </div>
+    )}
+  </>
+)
+
+export default FormLayoutDescription

--- a/pro/src/components/FormLayout/FormLayoutSection.tsx
+++ b/pro/src/components/FormLayout/FormLayoutSection.tsx
@@ -7,7 +7,7 @@ import { Link } from 'ui-kit/Banners/Banner'
 import style from './FormLayout.module.scss'
 
 interface IFormLayoutSectionProps {
-  title: React.ReactNode
+  title?: React.ReactNode
   description?: string
   children: React.ReactNode | React.ReactNode[]
   className?: string

--- a/pro/src/components/FormLayout/FormLayoutSection.tsx
+++ b/pro/src/components/FormLayout/FormLayoutSection.tsx
@@ -1,13 +1,15 @@
 import cn from 'classnames'
 import React from 'react'
 
-import { Title, Banner } from 'ui-kit'
+import { Title } from 'ui-kit'
 import { Link } from 'ui-kit/Banners/Banner'
 
 import style from './FormLayout.module.scss'
 
+import { FormLayoutDescription } from '.'
+
 interface IFormLayoutSectionProps {
-  title?: React.ReactNode
+  title: React.ReactNode
   description?: string
   children: React.ReactNode | React.ReactNode[]
   className?: string
@@ -31,20 +33,11 @@ const Section = ({
             {title}
           </Title>
         </legend>
-        {description && !descriptionAsBanner && (
-          <p className={style['form-layout-section-description']}>
-            {description}
-          </p>
-        )}
-        {description && descriptionAsBanner && (
-          <Banner
-            type="notification-info"
-            className={style['form-layout-section-description']}
-            links={links}
-          >
-            {description}
-          </Banner>
-        )}
+        <FormLayoutDescription
+          description={description}
+          isBanner={descriptionAsBanner}
+          links={links}
+        />
       </div>
       {children}
     </div>

--- a/pro/src/components/FormLayout/__specs__/FormLayoutDescription.spec.tsx
+++ b/pro/src/components/FormLayout/__specs__/FormLayoutDescription.spec.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom'
+
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { FormLayoutDescription } from '..'
+import { IFormLayoutDescriptionProps } from '../FormLayoutDescription'
+
+const renderFormLayoutDescription = ({
+  description,
+  isBanner,
+  links,
+}: IFormLayoutDescriptionProps) => {
+  render(
+    <FormLayoutDescription
+      description={description}
+      links={links}
+      isBanner={isBanner}
+    />
+  )
+}
+
+describe('Description', () => {
+  let descriptionProps: IFormLayoutDescriptionProps
+
+  beforeEach(() => {
+    descriptionProps = {
+      description: 'This is a description',
+    }
+  })
+
+  it('should render the description as text', async () => {
+    renderFormLayoutDescription(descriptionProps)
+    expect(screen.getByText('This is a description')).toBeInTheDocument()
+  })
+
+  it('should render the description as a banner', async () => {
+    descriptionProps.isBanner = true
+    renderFormLayoutDescription(descriptionProps)
+    expect(screen.getByText('This is a description')).toBeInTheDocument()
+  })
+
+  it('should not render component', async () => {
+    descriptionProps.description = undefined
+    renderFormLayoutDescription(descriptionProps)
+    expect(screen.queryByText('This is a description')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/components/FormLayout/index.tsx
+++ b/pro/src/components/FormLayout/index.tsx
@@ -1,1 +1,4 @@
+import FormLayoutDescription from './FormLayoutDescription'
+
 export { default } from './FormLayout'
+export { FormLayoutDescription }

--- a/pro/src/components/OfferFormLayout/OfferFormLayout.module.scss
+++ b/pro/src/components/OfferFormLayout/OfferFormLayout.module.scss
@@ -7,7 +7,7 @@
 }
 
 .content {
-  margin-top: rem.torem(32px);
+  margin-top: rem.torem(15px);
 }
 
 h4 {

--- a/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
+import { OfferStatus } from 'apiClient/v1'
 import {
   IOfferIndividualContext,
   OfferIndividualContext,
@@ -88,8 +89,50 @@ describe('screens:Stocks', () => {
     renderStocksScreen({ storeOverride, contextOverride })
     expect(
       screen.getByText(
-        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’évènement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
+        'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
       )
     ).toBeInTheDocument()
   })
+
+  const offerStatusWithoutBanner = [OfferStatus.REJECTED, OfferStatus.PENDING]
+  it.each(offerStatusWithoutBanner)(
+    'should not render stock description banner',
+    async offerStatus => {
+      contextOverride.offer = {
+        ...contextOverride.offer,
+        isEvent: true,
+        status: offerStatus,
+      } as IOfferIndividual
+      renderStocksScreen({ storeOverride, contextOverride })
+      expect(
+        screen.queryByText(
+          'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
+        )
+      ).not.toBeInTheDocument()
+    }
+  )
+
+  const offerStatusWithBanner = [
+    OfferStatus.ACTIVE,
+    OfferStatus.EXPIRED,
+    OfferStatus.SOLD_OUT,
+    OfferStatus.INACTIVE,
+    OfferStatus.DRAFT,
+  ]
+  it.each(offerStatusWithBanner)(
+    'should render stock description banner',
+    async offerStatus => {
+      contextOverride.offer = {
+        ...contextOverride.offer,
+        isEvent: true,
+        status: offerStatus,
+      } as IOfferIndividual
+      renderStocksScreen({ storeOverride, contextOverride })
+      expect(
+        screen.queryByText(
+          'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
+        )
+      ).toBeInTheDocument()
+    }
+  )
 })

--- a/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.module.scss
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StockFormList/StockFormList.module.scss
@@ -1,5 +1,5 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .form-list {
-  margin-top: rem.torem(32px);
+  margin-top: rem.torem(16px);
 }

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -2,7 +2,7 @@ import { FormikProvider, useFormik } from 'formik'
 import React, { useState, useEffect } from 'react'
 
 import { api } from 'apiClient/api'
-import FormLayout from 'components/FormLayout'
+import FormLayout, { FormLayoutDescription } from 'components/FormLayout'
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { RouteLeavingGuardOfferIndividual } from 'components/RouteLeavingGuardOfferIndividual'
 import {
@@ -109,6 +109,26 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
   const isPriceCategoriesActive = useActiveFeature(
     'WIP_ENABLE_MULTI_PRICE_STOCKS'
   )
+
+  let description
+  let links
+
+  if (!isOfferDisabled(offer.status)) {
+    if (mode === OFFER_WIZARD_MODE.EDITION) {
+      description =
+        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’évènement. \n Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
+      links = [
+        {
+          href: 'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-',
+          linkTitle: 'Comment reporter ou annuler un évènement ?',
+        },
+      ]
+    } else {
+      description =
+        'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
+    }
+  }
+
   const onSubmit = async (formValues: { stocks: IStockEventFormValues[] }) => {
     if (mode === OFFER_WIZARD_MODE.EDITION) {
       const changesOnStockWithBookings = hasChangesOnStockWithBookings(
@@ -342,28 +362,13 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         />
       )}
       <FormLayout>
-        <form onSubmit={formik.handleSubmit} data-testid="stock-event-form">
-          <FormLayout.Section
-            description={
-              isOfferDisabled(offer.status)
-                ? undefined
-                : 'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’évènement. \n Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
-            }
-            links={
-              isOfferDisabled(offer.status)
-                ? undefined
-                : [
-                    {
-                      href: 'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-',
-                      linkTitle: 'Comment reporter ou annuler un évènement ?',
-                    },
-                  ]
-            }
-            descriptionAsBanner={
-              !isOfferDisabled(offer.status) &&
-              mode === OFFER_WIZARD_MODE.EDITION
-            }
-          >
+        <div aria-current="page">
+          <form onSubmit={formik.handleSubmit} data-testid="stock-event-form">
+            <FormLayoutDescription
+              description={description}
+              links={links}
+              isBanner
+            />
             <StockFormList offer={offer} onDeleteStock={onDeleteStock} />
             <ActionBar
               isDisabled={formik.isSubmitting || isOfferDisabled(offer.status)}
@@ -375,8 +380,8 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
               shouldTrack={shouldTrack}
               isFormEmpty={isFormEmpty()}
             />
-          </FormLayout.Section>
-        </form>
+          </form>
+        </div>
       </FormLayout>
 
       <RouteLeavingGuardOfferIndividual

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -255,27 +255,30 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         setIsClickingFromActionBar(false)
       }
 
+      const nextStepUrl = getOfferIndividualUrl({
+        offerId: offer.id,
+        step: saveDraft
+          ? OFFER_WIZARD_STEP_IDS.STOCKS
+          : OFFER_WIZARD_STEP_IDS.SUMMARY,
+        mode,
+      })
+
       // When saving draft with an empty form or in edition mode
       // we display a success notification even if nothing is done
       if (isFormEmpty() && (saveDraft || mode === OFFER_WIZARD_MODE.EDITION)) {
         setIsClickingFromActionBar(false)
-        saveDraft
-          ? notify.success('Brouillon sauvegardé dans la liste des offres')
-          : notify.success(getSuccessMessage(mode))
-        return
+        if (saveDraft) {
+          notify.success('Brouillon sauvegardé dans la liste des offres')
+          return
+        } else {
+          notify.success(getSuccessMessage(mode))
+          navigate(nextStepUrl)
+        }
       }
       // tested but coverage don't see it.
       /* istanbul ignore next */
       setIsSubmittingDraft(saveDraft)
-      setAfterSubmitUrl(
-        getOfferIndividualUrl({
-          offerId: offer.id,
-          step: saveDraft
-            ? OFFER_WIZARD_STEP_IDS.STOCKS
-            : OFFER_WIZARD_STEP_IDS.SUMMARY,
-          mode,
-        })
-      )
+      setAfterSubmitUrl(nextStepUrl)
 
       const hasSavedStock = formik.values.stocks.some(
         stock => stock.stockId !== undefined
@@ -288,15 +291,7 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         notify.success(getSuccessMessage(mode))
         /* istanbul ignore next: DEBT to fix */
         if (!saveDraft) {
-          navigate(
-            getOfferIndividualUrl({
-              offerId: offer.id,
-              step: saveDraft
-                ? OFFER_WIZARD_STEP_IDS.STOCKS
-                : OFFER_WIZARD_STEP_IDS.SUMMARY,
-              mode,
-            })
-          )
+          navigate(nextStepUrl)
         }
         setIsClickingFromActionBar(false)
       } else {

--- a/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/StocksEvent.tsx
@@ -347,9 +347,8 @@ const StocksEvent = ({ offer }: IStocksEventProps): JSX.Element => {
         />
       )}
       <FormLayout>
-        <form onSubmit={formik.handleSubmit}>
+        <form onSubmit={formik.handleSubmit} data-testid="stock-event-form">
           <FormLayout.Section
-            title="Stock & Prix"
             description={
               isOfferDisabled(offer.status)
                 ? undefined

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -613,8 +613,6 @@ describe('screens:StocksEvent:Edition', () => {
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     await screen.findByTestId('stock-event-form')
 
-    await screen.findByTestId('stock-event-form')
-
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
     )

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -309,7 +309,7 @@ describe('screens:StocksEvent:Edition', () => {
     ]
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
     await userEvent.click(
       screen.getAllByTestId('stock-form-actions-button-open')[0]
     )
@@ -333,7 +333,7 @@ describe('screens:StocksEvent:Edition', () => {
   it("should allow user to delete a stock he just created (and didn't save)", async () => {
     jest.spyOn(api, 'deleteStock').mockResolvedValue({ id: 'OFFER_ID' })
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     // create new stock
     await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -381,7 +381,7 @@ describe('screens:StocksEvent:Edition', () => {
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
 
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     // create new stock
     await userEvent.click(await screen.findByText('Ajouter une date'))
@@ -423,7 +423,7 @@ describe('screens:StocksEvent:Edition', () => {
     ]
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.click(
       screen.getAllByTestId('stock-form-actions-button-open')[1]
@@ -446,7 +446,7 @@ describe('screens:StocksEvent:Edition', () => {
     }
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.click(
       screen.getAllByTestId('stock-form-actions-button-open')[1]
@@ -475,7 +475,7 @@ describe('screens:StocksEvent:Edition', () => {
     }
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     expect(screen.queryByText('Ajouter une date')).toBeDisabled()
   })
@@ -493,7 +493,7 @@ describe('screens:StocksEvent:Edition', () => {
     }
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
     await userEvent.type(screen.getByLabelText('Quantité'), '30')
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
@@ -516,7 +516,7 @@ describe('screens:StocksEvent:Edition', () => {
       )
     )
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.click(screen.getByTestId('stock-form-actions-button-open'))
     await userEvent.click(screen.getByText('Supprimer le stock'))
@@ -544,7 +544,7 @@ describe('screens:StocksEvent:Edition', () => {
     ]
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.type(await screen.getByLabelText('Prix'), '20')
     await userEvent.click(
@@ -559,7 +559,7 @@ describe('screens:StocksEvent:Edition', () => {
       .spyOn(api, 'upsertStocks')
       .mockResolvedValue({ stocks: [{ id: 'STOCK_ID' } as StockResponseModel] })
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
     // FireEvent.change instead of userEvent.type because userEvent change value but the test doesn"t work (it probably doesn't set touched at true for price field, only with inputs type number)
     fireEvent.change(screen.getByLabelText('Prix'), { target: { value: '20' } })
     await expect(screen.getByLabelText('Prix')).toHaveValue(20)
@@ -575,7 +575,7 @@ describe('screens:StocksEvent:Edition', () => {
 
   it('should show a success notification if nothing has been touched', async () => {
     renderStockEventScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
@@ -583,9 +583,7 @@ describe('screens:StocksEvent:Edition', () => {
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('heading', { name: /Stock & Prix/ })
-    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId('stock-event-form')).not.toBeInTheDocument()
     expect(screen.getByText(/Next page/)).toBeInTheDocument()
   })
   it('should not display any message when user delete empty stock', async () => {
@@ -595,7 +593,7 @@ describe('screens:StocksEvent:Edition', () => {
     })
     apiOffer.stocks = []
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
     await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
     expect(
       screen.queryByText('Voulez-vous supprimer ce stock ?')
@@ -613,7 +611,9 @@ describe('screens:StocksEvent:Edition', () => {
     })
     apiOffer.stocks = []
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-event-form')
+
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
@@ -621,8 +621,6 @@ describe('screens:StocksEvent:Edition', () => {
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.queryByTestId('stock-event-form')).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StockEvent.edition.spec.tsx
@@ -605,7 +605,7 @@ describe('screens:StocksEvent:Edition', () => {
     expect(api.deleteStock).not.toHaveBeenCalled()
     expect(api.deleteStock).toHaveBeenCalledTimes(0)
   })
-  it('should display draft success message on save button when stock form is empty and not redirect to next page', async () => {
+  it('should display draft success message on save button when stock form is empty and redirect to next page', async () => {
     renderStockEventScreen({
       storeOverride: { ...storeOverride },
     })
@@ -621,6 +621,7 @@ describe('screens:StocksEvent:Edition', () => {
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()
-    expect(screen.queryByTestId('stock-event-form')).toBeInTheDocument()
+    expect(screen.queryByTestId('stock-event-form')).not.toBeInTheDocument()
+    expect(screen.getByText(/Next page/)).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.RouteLeavingGuard.spec.tsx
@@ -238,7 +238,7 @@ describe('screens:StocksEvent', () => {
 
     await userEvent.click(screen.getByText('Rester sur cette page'))
 
-    expect(screen.getByText('Stock & Prix')).toBeInTheDocument()
+    expect(screen.queryByTestId('stock-event-form')).toBeInTheDocument()
   })
 
   it('should be able to quit without submitting from RouteLeavingGuard', async () => {

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -155,7 +155,7 @@ describe('screens:StocksEvent', () => {
     expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
     expect(
       screen.getByText(
-        'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’évènement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
+        'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
       )
     ).toBeInTheDocument()
 

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -305,7 +305,7 @@ describe('screens:StocksEvent', () => {
   it('should display draft success message on save draft button when stock form is empty', async () => {
     renderStockEventScreen({ props, storeOverride, contextValue })
 
-    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
+    await screen.findByTestId('stock-event-form')
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Sauvegarder le brouillon' })

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.spec.tsx
@@ -152,9 +152,7 @@ describe('screens:StocksEvent', () => {
     expect(
       screen.getByText('Offre synchronisée avec Ciné Office')
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
     expect(
       screen.getByText(
         'Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas le faire à moins de 48h de l’évènement. Vous pouvez annuler un évènement en supprimant la ligne de stock associée. Cette action est irréversible.'
@@ -188,9 +186,7 @@ describe('screens:StocksEvent', () => {
     expect(
       screen.getByText('Brouillon sauvegardé dans la liste des offres')
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole('heading', { name: 'Stock & Prix' })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
     expect(api.getOffer).toHaveBeenCalledWith('OFFER_ID')
   })
 
@@ -309,7 +305,7 @@ describe('screens:StocksEvent', () => {
   it('should display draft success message on save draft button when stock form is empty', async () => {
     renderStockEventScreen({ props, storeOverride, contextValue })
 
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
@@ -317,9 +313,7 @@ describe('screens:StocksEvent', () => {
     expect(
       screen.getByText('Brouillon sauvegardé dans la liste des offres')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
   })
 
   it('should not display any message when user delete empty stock', async () => {
@@ -341,7 +335,7 @@ describe('screens:StocksEvent', () => {
       stocks: [stock],
     }
     renderStockEventScreen({ props, storeOverride, contextValue })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
     await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
     expect(
       screen.queryByText('Voulez-vous supprimer ce stock ?')
@@ -361,7 +355,7 @@ describe('screens:StocksEvent', () => {
       stocks: [],
     }
     renderStockEventScreen({ props, storeOverride, contextValue })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    expect(screen.getByTestId('stock-event-form')).toBeInTheDocument()
     await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
     expect(
       screen.queryByText('Voulez-vous supprimer ce stock ?')

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -338,14 +338,13 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
       )}
       <FormLayout>
         <FormLayout.Section
-          title="Stock & Prix"
           description={isDisabled ? undefined : description}
           links={isDisabled ? undefined : links}
           descriptionAsBanner={
             !isDisabled && mode === OFFER_WIZARD_MODE.EDITION
           }
         >
-          <form onSubmit={formik.handleSubmit}>
+          <form onSubmit={formik.handleSubmit} data-testid="stock-thing-form">
             <StockThingFormRow
               actions={actions}
               actionDisabled={false}

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -2,7 +2,7 @@ import { FormikProvider, useFormik } from 'formik'
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { api } from 'apiClient/api'
-import FormLayout from 'components/FormLayout'
+import FormLayout, { FormLayoutDescription } from 'components/FormLayout'
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { RouteLeavingGuardOfferIndividual } from 'components/RouteLeavingGuardOfferIndividual'
 import { IStockFormRowAction } from 'components/StockFormActions/types'
@@ -341,13 +341,12 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
         <SynchronizedProviderInformation providerName={providerName} />
       )}
       <FormLayout>
-        <FormLayout.Section
-          description={isDisabled ? undefined : description}
-          links={isDisabled ? undefined : links}
-          descriptionAsBanner={
-            !isDisabled && mode === OFFER_WIZARD_MODE.EDITION
-          }
-        >
+        <div aria-current="page">
+          <FormLayoutDescription
+            description={description}
+            links={links}
+            isBanner
+          />
           <form onSubmit={formik.handleSubmit} data-testid="stock-thing-form">
             <StockThingFormRow
               actions={actions}
@@ -376,7 +375,7 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
               isFormEmpty={isFormEmpty()}
             />
           </form>
-        </FormLayout.Section>
+        </div>
       </FormLayout>
       <RouteLeavingGuardOfferIndividual
         when={formik.dirty && !isClickingFromActionBar}

--- a/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/StocksThing.tsx
@@ -164,18 +164,6 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
         setIsClickingFromActionBar(false)
       }
 
-      // When saving draft with an empty form or in edition mode
-      // we display a success notification even if nothing is done
-      if (isFormEmpty() && (saveDraft || mode === OFFER_WIZARD_MODE.EDITION)) {
-        setIsClickingFromActionBar(false)
-        saveDraft
-          ? notify.success('Brouillon sauvegardé dans la liste des offres')
-          : notify.success(getSuccessMessage(mode))
-        return
-      }
-      // tested but coverage don't see it.
-      /* istanbul ignore next */
-      setIsSubmittingDraft(saveDraft)
       const nextStepUrl = getOfferIndividualUrl({
         offerId: offer.id,
         step: saveDraft
@@ -183,6 +171,22 @@ const StocksThing = ({ offer }: IStocksThingProps): JSX.Element => {
           : OFFER_WIZARD_STEP_IDS.SUMMARY,
         mode,
       })
+
+      // When saving draft with an empty form or in edition mode
+      // we display a success notification even if nothing is done
+      if (isFormEmpty() && (saveDraft || mode === OFFER_WIZARD_MODE.EDITION)) {
+        setIsClickingFromActionBar(false)
+        if (saveDraft) {
+          notify.success('Brouillon sauvegardé dans la liste des offres')
+          return
+        } else {
+          notify.success(getSuccessMessage(mode))
+          navigate(nextStepUrl)
+        }
+      }
+      // tested but coverage don't see it.
+      /* istanbul ignore next */
+      setIsSubmittingDraft(saveDraft)
       setAfterSubmitUrl(nextStepUrl)
 
       const hasSavedStock = formik.values.stockId !== undefined

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.RouteLeavingGuard.spec.tsx
@@ -258,7 +258,7 @@ describe('screens:StocksThing', () => {
 
     await userEvent.click(screen.getByText('Rester sur cette page'))
 
-    expect(screen.getByText('Stock & Prix')).toBeInTheDocument()
+    expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
   })
 
   it('should be able to quit without submitting from RouteLeavingGuard', async () => {

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.draft.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.draft.spec.tsx
@@ -150,9 +150,7 @@ describe('screens:StocksThing::draft', () => {
     expect(
       screen.getByText('Brouillon sauvegardé dans la liste des offres')
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
     expect(screen.queryByText(/Next page/)).not.toBeInTheDocument()
   })
 
@@ -169,6 +167,7 @@ describe('screens:StocksThing::draft', () => {
     expect(
       screen.getByText('Brouillon sauvegardé dans la liste des offres')
     ).toBeInTheDocument()
+    expect(screen.queryByTestId('stock-thing-form')).not.toBeInTheDocument()
     expect(screen.queryByText(/Next page/)).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -423,7 +423,7 @@ describe('screens:StocksThing', () => {
     expect(api.deleteStock).not.toHaveBeenCalled()
     expect(api.deleteStock).toHaveBeenCalledTimes(0)
   })
-  it('should display draft success message on save button when stock form is empty and not redirect to next page', async () => {
+  it('should display draft success message on save button when stock form is empty and redirect to next page', async () => {
     renderStockThingScreen({
       storeOverride: { ...storeOverride },
     })
@@ -437,6 +437,7 @@ describe('screens:StocksThing', () => {
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()
-    expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
+    expect(screen.queryByTestId('stock-thing-form')).not.toBeInTheDocument()
+    expect(screen.getByText(/Next page/)).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.edition.spec.tsx
@@ -308,7 +308,7 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen({
       storeOverride,
     })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-thing-form')
     await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
     expect(
       screen.getByText('Voulez-vous supprimer ce stock ?')
@@ -342,7 +342,7 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen({
       storeOverride,
     })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-thing-form')
 
     await userEvent.click(
       screen.getAllByTestId('stock-form-actions-button-open')[1]
@@ -374,7 +374,7 @@ describe('screens:StocksThing', () => {
     renderStockThingScreen({
       storeOverride,
     })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-thing-form')
 
     await userEvent.click(screen.getByTestId('stock-form-actions-button-open'))
     await userEvent.click(screen.getByText('Supprimer le stock'))
@@ -392,7 +392,7 @@ describe('screens:StocksThing', () => {
 
   it('should show a success notification if nothing has been touched', async () => {
     renderStockThingScreen({ storeOverride })
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-thing-form')
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
@@ -400,9 +400,8 @@ describe('screens:StocksThing', () => {
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('heading', { name: /Stock & Prix/ })
-    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId('stock-thing-form')).not.toBeInTheDocument()
+
     expect(screen.getByText(/Next page/)).toBeInTheDocument()
   })
   it('should not display any message when user delete empty stock', async () => {
@@ -412,7 +411,7 @@ describe('screens:StocksThing', () => {
     })
     apiOffer.stocks = []
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-thing-form')
     await userEvent.click(screen.getAllByTitle('Supprimer le stock')[1])
     expect(
       screen.queryByText('Voulez-vous supprimer ce stock ?')
@@ -430,7 +429,7 @@ describe('screens:StocksThing', () => {
     })
     apiOffer.stocks = []
     jest.spyOn(api, 'getOffer').mockResolvedValue(apiOffer)
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await screen.findByTestId('stock-thing-form')
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
@@ -438,8 +437,6 @@ describe('screens:StocksThing', () => {
     expect(
       screen.getByText('Vos modifications ont bien été enregistrées')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -481,7 +481,7 @@ describe('screens:StocksThing', () => {
       expect(quantityInput).toHaveValue(expectedNumber)
     }
   )
-  it('should display draft success message on save draft button when stock form is empty', async () => {
+  it('should display success message on save draft button when stock form is empty', async () => {
     renderStockThingScreen({ props, storeOverride, contextValue })
 
     await expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -160,9 +160,7 @@ describe('screens:StocksThing', () => {
     expect(
       screen.getByText('Offre synchronisée avec Ciné Office')
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
     expect(
       screen.getByText(
         'Les bénéficiaires ont 30 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
@@ -486,7 +484,7 @@ describe('screens:StocksThing', () => {
   it('should display draft success message on save draft button when stock form is empty', async () => {
     renderStockThingScreen({ props, storeOverride, contextValue })
 
-    await screen.findByRole('heading', { name: /Stock & Prix/ })
+    await expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
@@ -494,8 +492,6 @@ describe('screens:StocksThing', () => {
     expect(
       screen.getByText('Brouillon sauvegardé dans la liste des offres')
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole('heading', { name: /Stock & Prix/ })
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20020

## But de la pull request

- Ajuster l'espacement (bouton ajouter une date) entre la bannière et le formulaire de stock
- édition de stock: Lors du clique sur le bouton "enregistrer les modifications" avec un stock vide, rediriger vers le récapitulatif.
- Supprimer le titre Stock & prix en édition.

## Implémentation

- 45px au dessus des bannières en édition de stock, 16px entre le bouton 'ajouter une date" et la ligne de stock (event), 32p entre le bouton "ajouter une date" et la bannière.
- Plus de titre "Stock & prix"
- Redirection vers le récapitulatif lorsque l'utilisateur enregistre les modifications avec un formulaire vide.

![Capture d’écran du 2023-01-24 12-32-45](https://user-images.githubusercontent.com/106379750/214284539-5d6ec3e7-0ed1-4567-83b1-5f52f9166921.png)
![Capture d’écran du 2023-01-24 12-32-11](https://user-images.githubusercontent.com/106379750/214284551-1b4eb4d3-c0ff-4269-a3ae-498b09948f89.png)


## Informations supplémentaires

- Modifications dans les tests:
  - Ajout de data-testid  pour compenser le findByRole('heading') dans les tests, pour les formulaires:
    - StocksThing: stock-thing-form
    - StocksEvent: stock-event-form

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
