### PR TITLE
(BSR)[API] chore: Bump bcrypt

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,7 +4,7 @@ Authlib==0.15.5
 attrs==22.1.0
 Babel==2.9.1
 basecrm==1.2.9
-bcrypt==3.2.0
+bcrypt==4.0.1
 beautifulsoup4==4.9.3
 black
 # `sentry_sdk.init()` uses `flask.signals`, which requires `blinker`


### PR DESCRIPTION
See changelog: https://github.com/pyca/bcrypt/#changelog

Fixes include:

- NUL bytes are now allowed in inputs. This is nice for us because we
  occasionally got some of those and bcrypt would raise an error that
  was not caught.