### PR TITLE
Pc 19694 backoffice bookings filters

### DIFF
--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -64,6 +64,12 @@ class CancelledBookingFactory(BookingFactory):
     cancellationReason = models.BookingCancellationReasons.BENEFICIARY
 
 
+class ReimbursedBookingFactory(BookingFactory):
+    status = models.BookingStatus.REIMBURSED
+    dateUsed = factory.LazyFunction(datetime.datetime.utcnow)
+    reimbursementDate = factory.LazyFunction(datetime.datetime.utcnow)
+
+
 class IndividualBookingSubFactory(BaseFactory):
     class Meta:
         model = models.IndividualBooking

--- a/api/src/pcapi/core/categories/categories.py
+++ b/api/src/pcapi/core/categories/categories.py
@@ -93,5 +93,6 @@ ALL_CATEGORIES = (
 )
 ALL_CATEGORIES_DICT = {category.id: category for category in ALL_CATEGORIES}
 CategoryIdEnum = Enum("CategoryIdEnum", {category.id: category.id for category in ALL_CATEGORIES})  # type: ignore [misc]
+CategoryIdLabelEnum = Enum("CategoryIdLabelEnum", {category.id: category.pro_label for category in ALL_CATEGORIES})  # type: ignore [misc]
 
 assert set(ALL_CATEGORIES) == set(category for category in locals().values() if isinstance(category, Category))

--- a/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
@@ -1,11 +1,16 @@
+import datetime
 from functools import partial
 
 from flask import render_template
 from flask import request
 from flask import url_for
+import sqlalchemy as sa
 
+from pcapi.core.categories import subcategories_v2
 from pcapi.core.educational import models as educational_models
 from pcapi.core.permissions import models as perm_models
+from pcapi.utils import date as date_utils
+from pcapi.utils.clean_accents import clean_accents
 
 from . import search_utils
 from . import utils
@@ -20,18 +25,88 @@ collective_bookings_blueprint = utils.child_backoffice_blueprint(
 )
 
 
+def _get_collective_bookings(form: collective_booking_forms.GetCollectiveBookingListForm) -> sa.orm.Query:
+    query = (
+        educational_models.CollectiveBooking.query.outerjoin(educational_models.CollectiveStock)
+        .outerjoin(educational_models.CollectiveOffer)
+        .outerjoin(
+            educational_models.EducationalInstitution, educational_models.CollectiveBooking.educationalInstitution
+        )
+        .options(
+            sa.orm.joinedload(educational_models.CollectiveBooking.collectiveStock)
+            .load_only(educational_models.CollectiveStock.collectiveOfferId)
+            .joinedload(educational_models.CollectiveStock.collectiveOffer)
+            .load_only(
+                educational_models.CollectiveOffer.id,
+                educational_models.CollectiveOffer.name,
+                educational_models.CollectiveOffer.subcategoryId,
+            ),
+            sa.orm.joinedload(educational_models.CollectiveBooking.educationalInstitution).load_only(
+                educational_models.EducationalInstitution.id, educational_models.EducationalInstitution.name
+            ),
+        )
+    )
+
+    if form.q.data:
+        search_query = form.q.data
+
+        if search_query.isnumeric():
+            query = query.filter(
+                sa.or_(
+                    educational_models.CollectiveBooking.id == search_query,
+                    educational_models.CollectiveOffer.id == search_query,
+                    educational_models.EducationalInstitution.id == search_query,
+                )
+            )
+        else:
+            name = search_query.replace(" ", "%").replace("-", "%")
+            name = clean_accents(name)
+            query = query.filter(
+                sa.func.unaccent(educational_models.EducationalInstitution.name).ilike(f"%{name}%"),
+            )
+
+    if form.from_date.data:
+        from_datetime = date_utils.date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time())
+        query = query.filter(educational_models.CollectiveBooking.dateCreated >= from_datetime)
+
+    if form.to_date.data:
+        to_datetime = date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time())
+        query = query.filter(educational_models.CollectiveBooking.dateCreated <= to_datetime)
+
+    if form.category.data:
+        query = query.filter(
+            educational_models.CollectiveOffer.subcategoryId.in_(
+                subcategory.id
+                for subcategory in subcategories_v2.ALL_SUBCATEGORIES
+                if subcategory.category.id in form.category.data
+            )
+        )
+
+    if form.status.data:
+        query = query.filter(educational_models.CollectiveBooking.status.in_(form.status.data))
+
+    return query.order_by(educational_models.CollectiveBooking.dateCreated.desc())
+
+
 @collective_bookings_blueprint.route("", methods=["GET"])
 def list_collective_bookings() -> utils.BackofficeResponse:
     form = collective_booking_forms.GetCollectiveBookingListForm(request.args)
     if not form.validate():
         return render_template("collective_bookings/list.html", isEAC=True, rows=[], form=form), 400
 
