### PR TITLE
(PC-20160)[API] feat: add price category to api return objects

### DIFF
--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -100,9 +100,7 @@ class PriceCategoryFactory(BaseFactory):
         model = models.PriceCategory
 
     price = 10
-    priceCategoryLabel = factory.SubFactory(
-        PriceCategoryLabelFactory,
-    )
+    priceCategoryLabel = factory.SubFactory(PriceCategoryLabelFactory)
 
 
 class StockFactory(BaseFactory):

--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -108,6 +108,11 @@ def _retrieve_offer_relations_query(query: sqla_orm.Query) -> sqla_orm.Query:
                 offers_models.Product.id, offers_models.Product.thumbCount
             )
         )
+        .options(
+            sqla_orm.joinedload(offers_models.Offer.priceCategories).joinedload(
+                offers_models.PriceCategory.priceCategoryLabel
+            )
+        )
     )
 
 
@@ -466,6 +471,11 @@ def get_event_dates(event_id: int, query: serialization.GetDatesQueryParams) -> 
 
     stocks = (
         offers_models.Stock.query.filter(offers_models.Stock.id.in_(total_stock_ids[offset : offset + query.limit]))
+        .options(
+            sqla_orm.joinedload(offers_models.Stock.priceCategory).joinedload(
+                offers_models.PriceCategory.priceCategoryLabel
+            )
+        )
         .order_by(offers_models.Stock.id)
         .all()
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20160

## Implémentation

Les dates qui n'ont pas de `PriceCategory` associés renvoient un `PartialPriceCategoryResponse` qui est similaire au `PriceCategoryResponse` avec l'`id` et le `label` à `None`