### PR TITLE
(PC-20144)[BO] test: reintegrate auto tests created from backoffice v2 in v3

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/search.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/search.py
@@ -36,6 +36,11 @@ class SearchForm(FlaskForm):
             case _:
                 return "Champ inconnu"
 
+    def validate_terms(self, terms: fields.PCOptSearchField) -> fields.PCOptSearchField:
+        if terms.data and "%" in terms.data:
+            raise wtforms.validators.ValidationError("Le caractère % n'est pas autorisé")
+        return terms
+
 
 class ProSearchForm(SearchForm):
     pro_type = fields.PCSelectField(

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/credit.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/credit.html
@@ -4,7 +4,7 @@
             {% if credit is not none %}
                 <div class="card-body">
                     <h5 class="card-title fs-1 mb-3">
-                        {{ credit.all.remaining.to_integral() | format_amount }}
+                        {{ credit.all.remaining | format_amount }}
                     </h5>
 
                     <div class="d-flex">
@@ -13,7 +13,7 @@
                         </h6>
 
                         <h6 class="card-subtitle text-muted ms-auto">
-                            {{ credit.all.initial.to_integral() | format_amount }}
+                            {{ credit.all.initial | format_amount }}
                         </h6>
                     </div>
 
@@ -41,7 +41,7 @@
             {% if credit is not none and credit.digital is not none %}
                 <div class="card-body">
                     <h5 class="card-title fs-1 mb-3">
-                        {{ credit.digital.remaining.to_integral() | format_amount }}
+                        {{ credit.digital.remaining | format_amount }}
                     </h5>
 
                     <div class="d-flex">
@@ -50,7 +50,7 @@
                         </h6>
 
                         <h6 class="card-subtitle text-muted ms-auto">
-                            {{ credit.digital.initial.to_integral() | format_amount }}
+                            {{ credit.digital.initial | format_amount }}
                         </h6>
                     </div>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/badges.html
@@ -28,6 +28,13 @@
             Lieu
         {% endif %}
     </span>
+
+    {% if not venue.managingOfferer.isActive %}
+        <span class="me-1 pb-1 badge rounded-pill text-bg-dark">
+            <i class="bi bi-x-circle"></i>
+                Suspendu
+        </span>
+    {% endif %}
 {% endmacro %}
 
 {% macro build_offerer_badges(offerer) %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card.html
@@ -2,7 +2,7 @@
 
 <div class="card shadow">
     <div class="card-body">
-        <h5 class="card-title mb-3">
+        <h5 class="mb-3">
             {% if not row.isActive %}
                 <span class="badge rounded-pill text-bg-primary">
                     {{ row.isActive | format_state }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_offerer.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_offerer.html
@@ -2,7 +2,7 @@
 
 <div class="card shadow">
     <div class="card-body">
-        <h5 class="card-title mb-3">
+        <h5 class="mb-3">
             {{ build_offerer_badges(row) }}
         </h5>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_venue.html
@@ -1,13 +1,9 @@
+{% from "components/badges.html" import build_venue_badges %}
+
 <div class="card shadow">
     <div class="card-body">
-        <h5 class="card-title mb-3">
-            <span class="me-1 pb-1 badge rounded-pill text-bg-secondary align-middle">
-                {% if row.isPermanent %}
-                    Lieu permanent
-                {% else %}
-                    Lieu
-                {% endif %}
-            </span>
+        <h5 class="mb-3">
+            {{ build_venue_badges(row) }}
         </h5>
 
         <h5 class="card-title">
@@ -23,8 +19,8 @@
         </h6>
 
         <div class="fs-6">
-            <p class="mb-1"><span class="fw-bold">mail:</span> {{ row.contact.email | empty_string_if_null }} </p>
-            <p><span class="fw-bold">tel:</span> {{ row.contact.phone_number | format_phone_number }} </p>
+            <p class="mb-1"><span class="fw-bold">E-mail :</span> {{ row.contact.email | empty_string_if_null }} </p>
+            <p><span class="fw-bold">Tél :</span> {{ row.contact.phone_number | format_phone_number }} </p>
         </div>
 
         <a href="{{ get_link_to_detail(row.id) }}" class="card-link">

--- a/api/tests/routes/backoffice/pro_search_test.py
+++ b/api/tests/routes/backoffice/pro_search_test.py
@@ -466,41 +466,6 @@ class ProSearchVenueTest:
         assert_venue_equals(response_list[0], self.venues[2])  # Théâtre du Centre (most relevant)
         assert_venue_equals(response_list[1], self.venues[11])  # Théâtre du Centaure (very close to the first one)
 
-    @override_features(ENABLE_BACKOFFICE_API=True)
-    def test_can_search_pro_by_two_consistent_criteria(self, client):
-        # given
-        self._create_venues()
-        user = users_factories.UserFactory()
-        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
-
-        # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.search_pro", q=f"{self.venues[2].siret} {self.venues[2].name}", type="venue"),
-        )
-
-        # then
-        assert response.status_code == 200
-        response_list = response.json["data"]
-        assert len(response_list) == 1  # Single result because only one is matching SIREN even if name is close
-        assert_venue_equals(response_list[0], self.venues[2])
-
-    @override_features(ENABLE_BACKOFFICE_API=True)
-    def test_can_search_pro_by_two_unconsistent_criteria(self, client):
-        # given
-        self._create_venues()
-        user = users_factories.UserFactory()
-        auth_token = generate_token(user, [Permissions.SEARCH_PRO_ACCOUNT])
-
-        # when
-        response = client.with_explicit_token(auth_token).get(
-            url_for("backoffice_blueprint.search_pro", q=f"{self.venues[0].siret} {self.venues[1].name}", type="venue"),
-        )
-
-        # then
-        assert response.status_code == 200
-        response_list = response.json["data"]
-        assert len(response_list) == 0
-
     @pytest.mark.parametrize("query", ["987654321", "festival@example.com", "Festival de la Montagne", ""])
     @override_features(ENABLE_BACKOFFICE_API=True)
     def test_can_search_venue_no_result(self, client, query):

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -1,5 +1,7 @@
 import datetime
+from unittest import mock
 
+from dateutil.relativedelta import relativedelta
 from flask import g
 from flask import url_for
 import pytest
@@ -7,9 +9,13 @@ import pytest
 from pcapi.core.bookings import factories as bookings_factories
 import pcapi.core.fraud.models as fraud_models
 from pcapi.core.mails import testing as mails_testing
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
 import pcapi.core.permissions.models as perm_models
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
+from pcapi.models import db
 from pcapi.notifications.sms import testing as sms_testing
 import pcapi.utils.email as email_utils
 
@@ -25,12 +31,70 @@ pytestmark = [
 ]
 
 
+def create_bunch_of_accounts():
+    underage = users_factories.UnderageBeneficiaryFactory(
+        firstName="Gédéon",
+        lastName="Groidanlabénoir",
+        email="gg@example.net",
+        phoneNumber="+33123456789",
+        phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+    )
+    grant_18 = users_factories.BeneficiaryGrant18Factory(
+        firstName="Abdel Yves Akhim",
+        lastName="Flaille",
+        email="ayaf@example.net",
+        phoneNumber="+33756273849",
+        phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+    )
+    pro = users_factories.ProFactory(  # associated with no offerer
+        firstName="Gérard", lastName="Mentor", email="gm@example.com", phoneNumber="+33246813579"
+    )
+    random = users_factories.UserFactory(
+        firstName="Anne", lastName="Algézic", email="aa@example.net", phoneNumber="+33606060606"
+    )
+    no_address = users_factories.UserFactory(
+        firstName="Jean-Luc",
+        lastName="Delarue",
+        email="jld@example.com",
+        phoneNumber="+33234567890",
+        city=None,
+        address=None,
+    )
+    # Same first name as random:
+    users_factories.UserFactory(
+        firstName="Anne", lastName="Autre", email="autre@example.com", phoneNumber="+33780000000"
+    )
+
+    # Pro account should not be returned
+    pro_user = users_factories.ProFactory(firstName="Gérard", lastName="Flaille", email="pro@example.net")
+    offerers_factories.UserOffererFactory(user=pro_user)
+
+    # Beneficiary which is also hired by a pro should be returned
+    offerers_factories.UserOffererFactory(user=grant_18)
+
+    return underage, grant_18, pro, random, no_address
+
+
+def assert_user_equals(result_card_text: str, expected_user: users_models.User):
+    assert f"{expected_user.firstName} {expected_user.lastName} " in result_card_text
+    assert f"User ID : {expected_user.id} " in result_card_text
+    assert f"E-mail : {expected_user.email} " in result_card_text
+    if expected_user.phoneNumber:
+        assert f"Tél : {expected_user.phoneNumber} " in result_card_text
+    if users_models.UserRole.BENEFICIARY in expected_user.roles:
+        assert "Pass 18 " in result_card_text
+    if users_models.UserRole.UNDERAGE_BENEFICIARY in expected_user.roles:
+        assert "Pass 15-17 " in result_card_text
+    if not expected_user.isActive:
+        assert "Suspendu " in result_card_text
+
+
 class SearchPublicAccountsUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
     endpoint = "backoffice_v3_web.public_accounts.search_public_accounts"
     needed_permission = perm_models.Permissions.READ_PUBLIC_ACCOUNT
 
 
-class SearchPublicAccountsAuthorizedTest(search_helpers.SearchHelper):
+class SearchPublicAccountsTest(search_helpers.SearchHelper):
     endpoint = "backoffice_v3_web.public_accounts.search_public_accounts"
 
     def test_search_result_page(self, authenticated_client, legit_user):  # type: ignore
@@ -48,6 +112,207 @@ class SearchPublicAccountsAuthorizedTest(search_helpers.SearchHelper):
 
         assert response.status_code == 400
 
+    def test_can_search_public_account_by_id(self, authenticated_client):
+        # given
+        underage, _, _, _, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=underage.id))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], underage)
+
+    @pytest.mark.parametrize(
+        "query,expected_found",
+        [
+            ("Yves", "Abdel Yves Akhim"),
+            ("Abdel Akhim", "Abdel Yves Akhim"),
+            ("Gérard", "Gérard"),
+            ("Gerard", "Gérard"),
+            ("Jean Luc", "Jean-Luc"),
+        ],
+    )
+    def test_can_search_public_account_by_first_name(self, authenticated_client, query, expected_found):
+        # given
+        _, _, _, _, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert expected_found in cards_text[0]
+
+    @pytest.mark.parametrize("query", ["ALGÉZIC", "Algézic", "Algezic"])
+    def test_can_search_public_account_by_name(self, authenticated_client, query):
+        # given
+        _, _, _, random, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], random)
+
+    def test_can_search_public_account_order_by_priority(self, authenticated_client):
+        # given
+        create_bunch_of_accounts()
+        users_factories.BeneficiaryGrant18Factory(firstName="Théo", lastName="Dorant")
+        users_factories.BeneficiaryGrant18Factory(firstName="Théodule", lastName="Dorantissime")
+        users_factories.BeneficiaryGrant18Factory(firstName="Théos", lastName="Doranta")
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="Théo Dorant"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 3
+        assert " Théo Dorant " in cards_text[0]
+        assert " Théodule Dorantissime " in cards_text[1]
+        assert " Théos Doranta " in cards_text[2]
+
+    def test_can_search_public_account_by_email(self, authenticated_client):
+        # given
+        _, _, _, random, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=random.email))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], random)
+
+    def test_can_search_public_account_by_email_domain(self, authenticated_client):
+        # given
+        underage, grant_18, _, random, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="@example.net"))
+
+        # then
+        assert response.status_code == 200
+        cards_titles = html_parser.extract_cards_titles(response.data)
+        assert set(cards_titles) == {underage.full_name, grant_18.full_name, random.full_name}
+
+    @pytest.mark.parametrize("query", ["+33756273849", "0756273849", "756273849"])
+    def test_can_search_public_account_by_phone(self, authenticated_client, query):
+        # given
+        _, grant_18, _, _, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], grant_18)
+
+    def test_can_search_public_account_even_with_missing_city_address(self, authenticated_client):
+        # given
+        _, _, _, _, no_address = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=no_address.phoneNumber))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], no_address)
+
+    @pytest.mark.parametrize("query", ["Abdel Yves Akhim Flaille", "Abdel Flaille", "Flaille Akhim", "Yves Abdel"])
+    def test_can_search_public_account_by_both_first_name_and_name(self, authenticated_client, query):
+        # given
+        _, grant_18, _, _, _ = create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], grant_18)
+
+    @pytest.mark.parametrize("query", ["Gédéon Flaille", "Abdal Flaille", "Autre Algézic"])
+    def test_can_search_public_account_names_which_do_not_match(self, authenticated_client, query):
+        # given
+        create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 0
+
+    def test_can_search_public_account_empty_query(self, authenticated_client):
+        # given
+        create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=""))
+
+        # then
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize("query", ["'", '""', "Ge*", "([{#/="])
+    def test_can_search_public_account_unexpected(self, authenticated_client, query):
+        # given
+        create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 0
+
+    def test_search_public_account_with_percent_is_forbidden(self, authenticated_client):
+        # given
+        create_bunch_of_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="%terms"))
+
+        # then
+        assert response.status_code == 400
+        assert "Le caractère % n'est pas autorisé" in html_parser.extract_warnings(response.data)
+
+    def test_can_search_public_account_young_but_also_pro(self, authenticated_client):
+        # given
+        # She has started subscription process, but is also hired by an offerer
+        young_and_pro = users_factories.BeneficiaryGrant18Factory(
+            firstName="Maud",
+            lastName="Zarella",
+            email="mz@example.com",
+            dateOfBirth=datetime.date.today() - relativedelta(years=16, days=5),
+        )
+        offerers_factories.UserOffererFactory(user=young_and_pro)
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=young_and_pro.email))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], young_and_pro)
+
 
 class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
     endpoint = "backoffice_v3_web.public_accounts.get_public_account"
