### PR TITLE
(PC-20148)[API] feat: bov3: refactor details tabs

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details.html
@@ -1,90 +1,28 @@
-<div class="row row-cols-1 g-4 py-3">
-    <div class="col">
-        <div class="card">
-            <div class="card-body">
+{% from "components/presentation/details/tabs.html" import build_details_tab %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
+{% from "components/presentation/details/tabs.html" import build_details_tab_content %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
 
-                <ul class="nav nav-tabs" id="account-details-tab" role="tablist">
-                    <li class="nav-item" role="presentation">
-                        <button
-                            class="nav-link"
-                            id="history-tab"
-                            data-bs-toggle="tab"
-                            data-bs-target="#history-tab-pane"
-                            type="button"
-                            role="tab"
-                            aria-controls="history-tab-pane"
-                            aria-selected="true"
-                        >
-                            Historique du compte
-                        </button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button
-                            class="nav-link active"
-                            id="personal-information-tab"
-                            data-bs-toggle="tab"
-                            data-bs-target="#personal-information-tab-pane"
-                            type="button"
-                            role="tab"
-                            aria-controls="personal-information-tab-pane"
-                            aria-selected="false"
-                        >
-                            Informations personnelles
-                        </button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button
-                            class="nav-link"
-                            id="bookings-tab"
-                            data-bs-toggle="tab"
-                            data-bs-target="#bookings-tab-pane"
-                            type="button"
-                            role="tab"
-                            aria-controls="bookings-tab-pane"
-                            aria-selected="false"
-                        >
-                            Suivi des réservations
-                        </button>
-                    </li>
-                </ul>
+    {% call build_details_tabs_wrapper() %}
+        {{ build_details_tab("history", "Historique du compte", true) }}
+        {{ build_details_tab("personal-information", "Informations personnelles") }}
+        {{ build_details_tab("bookings", "Suivi des réservations") }}
+    {% endcall %}
 
-                <div class="tab-content" id="account-details-tab-content">
-                    <div
-                        class="tab-pane fade"
-                        id="history-tab-pane"
-                        role="tabpanel"
-                        aria-labelledby="history-tab"
-                        tabindex="0"
-                    >
-                        {% include "accounts/get/details/history.html" %}
-                    </div>
+    {% call build_details_tabs_content_wrapper() %}
+        {% call build_details_tab_content("history", true) %}
+            {% include "accounts/get/details/history.html" %}
+        {% endcall %}
 
-                    <div
-                        class="tab-pane fade show active"
-                        id="personal-information-tab-pane"
-                        role="tabpanel"
-                        aria-labelledby="personal-information-tab"
-                        tabindex="0"
-                    >
-                        {% include "accounts/get/details/personal_information_bookmarks.html" %}
-                        {% include "accounts/get/details/personal_information_user_details.html" %}
-                        {% for history_type, history in eligibility_history.items() %}
-                            {% include "accounts/get/details/personal_information_registration.html" %}
-                        {% endfor %}
-                    </div>
+        {% call build_details_tab_content("personal-information") %}
+            {% include "accounts/get/details/personal_information_bookmarks.html" %}
+            {% include "accounts/get/details/personal_information_user_details.html" %}
+            {% for history_type, history in eligibility_history.items() %}
+                {% include "accounts/get/details/personal_information_registration.html" %}
+            {% endfor %}
+        {% endcall %}
 
-                    <div
-                        class="tab-pane fade"
-                        id="bookings-tab-pane"
-                        role="tabpanel"
-                        aria-labelledby="bookings-tab"
-                        tabindex="0"
-                    >
-                        {% include "accounts/get/details/bookings.html" %}
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    </div>
-</div>
+        {% call build_details_tab_content("bookings") %}
+            {% include "accounts/get/details/bookings.html" %}
+        {% endcall %}
+    {% endcall %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/presentation/details/tabs.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/presentation/details/tabs.html
@@ -1,0 +1,43 @@
+{% macro build_details_tab(name, title, is_active=False) %}
+    <li class="nav-item" role="presentation">
+        <button
+            class="{{ 'nav-link active fw-bolder' if is_active else 'nav-link' }}"
+            id="{{ name ~ '-tab' }}"
+            data-bs-toggle="tab"
+            data-bs-target="{{ '#' ~ name ~ '-tab-pane' }}"
+            type="button"
+            role="tab"
+            aria-controls="{{ name ~ 'tab-pane' }}"
+            aria-selected="true"
+        >
+            {{ title }}
+        </button>
+    </li>
+{% endmacro %}
+
+
+{% macro build_details_tabs_wrapper(name="details-tab") %}
+    <ul class="nav nav-tabs nav-fill mt-4" id="{{ name }}" role="tablist">
+        {{ caller() }}
+    </ul>
+{% endmacro %}
+
+
+{% macro build_details_tab_content(name, is_active=False) %}
+    <div
+        class="tab-pane fade p-4 {{ 'show active' if is_active }}"
+        id="{{ name ~ '-tab-pane' }}"
+        role="tabpanel"
+        aria-labelledby="{{ name ~ '-tab' }}"
+        tabindex="0"
+    >
+        {{ caller() }}
+    </div>
+{% endmacro %}
+
+
+{% macro build_details_tabs_content_wrapper() %}
+    <div class="tab-content bg-body border border-top-0" id="account-details-tab-content">
+        {{ caller() }}
+    </div>
+{% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
@@ -1,80 +1,28 @@
+{% from "components/presentation/details/tabs.html" import build_details_tab %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
+{% from "components/presentation/details/tabs.html" import build_details_tab_content %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
+
 <turbo-frame id="offerer_details_frame">
 
-    <ul class="nav nav-tabs nav-fill" id="pills-tab" role="tablist">
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'history' else '' }}"
-                id="pills-home-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-home"
-                type="button"
-                role="tab"
-                aria-controls="pills-home"
-                aria-selected="true"
-            >
-                HISTORIQUE DU COMPTE
-            </button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'users' else '' }}"
-                id="pills-pro-users-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-pro-users"
-                type="button"
-                role="tab"
-                aria-controls="pills-pro-users"
-                aria-selected="false"
-            >
-                COMPTE(S) PRO RATTACHÉ(S)
-            </button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'managed_venues' else '' }}"
-                id="pills-managed-venues-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-managed-venues"
-                type="button"
-                role="tab"
-                aria-controls="pills-managed-venues"
-                aria-selected="false"
-            >
-                LIEUX ASSOCIÉS
-            </button>
-        </li>
-    </ul>
+    {% call build_details_tabs_wrapper() %}
+        {{ build_details_tab("history", "Historique du compte", active_tab == 'history') }}
+        {{ build_details_tab("pro-users", "Compte(s) pro rattaché(s)", active_tab == 'users') }}
+        {{ build_details_tab("managed-venues", "Lieux associés", active_tab == 'managed_venues') }}
+    {% endcall %}
 
