### PR TITLE
(PC-20129)[API] fix: Liste des rattachements - Touche retour modale multi-sélection

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -43,7 +43,8 @@
 
         };
         new TomSelect(el, settings);
-    });
+    })
+
     document.getElementsByName("form").forEach((el) => {
         el.addEventListener("submit", (event) => {
             event.preventDefault();

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -144,6 +144,7 @@
 
 {% block scripts %}
     <script src="{{ url_for('static', filename='backoffice/js/pc-table-multi-select.js') }}"></script>
+    <script src="{{ url_for('static', filename='backoffice/js/pc-override-custom-textarea-enter.js') }}"></script>
     <script>
 
         document.getElementById("batch-pending-button").addEventListener('click', (e) => {
@@ -175,10 +176,10 @@
                 <div class="modal-body row">
                     <div class="form-floating my-3 col">
                         <input name="object_ids" type="hidden" value="${idValidations}"></input>
-                        <textarea name="comment" class="form-control" id="${ div_id }-textarea" rows="3" style="height:100%;"></textarea>
-                        <label for=${ div_id }-textarea"><label for="comment">Raison</label></label>
+                        <textarea name="comment" class="form-control" id="${div_id}-textarea" rows="3" style="height:100%;" onkeydown="manageTextAreaKeydown(event)"></textarea>
+                        <label for=${div_id}-textarea"><label for="comment">Raison</label></label>
                     </div>
-                    <button type="button" class="btn btn-outline-secondary col-1 h-50" id="${ div_id }-newline">⏎</button>
+                    <button type="button" class="btn btn-outline-secondary col-1 h-50" id="${div_id}-newline" onclick="manageReturnButton(event)">⏎</button>
                 </div>
 
                 <div class="modal-footer">
@@ -203,6 +204,8 @@
             getBatchModal().querySelector('.modal-content').innerHTML = html
         }
 
+
+
         function initBatchModal() {
             var modal = document.createElement('div')
             modal.classList.add('modal', 'fade')
@@ -213,9 +216,14 @@
             modal.innerHTML = `<div class="modal-dialog">
                 <div class="modal-content"></div>
             </div>`
+
             document.getElementById("batch-modal").appendChild(modal)
             return modal
         }
+
+
+
+
     </script>
 
 

--- a/api/src/pcapi/static/backoffice/js/pc-override-custom-textarea-enter.js
+++ b/api/src/pcapi/static/backoffice/js/pc-override-custom-textarea-enter.js
@@ -1,0 +1,23 @@
+function manageTextAreaKeydown(event) {
+    const elementId = event.target.id.replace('-textarea', '')
+    const returnButton = document.getElementById(elementId + '-newline')
+    const customForm = document.getElementById(elementId + '-form')
+    if (event.keyCode === 13) {
+        event.preventDefault();
+        if (event.ctrlKey || event.shiftKey) {
+            manageReturnButton(event)
+        } else {
+            customForm.submit();
+        }
+        return false;
+    }
+}
+
+function manageReturnButton(event) {
+    const elementId = event.target.id.replace('-newline', '')
+    const textarea = document.getElementById(elementId + '-textarea')
+    const start = textarea.selectionStart
+    textarea.value = textarea.value.slice(0, start) + "\n" + textarea.value.slice(textarea.selectionEnd)
+    textarea.setSelectionRange(start + 1, start + 1)
+    textarea.focus()
+}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20129

## But de la pull request

Resoudre le bug lié à ce Comportement Observé : 
Lorsqu’on sélectionne plusieurs demandes de rattachement pour mise en attente ou rejet en masse, il n’est pas possible de valider le commentaire et le changement de statut en appuyant sur Entrée (il faut cliquer sur le bouton), alors que c’est possible lors d’une sélection unique

## Implémentation

Création des fonctions pour soumettre le formulaire lors de l'appui sur la touche entrée depuis le champs de commentaire et le retour à la ligne forcé depuis le clic du bouton. 
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
