### PR TITLE
(BSR)[API] feat: handle empty names in bov3 history

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -380,8 +380,10 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         return fraud_api.decide_eligibility(self, self.birth_date, datetime.utcnow())
 
     @property
-    def full_name(self) -> str | None:
-        return (f"{self.firstName or ''} {self.lastName or ''}".strip()) or self.publicName
+    def full_name(self) -> str:
+        # full_name is used for display and should never be empty, which would be confused with no user.
+        # We use the email as a fallback because it is the most human-readable way to identify a single user
+        return (f"{self.firstName or ''} {self.lastName or ''}".strip()) or self.publicName.strip() or self.email
 
     @property
     def has_active_deposit(self):  # type: ignore [no-untyped-def]

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -285,7 +285,10 @@ class UserTest:
         assert user.full_name == f"{user.firstName} {user.lastName}"
 
         no_name_user = users_factories.UserFactory(firstName="", lastName="")
-        assert no_name_user.full_name == no_name_user.publicName
+        assert no_name_user.full_name is no_name_user.publicName
+
+        really_no_name_user = users_factories.UserFactory(firstName="", lastName="", publicName="   ")
+        assert really_no_name_user.full_name is really_no_name_user.email
 
     def test_pro_validation_status(self):
         user = users_factories.UserFactory()


### PR DESCRIPTION
## But de la pull request

Gérer le cas où quand le nom et prénom d'un user sont nuls, une info apparaît quand même dans l'historique.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
