### PR TITLE
(PC-19405)[PRO] fix: fix toaster wording when updating collective stock

### DIFF
--- a/pro/src/pages/CollectiveOfferStockEdition/adapters/patchCollectiveStockAdapter.ts
+++ b/pro/src/pages/CollectiveOfferStockEdition/adapters/patchCollectiveStockAdapter.ts
@@ -47,7 +47,7 @@ const patchCollectiveStockAdapter: PatchCollectiveStockAdapter = async ({
     const stock = await api.editCollectiveStock(stockId, patchStockPayload)
     return {
       isOk: true,
-      message: 'Le détail de votre stock a bien été modifié.',
+      message: 'Vos modifications ont bien été enregistrées',
       payload: stock,
     }
   } catch (error) {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19405

## But de la pull request

Modifier le toaster apparaissant lors de la modification du stock d'une offre collective


## Screenshot

<img width="1106" alt="Capture d’écran 2023-01-25 à 15 01 35" src="https://user-images.githubusercontent.com/71768799/214583693-a0ebe01c-2b3e-49f4-9d40-9c02fc60a99b.png">
