### PR TITLE
(PC-18464)[API] fix: bov3: save contact data on early return

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -101,6 +101,8 @@ def update_venue(
         upsert_venue_contact(venue, contact_data)
 
     if not modifications:
+        # avoid any contact information update loss
+        venue_snapshot.log_update(save=True)
         return venue
 
     if reimbursement_point_id != venue.current_reimbursement_point_id:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18464

## But de la pull request

Bug : si on ne modifie que des informations de contact via la page de détails d'un lieu, ceux-ci ne sont pas enregistrés dans l'historique.

L'historique de modification est sauvegardé à la fin de la fonction alors que celle-ci peut se terminer bien plus tôt s'il n'y a aucun changement à apporter au lieu. 

Fix : s'il n'y a aucun changement à apporter au lieu, sauvegarder l'historique de changement des informations de contact (s'il y en a).