### PR TITLE
(PC-19306)[PRO] fix: duplication booking_limit_datetime in CollectiveBookingCollectiveStockResponseModel

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
@@ -80,7 +80,6 @@ class CollectiveBookingCollectiveStockResponseModel(BaseModel):
     offer_name: str
     offer_identifier: str
     event_beginning_datetime: str
-    booking_limit_datetime: str
     offer_isbn: str | None
     offer_is_educational: bool
     number_of_tickets: int


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19306

## But de la pull request

Le booking_limit_datetime était dupliqué dans le model `CollectiveBookingCollectiveStockResponseModel` on garde celui en string | None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
