### PR TITLE
(PC-18987)[API] fix: updated booking cancellation limit date

### DIFF
--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -39,7 +39,7 @@ class BookingFactory(BaseFactory):
         if extracted:
             self.cancellationLimitDate = extracted
         else:
-            self.cancellationLimitDate = api.compute_cancellation_limit_date(
+            self.cancellationLimitDate = api.compute_booking_cancellation_limit_date(
                 self.stock.beginningDatetime, self.dateCreated
             )  # type: ignore [assignment]
         db.session.add(self)

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -5,7 +5,7 @@ from typing import Callable
 from pydantic.class_validators import validator
 from pydantic.fields import Field
 
-from pcapi.core.bookings.api import compute_cancellation_limit_date
+from pcapi.core.bookings.api import compute_booking_cancellation_limit_date
 from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers import models as offerers_models
@@ -70,7 +70,7 @@ class OfferStockResponse(BaseModel):
     @staticmethod
     def _get_cancellation_limit_datetime(stock: Stock) -> datetime | None:
         # compute date as if it were booked now
-        return compute_cancellation_limit_date(stock.beginningDatetime, datetime.utcnow())
+        return compute_booking_cancellation_limit_date(stock.beginningDatetime, datetime.utcnow())
 
     @staticmethod
     def _get_non_scrappable_activation_code(stock: Stock) -> dict | None:

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -12,7 +12,7 @@ from pydantic import root_validator
 from pydantic import validator
 from pydantic.utils import GetterDict
 
-from pcapi.core.bookings.api import compute_cancellation_limit_date
+from pcapi.core.bookings.api import compute_booking_cancellation_limit_date
 from pcapi.core.categories.subcategories import SubcategoryIdEnum
 from pcapi.core.offers import api as offers_api
 from pcapi.core.offers import models as offers_models
@@ -321,7 +321,7 @@ class GetOfferStockResponseModel(BaseModel):
     def validate_cancellation_limit_date(
         cls, cancellation_limit_date: datetime | None, values: dict
     ) -> datetime | None:
-        return compute_cancellation_limit_date(values.get("beginningDatetime"), datetime.utcnow())
+        return compute_booking_cancellation_limit_date(values.get("beginningDatetime"), datetime.utcnow())
 
     class Config:
         allow_population_by_field_name = True

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -846,12 +846,12 @@ class MarkAsUnusedTest:
 class ComputeCancellationDateTest:
     def test_returns_none_if_no_event_beginning(self, booking_creation_date):
         event_beginning = None
-        assert api.compute_cancellation_limit_date(event_beginning, booking_creation_date) is None
+        assert api.compute_booking_cancellation_limit_date(event_beginning, booking_creation_date) is None
 
     def test_returns_creation_date_if_event_begins_too_soon(self, booking_creation_date):
         event_date_too_close_to_cancel_booking = booking_creation_date + timedelta(days=1)
         assert (
-            api.compute_cancellation_limit_date(event_date_too_close_to_cancel_booking, booking_creation_date)
+            api.compute_booking_cancellation_limit_date(event_date_too_close_to_cancel_booking, booking_creation_date)
             == booking_creation_date
         )
 
@@ -859,7 +859,7 @@ class ComputeCancellationDateTest:
         self, booking_creation_date
     ):
         event_date_more_ten_days_from_now = booking_creation_date + timedelta(days=6)
-        assert api.compute_cancellation_limit_date(
+        assert api.compute_booking_cancellation_limit_date(
             event_date_more_ten_days_from_now, booking_creation_date
         ) == booking_creation_date + timedelta(days=2)
 
@@ -867,7 +867,7 @@ class ComputeCancellationDateTest:
         self, booking_creation_date
     ):
         event_date_four_days_from_now = booking_creation_date + timedelta(days=4)
-        assert api.compute_cancellation_limit_date(
+        assert api.compute_booking_cancellation_limit_date(
             event_date_four_days_from_now, booking_creation_date
         ) == event_date_four_days_from_now - timedelta(days=2)
 
@@ -884,13 +884,14 @@ class UpdateCancellationLimitDatesTest:
             stock=recent_booking.stock, dateCreated=(datetime.utcnow() - timedelta(days=7))
         )
         # When
+        tomorrow = datetime.utcnow() + timedelta(days=1)
         updated_bookings = api.update_cancellation_limit_dates(
             bookings_to_update=[recent_booking, old_booking],
-            new_beginning_datetime=datetime.utcnow() + timedelta(days=1),
+            new_beginning_datetime=tomorrow,
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
-        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == datetime(2032, 11, 17, 15)
+        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == tomorrow
 
     def should_update_bookings_cancellation_limit_dates_for_event_beginning_in_three_days(self):
         #  Given
@@ -907,7 +908,8 @@ class UpdateCancellationLimitDatesTest:
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
-        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == datetime(2032, 11, 18, 15)
+        two_days_past_today = datetime.utcnow() + timedelta(days=2)
+        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == two_days_past_today
 
     def should_update_bookings_cancellation_limit_dates_for_event_beginning_in_a_week(self):
         #  Given
@@ -924,7 +926,8 @@ class UpdateCancellationLimitDatesTest:
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
-        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == datetime(2032, 11, 19, 15)
+        two_days_past_today = datetime.utcnow() + timedelta(days=2)
+        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == two_days_past_today
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18987

## But de la pull request

La période de 2 jours d'annulation possible prime sur l'impossibilité d'annuler deux jours avant le début de l'évènement en cas de modification de la date de l'évènement.