### PR TITLE
PC-18797 add user events for id check

### DIFF
--- a/api/src/pcapi/core/external/batch.py
+++ b/api/src/pcapi/core/external/batch.py
@@ -3,6 +3,7 @@ import logging
 
 from pcapi.core.external.attributes import models as attributes_models
 import pcapi.core.finance.models as finance_models
+import pcapi.core.fraud.models as fraud_models
 import pcapi.notifications.push as push_notifications
 from pcapi.tasks import batch_tasks
 
@@ -71,4 +72,12 @@ def track_deposit_activated_event(user_id: int, deposit: finance_models.Deposit)
     event_name = push_notifications.BatchEvent.USER_DEPOSIT_ACTIVATED.value
     event_payload = {"deposit_type": deposit.type.value, "deposit_amount": deposit.amount}
     payload = batch_tasks.TrackBatchEventRequest(event_name=event_name, event_payload=event_payload, user_id=user_id)
+    batch_tasks.track_event_task.delay(payload)
+
+
+def track_identity_check_started_event(user_id: int, fraud_check_type: fraud_models.FraudCheckType) -> None:
+    event_name = push_notifications.BatchEvent.USER_IDENTITY_CHECK_STARTED.value
+    payload = batch_tasks.TrackBatchEventRequest(
+        event_name=event_name, event_payload={"type": fraud_check_type.value}, user_id=user_id
+    )
     batch_tasks.track_event_task.delay(payload)

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -67,16 +67,13 @@ class DuplicateIneHash(Exception):
 def on_educonnect_result(
     user: users_models.User, educonnect_content: models.EduconnectContent
 ) -> models.BeneficiaryFraudCheck:
-    eligibility_type = educonnect_content.get_eligibility_type_at_registration()
-
-    fraud_check = models.BeneficiaryFraudCheck(
+    fraud_check = subscription_api.initialize_identity_fraud_check(
+        eligibility_type=educonnect_content.get_eligibility_type_at_registration(),
+        fraud_check_type=models.FraudCheckType.EDUCONNECT,
+        identity_content=educonnect_content,
+        third_party_id=str(educonnect_content.educonnect_id),
         user=user,
-        type=models.FraudCheckType.EDUCONNECT,
-        thirdPartyId=str(educonnect_content.educonnect_id),
-        resultContent=educonnect_content.dict(),
-        eligibilityType=eligibility_type,
     )
-
     on_identity_fraud_check_result(user, fraud_check)
     repository.save(fraud_check)
     return fraud_check

--- a/api/src/pcapi/core/fraud/dms/api.py
+++ b/api/src/pcapi/core/fraud/dms/api.py
@@ -1,9 +1,7 @@
 import logging
 
-import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.models as fraud_models
 import pcapi.core.users.models as users_models
-from pcapi.repository import repository
 
 
 logger = logging.getLogger(__name__)
@@ -19,25 +17,3 @@ def get_fraud_check(user: users_models.User, application_number: int) -> fraud_m
         .order_by(fraud_models.BeneficiaryFraudCheck.id.desc())
         .first()
     )
-
-
-def create_fraud_check(
-    user: users_models.User,
-    application_number: int,
-    source_data: fraud_models.DMSContent | None,
-) -> fraud_models.BeneficiaryFraudCheck:
-    eligibility_type = (
-        fraud_api.decide_eligibility(user, source_data.get_birth_date(), source_data.get_registration_datetime())
-        if source_data
-        else None
-    )
-    fraud_check = fraud_models.BeneficiaryFraudCheck(
-        user=user,
-        type=fraud_models.FraudCheckType.DMS,
-        thirdPartyId=str(application_number),
-        resultContent=source_data.dict() if source_data else None,
-        status=fraud_models.FraudCheckStatus.STARTED,
-        eligibilityType=eligibility_type,
-    )
-    repository.save(fraud_check)
-    return fraud_check

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -9,7 +9,6 @@ from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 from pcapi.core.users import utils as users_utils
-from pcapi.models import db
 
 
 UBBLE_TEST_EMAIL_RE = re.compile(r"^.+(\+ubble_test@.+|@yeswehack.ninja)$")
