### PR TITLE
(BSR)[API] fix: use bov3 links in zendesk instead of bov2

### DIFF
--- a/api/.env.production
+++ b/api/.env.production
@@ -7,7 +7,7 @@ ALGOLIA_OFFERS_BY_VENUE_CHUNK_SIZE=10000
 ALGOLIA_TRIGGER_INDEXATION=0
 API_URL=https://backend.passculture.app
 API_URL_FOR_EDUCONNECT=https://backend.passculture.app
-BACKOFFICE_URL=https://backoffice.passculture.team/
+BACKOFFICE_URL=https://backend.passculture.team/backofficev3
 # Batch keys below are public keys:
 BATCH_ANDROID_API_KEY=602A91C34D0DA9B3D80FA399E3430F # ggignore
 BATCH_IOS_API_KEY=602A919A229DBCF8E8FA31A0186A1F     # ggignore

--- a/api/.env.staging
+++ b/api/.env.staging
@@ -8,7 +8,7 @@ ALGOLIA_TRIGGER_INDEXATION=0
 API_URL=https://backend.staging.passculture.team
 API_URL_FOR_EDUCONNECT=https://backend.staging.passculture.team
 BACKOFFICE_SEARCH_SIMILARITY_MINIMAL_SCORE=0.2
-BACKOFFICE_URL=https://backoffice.staging.passculture.team/
+BACKOFFICE_URL=https://backend.staging.passculture.team/backofficev3
 # Batch keys below are public keys:
 BATCH_ANDROID_API_KEY=602A91720C82221ABC77F107995A6F # ggignore
 BATCH_IOS_API_KEY=602A9140067E6F4098851F7EA61988     # ggignore

--- a/api/.env.testing
+++ b/api/.env.testing
@@ -9,7 +9,7 @@ API_URL=https://backend.testing.passculture.team
 API_URL_FOR_EDUCONNECT=https://backend.testing.passculture.team
 BACKOFFICE_ALLOW_USER_CREATION="True"
 BACKOFFICE_SEARCH_SIMILARITY_MINIMAL_SCORE=0.2
-BACKOFFICE_URL=https://backoffice.testing.passculture.team/
+BACKOFFICE_URL=https://backend.testing.passculture.team/backofficev3
 # Batch keys below are public keys:
 BATCH_ANDROID_API_KEY=5F8E91B93C5C1EADFF860843D4616B # ggignore
 BATCH_IOS_API_KEY=5F8EF34DD5CF8B0662ADE77220FDDE     # ggignore

--- a/api/src/pcapi/core/external/zendesk.py
+++ b/api/src/pcapi/core/external/zendesk.py
@@ -36,18 +36,18 @@ ZENDESK_TAG_SUSPENDED = "suspendu"
 
 def _get_backoffice_support_beneficiary_user_links(user_id: int) -> list[str]:
     return [
-        f"{settings.API_URL}/backofficev3/public-accounts/{user_id}",
+        f"{settings.BACKOFFICE_URL}/public-accounts/{user_id}",
         f"{settings.API_URL}/pc/back-office/support_beneficiary/details/?id={user_id}",
         f"{settings.API_URL}/pc/back-office/beneficiary_users/details/?id={user_id}",
     ]
 
 
 def _get_backoffice_pro_user_link(user_id: int) -> str:
-    return f"{settings.API_URL}/backofficev3/pro/user/{user_id}"
+    return f"{settings.BACKOFFICE_URL}/pro/user/{user_id}"
 
 
 def _get_backoffice_venues_links(venues_ids: Iterable[int]) -> list[str]:
-    return [f"{settings.API_URL}/backofficev3/pro/venue/{venue_id}" for venue_id in venues_ids]
+    return [f"{settings.BACKOFFICE_URL}/pro/venue/{venue_id}" for venue_id in venues_ids]
 
 
 def _format_list(raw_list: Iterable[str] | None) -> str | None:

--- a/api/src/pcapi/core/external/zendesk_sell.py
+++ b/api/src/pcapi/core/external/zendesk_sell.py
@@ -25,11 +25,11 @@ SEARCH_PARENT = -1
 
 
 def _build_backoffice_offerer_link(offerer: offerers_models.Offerer) -> str:
