### PR TITLE
(BSR)[API] feat: make sure fullname always has a value

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -381,7 +381,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
 
     @property
     def full_name(self) -> str | None:
-        return f"{self.firstName or ''} {self.lastName or ''}".strip()
+        return (f"{self.firstName or ''} {self.lastName or ''}".strip()) or self.publicName
 
     @property
     def has_active_deposit(self):  # type: ignore [no-untyped-def]

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -285,7 +285,7 @@ class UserTest:
         assert user.full_name == f"{user.firstName} {user.lastName}"
 
         no_name_user = users_factories.UserFactory(firstName="", lastName="")
-        assert no_name_user.full_name == ""
+        assert no_name_user.full_name == no_name_user.publicName
 
     def test_pro_validation_status(self):
         user = users_factories.UserFactory()


### PR DESCRIPTION
## But de la pull request

Toujours avoir une valeur a full_name si jamais nom et prénom sont vides

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
