### PR TITLE
(PC-20157)[API] fix: Boost add default None to next() in udpate stock quantity to match cinema remaining places add

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1053,7 +1053,8 @@ def update_stock_quantity_to_match_cinema_venue_provider_remaining_place(
                 for s in offer.activeStocks
                 if cinema_providers_utils.get_showtime_id_from_uuid(s.idAtProviders, venue_provider.provider.localClass)
                 == show_id
-            )
+            ),
+            None,
         )
         if stock and remaining_places <= 0:
             update_stock_quantity_to_dn_booked_quantity(stock.id)

--- a/api/tests/local_providers/cinema_providers/boost/fixtures.py
+++ b/api/tests/local_providers/cinema_providers/boost/fixtures.py
@@ -99,6 +99,34 @@ SHOWTIME_36684 = {
         "seatingAllowed": False,
     },
 }
+SHOWTIME_36685 = {
+    "id": 36685,
+    "showDate": "2022-11-30T09:00:00+01:00",
+    "showEndDate": "2022-11-30T11:52:00+01:00",
+    "soldOut": False,
+    "authorizedAccess": False,
+    "vfstfr": False,
+    "preview": False,
+    "numberSeatsRemaining": 12,
+    "numberRemainingSeatsForOnlineSale": 12,
+    "film": FILM_207,
+    "format": {"id": 1, "title": "2D"},
+    "version": {"id": 3, "title": "Film Etranger en Langue Française", "code": "VF"},
+    "screen": {
+        "id": 1,
+        "auditoriumNumber": 1,
+        "name": "SALLE CINEMAX",
+        "capacity": 136,
+        "HFR": False,
+        "is4K": False,
+        "ice": True,
+        "lightVibes": False,
+        "eclairColor": False,
+        "hearingImpaired": False,
+        "audioDescription": False,
+        "seatingAllowed": False,
+    },
+}
 SHOWTIME_36848 = {
     "id": 36848,
     "showDate": "2022-11-28T09:00:00+01:00",
@@ -180,6 +208,15 @@ class ShowtimesWithFilmIdEndpointResponse:
         "nextPage": 1,
         "totalPages": 1,
         "totalCount": 2,
+    }
+    PAGE_1_JSON_DATA_3_SHOWTIMES = {
+        "data": [SHOWTIME_36683, SHOWTIME_36684, SHOWTIME_36685],
+        "message": "OK",
+        "page": 1,
+        "previousPage": 1,
+        "nextPage": 1,
+        "totalPages": 1,
+        "totalCount": 3,
     }
 
 

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -290,7 +290,7 @@ class OffersTest:
 
         response_return_value = mock.MagicMock(status_code=200, text="", headers={"Content-Type": "application/json"})
         response_return_value.json = mock.MagicMock(
-            return_value=fixtures.ShowtimesWithFilmIdEndpointResponse.PAGE_1_JSON_DATA
+            return_value=fixtures.ShowtimesWithFilmIdEndpointResponse.PAGE_1_JSON_DATA_3_SHOWTIMES
         )
         request_get.return_value = response_return_value
 
@@ -318,7 +318,8 @@ class OffersTest:
             offer=offer, idAtProviders=f"{offer_id_at_provider}#{second_show_id}", quantity=96
         )
 
-        client.get(f"/native/v1/offer/{offer.id}")
+        response = client.get(f"/native/v1/offer/{offer.id}")
+        assert response.status_code == 200
         assert first_show_stock.remainingQuantity == 96
         assert second_show_stock.remainingQuantity == 0
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20157

## But de la pull request

Ajouter `None` comme valeur par défaut à `next()` pour ne pas avoir l'exception `StopIteration`


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