-    return urllib.parse.urljoin(BACKOFFICE_URL, f"offerers/{offerer.id}")
+    return urllib.parse.urljoin(BACKOFFICE_URL, f"/pro/offerer/{offerer.id}")
 
 
 def _build_backoffice_venue_link(venue: offerers_models.Venue) -> str:
-    return urllib.parse.urljoin(BACKOFFICE_URL, f"venues/{venue.id}")
+    return urllib.parse.urljoin(BACKOFFICE_URL, f"/pro/venue/{venue.id}")
 
 
 class ZendeskError(Exception):

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -39,7 +39,7 @@ class ZendeskWebhookTest:
             },
         )
 
-        expected_bo_url = f"{settings.API_URL}/backofficev3/public-accounts/{user.id}"
+        expected_bo_url = f"{settings.BACKOFFICE_URL}/public-accounts/{user.id}"
 
         assert response.status_code == 204
         assert len(users_testing.zendesk_requests) == 2  # user attributes and internal note
@@ -99,7 +99,7 @@ class ZendeskWebhookTest:
                 "phone": "+33634567890",
                 "tags": ["suspendu", "éligible"],
                 "user_fields": {
-                    "backoffice_url": f"{settings.API_URL}/backofficev3/public-accounts/{user.id}",
+                    "backoffice_url": f"{settings.BACKOFFICE_URL}/public-accounts/{user.id}",
                     "user_id": user.id,
                     "first_name": user.firstName,
                     "last_name": user.lastName,
@@ -137,7 +137,7 @@ class ZendeskWebhookTest:
             },
         )
 
-        expected_bo_url = f"{settings.API_URL}/backofficev3/public-accounts/{user.id}"
+        expected_bo_url = f"{settings.BACKOFFICE_URL}/public-accounts/{user.id}"
 
         assert response.status_code == 204
         assert len(users_testing.zendesk_requests) == 2  # user attributes and internal note
@@ -188,7 +188,7 @@ class ZendeskWebhookTest:
                 "email": pro_user.email,
                 "tags": ["PRO", "département_75"],
                 "user_fields": {
-                    "backoffice_url": f"{settings.API_URL}/backofficev3/pro/user/{pro_user.id}",
+                    "backoffice_url": f"{settings.BACKOFFICE_URL}/pro/user/{pro_user.id}",
                     "user_id": pro_user.id,
                     "first_name": pro_user.firstName,
                     "last_name": pro_user.lastName,
@@ -199,7 +199,7 @@ class ZendeskWebhookTest:
                 },
             }
         }
-        assert f"{settings.API_URL}/backofficev3/pro/user/{pro_user.id}" in str(
+        assert f"{settings.BACKOFFICE_URL}/pro/user/{pro_user.id}" in str(
             users_testing.zendesk_requests[1]["data"]["ticket"]["comment"]["html_body"]
         )
         assert users_testing.zendesk_requests[1]["data"]["ticket"]["comment"]["public"] is False
@@ -227,7 +227,7 @@ class ZendeskWebhookTest:
                 "email": venue.bookingEmail,
                 "tags": ["PRO", "département_06"],
                 "user_fields": {
-                    "backoffice_url": f"{settings.API_URL}/backofficev3/pro/venue/{venue.id}",
+                    "backoffice_url": f"{settings.BACKOFFICE_URL}/pro/venue/{venue.id}",
                     "user_id": None,
                     "first_name": None,
                     "last_name": None,
@@ -238,7 +238,7 @@ class ZendeskWebhookTest:
                 },
             }
         }
-        assert f"{settings.API_URL}/backofficev3/pro/venue/{venue.id}" in str(
+        assert f"{settings.BACKOFFICE_URL}/pro/venue/{venue.id}" in str(
             users_testing.zendesk_requests[1]["data"]["ticket"]["comment"]["html_body"]
         )
         assert users_testing.zendesk_requests[1]["data"]["ticket"]["comment"]["public"] is False


### PR DESCRIPTION
## But de la pull request

Fix des liens vers le backoffice dans zendesk, qui utilise les liens de la v2 et pas de la v3. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
