### PR TITLE
(BSR)[API] chore: Bump version of `rq`

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -157,7 +157,7 @@ filterwarnings = [
     "ignore:Coercing Subquery object into a select\\(\\) for use in IN\\(\\):sqlalchemy.exc.SAWarning",
     # ---------------------------- #
 
-    # FIXME (rpaoloni, 2022-04-19): some of our dependencies (rq, at least) use `distutils.version.StrictVersion`,
+    # FIXME (rpaoloni, 2022-04-19): some of our dependencies (flask_limiter, at least) use `distutils.version.StrictVersion`,
     # which emits a deprecation warnings with setuptools >=59.6.0. Remove this when we update or remove those
     # dependencies.
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -57,7 +57,7 @@ python-dotenv==0.21.1
 pyyaml==6.0
 requests==2.26.0
 requests_mock
-rq==1.5.2
+rq==1.12.0
 schwifty==2020.9.0
 semver==2.13.0
 sentry-sdk==1.8.0


### PR DESCRIPTION
Changelog: https://github.com/rq/rq/blob/master/CHANGES.md

Nothing notable, except `rq` stopped using deprecated `StrictVersion`
from distutils.