-    # This query only returns a single row, but will receive other possible criteria in the near future
-    bookings = educational_models.CollectiveBooking.query.filter(
-        educational_models.CollectiveBooking.id == form.q.data
-    ).order_by(educational_models.CollectiveBooking.dateCreated.desc())
+    if (
+        not form.q.data
+        and not form.category.data
+        and not form.status.data
+        and not form.from_date.data
+        and not form.to_date.data
+    ):
+        # Empty results when no filter is set
+        return render_template("collective_bookings/list.html", rows=[], form=form)
 
-    paginated_bookings = bookings.paginate(
+    bookings = _get_collective_bookings(form)
+
+    paginated_bookings = bookings.paginate(  # type: ignore [attr-defined]
         page=int(form.data["page"]),
         per_page=int(form.data["per_page"]),
     )

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
@@ -1,20 +1,36 @@
 from flask_wtf import FlaskForm
 import wtforms
 
+from pcapi.core.categories import categories
+from pcapi.core.educational.models import CollectiveBookingStatus
+
 from . import fields
+from . import utils
+from .. import filters
 
 
 class GetCollectiveBookingListForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("ID réservation collective")
+    q = fields.PCOptSearchField("ID réservation collective, ID offre, Nom ou ID de l'établissement")
+    category = fields.PCSelectMultipleField(
+        "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)
+    )
+    status = fields.PCSelectMultipleField(
+        "États", choices=utils.choices_from_enum(CollectiveBookingStatus, formatter=filters.format_booking_status)
+    )
+    from_date = fields.PCDateField("À partir du", validators=(wtforms.validators.Optional(),))
+    to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
     page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
-    per_page = wtforms.HiddenField("Par page", default="100", validators=(wtforms.validators.Optional(),))
+    per_page = fields.PCSelectField(
+        "Par page",
+        choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
+        default="100",
+        validators=(wtforms.validators.Optional(),),
+    )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data:
             q.data = q.data.strip()
-            if not q.data.isnumeric():
-                raise wtforms.validators.ValidationError("Le format de l'ID de réservation est incorrect")
         return q

--- a/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
@@ -1,25 +1,36 @@
-import re
-
 from flask_wtf import FlaskForm
 import wtforms
 
+from pcapi.core.bookings.models import BookingStatus
+from pcapi.core.categories import categories
+
 from . import fields
-
-
-BOOKING_TOKEN_RE = re.compile(r"^[\dA-Z]{6}$")
+from . import utils
+from .. import filters
 
 
 class GetIndividualBookingListForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Code contremarque")
+    q = fields.PCOptSearchField("Code contremarque, ID offre, Nom ou ID du bénéficiaire")
+    category = fields.PCSelectMultipleField(
+        "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)
+    )
+    status = fields.PCSelectMultipleField(
+        "États", choices=utils.choices_from_enum(BookingStatus, formatter=filters.format_booking_status)
+    )
+    from_date = fields.PCDateField("À partir du", validators=(wtforms.validators.Optional(),))
+    to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
     page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
-    per_page = wtforms.HiddenField("Par page", default="100", validators=(wtforms.validators.Optional(),))
+    per_page = fields.PCSelectField(
+        "Par page",
+        choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
+        default="100",
+        validators=(wtforms.validators.Optional(),),
+    )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data:
             q.data = q.data.strip()
-            if not BOOKING_TOKEN_RE.match(q.data):
-                raise wtforms.validators.ValidationError("Le format de la contremarque est incorrect")
         return q

--- a/api/src/pcapi/routes/backoffice_v3/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/utils.py
@@ -13,8 +13,10 @@ class PCForm(FlaskForm):
         return email_utils.sanitize_email(raw_email)
 
 
-def choices_from_enum(enum_cls: typing.Type[enum.Enum]) -> list[tuple]:
-    return [(opt.name, opt.value) for opt in enum_cls]
+def choices_from_enum(
+    enum_cls: typing.Type[enum.Enum], formatter: typing.Callable[[typing.Any], str] | None = None
+) -> list[tuple]:
+    return [(opt.name, formatter(opt) if formatter else opt.value) for opt in enum_cls]
 
 
 def values_from_enum(enum_cls: typing.Type[enum.Enum]) -> list[tuple]:

--- a/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
@@ -1,11 +1,18 @@
+import datetime
 from functools import partial
 
 from flask import render_template
 from flask import request
 from flask import url_for
+import sqlalchemy as sa
 
 from pcapi.core.bookings import models as bookings_models
+from pcapi.core.categories import subcategories_v2
+from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
+from pcapi.core.users import models as users_models
+from pcapi.utils import date as date_utils
+from pcapi.utils.clean_accents import clean_accents
 
 from . import search_utils
 from . import utils
@@ -20,17 +27,90 @@ individual_bookings_blueprint = utils.child_backoffice_blueprint(
 )
 
 
+def _get_individual_bookings(form: individual_booking_forms.GetIndividualBookingListForm) -> sa.orm.Query:
+    query = (
+        bookings_models.Booking.query.outerjoin(offers_models.Stock)
+        .outerjoin(offers_models.Offer)
+        .outerjoin(users_models.User, bookings_models.Booking.user)
+        .options(
+            sa.orm.joinedload(bookings_models.Booking.stock)
+            .load_only(offers_models.Stock.quantity, offers_models.Stock.offerId)
+            .joinedload(offers_models.Stock.offer)
+            .load_only(
+                offers_models.Offer.id,
+                offers_models.Offer.name,
+                offers_models.Offer.subcategoryId,
+            ),
+            sa.orm.joinedload(bookings_models.Booking.user).load_only(
+                users_models.User.id, users_models.User.firstName, users_models.User.lastName
+            ),
+        )
+    )
+
+    if form.q.data:
+        search_query = form.q.data
+
+        if search_query.isnumeric():
+            query = query.filter(
+                sa.or_(
+                    bookings_models.Booking.token == search_query,
+                    offers_models.Offer.id == search_query,
+                    users_models.User.id == search_query,
+                )
+            )
+        elif len(search_query) == 6:
+            query = query.filter(bookings_models.Booking.token == search_query)
+        else:
+            name = search_query.replace(" ", "%").replace("-", "%")
+            name = clean_accents(name)
+            query = query.filter(
+                sa.func.unaccent(sa.func.concat(users_models.User.firstName, " ", users_models.User.lastName)).ilike(
+                    f"%{name}%"
+                ),
+            )
+
+    if form.from_date.data:
+        from_datetime = date_utils.date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time())
+        query = query.filter(bookings_models.Booking.dateCreated >= from_datetime)
+
+    if form.to_date.data:
+        to_datetime = date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time())
+        query = query.filter(bookings_models.Booking.dateCreated <= to_datetime)
+
+    if form.category.data:
+        query = query.filter(
+            offers_models.Offer.subcategoryId.in_(
+                subcategory.id
+                for subcategory in subcategories_v2.ALL_SUBCATEGORIES
+                if subcategory.category.id in form.category.data
+            )
+        )
+
+    if form.status.data:
+        query = query.filter(bookings_models.Booking.status.in_(form.status.data))
+
+    return query.order_by(bookings_models.Booking.dateCreated.desc())
+
+
 @individual_bookings_blueprint.route("", methods=["GET"])
 def list_individual_bookings() -> utils.BackofficeResponse:
     form = individual_booking_forms.GetIndividualBookingListForm(request.args)
     if not form.validate():
         return render_template("individual_bookings/list.html", rows=[], form=form), 400
 
