### PR TITLE
(PC-20141)[BO] fix: consistent ids displayed in results/details

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_offerer.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_offerer.html
@@ -11,7 +11,7 @@
         </h5>
 
         <h6 class="card-subtitle mt-4 mb-3 text-muted">
-            ID : {{ row.id }}
+            Offerer ID : {{ row.id }}
         </h6>
 
         <h6 class="card-subtitle mb-4 text-muted">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_venue.html
@@ -15,7 +15,7 @@
         </h5>
 
         <h6 class="card-subtitle mt-4 mb-3 text-muted">
-            Offerer ID : {{ row.managingOffererId | empty_string_if_null }}
+            Venue ID : {{ row.id }}
         </h6>
 
         <h6 class="card-subtitle mb-4 text-muted">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -53,7 +53,7 @@
                 </div>
 
                 <p class="card-subtitle text-muted mb-3 h5">
-                    User ID : {{ offerer.id }}
+                    Offerer ID : {{ offerer.id }}
                 </p>
 
                 <p class="card-subtitle text-muted mb-3 h5">

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -85,14 +85,14 @@ class GetOffererTest:
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
-        content = response.data.decode("utf-8")
+        content = html_parser.content_as_text(response.data)
 
         assert offerer.name in content
-        assert str(offerer.id) in content
-        assert offerer.siren in content
-        assert offerer.city in content
-        assert offerer.postalCode in content
-        assert offerer.address in content
+        assert f"Offerer ID : {offerer.id} " in content
+        assert f"SIREN : {offerer.siren} " in content
+        assert f"Ville : {offerer.city} " in content
+        assert f"Code postal : {offerer.postalCode} " in content
+        assert f"Adresse : {offerer.address} " in content
         assert "Structure" in content
 
 

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -13,6 +13,7 @@ from pcapi.routes.backoffice_v3.filters import format_date
 import pcapi.utils.email as email_utils
 
 from .helpers import comment as comment_helpers
+from .helpers import html_parser
 from .helpers import unauthorized as unauthorized_helpers
 
 
@@ -38,15 +39,15 @@ class GetProUserTest:
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
-        content = response.data.decode("utf-8")
+        content = html_parser.content_as_text(response.data)
 
-        assert str(user.id) in content
+        assert f"User ID : {str(user.id)} " in content
         assert user.firstName in content
         assert user.lastName.upper() in content
         assert user.email in content
-        assert user.phoneNumber in content
-        assert user.postalCode in content
-        assert user.departementCode in content
+        assert f"Tél : {user.phoneNumber} " in content
+        assert f"Code postal : {user.postalCode} " in content
+        assert f"Département : {user.departementCode} " in content
         assert "Pro" in content
 
     def test_get_not_pro_user(self, authenticated_client):  # type: ignore

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -68,8 +68,9 @@ class GetVenueTest:
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
-        assert venue.name in response.data.decode("utf-8")
         response_text = html_parser.content_as_text(response.data)
+        assert venue.name in response_text
+        assert f"Venue ID : {venue.id} " in response_text
         assert "Éligible EAC : Non" in response_text
         assert "ID Adage" not in response_text
         assert f"Site web : {venue.contact.website}" in response_text


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20141

## But de la pull request

Uniformiser les ID entre les résultats de recherche et le profil des AC 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
