### PR TITLE
(PC-19983)[PRO] fix: buttons display before eligibility banner

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -320,6 +320,7 @@ const OfferType = (): JSX.Element => {
 
           {isDuplicateOfferSelectionActive &&
             isEligible &&
+            !isLoadingEligibility &&
             collectiveOfferSubtype === COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE &&
             hasCollectiveTemplateOffer && (
               <FormLayout.Section


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19983

## But de la pull request

Les boutons `Créer une nouvelle offre ou dupliquer une offre ?` s'affichent avant la banner demande de référencement

## Implémentation

- Ajouter une condition pour l'affichage de ces boutons pour ne pas les afficher si l'appel api checkant l'eligibility n'est pas terminé

