### PR TITLE
(BSR) feat: update slack webhook variable

### DIFF
--- a/.github/workflows/reusable--build-and-tag.yml
+++ b/.github/workflows/reusable--build-and-tag.yml
@@ -122,7 +122,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: ${{ !failure() }}
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_MANAGEMENT_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Jean Github
           SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
@@ -134,7 +134,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: ${{ failure() }}
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_MANAGEMENT_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Jean Github
           SLACK_ICON: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png

--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
@@ -110,7 +110,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
@@ -206,7 +206,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot
@@ -315,7 +315,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot

--- a/.github/workflows/tests-backoffice-v3.yml
+++ b/.github/workflows/tests-backoffice-v3.yml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot

--- a/.github/workflows/tests-backoffice.yml
+++ b/.github/workflows/tests-backoffice.yml
@@ -55,7 +55,7 @@ jobs:
       - if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot

--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -122,7 +122,7 @@ jobs:
       - if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ACCESS_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CI_WEBHOOK }}
           SLACK_CHANNEL: dev
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions Bot


### PR DESCRIPTION
we want separate chanels for release management notifications (on shérif chanel)  and ci notifications (on dev chanel). the latter already worked on the right chanel, but we update the variable for a more precise wording

vu avec Charles du Portal