@@ -56,6 +321,68 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         endpoint = "backoffice_v3_web.public_accounts.get_public_account"
         endpoint_kwargs = {"user_id": 1}
         needed_permission = perm_models.Permissions.READ_PUBLIC_ACCOUNT
+
+    @pytest.mark.parametrize(
+        "index,expected_badge",
+        [(0, "Pass 15-17"), (1, "Pass 18"), (2, "Pro"), (3, None)],
+    )
+    def test_get_public_account(self, authenticated_client, index, expected_badge):
+        # given
+        users = create_bunch_of_accounts()
+        user = users[index]
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
+
+        # then
+        assert response.status_code == 200
+        content = html_parser.content_as_text(response.data)
+        assert f"User ID : {user.id} " in content
+        assert f"Nom {user.lastName.upper()} " in content
+        assert f"Prénom {user.firstName} " in content
+        assert f"Email {user.email} " in content
+        assert f"Numéro de téléphone {user.phoneNumber} " in content
+        if user.dateOfBirth:
+            assert f"Date de naissance {user.dateOfBirth.strftime('%d/%m/%Y')} " in content
+        assert f"Adresse {user.address} " in content
+        if user.postalCode:
+            assert f"Code postal {user.postalCode} " in content
+        assert f"Ville {user.city} " in content
+        if expected_badge:
+            assert expected_badge in content
+        assert "Suspendu" not in content
+
+    def test_get_beneficiary_credit(self, authenticated_client):
+        # given
+        _, grant_18, _, _, _ = create_bunch_of_accounts()
+
+        bookings_factories.IndividualBookingFactory(
+            individualBooking__user=grant_18,
+            stock__offer__product=offers_factories.DigitalProductFactory(),
+            amount=12.5,
+        )
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, user_id=grant_18.id))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        # Remaining credit + Title + Initial Credit
+        assert "287,50 € Crédit restant 300,00 €" in cards_text
+        assert "87,50 € Crédit digital restant 100,00 €" in cards_text
+
+    def test_get_non_beneficiary_credit(self, authenticated_client):
+        # given
+        _, _, pro, random, _ = create_bunch_of_accounts()
+
+        # when
+        responses = [authenticated_client.get(url_for(self.endpoint, user_id=user.id)) for user in (pro, random)]
+
+        # then
+        for response in responses:
+            assert response.status_code == 200
+            assert "Crédit restant" not in html_parser.content_as_text(response.data)
 
     def test_get_beneficiary_bookings(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory()
@@ -104,6 +431,17 @@ class EditPublicAccountTest(accounts_helpers.PageRendersHelper):
         endpoint = "backoffice_v3_web.public_accounts.edit_public_account"
         endpoint_kwargs = {"user_id": 1}
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
+
+    def test_edit_public_account(self, authenticated_client):
+        # given
+        user = users_factories.BeneficiaryGrant18Factory()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
+
+        # then
+        # form page is generated without exception
+        assert response.status_code == 200
 
 
 class UpdatePublicAccountTest:
@@ -155,6 +493,51 @@ class UpdatePublicAccountTest:
         response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 400
 
+    def test_update_email_triggers_history_token_and_mail(self, authenticated_client):
+        # given
+        user, _, _, _, _ = create_bunch_of_accounts()
+
+        # when
+        response = self.update_account(authenticated_client, user, {"email": "Updated@example.com"})
+
+        # then
+        assert response.status_code == 303
+
+        # check that email has been changed immediately after admin request
+        db.session.refresh(user)
+        assert user.email == "updated@example.com"
+        assert not user.isEmailValidated
+
+        # check that a line has been added in email history
+        email_history: list[users_models.UserEmailHistory] = users_models.UserEmailHistory.query.filter(
+            users_models.UserEmailHistory.userId == user.id
+        ).all()
+        assert len(email_history) == 1
+        assert email_history[0].eventType == users_models.EmailHistoryEventTypeEnum.ADMIN_UPDATE_REQUEST
+        assert email_history[0].oldEmail == "gg@example.net"
+        assert email_history[0].newEmail == "updated@example.com"
+
+        # check that a new token has been generated
+        token: users_models.Token = users_models.Token.query.filter(users_models.Token.userId == user.id).one()
+        assert token.type == users_models.TokenType.EMAIL_VALIDATION
+
+        # check that email is sent
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0].sent_data["To"] == "updated@example.com"
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.EMAIL_CONFIRMATION.value.__dict__
+        assert token.value in mails_testing.outbox[0].sent_data["params"]["CONFIRMATION_LINK"]
+
+    def test_update_invalid_email(self, authenticated_client):
+        # given
+        user, _, _, _, _ = create_bunch_of_accounts()
+
+        # when
+        response = self.update_account(authenticated_client, user, {"email": "updated.example.com"})
+
+        # then
+        assert response.status_code == 400
+        assert html_parser.extract_warnings(response.data) == ["Email obligatoire"]
+
     def test_email_already_exists(self, authenticated_client):
         user_to_edit = users_factories.BeneficiaryGrant18Factory()
         other_user = users_factories.BeneficiaryGrant18Factory()