-    bookings = bookings_models.Booking.query.filter(bookings_models.Booking.token == form.q.data).order_by(
-        bookings_models.Booking.dateCreated.desc()
-    )
+    if (
+        not form.q.data
+        and not form.category.data
+        and not form.status.data
+        and not form.from_date.data
+        and not form.to_date.data
+    ):
+        # Empty results when no filter is set
+        return render_template("individual_bookings/list.html", rows=[], form=form)
 
-    paginated_bookings = bookings.paginate(
+    bookings = _get_individual_bookings(form)
+
+    paginated_bookings = bookings.paginate(  # type: ignore [attr-defined]
         page=int(form.data["page"]),
         per_page=int(form.data["per_page"]),
     )

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -11,7 +11,6 @@ from flask import request
 from flask import url_for
 from flask_login import current_user
 from markupsafe import Markup
-import pytz
 import sqlalchemy as sa
 from werkzeug.exceptions import NotFound
 
@@ -24,24 +23,13 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils import date as date_utils
 import pcapi.utils.regions as regions_utils
 
 from . import search_utils
 from . import utils
 from .forms import offerer as offerer_forms
 from .serialization import offerers as serialization
-
-
-PARIS_TZ = pytz.timezone("Europe/Paris")
-
-
-def _date_to_localized_datetime(date_: datetime.date | None, time_: datetime.time) -> datetime.datetime | None:
-    # When min/max date filters are used in requests, backoffice user expect Metroplitan French time (CET),
-    # since date and time in the backoffice are formatted to show CET times.
-    if not date_:
-        return None
-    naive_utc_datetime = datetime.datetime.combine(date_, time_)
-    return PARIS_TZ.localize(naive_utc_datetime).astimezone(pytz.utc)
 
 
 offerer_blueprint = utils.child_backoffice_blueprint(
@@ -334,8 +322,8 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
         form.regions.data,
         form.tags.data,
         form.status.data,
-        _date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
-        _date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
+        date_utils.date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
+        date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
     )
 
     sorted_offerers = offerers.order_by(offerers_models.Offerer.dateCreated.desc())
@@ -479,8 +467,8 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
         form.tags.data,
         form.status.data,
         form.offerer_status.data,
-        _date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
-        _date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
+        date_utils.date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time()),
+        date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
     )
 
     sorted_users_offerers = users_offerers.order_by(offerers_models.UserOfferer.id.desc())

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/filters_form.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/filters_form.html
@@ -9,7 +9,7 @@
                     {% set _ = select_multiple.append(form_field) %}
                 {% endif %}
             {% endfor %}
