### PR TITLE
(BSR)[PRO] refactor: add renderWithProviders utils

### DIFF
--- a/pro/src/app/__specs__/App.spec.jsx
+++ b/pro/src/app/__specs__/App.spec.jsx
@@ -1,11 +1,10 @@
 import { setUser } from '@sentry/browser'
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
 import { URL_FOR_MAINTENANCE } from 'utils/config'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { App } from '../App'
 
@@ -15,26 +14,21 @@ jest.mock('hooks/useAnalytics', () => ({
 
 jest.mock('hooks/useLogNavigation', () => jest.fn())
 
-const renderApp = ({ props, store: storeOverride, initialEntries = '/' }) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <App {...props}>
-          <Route path={'/'}>
-            <p>Sub component</p>
-          </Route>
-          <Route path={'/login'}>
-            <p>Login page</p>
-          </Route>
-          <Route path={'/offres'}>
-            <p>Private Page</p>
-          </Route>
-        </App>
-      </MemoryRouter>
-    </Provider>
+const renderApp = ({ props, store: storeOverrides, initialEntries = '/' }) =>
+  renderWithProviders(
+    <App {...props}>
+      <Route path={'/'}>
+        <p>Sub component</p>
+      </Route>
+      <Route path={'/login'}>
+        <p>Login page</p>
+      </Route>
+      <Route path={'/offres'}>
+        <p>Private Page</p>
+      </Route>
+    </App>,
+    { storeOverrides, initialRouterEntries: [initialEntries] }
   )
-}
 
 jest.mock('@sentry/browser', () => ({
   setUser: jest.fn(),
@@ -86,6 +80,7 @@ describe('src | App', () => {
       expect(setHrefSpy).toHaveBeenCalledWith(URL_FOR_MAINTENANCE)
     })
   })
+
   it('should render a Redirect component when route is private and user not logged in', () => {
     store = {
       ...store,
@@ -95,6 +90,7 @@ describe('src | App', () => {
 
     expect(screen.getByText('Sub component')).toBeInTheDocument()
   })
+
   it('should render a Redirect component when loging out', () => {
     store = {
       ...store,

--- a/pro/src/app/__specs__/AppLayout.spec.jsx
+++ b/pro/src/app/__specs__/AppLayout.spec.jsx
@@ -1,38 +1,32 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import AppLayout from '../AppLayout'
 
-const renderApp = async (props, store, url = '/') => {
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <AppLayout {...props}>
-          <p>Sub component</p>
-        </AppLayout>
-      </MemoryRouter>
-    </Provider>
+const renderApp = async (props, storeOverrides, url = '/') =>
+  renderWithProviders(
+    <AppLayout {...props}>
+      <p>Sub component</p>
+    </AppLayout>,
+    { storeOverrides, initialRouterEntries: [url] }
   )
-}
 
 describe('src | AppLayout', () => {
   let props
-  let store
+  let storeOverrides
 
   beforeEach(() => {
     props = {}
-    store = configureTestStore({
+    storeOverrides = {
       user: { currentUser: { publicName: 'François', isAdmin: false } },
-    })
+    }
   })
 
   it('should not render domain name banner when arriving from new domain name', async () => {
     // Given / When
-    renderApp(props, store)
+    renderApp(props, storeOverrides)
 
     // Then
     await waitFor(() =>
@@ -46,7 +40,7 @@ describe('src | AppLayout', () => {
 
   it('should render domain name banner when coming from old domain name', async () => {
     // When
-    renderApp(props, store, '/?redirect=true')
+    renderApp(props, storeOverrides, '/?redirect=true')
 
     // Then
     await waitFor(() =>

--- a/pro/src/components/ActionsBarSticky/__specs__/ActionsBarSticky.spec.tsx
+++ b/pro/src/components/ActionsBarSticky/__specs__/ActionsBarSticky.spec.tsx
@@ -1,26 +1,22 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ActionsBarSticky from '../ActionsBarSticky'
 
-const renderActionsBar = () => {
-  render(
-    <Provider store={configureTestStore()}>
-      <ActionsBarSticky>
-        <ActionsBarSticky.Left>
-          <div>left content</div>
-        </ActionsBarSticky.Left>
+const renderActionsBar = () =>
+  renderWithProviders(
+    <ActionsBarSticky>
+      <ActionsBarSticky.Left>
+        <div>left content</div>
+      </ActionsBarSticky.Left>
 
-        <ActionsBarSticky.Right>
-          <div>right content</div>
-        </ActionsBarSticky.Right>
-      </ActionsBarSticky>
-    </Provider>
+      <ActionsBarSticky.Right>
+        <div>right content</div>
+      </ActionsBarSticky.Right>
+    </ActionsBarSticky>
   )
-}
 
 describe('ActionsBarSticky', () => {
   it('should render contents', () => {

--- a/pro/src/components/Banner/__specs__/BannerSummary.spec.tsx
+++ b/pro/src/components/Banner/__specs__/BannerSummary.spec.tsx
@@ -1,19 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { OFFER_WIZARD_MODE } from 'core/Offers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { BannerSummary } from '../'
 
 describe('components:BannerSummary', () => {
   it('renders component successfully when offer is not draft', async () => {
-    render(
-      <Provider store={configureTestStore()}>
-        <BannerSummary mode={OFFER_WIZARD_MODE.CREATION} />
-      </Provider>
-    )
+    renderWithProviders(<BannerSummary mode={OFFER_WIZARD_MODE.CREATION} />)
     expect(
       screen.getByText(
         /Vérifiez les informations ci-dessous avant de publier votre offre./
@@ -25,12 +20,9 @@ describe('components:BannerSummary', () => {
       )
     ).toBeInTheDocument()
   })
+
   it('renders component successfully when offer is draft', async () => {
-    render(
-      <Provider store={configureTestStore()}>
-        <BannerSummary mode={OFFER_WIZARD_MODE.DRAFT} />
-      </Provider>
-    )
+    renderWithProviders(<BannerSummary mode={OFFER_WIZARD_MODE.DRAFT} />)
     expect(
       screen.getByText(
         /Vérifiez les informations ci-dessous avant de publier votre offre./

--- a/pro/src/components/ButtonDownloadCSV/__specs__/ButtonDownloadCSV.spec.jsx
+++ b/pro/src/components/ButtonDownloadCSV/__specs__/ButtonDownloadCSV.spec.jsx
@@ -1,24 +1,22 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import fetch from 'jest-fetch-mock'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import Notification from 'components/Notification/Notification'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
-import { configureTestStore } from '../../../store/testUtils'
 import ButtonDownloadCSV from '../ButtonDownloadCSV'
 
-const renderButtonDownloadCSV = async ({ props, storeOverrides }) => {
-  const store = configureTestStore(storeOverrides)
-
-  return render(
-    <Provider store={store}>
+const renderButtonDownloadCSV = async ({ props, storeOverrides }) =>
+  renderWithProviders(
+    <>
       <ButtonDownloadCSV {...props}>Fake Button</ButtonDownloadCSV>
       <Notification />
-    </Provider>
+    </>,
+    { storeOverrides }
   )
-}
+
 describe('src | components | Layout | ButtonDownloadCSV', () => {
   describe('render', () => {
     it('should disable button during download', async () => {

--- a/pro/src/components/ButtonLinkNewWindow/__specs__/ButtonLinkNewWindow.tracker.spec.tsx
+++ b/pro/src/components/ButtonLinkNewWindow/__specs__/ButtonLinkNewWindow.tracker.spec.tsx
@@ -1,25 +1,21 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { ButtonLinkNewWindow, IButtonLinkNewWindowProps } from '..'
-import { configureTestStore } from '../../../store/testUtils'
 
 window.open = jest.fn()
 const mockLogEvent = jest.fn()
 
-const renderButtonLinkNewWindow = async (props: IButtonLinkNewWindowProps) => {
-  const store = configureTestStore()
-
-  return render(
-    <Provider store={store}>
-      <ButtonLinkNewWindow {...props}>
-        <p>clique moi</p>
-      </ButtonLinkNewWindow>
-    </Provider>
+const renderButtonLinkNewWindow = (props: IButtonLinkNewWindowProps) =>
+  renderWithProviders(
+    <ButtonLinkNewWindow {...props}>
+      <p>clique moi</p>
+    </ButtonLinkNewWindow>
   )
-}
+
 describe('tracker ButtonLinkNewWindow', () => {
   it('should track offer when clicking on link', async () => {
     const props = {

--- a/pro/src/components/CollectiveOfferBreadcrumb/__specs__/CollectiveOfferBreadcrumb.spec.tsx
+++ b/pro/src/components/CollectiveOfferBreadcrumb/__specs__/CollectiveOfferBreadcrumb.spec.tsx
@@ -1,25 +1,15 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router-dom'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferBreadcrumb, {
   CollectiveOfferBreadcrumbStep,
   IOfferBreadcrumb,
 } from '../CollectiveOfferBreadcrumb'
 
-const renderCollectiveOfferBreadcrumb = (props: IOfferBreadcrumb) => {
-  const store = configureTestStore()
-  return render(
-    <MemoryRouter>
-      <Provider store={store}>
-        <CollectiveOfferBreadcrumb {...props} />
-      </Provider>
-    </MemoryRouter>
-  )
-}
+const renderCollectiveOfferBreadcrumb = (props: IOfferBreadcrumb) =>
+  renderWithProviders(<CollectiveOfferBreadcrumb {...props} />)
 
 describe('src | components | CollectiveOfferBreadcrumb', () => {
   let props: IOfferBreadcrumb

--- a/pro/src/components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
+++ b/pro/src/components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferLayout from '../CollectiveOfferLayout'
 
@@ -14,21 +13,16 @@ const renderCollectiveOfferLayout = ({
   isTemplate?: boolean
   title: string
   subTitle?: string
-}) => {
-  const store = configureTestStore()
-
-  render(
-    <Provider store={store}>
-      <CollectiveOfferLayout
-        title={title}
-        subTitle={subTitle}
-        isTemplate={isTemplate}
-      >
-        Test
-      </CollectiveOfferLayout>
-    </Provider>
+}) =>
+  renderWithProviders(
+    <CollectiveOfferLayout
+      title={title}
+      subTitle={subTitle}
+      isTemplate={isTemplate}
+    >
+      Test
+    </CollectiveOfferLayout>
   )
-}
 
 describe('CollectiveOfferLayout', () => {
   let props: { isTemplate?: boolean; title: string; subTitle?: string }

--- a/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/__specs__/CollectiveOfferPracticalInformation.spec.tsx
+++ b/pro/src/components/CollectiveOfferSummary/components/CollectiveOfferPracticalInformation/__specs__/CollectiveOfferPracticalInformation.spec.tsx
@@ -1,15 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { api } from 'apiClient/api'
 import { GetVenueResponseModel } from 'apiClient/v1'
-import { configureTestStore } from 'store/testUtils'
 import {
   collectiveOfferFactory,
   collectiveOfferTemplateFactory,
   collectiveStockFactory,
 } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferPracticalInformation from '..'
 
@@ -24,15 +23,12 @@ describe('CollectiveOfferPracticalInformation', () => {
     jest.spyOn(api, 'getVenue').mockResolvedValue({
       id: 'AE',
     } as GetVenueResponseModel)
-    const store = configureTestStore()
-    render(
-      <Provider store={store}>
-        <CollectiveOfferPracticalInformation
-          offer={collectiveOfferTemplateFactory({
-            educationalPriceDetail: 'Le détail du prix',
-          })}
-        />
-      </Provider>
+    renderWithProviders(
+      <CollectiveOfferPracticalInformation
+        offer={collectiveOfferTemplateFactory({
+          educationalPriceDetail: 'Le détail du prix',
+        })}
+      />
     )
     await waitFor(() => {
       expect(api.getVenue).toHaveBeenCalledTimes(1)
@@ -43,18 +39,15 @@ describe('CollectiveOfferPracticalInformation', () => {
   })
 
   it('when offer is not template', () => {
-    const store = configureTestStore()
-    render(
-      <Provider store={store}>
-        <CollectiveOfferPracticalInformation
-          offer={collectiveOfferFactory(
-            {},
-            collectiveStockFactory({
-              educationalPriceDetail: 'Le détail du prix',
-            })
-          )}
-        />
-      </Provider>
+    renderWithProviders(
+      <CollectiveOfferPracticalInformation
+        offer={collectiveOfferFactory(
+          {},
+          collectiveStockFactory({
+            educationalPriceDetail: 'Le détail du prix',
+          })
+        )}
+      />
     )
 
     const priceDetail = screen.queryByText(/Informations sur le prix/)

--- a/pro/src/components/Header/__specs__/Header.spec.jsx
+++ b/pro/src/components/Header/__specs__/Header.spec.jsx
@@ -1,13 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Header from '../Header'
 
@@ -27,17 +25,11 @@ const defaultStore = {
   },
 }
 
-const renderHeader = (overrideStore = defaultStore) => {
-  const stubStore = configureTestStore(overrideStore)
-
-  return render(
-    <Provider store={stubStore}>
-      <MemoryRouter initialEntries={['/accueil']}>
-        <Header />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderHeader = (storeOverrides = defaultStore) =>
+  renderWithProviders(<Header />, {
+    storeOverrides,
+    initialRouterEntries: ['/accueil'],
+  })
 
 describe('navigation menu', () => {
   beforeEach(() => {

--- a/pro/src/components/ImageUploader/AppPreviewVenue/__specs__/AppPreviewVenue.spec.tsx
+++ b/pro/src/components/ImageUploader/AppPreviewVenue/__specs__/AppPreviewVenue.spec.tsx
@@ -1,24 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import AppPreviewVenue, { IAppPreviewVenueProps } from '../AppPreviewVenue'
 
-interface IRenderAppPreviewVenueProps {
-  storeOverride?: Partial<RootState>
-  props: IAppPreviewVenueProps
-}
-const renderAppPreviewVenue = ({ props }: IRenderAppPreviewVenueProps) => {
-  const store = configureTestStore()
-  return render(
-    <Provider store={store}>
-      <AppPreviewVenue {...props} />
-    </Provider>
-  )
-}
+const renderAppPreviewVenue = (props: IAppPreviewVenueProps) =>
+  renderWithProviders(<AppPreviewVenue {...props} />)
 
 describe('AppPreviewVenue', () => {
   let props: IAppPreviewVenueProps
@@ -30,9 +18,7 @@ describe('AppPreviewVenue', () => {
   })
 
   it('should render app preview venue', async () => {
-    await renderAppPreviewVenue({
-      props,
-    })
+    await renderAppPreviewVenue(props)
     expect(screen.getByTestId('app-preview-venue-img-home')).toBeInTheDocument()
     expect(screen.getByTestId('app-preview-venue-img')).toBeInTheDocument()
   })

--- a/pro/src/components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/__specs__/ModalImageCrop.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/ModalImageEdit/ModalImageCrop/__specs__/ModalImageCrop.spec.tsx
@@ -1,10 +1,8 @@
-import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { UploaderModeEnum } from 'components/ImageUploader/types'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ModalImageCrop from '../ModalImageCrop'
 
@@ -26,11 +24,8 @@ const defaultProps = {
 
 describe('venue image edit', () => {
   it('closes the modal on cancel button click', async () => {
-    const store = configureTestStore()
-    const { getByText } = render(
-      <Provider store={store}>
-        <ModalImageCrop {...defaultProps} />
-      </Provider>
+    const { getByText } = renderWithProviders(
+      <ModalImageCrop {...defaultProps} />
     )
     await userEvent.click(getByText('Remplacer l’image'))
     expect(mockReplaceImage).toHaveBeenCalledTimes(1)

--- a/pro/src/components/ImageUploader/ButtonImageEdit/__specs__/ButtonImageEdit.spec.tsx
+++ b/pro/src/components/ImageUploader/ButtonImageEdit/__specs__/ButtonImageEdit.spec.tsx
@@ -1,22 +1,15 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import * as apiHelpers from 'apiClient/helpers'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ButtonImageEdit, { IButtonImageEditProps } from '../ButtonImageEdit'
 
-const renderButtonImageEdit = (props: IButtonImageEditProps) => {
-  const store = configureTestStore()
-  return render(
-    <Provider store={store}>
-      <ButtonImageEdit {...props} />
-    </Provider>
-  )
-}
+const renderButtonImageEdit = (props: IButtonImageEditProps) =>
+  renderWithProviders(<ButtonImageEdit {...props} />)
 
 describe('test ButtonImageEdit', () => {
   let props: IButtonImageEditProps

--- a/pro/src/components/ImageUploader/__specs__/ImageUploader.spec.tsx
+++ b/pro/src/components/ImageUploader/__specs__/ImageUploader.spec.tsx
@@ -1,29 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ImageUploader, { IImageUploaderProps } from '../ImageUploader'
 import { UploaderModeEnum } from '../types'
 
-interface IRenderImageUploaderProps {
-  storeOverride?: Partial<RootState>
-  props: IImageUploaderProps
-}
-const renderImageUploader = ({
-  storeOverride = {},
-  props,
-}: IRenderImageUploaderProps) => {
-  const store = configureTestStore(storeOverride)
-
-  return render(
-    <Provider store={store}>
-      <ImageUploader {...props} />
-    </Provider>
-  )
-}
+const renderImageUploader = (props: IImageUploaderProps) =>
+  renderWithProviders(<ImageUploader {...props} />)
 
 describe('ImageUploader', () => {
   let props: IImageUploaderProps
@@ -48,9 +32,7 @@ describe('ImageUploader', () => {
   })
 
   it('should render image uploader for existing file', async () => {
-    renderImageUploader({
-      props,
-    })
+    renderImageUploader(props)
     expect(
       screen.getByAltText('Prévisualisation de l’image')
     ).toBeInTheDocument()
@@ -75,9 +57,7 @@ describe('ImageUploader', () => {
       onImageDelete: async () => {},
       mode: UploaderModeEnum.OFFER,
     }
-    renderImageUploader({
-      props,
-    })
+    renderImageUploader(props)
     expect(
       screen.queryByAltText('Prévisualisation de l’image')
     ).not.toBeInTheDocument()

--- a/pro/src/components/Notification/__specs__/Notification.spec.jsx
+++ b/pro/src/components/Notification/__specs__/Notification.spec.jsx
@@ -1,9 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import Notification from 'components/Notification/Notification'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 jest.mock('core/Notification/constants', () => ({
   NOTIFICATION_TRANSITION_DURATION: 10,
@@ -11,19 +10,12 @@ jest.mock('core/Notification/constants', () => ({
 }))
 
 describe('src | components | layout | Notification', () => {
-  let store
-
-  const renderNotification = sentNotification => {
-    store = configureTestStore({
-      notification: { notification: sentNotification },
+  const renderNotification = sentNotification =>
+    renderWithProviders(<Notification />, {
+      storeOverrides: {
+        notification: { notification: sentNotification },
+      },
     })
-
-    return render(
-      <Provider store={store}>
-        <Notification />
-      </Provider>
-    )
-  }
 
   const notificationTypes = ['', 'success', 'error', 'information', 'pending']
   it.each(notificationTypes)(

--- a/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
+++ b/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
@@ -1,13 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { CollectiveBookingStatus, OfferStatus } from 'apiClient/v1'
 import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
 import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferEducationalActions, {
   IOfferEducationalActions,
@@ -17,7 +15,7 @@ const renderOfferEducationalActions = (
   props: IOfferEducationalActions,
   storeOverride?: Partial<RootState>
 ) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -36,14 +34,10 @@ const renderOfferEducationalActions = (
       ],
     },
     ...storeOverride,
+  }
+  return renderWithProviders(<OfferEducationalActions {...props} />, {
+    storeOverrides,
   })
-  return render(
-    <MemoryRouter>
-      <Provider store={store}>
-        <OfferEducationalActions {...props} />
-      </Provider>
-    </MemoryRouter>
-  )
 }
 
 describe('OfferEducationalActions', () => {

--- a/pro/src/components/OfferIndividualBreadcrumb/__specs__/OfferIndividualBreadcrumb.spec.tsx
+++ b/pro/src/components/OfferIndividualBreadcrumb/__specs__/OfferIndividualBreadcrumb.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route, Switch } from 'react-router'
+import { generatePath, Switch, Route } from 'react-router'
 
 import {
   IOfferIndividualContext,
@@ -11,8 +10,8 @@ import {
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { IOfferIndividual, IOfferIndividualStock } from 'core/Offers/types'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
-import { configureTestStore } from 'store/testUtils'
 import { individualOfferFactory } from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { OFFER_WIZARD_STEP_IDS } from '../constants'
 import OfferIndividualBreadcrumb from '../OfferIndividualBreadcrumb'
@@ -38,81 +37,78 @@ const renderOfferIndividualBreadcrumb = (
     showVenuePopin: {},
     ...contextOverride,
   }
-  const store = configureTestStore(storeOverrides)
-  const rtlReturns = render(
-    <Provider store={store}>
-      <OfferIndividualContext.Provider value={contextValues}>
-        <MemoryRouter initialEntries={[url]}>
-          <OfferIndividualBreadcrumb />
-          <Switch>
-            <Route
-              path={[
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-                  mode: OFFER_WIZARD_MODE.CREATION,
-                }),
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-                  mode: OFFER_WIZARD_MODE.EDITION,
-                }),
-              ]}
-            >
-              <div>Informations screen</div>
-            </Route>
-            <Route
-              path={[
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.STOCKS,
-                  mode: OFFER_WIZARD_MODE.CREATION,
-                }),
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.STOCKS,
-                  mode: OFFER_WIZARD_MODE.EDITION,
-                }),
-              ]}
-            >
-              <div>Stocks screen</div>
-            </Route>
-            <Route
-              path={[
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.TARIFS,
-                  mode: OFFER_WIZARD_MODE.CREATION,
-                }),
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.TARIFS,
-                  mode: OFFER_WIZARD_MODE.EDITION,
-                }),
-              ]}
-            >
-              <div>Tarifs screen</div>
-            </Route>
-            <Route
-              path={[
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-                  mode: OFFER_WIZARD_MODE.CREATION,
-                }),
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-                  mode: OFFER_WIZARD_MODE.EDITION,
-                }),
-              ]}
-            >
-              <div>Summary screen</div>
-            </Route>
-            <Route
-              path={getOfferIndividualPath({
-                step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
-                mode: OFFER_WIZARD_MODE.CREATION,
-              })}
-            >
-              <div>Confirmation screen</div>
-            </Route>
-          </Switch>
-        </MemoryRouter>
-      </OfferIndividualContext.Provider>
-    </Provider>
+
+  const rtlReturns = renderWithProviders(
+    <OfferIndividualContext.Provider value={contextValues}>
+      <OfferIndividualBreadcrumb />
+      <Switch>
+        <Route
+          path={[
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+              mode: OFFER_WIZARD_MODE.CREATION,
+            }),
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+              mode: OFFER_WIZARD_MODE.EDITION,
+            }),
+          ]}
+        >
+          <div>Informations screen</div>
+        </Route>
+        <Route
+          path={[
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.STOCKS,
+              mode: OFFER_WIZARD_MODE.CREATION,
+            }),
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.STOCKS,
+              mode: OFFER_WIZARD_MODE.EDITION,
+            }),
+          ]}
+        >
+          <div>Stocks screen</div>
+        </Route>
+        <Route
+          path={[
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.TARIFS,
+              mode: OFFER_WIZARD_MODE.CREATION,
+            }),
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.TARIFS,
+              mode: OFFER_WIZARD_MODE.EDITION,
+            }),
+          ]}
+        >
+          <div>Tarifs screen</div>
+        </Route>
+        <Route
+          path={[
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+              mode: OFFER_WIZARD_MODE.CREATION,
+            }),
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+              mode: OFFER_WIZARD_MODE.EDITION,
+            }),
+          ]}
+        >
+          <div>Summary screen</div>
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
+            mode: OFFER_WIZARD_MODE.CREATION,
+          })}
+        >
+          <div>Confirmation screen</div>
+        </Route>
+      </Switch>
+    </OfferIndividualContext.Provider>,
+    { storeOverrides, initialRouterEntries: [url] }
   )
 
   const tabInformations = screen.queryByText('Détails de l’offre')

--- a/pro/src/components/OfferIndividualBreadcrumb/__specs__/OfferIndividualBreadcrumb.tracker.spec.tsx
+++ b/pro/src/components/OfferIndividualBreadcrumb/__specs__/OfferIndividualBreadcrumb.tracker.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route, Switch } from 'react-router'
+import { generatePath, Route, Switch } from 'react-router'
 
 import {
   IOfferIndividualContext,
@@ -13,7 +12,7 @@ import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { IOfferIndividual, IOfferIndividualStock } from 'core/Offers/types'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { OFFER_WIZARD_STEP_IDS } from '../constants'
 import OfferIndividualBreadcrumb from '../OfferIndividualBreadcrumb'
@@ -41,56 +40,51 @@ const renderOfferIndividualBreadcrumb = (
     ...contextOverride,
   }
 
-  const store = configureTestStore({})
-
-  const rtlReturns = render(
-    <Provider store={store}>
-      <OfferIndividualContext.Provider value={contextValues}>
-        <MemoryRouter initialEntries={[url]}>
-          <OfferIndividualBreadcrumb />
-          <Switch>
-            <Route
-              path={Object.values(OFFER_WIZARD_MODE).map(mode =>
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-                  mode,
-                })
-              )}
-            >
-              <div>Informations screen</div>
-            </Route>
-            <Route
-              path={Object.values(OFFER_WIZARD_MODE).map(mode =>
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.STOCKS,
-                  mode,
-                })
-              )}
-            >
-              <div>Stocks screen</div>
-            </Route>
-            <Route
-              path={Object.values(OFFER_WIZARD_MODE).map(mode =>
-                getOfferIndividualPath({
-                  step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-                  mode,
-                })
-              )}
-            >
-              <div>Summary screen</div>
-            </Route>
-            <Route
-              path={getOfferIndividualPath({
-                step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
-                mode: OFFER_WIZARD_MODE.CREATION,
-              })}
-            >
-              <div>Confirmation screen</div>
-            </Route>
-          </Switch>
-        </MemoryRouter>
-      </OfferIndividualContext.Provider>
-    </Provider>
+  const rtlReturns = renderWithProviders(
+    <OfferIndividualContext.Provider value={contextValues}>
+      <OfferIndividualBreadcrumb />
+      <Switch>
+        <Route
+          path={Object.values(OFFER_WIZARD_MODE).map(mode =>
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+              mode,
+            })
+          )}
+        >
+          <div>Informations screen</div>
+        </Route>
+        <Route
+          path={Object.values(OFFER_WIZARD_MODE).map(mode =>
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.STOCKS,
+              mode,
+            })
+          )}
+        >
+          <div>Stocks screen</div>
+        </Route>
+        <Route
+          path={Object.values(OFFER_WIZARD_MODE).map(mode =>
+            getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+              mode,
+            })
+          )}
+        >
+          <div>Summary screen</div>
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
+            mode: OFFER_WIZARD_MODE.CREATION,
+          })}
+        >
+          <div>Confirmation screen</div>
+        </Route>
+      </Switch>
+    </OfferIndividualContext.Provider>,
+    { initialRouterEntries: [url] }
   )
 
   const tabInformations = screen.queryByText('Détails de l’offre')

--- a/pro/src/components/OfferIndividualForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/ImageUploaderOffer/__specs__/ImageUploaderOffer.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ImageUploaderOffer, {
   IImageUploaderOfferProps,
@@ -13,14 +12,8 @@ jest.mock('../utils', () => ({
   buildInitialValues: jest.fn(),
 }))
 
-const renderImageUploaderOffer = (props: IImageUploaderOfferProps) => {
-  const store = configureTestStore()
-  return render(
-    <Provider store={store}>
-      <ImageUploaderOffer {...props} />
-    </Provider>
-  )
-}
+const renderImageUploaderOffer = (props: IImageUploaderOfferProps) =>
+  renderWithProviders(<ImageUploaderOffer {...props} />)
 
 describe('test ImageUploaderOffer', () => {
   let props: IImageUploaderOfferProps

--- a/pro/src/components/OfferIndividualForm/Notifications/__specs__/Notifications.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/Notifications/__specs__/Notifications.spec.tsx
@@ -1,13 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
-import { Provider } from 'react-redux'
 import * as yup from 'yup'
 
 import { IOfferIndividualFormValues } from 'components/OfferIndividualForm'
-import { configureTestStore } from 'store/testUtils'
 import { SubmitButton } from 'ui-kit'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Notifications, { INotifications } from '../Notifications'
 import validationSchema from '../validationSchema'
@@ -23,7 +22,7 @@ const renderNotifications = ({
   onSubmit: () => void
   venueBookingEmail?: string | null
 }) => {
-  const store = {
+  const storeOverrides = {
     user: {
       currentUser: {
         email: 'email@example.com',
@@ -31,21 +30,21 @@ const renderNotifications = ({
       initialized: true,
     },
   }
-  return render(
-    <Provider store={configureTestStore(store)}>
-      <Formik
-        initialValues={initialValues}
-        onSubmit={onSubmit}
-        validationSchema={yup.object().shape(validationSchema)}
-      >
-        <Form>
-          <Notifications {...props} venueBookingEmail={venueBookingEmail} />
-          <SubmitButton className="primary-button" isLoading={false}>
-            Submit
-          </SubmitButton>
-        </Form>
-      </Formik>
-    </Provider>
+
+  return renderWithProviders(
+    <Formik
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validationSchema={yup.object().shape(validationSchema)}
+    >
+      <Form>
+        <Notifications {...props} venueBookingEmail={venueBookingEmail} />
+        <SubmitButton className="primary-button" isLoading={false}>
+          Submit
+        </SubmitButton>
+      </Form>
+    </Formik>,
+    { storeOverrides }
   )
 }
 

--- a/pro/src/components/OfferIndividualForm/__specs__/OfferIndividualForm.BannerAddVenue.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/__specs__/OfferIndividualForm.BannerAddVenue.spec.tsx
@@ -1,16 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { REIMBURSEMENT_RULES } from 'core/Finances'
 import { TOffererName } from 'core/Offerers/types'
 import { CATEGORY_STATUS } from 'core/Offers'
 import { IOfferCategory, IOfferSubCategory } from 'core/Offers/types'
 import { TOfferIndividualVenue } from 'core/Venue/types'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
   FORM_DEFAULT_VALUES,
@@ -30,21 +28,18 @@ const renderOfferIndividualForm = ({
   onSubmit: () => void
   props: IOfferIndividualFormProps
 }) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: { currentUser: { publicName: 'François', isAdmin: false } },
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Formik
-          initialValues={initialValues}
-          onSubmit={onSubmit}
-          validationSchema={validationSchema}
-        >
-          <OfferIndividualForm {...props} />
-        </Formik>
-      </MemoryRouter>
-    </Provider>
+  }
+  return renderWithProviders(
+    <Formik
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validationSchema={validationSchema}
+    >
+      <OfferIndividualForm {...props} />
+    </Formik>,
+    { storeOverrides }
   )
 }
 

--- a/pro/src/components/OfferIndividualForm/__specs__/OfferIndividualForm.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/__specs__/OfferIndividualForm.spec.tsx
@@ -1,9 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import {
   IOfferIndividualContext,
@@ -18,8 +16,8 @@ import {
   IOfferSubCategory,
 } from 'core/Offers/types'
 import { TOfferIndividualVenue } from 'core/Venue/types'
-import { configureTestStore } from 'store/testUtils'
 import { SubmitButton } from 'ui-kit'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
   FORM_DEFAULT_VALUES,
@@ -41,9 +39,9 @@ const renderOfferIndividualForm = ({
   props: IOfferIndividualFormProps
   contextOverride?: Partial<IOfferIndividualContext>
 }) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: { currentUser: { publicName: 'François', isAdmin: false } },
-  })
+  }
   const contextValues: IOfferIndividualContext = {
     offerId: null,
     offer: null,
@@ -57,23 +55,21 @@ const renderOfferIndividualForm = ({
     showVenuePopin: {},
     ...contextOverride,
   }
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <OfferIndividualContext.Provider value={contextValues}>
-          <Formik
-            initialValues={initialValues}
-            onSubmit={onSubmit}
-            validationSchema={validationSchema}
-          >
-            <Form>
-              <OfferIndividualForm {...props} />
-              <SubmitButton isLoading={false}>Submit</SubmitButton>
-            </Form>
-          </Formik>
-        </OfferIndividualContext.Provider>
-      </MemoryRouter>
-    </Provider>
+
+  return renderWithProviders(
+    <OfferIndividualContext.Provider value={contextValues}>
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        validationSchema={validationSchema}
+      >
+        <Form>
+          <OfferIndividualForm {...props} />
+          <SubmitButton isLoading={false}>Submit</SubmitButton>
+        </Form>
+      </Formik>
+    </OfferIndividualContext.Provider>,
+    { storeOverrides }
   )
 }
 

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/__specs__/RouteLeavingGuardCollectiveOfferCreation.spec.tsx
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/__specs__/RouteLeavingGuardCollectiveOfferCreation.spec.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import type { History } from 'history'
 import { createBrowserHistory } from 'history'
 import React from 'react'
-import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 import { Link } from 'react-router-dom'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import RouteLeavingGuardCollectiveOfferCreation, {
   RouteLeavingGuardCollectiveOfferCreationProps,
@@ -14,20 +13,17 @@ import RouteLeavingGuardCollectiveOfferCreation, {
 
 const renderRouteLeavingGuardCollectiveOfferCreation = async (
   props: RouteLeavingGuardCollectiveOfferCreationProps,
-  history: History,
-  store = configureTestStore({})
+  history: History
 ) => {
-  render(
-    <Provider store={store}>
-      <Router history={history}>
-        <Link to="/about">About</Link>
-        <Link to={`/offre/creation/collective`}>Création</Link>
-        <Link to={`/offre/AE/collective/stocks`}>Stocks</Link>
-        <Link to={`/offre/AE/collectif/visibilite`}>Visibilité</Link>
-        <Link to={`/offre/AE/collective/confirmation`}>Confirmation</Link>
-        <RouteLeavingGuardCollectiveOfferCreation {...props} />
-      </Router>
-    </Provider>
+  renderWithProviders(
+    <Router history={history}>
+      <Link to="/about">About</Link>
+      <Link to={`/offre/creation/collective`}>Création</Link>
+      <Link to={`/offre/AE/collective/stocks`}>Stocks</Link>
+      <Link to={`/offre/AE/collectif/visibilite`}>Visibilité</Link>
+      <Link to={`/offre/AE/collective/confirmation`}>Confirmation</Link>
+      <RouteLeavingGuardCollectiveOfferCreation {...props} />
+    </Router>
   )
 }
 
@@ -63,8 +59,7 @@ describe('components | RouteLeavingGuardCollectiveOfferCreation', () => {
 
     it('should not display confirmation modal when following template creation flow', async () => {
       history.push('/offre/creation/collectif')
-      const store = configureTestStore()
-      renderRouteLeavingGuardCollectiveOfferCreation(props, history, store)
+      renderRouteLeavingGuardCollectiveOfferCreation(props, history)
 
       history.push('/offre/AE/collectif/vitrine/creation/recapitulatif')
       expect(
@@ -131,11 +126,9 @@ describe('components | RouteLeavingGuardCollectiveOfferCreation', () => {
   })
 
   describe('when going backward', () => {
-    const store = configureTestStore()
-
     it('should not display confirmation modal when going from stocks to offer creation', () => {
       history.push('/offre/AE/collectif/stocks')
-      renderRouteLeavingGuardCollectiveOfferCreation(props, history, store)
+      renderRouteLeavingGuardCollectiveOfferCreation(props, history)
       history.push('/offre/creation/collectif')
 
       expect(
@@ -145,7 +138,7 @@ describe('components | RouteLeavingGuardCollectiveOfferCreation', () => {
 
     it('should not display confirmation modal when going from stocks to offer creation with offer id in url', () => {
       history.push('/offre/AE/collectif/stocks')
-      renderRouteLeavingGuardCollectiveOfferCreation(props, history, store)
+      renderRouteLeavingGuardCollectiveOfferCreation(props, history)
       history.push('/offre/collectif/AE/creation')
 
       expect(
@@ -155,7 +148,7 @@ describe('components | RouteLeavingGuardCollectiveOfferCreation', () => {
 
     it('should not display confirmation modal when going from visibility to stocks', () => {
       history.push('/offre/AE/collectif/visibilite')
-      renderRouteLeavingGuardCollectiveOfferCreation(props, history, store)
+      renderRouteLeavingGuardCollectiveOfferCreation(props, history)
       history.push('/offre/AE/collectif/stocks')
 
       expect(
@@ -165,7 +158,7 @@ describe('components | RouteLeavingGuardCollectiveOfferCreation', () => {
 
     it('should not display confirmation modal when going from visibility to offer creation', () => {
       history.push('/offre/AE/collectif/visibilite')
-      renderRouteLeavingGuardCollectiveOfferCreation(props, history, store)
+      renderRouteLeavingGuardCollectiveOfferCreation(props, history)
       history.push('/offre/collectif/AE/creation')
 
       expect(

--- a/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/__specs__/RouteLeavingGuardCollectiveOfferCreation.spec.tsx
+++ b/pro/src/components/RouteLeavingGuardCollectiveOfferCreation/__specs__/RouteLeavingGuardCollectiveOfferCreation.spec.tsx
@@ -11,7 +11,7 @@ import RouteLeavingGuardCollectiveOfferCreation, {
   RouteLeavingGuardCollectiveOfferCreationProps,
 } from '../RouteLeavingGuardCollectiveOfferCreation'
 
-const renderRouteLeavingGuardCollectiveOfferCreation = async (
+const renderRouteLeavingGuardCollectiveOfferCreation = (
   props: RouteLeavingGuardCollectiveOfferCreationProps,
   history: History
 ) => {

--- a/pro/src/components/UserEmailForm/__specs__/UserEmail.spec.tsx
+++ b/pro/src/components/UserEmailForm/__specs__/UserEmail.spec.tsx
@@ -1,11 +1,8 @@
-// react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
-
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { UserEmailForm } from '..'
 import { IUserEmailFormProps } from '../UserEmailForm'
@@ -13,7 +10,7 @@ import { IUserEmailFormProps } from '../UserEmailForm'
 const postEmailAdapterMock = jest.fn()
 
 const renderUserEmailForm = (props: IUserEmailFormProps) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -24,12 +21,9 @@ const renderUserEmailForm = (props: IUserEmailFormProps) => {
         lastName: 'Do',
       },
     },
-  })
-  return render(
-    <Provider store={store}>
-      <UserEmailForm {...props} />
-    </Provider>
-  )
+  }
+
+  return renderWithProviders(<UserEmailForm {...props} />, { storeOverrides })
 }
 
 describe('components:UserEmailForm', () => {

--- a/pro/src/components/UserIdentityForm/__specs__/UserIdentity.spec.tsx
+++ b/pro/src/components/UserIdentityForm/__specs__/UserIdentity.spec.tsx
@@ -1,11 +1,8 @@
-// react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
-
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { UserIdentityForm } from '../'
 import { IUserIdentityFormProps } from '../UserIdentityForm'
@@ -13,7 +10,7 @@ import { IUserIdentityFormProps } from '../UserIdentityForm'
 const patchIdentityAdapterMock = jest.fn()
 
 const renderUserIdentityForm = (props: IUserIdentityFormProps) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -24,12 +21,11 @@ const renderUserIdentityForm = (props: IUserIdentityFormProps) => {
         lastName: 'Do',
       },
     },
+  }
+
+  return renderWithProviders(<UserIdentityForm {...props} />, {
+    storeOverrides,
   })
-  return render(
-    <Provider store={store}>
-      <UserIdentityForm {...props} />
-    </Provider>
-  )
 }
 
 describe('components:UserIdentityForm', () => {

--- a/pro/src/components/UserPasswordForm/__specs__/UserPassword.spec.tsx
+++ b/pro/src/components/UserPasswordForm/__specs__/UserPassword.spec.tsx
@@ -1,11 +1,8 @@
-// react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
-
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { UserPasswordForm } from '..'
 import { IUserPasswordFormProps } from '../UserPasswordForm'
@@ -13,7 +10,7 @@ import { IUserPasswordFormProps } from '../UserPasswordForm'
 const postPasswordAdapterMock = jest.fn()
 
 const renderUserPasswordForm = (props: IUserPasswordFormProps) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -24,12 +21,11 @@ const renderUserPasswordForm = (props: IUserPasswordFormProps) => {
         lastName: 'Do',
       },
     },
+  }
+
+  return renderWithProviders(<UserPasswordForm {...props} />, {
+    storeOverrides,
   })
-  return render(
-    <Provider store={store}>
-      <UserPasswordForm {...props} />
-    </Provider>
-  )
 }
 
 describe('components:UserPasswordForm', () => {

--- a/pro/src/components/UserPhoneForm/__specs__/UserPhoneForm.spec.tsx
+++ b/pro/src/components/UserPhoneForm/__specs__/UserPhoneForm.spec.tsx
@@ -1,11 +1,8 @@
-// react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
-
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { UserPhoneForm } from '../'
 import { IUserPhoneFormProps } from '../UserPhoneForm'
@@ -13,7 +10,7 @@ import { IUserPhoneFormProps } from '../UserPhoneForm'
 const patchPhoneAdapterMock = jest.fn()
 
 const renderUserPhoneForm = (props: IUserPhoneFormProps) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -24,12 +21,9 @@ const renderUserPhoneForm = (props: IUserPhoneFormProps) => {
         lastName: 'Do',
       },
     },
-  })
-  return render(
-    <Provider store={store}>
-      <UserPhoneForm {...props} />
-    </Provider>
-  )
+  }
+
+  return renderWithProviders(<UserPhoneForm {...props} />, { storeOverrides })
 }
 
 describe('components:UserPhoneForm', () => {

--- a/pro/src/components/VenueForm/EACInformation/CollectiveData/__specs__/CollectiveData.spec.tsx
+++ b/pro/src/components/VenueForm/EACInformation/CollectiveData/__specs__/CollectiveData.spec.tsx
@@ -1,10 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { api } from 'apiClient/api'
 import { IVenue } from 'core/Venue'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveData from '../CollectiveData'
 
@@ -27,8 +26,6 @@ describe('CollectiveData', () => {
       .mockResolvedValue({ partners: [] })
   })
 
-  const store = configureTestStore({})
-
   it('should display title if the value is available', async () => {
     const venue = {
       collectiveDescription: 'une description',
@@ -46,11 +43,7 @@ describe('CollectiveData', () => {
       .spyOn(api, 'getEducationalPartners')
       .mockResolvedValue({ partners: [] })
 
-    render(
-      <Provider store={store}>
-        <CollectiveData venue={venue} />
-      </Provider>
-    )
+    renderWithProviders(<CollectiveData venue={venue} />)
 
     expect(
       await screen.findByText(/Domaines artistiques et culturels/)
@@ -73,11 +66,7 @@ describe('CollectiveData', () => {
       .spyOn(api, 'getEducationalPartners')
       .mockResolvedValue({ partners: [] })
 
-    render(
-      <Provider store={store}>
-        <CollectiveData venue={venue} />
-      </Provider>
-    )
+    renderWithProviders(<CollectiveData venue={venue} />)
 
     expect(screen.queryByText(/Téléphone :/)).not.toBeInTheDocument()
     expect(
@@ -94,11 +83,7 @@ describe('CollectiveData', () => {
       ],
     })
 
-    render(
-      <Provider store={store}>
-        <CollectiveData venue={venue} />
-      </Provider>
-    )
+    renderWithProviders(<CollectiveData venue={venue} />)
 
     expect(await screen.findByText('Libellé 1')).toBeInTheDocument()
     expect(await screen.queryByText('Libellé 2')).not.toBeInTheDocument()

--- a/pro/src/components/VenueForm/EACInformation/__specs__/EACInformation.spec.tsx
+++ b/pro/src/components/VenueForm/EACInformation/__specs__/EACInformation.spec.tsx
@@ -1,11 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { createBrowserHistory } from 'history'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Router } from 'react-router-dom'
 
 import { IVenue } from 'core/Venue'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import EACInformation from '../EACInformation'
 
@@ -15,15 +12,10 @@ const renderEACInformation = async ({
 }: {
   venue?: IVenue | null
   isCreatingVenue: boolean
-}) => {
-  render(
-    <Router history={createBrowserHistory()}>
-      <Provider store={configureTestStore({})}>
-        <EACInformation isCreatingVenue={isCreatingVenue} venue={venue} />
-      </Provider>
-    </Router>
+}) =>
+  renderWithProviders(
+    <EACInformation isCreatingVenue={isCreatingVenue} venue={venue} />
   )
-}
 
 describe('components | EACInformation', () => {
   it('should not be able to access information page when creating a venue', async () => {

--- a/pro/src/components/VenueForm/VenueFormActionBar/__specs__/VenueFormActionBar.spec.tsx
+++ b/pro/src/components/VenueForm/VenueFormActionBar/__specs__/VenueFormActionBar.spec.tsx
@@ -1,13 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { Formik } from 'formik'
-import { createBrowserHistory } from 'history'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Router } from 'react-router'
 
 import { SharedCurrentUserResponseModel } from 'apiClient/v1'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { VenueFormActionBar } from '../index'
 
@@ -16,37 +13,31 @@ const renderVanueFormActionBar = ({
 }: {
   isCreatingVenue: boolean
 }) => {
-  render(
-    <Provider
-      store={configureTestStore({
-        user: {
-          initialized: true,
-          currentUser: {
-            id: 'EY',
-            isAdmin: true,
-            publicName: 'USER',
-          } as SharedCurrentUserResponseModel,
+  const storeOverrides = {
+    user: {
+      initialized: true,
+      currentUser: {
+        id: 'EY',
+        isAdmin: true,
+        publicName: 'USER',
+      } as SharedCurrentUserResponseModel,
+    },
+    features: {
+      list: [
+        {
+          nameKey: 'WIP_ENABLE_NEW_OFFER_CREATION_JOURNEY',
+          isActive: true,
         },
-        features: {
-          list: [
-            {
-              nameKey: 'WIP_ENABLE_NEW_OFFER_CREATION_JOURNEY',
-              isActive: true,
-            },
-          ],
-          initialized: true,
-        },
-      })}
-    >
-      <Router history={createBrowserHistory()}>
-        <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <VenueFormActionBar
-            isCreatingVenue={isCreatingVenue}
-            offererId="59"
-          />
-        </Formik>
-      </Router>
-    </Provider>
+      ],
+      initialized: true,
+    },
+  }
+
+  renderWithProviders(
+    <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <VenueFormActionBar isCreatingVenue={isCreatingVenue} offererId="59" />
+    </Formik>,
+    { storeOverrides }
   )
 }
 jest.mock('hooks/useRemoteConfig', () => ({

--- a/pro/src/hooks/__specs__/useLogNavigation.spec.tsx
+++ b/pro/src/hooks/__specs__/useLogNavigation.spec.tsx
@@ -1,13 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 import { Link } from 'react-router-dom'
 
 import * as useAnalytics from 'hooks/useAnalytics'
 import useLogNavigation from 'hooks/useLogNavigation'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 const mockLogEvent = jest.fn()
 
@@ -24,21 +23,18 @@ describe('useLogNavigation', () => {
       setLogEvent: null,
     }))
 
-    const store = configureTestStore({})
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <NavigationLogger />
-          <Route path="*">
-            <span>Main page</span>
-            <Link to="/structures">Structures</Link>
-          </Route>
-          <Route path="/structures">
-            <span>Structure page</span>
-            <Link to="/">Accueil</Link>
-          </Route>
-        </MemoryRouter>
-      </Provider>
+    renderWithProviders(
+      <>
+        <NavigationLogger />
+        <Route path="*">
+          <span>Main page</span>
+          <Link to="/structures">Structures</Link>
+        </Route>
+        <Route path="/structures">
+          <span>Structure page</span>
+          <Link to="/">Accueil</Link>
+        </Route>
+      </>
     )
 
     const button = screen.getByRole('link', { name: 'Structures' })

--- a/pro/src/hooks/__specs__/useNotification.spec.tsx
+++ b/pro/src/hooks/__specs__/useNotification.spec.tsx
@@ -1,10 +1,8 @@
-import { render } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import useNotification from 'hooks/useNotification'
 import * as notificationReducer from 'store/reducers/notificationReducer'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 const TestComponent = (): JSX.Element | null => {
   const notify = useNotification()
@@ -37,11 +35,7 @@ describe('useNotification', () => {
       'showNotification'
     )
 
-    render(
-      <Provider store={configureTestStore()}>
-        <TestComponent />
-      </Provider>
-    )
+    renderWithProviders(<TestComponent />)
 
     expect(mockShowNotification).toHaveBeenCalledTimes(4)
     expect(mockShowNotification).toHaveBeenNthCalledWith(1, {

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -1,8 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -12,12 +10,12 @@ import {
 import Notification from 'components/Notification/Notification'
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings'
 import * as pcapi from 'repository/pcapi/pcapi'
-import { configureTestStore } from 'store/testUtils'
 import { bookingRecapFactory, venueFactory } from 'utils/apiFactories'
 import {
   FORMAT_ISO_DATE_ONLY,
   formatBrowserTimezonedDateAsUTC,
 } from 'utils/date'
+import { renderWithProviders } from 'utils/renderWithProviders'
 import { getNthCallNthArg } from 'utils/testHelpers'
 
 import BookingsRecapContainer from '../Bookings'
@@ -56,17 +54,16 @@ const NTH_ARGUMENT_GET_BOOKINGS = {
 }
 
 const renderBookingsRecap = async (
-  store: any,
+  storeOverrides: any,
   initialEntries = '/reservations',
   waitDomReady?: boolean
 ) => {
-  const rtlReturn = render(
-    <Provider store={configureTestStore(store)}>
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <BookingsRecapContainer />
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+  const rtlReturn = renderWithProviders(
+    <>
+      <BookingsRecapContainer />
+      <Notification />
+    </>,
+    { storeOverrides, initialRouterEntries: [initialEntries] }
   )
 
   const { hasBookings } = await api.getUserHasBookings()

--- a/pro/src/pages/Home/Offerers/__specs__/CreationLinks.spec.jsx
+++ b/pro/src/pages/Home/Offerers/__specs__/CreationLinks.spec.jsx
@@ -1,16 +1,13 @@
 import {
-  render,
   screen,
   waitForElementToBeRemoved,
   within,
 } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Homepage from '../../Homepage'
 
@@ -28,7 +25,7 @@ jest.mock('hooks/useNewOfferCreationJourney', () => ({
 }))
 
 const renderHomePage = async () => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       currentUser: {
         id: 'fake_id',
@@ -39,15 +36,9 @@ const renderHomePage = async () => {
       },
       initialized: true,
     },
-  })
+  }
 
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Homepage />
-      </MemoryRouter>
-    </Provider>
-  )
+  renderWithProviders(<Homepage />, { storeOverrides })
 
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }

--- a/pro/src/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
+++ b/pro/src/pages/Home/Offerers/__specs__/CreationLinks.tracker.spec.jsx
@@ -1,17 +1,11 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Homepage from '../../Homepage'
 
@@ -25,7 +19,7 @@ jest.mock('apiClient/api', () => ({
 
 const mockLogEvent = jest.fn()
 const renderHomePage = () => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       currentUser: {
         id: 'fake_id',
@@ -36,15 +30,9 @@ const renderHomePage = () => {
       },
       initialized: true,
     },
-  })
+  }
 
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Homepage />
-      </MemoryRouter>
-    </Provider>
-  )
+  renderWithProviders(<Homepage />, { storeOverrides })
 }
 
 describe('trackers creationLinks', () => {

--- a/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
+++ b/pro/src/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
@@ -1,18 +1,15 @@
 import {
-  render,
   screen,
   waitForElementToBeRemoved,
   within,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import * as useAnalytics from 'hooks/useAnalytics'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Homepage from '../../Homepage'
 
@@ -37,14 +34,8 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderHomePage = async ({ store }) => {
-  const utils = render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Homepage />
-      </MemoryRouter>
-    </Provider>
-  )
+const renderHomePage = async storeOverrides => {
+  const utils = renderWithProviders(<Homepage />, { storeOverrides })
 
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
@@ -88,7 +79,7 @@ describe('offererDetailsLegacy', () => {
   let physicalVenueWithPublicName
 
   beforeEach(() => {
-    store = configureTestStore({
+    store = {
       user: {
         currentUser: {
           id: 'fake_id',
@@ -99,7 +90,7 @@ describe('offererDetailsLegacy', () => {
         },
         initialized: true,
       },
-    })
+    }
 
     virtualVenue = {
       id: 'test_venue_id_1',
@@ -211,7 +202,7 @@ describe('offererDetailsLegacy', () => {
   })
 
   it('should display offerer select', async () => {
-    const { waitForElements } = await renderHomePage({ store })
+    const { waitForElements } = await renderHomePage(store)
     const { offerer } = await waitForElements()
     const showButton = within(offerer).getByRole('button', { name: 'Afficher' })
     await userEvent.click(showButton)
@@ -223,7 +214,7 @@ describe('offererDetailsLegacy', () => {
 
   it('should not warn user when offerer is validated', async () => {
     // Given
-    const { waitForElements } = await renderHomePage({ store })
+    const { waitForElements } = await renderHomePage(store)
     const { offerer } = await waitForElements()
     const showButton = within(offerer).getByRole('button', { name: 'Afficher' })
 
@@ -239,7 +230,7 @@ describe('offererDetailsLegacy', () => {
   })
 
   it('should display first offerer informations', async () => {
-    const { waitForElements } = await renderHomePage({ store })
+    const { waitForElements } = await renderHomePage(store)
     const { offerer } = await waitForElements()
     const showButton = within(offerer).getByRole('button', { name: 'Afficher' })
     await userEvent.click(showButton)
@@ -261,7 +252,7 @@ describe('offererDetailsLegacy', () => {
   })
 
   it('should display offerer venues informations', async () => {
-    const { waitForElements } = await renderHomePage({ store })
+    const { waitForElements } = await renderHomePage(store)
     const { offerer } = await waitForElements()
     const showButton = within(offerer).getByRole('button', { name: 'Afficher' })
     await userEvent.click(showButton)
@@ -291,7 +282,7 @@ describe('offererDetailsLegacy', () => {
     await jest
       .spyOn(useNewOfferCreationJourney, 'default')
       .mockReturnValue(true)
-    await renderHomePage({ store })
+    await renderHomePage(store)
 
     const selectedOfferer = firstOffererByAlphabeticalOrder
     const physicalVenueTitle = screen.getByText(
@@ -321,7 +312,7 @@ describe('offererDetailsLegacy', () => {
     api.getOfferer.mockResolvedValue(firstOffererByAlphabeticalOrder)
 
     // When
-    const { waitForElements } = await renderHomePage({ store })
+    const { waitForElements } = await renderHomePage(store)
     const { venues } = await waitForElements()
 
     // Then
@@ -333,7 +324,7 @@ describe('offererDetailsLegacy', () => {
 
   describe('when user click on edit button', () => {
     it('should trigger an event when clicking on "Modifier" for offerers', async () => {
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
 
       const editButton = screen.getAllByText('Modifier', { exact: false })[0]
@@ -382,7 +373,7 @@ describe('offererDetailsLegacy', () => {
         ],
       }
       api.getOfferer.mockResolvedValue(newSelectedOfferer)
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { selectOfferer } = await waitForElements()
 
       await selectOfferer(newSelectedOfferer.name)
@@ -439,7 +430,7 @@ describe('offererDetailsLegacy', () => {
   describe('when selecting "add offerer" option"', () => {
     it('should redirect to offerer creation page', async () => {
       // Given
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { selectOfferer } = await waitForElements()
 
       // When
@@ -481,7 +472,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should not display offerer informations', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
 
       // Then
@@ -508,7 +499,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should hide offerer informations on click on hide button', async () => {
       // Given
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
       const hideButton = within(offerer).getByRole('button', {
         name: 'Masquer',
@@ -573,7 +564,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should not display offerer informations', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
 
       // Then
@@ -593,7 +584,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should show offerer informations on click on show button', async () => {
       // Given
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
       const showButton = within(offerer).getByRole('button', {
         name: 'Afficher',
@@ -643,7 +634,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should warn user that offerer is being validated', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
 
       // Then
@@ -656,7 +647,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should allow user to view offerer informations', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
 
       // Then
@@ -667,7 +658,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should allow user to add venue and offer', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
 
       // Then
@@ -696,7 +687,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should warn user offerer is being validated', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
 
       // Then
@@ -709,7 +700,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should not allow user to view offerer informations', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
       // Then
       expect(
@@ -722,7 +713,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should not allow user to update offerer informations', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
 
       // Then
@@ -735,7 +726,7 @@ describe('offererDetailsLegacy', () => {
 
     it('should not allow user to add venue and virtual offer', async () => {
       // When
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
 
       // Then
@@ -765,7 +756,7 @@ describe('offererDetailsLegacy', () => {
         })
         .mockRejectedValueOnce({ status: 403 })
 
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       await waitForElements()
 
       // When
@@ -792,7 +783,7 @@ describe('offererDetailsLegacy', () => {
 
   describe('when FF new bank informations creation', () => {
     beforeEach(() => {
-      store = configureTestStore({
+      store = {
         user: {
           currentUser: {
             id: 'fake_id',
@@ -804,7 +795,7 @@ describe('offererDetailsLegacy', () => {
           initialized: true,
         },
         app: { logEvent: mockLogEvent },
-      })
+      }
     })
 
     it('should display missing bank information when at least one venue does not have a reimbursement point', async () => {
@@ -823,7 +814,7 @@ describe('offererDetailsLegacy', () => {
       }
       api.getOfferer.mockResolvedValue(firstOffererByAlphabeticalOrder)
 
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
 
       expect(
@@ -852,7 +843,7 @@ describe('offererDetailsLegacy', () => {
       }
       api.getOfferer.mockResolvedValue(firstOffererByAlphabeticalOrder)
 
-      const { waitForElements } = await renderHomePage({ store })
+      const { waitForElements } = await renderHomePage(store)
       const { offerer } = await waitForElements()
 
       const displayButton = within(offerer).getByRole('button', {

--- a/pro/src/pages/Home/Offerers/__specs__/Offerers.spec.tsx
+++ b/pro/src/pages/Home/Offerers/__specs__/Offerers.spec.tsx
@@ -1,14 +1,9 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { api } from '../../../../apiClient/api'
-import { configureTestStore } from '../../../../store/testUtils'
 import Offerers from '../Offerers'
 
 jest.mock('apiClient/api', () => ({
@@ -18,22 +13,19 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderOfferers = async () => {
-  render(
-    <Provider store={configureTestStore()}>
-      <MemoryRouter>
-        <Offerers
-          receivedOffererNames={{
-            offerersNames: [{ id: 'idd', name: 'name', nonHumanizedId: 1 }],
-          }}
-        />
-      </MemoryRouter>
-    </Provider>
+  renderWithProviders(
+    <Offerers
+      receivedOffererNames={{
+        offerersNames: [{ id: 'idd', name: 'name', nonHumanizedId: 1 }],
+      }}
+    />
   )
 
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'), {
     timeout: 20000,
   })
 }
+
 describe('Offerers', () => {
   beforeEach(async () => {
     jest.spyOn(api, 'getOfferer').mockRejectedValue({ status: 403 })

--- a/pro/src/pages/Home/ProfileAndSupport/__specs__/ProfileAndSupport.spec.tsx
+++ b/pro/src/pages/Home/ProfileAndSupport/__specs__/ProfileAndSupport.spec.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router-dom'
+import { Route } from 'react-router-dom'
 
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ProfileAndSupport from '../ProfileAndSupport'
 
@@ -16,23 +15,23 @@ const renderProfileAndSupport = () => {
   const currentUser = {
     id: 'EY',
   }
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser,
     },
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/accueil']}>
-        <Route path="/profil">
-          <h1>Page profil</h1>
-        </Route>
-        <Route path="/accueil">
-          <ProfileAndSupport />
-        </Route>
-      </MemoryRouter>
-    </Provider>
+  }
+
+  return renderWithProviders(
+    <>
+      <Route path="/profil">
+        <h1>Page profil</h1>
+      </Route>
+      <Route path="/accueil">
+        <ProfileAndSupport />
+      </Route>
+    </>,
+    { storeOverrides, initialRouterEntries: ['/accueil'] }
   )
 }
 

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
@@ -1,9 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { VenueOfferSteps } from '../index'
 
@@ -14,22 +12,20 @@ const renderVenueOfferSteps = ({
   const currentUser = {
     id: 'EY',
   }
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser,
     },
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/accueil']}>
-        <VenueOfferSteps
-          hasVenue={hasVenue}
-          offererId="AB"
-          hasMissingReimbursementPoint={hasMissingReimbursementPoint}
-        />
-      </MemoryRouter>
-    </Provider>
+  }
+
+  return renderWithProviders(
+    <VenueOfferSteps
+      hasVenue={hasVenue}
+      offererId="AB"
+      hasMissingReimbursementPoint={hasMissingReimbursementPoint}
+    />,
+    { storeOverrides, initialRouterEntries: ['/accueil'] }
   )
 }
 

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
@@ -1,10 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
   Events,
@@ -25,23 +23,21 @@ const renderVenueOfferSteps = (
   const currentUser = {
     id: 'EY',
   }
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser,
     },
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/accueil']}>
-        <VenueOfferSteps
-          hasVenue={venueId != null}
-          venueId={venueId}
-          offererId="AB"
-          hasMissingReimbursementPoint={hasMissingReimbursementPoint}
-        />
-      </MemoryRouter>
-    </Provider>
+  }
+
+  return renderWithProviders(
+    <VenueOfferSteps
+      hasVenue={venueId != null}
+      venueId={venueId}
+      offererId="AB"
+      hasMissingReimbursementPoint={hasMissingReimbursementPoint}
+    />,
+    { storeOverrides, initialRouterEntries: ['/accueil'] }
   )
 }
 

--- a/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
@@ -1,14 +1,11 @@
-import { render, screen, within } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
-import type { Store } from 'redux'
 
 import { api } from 'apiClient/api'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
 import { loadFakeApiVenueStats } from 'utils/fakeApi'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Venue, { IVenueProps } from '../Venue'
 
@@ -18,22 +15,13 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderVenue = (props: IVenueProps, store: Store) => {
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Venue {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderVenue = (props: IVenueProps) =>
+  renderWithProviders(<Venue {...props} />)
 
 describe('venues', () => {
   let props: IVenueProps
-  let store: Store
 
   beforeEach(() => {
-    store = configureTestStore()
     props = {
       id: 'VENUE01',
       isVirtual: false,
@@ -50,7 +38,7 @@ describe('venues', () => {
 
   it('should display stats tiles', async () => {
     // When
-    renderVenue(props, store)
+    renderVenue(props)
 
     await userEvent.click(
       screen.getByTitle('Afficher les statistiques de My venue')
@@ -90,7 +78,7 @@ describe('venues', () => {
 
   it('should contain a link for each stats', async () => {
     // When
-    renderVenue(props, store)
+    renderVenue(props)
     await userEvent.click(
       screen.getByTitle('Afficher les statistiques de My venue')
     )
@@ -103,7 +91,7 @@ describe('venues', () => {
 
   it('should redirect to filtered bookings when clicking on link', async () => {
     // When
-    renderVenue(props, store)
+    renderVenue(props)
     await userEvent.click(
       screen.getByTitle('Afficher les statistiques de My venue')
     )
@@ -141,7 +129,7 @@ describe('venues', () => {
       props.isVirtual = true
 
       // When
-      renderVenue(props, store)
+      renderVenue(props)
       await userEvent.click(
         screen.getByTitle('Afficher les statistiques de My venue')
       )
@@ -161,7 +149,7 @@ describe('venues', () => {
       props.isVirtual = false
 
       // When
-      renderVenue(props, store)
+      renderVenue(props)
       await userEvent.click(
         screen.getByTitle('Afficher les statistiques de My venue')
       )
@@ -179,7 +167,7 @@ describe('venues', () => {
       props.isVirtual = false
 
       // When
-      renderVenue(props, store)
+      renderVenue(props)
       await userEvent.click(
         screen.getByTitle('Afficher les statistiques de My venue')
       )
@@ -200,7 +188,7 @@ describe('venues', () => {
         .spyOn(useNewOfferCreationJourney, 'default')
         .mockReturnValue(true)
       // When
-      renderVenue(props, store)
+      renderVenue(props)
 
       // Then
       expect(
@@ -217,7 +205,7 @@ describe('venues', () => {
       props.hasCreatedOffer = true
 
       // When
-      renderVenue(props, store)
+      renderVenue(props)
 
       // Then
       expect(

--- a/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.tracker.spec.tsx
@@ -1,29 +1,19 @@
-import { render, screen, within } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { Events, VenueEvents } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
 import { loadFakeApiVenueStats } from 'utils/fakeApi'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Venue, { IVenueProps } from '../Venue'
 
 const mockLogEvent = jest.fn()
 
-const renderVenue = async (props: IVenueProps) => {
-  const store = configureTestStore()
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Venue {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderVenue = async (props: IVenueProps) =>
+  renderWithProviders(<Venue {...props} />)
 
 const trackerForVenue = [
   {

--- a/pro/src/pages/Home/__specs__/Homepage.spec.jsx
+++ b/pro/src/pages/Home/__specs__/Homepage.spec.jsx
@@ -1,19 +1,13 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { RemoteContextProvider } from 'context/remoteConfigContext'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 import { doesUserPreferReducedMotion } from 'utils/windowMatchMedia'
 
 import Homepage from '../Homepage'
@@ -50,15 +44,12 @@ jest.mock('hooks/useNewOfferCreationJourney', () => ({
   default: jest.fn().mockReturnValue(false),
 }))
 
-const renderHomePage = store => {
-  render(
-    <Provider store={store}>
-      <RemoteContextProvider>
-        <MemoryRouter>
-          <Homepage />
-        </MemoryRouter>
-      </RemoteContextProvider>
-    </Provider>
+const renderHomePage = storeOverrides => {
+  renderWithProviders(
+    <RemoteContextProvider>
+      <Homepage />
+    </RemoteContextProvider>,
+    { storeOverrides }
   )
 }
 
@@ -70,7 +61,7 @@ describe('homepage', () => {
   let store
 
   beforeEach(() => {
-    store = configureTestStore({
+    store = {
       user: {
         currentUser: {
           id: 'fake_id',
@@ -81,7 +72,7 @@ describe('homepage', () => {
         },
         initialized: true,
       },
-    })
+    }
     baseOfferers = [
       {
         address: 'LA COULÉE D’OR',
@@ -287,7 +278,7 @@ describe('homepage', () => {
 
     describe('offererStats', () => {
       beforeEach(() => {
-        store = configureTestStore({
+        store = {
           user: {
             currentUser: {
               id: 'fake_id',
@@ -301,7 +292,7 @@ describe('homepage', () => {
           features: {
             list: [{ isActive: true, nameKey: 'ENABLE_OFFERER_STATS' }],
           },
-        })
+        }
       })
       it('should display section when ff is active', async () => {
         renderHomePage(store)

--- a/pro/src/pages/LostPassword/__specs__/LostPassword.spec.jsx
+++ b/pro/src/pages/LostPassword/__specs__/LostPassword.spec.jsx
@@ -1,10 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import LostPassword from '../LostPassword'
 
@@ -23,19 +21,16 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderLostPassword = url => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       currentUser: { id: 'CMOI' },
     },
-  })
+  }
 
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <LostPassword />
-      </MemoryRouter>
-    </Provider>
-  )
+  renderWithProviders(<LostPassword />, {
+    storeOverrides,
+    initialRouterEntries: [url],
+  })
 }
 
 describe('src | components | pages | LostPassword', () => {

--- a/pro/src/pages/OfferIndividualWizard/Confirmation/__specs__/Confirmation.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/Confirmation/__specs__/Confirmation.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route } from 'react-router'
+import { generatePath, Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
@@ -16,7 +15,7 @@ import { Events } from 'core/FirebaseEvents/constants'
 import { IOfferIndividual } from 'core/Offers/types'
 import * as useAnalytics from 'hooks/useAnalytics'
 import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Confirmation from '../Confirmation'
 
@@ -46,7 +45,7 @@ const renderOffer = (
     showVenuePopin: {},
     ...contextOverride,
   }
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -56,18 +55,18 @@ const renderOffer = (
       },
     },
     ...storeOverride,
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/confirmation']}>
-        <Route path="/confirmation">
-          <OfferIndividualContext.Provider value={contextValue}>
-            <Confirmation />
-          </OfferIndividualContext.Provider>
-        </Route>
-      </MemoryRouter>
+  }
+
+  return renderWithProviders(
+    <>
+      <Route path="/confirmation">
+        <OfferIndividualContext.Provider value={contextValue}>
+          <Confirmation />
+        </OfferIndividualContext.Provider>
+      </Route>
       <Notification />
-    </Provider>
+    </>,
+    { storeOverrides, initialRouterEntries: ['/confirmation'] }
   )
 }
 

--- a/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/Stocks/__specs__/Stocks.spec.tsx
@@ -1,7 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { OfferStatus } from 'apiClient/v1'
 import {
@@ -10,18 +8,14 @@ import {
 } from 'context/OfferIndividualContext'
 import { IOfferIndividual, IOfferIndividualVenue } from 'core/Offers/types'
 import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Stocks from '../Stocks'
 
-const renderStocksScreen = ({
-  storeOverride = {},
-  contextOverride,
-}: {
-  storeOverride: Partial<RootState>
+const renderStocksScreen = (
+  storeOverrides: Partial<RootState> = {},
   contextOverride: Partial<IOfferIndividualContext>
-}) => {
-  const store = configureTestStore(storeOverride)
+) => {
   const contextValue: IOfferIndividualContext = {
     offerId: null,
     offer: null,
@@ -35,19 +29,16 @@ const renderStocksScreen = ({
     showVenuePopin: {},
     ...contextOverride,
   }
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/creation/stocks']}>
-        <OfferIndividualContext.Provider value={contextValue}>
-          <Stocks />
-        </OfferIndividualContext.Provider>
-      </MemoryRouter>
-    </Provider>
+  return renderWithProviders(
+    <OfferIndividualContext.Provider value={contextValue}>
+      <Stocks />
+    </OfferIndividualContext.Provider>,
+    { storeOverrides, initialRouterEntries: ['/creation/stocks'] }
   )
 }
 
 describe('screens:Stocks', () => {
-  let storeOverride: Partial<RootState>
+  let storeOverrides: Partial<RootState>
   let contextOverride: Partial<IOfferIndividualContext>
   let offer: Partial<IOfferIndividual>
 
@@ -59,7 +50,7 @@ describe('screens:Stocks', () => {
       } as IOfferIndividualVenue,
       stocks: [],
     }
-    storeOverride = {}
+    storeOverrides = {}
     contextOverride = {
       offerId: 'OFFER_ID',
       offer: offer as IOfferIndividual,
@@ -72,7 +63,7 @@ describe('screens:Stocks', () => {
       isEvent: false,
       isDigital: false,
     } as IOfferIndividual
-    renderStocksScreen({ storeOverride, contextOverride })
+    renderStocksScreen(storeOverrides, contextOverride)
     expect(
       screen.getByText(
         'Les bénéficiaires ont 30 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
@@ -84,7 +75,7 @@ describe('screens:Stocks', () => {
       ...contextOverride.offer,
       isEvent: true,
     } as IOfferIndividual
-    renderStocksScreen({ storeOverride, contextOverride })
+    renderStocksScreen(storeOverrides, contextOverride)
     expect(
       screen.getByText(
         'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
@@ -101,7 +92,7 @@ describe('screens:Stocks', () => {
         isEvent: true,
         status: offerStatus,
       } as IOfferIndividual
-      renderStocksScreen({ storeOverride, contextOverride })
+      renderStocksScreen(storeOverrides, contextOverride)
       expect(
         screen.queryByText(
           'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'
@@ -125,7 +116,7 @@ describe('screens:Stocks', () => {
         isEvent: true,
         status: offerStatus,
       } as IOfferIndividual
-      renderStocksScreen({ storeOverride, contextOverride })
+      renderStocksScreen(storeOverrides, contextOverride)
       expect(
         screen.queryByText(
           'Les utilisateurs ont un délai de 48h pour annuler leur réservation mais ne peuvent pas le faire moins de 48h avant le début de l’évènement. Si la date limite de réservation n’est pas encore passée, la place est alors automatiquement remise en vente'

--- a/pro/src/pages/OfferIndividualWizard/__specs__/OfferIndividualWizard.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/__specs__/OfferIndividualWizard.spec.tsx
@@ -1,11 +1,6 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route } from 'react-router'
+import { generatePath, Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -21,7 +16,7 @@ import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { CATEGORY_STATUS, OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { OfferIndividualWizard } from '..'
 
@@ -165,22 +160,20 @@ const apiOffer: GetIndividualOfferResponseModel = {
 }
 
 const renderOfferIndividualWizardRoute = (
-  storeOverride: any,
+  storeOverrides: any,
   url = '/offre/v3'
-) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route path={['/offre/individuelle/:offerId']}>
-          <OfferIndividualWizard />
-        </Route>
-        <Route path={['/structures', '/accueil']}>Home Page</Route>
-      </MemoryRouter>
+) =>
+  renderWithProviders(
+    <>
+      <Route path={['/offre/individuelle/:offerId']}>
+        <OfferIndividualWizard />
+      </Route>
+      <Route path={['/structures', '/accueil']}>Home Page</Route>
       <Notification />
-    </Provider>
+    </>,
+    { storeOverrides, initialRouterEntries: [url] }
   )
-}
+
 describe('test OfferIndividualWisard', () => {
   let store: any
 

--- a/pro/src/pages/OfferIndividualWizard/__specs__/OfferIndividualWizardAdmin.spec.tsx
+++ b/pro/src/pages/OfferIndividualWizard/__specs__/OfferIndividualWizardAdmin.spec.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route } from 'react-router'
+import { generatePath, Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -12,7 +11,7 @@ import {
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { CATEGORY_STATUS, OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { OfferIndividualWizard } from '..'
 
@@ -151,20 +150,16 @@ const apiOffer: GetIndividualOfferResponseModel = {
 }
 
 const renderOfferIndividualWizardRoute = (
-  storeOverride: any,
+  storeOverrides: any,
   url = '/offre/v3'
-) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route path={['/offre/individuelle/:offerId']}>
-          <OfferIndividualWizard />
-        </Route>
-      </MemoryRouter>
-    </Provider>
+) =>
+  renderWithProviders(
+    <Route path={['/offre/individuelle/:offerId']}>
+      <OfferIndividualWizard />
+    </Route>,
+    { storeOverrides, initialRouterEntries: [url] }
   )
-}
+
 describe('test OfferIndividualWisard', () => {
   let store: any
 

--- a/pro/src/pages/OffererStats/__specs__/OffererStats.spec.tsx
+++ b/pro/src/pages/OffererStats/__specs__/OffererStats.spec.tsx
@@ -1,12 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import type { Store } from 'redux'
 
 import { api } from 'apiClient/api'
 import { GetOffererResponseModel } from 'apiClient/v1'
 import * as useNotification from 'hooks/useNotification'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OffererStats from '../OffererStats'
 
@@ -28,35 +26,28 @@ jest.mock('hooks/useRemoteConfig', () => ({
   default: () => ({ remoteConfig: {} }),
 }))
 
-const renderOffererStats = (store: Store) => {
-  render(
-    <Provider store={store}>
-      <OffererStats />
-    </Provider>
-  )
+const renderOffererStats = () => {
+  const storeOverrides = {
+    user: {
+      initialized: true,
+      currentUser: {
+        firstName: 'John',
+        dateCreated: '2022-07-29T12:18:43.087097Z',
+        email: 'john@do.net',
+        id: '1',
+        nonHumanizedId: '1',
+        isAdmin: false,
+        isEmailValidated: true,
+        roles: [],
+      },
+    },
+  }
+
+  renderWithProviders(<OffererStats />, { storeOverrides })
 }
 
 describe('OffererStatsScreen', () => {
-  let currentUser
-  let store: Store
   beforeEach(() => {
-    currentUser = {
-      firstName: 'John',
-      dateCreated: '2022-07-29T12:18:43.087097Z',
-      email: 'john@do.net',
-      id: '1',
-      nonHumanizedId: '1',
-      isAdmin: false,
-      isEmailValidated: true,
-      roles: [],
-    }
-
-    store = configureTestStore({
-      user: {
-        initialized: true,
-        currentUser,
-      },
-    })
     jest.spyOn(api, 'getOfferer').mockResolvedValue({
       id: 'A1',
       managedVenues: [
@@ -87,7 +78,7 @@ describe('OffererStatsScreen', () => {
   })
 
   it('should display all offerer options on render', async () => {
-    renderOffererStats(store)
+    renderOffererStats()
 
     await waitFor(() => {
       expect(api.listOfferersNames).toHaveBeenCalledTimes(1)
@@ -103,7 +94,7 @@ describe('OffererStatsScreen', () => {
       error: notifyError,
     }))
     jest.spyOn(api, 'listOfferersNames').mockRejectedValueOnce('')
-    renderOffererStats(store)
+    renderOffererStats()
 
     await waitFor(() => {
       expect(api.listOfferersNames).toHaveBeenCalledTimes(1)

--- a/pro/src/pages/Offerers/List/OffererItem/__specs__/OffererItem.spec.jsx
+++ b/pro/src/pages/Offerers/List/OffererItem/__specs__/OffererItem.spec.jsx
@@ -1,9 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router-dom'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OffererItem from '../OffererItem'
 
@@ -14,16 +12,8 @@ describe('src | components | pages | Offerers | OffererItem | OffererItem', () =
   const parseMock = () => ({ 'mots-cles': null })
   const queryChangeMock = jest.fn()
 
-  const renderOfferItem = (overrideStore = {}) => {
-    const store = configureTestStore(overrideStore)
-    return render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <OffererItem {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
-  }
+  const renderOfferItem = (storeOverrides = {}) =>
+    renderWithProviders(<OffererItem {...props} />, { storeOverrides })
 
   beforeEach(() => {
     props = {

--- a/pro/src/pages/Offerers/List/__specs__/Offerers.spec.jsx
+++ b/pro/src/pages/Offerers/List/__specs__/Offerers.spec.jsx
@@ -1,22 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Offerers from '../Offerers'
 
-const renderOfferers = async (storeOverride = {}) => {
-  const store = configureTestStore(storeOverride)
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Offerers />
-      </MemoryRouter>
-    </Provider>
-  )
+const renderOfferers = async (storeOverrides = {}) => {
+  renderWithProviders(<Offerers />, { storeOverrides })
 }
 
 jest.mock('apiClient/api', () => ({

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.jsx
@@ -1,19 +1,17 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { api } from 'apiClient/api'
 import * as notificationReducer from 'store/reducers/notificationReducer'
-import { configureTestStore } from 'store/testUtils'
 import {
   failToGenerateOffererApiKey,
   generateFakeOffererApiKey,
 } from 'utils/fakeApi'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ApiKey from '../ApiKey'
 
-const store = configureTestStore()
 const defaultProps = {
   maxAllowedApiKeys: 5,
   savedApiKeys: ['key-prefix1'],
@@ -26,18 +24,15 @@ Object.assign(navigator, {
   },
 })
 
-const renderApiKey = (props = defaultProps) => {
-  return render(
-    <Provider store={store}>
-      <ApiKey
-        maxAllowedApiKeys={props.maxAllowedApiKeys}
-        offererId="AE"
-        reloadOfferer={props.reloadOfferer}
-        savedApiKeys={props.savedApiKeys}
-      />
-    </Provider>
+const renderApiKey = (props = defaultProps) =>
+  renderWithProviders(
+    <ApiKey
+      maxAllowedApiKeys={props.maxAllowedApiKeys}
+      offererId="AE"
+      reloadOfferer={props.reloadOfferer}
+      savedApiKeys={props.savedApiKeys}
+    />
   )
-}
 
 Object.defineProperty(navigator, 'clipboard', {
   value: {

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/VenueItem/__specs__/VenueItem.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/VenueItem/__specs__/VenueItem.spec.jsx
@@ -1,28 +1,16 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router-dom'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import VenueItem from '../VenueItem'
 
 describe('src | components | pages | OffererCreation | VenueItem', () => {
   let props
-  let store
 
-  const renderVenueItem = () => {
-    return render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <VenueItem {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
-  }
+  const renderVenueItem = () => renderWithProviders(<VenueItem {...props} />)
 
   beforeEach(() => {
-    store = configureTestStore({})
     props = {
       venue: {
         id: 'AAA',

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/VenueItem/__specs__/VenueItem.tracker.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/VenueItem/__specs__/VenueItem.tracker.spec.jsx
@@ -1,19 +1,16 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import VenueItem from '../VenueItem'
 
 const mockLogEvent = jest.fn()
 
 const renderItem = () => {
-  const store = configureTestStore({})
   const props = {
     venue: {
       id: 'AAA',
@@ -23,13 +20,7 @@ const renderItem = () => {
     },
   }
 
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <VenueItem {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
+  return renderWithProviders(<VenueItem {...props} />)
 }
 
 describe('venue Item offer link', () => {

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/__specs__/Venues.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/Venues/__specs__/Venues.spec.jsx
@@ -1,9 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Venues from '../Venues'
 
@@ -16,16 +14,8 @@ describe('src | components | pages | OffererCreation | Venues', () => {
       venues: [],
     }
   })
-  const renderReturnVenues = (overrideStore = {}) => {
-    const store = configureTestStore(overrideStore)
-    return render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Venues {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
-  }
+  const renderReturnVenues = (storeOverrides = {}) =>
+    renderWithProviders(<Venues {...props} />, { storeOverrides })
 
   describe('render', () => {
     it('should render a title', () => {

--- a/pro/src/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/OffererDetails/__specs__/OffererDetails.spec.jsx
@@ -1,14 +1,8 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OffererDetails from '../OffererDetails'
 
@@ -17,16 +11,6 @@ jest.mock('apiClient/api', () => ({
     getOfferer: jest.fn(),
   },
 }))
-
-const renderOffererDetails = ({ props, store }) => {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <OffererDetails {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -37,10 +21,6 @@ jest.mock('react-router-dom', () => ({
 
 describe('src | components | pages | Offerer | OffererDetails', () => {
   let props
-  let store
-  beforeEach(() => {
-    store = configureTestStore()
-  })
 
   api.getOfferer.mockResolvedValue({
     id: 'AA',
@@ -63,7 +43,7 @@ describe('src | components | pages | Offerer | OffererDetails', () => {
   describe('render', () => {
     it('should render Venues', async () => {
       // when
-      renderOffererDetails({ props, store })
+      renderWithProviders(<OffererDetails {...props} />)
       await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
       // then

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
@@ -1,8 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { ApiError, GetVenueResponseModel } from 'apiClient/v1'
@@ -11,7 +9,7 @@ import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
 import { mainlandOptions, domtomOptions } from 'core/shared/interventionOptions'
 import * as useNotification from 'hooks/useNotification'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveDataEdition from '../CollectiveDataEdition'
 
@@ -87,13 +85,7 @@ const waitForLoader = () =>
   })
 
 const renderCollectiveDataEdition = () =>
-  render(
-    <MemoryRouter>
-      <Provider store={configureTestStore({})}>
-        <CollectiveDataEdition />
-      </Provider>
-    </MemoryRouter>
-  )
+  renderWithProviders(<CollectiveDataEdition />)
 
 describe('CollectiveDataEdition', () => {
   const notifyErrorMock = jest.fn()

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.jsx
@@ -1,19 +1,13 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 import ReactTooltip from 'react-tooltip'
 
 import { api } from 'apiClient/api'
 import { ApiError } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
 import * as pcapi from 'repository/pcapi/pcapi'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import VenueProvidersManager from '../../index'
 
@@ -30,14 +24,12 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderVenueProvidersManager = async props => {
-  render(
-    <Provider store={configureTestStore()}>
-      <MemoryRouter>
-        <VenueProvidersManager {...props} />
-        <Notification />
-        <ReactTooltip html />
-      </MemoryRouter>
-    </Provider>
+  renderWithProviders(
+    <>
+      <VenueProvidersManager {...props} />
+      <Notification />
+      <ReactTooltip html />
+    </>
   )
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/__specs__/CinemaProviderForm.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/__specs__/CinemaProviderForm.spec.jsx
@@ -1,19 +1,13 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 import ReactTooltip from 'react-tooltip'
 
 import { api } from 'apiClient/api'
 import { ApiError } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
 import * as pcapi from 'repository/pcapi/pcapi'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import VenueProvidersManager from '../../index'
 
@@ -30,14 +24,12 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderVenueProvidersManager = async props => {
-  render(
-    <Provider store={configureTestStore()}>
-      <MemoryRouter>
-        <VenueProvidersManager {...props} />
-        <Notification />
-        <ReactTooltip html />
-      </MemoryRouter>
-    </Provider>
+  renderWithProviders(
+    <>
+      <VenueProvidersManager {...props} />
+      <Notification />
+      <ReactTooltip html />
+    </>
   )
 
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
@@ -1,18 +1,12 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { ApiError } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
 import * as pcapi from 'repository/pcapi/pcapi'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import VenueProvidersManager from '../../index'
 
@@ -28,13 +22,11 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderVenueProvidersManager = async props => {
-  render(
-    <Provider store={configureTestStore()}>
-      <MemoryRouter>
-        <VenueProvidersManager {...props} />
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+  renderWithProviders(
+    <>
+      <VenueProvidersManager {...props} />
+      <Notification />
+    </>
   )
 
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
@@ -1,17 +1,14 @@
 import {
-  render,
   screen,
   within,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import * as pcapi from 'repository/pcapi/pcapi'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 import { queryByTextTrimHtml } from 'utils/testHelpers'
 
 import { DEFAULT_PROVIDER_OPTION } from '../utils/_constants'
@@ -30,13 +27,7 @@ jest.mock('apiClient/api', () => ({
 }))
 
 const renderVenueProvidersManager = async props => {
-  render(
-    <Provider store={configureTestStore()}>
-      <MemoryRouter>
-        <VenueProvidersManager {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
+  renderWithProviders(<VenueProvidersManager {...props} />)
 
   await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 }

--- a/pro/src/pages/Offerers/Offerer/VenueV1/__specs__/Notification.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/__specs__/Notification.spec.jsx
@@ -1,23 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router-dom'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 import { queryByTextTrimHtml } from 'utils/testHelpers'
 
 import NotificationMessage from '../Notification'
 
-const renderNotificationMessage = ({ props, storeOverrides = {} }) => {
-  const store = configureTestStore(storeOverrides)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <NotificationMessage {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderNotificationMessage = props =>
+  renderWithProviders(<NotificationMessage {...props} />)
 
 describe('src | components | pages | Venue | Notification', () => {
   const props = {
@@ -27,7 +17,7 @@ describe('src | components | pages | Venue | Notification', () => {
   }
 
   it('should display a succes messsage when venue is created', () => {
-    renderNotificationMessage({ props })
+    renderNotificationMessage(props)
     expect(
       queryByTextTrimHtml(
         screen,

--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/__specs__/ReimbursementFields.spec.jsx
@@ -1,29 +1,23 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { Formik } from 'formik'
-import { createBrowserHistory } from 'history'
 import React from 'react'
 import { Form } from 'react-final-form'
-import { Provider } from 'react-redux'
-import { Router } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import ReimbursementFields from '../ReimbursementFields'
 
-const renderReimbursementFields = async (props, store) => {
-  const rtlReturn = render(
-    <Router history={createBrowserHistory()}>
-      <Provider store={store}>
-        <Formik onSubmit={() => {}} initialValues={{}}>
-          {({ handleSubmit }) => (
-            <Form onSubmit={handleSubmit}>
-              {() => <ReimbursementFields {...props} />}
-            </Form>
-          )}
-        </Formik>
-      </Provider>
-    </Router>
+const renderReimbursementFields = async (props, storeOverrides) => {
+  const rtlReturn = renderWithProviders(
+    <Formik onSubmit={() => {}} initialValues={{}}>
+      {({ handleSubmit }) => (
+        <Form onSubmit={handleSubmit}>
+          {() => <ReimbursementFields {...props} />}
+        </Form>
+      )}
+    </Formik>,
+    { storeOverrides }
   )
 
   const loadingMessage = screen.queryByText('Chargement en cours ...')
@@ -61,9 +55,9 @@ describe('src | Venue | ReimbursementFields', () => {
   let store
   beforeEach(() => {
     props = { venue, offerer }
-    store = configureTestStore({
+    store = {
       app: { logEvent: mockLogEvent },
-    })
+    }
     jest.spyOn(api, 'getAvailableReimbursementPoints').mockResolvedValue([])
   })
 

--- a/pro/src/pages/Offerers/OffererCreation/OffererCreationForm/__specs__/OffererCreationForm.spec.jsx
+++ b/pro/src/pages/Offerers/OffererCreation/OffererCreationForm/__specs__/OffererCreationForm.spec.jsx
@@ -1,30 +1,22 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Form } from 'react-final-form'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import * as getSirenDataAdapter from 'core/Offerers/adapters/getSirenDataAdapter'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OffererCreationForm from '../OffererCreationForm'
 
 describe('src | components | pages | OffererCreationForm', () => {
-  const renderOffererCreationForm = () => {
-    const store = configureTestStore()
-    return render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Form
-            backTo="/accueil"
-            onSubmit={() => {}}
-            component={OffererCreationForm}
-          />
-        </MemoryRouter>
-      </Provider>
+  const renderOffererCreationForm = () =>
+    renderWithProviders(
+      <Form
+        backTo="/accueil"
+        onSubmit={() => {}}
+        component={OffererCreationForm}
+      />
     )
-  }
 
   it('should be clickable when values have been changed and are valid', async () => {
     // given

--- a/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.jsx
+++ b/pro/src/pages/Offerers/OffererCreation/__specs__/OffererCreation.spec.jsx
@@ -1,26 +1,17 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OffererCreation from '../OffererCreation'
 
-const renderOffererCreation = store => {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <OffererCreation />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderOffererCreation = storeOverrides =>
+  renderWithProviders(<OffererCreation />, { storeOverrides })
 
 describe('src | components | OffererCreation', () => {
   describe('render', () => {
     it('should render a OffererCreationUnavailable component when pro offerer creation is disabled', () => {
-      const store = configureTestStore({
+      const store = {
         features: {
           initialized: true,
           list: [
@@ -33,7 +24,7 @@ describe('src | components | OffererCreation', () => {
             },
           ],
         },
-      })
+      }
 
       renderOffererCreation(store)
 
@@ -43,7 +34,7 @@ describe('src | components | OffererCreation', () => {
     })
 
     it('should render a OffererCreation component', () => {
-      const store = configureTestStore({})
+      const store = {}
 
       renderOffererCreation(store)
 

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -1,11 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import * as createFromTemplateUtils from 'core/OfferEducational/utils/createOfferFromTemplate'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import DuplicateOfferCell, {
   LOCAL_STORAGE_HAS_SEEN_MODAL_KEY,
@@ -16,7 +15,7 @@ jest.mock('core/OfferEducational/utils/createOfferFromTemplate', () => ({
 }))
 
 const renderDuplicateOfferCell = () => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -25,24 +24,24 @@ const renderDuplicateOfferCell = () => {
         email: 'email@example.com',
       },
     },
-  })
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/offres']}>
-        <Route path="/offres">
-          <table>
-            <tbody>
-              <tr>
-                <DuplicateOfferCell templateOfferId="AE" />
-              </tr>
-            </tbody>
-          </table>
-        </Route>
-        <Route path="/offre/duplication/collectif/AE">
-          <div>Parcours de duplication d’offre</div>
-        </Route>
-      </MemoryRouter>
-    </Provider>
+  }
+
+  renderWithProviders(
+    <>
+      <Route path="/offres">
+        <table>
+          <tbody>
+            <tr>
+              <DuplicateOfferCell templateOfferId="AE" />
+            </tr>
+          </tbody>
+        </table>
+      </Route>
+      <Route path="/offre/duplication/collectif/AE">
+        <div>Parcours de duplication d’offre</div>
+      </Route>
+    </>,
+    { storeOverrides, initialRouterEntries: ['/offres'] }
   )
 }
 

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/OfferNameCell/__specs__/OfferNameCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/OfferNameCell/__specs__/OfferNameCell.spec.tsx
@@ -1,27 +1,18 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { add } from 'date-fns'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
-import type { Store } from 'redux'
 
 import { OfferStatus } from 'apiClient/v1'
 import { Offer } from 'core/Offers/types'
 import { Audience } from 'core/shared'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferNameCell, { OfferNameCellProps } from '../OfferNameCell'
 
-const renderOfferNameCell = (props: OfferNameCellProps, store: Store) => {
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/offres']}>
-        <OfferNameCell {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderOfferNameCell = (props: OfferNameCellProps) =>
+  renderWithProviders(<OfferNameCell {...props} />, {
+    initialRouterEntries: ['/offres'],
+  })
 
 jest.mock('hooks/useActiveFeature', () => ({
   __esModule: true,
@@ -29,7 +20,6 @@ jest.mock('hooks/useActiveFeature', () => ({
 }))
 
 describe('OfferNameCell', () => {
-  const store: Store<RootState> = configureTestStore({})
   let defaultOffer: Offer
   beforeEach(() => {
     defaultOffer = {
@@ -72,14 +62,11 @@ describe('OfferNameCell', () => {
       ],
     }
 
-    renderOfferNameCell(
-      {
-        offer: eventOffer,
-        editionOfferLink: '#',
-        audience: Audience.COLLECTIVE,
-      },
-      store
-    )
+    renderOfferNameCell({
+      offer: eventOffer,
+      editionOfferLink: '#',
+      audience: Audience.COLLECTIVE,
+    })
 
     const warningIco = screen.queryByAltText('Attention')
     expect(warningIco).not.toBeNull()
@@ -99,14 +86,11 @@ describe('OfferNameCell', () => {
         },
       ],
     }
-    renderOfferNameCell(
-      {
-        offer: eventOffer,
-        editionOfferLink: '#',
-        audience: Audience.COLLECTIVE,
-      },
-      store
-    )
+    renderOfferNameCell({
+      offer: eventOffer,
+      editionOfferLink: '#',
+      audience: Audience.COLLECTIVE,
+    })
 
     const warningIco = screen.queryByAltText('Attention')
     expect(warningIco).toBeNull()

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
@@ -1,9 +1,6 @@
-import { render, screen, within } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
-import type { Store } from 'redux'
 
 import { api } from 'apiClient/api'
 import { ApiError, OfferStatus } from 'apiClient/v1'
@@ -12,8 +9,7 @@ import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import Notification from 'components/Notification/Notification'
 import { Offer } from 'core/Offers/types'
 import { Audience } from 'core/shared'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferItem, { OfferItemProps } from '../OfferItem'
 
@@ -25,29 +21,23 @@ jest.mock('apiClient/api', () => ({
 
 const mockRefreshOffer = jest.fn()
 
-const renderOfferItem = (props: OfferItemProps, store: Store) => {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <table>
-          <tbody>
-            <OfferItem {...props} />
-          </tbody>
-        </table>
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+const renderOfferItem = (props: OfferItemProps) =>
+  renderWithProviders(
+    <>
+      <table>
+        <tbody>
+          <OfferItem {...props} />
+        </tbody>
+      </table>
+      <Notification />
+    </>
   )
-}
 
 describe('src | components | pages | Offers | OfferItem', () => {
   let props: OfferItemProps
   let eventOffer: Offer
-  let store: Store<RootState>
 
   beforeEach(() => {
-    store = configureTestStore({})
-
     eventOffer = {
       id: 'M4',
       isActive: true,
@@ -79,7 +69,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     describe('thumb Component', () => {
       it('should render an image with url from offer when offer has a thumb url', () => {
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(
@@ -92,7 +82,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         props.offer.thumbUrl = null
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(
@@ -104,7 +94,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     describe('action buttons', () => {
       it('should display a button to show offer stocks', () => {
         // given
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText('Stocks')).toBeInTheDocument()
@@ -118,7 +108,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
           // given
           props.offer.status = OfferStatus.DRAFT
 
-          renderOfferItem(props, store)
+          renderOfferItem(props)
 
           await userEvent.click(screen.getByRole('button'))
           const deleteButton = screen.getByRole('button', {
@@ -138,7 +128,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
           // given
           props.offer.status = OfferStatus.DRAFT
 
-          renderOfferItem(props, store)
+          renderOfferItem(props)
           jest.spyOn(api, 'deleteDraftOffers').mockRejectedValue(
             new ApiError(
               {} as ApiRequestOptions,
@@ -171,7 +161,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       describe('edit offer link', () => {
         it('should be displayed when offer is editable', () => {
           // when
-          renderOfferItem(props, store)
+          renderOfferItem(props)
 
           // then
           const links = screen.getAllByRole('link')
@@ -185,7 +175,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
           props.offer.isEditable = false
 
           // when
-          renderOfferItem(props, store)
+          renderOfferItem(props)
 
           // then
           const links = screen.getAllByRole('link')
@@ -200,7 +190,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     describe('offer title', () => {
       it('should contain a link with the offer name and details link', () => {
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         const offerTitle = screen.queryByText(props.offer.name as string, {
@@ -223,7 +213,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       }
 
       // when
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       expect(screen.queryByText(props.offer.venue.name)).toBeInTheDocument()
@@ -239,7 +229,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       }
 
       // when
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       expect(screen.queryByText('lieu de ouf')).toBeInTheDocument()
@@ -255,7 +245,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       }
 
       // when
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       expect(
@@ -268,7 +258,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       eventOffer.productIsbn = '123456789'
 
       // when
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       expect(screen.queryByText('123456789')).toBeInTheDocument()
@@ -277,7 +267,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     describe('offer remaining quantity or institution', () => {
       it('should be 0 when individual offer has no stock', () => {
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText('0')).toBeInTheDocument()
@@ -292,7 +282,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText('5')).toBeInTheDocument()
@@ -306,7 +296,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText('Illimité')).toBeInTheDocument()
@@ -318,7 +308,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         props.offer.educationalInstitution = null
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(
@@ -339,7 +329,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         }
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText('Collège Bellevue')).toBeInTheDocument()
@@ -361,7 +351,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText('2 dates')).toBeInTheDocument()
@@ -377,7 +367,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.getByText('27/05/2021 17:00')).toBeInTheDocument()
@@ -391,7 +381,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText(/épuisée/)).not.toBeInTheDocument()
@@ -406,7 +396,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         eventOffer.status = OfferStatus.SOLD_OUT
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(screen.queryByText(/épuisées/)).not.toBeInTheDocument()
@@ -422,7 +412,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         const numberOfStocks = screen.getByText('1 date épuisée', {
@@ -440,7 +430,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         ]
 
         // when
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // then
         expect(
@@ -454,7 +444,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       props.offer.isActive = false
 
       // When
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // Then
       expect(screen.getByText('My little offer').closest('tr')).toHaveClass(
@@ -467,7 +457,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       'should display the offer greyed when offer is %s',
       status => {
         props.offer.status = status
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // Then
         expect(screen.getByText('My little offer').closest('tr')).toHaveClass(
@@ -481,7 +471,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       'should not display the offer greyed when offer is %s',
       status => {
         props.offer.status = status
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         // Then
         expect(
@@ -495,7 +485,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       props.offer.status = OfferStatus.DRAFT
 
       // When
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // Then
       const links = screen.getAllByRole('link')
@@ -509,7 +499,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       it('should display a tag when offer is template', () => {
         props.audience = Audience.COLLECTIVE
         props.offer.isShowcase = true
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         expect(
           within(screen.getAllByRole('cell')[2]).getByText('Offre vitrine')
@@ -519,7 +509,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       it('should not display a tag when offer is not template', () => {
         props.audience = Audience.COLLECTIVE
         props.offer.isShowcase = false
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         expect(
           within(screen.getAllByRole('cell')[1]).queryByText('Offre vitrine')
@@ -529,7 +519,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
       it('should not display a duplicate offer button when offer is not template', () => {
         props.audience = Audience.COLLECTIVE
         props.offer.isShowcase = false
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         const duplicateButton = screen.queryByRole('button', {
           name: 'Créer une offre réservable pour un établissement scolaire',
@@ -542,7 +532,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         props.audience = Audience.COLLECTIVE
         props.offer.isShowcase = true
 
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         const duplicateButton = screen.getByRole('button', {
           name: 'Créer une offre réservable pour un établissement scolaire',
@@ -560,7 +550,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         props.offer.isShowcase = true
         Storage.prototype.getItem = jest.fn(() => 'true')
 
-        renderOfferItem(props, store)
+        renderOfferItem(props)
 
         const duplicateButton = screen.getByRole('button', {
           name: 'Créer une offre réservable pour un établissement scolaire',

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.tracker.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.tracker.spec.tsx
@@ -1,16 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
-import type { Store } from 'redux'
 
 import { OfferStatus } from 'apiClient/v1'
 import { Events } from 'core/FirebaseEvents/constants'
 import { Offer } from 'core/Offers/types'
 import { Audience } from 'core/shared'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferItem, { OfferItemProps } from '../OfferItem'
 
@@ -25,28 +22,20 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderOfferItem = (props: OfferItemProps, store: Store) => {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <table>
-          <tbody>
-            <OfferItem {...props} />
-          </tbody>
-        </table>
-      </MemoryRouter>
-    </Provider>
+const renderOfferItem = (props: OfferItemProps) =>
+  renderWithProviders(
+    <table>
+      <tbody>
+        <OfferItem {...props} />
+      </tbody>
+    </table>
   )
-}
 
 describe('src | components | pages | Offers | OfferItem', () => {
   let props: OfferItemProps
   let eventOffer: Offer
-  let store: Store
 
   beforeEach(() => {
-    store = configureTestStore({})
-
     eventOffer = {
       id: 'M4',
       isActive: true,
@@ -82,7 +71,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
   describe('offer item tracking', () => {
     it('track when clicking on offer thumb', async () => {
       // when
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       await userEvent.click(
@@ -105,7 +94,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
     it('should track when clicking on offer stocks', async () => {
       // given
-      renderOfferItem(props, store)
+      renderOfferItem(props)
       await userEvent.click(screen.getByText('Stocks'))
 
       // then
@@ -126,7 +115,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
     it('should track when clicking on offer pen', async () => {
       // when
-      renderOfferItem(props, store)
+      renderOfferItem(props)
       // then
       const editLink = screen.getAllByRole('link')
       await userEvent.click(editLink[3])
@@ -148,7 +137,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
   it('should track when clicking on offer title', async () => {
     // when
-    renderOfferItem(props, store)
+    renderOfferItem(props)
 
     // then
     const offerTitle = screen.getByText(props.offer.name as string, {
@@ -174,7 +163,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     it('should track with draft informations', async () => {
       // when
       props.offer.status = OfferStatus.DRAFT
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       const offerTitle = screen.getByText(props.offer.name as string, {
@@ -199,7 +188,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
     it('should track with draft informations', async () => {
       // when
       props.offer.status = OfferStatus.DRAFT
-      renderOfferItem(props, store)
+      renderOfferItem(props)
 
       // then
       const deleteDraftOfferButton = screen.getByRole('button', {

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.jsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.jsx
@@ -1,11 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Reimbursements from '../Reimbursements'
 
@@ -24,26 +23,23 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const initialStore = {
-  user: {
-    currentUser: {
-      publicName: 'François',
-      isAdmin: false,
-      hasSeenProTutorials: true,
+const renderReimbursements = props => {
+  const storeOverrides = {
+    user: {
+      currentUser: {
+        publicName: 'François',
+        isAdmin: false,
+        hasSeenProTutorials: true,
+      },
+      initialized: true,
     },
-    initialized: true,
-  },
-}
+  }
 
-const renderReimbursements = (store, props) => {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/remboursements/justificatifs']}>
-        <Route path="/remboursements" exact={false}>
-          <Reimbursements {...props} />
-        </Route>
-      </MemoryRouter>
-    </Provider>
+  renderWithProviders(
+    <Route path="/remboursements" exact={false}>
+      <Reimbursements {...props} />
+    </Route>,
+    { storeOverrides, initialRouterEntries: ['/remboursements/justificatifs'] }
   )
 }
 
@@ -99,10 +95,8 @@ const BASE_INVOICES = [
 
 describe('reimbursementsWithFilters', () => {
   let props
-  let store
 
   beforeEach(() => {
-    store = configureTestStore(initialStore)
     props = { currentUser: { isAdmin: false } }
     jest.spyOn(api, 'getVenues').mockResolvedValue({ venues: BASE_VENUES })
     jest.spyOn(api, 'getInvoices').mockResolvedValue(BASE_INVOICES)
@@ -110,7 +104,7 @@ describe('reimbursementsWithFilters', () => {
   })
 
   it('shoud render a table with invoices', async () => {
-    renderReimbursements(store, props)
+    renderReimbursements(props)
 
     const button = screen.queryByRole('link', {
       name: /Lancer la recherche/i,
@@ -156,7 +150,7 @@ describe('reimbursementsWithFilters', () => {
   })
 
   it('shoud reorder invoices on order buttons click', async () => {
-    renderReimbursements(store, props)
+    renderReimbursements(props)
     const button = screen.queryByRole('link', {
       name: /Lancer la recherche/i,
     })

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementWithFilters.spec.jsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementWithFilters.spec.jsx
@@ -1,5 +1,4 @@
 import {
-  render,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -7,11 +6,10 @@ import {
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Reimbursements from '../Reimbursements'
 
@@ -30,16 +28,12 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderReimbursements = (storeOverride = {}) => {
-  const store = configureTestStore(storeOverride)
-  const utils = render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/remboursements/details']}>
-        <Route path="/remboursements" exact={false}>
-          <Reimbursements />
-        </Route>
-      </MemoryRouter>
-    </Provider>
+const renderReimbursements = (storeOverrides = {}) => {
+  const utils = renderWithProviders(
+    <Route path="/remboursements" exact={false}>
+      <Reimbursements />
+    </Route>,
+    { storeOverrides, initialRouterEntries: ['/remboursements/details'] }
   )
 
   const getElements = () => ({
@@ -91,7 +85,7 @@ const renderReimbursements = (storeOverride = {}) => {
 
   const getElementsOnLoadingComplete = async () => {
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
-    const elements = getElements(storeOverride)
+    const elements = getElements(storeOverrides)
 
     return {
       ...elements,

--- a/pro/src/pages/SetPassword/__specs__/SetPassword.spec.jsx
+++ b/pro/src/pages/SetPassword/__specs__/SetPassword.spec.jsx
@@ -1,14 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createBrowserHistory } from 'history'
 import React from 'react'
-import { Provider } from 'react-redux'
 import { Route, Router } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { ApiError } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SetPassword from '../SetPassword'
 
@@ -16,34 +15,33 @@ jest.mock('apiClient/api', () => ({
   api: { postNewPassword: jest.fn() },
 }))
 
-const renderSetPassword = (store, history) =>
-  render(
-    <Provider store={store}>
-      <Router history={history}>
-        <Route path="/creation-de-mot-de-passe/:token?">
-          <>
-            <SetPassword />
-            <Notification />
-          </>
-        </Route>
-      </Router>
-    </Provider>
+const renderSetPassword = (storeOverrides, history) =>
+  renderWithProviders(
+    <Router history={history}>
+      <Route path="/creation-de-mot-de-passe/:token?">
+        <>
+          <SetPassword />
+          <Notification />
+        </>
+      </Route>
+    </Router>,
+    { storeOverrides }
   )
 
 describe('src | components | pages | SetPassword', () => {
   let store, history, historyPushSpy
   beforeEach(() => {
-    store = configureTestStore()
+    store = {}
     history = createBrowserHistory()
     history.push('/creation-de-mot-de-passe/AT3VXY5EB')
     historyPushSpy = jest.spyOn(history, 'push')
   })
+
   it('should redirect the user to structure page', async () => {
     // Given
-
-    store = configureTestStore({
+    store = {
       user: { currentUser: { publicName: 'Bosetti' } },
-    })
+    }
     renderSetPassword(store, history)
 
     // Then

--- a/pro/src/pages/SetPasswordConfirm/__specs__/SetPasswordConfirm.spec.jsx
+++ b/pro/src/pages/SetPasswordConfirm/__specs__/SetPasswordConfirm.spec.jsx
@@ -1,39 +1,37 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createBrowserHistory } from 'history'
 import React from 'react'
-import { Provider } from 'react-redux'
 import { Route, Router } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SetPasswordConfirm from '../SetPasswordConfirm'
 
-const renderSetPassword = (store, history) =>
-  render(
-    <Provider store={store}>
-      <Router history={history}>
-        <Route path="/creation-de-mot-de-passe-confirmation">
-          <SetPasswordConfirm />
-        </Route>
-      </Router>
-    </Provider>
+const renderSetPassword = (storeOverrides, history) =>
+  renderWithProviders(
+    <Router history={history}>
+      <Route path="/creation-de-mot-de-passe-confirmation">
+        <SetPasswordConfirm />
+      </Route>
+    </Router>,
+    { storeOverrides }
   )
 
 describe('src | components | pages | SetPassword', () => {
   let store, history, historyPushSpy
   beforeEach(() => {
-    store = configureTestStore()
+    store = {}
     history = createBrowserHistory()
     history.push('/creation-de-mot-de-passe-confirmation')
     historyPushSpy = jest.spyOn(history, 'push')
   })
+
   it('should redirect the user to structure page', async () => {
     // Given
-
-    store = configureTestStore({
+    store = {
       user: { currentUser: { publicName: 'Bosetti' } },
-    })
+    }
     renderSetPassword(store, history)
 
     // Then

--- a/pro/src/pages/SignIn/__specs__/SignIn.spec.jsx
+++ b/pro/src/pages/SignIn/__specs__/SignIn.spec.jsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { HTTP_STATUS } from 'apiClient/helpers'
@@ -10,7 +9,7 @@ import { ApiError } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SignIn from '../SignIn'
 
@@ -21,26 +20,23 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderSignIn = storeOveride => {
-  const store = configureTestStore(storeOveride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/connexion']}>
-        <SignIn />
-        <Route path="/accueil">
-          <span>I'm logged standard user redirect route</span>
-        </Route>
-        <Route path="/structures">
-          <span>I'm logged admin redirect route</span>
-        </Route>
-        <Route path="/inscription">
-          <span>I'm the inscription page</span>
-        </Route>
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+const renderSignIn = storeOverrides =>
+  renderWithProviders(
+    <>
+      <SignIn />
+      <Route path="/accueil">
+        <span>I'm logged standard user redirect route</span>
+      </Route>
+      <Route path="/structures">
+        <span>I'm logged admin redirect route</span>
+      </Route>
+      <Route path="/inscription">
+        <span>I'm the inscription page</span>
+      </Route>
+      <Notification />
+    </>,
+    { storeOverrides, initialRouterEntries: ['/connexion'] }
   )
-}
 
 describe('src | components | pages | SignIn', () => {
   let store

--- a/pro/src/pages/SignUpValidation/__specs__/SignupValidation.spec.tsx
+++ b/pro/src/pages/SignUpValidation/__specs__/SignupValidation.spec.tsx
@@ -1,8 +1,7 @@
-import { render, waitFor } from '@testing-library/react'
+import { waitFor } from '@testing-library/react'
 import type { Action, History } from 'history'
 import { createBrowserHistory } from 'history'
 import React from 'react'
-import { Provider } from 'react-redux'
 import reactRouter from 'react-router'
 import { Router } from 'react-router-dom'
 
@@ -13,8 +12,8 @@ import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import type { IUseCurrentUserReturn } from 'hooks/useCurrentUser'
 import * as useCurrentUser from 'hooks/useCurrentUser'
 import * as useNotification from 'hooks/useNotification'
-import { configureTestStore } from 'store/testUtils'
 import { campaignTracker } from 'tracking/mediaCampaignsTracking'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SignUpValidation from '../SignUpValidation'
 
@@ -24,7 +23,6 @@ jest.mock('hooks/useNotification')
 
 describe('src | components | pages | Signup | validation', () => {
   let history: History
-  let store = configureTestStore()
   const mockUseNotification = {
     close: jest.fn(),
     error: jest.fn(),
@@ -34,17 +32,8 @@ describe('src | components | pages | Signup | validation', () => {
   }
 
   beforeEach(() => {
-    store = configureTestStore({
-      user: {
-        currentUser: null,
-      },
-      features: {
-        list: [{ isActive: true, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
-      },
-    })
     history = createBrowserHistory()
     jest.spyOn(reactRouter, 'useParams').mockReturnValue({ token: 'AAA' })
-    store = configureTestStore()
     jest.spyOn(useNotification, 'default').mockImplementation(() => ({
       ...mockUseNotification,
     }))
@@ -82,12 +71,10 @@ describe('src | components | pages | Signup | validation', () => {
       },
     } as IUseCurrentUserReturn)
     // when the user is logged in and lands on signup validation page
-    render(
-      <Provider store={store}>
-        <Router history={history}>
-          <SignUpValidation />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <Router history={history}>
+        <SignUpValidation />
+      </Router>
     )
     // then the validity of his token should not be verified
     expect(validateUser).not.toHaveBeenCalled()
@@ -99,12 +86,10 @@ describe('src | components | pages | Signup | validation', () => {
   it('should verify validity of user token and redirect to connexion', async () => {
     const validateUser = jest.spyOn(api, 'validateUser').mockResolvedValue()
     // when the user lands on signup validation page
-    render(
-      <Provider store={store}>
-        <Router history={history}>
-          <SignUpValidation />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <Router history={history}>
+        <SignUpValidation />
+      </Router>
     )
     // then the validity of his token should be verified
     expect(validateUser).toHaveBeenCalledTimes(1)
@@ -118,12 +103,10 @@ describe('src | components | pages | Signup | validation', () => {
   it('should call media campaign tracker once', () => {
     jest.spyOn(api, 'validateUser').mockResolvedValue()
     // when the user lands on signup validation page
-    render(
-      <Provider store={store}>
-        <Router history={history}>
-          <SignUpValidation />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <Router history={history}>
+        <SignUpValidation />
+      </Router>
     )
     // then the media campaign tracker should be called once
     expect(campaignTracker.signUpValidation).toHaveBeenCalledTimes(1)
@@ -137,12 +120,10 @@ describe('src | components | pages | Signup | validation', () => {
       success: notifySuccess,
     }))
     // given the user lands on signup validation page
-    render(
-      <Provider store={store}>
-        <Router history={history}>
-          <SignUpValidation />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <Router history={history}>
+        <SignUpValidation />
+      </Router>
     )
     // when his token is successfully validated
     // then a success message should be dispatched
@@ -172,12 +153,10 @@ describe('src | components | pages | Signup | validation', () => {
       )
     )
     // given the user lands on signup validation page
-    render(
-      <Provider store={store}>
-        <Router history={history}>
-          <SignUpValidation />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <Router history={history}>
+        <SignUpValidation />
+      </Router>
     )
     // when his token is not successfully validated
     // then an error message should be dispatched

--- a/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.jsx
+++ b/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.jsx
@@ -1,15 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { HTTP_STATUS } from 'apiClient/helpers'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as getSirenDataAdapter from 'core/Offerers/adapters/getSirenDataAdapter'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SignupContainer from '../SignupContainer'
 
@@ -24,27 +23,24 @@ jest.mock('apiClient/api', () => ({
   },
 }))
 
-const renderSignUp = storeOveride => {
-  const store = configureTestStore(storeOveride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/inscription']}>
-        <Route path="/inscription">
-          <SignupContainer />
-        </Route>
-        <Route path="/accueil">
-          <span>I'm logged in as a pro user</span>
-        </Route>
-        <Route path="/structures">
-          <span>I'm logged in as an Admin</span>
-        </Route>
-        <Route path="/inscription/confirmation">
-          <span>I'm the confirmation page</span>
-        </Route>
-      </MemoryRouter>
-    </Provider>
+const renderSignUp = storeOverrides =>
+  renderWithProviders(
+    <>
+      <Route path="/inscription">
+        <SignupContainer />
+      </Route>
+      <Route path="/accueil">
+        <span>I'm logged in as a pro user</span>
+      </Route>
+      <Route path="/structures">
+        <span>I'm logged in as an Admin</span>
+      </Route>
+      <Route path="/inscription/confirmation">
+        <span>I'm the confirmation page</span>
+      </Route>
+    </>,
+    { storeOverrides, initialRouterEntries: ['/inscription'] }
   )
-}
 
 describe('Signup', () => {
   let store
@@ -64,7 +60,7 @@ describe('Signup', () => {
     Element.prototype.scrollIntoView = jest.fn()
   })
 
-  it('should redirect to accueil page if the user is logged in', async () => {
+  it.only('should redirect to accueil page if the user is logged in', async () => {
     // when the user is logged in and lands on signup validation page
     store.user = {
       currentUser: {

--- a/pro/src/pages/Signup/__specs__/Signup.spec.jsx
+++ b/pro/src/pages/Signup/__specs__/Signup.spec.jsx
@@ -1,11 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
-import { configureTestStore } from 'store/testUtils'
 import { campaignTracker } from 'tracking/mediaCampaignsTracking'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Signup from '../Signup'
 
@@ -17,16 +15,16 @@ jest.mock('apiClient/api', () => ({
 }))
 
 describe('src | components | pages | Signup', () => {
-  let store
+  let storeOverrides
   beforeEach(() => {
-    store = configureTestStore({
+    storeOverrides = {
       user: {
         currentUser: null,
       },
       features: {
         list: [{ isActive: true, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    })
+    }
     api.listFeatures.mockResolvedValue([])
   })
   afterEach(jest.resetAllMocks)
@@ -40,13 +38,7 @@ describe('src | components | pages | Signup', () => {
     }
 
     // when
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Signup {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
+    renderWithProviders(<Signup {...props} />, { storeOverrides })
 
     // then
     expect(
@@ -63,13 +55,7 @@ describe('src | components | pages | Signup', () => {
     }
 
     // when
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Signup {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
+    renderWithProviders(<Signup {...props} />, { storeOverrides })
 
     // then
     expect(
@@ -84,20 +70,14 @@ describe('src | components | pages | Signup', () => {
         pathname: '/inscription',
       },
     }
-    const store = configureTestStore({
+    const storeOverrides = {
       features: {
         list: [{ isActive: false, nameKey: 'ENABLE_PRO_ACCOUNT_CREATION' }],
       },
-    })
+    }
 
     // when
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Signup {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
+    renderWithProviders(<Signup {...props} />, { storeOverrides })
 
     // then
     expect(
@@ -118,21 +98,12 @@ describe('src | components | pages | Signup', () => {
     }
 
     // when
-    const { rerender } = render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Signup {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
+    const { rerender } = renderWithProviders(<Signup {...props} />, {
+      storeOverrides,
+    })
+
     // when rerender
-    rerender(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Signup {...props} />
-        </MemoryRouter>
-      </Provider>
-    )
+    rerender(<Signup {...props} />)
 
     // then
     expect(campaignTracker.signUp).toHaveBeenCalledTimes(1)

--- a/pro/src/pages/VenueCreation/__specs__/VenueCreation.spec.tsx
+++ b/pro/src/pages/VenueCreation/__specs__/VenueCreation.spec.tsx
@@ -1,32 +1,41 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
-import type { Store } from 'redux'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
-import {
-  GetOffererResponseModel,
-  SharedCurrentUserResponseModel,
-} from 'apiClient/v1'
-import { configureTestStore } from 'store/testUtils'
+import { GetOffererResponseModel } from 'apiClient/v1'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import AppLayout from '../../../app/AppLayout'
 import VenueCreation from '../VenueCreation'
 
-const renderVenueCreation = async (offererId: string, store: Store) => {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[`/structures/${offererId}/lieux/creation`]}
-      >
-        <AppLayout>
-          <Route exact path={'/structures/:offererId/lieux/creation'}>
-            <VenueCreation />
-          </Route>
-        </AppLayout>
-      </MemoryRouter>
-    </Provider>
+const renderVenueCreation = async (offererId: string) => {
+  const storeOverrides = {
+    user: {
+      initialized: true,
+      currentUser: {
+        firstName: 'John',
+        dateCreated: '2022-07-29T12:18:43.087097Z',
+        email: 'john@do.net',
+        id: '1',
+        nonHumanizedId: '1',
+        isAdmin: false,
+        isEmailValidated: true,
+        roles: [],
+      },
+    },
+  }
+
+  return renderWithProviders(
+    <AppLayout>
+      <Route exact path={'/structures/:offererId/lieux/creation'}>
+        <VenueCreation />
+      </Route>
+    </AppLayout>,
+    {
+      storeOverrides,
+      initialRouterEntries: [`/structures/${offererId}/lieux/creation`],
+    }
   )
 }
 
@@ -39,27 +48,9 @@ jest.mock('apiClient/api', () => ({
 }))
 
 describe('route VenueCreation', () => {
-  let currentUser: SharedCurrentUserResponseModel
-  let store: Store
   let offerer: GetOffererResponseModel
 
   beforeEach(() => {
-    currentUser = {
-      firstName: 'John',
-      dateCreated: '2022-07-29T12:18:43.087097Z',
-      email: 'john@do.net',
-      id: '1',
-      nonHumanizedId: '1',
-      isAdmin: false,
-      isEmailValidated: true,
-      roles: [],
-    }
-    store = configureTestStore({
-      user: {
-        initialized: true,
-        currentUser,
-      },
-    })
     offerer = {
       id: 'ABCD',
     } as GetOffererResponseModel
@@ -70,7 +61,7 @@ describe('route VenueCreation', () => {
   })
   it('should display venue form screen with creation title', async () => {
     // When
-    await renderVenueCreation(offerer.id, store)
+    await renderVenueCreation(offerer.id)
 
     // Then
     const venueCreationTitle = await screen.findByText('Création d’un lieu')
@@ -78,7 +69,7 @@ describe('route VenueCreation', () => {
   })
   it('should display modal when user try to quite venue creation', async () => {
     // When
-    await renderVenueCreation(offerer.id, store)
+    await renderVenueCreation(offerer.id)
     // Then
     const homeNavBarButton = await screen.findByText('Accueil')
     await homeNavBarButton.click()
@@ -93,7 +84,7 @@ describe('route VenueCreation', () => {
   })
   it('should display modal when user cancel venue creation', async () => {
     // When
-    await renderVenueCreation(offerer.id, store)
+    await renderVenueCreation(offerer.id)
     // Then
     const cancelFormButton = await screen.findByText('Annuler et quitter')
     await cancelFormButton.click()
@@ -108,7 +99,7 @@ describe('route VenueCreation', () => {
   })
   it('should not display modal when user submit venue creation', async () => {
     // When
-    await renderVenueCreation(offerer.id, store)
+    await renderVenueCreation(offerer.id)
     // Then
     const homeNavBarButton = await screen.findByText('Enregistrer et continuer')
     await homeNavBarButton.click()

--- a/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.tsx
@@ -1,17 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React, { ComponentProps } from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
-import type { Store } from 'redux'
 
 import { Audience } from 'core/shared'
 import { EMPTY_FILTER_VALUE } from 'screens/Bookings/BookingsRecapTable/components/Filters/_constants'
 import * as constants from 'screens/Bookings/BookingsRecapTable/constants/NB_BOOKINGS_PER_PAGE'
 import * as filterBookingsRecap from 'screens/Bookings/BookingsRecapTable/utils/filterBookingsRecap'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
 import { bookingRecapFactory } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import BookingsRecapTable from '../BookingsRecapTable'
 
@@ -36,7 +32,6 @@ const bookingInstitutionCustom = {
 }
 
 describe('components | BookingsRecapTable', () => {
-  let store: Store<Partial<RootState>>
   type Props = ComponentProps<typeof BookingsRecapTable>
 
   const defaultProps: Props = {
@@ -47,18 +42,10 @@ describe('components | BookingsRecapTable', () => {
     bookingsRecap: [],
   }
 
-  const renderBookingRecap = (props: Props) => {
-    return render(
-      <MemoryRouter initialEntries={['/reservations/collectives']}>
-        <Provider store={store}>
-          <BookingsRecapTable {...props} />
-        </Provider>
-      </MemoryRouter>
-    )
-  }
-  beforeEach(() => {
-    store = configureTestStore({})
-  })
+  const renderBookingRecap = (props: Props) =>
+    renderWithProviders(<BookingsRecapTable {...props} />, {
+      initialRouterEntries: ['/reservations/collectives'],
+    })
 
   it('should filter when filters change', async () => {
     const bookingsRecap = [

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingOfferCell.spec.jsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingOfferCell.spec.jsx
@@ -1,19 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { add } from 'date-fns'
 import React from 'react'
-import { Provider } from 'react-redux'
 
-import { configureTestStore } from 'store/testUtils'
 import { collectiveBookingRecapFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import BookingOfferCell from '../BookingOfferCell'
 
-const renderOfferCell = (props, store) =>
-  render(
-    <Provider store={store}>
-      <BookingOfferCell {...props} />
-    </Provider>
-  )
+const renderOfferCell = props =>
+  renderWithProviders(<BookingOfferCell {...props} />)
 
 jest.mock('hooks/useActiveFeature', () => ({
   __esModule: true,
@@ -22,12 +17,6 @@ jest.mock('hooks/useActiveFeature', () => ({
 
 describe('bookings offer cell', () => {
   describe('should always display', () => {
-    let store
-
-    beforeEach(() => {
-      store = configureTestStore({})
-    })
-
     it('offer name and isbn with a link to the offer when stock is a book', () => {
       // Given
       const props = {
@@ -42,7 +31,7 @@ describe('bookings offer cell', () => {
       }
 
       // When
-      renderOfferCell(props, store)
+      renderOfferCell(props)
 
       // Then
       const isbn = screen.getByText('97834567654')
@@ -66,7 +55,7 @@ describe('bookings offer cell', () => {
       }
 
       // When
-      renderOfferCell(props, store)
+      renderOfferCell(props)
 
       // Then
       const offer_name = screen.getByText('Guitare acoustique')
@@ -89,7 +78,7 @@ describe('bookings offer cell', () => {
       }
 
       // When
-      renderOfferCell(props, store)
+      renderOfferCell(props)
 
       // Then
       expect(screen.getByText('12/05/2020 11:03')).toBeInTheDocument()
@@ -116,14 +105,11 @@ describe('bookings offer cell', () => {
         },
       })
 
-      renderOfferCell(
-        {
-          offer: eventOffer.stock,
-          bookingRecapInfo: { values: eventOffer },
-          isCollective: true,
-        },
-        store
-      )
+      renderOfferCell({
+        offer: eventOffer.stock,
+        bookingRecapInfo: { values: eventOffer },
+        isCollective: true,
+      })
 
       const warningIco = screen.queryByAltText('Attention')
       expect(warningIco).not.toBeNull()
@@ -145,14 +131,11 @@ describe('bookings offer cell', () => {
           offerName: 'ma super offre collective 2',
         },
       })
-      renderOfferCell(
-        {
-          offer: eventOffer.stock,
-          bookingRecapInfo: { values: eventOffer },
-          isCollective: true,
-        },
-        store
-      )
+      renderOfferCell({
+        offer: eventOffer.stock,
+        bookingRecapInfo: { values: eventOffer },
+        isCollective: true,
+      })
 
       const warningIco = screen.queryByAltText('Attention')
       expect(warningIco).toBeNull()

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingOfferCell.tracking.spec.jsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingOfferCell.tracking.spec.jsx
@@ -1,24 +1,19 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import BookingOfferCell from '../BookingOfferCell'
 
 const mockLogEvent = jest.fn()
 
 const renderOfferCell = props => {
-  const store = configureTestStore({ app: { logEvent: mockLogEvent } })
+  const storeOverrides = { app: { logEvent: mockLogEvent } }
 
-  render(
-    <Provider store={store}>
-      <BookingOfferCell {...props} />
-    </Provider>
-  )
+  renderWithProviders(<BookingOfferCell {...props} />, { storeOverrides })
 }
 
 describe('tracking bookings offer cell', () => {

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingStatusCell.spec.jsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingStatusCell.spec.jsx
@@ -1,23 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import BookingStatusCell from '../BookingStatusCell'
 
-const renderBookingStatusCell = props => {
-  const store = configureTestStore()
-
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <BookingStatusCell {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderBookingStatusCell = props =>
+  renderWithProviders(<BookingStatusCell {...props} />)
 
 describe('bookings | bookingsStatusCell', () => {
   it('should display the status label', () => {

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/__specs__/FilterByBookingStatus.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/__specs__/FilterByBookingStatus.spec.tsx
@@ -1,16 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import {
   BookingRecapResponseModel,
   CollectiveBookingResponseModel,
 } from 'apiClient/v1'
 import { Audience } from 'core/shared'
-import { configureTestStore } from 'store/testUtils'
 import { bookingRecapFactory } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import FilterByBookingStatus from '../FilterByBookingStatus'
 import { FilterByBookingStatusProps } from '../FilterByBookingStatus/FilterByBookingStatus'
@@ -19,16 +17,7 @@ const renderFilterByBookingStatus = (
   props: FilterByBookingStatusProps<
     BookingRecapResponseModel | CollectiveBookingResponseModel
   >
-) => {
-  const store = configureTestStore()
-  return render(
-    <MemoryRouter>
-      <Provider store={store}>
-        <FilterByBookingStatus {...props} />
-      </Provider>
-    </MemoryRouter>
-  )
-}
+) => renderWithProviders(<FilterByBookingStatus {...props} />)
 
 describe('components | FilterByBookingStatus', () => {
   let props: FilterByBookingStatusProps<

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
@@ -1,8 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { createMemoryHistory } from 'history'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Router } from 'react-router'
 
 import {
   CollectiveBookingBankInformationStatus,
@@ -11,29 +8,24 @@ import {
 } from 'apiClient/v1'
 import { CollectiveBookingCancellationReasons } from 'apiClient/v1/models/CollectiveBookingCancellationReasons'
 import { BOOKING_STATUS } from 'core/Bookings'
-import { configureTestStore } from 'store/testUtils'
 import {
   collectiveBookingDetailsFactory,
   collectiveBookingRecapFactory,
 } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveTimeLine from '../CollectiveTimeLine'
 
 const renderCollectiveTimeLine = (
   bookingRecap: CollectiveBookingResponseModel,
   bookingDetails: CollectiveBookingByIdResponseModel
-) => {
-  render(
-    <Provider store={configureTestStore()}>
-      <Router history={createMemoryHistory()}>
-        <CollectiveTimeLine
-          bookingRecap={bookingRecap}
-          bookingDetails={bookingDetails}
-        />
-      </Router>
-    </Provider>
+) =>
+  renderWithProviders(
+    <CollectiveTimeLine
+      bookingRecap={bookingRecap}
+      bookingDetails={bookingDetails}
+    />
   )
-}
 
 describe('collective timeline', () => {
   let bookingDetails = collectiveBookingDetailsFactory()

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/OldCollectiveBookingDetails/__specs__/CollectiveBookingDetails.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/OldCollectiveBookingDetails/__specs__/CollectiveBookingDetails.spec.tsx
@@ -1,9 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createBrowserHistory } from 'history'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Router } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import {
@@ -11,7 +8,7 @@ import {
   OfferAddressType,
   StudentLevels,
 } from 'apiClient/v1'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveBookingDetails from '../CollectiveBookingDetails'
 
@@ -59,17 +56,13 @@ describe('CollectiveBookingDetails', () => {
   it('should reload bookings after cancelling one', async () => {
     const reloadBookings = jest.fn()
 
-    render(
-      <Provider store={configureTestStore({})}>
-        <Router history={createBrowserHistory()}>
-          <CollectiveBookingDetails
-            bookingDetails={bookingDetails}
-            reloadBookings={reloadBookings}
-            offerId="A1"
-            canCancelBooking={true}
-          />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <CollectiveBookingDetails
+        bookingDetails={bookingDetails}
+        reloadBookings={reloadBookings}
+        offerId="A1"
+        canCancelBooking={true}
+      />
     )
 
     await userEvent.click(
@@ -84,17 +77,13 @@ describe('CollectiveBookingDetails', () => {
   })
 
   it('Cancel booking button should be disabled when booking cannot be cancelled', async () => {
-    render(
-      <Provider store={configureTestStore({})}>
-        <Router history={createBrowserHistory()}>
-          <CollectiveBookingDetails
-            bookingDetails={bookingDetails}
-            reloadBookings={jest.fn()}
-            offerId="A1"
-            canCancelBooking={false}
-          />
-        </Router>
-      </Provider>
+    renderWithProviders(
+      <CollectiveBookingDetails
+        bookingDetails={bookingDetails}
+        reloadBookings={jest.fn()}
+        offerId="A1"
+        canCancelBooking={false}
+      />
     )
 
     expect(

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/__specs__/CollectiveTableRow.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/TableRow/__specs__/CollectiveTableRow.spec.tsx
@@ -1,8 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { createBrowserHistory } from 'history'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { Router } from 'react-router-dom'
 import type { Row } from 'react-table'
 
 import { api } from 'apiClient/api'
@@ -14,7 +11,7 @@ import {
   OfferAddressType,
   StudentLevels,
 } from 'apiClient/v1'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveTableRow, { ITableBodyProps } from '../CollectiveTableRow'
 
@@ -28,16 +25,12 @@ jest.mock(
 )
 
 const renderCollectiveTableRow = (props: ITableBodyProps) =>
-  render(
-    <Router history={createBrowserHistory()}>
-      <Provider store={configureTestStore({})}>
-        <table>
-          <tbody>
-            <CollectiveTableRow {...props} />
-          </tbody>
-        </table>
-      </Provider>
-    </Router>
+  renderWithProviders(
+    <table>
+      <tbody>
+        <CollectiveTableRow {...props} />
+      </tbody>
+    </table>
   )
 
 describe('CollectiveTableRow', () => {

--- a/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
+++ b/pro/src/screens/Bookings/PreFilters/FilterByBookingStatusPeriod/__specs__/FilterByBookingStatusPeriod.spec.tsx
@@ -1,12 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import type { Store } from 'redux'
 
 import { DEFAULT_PRE_FILTERS } from 'core/Bookings'
-import { configureTestStore } from 'store/testUtils'
 import { venueFactory } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import PreFilters, { IPreFiltersProps } from '../../PreFilters'
 
@@ -21,17 +19,13 @@ jest.mock('apiClient/api', () => ({
   api: { getVenues: jest.fn() },
 }))
 
-const renderPreFilters = (props: IPreFiltersProps, store: Store) => {
-  render(
-    <Provider store={store}>
-      <PreFilters {...props} />
-    </Provider>
-  )
+const renderPreFilters = (props: IPreFiltersProps) => {
+  renderWithProviders(<PreFilters {...props} />)
 }
 
 describe('filter bookings by bookings period', () => {
   let props: IPreFiltersProps
-  let store: Store
+
   beforeEach(() => {
     props = {
       appliedPreFilters: { ...DEFAULT_PRE_FILTERS },
@@ -49,13 +43,11 @@ describe('filter bookings by bookings period', () => {
       wereBookingsRequested: true,
       isLocalLoading: false,
     }
-
-    store = configureTestStore()
   })
 
   it('should select 30 days before today as period beginning date by default', () => {
     // When
-    renderPreFilters(props, store)
+    renderPreFilters(props)
 
     // Then
     expect(screen.getByDisplayValue('15/11/2020')).toBeInTheDocument()
@@ -63,7 +55,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should select today as period ending date by default', () => {
     // When
-    renderPreFilters(props, store)
+    renderPreFilters(props)
 
     // Then
     expect(screen.getByDisplayValue('15/12/2020')).toBeInTheDocument()
@@ -71,7 +63,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should allow to select period ending date before today', async () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
     const periodEndingDateInput = screen.getByDisplayValue('15/12/2020')
 
     // When
@@ -84,7 +76,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should not allow to select period ending date after today', async () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
 
     // When
     const periodEndingDateInput = await screen.getByDisplayValue('15/12/2020')
@@ -97,7 +89,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should not allow to select period ending date before selected beginning date', async () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
     const periodEndingDateInput = screen.getByDisplayValue('15/12/2020')
 
     // When
@@ -111,7 +103,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should allow to select period beginning date before selected ending date', async () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
     const periodBeginningDateInput = screen.getByDisplayValue('15/11/2020')
 
     // When
@@ -124,7 +116,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should not allow to select period beginning date after ending date', async () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
 
     // When
     const periodBeginningDateInput = screen.getByDisplayValue('15/11/2020')
@@ -137,7 +129,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should select booked status as booking status filter by default', () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
 
     // Then
     expect(
@@ -147,7 +139,7 @@ describe('filter bookings by bookings period', () => {
 
   it('should allow to select booking status filter', async () => {
     // Given
-    renderPreFilters(props, store)
+    renderPreFilters(props)
     const bookingStatusFilterInput = screen.getByDisplayValue(
       'Période de réservation'
     )

--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -1,8 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -19,12 +17,12 @@ import {
   categoriesFactory,
   subCategoriesFactory,
 } from 'screens/OfferEducational/__tests-utils__'
-import { configureTestStore } from 'store/testUtils'
 import {
   collectiveStockFactory,
   collectiveOfferTemplateFactory,
   collectiveOfferFactory,
 } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferSummaryEdition from '../CollectiveOfferSummaryEdition'
 
@@ -32,7 +30,7 @@ const renderCollectiveOfferSummaryEdition = (
   offer: CollectiveOfferTemplate | CollectiveOffer,
   categories: EducationalCategories
 ) => {
-  const store = configureTestStore({
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -46,17 +44,15 @@ const renderCollectiveOfferSummaryEdition = (
         roles: [],
       },
     },
-  })
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <CollectiveOfferSummaryEdition
-          offer={offer}
-          categories={categories}
-          reloadCollectiveOffer={jest.fn()}
-        />
-      </MemoryRouter>
-    </Provider>
+  }
+
+  renderWithProviders(
+    <CollectiveOfferSummaryEdition
+      offer={offer}
+      categories={categories}
+      reloadCollectiveOffer={jest.fn()}
+    />,
+    { storeOverrides }
   )
 }
 

--- a/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/screens/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -1,15 +1,13 @@
 import 'react-router-dom'
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { EducationalInstitutionResponseModel } from 'apiClient/v1'
 import { DEFAULT_VISIBILITY_FORM_VALUES, Mode } from 'core/OfferEducational'
 import * as useNotification from 'hooks/useNotification'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferVisibility, {
   CollectiveOfferVisibilityProps,
@@ -55,15 +53,8 @@ const institutions: EducationalInstitutionResponseModel[] = [
   },
 ]
 
-export const renderVisibilityStep = (props: CollectiveOfferVisibilityProps) => {
-  render(
-    <Provider store={configureTestStore()}>
-      <MemoryRouter>
-        <CollectiveOfferVisibility {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderVisibilityStep = (props: CollectiveOfferVisibilityProps) =>
+  renderWithProviders(<CollectiveOfferVisibility {...props} />)
 
 describe('CollectiveOfferVisibility', () => {
   let props: CollectiveOfferVisibilityProps

--- a/pro/src/screens/CsvTable/__specs__/CsvTable.spec.tsx
+++ b/pro/src/screens/CsvTable/__specs__/CsvTable.spec.tsx
@@ -1,10 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import * as csvService from 'pages/CsvTable/adapters/getCsvData'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CsvTable, { ICsvTableProps } from '../CsvTable'
 import { ITableData } from '../types'
@@ -15,22 +13,8 @@ interface ICsvTableTestProps {
 
 // FIXME: we don't have store type yet.
 // This will be irrelevant soon as we are removing it
-const renderCsvTable = async ({
-  props,
-  storeOverride = {},
-}: {
-  props: ICsvTableTestProps
-  storeOverride?: any
-}) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <CsvTable {...(props as unknown as ICsvTableProps)} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderCsvTable = (props: ICsvTableTestProps) =>
+  renderWithProviders(<CsvTable {...(props as unknown as ICsvTableProps)} />)
 
 const getCsvDataMock = jest.spyOn(csvService, 'getCsvData')
 
@@ -55,7 +39,7 @@ describe('src | components | layout | CsvTable', () => {
   describe('render', () => {
     it('should render a CsvTable component with a spinner, then a message with no data when there is an error', async () => {
       props.getCsvData.mockRejectedValue(null)
-      renderCsvTable({ props })
+      renderCsvTable(props)
 
       expect(screen.getByText('Chargement en cours')).toBeInTheDocument()
       await waitFor(() => {
@@ -67,7 +51,7 @@ describe('src | components | layout | CsvTable', () => {
 
     it('should render a CsvTable component with a spinner, then a message with no data when there is no data', async () => {
       props.getCsvData.mockResolvedValue({ ...dataFromCsv, data: [] })
-      renderCsvTable({ props })
+      renderCsvTable(props)
 
       expect(screen.getByText('Chargement en cours')).toBeInTheDocument()
       await waitFor(() => {
@@ -78,7 +62,7 @@ describe('src | components | layout | CsvTable', () => {
     })
 
     it('should render a CsvTable component with a spinner, then a table with the data', async () => {
-      renderCsvTable({ props })
+      renderCsvTable(props)
 
       expect(screen.getByText('Chargement en cours')).toBeInTheDocument()
       await waitFor(() => {

--- a/pro/src/screens/OfferIndividual/ActionBar/__specs__/ActionBar.spec.tsx
+++ b/pro/src/screens/OfferIndividual/ActionBar/__specs__/ActionBar.spec.tsx
@@ -1,11 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { ActionBar } from '..'
 import { IActionBarProps } from '../ActionBar'
@@ -17,23 +15,20 @@ const renderActionBar = ({
   props: IActionBarProps
   url?: string
 }) => {
-  return render(
-    <Provider
-      store={configureTestStore({
-        offers: {
-          searchFilters: {
-            filter: 'my_filter',
-            other_filter: 'my_other_filter',
-          },
-          pageNumber: 3,
-        },
-      })}
-    >
-      <MemoryRouter initialEntries={[url]}>
-        <ActionBar {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
+  const storeOverrides = {
+    offers: {
+      searchFilters: {
+        filter: 'my_filter',
+        other_filter: 'my_other_filter',
+      },
+      pageNumber: 3,
+    },
+  }
+
+  return renderWithProviders(<ActionBar {...props} />, {
+    storeOverrides,
+    initialRouterEntries: [url],
+  })
 }
 
 describe('OfferIndividual::ActionBar', () => {

--- a/pro/src/screens/OfferIndividual/PriceCategories/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
+++ b/pro/src/screens/OfferIndividual/PriceCategories/__specs__/PriceCategories.RouteLeavingGuard.spec.tsx
@@ -1,17 +1,16 @@
 import '@testing-library/jest-dom'
 
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route } from 'react-router'
+import { generatePath, Route } from 'react-router'
 
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
-import { configureTestStore } from 'store/testUtils'
 import { ButtonLink } from 'ui-kit'
 import { individualOfferFactory } from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import PriceCategories, { IPriceCategories } from '../PriceCategories'
 
@@ -32,51 +31,47 @@ const renderPriceCategories = (
     }),
     { offerId: 'AA' }
   )
-) => {
-  const store = configureTestStore()
-
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route
-          path={Object.values(OFFER_WIZARD_MODE).map(mode =>
-            getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.TARIFS,
-              mode,
-            })
-          )}
+) =>
+  renderWithProviders(
+    <>
+      <Route
+        path={Object.values(OFFER_WIZARD_MODE).map(mode =>
+          getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.TARIFS,
+            mode,
+          })
+        )}
+      >
+        <PriceCategories {...props} />
+        <ButtonLink link={{ to: '/outside', isExternal: false }}>
+          Go outside !
+        </ButtonLink>
+        <ButtonLink
+          link={{
+            to: getOfferIndividualPath({
+              step: OFFER_WIZARD_STEP_IDS.STOCKS,
+              mode: OFFER_WIZARD_MODE.DRAFT,
+            }),
+            isExternal: false,
+          }}
         >
-          <PriceCategories {...props} />
-          <ButtonLink link={{ to: '/outside', isExternal: false }}>
-            Go outside !
-          </ButtonLink>
-          <ButtonLink
-            link={{
-              to: getOfferIndividualPath({
-                step: OFFER_WIZARD_STEP_IDS.STOCKS,
-                mode: OFFER_WIZARD_MODE.DRAFT,
-              }),
-              isExternal: false,
-            }}
-          >
-            Go to stocks !
-          </ButtonLink>
-        </Route>
-        <Route path="/outside">
-          <div>This is outside offer creation</div>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.DRAFT,
-          })}
-        >
-          <div>There is the stock route content</div>
-        </Route>
-      </MemoryRouter>
-    </Provider>
+          Go to stocks !
+        </ButtonLink>
+      </Route>
+      <Route path="/outside">
+        <div>This is outside offer creation</div>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.DRAFT,
+        })}
+      >
+        <div>There is the stock route content</div>
+      </Route>
+    </>,
+    { initialRouterEntries: [url] }
   )
-}
 
 describe('PriceCategories', () => {
   it('should let going to information when clicking on previous step in creation', async () => {

--- a/pro/src/screens/OfferIndividual/PriceCategories/__specs__/PriceCategories.spec.tsx
+++ b/pro/src/screens/OfferIndividual/PriceCategories/__specs__/PriceCategories.spec.tsx
@@ -1,24 +1,13 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
-import { configureTestStore } from 'store/testUtils'
 import { individualOfferFactory } from 'utils/individualApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import PriceCategories, { IPriceCategories } from '../PriceCategories'
 
-const renderPriceCategories = (props: IPriceCategories) => {
-  const store = configureTestStore()
-
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <PriceCategories {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderPriceCategories = (props: IPriceCategories) =>
+  renderWithProviders(<PriceCategories {...props} />)
 
 describe('PriceCategories', () => {
   it('should render without error', () => {

--- a/pro/src/screens/OfferIndividual/Status/__specs__/StatusToggleButton.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Status/__specs__/StatusToggleButton.spec.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
 
 import { api } from 'apiClient/api'
 import { OfferStatus } from 'apiClient/v1'
 import * as useNotification from 'hooks/useNotification'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StatusToggleButton, { IStatusToggleButton } from '../StatusToggleButton'
 
@@ -17,13 +16,9 @@ jest.mock('react-router-dom', () => ({
   }),
 }))
 
-const renderStatusToggleButton = (props: IStatusToggleButton) => {
-  render(
-    <Provider store={configureTestStore({})}>
-      <StatusToggleButton {...props} />
-    </Provider>
-  )
-}
+const renderStatusToggleButton = (props: IStatusToggleButton) =>
+  renderWithProviders(<StatusToggleButton {...props} />)
+
 describe('StatusToggleButton', () => {
   let props: IStatusToggleButton
   beforeEach(() => {

--- a/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEvent/__specs__/StocksEvent.tracker.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -17,9 +16,8 @@ import {
 import { Events } from 'core/FirebaseEvents/constants'
 import { IOfferIndividual, IOfferIndividualVenue } from 'core/Offers/types'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
 import { getToday } from 'utils/date'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StocksEvent, { IStocksEventProps } from '../StocksEvent'
 
@@ -42,37 +40,27 @@ jest.mock('utils/date', () => ({
     .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
 }))
 
-const renderStockEventScreen = ({
-  props,
-  storeOverride = {},
-  contextValue,
-  url = '/creation/stocks',
-}: {
-  props: IStocksEventProps
-  storeOverride: Partial<RootState>
-  contextValue: IOfferIndividualContext
-  url?: string
-}) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route path={['/creation/stocks', '/brouillon/stocks', '/stocks']}>
-          <OfferIndividualContext.Provider value={contextValue}>
-            <StocksEvent {...props} />
-          </OfferIndividualContext.Provider>
-        </Route>
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+const renderStockEventScreen = (
+  props: IStocksEventProps,
+  contextValue: IOfferIndividualContext,
+  url = '/creation/stocks'
+) =>
+  renderWithProviders(
+    <>
+      <Route path={['/creation/stocks', '/brouillon/stocks', '/stocks']}>
+        <OfferIndividualContext.Provider value={contextValue}>
+          <StocksEvent {...props} />
+        </OfferIndividualContext.Provider>
+      </Route>
+      <Notification />
+    </>,
+    { initialRouterEntries: [url] }
   )
-}
 
 const today = getToday()
 
 describe('screens:StocksEvent', () => {
   let props: IStocksEventProps
-  let storeOverride: Partial<RootState>
   let contextValue: IOfferIndividualContext
   let offer: Partial<IOfferIndividual>
 
@@ -87,7 +75,6 @@ describe('screens:StocksEvent', () => {
     props = {
       offer: offer as IOfferIndividual,
     }
-    storeOverride = {}
     contextValue = {
       offerId: null,
       offer: null,
@@ -114,7 +101,7 @@ describe('screens:StocksEvent', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockEventScreen({ props, storeOverride, contextValue })
+    renderStockEventScreen(props, contextValue)
 
     await userEvent.click(screen.getByLabelText('Date', { exact: true }))
     await userEvent.click(await screen.getByText(today.getDate()))
@@ -142,12 +129,7 @@ describe('screens:StocksEvent', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockEventScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/brouillon/stocks',
-    })
+    renderStockEventScreen(props, contextValue, '/brouillon/stocks')
 
     await userEvent.click(screen.getByLabelText('Date', { exact: true }))
     await userEvent.click(await screen.getByText(today.getDate()))
@@ -175,12 +157,7 @@ describe('screens:StocksEvent', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockEventScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/stocks',
-    })
+    renderStockEventScreen(props, contextValue, '/stocks')
 
     await userEvent.click(screen.getByLabelText('Date', { exact: true }))
     await userEvent.click(await screen.getByText(today.getDate()))
@@ -207,7 +184,7 @@ describe('screens:StocksEvent', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockEventScreen({ props, storeOverride, contextValue })
+    renderStockEventScreen(props, contextValue)
 
     await userEvent.click(screen.getByLabelText('Date', { exact: true }))
     await userEvent.click(await screen.getByText(today.getDate()))
@@ -235,12 +212,7 @@ describe('screens:StocksEvent', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockEventScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/brouillon/stocks/',
-    })
+    renderStockEventScreen(props, contextValue, '/brouillon/stocks/')
 
     await userEvent.click(screen.getByLabelText('Date', { exact: true }))
     await userEvent.click(await screen.getByText(today.getDate()))
@@ -269,7 +241,7 @@ describe('screens:StocksEvent', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockEventScreen({ props, storeOverride, contextValue })
+    renderStockEventScreen(props, contextValue)
 
     await userEvent.click(screen.getByText('Étape précédente'))
 
@@ -293,12 +265,7 @@ describe('screens:StocksEvent', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockEventScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/brouillon/stocks',
-    })
+    renderStockEventScreen(props, contextValue, '/brouillon/stocks')
 
     await userEvent.click(screen.getByText('Étape précédente'))
 
@@ -322,12 +289,7 @@ describe('screens:StocksEvent', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockEventScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/stocks',
-    })
+    renderStockEventScreen(props, contextValue, '/stocks')
 
     await userEvent.click(screen.getByText('Annuler et quitter'))
 

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.draft.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.draft.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { GetIndividualOfferResponseModel } from 'apiClient/v1'
@@ -22,8 +21,7 @@ import {
   getOfferIndividualPath,
   getOfferIndividualUrl,
 } from 'core/Offers/utils/getOfferIndividualUrl'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StocksThing, { IStocksThingProps } from '../StocksThing'
 
@@ -44,54 +42,45 @@ jest.mock('utils/date', () => ({
     .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
 }))
 
-const renderStockThingScreen = ({
-  props,
-  storeOverride = {},
-  contextValue,
-}: {
-  props: IStocksThingProps
-  storeOverride: Partial<RootState>
+const renderStockThingScreen = (
+  props: IStocksThingProps,
   contextValue: IOfferIndividualContext
-}) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[
-          getOfferIndividualUrl({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.DRAFT,
-            offerId: contextValue.offerId || undefined,
-          }),
-        ]}
+) =>
+  renderWithProviders(
+    <>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.DRAFT,
+        })}
       >
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.DRAFT,
-          })}
-        >
-          <OfferIndividualContext.Provider value={contextValue}>
-            <StocksThing {...props} />
-          </OfferIndividualContext.Provider>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-            mode: OFFER_WIZARD_MODE.DRAFT,
-          })}
-        >
-          <div>Next page</div>
-        </Route>
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+        <OfferIndividualContext.Provider value={contextValue}>
+          <StocksThing {...props} />
+        </OfferIndividualContext.Provider>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+          mode: OFFER_WIZARD_MODE.DRAFT,
+        })}
+      >
+        <div>Next page</div>
+      </Route>
+      <Notification />
+    </>,
+    {
+      initialRouterEntries: [
+        getOfferIndividualUrl({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.DRAFT,
+          offerId: contextValue.offerId || undefined,
+        }),
+      ],
+    }
   )
-}
 
 describe('screens:StocksThing::draft', () => {
   let props: IStocksThingProps
-  let storeOverride: Partial<RootState>
   let contextValue: IOfferIndividualContext
   let offer: Partial<IOfferIndividual>
   let stock: Partial<IOfferIndividualStock>
@@ -116,7 +105,6 @@ describe('screens:StocksThing::draft', () => {
     props = {
       offer: offer as IOfferIndividual,
     }
-    storeOverride = {}
     contextValue = {
       offerId: 'OFFER_ID',
       offer: offer as IOfferIndividual,
@@ -136,7 +124,7 @@ describe('screens:StocksThing::draft', () => {
   })
 
   it('should show a success notification if nothing has been touched', async () => {
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -153,7 +141,7 @@ describe('screens:StocksThing::draft', () => {
   })
 
   it('should show a success notification if nothing has been touched and click on next step', async () => {
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.click(
       screen.getByRole('button', {

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -28,8 +27,7 @@ import {
   getOfferIndividualPath,
   getOfferIndividualUrl,
 } from 'core/Offers/utils/getOfferIndividualUrl'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StocksThing, { IStocksThingProps } from '../StocksThing'
 
@@ -50,70 +48,61 @@ jest.mock('utils/date', () => ({
     .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
 }))
 
-const renderStockThingScreen = ({
-  props,
-  storeOverride = {},
-  contextValue,
-}: {
-  props: IStocksThingProps
-  storeOverride: Partial<RootState>
+const renderStockThingScreen = (
+  props: IStocksThingProps,
   contextValue: IOfferIndividualContext
-}) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[
-          getOfferIndividualUrl({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.CREATION,
-            offerId: contextValue.offerId || undefined,
-          }),
-        ]}
+) =>
+  renderWithProviders(
+    <>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.CREATION,
+        })}
       >
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.CREATION,
-          })}
-        >
-          <OfferIndividualContext.Provider value={contextValue}>
-            <StocksThing {...props} />
-          </OfferIndividualContext.Provider>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-            mode: OFFER_WIZARD_MODE.CREATION,
-          })}
-        >
-          <div>Next page</div>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.CREATION,
-          })}
-        >
-          <div>Save draft page</div>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
-            mode: OFFER_WIZARD_MODE.CREATION,
-          })}
-        >
-          <div>Previous page</div>
-        </Route>
-        <Notification />
-      </MemoryRouter>
-    </Provider>
+        <OfferIndividualContext.Provider value={contextValue}>
+          <StocksThing {...props} />
+        </OfferIndividualContext.Provider>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+          mode: OFFER_WIZARD_MODE.CREATION,
+        })}
+      >
+        <div>Next page</div>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.CREATION,
+        })}
+      >
+        <div>Save draft page</div>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.INFORMATIONS,
+          mode: OFFER_WIZARD_MODE.CREATION,
+        })}
+      >
+        <div>Previous page</div>
+      </Route>
+      <Notification />
+    </>,
+    {
+      initialRouterEntries: [
+        getOfferIndividualUrl({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.CREATION,
+          offerId: contextValue.offerId || undefined,
+        }),
+      ],
+    }
   )
-}
 
 describe('screens:StocksThing', () => {
   let props: IStocksThingProps
-  let storeOverride: Partial<RootState>
   let contextValue: IOfferIndividualContext
   let offer: Partial<IOfferIndividual>
 
@@ -129,7 +118,6 @@ describe('screens:StocksThing', () => {
     props = {
       offer: offer as IOfferIndividual,
     }
-    storeOverride = {}
     contextValue = {
       offerId: 'OFFER_ID',
       offer: offer as IOfferIndividual,
@@ -154,7 +142,7 @@ describe('screens:StocksThing', () => {
       isDigital: false,
     }
 
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
     expect(
       screen.getByText('Offre synchronisée avec Ciné Office')
     ).toBeInTheDocument()
@@ -178,7 +166,7 @@ describe('screens:StocksThing', () => {
       subcategoryId: 'TESTID',
       isDigital: true,
     }
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
     expect(
       screen.getByText('Offre synchronisée avec Ciné Office')
     ).toBeInTheDocument()
@@ -197,7 +185,7 @@ describe('screens:StocksThing', () => {
       subcategoryId: LIVRE_PAPIER_SUBCATEGORY_ID,
       isDigital: false,
     }
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
     expect(
       screen.getByText(
         'Les bénéficiaires ont 10 jours pour faire valider leur contremarque. Passé ce délai, la réservation est automatiquement annulée et l’offre remise en vente.'
@@ -212,7 +200,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
     const nextButton = screen.getByRole('button', { name: 'Étape suivante' })
     const draftButton = screen.getByRole('button', {
       name: 'Sauvegarder le brouillon',
@@ -233,7 +221,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
     const nextButton = screen.getByRole('button', { name: 'Étape suivante' })
     const draftButton = screen.getByRole('button', {
       name: 'Sauvegarder le brouillon',
@@ -263,7 +251,7 @@ describe('screens:StocksThing', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape précédente' })
@@ -291,7 +279,7 @@ describe('screens:StocksThing', () => {
       )
     )
 
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(
@@ -312,7 +300,7 @@ describe('screens:StocksThing', () => {
         ...(offer as IOfferIndividual),
         isDigital: true,
       }
-      renderStockThingScreen({ props, storeOverride, contextValue })
+      renderStockThingScreen(props, contextValue)
 
       await userEvent.type(screen.getByLabelText('Prix'), '20')
 
@@ -377,7 +365,7 @@ describe('screens:StocksThing', () => {
         ...(offer as IOfferIndividual),
         isDigital: true,
       }
-      renderStockThingScreen({ props, storeOverride, contextValue })
+      renderStockThingScreen(props, contextValue)
 
       await userEvent.click(
         screen.getByTestId('stock-form-actions-button-open')
@@ -421,7 +409,7 @@ describe('screens:StocksThing', () => {
           } as IOfferIndividualStock,
         ],
       }
-      renderStockThingScreen({ props, storeOverride, contextValue })
+      renderStockThingScreen(props, contextValue)
 
       expect(screen.getByLabelText('Quantité')).toBeDisabled()
       const expirationInput = screen.getByLabelText("Date d'expiration")
@@ -430,7 +418,7 @@ describe('screens:StocksThing', () => {
     })
 
     it('should show a success notification if nothing has been touched', async () => {
-      renderStockThingScreen({ props, storeOverride, contextValue })
+      renderStockThingScreen(props, contextValue)
       await userEvent.click(
         screen.getByRole('button', { name: 'Sauvegarder le brouillon' })
       )
@@ -450,7 +438,7 @@ describe('screens:StocksThing', () => {
   it.each(setNumberPriceValue)(
     'should only type numbers for price input',
     async ({ value, expectedNumber }) => {
-      renderStockThingScreen({ props, storeOverride, contextValue })
+      renderStockThingScreen(props, contextValue)
 
       const priceInput = screen.getByLabelText('Prix', {
         exact: false,
@@ -470,7 +458,7 @@ describe('screens:StocksThing', () => {
   it.each(setNumberQuantityValue)(
     'should only type numbers for quantity input',
     async ({ value, expectedNumber }) => {
-      renderStockThingScreen({ props, storeOverride, contextValue })
+      renderStockThingScreen(props, contextValue)
 
       const quantityInput = screen.getByLabelText('Quantité', {
         exact: false,
@@ -480,7 +468,7 @@ describe('screens:StocksThing', () => {
     }
   )
   it('should display success message on save draft button when stock form is empty', async () => {
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await expect(screen.getByTestId('stock-thing-form')).toBeInTheDocument()
 

--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.tracker.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -16,8 +15,7 @@ import {
 import { Events } from 'core/FirebaseEvents/constants'
 import { IOfferIndividual, IOfferIndividualVenue } from 'core/Offers/types'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StocksThing, { IStocksThingProps } from '../StocksThing'
 
@@ -40,34 +38,22 @@ jest.mock('utils/date', () => ({
     .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
 }))
 
-const renderStockThingScreen = ({
-  props,
-  storeOverride = {},
-  contextValue,
-  url = '/creation/stocks',
-}: {
-  props: IStocksThingProps
-  storeOverride: Partial<RootState>
-  contextValue: IOfferIndividualContext
-  url?: string
-}) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route path={['/creation/stocks', '/brouillon/stocks', '/stocks']}>
-          <OfferIndividualContext.Provider value={contextValue}>
-            <StocksThing {...props} />
-          </OfferIndividualContext.Provider>
-        </Route>
-      </MemoryRouter>
-    </Provider>
+const renderStockThingScreen = (
+  props: IStocksThingProps,
+  contextValue: IOfferIndividualContext,
+  url = '/creation/stocks'
+) =>
+  renderWithProviders(
+    <Route path={['/creation/stocks', '/brouillon/stocks', '/stocks']}>
+      <OfferIndividualContext.Provider value={contextValue}>
+        <StocksThing {...props} />
+      </OfferIndividualContext.Provider>
+    </Route>,
+    { initialRouterEntries: [url] }
   )
-}
 
 describe('screens:StocksThing', () => {
   let props: IStocksThingProps
-  let storeOverride: Partial<RootState>
   let contextValue: IOfferIndividualContext
   let offer: Partial<IOfferIndividual>
 
@@ -82,7 +68,6 @@ describe('screens:StocksThing', () => {
     props = {
       offer: offer as IOfferIndividual,
     }
-    storeOverride = {}
     contextValue = {
       offerId: null,
       offer: null,
@@ -108,7 +93,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
@@ -132,12 +117,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/brouillon/stocks',
-    })
+    renderStockThingScreen(props, contextValue, '/brouillon/stocks')
 
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Sauvegarder le brouillon'))
@@ -161,7 +141,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Étape suivante'))
@@ -185,12 +165,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/brouillon/stocks',
-    })
+    renderStockThingScreen(props, contextValue, '/brouillon/stocks')
 
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Étape suivante'))
@@ -214,12 +189,7 @@ describe('screens:StocksThing', () => {
     jest.spyOn(api, 'upsertStocks').mockResolvedValue({
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
-    renderStockThingScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/stocks',
-    })
+    renderStockThingScreen(props, contextValue, '/stocks')
 
     await userEvent.type(screen.getByLabelText('Prix'), '20')
     await userEvent.click(screen.getByText('Enregistrer les modifications'))
@@ -244,7 +214,7 @@ describe('screens:StocksThing', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockThingScreen({ props, storeOverride, contextValue })
+    renderStockThingScreen(props, contextValue)
 
     await userEvent.click(screen.getByText('Étape précédente'))
 
@@ -268,12 +238,7 @@ describe('screens:StocksThing', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockThingScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/brouillon/stocks',
-    })
+    renderStockThingScreen(props, contextValue, '/brouillon/stocks')
 
     await userEvent.click(screen.getByText('Étape précédente'))
 
@@ -297,12 +262,7 @@ describe('screens:StocksThing', () => {
       stocks: [{ id: 'CREATED_STOCK_ID' } as StockResponseModel],
     })
 
-    renderStockThingScreen({
-      props,
-      storeOverride,
-      contextValue,
-      url: '/stocks',
-    })
+    renderStockThingScreen(props, contextValue, '/stocks')
 
     await userEvent.click(screen.getByText('Annuler et quitter'))
 

--- a/pro/src/screens/OfferIndividual/Summary/StockSection/__specs__/StockSection.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockSection/__specs__/StockSection.spec.tsx
@@ -1,91 +1,79 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route } from 'react-router'
+import { generatePath, Route } from 'react-router'
 
 import { OfferStatus } from 'apiClient/v1'
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StockSection, { IStockSection } from '../StockSection'
 
 const mockLogEvent = jest.fn()
 
-const renderStockSection = ({
-  props,
-  storeOverride = {},
-  url = getOfferIndividualPath({
+const renderStockSection = (
+  props: IStockSection,
+  url: string = getOfferIndividualPath({
     step: OFFER_WIZARD_STEP_IDS.SUMMARY,
     mode: OFFER_WIZARD_MODE.EDITION,
-  }),
-}: {
-  props: IStockSection
-  storeOverride?: Partial<RootState>
-  url?: string
-}) => {
-  const store = configureTestStore({
-    ...storeOverride,
   })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-            mode: OFFER_WIZARD_MODE.EDITION,
-          })}
-        >
-          <StockSection {...props} />
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-            mode: OFFER_WIZARD_MODE.CREATION,
-          })}
-        >
-          <StockSection {...props} />
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-            mode: OFFER_WIZARD_MODE.DRAFT,
-          })}
-        >
-          <StockSection {...props} />
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.CREATION,
-          })}
-        >
-          <div>Offer V3 creation: page stocks</div>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.EDITION,
-          })}
-        >
-          <div>Offer V3 edition: page stocks</div>
-        </Route>
-        <Route
-          path={getOfferIndividualPath({
-            step: OFFER_WIZARD_STEP_IDS.STOCKS,
-            mode: OFFER_WIZARD_MODE.DRAFT,
-          })}
-        >
-          <div>Offer V3 brouillon: page stocks</div>
-        </Route>
-      </MemoryRouter>
-    </Provider>
+) =>
+  renderWithProviders(
+    <>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+          mode: OFFER_WIZARD_MODE.EDITION,
+        })}
+      >
+        <StockSection {...props} />
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+          mode: OFFER_WIZARD_MODE.CREATION,
+        })}
+      >
+        <StockSection {...props} />
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+          mode: OFFER_WIZARD_MODE.DRAFT,
+        })}
+      >
+        <StockSection {...props} />
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.CREATION,
+        })}
+      >
+        <div>Offer V3 creation: page stocks</div>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.EDITION,
+        })}
+      >
+        <div>Offer V3 edition: page stocks</div>
+      </Route>
+      <Route
+        path={getOfferIndividualPath({
+          step: OFFER_WIZARD_STEP_IDS.STOCKS,
+          mode: OFFER_WIZARD_MODE.DRAFT,
+        })}
+      >
+        <div>Offer V3 brouillon: page stocks</div>
+      </Route>
+    </>,
+    { initialRouterEntries: [url] }
   )
-}
 
 describe('Summary stock section', () => {
   let props: IStockSection
@@ -107,16 +95,16 @@ describe('Summary stock section', () => {
         offerId: 'TEST_OFFER_ID',
         offerStatus: OfferStatus.SOLD_OUT,
       }
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -135,16 +123,16 @@ describe('Summary stock section', () => {
         offerId: 'TEST_OFFER_ID',
         offerStatus: OfferStatus.EXPIRED,
       }
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -157,16 +145,16 @@ describe('Summary stock section', () => {
         offerId: 'TEST_OFFER_ID',
         offerStatus: OfferStatus.SOLD_OUT,
       }
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -191,16 +179,16 @@ describe('Summary stock section', () => {
     })
 
     it('should render creation summary (v3)', async () => {
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -215,7 +203,7 @@ describe('Summary stock section', () => {
     })
 
     it('should render edition summary (v3)', async () => {
-      renderStockSection({ props })
+      renderStockSection(props)
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -238,7 +226,7 @@ describe('Summary stock section', () => {
           bookingLimitDatetime: '2001-06-12',
         },
       }
-      renderStockSection({ props })
+      renderStockSection(props)
       expect(screen.getByText(/Date limite de réservation/)).toBeInTheDocument()
     })
 
@@ -254,7 +242,7 @@ describe('Summary stock section', () => {
           },
         }
 
-        renderStockSection({ props })
+        renderStockSection(props)
         expect(screen.getByText('Illimité')).toBeInTheDocument()
       }
     )
@@ -285,16 +273,16 @@ describe('Summary stock section', () => {
     })
 
     it('should render creation summary (v3)', async () => {
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -307,16 +295,16 @@ describe('Summary stock section', () => {
     })
 
     it('should render brouillon summary (v3)', async () => {
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.DRAFT,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -329,7 +317,7 @@ describe('Summary stock section', () => {
     })
 
     it('should render edition summary (v3)', async () => {
-      renderStockSection({ props })
+      renderStockSection(props)
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()
@@ -365,16 +353,16 @@ describe('Summary stock section', () => {
           departmentCode: '78',
         },
       ]
-      renderStockSection({
+      renderStockSection(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       expect(
         screen.getByRole('heading', { name: /Stocks et prix/ })
       ).toBeInTheDocument()

--- a/pro/src/screens/OfferIndividual/Summary/StockSection/__specs__/StockSection.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/StockSection/__specs__/StockSection.tracker.spec.tsx
@@ -1,47 +1,32 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter, Route } from 'react-router'
+import { Route } from 'react-router'
 
 import { OfferStatus } from 'apiClient/v1'
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import StockSection, { IStockSection } from '../StockSection'
 
 const mockLogEvent = jest.fn()
 
-const renderStockSection = ({
-  props,
-  storeOverride = {},
-  url = '/recapitulatif',
-}: {
-  props: IStockSection
-  storeOverride?: Partial<RootState>
-  url?: string
-}) => {
-  const store = configureTestStore({
-    ...storeOverride,
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route path="/recapitulatif">
-          <StockSection {...props} />
-        </Route>
-        <Route path="/creation/recapitulatif">
-          <StockSection {...props} />
-        </Route>
-        <Route path="/brouillon/recapitulatif">
-          <StockSection {...props} />
-        </Route>
-      </MemoryRouter>
-    </Provider>
+const renderStockSection = (props: IStockSection, url = '/recapitulatif') =>
+  renderWithProviders(
+    <>
+      <Route path="/recapitulatif">
+        <StockSection {...props} />
+      </Route>
+      <Route path="/creation/recapitulatif">
+        <StockSection {...props} />
+      </Route>
+      <Route path="/brouillon/recapitulatif">
+        <StockSection {...props} />
+      </Route>
+    </>,
+    { initialRouterEntries: [url] }
   )
-}
 
 describe('Summary stock section trackers', () => {
   let props: IStockSection
@@ -62,7 +47,7 @@ describe('Summary stock section trackers', () => {
     }))
   })
   it('should track creation summary (v2)', async () => {
-    renderStockSection({ props, url: '/creation/recapitulatif' })
+    renderStockSection(props, '/creation/recapitulatif')
 
     await userEvent.click(screen.getByRole('link', { name: /Modifier/ }))
 
@@ -82,7 +67,7 @@ describe('Summary stock section trackers', () => {
   })
 
   it('should track edition summary (v2)', async () => {
-    renderStockSection({ props })
+    renderStockSection(props)
 
     await userEvent.click(screen.getByRole('link', { name: /Modifier/ }))
 
@@ -102,7 +87,7 @@ describe('Summary stock section trackers', () => {
   })
 
   it('should track draft summary (v2)', async () => {
-    renderStockSection({ props, url: '/brouillon/recapitulatif' })
+    renderStockSection(props, '/brouillon/recapitulatif')
 
     await userEvent.click(screen.getByRole('link', { name: /Modifier/ }))
 
@@ -122,10 +107,7 @@ describe('Summary stock section trackers', () => {
   })
 
   it('should track creation summary (v3)', async () => {
-    renderStockSection({
-      props,
-      url: '/creation/recapitulatif',
-    })
+    renderStockSection(props, '/creation/recapitulatif')
 
     await userEvent.click(screen.getByRole('link', { name: /Modifier/ }))
 
@@ -145,7 +127,7 @@ describe('Summary stock section trackers', () => {
   })
 
   it('should track edition summary (v3)', async () => {
-    renderStockSection({ props })
+    renderStockSection(props)
     await userEvent.click(screen.getByRole('link', { name: /Modifier/ }))
 
     expect(mockLogEvent).toHaveBeenCalledTimes(1)

--- a/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter, Route } from 'react-router'
+import { generatePath, Route } from 'react-router'
 
 import { api } from 'apiClient/api'
 import {
@@ -24,8 +23,7 @@ import { CATEGORY_STATUS, OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
 import * as useAnalytics from 'hooks/useAnalytics'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Summary, { ISummaryProps } from '../Summary'
 
@@ -49,21 +47,16 @@ const contextValues: IOfferIndividualContext = {
   showVenuePopin: {},
 }
 
-const renderSummary = ({
-  props,
-  storeOverride = {},
-  url = getOfferIndividualPath({
+const renderSummary = (
+  props: ISummaryProps,
+  url: string = getOfferIndividualPath({
     step: OFFER_WIZARD_STEP_IDS.SUMMARY,
     mode: OFFER_WIZARD_MODE.EDITION,
   }),
-  context = contextValues,
-}: {
-  props: ISummaryProps
-  storeOverride?: Partial<RootState>
-  url?: string
-  context?: IOfferIndividualContext
-}) => {
-  const store = configureTestStore({
+  context: IOfferIndividualContext = contextValues,
+  storeOverride: any = {}
+) => {
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -73,73 +66,73 @@ const renderSummary = ({
       },
     },
     ...storeOverride,
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>
-        <OfferIndividualContext.Provider value={context}>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-              mode: OFFER_WIZARD_MODE.EDITION,
-            })}
-          >
-            <Summary {...props} />
-          </Route>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-              mode: OFFER_WIZARD_MODE.CREATION,
-            })}
-          >
-            <Summary {...props} />
-          </Route>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.SUMMARY,
-              mode: OFFER_WIZARD_MODE.DRAFT,
-            })}
-          >
-            <Summary {...props} />
-          </Route>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
-              mode: OFFER_WIZARD_MODE.DRAFT,
-            })}
-          >
-            <div>Confirmation page: draft</div>
-          </Route>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
-              mode: OFFER_WIZARD_MODE.CREATION,
-            })}
-          >
-            <div>Confirmation page: creation</div>
-          </Route>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
-              mode: OFFER_WIZARD_MODE.DRAFT,
-              isV2: true,
-            })}
-          >
-            <div>Confirmation page: draft V2</div>
-          </Route>
-          <Route
-            path={getOfferIndividualPath({
-              step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
-              mode: OFFER_WIZARD_MODE.CREATION,
-              isV2: true,
-            })}
-          >
-            <div>Confirmation page: creation V2</div>
-          </Route>
-        </OfferIndividualContext.Provider>
-      </MemoryRouter>
+  }
+
+  return renderWithProviders(
+    <>
+      <OfferIndividualContext.Provider value={context}>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+            mode: OFFER_WIZARD_MODE.EDITION,
+          })}
+        >
+          <Summary {...props} />
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+            mode: OFFER_WIZARD_MODE.CREATION,
+          })}
+        >
+          <Summary {...props} />
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+            mode: OFFER_WIZARD_MODE.DRAFT,
+          })}
+        >
+          <Summary {...props} />
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
+            mode: OFFER_WIZARD_MODE.DRAFT,
+          })}
+        >
+          <div>Confirmation page: draft</div>
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
+            mode: OFFER_WIZARD_MODE.CREATION,
+          })}
+        >
+          <div>Confirmation page: creation</div>
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
+            mode: OFFER_WIZARD_MODE.DRAFT,
+            isV2: true,
+          })}
+        >
+          <div>Confirmation page: draft V2</div>
+        </Route>
+        <Route
+          path={getOfferIndividualPath({
+            step: OFFER_WIZARD_STEP_IDS.CONFIRMATION,
+            mode: OFFER_WIZARD_MODE.CREATION,
+            isV2: true,
+          })}
+        >
+          <div>Confirmation page: creation V2</div>
+        </Route>
+      </OfferIndividualContext.Provider>
       <Notification />
-    </Provider>
+    </>,
+    { storeOverrides, initialRouterEntries: [url] }
   )
 }
 
@@ -265,7 +258,7 @@ describe('Summary', () => {
   describe('On edition', () => {
     it('should render component with informations', async () => {
       // given / when
-      renderSummary({ props })
+      renderSummary(props)
 
       // then
       expect(
@@ -317,16 +310,16 @@ describe('Summary', () => {
     })
     it('should render component with informations', async () => {
       // given / when
-      renderSummary({
+      renderSummary(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
 
       // then
       expect(screen.getAllByText('Modifier')).toHaveLength(2)
@@ -370,16 +363,16 @@ describe('Summary', () => {
     describe('When it is form v3', () => {
       it('should render component with right buttons', async () => {
         // when
-        renderSummary({
+        renderSummary(
           props,
-          url: generatePath(
+          generatePath(
             getOfferIndividualPath({
               step: OFFER_WIZARD_STEP_IDS.SUMMARY,
               mode: OFFER_WIZARD_MODE.CREATION,
             }),
             { offerId: 'AA' }
-          ),
-        })
+          )
+        )
 
         // then
         expect(screen.getByText('Étape précédente')).toBeInTheDocument()
@@ -391,16 +384,16 @@ describe('Summary', () => {
 
       it('should link to creation confirmation page', async () => {
         // when
-        renderSummary({
+        renderSummary(
           props,
-          url: generatePath(
+          generatePath(
             getOfferIndividualPath({
               step: OFFER_WIZARD_STEP_IDS.SUMMARY,
               mode: OFFER_WIZARD_MODE.CREATION,
             }),
             { offerId: 'AA' }
-          ),
-        })
+          )
+        )
 
         await userEvent.click(
           screen.getByRole('button', { name: /Publier l’offre/ })
@@ -414,16 +407,17 @@ describe('Summary', () => {
 
     it('should disabled publish button link during submit', async () => {
       // when
-      renderSummary({
+      renderSummary(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
+
       const pageTitle = screen.getByRole('heading', {
         name: /Détails de l’offre/,
       })
@@ -449,16 +443,17 @@ describe('Summary', () => {
 
     it('should display notification on api error', async () => {
       // when
-      renderSummary({
+      renderSummary(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
+
       jest.spyOn(api, 'patchPublishOffer').mockRejectedValue(
         new ApiError(
           {} as ApiRequestOptions,
@@ -502,10 +497,9 @@ describe('Summary', () => {
         },
       }
 
-      renderSummary({
+      renderSummary(
         props,
-        storeOverride,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
@@ -513,7 +507,8 @@ describe('Summary', () => {
           { offerId: 'AA' }
         ),
         context,
-      })
+        storeOverride
+      )
 
       await userEvent.click(
         screen.getByRole('button', { name: /Publier l’offre/ })
@@ -545,7 +540,7 @@ describe('Summary', () => {
     it.each(urlList)(
       'should display pre publishing banner in creation',
       url => {
-        renderSummary({ props, url })
+        renderSummary(props, url)
 
         // then
         expect(screen.getByText('Vous y êtes presque !')).toBeInTheDocument()
@@ -554,16 +549,16 @@ describe('Summary', () => {
 
     it('should display a notification when saving as draft', async () => {
       // when
-      renderSummary({
+      renderSummary(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.CREATION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
       await userEvent.click(
         screen.getByText('Sauvegarder le brouillon et quitter')
       )
@@ -573,16 +568,16 @@ describe('Summary', () => {
     })
     it('should not display pre publishing banner in edition mode', () => {
       // when
-      renderSummary({
+      renderSummary(
         props,
-        url: generatePath(
+        generatePath(
           getOfferIndividualPath({
             step: OFFER_WIZARD_STEP_IDS.SUMMARY,
             mode: OFFER_WIZARD_MODE.EDITION,
           }),
           { offerId: 'AA' }
-        ),
-      })
+        )
+      )
 
       // then
       expect(

--- a/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.tracker.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Summary/__specs__/Summary.tracker.spec.tsx
@@ -1,8 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { OfferStatus } from 'apiClient/v1'
 import { REIMBURSEMENT_RULES } from 'core/Finances'
@@ -10,8 +8,7 @@ import { Events, VenueEvents } from 'core/FirebaseEvents/constants'
 import { CATEGORY_STATUS, OFFER_WIZARD_MODE } from 'core/Offers'
 import * as useAnalytics from 'hooks/useAnalytics'
 import * as useOfferWizardMode from 'hooks/useOfferWizardMode'
-import { RootState } from 'store/reducers'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { api } from '../../../../apiClient/api'
 import {
@@ -41,16 +38,12 @@ const defaultContext: IOfferIndividualContext = {
   showVenuePopin: {},
 }
 
-const renderSummary = ({
-  props,
-  overrideStore = {},
-  context = defaultContext,
-}: {
-  props: ISummaryProps
-  overrideStore?: Partial<RootState>
-  context?: IOfferIndividualContext
-}) => {
-  const store = configureTestStore({
+const renderSummary = (
+  props: ISummaryProps,
+  context: IOfferIndividualContext = defaultContext,
+  customOverrides?: any
+) => {
+  const storeOverrides = {
     user: {
       initialized: true,
       currentUser: {
@@ -59,16 +52,14 @@ const renderSummary = ({
         email: 'email@example.com',
       },
     },
-    ...overrideStore,
-  })
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <OfferIndividualContext.Provider value={context}>
-          <Summary {...props} />
-        </OfferIndividualContext.Provider>
-      </MemoryRouter>
-    </Provider>
+    ...customOverrides,
+  }
+
+  return renderWithProviders(
+    <OfferIndividualContext.Provider value={context}>
+      <Summary {...props} />
+    </OfferIndividualContext.Provider>,
+    { storeOverrides }
   )
 }
 
@@ -189,7 +180,7 @@ describe('Summary trackers', () => {
   describe('On edition', () => {
     it('should track when clicking on "Modifier" on offer section', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(screen.getAllByText('Modifier')[0])
@@ -212,7 +203,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on "Modifier" on stock section', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(screen.getAllByText('Modifier')[1])
@@ -235,7 +226,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on return to offers button', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(
@@ -260,7 +251,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on see preview link', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(await screen.findByText('Visualiser dans l’app'))
@@ -292,7 +283,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on "Modifier" on offer section', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(screen.getAllByText('Modifier')[0])
@@ -315,7 +306,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on "Modifier" on stock section', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(screen.getAllByText('Modifier')[1])
@@ -339,7 +330,7 @@ describe('Summary trackers', () => {
     describe('When it is form v2', () => {
       it('should track when clicking on return to previous step button', async () => {
         // given
-        renderSummary({ props })
+        renderSummary(props)
 
         // when
         await userEvent.click(await screen.findByText('Étape précédente'))
@@ -362,7 +353,7 @@ describe('Summary trackers', () => {
 
       it('should track when clicking on return to publish offer button', async () => {
         // given
-        renderSummary({ props })
+        renderSummary(props)
 
         // when
         await userEvent.click(await screen.findByText('Publier l’offre'))
@@ -386,7 +377,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on return to previous step button', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(await screen.findByText('Étape précédente'))
@@ -409,7 +400,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on publish button', async () => {
       // given
-      renderSummary({ props })
+      renderSummary(props)
 
       // when
       await userEvent.click(await screen.findByText('Publier l’offre'))
@@ -432,7 +423,6 @@ describe('Summary trackers', () => {
   })
 
   describe('For Draft offers', () => {
-    const overrideStore: Partial<RootState> = {}
     beforeEach(() => {
       props.offer.status = OfferStatus.DRAFT
       jest
@@ -442,7 +432,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on "Modifier" on offer section', async () => {
       // given
-      renderSummary({ props, overrideStore })
+      renderSummary(props)
 
       // when
       await userEvent.click(screen.getAllByText('Modifier')[0])
@@ -465,7 +455,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on "Modifier" on stock section', async () => {
       // given
-      renderSummary({ props, overrideStore })
+      renderSummary(props)
 
       // when
       await userEvent.click(screen.getAllByText('Modifier')[1])
@@ -488,7 +478,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on return to previous step button', async () => {
       // given
-      renderSummary({ props, overrideStore })
+      renderSummary(props)
 
       // when
       await userEvent.click(await screen.findByText('Étape précédente'))
@@ -511,7 +501,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on return to publish offer button', async () => {
       // given
-      renderSummary({ props, overrideStore })
+      renderSummary(props)
 
       // when
       await userEvent.click(await screen.findByText('Publier l’offre'))
@@ -534,7 +524,7 @@ describe('Summary trackers', () => {
 
     it('should track when clicking on return to save draft button', async () => {
       // given
-      renderSummary({ props, overrideStore })
+      renderSummary(props)
 
       // when
       await userEvent.click(
@@ -573,7 +563,7 @@ describe('Summary trackers', () => {
       context.showVenuePopin = {
         AB: true,
       }
-      const overrideStore: Partial<RootState> = {
+      const overrideStore = {
         features: {
           initialized: true,
           list: [
@@ -585,11 +575,7 @@ describe('Summary trackers', () => {
         },
       }
 
-      renderSummary({
-        props,
-        overrideStore,
-        context,
-      })
+      renderSummary(props, context, overrideStore)
 
       await userEvent.click(
         screen.getByRole('button', { name: /Publier l’offre/ })

--- a/pro/src/screens/OfferIndividual/Template/__specs__/Template.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Template/__specs__/Template.spec.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { generatePath, MemoryRouter } from 'react-router'
+import { generatePath } from 'react-router'
 
 import { OfferStatus } from 'apiClient/v1'
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
@@ -12,7 +11,7 @@ import {
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { IOfferIndividual } from 'core/Offers/types'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Template, { ITemplateProps } from '../Template'
 
@@ -43,16 +42,14 @@ const renderTemplate = ({
     showVenuePopin: {},
     ...contextOverride,
   }
-  return render(
-    <Provider store={configureTestStore({})}>
-      <OfferIndividualContext.Provider value={contextValues}>
-        <MemoryRouter initialEntries={[url]}>
-          <Template {...props}>
-            <div>Template child</div>
-          </Template>
-        </MemoryRouter>
-      </OfferIndividualContext.Provider>
-    </Provider>
+
+  return renderWithProviders(
+    <OfferIndividualContext.Provider value={contextValues}>
+      <Template {...props}>
+        <div>Template child</div>
+      </Template>
+    </OfferIndividualContext.Provider>,
+    { initialRouterEntries: [url] }
   )
 }
 

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -1,28 +1,21 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { OFFER_WIZARD_STEP_IDS } from 'components/OfferIndividualBreadcrumb'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
 import { getOfferIndividualPath } from 'core/Offers/utils/getOfferIndividualUrl'
-import { configureTestStore } from 'store/testUtils'
 import { collectiveOfferFactory } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import OfferType from '../OfferType'
 
-const renderOfferTypes = (storeOverride: any) => {
-  const store = configureTestStore(storeOverride)
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={['/creation']}>
-        <OfferType />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderOfferTypes = (storeOverrides: any) =>
+  renderWithProviders(<OfferType />, {
+    storeOverrides,
+    initialRouterEntries: ['/creation'],
+  })
 
 const mockHistoryPush = jest.fn()
 jest.mock('react-router-dom', () => ({

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -1,9 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
-import type { Store } from 'redux'
 
 import { UserRole } from 'apiClient/v1'
 import {
@@ -20,20 +17,14 @@ import {
 } from 'core/Offers/constants'
 import { Offer } from 'core/Offers/types'
 import { Audience } from 'core/shared'
-import { configureTestStore } from 'store/testUtils'
 import { offerFactory, offererFactory } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 import { queryByTextTrimHtml } from 'utils/testHelpers'
 
 import Offers, { IOffersProps } from '../Offers'
 
-const renderOffers = (props: IOffersProps, store: Store) => {
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Offers {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
+const renderOffers = (props: IOffersProps, storeOverrides: any) => {
+  renderWithProviders(<Offers {...props} />, { storeOverrides })
 }
 
 const categoriesAndSubcategories = {
@@ -86,7 +77,7 @@ describe('screen Offers', () => {
     publicName: string
     roles: Array<UserRole>
   }
-  let store: Store
+  let store: any
   let offersRecap: Offer[]
 
   beforeEach(() => {
@@ -97,7 +88,7 @@ describe('screen Offers', () => {
       publicName: 'USER',
       roles: [UserRole.PRO],
     }
-    store = configureTestStore({
+    store = {
       user: {
         initialized: true,
         currentUser,
@@ -105,7 +96,7 @@ describe('screen Offers', () => {
       offers: {
         searchFilters: DEFAULT_SEARCH_FILTERS,
       },
-    })
+    }
     offersRecap = [offerFactory({ venue: proVenues[0] })]
 
     props = {
@@ -498,7 +489,7 @@ describe('screen Offers', () => {
                   venueId: 'JI',
                 },
               },
-              configureTestStore({
+              {
                 user: {
                   initialized: true,
                   currentUser,
@@ -506,7 +497,7 @@ describe('screen Offers', () => {
                 offers: {
                   searchFilters: { ...DEFAULT_SEARCH_FILTERS, venueId: 'JI' },
                 },
-              })
+              }
             )
             // When
             await userEvent.selectOptions(
@@ -543,7 +534,7 @@ describe('screen Offers', () => {
                   venueId: 'IJ',
                 },
               },
-              configureTestStore({
+              {
                 user: {
                   initialized: true,
                   currentUser,
@@ -551,7 +542,7 @@ describe('screen Offers', () => {
                 offers: {
                   searchFilters: { ...DEFAULT_SEARCH_FILTERS, venueId: 'IJ' },
                 },
-              })
+              }
             )
             // Then
             const selectAllOffersCheckbox =
@@ -568,7 +559,7 @@ describe('screen Offers', () => {
                   offererId: 'A4',
                 },
               },
-              configureTestStore({
+              {
                 user: {
                   initialized: true,
                   currentUser,
@@ -576,7 +567,7 @@ describe('screen Offers', () => {
                 offers: {
                   searchFilters: { ...DEFAULT_SEARCH_FILTERS, offererId: 'A4' },
                 },
-              })
+              }
             )
             // Then
             const selectAllOffersCheckbox =
@@ -691,13 +682,7 @@ describe('screen Offers', () => {
   describe('offers selection', () => {
     it('should display actionsBar when at least one offer is selected', async () => {
       // Given
-      render(
-        <Provider store={store}>
-          <MemoryRouter>
-            <Offers {...props} />
-          </MemoryRouter>
-        </Provider>
-      )
+      renderWithProviders(<Offers {...props} />, { storeOverrides: store })
 
       // When
       const checkbox = screen.getByTestId(`select-offer-${offersRecap[0].id}`)

--- a/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.tracker.spec.tsx
@@ -1,31 +1,21 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router'
 
 import { UserRole } from 'apiClient/v1'
 import { Events } from 'core/FirebaseEvents/constants'
 import { DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { Audience } from 'core/shared'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
 import { offererFactory } from 'utils/apiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Offers, { IOffersProps } from '../Offers'
 
 const mockLogEvent = jest.fn()
 
-const renderOffers = (props: IOffersProps) => {
-  const store = configureTestStore()
-  return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Offers {...props} />
-      </MemoryRouter>
-    </Provider>
-  )
-}
+const renderOffers = (props: IOffersProps) =>
+  renderWithProviders(<Offers {...props} />)
 
 describe('tracker screen Offers', () => {
   it('should track when clciking on offer link', async () => {

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -1,9 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryHistory } from 'history'
 import fetch from 'jest-fetch-mock'
 import React from 'react'
-import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 
 import { apiAdresse } from 'apiClient/adresse'
@@ -16,7 +15,7 @@ import { IVenueFormValues } from 'components/VenueForm'
 import { IOfferer } from 'core/Offerers/types'
 import { IVenue } from 'core/Venue'
 import * as useNewOfferCreationJourney from 'hooks/useNewOfferCreationJourney'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { VenueFormScreen } from '../index'
 
@@ -39,15 +38,15 @@ const renderForm = (
   isCreatingVenue: boolean,
   venue?: IVenue | undefined
 ) => {
-  render(
-    <Provider
-      store={configureTestStore({
-        user: {
-          initialized: true,
-          currentUser,
-        },
-      })}
-    >
+  const storeOverrides = {
+    user: {
+      initialized: true,
+      currentUser,
+    },
+  }
+
+  renderWithProviders(
+    <>
       <Router history={createMemoryHistory()}>
         <VenueFormScreen
           initialValues={initialValues}
@@ -61,9 +60,11 @@ const renderForm = (
         />
       </Router>
       <Notification />
-    </Provider>
+    </>,
+    { storeOverrides }
   )
 }
+
 jest.mock('apiClient/api', () => ({
   api: {
     postCreateVenue: jest.fn(),

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
@@ -1,9 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createBrowserHistory } from 'history'
 import fetch from 'jest-fetch-mock'
 import React from 'react'
-import { Provider } from 'react-redux'
 import { Router } from 'react-router'
 
 import { api } from 'apiClient/api'
@@ -18,7 +17,7 @@ import {
 } from 'core/FirebaseEvents/constants'
 import { IOfferer } from 'core/Offerers/types'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { VenueFormScreen } from '../index'
 
@@ -75,30 +74,29 @@ const formValues: IVenueFormValues = {
 }
 
 const renderForm = (isCreation: boolean) => {
-  render(
-    <Provider
-      store={configureTestStore({
-        user: {
-          initialized: true,
-          currentUser: {
-            isAdmin: false,
-          },
-        },
-      })}
-    >
-      <Router history={createBrowserHistory()}>
-        <VenueFormScreen
-          initialValues={formValues}
-          isCreatingVenue={isCreation}
-          offerer={{ id: 'AE', siren: '881457238' } as IOfferer}
-          venueTypes={venueTypes}
-          venueLabels={venueLabels}
-          providers={[]}
-          venueProviders={[]}
-        />
-      </Router>
+  const storeOverrides = {
+    user: {
+      initialized: true,
+      currentUser: {
+        isAdmin: false,
+      },
+    },
+  }
+
+  renderWithProviders(
+    <Router history={createBrowserHistory()}>
+      <VenueFormScreen
+        initialValues={formValues}
+        isCreatingVenue={isCreation}
+        offerer={{ id: 'AE', siren: '881457238' } as IOfferer}
+        venueTypes={venueTypes}
+        venueLabels={venueLabels}
+        providers={[]}
+        venueProviders={[]}
+      />
       <Notification />
-    </Provider>
+    </Router>,
+    { storeOverrides }
   )
 }
 

--- a/pro/src/ui-kit/form_rff/fields/SiretField/__specs__/SiretField.spec.tsx
+++ b/pro/src/ui-kit/form_rff/fields/SiretField/__specs__/SiretField.spec.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Form } from 'react-final-form'
-import { Provider } from 'react-redux'
 
 import { apiAdresse } from 'apiClient/adresse'
 import { IAdresseData } from 'apiClient/adresse/types'
@@ -11,7 +10,7 @@ import { ApiError } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import getSiretData from 'core/Venue/adapters/getSiretDataAdapter'
-import { configureTestStore } from 'store/testUtils'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import SiretField from '../SiretField'
 import siretApiValidate from '../validators/siretApiValidate'
@@ -55,20 +54,18 @@ describe('components | SiretField', () => {
         postalCode: '14400',
       },
     })
-    const store = configureTestStore()
-    render(
-      <Provider store={store}>
-        <Form initialValues={{}} name="venue" onSubmit={() => {}}>
-          {() => (
-            <SiretField
-              siren={siren}
-              readOnly={false}
-              label="Siret field"
-              required
-            />
-          )}
-        </Form>
-      </Provider>
+
+    renderWithProviders(
+      <Form initialValues={{}} name="venue" onSubmit={() => {}}>
+        {() => (
+          <SiretField
+            siren={siren}
+            readOnly={false}
+            label="Siret field"
+            required
+          />
+        )}
+      </Form>
     )
     const siretField = screen.getByLabelText('Siret field*')
     expect(siretField).toBeInTheDocument()

--- a/pro/src/utils/renderWithProviders.tsx
+++ b/pro/src/utils/renderWithProviders.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+// c'est du bluff, l'import existe vraiment
+// eslint-disable-next-line
+import { LocationDescriptor } from 'history'
+import React, { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+
+import { configureTestStore } from 'store/testUtils'
+
+export const renderWithProviders = (
+  component: ReactNode,
+  overrides: {
+    storeOverrides?: any
+    initialRouterEntries?: LocationDescriptor<unknown>[]
+  }
+) => {
+  const store = configureTestStore(overrides.storeOverrides)
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={overrides.initialRouterEntries}>
+        {component}
+      </MemoryRouter>
+    </Provider>
+  )
+}

--- a/pro/src/utils/renderWithProviders.tsx
+++ b/pro/src/utils/renderWithProviders.tsx
@@ -10,16 +10,16 @@ import { configureTestStore } from 'store/testUtils'
 
 export const renderWithProviders = (
   component: ReactNode,
-  overrides: {
+  overrides?: {
     storeOverrides?: any
     initialRouterEntries?: LocationDescriptor<unknown>[]
   }
 ) => {
-  const store = configureTestStore(overrides.storeOverrides)
+  const store = configureTestStore(overrides?.storeOverrides)
 
   return render(
     <Provider store={store}>
-      <MemoryRouter initialEntries={overrides.initialRouterEntries}>
+      <MemoryRouter initialEntries={overrides?.initialRouterEntries}>
         {component}
       </MemoryRouter>
     </Provider>

--- a/pro/src/utils/renderWithProviders.tsx
+++ b/pro/src/utils/renderWithProviders.tsx
@@ -1,7 +1,5 @@
 import { render } from '@testing-library/react'
-// c'est du bluff, l'import existe vraiment
-// eslint-disable-next-line
-import { LocationDescriptor } from 'history'
+import type { LocationDescriptor } from 'history'
 import React, { ReactNode } from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
@@ -17,11 +15,23 @@ export const renderWithProviders = (
 ) => {
   const store = configureTestStore(overrides?.storeOverrides)
 
-  return render(
+  const { rerender, ...otherRenderResult } = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={overrides?.initialRouterEntries}>
         {component}
       </MemoryRouter>
     </Provider>
   )
+
+  return {
+    ...otherRenderResult,
+    rerender: (newChildren: ReactNode) =>
+      rerender(
+        <Provider store={store}>
+          <MemoryRouter initialEntries={overrides?.initialRouterEntries}>
+            {newChildren}
+          </MemoryRouter>
+        </Provider>
+      ),
+  }
 }


### PR DESCRIPTION
Refactorer les tests qui utilisent des providers.
Rendra toute tache chore bcp plus facile (mise à jour de react-router, si on doit ajouter un nouveau provider un jour, etc)