@@ -167,6 +550,7 @@ class UpdatePublicAccountTest:
 
         response = self.update_account(authenticated_client, user_to_edit, base_form)
         assert response.status_code == 400
+        assert html_parser.extract_warnings(response.data) == ["L'email est déjà associé à un autre utilisateur"]
 
         user_to_edit = users_models.User.query.get(user_to_edit.id)
         assert user_to_edit.email != other_user.email
@@ -223,11 +607,24 @@ class ResendValidationEmailTest:
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
     def test_resend_validation_email(self, authenticated_client):
-        user = users_factories.BeneficiaryGrant18Factory(isEmailValidated=False)
+        user = users_factories.UserFactory(isEmailValidated=False)
         response = self.send_resend_validation_email_request(authenticated_client, user)
 
         assert response.status_code == 303
+
+        # check that validation is unchanged
+        updated_user: users_models.User = users_models.User.query.get(user.id)
+        assert updated_user.isEmailValidated is False
+
+        # check that a new token has been generated
+        token: users_models.Token = users_models.Token.query.filter(users_models.Token.userId == user.id).one()
+        assert token.type == users_models.TokenType.EMAIL_VALIDATION
+
+        # check that email is sent
         assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0].sent_data["To"] == user.email
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.EMAIL_CONFIRMATION.value.__dict__
+        assert token.value in mails_testing.outbox[0].sent_data["params"]["CONFIRMATION_LINK"]
 
     @pytest.mark.parametrize("user_factory", [users_factories.AdminFactory, users_factories.ProFactory])
     def test_no_email_sent_if_admin_pro(self, authenticated_client, user_factory):