-            <div class="input-group mb-3">
+            <div class="input-group mb-3 px-1">
                 {% for form_field in form %}
                     {% if form_field.type != "HiddenField" and form_field.type != "PCSelectMultipleField" and form_field.type != "PCQuerySelectMultipleField" %}
                         {{ form_field }}
@@ -18,7 +18,7 @@
             </div>
             <div class="input-group mb-1 ">
                 {% for form_field in select_multiple %}
-                    <div class="col-{{ (12/(select_multiple|length))|round|int }} p-1"> {{ form_field }}</div>
+                    <div class="col-{{ [(12/(select_multiple|length))|round|int, 6] | min }} p-1"> {{ form_field }}</div>
                 {% endfor %}
             </div>
         </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -18,7 +18,7 @@
                     <thead>
                     <tr>
                         <th scope="col"></th>
-                        <th scope="col">Code</th>
+                        <th scope="col">Contremarque</th>
                         <th scope="col">Bénéficiaire</th>
                         <th scope="col">Nom de l'offre</th>
                         <th scope="col">ID offre</th>
@@ -26,6 +26,7 @@
                         <th scope="col">Sous-catégorie</th>
                         <th scope="col">Stock</th>
                         <th scope="col">Statut</th>
+                        <th scope="col">Date d'utilisation</th>
                         <th scope="col">Date d'annulation</th>
                     </tr>
                     </thead>
