### PR TITLE
(PC-20245)[API] fix: mark old digital bookings as USED

### DIFF
--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -204,7 +204,10 @@ def is_ended_booking(booking: Booking) -> bool:
     if booking.dateCreated < datetime.utcnow() - timedelta(days=30) and not (
         booking_subcategory.can_expire or booking_subcategory.is_event
     ):
-        # consider digital bookings with no expiration date as ended after 30 days
+        # consider digital bookings with no expiration date as used and ended after 30 days
+        booking.status = BookingStatus.USED
+        booking.dateUsed = datetime.utcnow()
+        repository.save(booking)
         return True
 
     return (

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -338,6 +338,7 @@ class GetBookingsTest:
         assert len(response.json["ongoing_bookings"]) == 0
         assert len(response.json["ended_bookings"]) == 1
         assert response.json["ended_bookings"][0]["id"] == booking.id
+        assert response.json["ended_bookings"][0]["dateUsed"] != None
 
 
 class CancelBookingTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20245

## But de la pull request

mark old digital bookings as USED

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
