### PR TITLE
(PC-18943)[PRO] fix: fix behaviour when collective booking is cancell…

### DIFF
--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 import React, { useState } from 'react'
 
-import { OfferStatus } from 'apiClient/v1'
+import { CollectiveBookingStatus, OfferStatus } from 'apiClient/v1'
 import {
   CollectiveOffer,
   CollectiveOfferTemplate,
@@ -101,18 +101,22 @@ const OfferEducationalActions = ({
               Annuler la réservation
             </Button>
           )}
-        {isImproveCollectiveStatusActive && lastBookingId && (
-          <ButtonLink
-            variant={ButtonVariant.TERNARY}
-            className={style['button-link']}
-            link={{ isExternal: false, to: getBookingLink() }}
-            Icon={IcoCircleArrow}
-            iconPosition={IconPositionEnum.LEFT}
-          >
-            Voir la{' '}
-            {lastBookingStatus == 'PENDING' ? 'préréservation' : 'réservation'}
-          </ButtonLink>
-        )}
+        {isImproveCollectiveStatusActive &&
+          lastBookingId &&
+          lastBookingStatus != CollectiveBookingStatus.CANCELLED && (
+            <ButtonLink
+              variant={ButtonVariant.TERNARY}
+              className={style['button-link']}
+              link={{ isExternal: false, to: getBookingLink() }}
+              Icon={IcoCircleArrow}
+              iconPosition={IconPositionEnum.LEFT}
+            >
+              Voir la{' '}
+              {lastBookingStatus == 'PENDING'
+                ? 'préréservation'
+                : 'réservation'}
+            </ButtonLink>
+          )}
         {offer?.status && isImproveCollectiveStatusActive && (
           <>
             {offer.status != OfferStatus.EXPIRED && (

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/CollectiveTimeLine.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/CollectiveTimeLine.tsx
@@ -259,9 +259,8 @@ const CollectiveTimeLine = ({
             CollectiveBookingCancellationReasons.EXPIRED &&
             `L’établissement scolaire n’a pas confirmé la préréservation avant la date limite de réservation fixée au ${cancellationLimitDate}.`}
           <div>
-            Votre offre a été automatiquement désactivée, elle n’est plus
-            visible sur ADAGE. Vous pouvez la republier en modifiant votre
-            offre.
+            Votre réservation a été annulée. Votre offre est de nouveau visible
+            sur ADAGE.
           </div>
         </div>
       </>


### PR DESCRIPTION
…ed to display correct wording and do not display booking link

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18943

## But de la pull request

- Afficher le bon wording dans le détails d'une réservation quand cette dernière est annulée 
- Ne pas afficher le lien vers une réservation quand celle ci est annulée dans le récap d'une offre collective

## Screenshot

![Capture d’écran 2023-01-24 à 14 26 00](https://user-images.githubusercontent.com/71768799/214306809-ebc1200d-2b4a-4026-bd25-bfb86873bb76.png)