@@ -61,6 +62,7 @@
                             <td>{{ offer.subcategory.pro_label }}</td>
                             <td>{{ booking.stock.quantity }}</td>
                             <td>{{ booking.status | format_booking_status }}</td>
+                            <td>{{ booking.dateUsed | format_date("%d/%m/%Y") }}</td>
                             <td>{{ booking.cancellationDate | format_date("%d/%m/%Y") }}</td>
                         </tr>
                     {% endfor %}

--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 from babel.dates import format_date
 from babel.dates import format_datetime as babel_format_datetime
 from dateutil.parser import parserinfo
-from pytz import BaseTzInfo as pytz_BaseTzInfo
+import pytz
 
 import pcapi.utils.postal_code as postal_code_utils
 
@@ -121,7 +121,7 @@ def get_time_in_seconds_from_datetime(date_time: datetime) -> int:
     return hour_in_seconds + minute_in_seconds + seconds
 
 
-def get_day_start(dt: date, timezone: pytz_BaseTzInfo) -> datetime:
+def get_day_start(dt: date, timezone: pytz.BaseTzInfo) -> datetime:
     """Return a ``datetime`` object that is the first second of the given
     ``date`` in the given timezone.
     """
@@ -151,3 +151,12 @@ def local_datetime_to_default_timezone(dt: datetime, local_tz: str) -> datetime:
     if dt.tzinfo:
         return dt.astimezone(to_zone)
     return dt.replace(tzinfo=from_zone).astimezone(to_zone)
+
+
+def date_to_localized_datetime(date_: date | None, time_: time) -> datetime | None:
+    # When min/max date filters are used in requests, backoffice user expect Metroplitan French time (CET),
+    # since date and time in the backoffice are formatted to show CET times.
+    if not date_:
+        return None
+    naive_utc_datetime = datetime.combine(date_, time_)
+    return pytz.timezone(METROPOLE_TIMEZONE).localize(naive_utc_datetime).astimezone(pytz.utc)

--- a/api/tests/routes/backoffice_v3/collective_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/collective_bookings_test.py
@@ -3,8 +3,10 @@ import datetime
 from flask import url_for
 import pytest
 
+from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories_v2
 from pcapi.core.educational import factories as educational_factories
+from pcapi.core.educational import models as educational_models
 import pcapi.core.permissions.models as perm_models
 from pcapi.core.testing import assert_no_duplicated_queries
 
@@ -20,15 +22,34 @@ pytestmark = [
 
 @pytest.fixture(scope="function", name="collective_bookings")
 def collective_bookings_fixture() -> tuple:
-    institution = educational_factories.EducationalInstitutionFactory(name="Collège Pépin le Bref")
-    pending = educational_factories.PendingCollectiveBookingFactory()
+    institution1 = educational_factories.EducationalInstitutionFactory(name="Collège Pépin le Bref")
+    institution2 = educational_factories.EducationalInstitutionFactory(name="Collège Bertrade de Laon")
+    institution3 = educational_factories.EducationalInstitutionFactory(name="Lycée Charlemagne")
+    # 0
+    pending = educational_factories.PendingCollectiveBookingFactory(
+        educationalInstitution=institution2,
+        collectiveStock__collectiveOffer__subcategoryId=subcategories_v2.EVENEMENT_PATRIMOINE.id,
+        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+    )
+    # 1
     confirmed = educational_factories.CollectiveBookingFactory(
-        educationalInstitution=institution,
+        educationalInstitution=institution1,
         collectiveStock__collectiveOffer__name="Visite des locaux primitifs du pass Culture",
         collectiveStock__collectiveOffer__subcategoryId=subcategories_v2.VISITE_GUIDEE.id,
+        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=3),
     )
