### PR TITLE
(PC-20305)[API] fix: bov3: bold tab titles

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/presentation/details/tabs.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/presentation/details/tabs.html
@@ -1,7 +1,7 @@
 {% macro build_details_tab(name, title, is_active=False) %}
     <li class="nav-item" role="presentation">
         <button
-            class="{{ 'nav-link active fw-bolder' if is_active else 'nav-link' }}"
+            class="{{ 'nav-link active fw-bolder' if is_active else 'nav-link fw-bolder' }}"
             id="{{ name ~ '-tab' }}"
             data-bs-toggle="tab"
             data-bs-target="{{ '#' ~ name ~ '-tab-pane' }}"


### PR DESCRIPTION
## But de la pull request

Tous les titres d'onglets doivent être en gras.