### PR TITLE
(PC-19591) Build pcapi-console on github

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -75,6 +75,7 @@ jobs:
     with:
       tag: ${{ github.sha }}
       pcapi: true
+      console: true
     secrets: inherit
 
   deploy-to-testing:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19591

## But de la pull request

Le build du de pcapi-console n'est actuellement pas effectué sur github-action, uniquement sur circle-ci (default = true)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