-    cancelled = educational_factories.CancelledCollectiveBookingFactory()
-    used = educational_factories.UsedCollectiveBookingFactory()
+    # 2
+    cancelled = educational_factories.CancelledCollectiveBookingFactory(
+        educationalInstitution=institution2,
+        collectiveStock__collectiveOffer__subcategoryId=subcategories_v2.DECOUVERTE_METIERS.id,
+        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+    )
+    # 3
+    used = educational_factories.UsedCollectiveBookingFactory(
+        educationalInstitution=institution3,
+        collectiveStock__collectiveOffer__subcategoryId=subcategories_v2.CONFERENCE.id,
+        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+    )
 
     return pending, confirmed, cancelled, used
 
@@ -59,36 +80,128 @@ class ListCollectiveBookingsTest:
         # then
         assert response.status_code == 200
         rows = html_parser.extract_table_rows(response.data)
-        assert len(rows) == 1
-        assert rows[0]["ID résa"] == searched_id
-        assert rows[0]["Établissement"].startswith("Collège Pépin le Bref")
-        assert rows[0]["Nom de l'offre"] == "Visite des locaux primitifs du pass Culture"
-        assert rows[0]["ID offre"].isdigit()
-        assert rows[0]["Catégorie"] == "Musée, patrimoine, architecture, arts visuels"
-        assert rows[0]["Sous-catégorie"] == "Visite guidée"
-        assert rows[0]["Statut"] == "Confirmée"
-        assert rows[0]["Date de validation"] == (datetime.date.today() - datetime.timedelta(days=1)).strftime(
-            "%d/%m/%Y"
-        )
-        assert not rows[0]["Date d'annulation"]
+        # Warning: test may return more than 1 row when an offer id or institution id is the same as booking id
+        assert len(rows) >= 1
+        result = [row for row in rows if row["ID résa"] == searched_id][0]
+        assert result["Établissement"].startswith("Collège Pépin le Bref")
+        assert result["Nom de l'offre"] == "Visite des locaux primitifs du pass Culture"
+        assert result["ID offre"].isdigit()
+        assert result["Catégorie"] == categories.MUSEE.pro_label
+        assert result["Sous-catégorie"] == subcategories_v2.VISITE_GUIDEE.pro_label
+        assert result["Statut"] == "Confirmée"
+        assert result["Date de validation"] == (datetime.date.today() - datetime.timedelta(days=1)).strftime("%d/%m/%Y")
+        assert not result["Date d'annulation"]
 
-        assert html_parser.extract_pagination_info(response.data) == (1, 1, 1)
+        assert html_parser.extract_pagination_info(response.data) == (1, 1, len(rows))
 
-    def test_list_bookings_by_invalid_id(self, authenticated_client, collective_bookings):
+    def test_list_bookings_by_id_not_found(self, authenticated_client, collective_bookings):
         # when
         with assert_no_duplicated_queries():
-            response = authenticated_client.get(url_for(self.endpoint, q="AB"))
-
-        # then
-        assert response.status_code == 400
-        assert html_parser.extract_warnings(response.data) == ["Le format de l'ID de réservation est incorrect"]
-        assert html_parser.count_table_rows(response.data) == 0
-
-    def test_list_bookings_by_token_not_found(self, authenticated_client, collective_bookings):
-        # when
-        with assert_no_duplicated_queries():
-            response = authenticated_client.get(url_for(self.endpoint, q=str(collective_bookings[-1].id + 1)))
+            response = authenticated_client.get(url_for(self.endpoint, q=str(collective_bookings[-1].id * 1000)))
 
         # then
         assert response.status_code == 200
         assert html_parser.count_table_rows(response.data) == 0