-    <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
-        <div
-            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'history' else '' }}"
-            id="pills-home"
-            role="tabpanel"
-            aria-labelledby="pills-home-tab"
-            tabindex="0"
-        >
+    {% call build_details_tabs_content_wrapper() %}
+        {% call build_details_tab_content("history", active_tab == 'history') %}
             {% include "offerer/get/details/history.html" %}
-        </div>
+        {% endcall %}
 
-        <div
-            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'users' else '' }}"
-            id="pills-pro-users"
-            role="tabpanel"
-            aria-labelledby="pills-pro-users-tab"
-            tabindex="0"
-        >
+        {% call build_details_tab_content("pro-users", active_tab == 'users') %}
             {% include "offerer/get/details/users.html" %}
-        </div>
+        {% endcall %}
 
-        <div 
-            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'managed_venues' else '' }}"
-            id="pills-managed-venues"
-            role="tabpanel"
-            aria-labelledby="pills-details-tab"
-            tabindex="0"
-        >
+        {% call build_details_tab_content("managed-venues", active_tab == 'managed_venues') %}
         {% include "offerer/get/details/managed_venues.html" %}
-        </div>
-    </div>
+        {% endcall %}
+    {% endcall %}
 
 </turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details.html
@@ -1,54 +1,24 @@
+{% from "components/presentation/details/tabs.html" import build_details_tab %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
+{% from "components/presentation/details/tabs.html" import build_details_tab_content %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
+
 <turbo-frame id="pro_user_details_frame">
 
-    <ul class="nav nav-tabs nav-fill" id="pills-tab" role="tablist">
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'history' else '' }}"
-                id="pills-home-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-home"
-                type="button"
-                role="tab"
-                aria-controls="pills-home"
-                aria-selected="true"
-            >
-                HISTORIQUE DU COMPTE
-            </button>
-        </li>
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link fw-bolder py-3 {{ 'active' if active_tab == 'user_offerers' else '' }}"
-                id="pills-offerers-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-offerers"
-                type="button"
-                role="tab"
-                aria-controls="pills-offerers"
-                aria-selected="false"
-            >
-                RATTACHEMENTS AUX STRUCTURES
-            </button>
-        </li>
-    </ul>
+    {% call build_details_tabs_wrapper() %}
+        {{ build_details_tab("history", "Historique du compte", active_tab == 'history') }}
 
-    <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
-        <div 
-            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'history' else '' }}"
-            id="pills-home"
-            role="tabpanel"
-            aria-labelledby="pills-home-tab"
-            tabindex="0"
-        >
+        {{ build_details_tab("user_offerers", "Rattachements aux structures", active_tab == 'user_offerers') }}
+    {% endcall %}
+
+    {% call build_details_tabs_content_wrapper() %}
+        {% call build_details_tab_content("history", active_tab == 'history') %}
             {% include "pro_user/get/details/history.html" %}
-        </div>
-        <div
-            class="tab-pane fade show p-4 {{ 'active' if active_tab == 'user_offerers' else '' }}"
-            id="pills-offerers"
-            role="tabpanel"
-            aria-labelledby="pills-offerers-tab"
-            tabindex="0">
+        {% endcall %}
+
+        {% call build_details_tab_content("user_offerers", active_tab == 'user_offerers') %}
             {% include "pro_user/get/details/user_offerer.html" %}