@@ -267,11 +664,37 @@ class SendValidationCodeTest:
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
     def test_send_validation_code(self, authenticated_client):
-        user = users_factories.UserFactory(phoneNumber="+33601020304", isEmailValidated=True)
+        user = users_factories.UserFactory(
+            phoneValidationStatus=None, phoneNumber="+33601020304", isEmailValidated=True
+        )
         response = self.send_request(authenticated_client, user)
 
         assert response.status_code == 303
+
         assert len(sms_testing.requests) == 1
+        assert sms_testing.requests[0]["recipient"] == user.phoneNumber
+
+        phone_validation_codes = users_models.Token.query.filter(
+            users_models.Token.user == user,
+            users_models.Token.type == users_models.TokenType.PHONE_VALIDATION,
+        ).all()
+        assert len(phone_validation_codes) == 1
+        assert phone_validation_codes[0].expirationDate is None
+        assert phone_validation_codes[0].isUsed is False
+
+    def test_phone_validation_code_sending_ignores_limit(self, authenticated_client):
+        # given
+        user = users_factories.UserFactory(phoneValidationStatus=None, phoneNumber="+33612345678")
+
+        # when
+        with mock.patch("pcapi.core.fraud.phone_validation.sending_limit.is_SMS_sending_allowed") as limit_mock:
+            limit_mock.return_value = False
+            response = self.send_request(authenticated_client, user)
+
+        # then
+        assert limit_mock.call_count == 0
+        assert response.status_code == 303
+        assert users_models.Token.query.count() == 1
 
     def test_nothing_sent_use_cases(self, authenticated_client):
         other_user = users_factories.BeneficiaryGrant18Factory(
@@ -319,6 +742,17 @@ class EditPublicAccountReviewTest(accounts_helpers.PageRendersHelper):
         endpoint_kwargs = {"user_id": 1}
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
+    def test_edit_review(self, authenticated_client):
+        # given
+        user = users_factories.UserFactory()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
+
+        # then
+        # form page is generated without exception
+        assert response.status_code == 200
+
 
 class UpdatePublicAccountReviewTest:
     class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
@@ -332,7 +766,7 @@ class UpdatePublicAccountReviewTest:
         needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
 
     def test_add_new_fraud_review_to_account(self, authenticated_client, legit_user):
-        user = users_factories.BeneficiaryGrant18Factory()
+        user = users_factories.UserFactory()
 
         base_form = {
             "status": fraud_models.FraudReviewStatus.KO.name,
@@ -348,11 +782,13 @@ class UpdatePublicAccountReviewTest:
 
         user = users_models.User.query.get(user.id)
 
-        assert len(user.deposits) == 1
         assert len(user.beneficiaryFraudReviews) == 1
-
         fraud_review = user.beneficiaryFraudReviews[0]
+        assert fraud_review.author == legit_user
+        assert fraud_review.review == fraud_models.FraudReviewStatus.KO
         assert fraud_review.reason == "test"
+
+        assert user.has_beneficiary_role is False
 
     def test_malformed_form(self, authenticated_client):
         user = users_factories.UserFactory()

--- a/api/tests/routes/backoffice_v3/admin_test.py
+++ b/api/tests/routes/backoffice_v3/admin_test.py
@@ -2,9 +2,11 @@ from flask import g
 from flask import url_for
 import pytest
 
-from pcapi.core.permissions import factories as permissions_factories
+from pcapi.core.permissions import factories as perm_factories
 from pcapi.core.permissions import models as perm_models
+from pcapi.models import db
 
+from .helpers import html_parser
 from .helpers import unauthorized as unauthorized_helpers
 
 
@@ -14,12 +16,46 @@ pytestmark = [
 ]
 
 
-class GetRolesAuthorizedTest:
+class GetRolesTest:
     endpoint = "backoffice_v3_web.get_roles"
 
     class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
         endpoint = "backoffice_v3_web.get_roles"
         needed_permission = perm_models.Permissions.MANAGE_PERMISSIONS
+
+    def test_can_list_roles_and_permissions(self, authenticated_client):
+        # given
+        perm_factories.RoleFactory(name="test_role_1")
+        perm_factories.RoleFactory(name="test_role_2")
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint))
+
+        # then
+        assert response.status_code == 200
+
+        roles = html_parser.extract(response.data, class_="card-header")
+        assert "test_role_1" in roles
+        assert "test_role_2" in roles
+
+        switches = html_parser.extract(response.data, class_="form-switch")
+        assert set(switches) == {p.value for p in perm_models.Permissions}
+
+    def test_can_list_roles_ignoring_obsolete_permissions(self, authenticated_client):
+        # given
+        obsolete_perm = perm_factories.PermissionFactory(name="OBSOLETE")
+        perm_factories.RoleFactory(name="test_role_1", permissions=[obsolete_perm])
+        perm_factories.RoleFactory(name="test_role_2")
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint))
+
+        # then
+        assert response.status_code == 200
+
+        roles = html_parser.extract(response.data, class_="card-header")
+        assert "test_role_1" in roles
+        assert "test_role_2" in roles
 
 
 class UpdateRoleTest:
