### PR TITLE
(PC-20056)[API] fix: handle null fraud check status on public account…

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1061,7 +1061,7 @@ def public_account_history(user: models.User) -> list[dict]:
             "datetime": check.dateCreated,
             "message": (
                 f"{check.type.value}, {getattr(check.eligibilityType, 'value', '[éligibilité inconnue]')}, "
-                f"{check.status.value}, {getattr(check.reasonCodes, 'value', '[raison inconnue]')}, {check.reason}"
+                f"{check.status.value if check.status else 'Statut inconnu'}, {getattr(check.reasonCodes, 'value', '[raison inconnue]')}, {check.reason}"
             ),
         }
         for check in fraud_checks

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1074,6 +1074,7 @@ class PublicAccountHistoryTest:
             user=user,
             type=fraud_models.FraudCheckType.HONOR_STATEMENT,
             dateCreated=datetime.datetime.utcnow() - datetime.timedelta(minutes=5),
+            status=None,
         )
 
         # when
@@ -1094,7 +1095,7 @@ class PublicAccountHistoryTest:
         assert {
             "action": "fraud check",
             "datetime": honor.dateCreated,
-            "message": f"{honor.type.value}, {honor.eligibilityType.value}, {honor.status.value}, [raison inconnue], {honor.reason}",
+            "message": f"{honor.type.value}, {honor.eligibilityType.value}, Statut inconnu, [raison inconnue], {honor.reason}",
         } in history
 
     def test_history_contains_reviews(self):


### PR DESCRIPTION
…s page

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20056

## But de la pull request

Fix l'historique d'un compte public dans le cas où le statut d'un fraud check est à None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