@@ -104,19 +103,6 @@ def ubble_fraud_checks(
             fraud_items.append(fraud_api.duplicate_id_piece_number_fraud_item(user, id_piece_number))
 
     return fraud_items
-
-
-def start_ubble_fraud_check(user: users_models.User, ubble_content: ubble_fraud_models.UbbleContent) -> None:
-    fraud_check = fraud_models.BeneficiaryFraudCheck(
-        user=user,
-        type=fraud_models.FraudCheckType.UBBLE,
-        thirdPartyId=str(ubble_content.identification_id),
-        resultContent=ubble_content,  # type: ignore [arg-type]
-        status=fraud_models.FraudCheckStatus.STARTED,
-        eligibilityType=user.eligibility,
-    )
-    db.session.add(fraud_check)
-    db.session.commit()
 
 
 def get_ubble_fraud_check(identification_id: str) -> fraud_models.BeneficiaryFraudCheck | None:

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -800,3 +800,23 @@ def _get_subscription_message(
             return educonnect_subscription_api.get_educonnect_subscription_message(fraud_check)
         case _:
             return subscription_messages.get_generic_ko_message(fraud_check.user.id)
+
+
+def initialize_identity_fraud_check(
+    eligibility_type: users_models.EligibilityType | None,
+    fraud_check_type: fraud_models.FraudCheckType,
+    identity_content: common_fraud_models.IdentityCheckContent,
+    third_party_id: str,
+    user: users_models.User,
+) -> fraud_models.BeneficiaryFraudCheck:
+    """Create a fraud check for the user, with the identity information provided by the identity provider."""
+    fraud_check = fraud_models.BeneficiaryFraudCheck(
+        user=user,
+        type=fraud_check_type,
+        thirdPartyId=third_party_id,
+        resultContent=identity_content.dict() if identity_content else None,
+        status=fraud_models.FraudCheckStatus.STARTED,
+        eligibilityType=eligibility_type,
+    )
+    pcapi_repository.repository.save(fraud_check)
+    return fraud_check

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -819,4 +819,5 @@ def initialize_identity_fraud_check(
         eligibilityType=eligibility_type,
     )
     pcapi_repository.repository.save(fraud_check)
+    batch.track_identity_check_started_event(user.id, fraud_check.type)
     return fraud_check

--- a/api/src/pcapi/notifications/push/__init__.py
+++ b/api/src/pcapi/notifications/push/__init__.py
@@ -9,6 +9,7 @@ from pcapi.utils.module_loading import import_string
 
 class BatchEvent(enum.Enum):
     USER_DEPOSIT_ACTIVATED = "user_deposit_activated"
+    USER_IDENTITY_CHECK_STARTED = "user_identity_check_started"
 
 
 def update_user_attributes(

--- a/api/tests/core/fraud/dms/test_api.py
+++ b/api/tests/core/fraud/dms/test_api.py
@@ -3,6 +3,7 @@ import pytest
 from pcapi.core.fraud import factories as fraud_factories
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.fraud.dms import api as dms_api
+from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 
@@ -12,9 +13,14 @@ class DmsApiTest:
     def test_create_fraud_check(self):
         user = users_factories.UserFactory()
         application_number = 1
-        result_content = None
 
-        fraud_check = dms_api.create_fraud_check(user, application_number, result_content)
+        fraud_check = subscription_api.initialize_identity_fraud_check(
+            eligibility_type=user.eligibility,
+            fraud_check_type=fraud_models.FraudCheckType.DMS,
+            identity_content=None,
+            third_party_id=str(application_number),
+            user=user,
+        )
 
         user_fraud_checks = user.beneficiaryFraudChecks
         assert len(user_fraud_checks) == 1

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -25,6 +25,7 @@ from pcapi.core.subscription.ubble import exceptions as ubble_exceptions
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+import pcapi.notifications.push.testing as push_testing
 from pcapi.utils import requests as requests_utils
 
 import tests
@@ -56,6 +57,13 @@ class UbbleWorkflowTest:
 
         ubble_request = ubble_mock.last_request.json()
         assert ubble_request["data"]["attributes"]["webhook"] == "http://localhost/webhooks/ubble/application_status"
+
+        assert push_testing.requests[0] == {
+            "can_be_asynchronously_retried": True,
+            "event_name": "user_identity_check_started",
+            "event_payload": {"type": "ubble"},
+            "user_id": user.id,
+        }
 
     @pytest.mark.parametrize(
         "state, status, fraud_check_status",

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -18,6 +18,7 @@ from pcapi.core.subscription.educonnect import api as educonnect_subscription_ap
 from pcapi.core.testing import override_settings
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as user_models
+import pcapi.notifications.push.testing as push_testing
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -168,6 +169,13 @@ class EduconnectTest:
         assert user.dateOfBirth == signup_birth_date
         assert user.validatedBirthDate == datetime.date(2006, 8, 18)
         assert user.ineHash is None
+
+        assert push_testing.requests[0] == {
+            "can_be_asynchronously_retried": True,
+            "event_name": "user_identity_check_started",
+            "event_payload": {"type": "educonnect"},
+            "user_id": user.id,
+        }
 
     @patch("pcapi.connectors.beneficiaries.educonnect.educonnect_connector.get_saml_client")
     def test_connexion_date_missing(self, mock_get_educonnect_saml_client, client, caplog, app):

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -173,7 +173,7 @@ class RunIntegrationTest:
         assert fraud_check.userId == user.id
         assert fraud_check.thirdPartyId == "123"
         assert fraud_check.status == fraud_models.FraudCheckStatus.OK
-        assert len(push_testing.requests) == 2
+        assert len(push_testing.requests) == 3
 
         # Check that a PROFILE_COMPLETION fraud check is created
         profile_completion_fraud_checks = [
@@ -277,7 +277,7 @@ class RunIntegrationTest:
             user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.OK
         ).one_or_none()
         assert dms_check
-        assert len(push_testing.requests) == 2
+        assert len(push_testing.requests) == 3
 
         assert not user.is_beneficiary
         assert not user.deposit
@@ -318,7 +318,7 @@ class RunIntegrationTest:
         ).one_or_none()
         assert dms_check
 
-        assert len(push_testing.requests) == 2
+        assert len(push_testing.requests) == 3
 
         assert not user.is_beneficiary
         assert not user.deposit
@@ -391,7 +391,7 @@ class RunIntegrationTest:
             if fraud_check.type == fraud_models.FraudCheckType.HONOR_STATEMENT
         )
 
-        assert len(push_testing.requests) == 3
+        assert len(push_testing.requests) == 4
 
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["template"]["id_prod"] == 96  # accepted as beneficiary email
@@ -548,8 +548,8 @@ class RunIntegrationTest:
             TransactionalEmail.ACCEPTED_AS_BENEFICIARY.value
         )
 
-        assert len(push_testing.requests) == 3
-        assert push_testing.requests[0]["attribute_values"]["u.is_beneficiary"]
+        assert len(push_testing.requests) == 4
+        assert push_testing.requests[1]["attribute_values"]["u.is_beneficiary"]
 
     @patch.object(dms_connector_api.DMSGraphQLClient, "get_applications_with_details")
     def test_dms_application_value_error(self, get_applications_with_details):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18797

## But de la pull request

Envoyer un event batch au démarrage d'id check
Ct event est utilisé comme 'cancel event'  d'un event envoyé par le front

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