@@ -28,18 +64,18 @@ class UpdateRoleTest:
         endpoint_kwargs = {"role_id": 1}
         method = "post"
 
-    def test_update_role(self, client, legit_user):
-        perms = permissions_factories.PermissionFactory.create_batch(4)
+    def test_update_role(self, authenticated_client):
+        perms = perm_factories.PermissionFactory.create_batch(4)
         old_perms = [perms[0], perms[1]]
-        role_to_edit = permissions_factories.RoleFactory(permissions=old_perms)
-        role_not_to_edit = permissions_factories.RoleFactory(permissions=old_perms)
+        role_to_edit = perm_factories.RoleFactory(permissions=old_perms)
+        role_not_to_edit = perm_factories.RoleFactory(permissions=old_perms)
 
         new_perms = [perms[1], perms[3]]
         base_form = {}
         for perm in perms:
             base_form[perm.name] = perm in new_perms
 
-        response = self.update_role(client, legit_user, role_to_edit, base_form)
+        response = self.update_role(authenticated_client, role_to_edit, base_form)
         assert response.status_code == 303
 
         expected_url = url_for("backoffice_v3_web.get_roles", _external=True)
@@ -51,12 +87,23 @@ class UpdateRoleTest:
         role_not_to_edit = perm_models.Role.query.get(role_not_to_edit.id)
         assert role_not_to_edit.permissions == old_perms
 
-    def update_role(self, client, legit_user, role_to_edit, form):
+    def test_update_role_with_empty_permissions(self, authenticated_client):
+        role = perm_factories.RoleFactory(name="dummy_role", permissions=[perm_factories.PermissionFactory()])
+
+        response = self.update_role(
+            authenticated_client, role, {perm.name: False for perm in perm_models.Permission.query.all()}
+        )
+        assert response.status_code == 303
+
+        db.session.refresh(role)
+        assert role.permissions == []
+
+    def update_role(self, authenticated_client, role_to_edit, form):
         # generate csrf token
         edit_url = url_for("backoffice_v3_web.get_roles")
