### PR TITLE
(BSR)[PRO] ci: allow pipeline to succeed on master if sonar scan fails

### DIFF
--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -113,6 +113,7 @@ jobs:
         run: yarn test:unit:ci --coverage
       - name: SonarCloud scan
         uses: SonarSource/sonarcloud-github-action@master
+        continue-on-error: ${{ github.ref == 'refs/heads/master'  }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Il y a eu quelque cas où le scan sonar échoue car GitHub Actions n'arrive pas à transmettre les infos à SonarCloud (à cause d'une erreur réseau)
Cette modif permet de continuer le déploiement même si le scan a échoué