### PR TITLE
PC-20196 fix users blocked while beneficiary

### DIFF
--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -27,6 +27,9 @@ def has_failed_phone_validation(user: users_models.User) -> bool:
 
 
 def has_admin_ko_review(user: users_models.User) -> bool:
-    return db.session.query(
-        models.BeneficiaryFraudReview.query.filter_by(userId=user.id, review=models.FraudReviewStatus.KO).exists()
-    ).scalar()
+    latest_admin_review = (
+        models.BeneficiaryFraudReview.query.filter_by(userId=user.id)
+        .order_by(models.BeneficiaryFraudReview.dateReviewed.desc())
+        .first()
+    )
+    return bool(latest_admin_review and latest_admin_review.review == models.FraudReviewStatus.KO)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -352,15 +352,6 @@ def get_user_subscription_state(user: users_models.User) -> subscription_models.
             ),
         )
 
-    # Early return if there is an admin manual review
-    if fraud_repository.has_admin_ko_review(user):
-        return subscription_models.UserSubscriptionState(
-            fraud_status=models.SubscriptionItemStatus.KO,
-            next_step=None,
-            young_status=young_status_module.NonEligible(),
-            subscription_message=subscription_messages.get_generic_ko_message(user.id),
-        )
-
     # Early return if user is beneficiary
     if user.is_beneficiary and not users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility):
         if user.has_active_deposit:
@@ -373,6 +364,15 @@ def get_user_subscription_state(user: users_models.User) -> subscription_models.
             fraud_status=models.SubscriptionItemStatus.OK,
             next_step=None,
             young_status=young_status_module.ExBeneficiary(),
+        )
+
+    # Early return if there is an admin manual review
+    if fraud_repository.has_admin_ko_review(user):
+        return subscription_models.UserSubscriptionState(
+            fraud_status=models.SubscriptionItemStatus.KO,
+            next_step=None,
+            young_status=young_status_module.NonEligible(),
+            subscription_message=subscription_messages.get_generic_ko_message(user.id),
         )
 
     # Early return if user is not eligible

--- a/api/tests/core/fraud/test_repository.py
+++ b/api/tests/core/fraud/test_repository.py
@@ -1,0 +1,39 @@
+import datetime
+
+import pytest
+
+from pcapi.core.fraud import repository
+import pcapi.core.fraud.factories as fraud_factories
+import pcapi.core.fraud.models as fraud_models
+import pcapi.core.users.factories as users_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class RepositoryTest:
+    def should_find_ko_reviews(self):
+        user = users_factories.UserFactory()
+        fraud_factories.BeneficiaryFraudReviewFactory(user=user, review=fraud_models.FraudReviewStatus.KO)
+
+        assert repository.has_admin_ko_review(user)
+
+    def should_override_ko_with_ok_review(self):
+        user = users_factories.UserFactory()
+        fraud_factories.BeneficiaryFraudReviewFactory(
+            user=user, review=fraud_models.FraudReviewStatus.KO, dateReviewed=datetime.datetime(2020, 1, 1)
+        )
+        fraud_factories.BeneficiaryFraudReviewFactory(
+            user=user, review=fraud_models.FraudReviewStatus.OK, dateReviewed=datetime.datetime(2020, 1, 2)
+        )
+
+        assert not repository.has_admin_ko_review(user)
+
+    def should_use_latest_review(self):
+        user = users_factories.UserFactory()
+        fraud_factories.BeneficiaryFraudReviewFactory(
+            user=user, review=fraud_models.FraudReviewStatus.OK, dateReviewed=datetime.datetime(2020, 1, 1)
+        )
+        fraud_factories.BeneficiaryFraudReviewFactory(
+            user=user, review=fraud_models.FraudReviewStatus.KO, dateReviewed=datetime.datetime(2020, 1, 2)
+        )
+
+        assert repository.has_admin_ko_review(user)

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -202,3 +202,17 @@ class YoungStatusTest:
         status = young_status.Suspended()
         with pytest.raises(attrs.exceptions.FrozenInstanceError):
             status.status_type = young_status.YoungStatusType.BENEFICIARY
+
+    @pytest.mark.parametrize(
+        "review_status",
+        [
+            fraud_models.FraudReviewStatus.OK,
+            fraud_models.FraudReviewStatus.KO,
+            fraud_models.FraudReviewStatus.REDIRECTED_TO_DMS,
+        ],
+    )
+    def should_be_beneficiary_when_beneficiary_with_any_admin_review(self, review_status):
+        user = users_factories.BeneficiaryGrant18Factory()
+        fraud_factories.BeneficiaryFraudReviewFactory(user=user, review=review_status)
+
+        assert young_status.young_status(user) == young_status.Beneficiary()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20196

## But de la pull request

Ne pas bloquer les utilisateurs bénéficiaires quand ils réservent une offre

## Implémentation

Early return si on est bénéficiaire, avant de checker les revues mannuelles
#beneficiaryTrumpsKOreviews

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