-        </div>
-    </div>
+        {% endcall %}
+    {% endcall %}
 
 </turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details.html
@@ -1,27 +1,18 @@
+{% from "components/presentation/details/tabs.html" import build_details_tab %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
+{% from "components/presentation/details/tabs.html" import build_details_tab_content %}
+{% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
+
 <turbo-frame id="venue_details_frame">
 
-    <ul class="nav nav-tabs nav-fill" id="pills-tab" role="tablist">
-        <li class="nav-item" role="presentation">
-            <button
-                class="nav-link active fw-bolder py-3"
-                id="pills-history-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-history"
-                type="button"
-                role="tab"
-                aria-controls="pills-history"
-                aria-selected="true"
-            >
-                HISTORIQUE DU COMPTE
-            </button>
-        </li>
-    </ul>
+    {% call build_details_tabs_wrapper() %}
+        {{ build_details_tab("history", "Historique du compte", true) }}
+    {% endcall %}
 
-    <div class="tab-content bg-body border border-top-0" id="pills-tabContent">
-        <div class="tab-pane fade show active p-4" id="pills-history" role="tabpanel" aria-labelledby="pills-history-tab" tabindex="0">
+    {% call build_details_tabs_content_wrapper() %}
+        {% call build_details_tab_content("history", true) %}
             {% include "venue/get/details/history.html" %}
-        </div>
-    </div>
+        {% endcall %}
+    {% endcall %}
 
 </turbo-frame>
-

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -186,7 +186,7 @@ class UpdateOffererTest:
         assert offerer_to_edit.postalCode == new_postal_code
         assert offerer_to_edit.address == new_address
 
-        history_rows = html_parser.extract_table_rows(response.data, parent_id="pills-home")
+        history_rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
         assert len(history_rows) == 1
         assert history_rows[0]["Type"] == history_models.ActionType.INFO_MODIFIED.value
         assert f"Ville : {old_city} => {offerer_to_edit.city}" in history_rows[0]["Commentaire"]
@@ -221,7 +221,7 @@ class UpdateOffererTest:
         assert updated_offerer.postalCode == "29200"
         assert updated_offerer.address == "Place de la Liberté"
 
-        history_rows = html_parser.extract_table_rows(response.data, parent_id="pills-home")
+        history_rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
         assert len(history_rows) == 1
         assert history_rows[0]["Type"] == history_models.ActionType.INFO_MODIFIED.value
         assert history_rows[0]["Auteur"] == legit_user.full_name
@@ -445,7 +445,7 @@ class GetOffererDetailsTest:
 
         assert response.status_code == 200
 
-        rows = html_parser.extract_table_rows(response.data, parent_id="pills-home")
+        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
         assert len(rows) == 1
         assert rows[0]["Type"] == history_models.ActionType.COMMENT.value
         assert rows[0]["Commentaire"] == action.comment
@@ -471,7 +471,7 @@ class GetOffererDetailsTest:
 
         assert response.status_code == 200
 
-        rows = html_parser.extract_table_rows(response.data, parent_id="pills-home")
+        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
         assert len(rows) == 1
         assert rows[0]["Type"] == history_models.ActionType.OFFERER_NEW.value
         assert rows[0]["Commentaire"] == action.comment
@@ -490,7 +490,7 @@ class GetOffererDetailsTest:
             response = authenticated_client.get(url)
 
         assert response.status_code == 200
-        assert html_parser.count_table_rows(response.data, parent_id="pills-home") == 0
+        assert html_parser.count_table_rows(response.data, parent_id="history-tab-pane") == 0
 
     def test_action_name_depends_on_type(self, authenticated_client, offerer):
         admin_user = users_factories.AdminFactory()
@@ -577,7 +577,7 @@ class GetOffererDetailsTest:
 
         # then
         assert response.status_code == 200
-        rows = html_parser.extract_table_rows(response.data, parent_id="pills-home")
+        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
         assert len(rows) == 4
 
         assert rows[0]["Type"] == "Structure validée"
@@ -618,7 +618,7 @@ class GetOffererDetailsTest:
 
         # then
         assert response.status_code == 200
-        rows = html_parser.extract_table_rows(response.data, "pills-pro-users")
+        rows = html_parser.extract_table_rows(response.data, "pro-users-tab-pane")
         assert len(rows) == 3
 
         assert rows[0]["ID"] == str(uo1.user.id)
@@ -687,7 +687,7 @@ class GetOffererDetailsTest:
             response = authenticated_client.get(url)
         assert response.status_code == 200
 
-        rows = html_parser.extract_table_rows(response.data, "pills-managed-venues")
+        rows = html_parser.extract_table_rows(response.data, "managed-venues-tab-pane")
         assert len(rows) == 2
 
         assert rows[0]["ID"] == str(venue_1.id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20148

## But de la pull request

Charger le html pour les bloc de détails des comptes jeunes et grand public, des structures, des lieux et des acteurs culturels de la même manière. Plus de html copié et collé, plus de styles (classes bootstrap principalement) différents.