### PR TITLE
(PC-19990)[BO] feat: Delete offerer tag

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -30,6 +30,7 @@ class Permissions(enum.Enum):
     VALIDATE_OFFERER = "gérer la validation des structures et des rattachements"
     MANAGE_BOOKINGS = "gérer les réservations"
     MANAGE_OFFERS = "gérer les offres"
+    DELETE_OFFERER_TAG = "supprimer un tag structure"
 
     @classmethod
     def exists(cls, name: str) -> bool:

--- a/api/src/pcapi/routes/backoffice_v3/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/blueprint.py
@@ -43,6 +43,7 @@ backoffice_v3_web_schema.register(backoffice_v3_web)
 def extra_funcs() -> dict:
     return {
         "csrf_token": empty_forms.EmptyForm().csrf_token,
+        "has_permission": utils.has_current_user_permission,
         "can_user_add_comment": utils.can_user_add_comment,
         "is_user_offerer_action_type": utils.is_user_offerer_action_type,
     }

--- a/api/src/pcapi/routes/backoffice_v3/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/blueprint.py
@@ -5,7 +5,6 @@ from spectree import SecurityScheme
 from pcapi import settings
 from pcapi.serialization.spec_tree import ExtendedSpecTree
 from pcapi.serialization.utils import before_handler
-from pcapi.utils.urls import build_pc_pro_venue_link
 
 from . import utils
 from .forms import empty as empty_forms
@@ -46,5 +45,4 @@ def extra_funcs() -> dict:
         "csrf_token": empty_forms.EmptyForm().csrf_token,
         "can_user_add_comment": utils.can_user_add_comment,
         "is_user_offerer_action_type": utils.is_user_offerer_action_type,
-        "build_pc_pro_venue_link": build_pc_pro_venue_link,
     }

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/managed_venues.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/managed_venues.html
@@ -21,7 +21,7 @@
                     </a>
                 </td>
                 <td class="text-break">
-                    <a href="{{ build_pc_pro_venue_link(venue) }}" class="link-primary">
+                    <a href="{{ venue | pc_pro_venue_link }}" class="link-primary">
                         {{ venue.publicName or venue.name }}
                     </a>
                 </td>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/offerer_tag.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/offerer_tag.html
@@ -59,6 +59,15 @@
                                                 Modifier le tag structure
                                         </a>
                                     </li>
+                                    {% if has_permission("DELETE_OFFERER_TAG") %}
+                                        <li class="dropdown-item p-0">
+                                            <a class="btn btn-sm d-block w-100 text-start px-3"
+                                                    data-bs-toggle="modal"
+                                                    data-bs-target="#delete-offerer-tag-modal-{{ offerer_tag.id }}">
+                                                    Supprimer le tag structure
+                                            </a>
+                                        </li>
+                                    {% endif %}
                                 </ul>
                                 {% set form = forms[offerer_tag.id] %}
                                 <div class="modal modal-lg fade" id="edit-offerer-tag-modal-{{ offerer_tag.id }}" tabindex="-1"
@@ -83,6 +92,35 @@
                                         </div>
                                     </div>
                                 </div>
+                                {% if has_permission("DELETE_OFFERER_TAG") %}
+                                    <div class="modal modal-lg fade" id="delete-offerer-tag-modal-{{ offerer_tag.id }}" tabindex="-1"
+                                        aria-labelledby="delete-offerer-tag-modal-{{ offerer_tag.id }}-label" aria-hidden="true">
+                                        <div class="modal-dialog modal-dialog-centered">
+                                            <div class="modal-content">
+                                                <form action="{{ url_for("backoffice_v3_web.offerer_tag.delete_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
+                                                    method="POST" data-turbo="false">
+                                                    <div class="modal-header" id="delete-offerer-tag-modal-{{ offerer_tag.id }}-label">
+                                                        <h5 class="modal-title">Supprimer le tag {{ offerer_tag.name }}</h5>
+                                                    </div>
+                                                    <div class="modal-body row">
+                                                        <p>
+                                                            Le tag <strong>{{ offerer_tag.label or offerer_tag.name }}</strong> sera définitivement supprimé
+                                                            de la base de données et retiré de toutes les structures auxquelles il est associé. Veuillez confirmer ce choix.
+                                                        </p>
+                                                        <div class="form-group">
+                                                            {% set form = delete_tag_form %}
+                                                            {% include "components/form_body.html" %}
+                                                        </div>
+                                                    </div>
+                                                    <div class="modal-footer">
+                                                        <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Annuler</button>
+                                                        <button type="submit" class="btn btn-primary">Confirmer</button>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endif %}
                             </div>
                         </td>
                         <td>{{ offerer_tag.id }}</td>

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -29,7 +29,9 @@ class UnauthenticatedUserError(Exception):
     pass
 
 
-def has_current_user_permission(permission: perm_models.Permissions) -> bool:
+def has_current_user_permission(permission: perm_models.Permissions | str) -> bool:
+    if isinstance(permission, str):
+        permission = perm_models.Permissions[permission]
     return permission in current_user.backoffice_profile.permissions or settings.IS_TESTING
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -5,6 +5,7 @@ from pcapi.core.permissions import models as perm_models
 ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "admin": [
         perm_models.Permissions.MANAGE_PERMISSIONS,
+        perm_models.Permissions.DELETE_OFFERER_TAG,
     ],
     "support-N1": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -28,6 +28,7 @@ pytestmark = [
 ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "admin": [
         perm_models.Permissions.MANAGE_PERMISSIONS,
+        perm_models.Permissions.DELETE_OFFERER_TAG,
     ],
     "support-N1": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19990

## But de la pull request

Possibilité de supprimer un tag de structures dans le backoffice v3.

Cette option nécessite une permission spécifique donnée aux admin, et n'est pas accessible pour tout utilisateur pouvant créer des tags ou gérer des structures (car ça retire le tag supprimé à toutes les structures ; donc plus destructif).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
