### PR TITLE
(PC-20200)[API] feat: add link to email validation

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -206,3 +206,4 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["pc_pro_venue_bookings_link"] = urls.build_pc_pro_venue_bookings_link
     app.jinja_env.filters["pc_pro_venue_offers_link"] = urls.build_pc_pro_venue_offers_link
     app.jinja_env.filters["pc_pro_venue_link"] = urls.build_pc_pro_venue_link
+    app.jinja_env.filters["pc_pro_user_email_validation_link"] = urls.build_pc_pro_user_email_validation_link

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -84,6 +84,22 @@
                             </p>
                         </div>
                     </div>
+
+                    <div class="col-4">
+                        <div class="fs-6">
+                            <p class="mb-1"><span
+                                    class="fw-bold">Email validé :</span> {{ "Oui" if user.isEmailValidated else "Non" }}
+                            </p>
+                            {% if not user.isEmailValidated and can_edit_user %}
+                                <p class="mb-1">
+                                    <a href="{{ user | pc_pro_user_email_validation_link }}" target="_blank" class="btn btn-outline-primary fw-bold"
+                                        role="button">
+                                        Valider l'email
+                                    </a>
+                                </p>
+                            {% endif %}
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/api/src/pcapi/utils/urls.py
+++ b/api/src/pcapi/utils/urls.py
@@ -6,6 +6,7 @@ from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.educational.models import CollectiveOfferTemplate
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers.models import Offer
+from pcapi.core.users import models as users_models
 from pcapi.utils.human_ids import humanize
 
 
@@ -55,3 +56,7 @@ def build_pc_pro_venue_bookings_link(venue: offerers_models.Venue) -> str:
 
 def build_pc_pro_venue_offers_link(venue: offerers_models.Venue) -> str:
     return f"{settings.PRO_URL}/offres?lieu={humanize(venue.id)}"
+
+
+def build_pc_pro_user_email_validation_link(user: users_models.User) -> str:
+    return f"{settings.PRO_URL}/inscription/validation/{user.validationToken}"

--- a/api/tests/routes/backoffice_v3/helpers/button.py
+++ b/api/tests/routes/backoffice_v3/helpers/button.py
@@ -13,7 +13,11 @@ pytestmark = [
 ]
 
 
-class CommentButtonHelper:
+class ButtonHelper:
+    @property
+    def button_label(self) -> str:
+        return ""
+
     @property
     def needed_permission(self) -> perm_models.Permissions:
         return perm_models.Permissions.MANAGE_PRO_ENTITY
@@ -32,16 +36,16 @@ class CommentButtonHelper:
 
         return user
 
-    def test_comment_button_when_can_add_one(self, authenticated_client):
+    def test_button_when_can_add_one(self, authenticated_client):
         response = authenticated_client.get(self.path)
         assert response.status_code == 200
 
-        assert "Ajouter un commentaire" in response.data.decode("utf-8")
+        assert self.button_label in response.data.decode("utf-8")
 
-    def test_not_comment_button(self, client, roles_with_permissions):
+    def test_no_button(self, client, roles_with_permissions):
         client = client.with_bo_session_auth(self.unauthorized_user)
 
         response = client.get(self.path)
         assert response.status_code == 200
 
-        assert "Ajouter un commentaire" not in response.data.decode("utf-8")
+        assert self.button_label not in response.data.decode("utf-8")

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -24,7 +24,7 @@ from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.routes.backoffice_v3 import offerers
 
-from .helpers import comment as comment_helpers
+from .helpers import button as button_helpers
 from .helpers import html_parser
 from .helpers import unauthorized as unauthorized_helpers
 
@@ -417,8 +417,9 @@ class GetOffererDetailsTest:
         endpoint_kwargs = {"offerer_id": 1}
         needed_permission = perm_models.Permissions.READ_PRO_ENTITY
 
-    class CommentButtonTest(comment_helpers.CommentButtonHelper):
+    class CommentButtonTest(button_helpers.ButtonHelper):
         needed_permission = perm_models.Permissions.MANAGE_PRO_ENTITY
+        button_label = "Ajouter un commentaire"
 
         @property
         def path(self):

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -18,7 +18,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.routes.backoffice_v3 import venues
 
-from .helpers import comment as comment_helpers
+from .helpers import button as button_helpers
 from .helpers import html_parser
 from .helpers import unauthorized as unauthorized_helpers
 
@@ -450,8 +450,9 @@ class GetVenueDetailsTest:
         endpoint_kwargs = {"venue_id": 1}
         needed_permission = perm_models.Permissions.READ_PRO_ENTITY
 
-    class CommentButtonTest(comment_helpers.CommentButtonHelper):
+    class CommentButtonTest(button_helpers.ButtonHelper):
         needed_permission = perm_models.Permissions.MANAGE_PRO_ENTITY
+        button_label = "Ajouter un commentaire"
 
         @property
         def path(self):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20200

## But de la pull request

Ajout du lien pour valider l'email d'un compte pro dans sa page.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