-        client.with_bo_session_auth(legit_user).get(edit_url)
+        authenticated_client.get(edit_url)
 
         url = url_for("backoffice_v3_web.update_role", role_id=role_to_edit.id)
 
         form["csrf_token"] = g.get("csrf_token", "")
-        return client.with_bo_session_auth(legit_user).post(url, form=form)
+        return authenticated_client.post(url, form=form)

--- a/api/tests/routes/backoffice_v3/helpers/html_parser.py
+++ b/api/tests/routes/backoffice_v3/helpers/html_parser.py
@@ -60,8 +60,12 @@ def extract_table_rows(html_content: str, parent_id: str | None = None) -> list[
     return rows
 
 
-def count_table_rows(html_content: str) -> int:
+def count_table_rows(html_content: str, parent_id: str | None = None) -> int:
     soup = get_soup(html_content)
+
+    if parent_id:
+        soup = soup.find(id=parent_id)
+        assert soup is not None
 
     tbody = soup.find("tbody")
     if tbody is None:
@@ -96,14 +100,28 @@ def extract_pagination_info(html_content: str) -> tuple[int, int, int]:
     return int(active_page_link.text), len(page_links), total_results
 
 
+def extract(html_content: str, tag: str = "div", class_: str | None = None) -> list[str]:
+    """
+    Extract text from all <div> matching the class, as strings
+    """
+    soup = get_soup(html_content)
+
+    elements = soup.find_all(tag, class_=class_)
+    return [_filter_whitespaces(element.text) for element in elements]
+
+
 def extract_cards_text(html_content: str) -> list[str]:
     """
     Extract text from all cards in the page, as strings
     """
-    soup = get_soup(html_content)
+    return extract(html_content, class_="card")
 
-    cards = soup.find_all("div", class_="card")
-    return [_filter_whitespaces(card.text) for card in cards]
+
+def extract_cards_titles(html_content: str) -> list[str]:
+    """
+    Extract titles from all cards in the page, as strings
+    """
+    return extract(html_content, tag="h5", class_="card-title")
 
 
 def extract_alert(html_content: str) -> str:
@@ -116,8 +134,5 @@ def extract_alert(html_content: str) -> str:
 
 
 def extract_warnings(html_content: str) -> list[str]:
-    soup = get_soup(html_content)
-
     # form validation errors have "text-warning" class
-    warnings = soup.find_all("p", class_="text-warning")
-    return [_filter_whitespaces(p.text) for p in warnings]
+    return extract(html_content, tag="p", class_="text-warning")

--- a/api/tests/routes/backoffice_v3/pro_test.py
+++ b/api/tests/routes/backoffice_v3/pro_test.py
@@ -1,9 +1,16 @@
+import re
+
 from flask import url_for
 import pytest
 
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
 import pcapi.core.permissions.models as perm_models
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
+from pcapi.models.validation_status_mixin import ValidationStatus
 
+from .helpers import html_parser
 from .helpers import search as search_helpers
 from .helpers import unauthorized as unauthorized_helpers
 
@@ -14,38 +21,386 @@ pytestmark = [
 ]
 
 
-def build_pro_user():
-    return offerers_factories.UserOffererFactory().user
-
-
-def build_offerer():
-    return offerers_factories.UserOffererFactory().offerer
-
-
-def build_venue():
-    return offerers_factories.VenueFactory()
-
-
 class SearchProUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
     endpoint = "backoffice_v3_web.search_pro"
     needed_permission = perm_models.Permissions.SEARCH_PRO_ACCOUNT
 
 
 class SearchProTest(search_helpers.SearchHelper):
+    # This class performs basic search tests by inheritance
     endpoint = "backoffice_v3_web.search_pro"
 
-    @pytest.mark.parametrize(
-        "pro_builder,pro_type",
-        [
-            (build_pro_user, "user"),
-            (build_offerer, "offerer"),
-            (build_venue, "venue"),
-        ],
-    )
-    def test_search_result_page(self, authenticated_client, pro_builder, pro_type):
-        pro_object = pro_builder()
 
-        url = url_for(self.endpoint, terms=pro_object.id, pro_type=pro_type)
-        response = authenticated_client.get(url)
+def assert_user_equals(result_card_text: str, expected_user: users_models.User):
+    assert f"{expected_user.firstName} {expected_user.lastName} " in result_card_text
+    assert f"User ID : {expected_user.id} " in result_card_text
+    assert f"E-mail : {expected_user.email} " in result_card_text
+    if expected_user.phoneNumber:
+        assert f"Tél : {expected_user.phoneNumber} " in result_card_text
+    assert "Pro " in result_card_text
+    if not expected_user.isActive:
+        assert "Suspendu " in result_card_text
 
-        assert response.status_code == 200, f"[{response.status_code}] {response.location}"
+
+def assert_offerer_equals(result_card_text: str, expected_offerer: offerers_models.Offerer):
+    assert f"{expected_offerer.name.upper()} " in result_card_text
+    assert f"Offerer ID : {expected_offerer.id} " in result_card_text
+    assert f"SIREN : {expected_offerer.siren} " in result_card_text
+    assert "Structure " in result_card_text
+    if expected_offerer.isValidated:
+        assert " Validée " in result_card_text
+    if expected_offerer.isRejected:
+        assert " Rejetée " in result_card_text
+    if not expected_offerer.isActive:
+        assert " Suspendue " in result_card_text
+
+
+def assert_venue_equals(result_card_text: str, expected_venue: offerers_models.Venue):
+    assert f"{expected_venue.name.upper()} " in result_card_text
+    assert f"Venue ID : {expected_venue.id} " in result_card_text
+    assert f"SIRET : {expected_venue.siret} " in result_card_text
+    if expected_venue.contact:
+        assert f"E-mail : {expected_venue.contact.email} " in result_card_text
+        assert f"Tél : {expected_venue.contact.phone_number} " in result_card_text
+    if expected_venue.isPermanent:
+        assert "Lieu permanent " in result_card_text
+    else:
+        assert "Lieu " in result_card_text
+        assert "Lieu permanent " not in result_card_text
+    if not expected_venue.managingOfferer.isActive:
+        assert " Suspendu " in result_card_text
+
+
+class SearchProUserTest:
+    endpoint = "backoffice_v3_web.search_pro"
+
+    def _create_accounts(
+        self,
+        number: int = 12,
+        first_names: list[str] = ("Alice", "Bob", "Oscar"),
+        last_names: list[str] = ("Martin", "Bernard", "Durand", "Dubois"),
+    ) -> None:
+        self.pro_accounts = []
+        for i in range(number):
+            first_name = first_names[i % len(first_names)]
+            last_name = last_names[i % len(last_names)]
+            user = users_factories.ProFactory(
+                firstName=first_name, lastName=last_name, email=f"{first_name.lower()}.{last_name.lower()}@example.com"
+            )
+            # Associate with two offerers, this helps to check that account is returned only once
+            offerers_factories.UserOffererFactory(user=user)
+            offerers_factories.UserOffererFactory(user=user)
+            self.pro_accounts.append(user)
+
+    def test_can_search_pro_by_id(self, authenticated_client):
+        # given
+        self._create_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.pro_accounts[5].id, pro_type="user"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], self.pro_accounts[5])
+
+    def test_can_search_pro_by_email(self, authenticated_client):
+        # given
+        self._create_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.pro_accounts[2].email, pro_type="user"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], self.pro_accounts[2])
+
+    def test_can_search_pro_by_last_name(self, authenticated_client):
+        # given
+        self._create_accounts()
+        users_factories.UserFactory(firstName="Admin", lastName="Dubois", roles=[users_models.UserRole.ADMIN])
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="Dubois", pro_type="user"))
+
+        # then
+        assert response.status_code == 200
+        cards_titles = html_parser.extract_cards_titles(response.data)
+        assert set(cards_titles) == {"Alice Dubois", "Bob Dubois", "Oscar Dubois"}
+
+    def test_can_search_pro_by_first_and_last_name(self, authenticated_client):
+        # given
+        self._create_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="Alice Dubois", pro_type="user"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], self.pro_accounts[3])
+
+    @pytest.mark.parametrize("query", ["'", '""', "*", "([{#/="])
+    def test_can_search_pro_unexpected(self, authenticated_client, query):
+        # given
+        self._create_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query, pro_type="user"))
+
+        # then
+        assert response.status_code == 200
+        assert len(html_parser.extract_cards_text(response.data)) == 0
+
+    def test_search_pro_with_percent_is_forbidden(self, authenticated_client):
+        # given
+        self._create_accounts()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="%terms", pro_type="user"))
+
+        # then
+        assert response.status_code == 400
+
+    def test_can_search_pro_also_beneficiary(self, authenticated_client):
+        # given
+        pro_beneficiary = users_factories.BeneficiaryGrant18Factory(
+            firstName="Paul",
+            lastName="Ochon",
+            email="po@example.net",
+            phoneNumber="+33740506070",
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+            roles=[users_models.UserRole.BENEFICIARY, users_models.UserRole.PRO],
+        )
+        offerers_factories.UserOffererFactory(user=pro_beneficiary)
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=pro_beneficiary.id, pro_type="user"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_user_equals(cards_text[0], pro_beneficiary)
+
+
+class SearchOffererTest:
+    endpoint = "backoffice_v3_web.search_pro"
+
+    def _create_offerers(
+        self,
+        number: int = 12,
+        name_part1: list[str] = ("Librairie", "Cinéma", "Théâtre"),
+        name_part2: list[str] = ("de la Gare", "de la Plage", "du Centre", "du Centaure"),
+    ) -> None:
+        validation_statuses = list(ValidationStatus)
+        self.offerers = []
+        for i in range(number):
+            offerer = offerers_factories.OffererFactory(
+                name=f"{name_part1[i % len(name_part1)]} {name_part2[i % len(name_part2)]}",
+                siren=str(123456000 + i),
+                validationStatus=validation_statuses[i % len(validation_statuses)],
+                isActive=bool(i % 4),
+            )
+            self.offerers.append(offerer)
+
+    def test_can_search_offerer_by_id(self, authenticated_client):
+        # given
+        self._create_offerers()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.offerers[2].id, pro_type="offerer"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_offerer_equals(cards_text[0], self.offerers[2])
+
+    def test_can_search_offerer_by_siren(self, authenticated_client):
+        # given
+        self._create_offerers()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.offerers[3].siren, pro_type="offerer"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_offerer_equals(cards_text[0], self.offerers[3])
+
+    def test_can_search_offerer_by_name(self, authenticated_client):
+        # given
+        self._create_offerers()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="Théâtre du Centre", pro_type="offerer"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) >= 2  # Results may contain all "Théâtre", "Centre", "Centaure"
+        assert len(cards_text) <= 8  # Results should not contain Libraire/Cinéma + Gare/Plage
+        assert_offerer_equals(cards_text[0], self.offerers[2])  # Théâtre du Centre (most relevant)
+        assert_offerer_equals(cards_text[1], self.offerers[11])  # Théâtre du Centaure (very close to the first one)
+
+    @pytest.mark.parametrize("query", ["987654321", "festival@example.com", "Festival de la Montagne"])
+    def test_can_search_offerer_no_result(self, authenticated_client, query):
+        # given
+        self._create_offerers()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query, pro_type="offerer"))
+
+        # then
+        assert response.status_code == 200
+        assert len(html_parser.extract_cards_text(response.data)) == 0
+
+
+class SearchVenueTest:
+    endpoint = "backoffice_v3_web.search_pro"
+
+    def _create_venues(
+        self,
+        number: int = 12,
+        name_part1: list[str] = ("Librairie", "Cinéma", "Théâtre"),
+        name_part2_admin: list[str] = ("Alpha", "Beta", "Gamma", "Delta"),
+        name_part2_public: list[str] = ("de la Gare", "de la Plage", "du Centre", "du Centaure"),
+        domains: list[str] = ("librairie.fr", "cinema.com", "theatre.net"),
+    ) -> None:
+        validation_statuses = list(ValidationStatus)
+        self.venues = []
+        for i in range(number):
+            venue = offerers_factories.VenueFactory(
+                name=f"{name_part1[i % len(name_part1)]} {name_part2_admin[i % len(name_part2_admin)]}",
+                publicName=f"{name_part1[i % len(name_part1)]} {name_part2_public[i % len(name_part2_public)]}",
+                siret=f"123456{i:03}{i:05}",
+                isPermanent=bool(i % 2 == 0),
+                contact=None,
+                managingOfferer__validationStatus=validation_statuses[i % len(validation_statuses)],
+                managingOfferer__isActive=bool(i % 3),
+            )
+            if i % 2:
+                offerers_factories.VenueContactFactory(
+                    venue=venue,
+                    email=f"contact{venue.id}@{domains[i % len(domains)]}",
+                    phone_number=f"+331020304{i:02}",
+                )
+            self.venues.append(venue)
+
+    def test_can_search_venue_by_id(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.venues[2].id, pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_venue_equals(cards_text[0], self.venues[2])
+
+    def test_can_search_venue_by_siret(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.venues[3].siret, pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_venue_equals(cards_text[0], self.venues[3])
+
+    def test_can_search_venue_by_booking_email(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=self.venues[1].bookingEmail, pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_venue_equals(cards_text[0], self.venues[1])
+
+    def test_can_search_venue_by_booking_email_domain(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="@librairie.fr", pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 2  # 4 * Librairie but only odd indexes in venues have contact email
+        sorted_cards_text = sorted(cards_text, key=lambda text: re.findall(r"Venue ID : \d+ ", text)[0])
+        assert_venue_equals(sorted_cards_text[0], self.venues[3])  # Librairie Delta / du Centaure
+        assert_venue_equals(sorted_cards_text[1], self.venues[9])  # Librairie Beta / de la Plage
+
+    def test_can_search_venue_by_contact_email(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(
+            url_for(self.endpoint, terms=self.venues[1].contact.email, pro_type="venue")
+        )
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 1
+        assert_venue_equals(cards_text[0], self.venues[1])
+
+    def test_can_search_venue_by_name(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="Alpha", pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) == 3
+        sorted_cards_text = sorted(cards_text, key=lambda text: re.findall(r"Venue ID : \d+ ", text)[0])
+        assert_venue_equals(sorted_cards_text[0], self.venues[0])  # Librairie Alpha
+        assert_venue_equals(sorted_cards_text[1], self.venues[4])  # Cinéma Alpha
+        assert_venue_equals(sorted_cards_text[2], self.venues[8])  # Théâtre Alpha
+
+    def test_can_search_venue_by_public_name(self, authenticated_client):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms="Théâtre du Centre", pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        cards_text = html_parser.extract_cards_text(response.data)
+        assert len(cards_text) >= 2  # Results may contain all "Théâtre", "Centre", "Centaure"
+        assert len(cards_text) <= 8  # Results should not contain Libraire/Cinéma + Gare/Plage
+        assert_venue_equals(cards_text[0], self.venues[2])  # Théâtre du Centre (most relevant)
+        assert_venue_equals(cards_text[1], self.venues[11])  # Théâtre du Centaure (very close to the first one)
+
+    @pytest.mark.parametrize("query", ["987654321", "festival@example.com", "Festival de la Montagne"])
+    def test_can_search_venue_no_result(self, authenticated_client, query):
+        # given
+        self._create_venues()
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, terms=query, pro_type="venue"))
+
+        # then
+        assert response.status_code == 200
+        assert len(html_parser.extract_cards_text(response.data)) == 0

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -48,7 +48,11 @@ class GetProUserTest:
         assert f"Tél : {user.phoneNumber} " in content
         assert f"Code postal : {user.postalCode} " in content
         assert f"Département : {user.departementCode} " in content
-        assert "Pro" in content
+
+        badges = html_parser.extract(response.data, tag="span", class_="badge")
+        assert "Pro" in badges
+        assert "Validé" in badges
+        assert "Suspendu" not in badges
 
     def test_get_not_pro_user(self, authenticated_client):  # type: ignore
         user = users_factories.BeneficiaryGrant18Factory()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20144

## But de la pull request

Les API du backoffice v2 étaient mieux testées que les routes du backoffice v3.
Le but de cette PR est de reporter les scénarios de test v2 qui n'étaient pas testés en v3.

Les écrans suivants sont concernés : 
- public accounts
- pro search
- pro users
- offerers
- venues
- roles

Cette PR corrige aussi des bugs découverts en exécutant ces scénarios de test :
- "%" was allowed in search query, which could cause to load the whole db
- search venues were not ordered by similarity; reported same fix as offerers
- remaining credit displayed was rounded
- venue did not have "Suspended" badge when its offerer was suspended
- minor display fixes

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
