### PR TITLE
(PC-20127)[API] feat: update subcategories mapping (again)

### DIFF
--- a/api/src/pcapi/core/categories/subcategories_v2.py
+++ b/api/src/pcapi/core/categories/subcategories_v2.py
@@ -28,7 +28,6 @@ class SearchGroups(Enum):
     MEDIA_PRESSE = "Médias & presse"
     MUSEES_VISITES_CULTURELLES = "Musées & visites culturelles"
     NONE = None
-    PLATEFORMES_EN_LIGNE = "Plateformes en ligne"
     RENCONTRES_CONFERENCES = "Conférences & rencontres"
     SPECTACLES = "Spectacles"
 
@@ -764,8 +763,8 @@ TELECHARGEMENT_LIVRE_AUDIO = Subcategory(
     native_category=NativeCategory.LIVRES_NUMERIQUE_ET_AUDIO,
     pro_label="Livre audio à télécharger",
     app_label="Livre audio à télécharger",
-    search_group_name=SearchGroups.PLATEFORMES_EN_LIGNE.name,
-    homepage_label_name=HomepageLabels.PLATEFORME.name,
+    search_group_name=SearchGroups.LIVRES.name,
+    homepage_label_name=HomepageLabels.LIVRES.name,
     is_event=False,
     conditional_fields={
         ExtraDataFieldEnum.AUTHOR.value: ConditionalField(),
@@ -1246,10 +1245,10 @@ ABO_PLATEFORME_MUSIQUE = Subcategory(
 CAPTATION_MUSIQUE = Subcategory(
     id="CAPTATION_MUSIQUE",
     category=categories.MUSIQUE_ENREGISTREE,
-    native_category=NativeCategory.MUSIQUE_EN_LIGNE,
+    native_category=NativeCategory.PRATIQUES_ET_ATELIERS_ARTISTIQUES,
     pro_label="Captation musicale",
     app_label="Captation musicale",
-    search_group_name=SearchGroups.CD_VINYLE_MUSIQUE_EN_LIGNE.name,
+    search_group_name=SearchGroups.ARTS_LOISIRS_CREATIFS.name,
     homepage_label_name=HomepageLabels.MUSIQUE.name,
     is_event=False,
     conditional_fields={

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1151,7 +1151,6 @@ def test_public_api(client):
                         "MEDIA_PRESSE",
                         "MUSEES_VISITES_CULTURELLES",
                         "NONE",
-                        "PLATEFORMES_EN_LIGNE",
                         "RENCONTRES_CONFERENCES",
                         "SPECTACLES",
                     ],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20127

le retour des changements qui ont cassé la prod lundi 23/01/23.
cette fois, [le front est capable de gérer des différences entre les catégories back et les catégories front](https://github.com/pass-culture/pass-culture-app-native/pull/4283), donc ça ne devrait plus péter la prod.

⚠️ ⚠️ ⚠️ **ne pas merger cette PR avant que le ticket front ait été MEP et suivi d'une MAJ forcée de l'app**

## But de la pull request

mettre à jour la catégorisation des offres:

- Supprimer la catégorie plateforme en ligne côté back
- Associer la sous-catégorie pro CAPTATION MUSICALE au searchGroup ‘Arts et Loisir créatif’ et la nativ catégorie associée PRATIQUE et ATELIER ARTISTIQUE

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