+
+    def test_list_bookings_by_offer_id(self, authenticated_client, collective_bookings):
+        # when
+        searched_id = str(collective_bookings[2].collectiveStock.collectiveOffer.id)
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, q=searched_id))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        # Warning: test may return more than 1 row when a booking id or institution id is the same as offer id
+        assert len(rows) >= 1
+        result = [row for row in rows if row["ID offre"] == searched_id][0]
+        assert result["ID résa"] == str(collective_bookings[2].id)
+        assert result["Établissement"].startswith("Collège Bertrade de Laon")
+        assert result["Nom de l'offre"] == collective_bookings[2].collectiveStock.collectiveOffer.name
+        assert result["Catégorie"] == categories.CONFERENCE_RENCONTRE.pro_label
+        assert result["Sous-catégorie"] == subcategories_v2.DECOUVERTE_METIERS.pro_label
+        assert result["Statut"] == "Annulée"
+        assert result["Date d'annulation"] == datetime.date.today().strftime("%d/%m/%Y")
+
+        assert html_parser.extract_pagination_info(response.data) == (1, 1, len(rows))
+
+    def test_list_bookings_by_institution_id(self, authenticated_client, collective_bookings):
+        # when
+        search_query = str(collective_bookings[1].educationalInstitution.id)
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, q=search_query))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        # Warning: test may return more than 1 row when an offer id is the same as expected institution id
+        assert len(rows) >= 1
+        assert str(collective_bookings[1].id) in set(row["ID résa"] for row in rows)
+
+    @pytest.mark.parametrize(
+        "search_query, expected_idx", [("Collège", (0, 1, 2)), ("Bref", (1,)), ("lycee charlemagne", (3,))]
+    )
+    def test_list_bookings_by_institution_name(
+        self, authenticated_client, collective_bookings, search_query, expected_idx
+    ):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, q=search_query))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(row["ID résa"] for row in rows) == {str(collective_bookings[idx].id) for idx in expected_idx}
+
+    def test_list_bookings_by_category(self, authenticated_client, collective_bookings):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, category=categories.CONFERENCE_RENCONTRE.id))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID résa"]) for row in rows) == {collective_bookings[2].id, collective_bookings[3].id}
+
+    @pytest.mark.parametrize(
+        "status, expected_idx",
+        [
+            ([educational_models.CollectiveBookingStatus.PENDING.name], (0,)),
+            ([educational_models.CollectiveBookingStatus.CONFIRMED.name], (1,)),
+            ([educational_models.CollectiveBookingStatus.CANCELLED.name], (2,)),
+            ([educational_models.CollectiveBookingStatus.USED.name], (3,)),
+            ([educational_models.CollectiveBookingStatus.REIMBURSED.name], ()),
+            (
+                [
+                    educational_models.CollectiveBookingStatus.CONFIRMED.name,
+                    educational_models.CollectiveBookingStatus.USED.name,
+                ],
+                (1, 3),
+            ),
+        ],
+    )
+    def test_list_bookings_by_status(self, authenticated_client, collective_bookings, status, expected_idx):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, status=status))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(row["ID résa"] for row in rows) == {str(collective_bookings[idx].id) for idx in expected_idx}
+
+    def test_list_bookings_by_date(self, authenticated_client, collective_bookings):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(
+                url_for(
+                    self.endpoint,
+                    from_date=(datetime.date.today() - datetime.timedelta(days=3)).isoformat(),
+                    to_date=(datetime.date.today() - datetime.timedelta(days=2)).isoformat(),
+                )
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID résa"]) for row in rows) == {collective_bookings[1].id, collective_bookings[2].id}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19694

## But de la pull request

Ajout de champs de recherche/filtrage sur les écrans de réservations individuelles et collectives (backoffice v3).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
