### PR TITLE
(PC-20237)[ADAGE] fix: add missing mock for AppFilterTags test

### DIFF
--- a/adage-front/src/app/__spec__/AppFilterTags.spec.tsx
+++ b/adage-front/src/app/__spec__/AppFilterTags.spec.tsx
@@ -86,6 +86,8 @@ jest.mock('apiClient/api', () => ({
     getVenueBySiret: jest.fn(),
     logCatalogView: jest.fn(),
     logSearchButtonClick: jest.fn(),
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
   },
 }))
 
@@ -135,6 +137,9 @@ describe('app', () => {
   })
 
   it('should display filter tags and send selected filters to Algolia', async () => {
+    // FIX ME: add timeout cause test is failing CI
+    jest.setTimeout(10000)
+
     window.location.search = ''
     // Given
     renderApp()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20237

## But de la pull request

Le test `should display filter tags and send selected filters to Algolia` fail sur la CI de master à cause d'un timeout. Il semblerait que 2 mocks soit manquant ce qui pourrait causer ce problème.

