### PR TITLE
(BSR)[API] chore: Bump version of `requests`

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -55,7 +55,7 @@ pytest-dotenv
 pytest-socket
 python-dotenv==0.21.1
 pyyaml==6.0
-requests==2.26.0
+requests==2.28.2
 requests_mock
 rq==1.12.0
 schwifty==2020.9.0


### PR DESCRIPTION
Changelog: https://requests.readthedocs.io/en/latest/community/updates/#release-history

Nothing notable.