### PR TITLE
(BSR)[API] test: Fix e-mail template param type in send_invoice_available_to_pro_email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/invoice_available_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/invoice_available_to_pro.py
@@ -9,7 +9,7 @@ def send_invoice_available_to_pro_email(invoice: finance_models.Invoice) -> bool
     data = models.TransactionalEmailData(
         template=TransactionalEmail.INVOICE_AVAILABLE_TO_PRO.value,
         params={
-            "MONTANT_REMBOURSEMENT": -finance_utils.to_euros(invoice.amount),
+            "MONTANT_REMBOURSEMENT": -float(finance_utils.to_euros(invoice.amount)),
         },
     )
     recipient = invoice.reimbursementPoint.bookingEmail


### PR DESCRIPTION
`to_euros()` returns a Decimal. It's automatically turned into a float
by `pcapi.tasks.decorator.task()` that serializes in JSON the
SendTransactionalEmailRequest object and then deserializes it back
before sending it to Google Cloud Tasks.

But when running locally (or in end-to-end tests) with the SendinBlue
backend, we don't use tasks. Thus, a `Decimal` param is sent to the
SendinBlue client, which does not know how to serialize it to JSON.

By converting to a float here, we don't change what happens when going
through Google Cloud Tasks, and we fix the behaviour when we don't use
tasks.