### PR TITLE
(PC-20023)[PRO] fix: home venue name alignment

### DIFF
--- a/pro/src/pages/Home/Venues/Venue.scss
+++ b/pro/src/pages/Home/Venues/Venue.scss
@@ -46,10 +46,9 @@
     cursor: pointer;
     background: none;
     border: none;
+    text-align: left;
 
     .h-card-title-ico {
-      display: flex;
-      align-self: baseline;
       margin-left: 0;
       margin-right: rem.torem(8px);
 
@@ -61,8 +60,6 @@
     }
 
     .title-text {
-      display: flex;
-      align-self: baseline;
       margin-right: rem.torem(16px);
       overflow: hidden;
       text-overflow: ellipsis;
@@ -71,6 +68,11 @@
       &:hover {
         text-decoration: underline;
       }
+    }
+
+    .align-baseline {
+      display: flex;
+      align-self: baseline;
     }
   }
 

--- a/pro/src/pages/Home/Venues/Venue.scss
+++ b/pro/src/pages/Home/Venues/Venue.scss
@@ -48,6 +48,8 @@
     border: none;
 
     .h-card-title-ico {
+      display: flex;
+      align-self: baseline;
       margin-left: 0;
       margin-right: rem.torem(8px);
 
@@ -59,10 +61,12 @@
     }
 
     .title-text {
-      display: block;
+      display: flex;
+      align-self: baseline;
       margin-right: rem.torem(16px);
       overflow: hidden;
       text-overflow: ellipsis;
+      text-align: left;
 
       &:hover {
         text-decoration: underline;

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import React, { Fragment, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -173,12 +174,18 @@ const Venue = ({
       className="h-section-row nested offerer-venue"
       data-testid="venue-wrapper"
     >
-      <div className={`h-card h-card-${isVirtual ? 'primary' : 'secondary'}`}>
+      <div
+        className={cn(
+          `h-card`,
+          { 'h-card-primary': isVirtual },
+          { 'h-card-secondary': !isVirtual }
+        )}
+      >
         <div className="h-card-inner">
           <div
-            className={`h-card-header-row ${
-              isStatOpen ? 'h-card-is-open' : ''
-            }`}
+            className={cn('h-card-header-row', {
+              'h-card-is-open': isStatOpen,
+            })}
           >
             <h3 className="h-card-title">
               <button
@@ -197,14 +204,14 @@ const Venue = ({
               >
                 <Icon
                   alt="icon"
-                  className="h-card-title-ico"
+                  className="h-card-title-ico align-baseline"
                   svg={isStatOpen ? 'ico-caret-down' : 'ico-caret-right'}
                 />
                 {hasNewOfferCreationJourney ? (
-                  <>{publicName || name}</>
+                  <div className="align-baseline">{publicName || name}</div>
                 ) : (
                   <Link
-                    className="title-text"
+                    className="title-text align-baseline"
                     title={publicName || name}
                     to={editVenueLink}
                   >


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20023

## But de la pull request

- Placer le nom du lieu à gauche, et aligner l'icône avec le texte.

## Implémentation

- Alignement de l'icône avec le nom du lieu pour que ça fonctionne avec une ou plusieurs lignes de texte.

![image](https://user-images.githubusercontent.com/106379750/214344946-1d4af12c-1b7a-4469-802a-5d9c2e7a12bd.png)
![image](https://user-images.githubusercontent.com/106379750/214600517-f5500509-5db8-4a16-964d-96a6fbe1f977.png)

