### PR TITLE
(PC-20245)[API] fix: remove ending of old digital offers

### DIFF
--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from datetime import timedelta
 import logging
 
 from sqlalchemy.orm import joinedload
@@ -199,13 +198,6 @@ def is_ended_booking(booking: Booking) -> bool:
         # consider digital bookings as special: is_used should be true anyway so
         # let's use displayAsEnded
         return booking.displayAsEnded  # type: ignore [return-value]
-
-    booking_subcategory = booking.stock.offer.subcategory
-    if booking.dateCreated < datetime.utcnow() - timedelta(days=30) and not (
-        booking_subcategory.can_expire or booking_subcategory.is_event
-    ):
-        # consider digital bookings with no expiration date as ended after 30 days
-        return True
 
     return (
         not booking.stock.offer.isPermanent

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -324,21 +324,6 @@ class GetBookingsTest:
             {"barcode": "111111112", "seat": "A_2"},
         ]
 
-    def test_digital_bookings_are_considered_used_after_30_days(self, client):
-        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
-        booking = booking_factories.IndividualBookingFactory(
-            dateCreated=datetime.utcnow() - timedelta(days=30, minutes=1),
-            individualBooking__user=user,
-            stock__offer__subcategoryId=subcategories.ABO_PRESSE_EN_LIGNE.id,
-        )
-
-        response = client.with_token(self.identifier).get("/native/v1/bookings")
-
-        assert response.status_code == 200
-        assert len(response.json["ongoing_bookings"]) == 0
-        assert len(response.json["ended_bookings"]) == 1
-        assert response.json["ended_bookings"][0]["id"] == booking.id
-
 
 class CancelBookingTest:
     identifier = "pascal.ture@example.com"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20245

## But de la pull request

retour sur le mecanisme d'archivage des réservations numériquees de plus de 30 jours ajoutée dans le ticket https://passculture.atlassian.net/browse/PC-18717

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
