### PR TITLE
(PC-19870)[PRO] chore: change collective stock page title

### DIFF
--- a/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferCreationRoutes/CollectiveOfferCreationRoutes.tsx
+++ b/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferCreationRoutes/CollectiveOfferCreationRoutes.tsx
@@ -125,7 +125,7 @@ const CollectiveOfferCreationRoutes = ({
               )}
             </Route>
             <Route path="/offre/:offerId/collectif/stocks">
-              <PageTitle title="Vos stocks" />
+              <PageTitle title="Date et prix" />
               {offer && isCollectiveOffer(offer) ? (
                 <CollectiveOfferStockCreation
                   offer={offer}

--- a/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferEditionRoutes/CollectiveOfferEditionRoutes.tsx
+++ b/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferEditionRoutes/CollectiveOfferEditionRoutes.tsx
@@ -89,7 +89,7 @@ const CollectiveOfferEditionRoutes = ({
         {!isTemplate && isCollectiveOffer(offer) && (
           <>
             <Route path="/offre/:offerId/collectif/stocks/edition">
-              <PageTitle title="Vos Stocks" />
+              <PageTitle title="Date et prix" />
               <CollectiveOfferStockEdition
                 offer={offer}
                 reloadCollectiveOffer={loadCollectiveOffer}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Modifier le titre de la page des stocks des offres collectives -> désormais `Date et prix` 

## Screenshot 
<img width="1433" alt="Capture d’écran 2023-01-25 à 15 32 47" src="https://user-images.githubusercontent.com/71768799/214591376-b54756d5-17d5-428f-8a92-bdece69b3597.png">


