### PR TITLE
(BSR)[API] fix: sync permission inside install_data

### DIFF
--- a/api/src/pcapi/scripts/install_data.py
+++ b/api/src/pcapi/scripts/install_data.py
@@ -1,6 +1,8 @@
 import logging
 
+from pcapi.core.permissions.models import sync_db_permissions
 from pcapi.install_database_extensions import install_database_extensions
+from pcapi.models import db
 from pcapi.models.feature import install_feature_flags
 from pcapi.utils.blueprint import Blueprint
 
@@ -13,6 +15,8 @@ logger = logging.getLogger(__name__)
 def install_data() -> None:
     install_feature_flags()
     logger.info("Feature flags installed")
+
+    sync_db_permissions(db.session)
     logger.info("Permissions synced")
 
 


### PR DESCRIPTION
## But de la pull request

Fix : appeler `sync_db_permissions` dans `install_data` comme c'était le cas avant. Cette étape avait été supprimée par erreur.