### PR TITLE
(BSR)[API] chore: Bump version of `click-option-group`

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,7 +10,7 @@ black
 # `sentry_sdk.init()` uses `flask.signals`, which requires `blinker`
 blinker==1.4
 boto3==1.21.9
-click-option-group==0.5.3
+click-option-group==0.5.5
 debugpy
 factory-boy
 Flask==2.0.*


### PR DESCRIPTION
Changelog: https://click-option-group.readthedocs.io/en/latest/changelog.html

Nothing notable.