### PR TITLE
(PC-20130)[API] feat: add booking creation date to bookings pages

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
@@ -25,6 +25,7 @@
                         <th scope="col">Catégorie</th>
                         <th scope="col">Sous-catégorie</th>
                         <th scope="col">Statut</th>
+                        <th scope="col">Date de réservation</th>
                         <th scope="col">Date de validation</th>
                         <th scope="col">Date d'annulation</th>
                     </tr>
@@ -57,6 +58,7 @@
                             <td>{{ collective_offer.subcategory.category.pro_label }}</td>
                             <td>{{ collective_offer.subcategory.pro_label }}</td>
                             <td>{{ collective_booking.status | format_booking_status }}</td>
+                            <td>{{ collective_booking.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ collective_booking.confirmationDate | format_date("%d/%m/%Y") }}</td>
                             <td>{{ collective_booking.cancellationDate | format_date("%d/%m/%Y") }}</td>
                         </tr>

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -26,6 +26,7 @@
                         <th scope="col">Sous-catégorie</th>
                         <th scope="col">Stock</th>
                         <th scope="col">Statut</th>
+                        <th scope="col">Date de réservation</th>
                         <th scope="col">Date d'utilisation</th>
                         <th scope="col">Date d'annulation</th>
                     </tr>
@@ -62,6 +63,7 @@
                             <td>{{ offer.subcategory.pro_label }}</td>
                             <td>{{ booking.stock.quantity }}</td>
                             <td>{{ booking.status | format_booking_status }}</td>
+                            <td>{{ booking.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ booking.dateUsed | format_date("%d/%m/%Y") }}</td>
                             <td>{{ booking.cancellationDate | format_date("%d/%m/%Y") }}</td>
                         </tr>

--- a/api/tests/routes/backoffice_v3/collective_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/collective_bookings_test.py
@@ -89,6 +89,9 @@ class ListCollectiveBookingsTest:
         assert result["Catégorie"] == categories.MUSEE.pro_label
         assert result["Sous-catégorie"] == subcategories_v2.VISITE_GUIDEE.pro_label
         assert result["Statut"] == "Confirmée"
+        assert result["Date de réservation"] == (datetime.date.today() - datetime.timedelta(days=3)).strftime(
+            "%d/%m/%Y"
+        )
         assert result["Date de validation"] == (datetime.date.today() - datetime.timedelta(days=1)).strftime("%d/%m/%Y")
         assert not result["Date d'annulation"]
 
@@ -121,6 +124,9 @@ class ListCollectiveBookingsTest:
         assert result["Catégorie"] == categories.CONFERENCE_RENCONTRE.pro_label
         assert result["Sous-catégorie"] == subcategories_v2.DECOUVERTE_METIERS.pro_label
         assert result["Statut"] == "Annulée"
+        assert result["Date de réservation"] == (datetime.date.today() - datetime.timedelta(days=2)).strftime(
+            "%d/%m/%Y"
+        )
         assert result["Date d'annulation"] == datetime.date.today().strftime("%d/%m/%Y")
 
         assert html_parser.extract_pagination_info(response.data) == (1, 1, len(rows))

--- a/api/tests/routes/backoffice_v3/individual_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/individual_bookings_test.py
@@ -98,6 +98,9 @@ class ListIndividualBookingsTest:
         assert rows[0]["Sous-catégorie"] == subcategories_v2.LIVRE_PAPIER.pro_label
         assert rows[0]["Stock"] == "212"
         assert rows[0]["Statut"] == "Validée"
+        assert rows[0]["Date de réservation"] == (datetime.date.today() - datetime.timedelta(days=4)).strftime(
+            "%d/%m/%Y"
+        )
         assert rows[0]["Date d'utilisation"] == datetime.date.today().strftime("%d/%m/%Y")
         assert not rows[0]["Date d'annulation"]
 
@@ -131,6 +134,9 @@ class ListIndividualBookingsTest:
         assert result["Sous-catégorie"] == subcategories_v2.LIVRE_PAPIER.pro_label
         assert result["Stock"] == "2"
         assert result["Statut"] == "Confirmée"
+        assert result["Date de réservation"] == (datetime.date.today() - datetime.timedelta(days=2)).strftime(
+            "%d/%m/%Y"
+        )
         assert not result["Date d'utilisation"]
         assert not result["Date d'annulation"]
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20130

## But de la pull request

Ajout de la date de réservation aux pages de réservations.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
