### PR TITLE
Pc 20063 eac make phone field optional in collective offer creation

### DIFF
--- a/adage-front/src/apiClient/models/CollectiveOfferResponseModel.ts
+++ b/adage-front/src/apiClient/models/CollectiveOfferResponseModel.ts
@@ -12,7 +12,7 @@ import type { StudentLevels } from './StudentLevels';
 export type CollectiveOfferResponseModel = {
   audioDisabilityCompliant: boolean;
   contactEmail: string;
-  contactPhone: string;
+  contactPhone?: string | null;
   description?: string | null;
   domains: Array<OfferDomain>;
   durationMinutes?: number | null;

--- a/adage-front/src/apiClient/models/CollectiveOfferTemplateResponseModel.ts
+++ b/adage-front/src/apiClient/models/CollectiveOfferTemplateResponseModel.ts
@@ -10,7 +10,7 @@ import type { StudentLevels } from './StudentLevels';
 export type CollectiveOfferTemplateResponseModel = {
   audioDisabilityCompliant: boolean;
   contactEmail: string;
-  contactPhone: string;
+  contactPhone?: string | null;
   description?: string | null;
   domains: Array<OfferDomain>;
   durationMinutes?: number | null;

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/ContactButton.tsx
@@ -16,7 +16,7 @@ const ContactButton = ({
 }: {
   className?: string
   contactEmail?: string
-  contactPhone?: string
+  contactPhone?: string | null
   offerId: number
   position: number
   queryId: string

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-fa7c663db77a (pre) (head)
+feba98cdb198 (pre) (head)
 930a602ac1af (post) (head)

--- a/api/src/pcapi/alembic/versions/20230131T093222_feba98cdb198_make_contact_phone_optional_collective_offer.py
+++ b/api/src/pcapi/alembic/versions/20230131T093222_feba98cdb198_make_contact_phone_optional_collective_offer.py
@@ -1,0 +1,22 @@
+"""make_contact_phone_optional_collective_offer
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "feba98cdb198"
+down_revision = "fa7c663db77a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("collective_offer", "contactPhone", existing_type=sa.TEXT(), nullable=True)
+    op.alter_column("collective_offer_template", "contactPhone", existing_type=sa.TEXT(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("collective_offer_template", "contactPhone", existing_type=sa.TEXT(), nullable=False)
+    op.alter_column("collective_offer", "contactPhone", existing_type=sa.TEXT(), nullable=False)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -240,7 +240,7 @@ class CollectiveOffer(
 
     contactEmail: str = sa.Column(sa.String(120), nullable=False)
 
-    contactPhone: str = sa.Column(sa.Text, nullable=False)
+    contactPhone: str | None = sa.Column(sa.Text, nullable=True)
 
     offerVenue: dict = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=False)
 
@@ -420,7 +420,7 @@ class CollectiveOfferTemplate(
 
     contactEmail: str = sa.Column(sa.String(120), nullable=False)
 
-    contactPhone: str = sa.Column(sa.Text, nullable=False)
+    contactPhone: str | None = sa.Column(sa.Text, nullable=True)
 
     offerVenue: dict = sa.Column(MutableDict.as_mutable(postgresql.json.JSONB), nullable=False)
 

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -144,7 +144,7 @@ class CollectiveOfferResponseModel(BaseModel, common_models.AccessibilityComplia
     students: list[educational_models.StudentLevels]
     offerVenue: CollectiveOfferOfferVenue
     contactEmail: str
-    contactPhone: str
+    contactPhone: str | None
     durationMinutes: int | None
     offerId: str | None
     educationalPriceDetail: str | None
@@ -195,7 +195,7 @@ class CollectiveOfferTemplateResponseModel(BaseModel, common_models.Accessibilit
     students: list[educational_models.StudentLevels]
     offerVenue: CollectiveOfferOfferVenue
     contactEmail: str
-    contactPhone: str
+    contactPhone: str | None
     durationMinutes: int | None
     educationalPriceDetail: str | None
     offerId: str | None

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -300,7 +300,7 @@ class GetCollectiveOfferBaseResponseModel(BaseModel, AccessibilityComplianceMixi
     students: list[StudentLevels]
     offerVenue: CollectiveOfferOfferVenueResponseModel
     contactEmail: str
-    contactPhone: str
+    contactPhone: str | None
     hasBookingLimitDatetimesPassed: bool
     offerId: str | None
     isActive: bool
@@ -398,7 +398,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     students: list[StudentLevels]
     offer_venue: CollectiveOfferVenueBodyModel
     contact_email: EmailStr
-    contact_phone: str
+    contact_phone: str | None
     intervention_area: list[str] | None
     template_id: str | None
     offerer_id: str | None  # FIXME (MathildeDuboille - 24/10/22) prevent bug in production where offererId is sent in params

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -17,7 +17,7 @@ export type GetCollectiveOfferResponseModel = {
   bookingEmails: Array<string>;
   collectiveStock?: GetCollectiveOfferCollectiveStockResponseModel | null;
   contactEmail: string;
-  contactPhone: string;
+  contactPhone?: string | null;
   dateCreated: string;
   description: string;
   domains: Array<OfferDomain>;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferTemplateResponseModel.ts
@@ -13,7 +13,7 @@ export type GetCollectiveOfferTemplateResponseModel = {
   audioDisabilityCompliant?: boolean | null;
   bookingEmails: Array<string>;
   contactEmail: string;
-  contactPhone: string;
+  contactPhone?: string | null;
   dateCreated: string;
   description: string;
   domains: Array<OfferDomain>;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferBodyModel.ts
@@ -9,7 +9,7 @@ export type PostCollectiveOfferBodyModel = {
   audioDisabilityCompliant?: boolean;
   bookingEmails: Array<string>;
   contactEmail: string;
-  contactPhone: string;
+  contactPhone?: string | null;
   description: string;
   domains?: Array<number> | null;
   durationMinutes?: number | null;

--- a/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostCollectiveOfferTemplateBodyModel.ts
@@ -9,7 +9,7 @@ export type PostCollectiveOfferTemplateBodyModel = {
   audioDisabilityCompliant?: boolean;
   bookingEmails: Array<string>;
   contactEmail: string;
-  contactPhone: string;
+  contactPhone?: string | null;
   description: string;
   domains?: Array<number> | null;
   durationMinutes?: number | null;

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferContactSection/CollectiveOfferContactSection.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferContactSection/CollectiveOfferContactSection.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { SummaryLayout } from 'components/SummaryLayout'
 
 interface ICollectiveOfferContactSectionProps {
-  phone: string
+  phone?: string | null
   email: string
 }
 

--- a/pro/src/pages/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
+++ b/pro/src/pages/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
@@ -136,6 +136,7 @@ export const createPatchOfferPayload = (
       changedValues = offerSerializer[key](changedValues, offer)
     }
   })
-
+  // We use this to patch phone number when user want to make it empty
+  changedValues.contactPhone = offer.phone || null
   return changedValues
 }

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormContact/FormContact.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormContact/FormContact.tsx
@@ -17,7 +17,7 @@ const FormContact = ({
     title="Contact"
   >
     <FormLayout.Row className={styles['phone-number-row']}>
-      <PhoneNumberInput name="phone" disabled={disableForm} />
+      <PhoneNumberInput name="phone" disabled={disableForm} isOptional />
     </FormLayout.Row>
     <FormLayout.Row>
       <TextInput

--- a/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
+++ b/pro/src/screens/OfferEducational/__specs__/OfferEducationalEdition.spec.tsx
@@ -77,7 +77,7 @@ describe('screens | OfferEducational', () => {
       screen.getByLabelText('Autre'), // one of every option
       screen.getByLabelText('Collège - 3e'), // one of every option
       screen.getByLabelText('Visuel'), // one of every option
-      screen.getByLabelText('Téléphone'),
+      screen.getByLabelText('Téléphone', { exact: false }),
       screen.getByLabelText(EMAIL_LABEL),
       screen.getByLabelText(NOTIFICATIONS_EMAIL_LABEL),
       screen.getByLabelText(INTERVENTION_AREA_LABEL),

--- a/pro/src/screens/OfferEducational/validationSchema.ts
+++ b/pro/src/screens/OfferEducational/validationSchema.ts
@@ -9,7 +9,7 @@ const isOneTrue = (values: Record<string, boolean>): boolean =>
 
 const isPhoneValid = (phone: string | undefined): boolean => {
   if (!phone) {
-    return false
+    return true
   }
 
   const phoneNumber = parsePhoneNumberFromString(phone, 'FR')
@@ -78,14 +78,11 @@ export const validationSchema = yup.object().shape({
       motor: yup.boolean(),
       none: yup.boolean(),
     }),
-  phone: yup
-    .string()
-    .required('Veuillez entrer un numéro de téléphone valide')
-    .test({
-      name: 'is-phone-valid',
-      message: 'Veuillez entrer un numéro de téléphone valide',
-      test: isPhoneValid,
-    }),
+  phone: yup.string().test({
+    name: 'is-phone-valid',
+    message: 'Veuillez entrer un numéro de téléphone valide',
+    test: isPhoneValid,
+  }),
   email: yup
     .string()
     .required('Veuillez renseigner une adresse e-mail')


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20063

## But de la pull request

Lors de la création/édition d'offre collectives : 

- Le champ téléphone n'est plus obligatoire 

