### PR TITLE
(PC-18475)[BO] feat: suspend and unsuspend user (beneficiary, gp, pro)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -859,61 +859,6 @@ jobs:
             - notify-slack:
                 channel: dev
 
-  tests-backoffice-front-unit-tests:
-    docker:
-      - image: cimg/node:14.18
-    working_directory: ~/pass-culture
-    steps:
-      - checkout
-      - skip_unchanged:
-          paths: backoffice
-      - unless:
-          condition:
-            equal: ["master", << pipeline.git.branch >>]
-          steps:
-            - restore_cache:
-                name: Restore Yarn Package Cache
-                key: << pipeline.parameters.backoffice-front_cache_key >>
-      - run:
-          name: Install packages
-          command: yarn install
-          working_directory: backoffice
-      - restore_cache:
-          name: Restore Jest Cache
-          key: node-14.18-jest-cache-
-      - when:
-          condition:
-            equal: ["master", << pipeline.git.branch >>]
-          steps:
-            - run:
-                name: Run Unit Test BACKOFFICE
-                command: yarn test:unit:ci
-                working_directory: backoffice
-      - run:
-          name: Unit Test FRONT BACKOFFICE
-          command: yarn test:unit:ci --changedSince=master
-          working_directory: backoffice
-      - unless:
-          condition:
-            equal: ["master", << pipeline.git.branch >>]
-          steps:
-            - save_cache:
-                name: Save Yarn Package Cache
-                key: << pipeline.parameters.backoffice-front_cache_key >>
-                paths:
-                  - ~/pass-culture/backoffice/node_modules
-      - save_cache:
-          name: Save Jest Package Cache
-          key: node-14.18-jest-cache-{{ epoch }}
-          paths:
-            - ~/pass-culture/backoffice/.jest_cache
-      - when:
-          condition:
-            equal: ["master", << pipeline.git.branch >>]
-          steps:
-            - notify-slack:
-                channel: dev
-
   build-and-push-image:
     executor: gcp-sdk-alpine
     environment:
@@ -1370,15 +1315,6 @@ workflows:
          context: Slack
          requires:
            - type-checking-pro
-      - tests-backoffice-front-unit-tests:
-         filters:
-           branches:
-             ignore:
-               - production
-               - staging
-               - integration
-               - docs
-         context: Slack
 #      - generate-pcapi-helm-values-files:
 #          filters:
 #            branches:
@@ -1445,7 +1381,6 @@ workflows:
 #             only:
 #               - master
 #         requires:
-#           - tests-backoffice-front-unit-tests
 #           - restart-pcapi
 #         context:
 #           - GCP
@@ -1471,7 +1406,6 @@ workflows:
 #           - tests-adage-front
 #           - tests-pro-unit-tests
 #           - tests-pro-e2e-tests
-#           - tests-backoffice-front-unit-tests
 #         context:
 #           - CI_MEASURE
   gcp-ehp:

--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -48,7 +48,7 @@ def log_action(
         user=user,
         offerer=offerer,  # type: ignore
         venue=venue,  # type: ignore
-        comment=comment,
+        comment=comment or None,  # do not store empty string
         extraData=extra_data,
     )
 

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -23,9 +23,9 @@ class Permissions(enum.Enum):
 
     SEARCH_PUBLIC_ACCOUNT = "rechercher un compte bénéficiaire/grand public"
     READ_PUBLIC_ACCOUNT = "visualiser un compte bénéficiaire/grand public"
-    REVIEW_PUBLIC_ACCOUNT = "faire une revue manuelle d'un compte bénéficiaire/grand public"
     MANAGE_PUBLIC_ACCOUNT = "gérer un compte bénéficiaire/grand public"
-    MANUAL_REVIEW_PUBLIC_ACCOUNT = "permet la revue manuelle sur le profil jeune"
+
+    REVIEW_SUSPEND_USER = "faire une revue manuelle, suspendre un compte utilisateur"
 
     SEARCH_PRO_ACCOUNT = "rechercher un acteur culturel"
     READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -191,7 +191,7 @@ def get_user_subscription_history(user_id: int) -> serialization.GetUserSubscrip
     on_success_status=200,
     api=blueprint.api,
 )
-@perm_utils.permission_required(perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT)
+@perm_utils.permission_required(perm_models.Permissions.REVIEW_SUSPEND_USER)
 def review_public_account(
     user_id: int, body: serialization.BeneficiaryReviewRequestModel
 ) -> serialization.BeneficiaryReviewResponseModel:

--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -16,6 +16,7 @@ def install_routes(app: Flask) -> None:
     from . import offers
     from . import pro
     from . import pro_users
+    from . import users
     from . import venues
 
     filters.install_template_filters(app)

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -35,6 +35,7 @@ from . import utils
 from .forms import account as account_forms
 from .forms import empty as empty_forms
 from .forms import search as search_forms
+from .forms import user as user_forms
 from .serialization import accounts
 from .serialization import search
 
@@ -129,16 +130,19 @@ def get_public_account(user_id: int) -> utils.BackofficeResponse:
         .order_by(bookings_models.Booking.dateCreated.desc())
     ).all()
 
+    empty_form = empty_forms.EmptyForm()
+
     return render_template(
         "accounts/get.html",
         user=user,
         credit=domains_credit,
         history=history,
         eligibility_history=eligibility_history,
-        resend_email_validation_form=empty_forms.EmptyForm(),
-        send_validation_code_form=empty_forms.EmptyForm(),
-        manual_validation_form=empty_forms.EmptyForm(),
+        resend_email_validation_form=empty_form,
+        send_validation_code_form=empty_form,
+        manual_validation_form=empty_form,
         bookings=bookings,
+        **user_forms.get_toggle_suspension_args(user),
     )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/blueprint.py
@@ -44,6 +44,5 @@ def extra_funcs() -> dict:
     return {
         "csrf_token": empty_forms.EmptyForm().csrf_token,
         "has_permission": utils.has_current_user_permission,
-        "can_user_add_comment": utils.can_user_add_comment,
         "is_user_offerer_action_type": utils.is_user_offerer_action_type,
     }

--- a/api/src/pcapi/routes/backoffice_v3/forms/user.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/user.py
@@ -1,0 +1,42 @@
+from flask import url_for
+from flask_wtf import FlaskForm
+
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.users import constants as users_constants
+from pcapi.core.users import models as users_models
+from pcapi.routes.backoffice_v3.utils import has_current_user_permission
+
+from . import fields
+
+
+class SuspendUserForm(FlaskForm):
+    reason = fields.PCSelectWithPlaceholderValueField(
+        "Raison de la suspension",
+        choices=[
+            (opt.name, users_constants.SUSPENSION_REASON_CHOICES[opt]) for opt in users_constants.SuspensionReason
+        ],
+    )
+    comment = fields.PCOptStringField("Commentaire interne optionnel")
+
+
+class UnsuspendUserForm(FlaskForm):
+    comment = fields.PCOptStringField("Commentaire interne optionnel")
+
+
+def get_toggle_suspension_args(user: users_models.User) -> dict:
+    """
+    Additional arguments which must be passed to render_template when the page may show suspend/unsuspend button.
+    """
+    if not has_current_user_permission(perm_models.Permissions.REVIEW_SUSPEND_USER):
+        return {}
+
+    if user.isActive:
+        return {
+            "suspension_form": SuspendUserForm(),
+            "suspension_dst": url_for("backoffice_v3_web.users.suspend_user", user_id=user.id),
+        }
+
+    return {
+        "suspension_form": UnsuspendUserForm(),
+        "suspension_dst": url_for("backoffice_v3_web.users.unsuspend_user", user_id=user.id),
+    }

--- a/api/src/pcapi/routes/backoffice_v3/pro_users.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_users.py
@@ -87,10 +87,7 @@ def update_pro_user(user_id: int) -> utils.BackofficeResponse:
     if not form.validate():
         dst = url_for(".update_pro_user", user_id=user_id)
         flash("Le formulaire n'est pas valide", "warning")
-        return (
-            render_template("pro_user/get.html", form=form, dst=dst, user=user, can_edit_user=True),
-            400,
-        )
+        return render_template("pro_user/get.html", form=form, dst=dst, user=user), 400
 
     snapshot = users_api.update_user_info(
         user,

--- a/api/src/pcapi/routes/backoffice_v3/pro_users.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_users.py
@@ -18,6 +18,7 @@ import pcapi.utils.email as email_utils
 
 from . import utils
 from .forms import pro_user as pro_user_forms
+from .forms import user as user_forms
 
 
 pro_user_blueprint = utils.child_backoffice_blueprint(
@@ -48,7 +49,9 @@ def get(user_id: int) -> utils.BackofficeResponse:
     )
     dst = url_for(".update_pro_user", user_id=user.id)
 
-    return render_template("pro_user/get.html", user=user, form=form, dst=dst)
+    return render_template(
+        "pro_user/get.html", user=user, form=form, dst=dst, **user_forms.get_toggle_suspension_args(user)
+    )
 
 
 @pro_user_blueprint.route("/details", methods=["GET"])

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -1,3 +1,5 @@
+{% from "components/generic_modal.html" import build_modal_form %}
+
 <div class="row row-cols-1 g-4 py-3">
     <div class="col">
         <div class="card">
@@ -37,15 +39,21 @@
                             }} </p>
                     </div>
 
-                    {% if has_permission("MANUAL_REVIEW_PUBLIC_ACCOUNT") %}
+                    {% if has_permission("REVIEW_SUSPEND_USER") %}
                         <div class="col-4">
-
-                            <a href="{{ url_for('.edit_public_account_review', user_id=user.id) }}"
-                               class="card-link btn btn-outline-primary lead fw-bold mt-2">
-
-                                Revue manuelle
-
-                            </a>
+                            <div>
+                                {% if user.isActive %}
+                                    {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
+                                {% else %}
+                                    {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
+                                {% endif %}
+                            </div>
+                            <div>
+                                <a href="{{ url_for('.edit_public_account_review', user_id=user.id) }}"
+                                   class="card-link btn btn-outline-primary lead fw-bold mt-2">
+                                    Revue manuelle
+                                </a>
+                            </div>
                         </div>
                     {% endif %}
                 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_with_placeholder_value_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_with_placeholder_value_field.html
@@ -1,5 +1,5 @@
 <div class="form-floating">
-    <select class="form-select" id="{{ field.name }}" name="{{ field.name }}" aria-label="{{ field.name }}">
+    <select class="form-select" id="{{ field.name }}" name="{{ field.name }}" aria-label="{{ field.name }}" {% if field.flags.required %}required{% endif %}>
         <option value="" selected>---Sélectionnez une valeur---</option>
         {% for choice_value, choice_label in field.choices %}
             <option value="{{ choice_value }}">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
@@ -1,0 +1,37 @@
+{% macro build_modal_form(modal_id, dst, form, title, button_text) %}
+    <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
+        data-bs-target="#{{ modal_id }}-modal" type="button">
+        {{ title }}
+    </button>
+    <div class="modal modal-lg fade" id="{{ modal_id }}-modal" tabindex="-1"
+        aria-describedby="{{ modal_id }}-modal-label" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header fs-5" id="{{ modal_id }}-modal-label">
+                    {{ title }}
+                </div>
+                <form action="{{ dst }}" method="POST">
+                    <div class="modal-body">
+                        <div class="form-group">
+                            {% for form_field in form %}
+                                <div class="w-100 my-4">
+                                    {% for error in form_field.errors %}
+                                        <p class="text-warning lead">{{ error }}</p>
+                                    {% endfor %}
+                                </div>
+                                {{ form_field }}
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-outline-primary"
+                                data-bs-dismiss="modal">
+                            Annuler
+                        </button>
+                        <button type="submit" class="btn btn-primary">{{ button_text }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
@@ -19,8 +19,6 @@
                         <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=action.userId) }}" class="link-primary">
                             {{ action.user.full_name | empty_string_if_null }} - {{ action.userId }}
                         </a>
-
-                        <p>{{ action.comment | empty_string_if_null | replace("\n", "<br/>"|safe) }}</p>
                     {% elif action.actionType.name == "INFO_MODIFIED" %}
                         <p class="fw-bold">Informations modifiées</p>
                         {% for info_name, modified_info in action.extraData.get('modified_info', {}).items() %}
@@ -31,7 +29,8 @@
                         {% endfor %}
                     {% elif action.actionType.name == "USER_SUSPENDED" %}
                         <p>{{ action.extraData['reason'] | format_reason_label }}</p>
-                    {% else %}
+                    {% endif %}
+                    {% if action.comment %}
                         <p>{{ action.comment | empty_string_if_null | replace("\n", "<br/>"|safe) }}</p>
                     {% endif %}
                 </td>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/comment.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/comment.html
@@ -1,6 +1,6 @@
-{# This macro must be imported with context because of can_user_add_comment() #} 
+{# This macro must be imported with context because of has_permission() #}
 {% macro build_comment_modal(dst, form) %}
-    {% if can_user_add_comment() %}
+    {% if has_permission("MANAGE_PRO_ENTITY") %}
         <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
             data-bs-target="#add-comment-pro-user-modal" type="button">
             Ajouter un commentaire

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -21,7 +21,7 @@
                         </span>
                     </div>
                     <div class="col-2">
-                        {% if can_edit_user %}
+                        {% if has_permission("MANAGE_PRO_ENTITY") %}
                             <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
                                     data-bs-target="#edit-offerer-modal" type="button">
                                 Modifier les informations

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -1,4 +1,5 @@
 {% from "components/badges.html" import build_pro_user_badges %}
+{% from "components/generic_modal.html" import build_modal_form %}
 
 {% extends "layouts/pro.html" %}
 
@@ -58,6 +59,13 @@
                                     </div>
                                 </div>
                             </div>
+                        {% endif %}
+                        {% if has_permission("REVIEW_SUSPEND_USER") %}
+                            {% if user.isActive %}
+                                {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
+                            {% else %}
+                                {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/api/src/pcapi/routes/backoffice_v3/users.py
+++ b/api/src/pcapi/routes/backoffice_v3/users.py
@@ -1,0 +1,65 @@
+from flask import flash
+from flask import redirect
+from flask import request
+from flask import url_for
+from flask_login import current_user
+
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.users import api as users_api
+from pcapi.core.users import constants as users_constants
+from pcapi.core.users import models as users_models
+
+from . import utils
+from .forms import user as user_forms
+
+
+# This blueprint is for common actions on User, which can be beneficiary, pro, admin...
+# Currently targets actions related to "Fraude & Conformité"
+users_blueprint = utils.child_backoffice_blueprint(
+    "users",
+    __name__,
+    url_prefix="/users/<int:user_id>",
+    permission=perm_models.Permissions.REVIEW_SUSPEND_USER,
+)
+
+
+def _redirect_to_user_page(user: users_models.User) -> utils.BackofficeResponse:
+    # Actions should always come from user details page
+    if request.referrer:
+        return redirect(request.referrer, code=303)
+
+    # Fallback in case referrer is missing (maybe because of browser settings)
+    if user.UserOfferers:
+        return redirect(url_for("backoffice_v3_web.pro_user.get", user_id=user.id), code=303)
+
+    return redirect(url_for("backoffice_v3_web.public_accounts.get_public_account", user_id=user.id), code=303)
+
+
+@users_blueprint.route("/suspend", methods=["POST"])
+def suspend_user(user_id: int) -> utils.BackofficeResponse:
+    user = users_models.User.query.get_or_404(user_id)
+
+    form = user_forms.SuspendUserForm()
+    if form.validate():
+        users_api.suspend_account(
+            user, users_constants.SuspensionReason[form.reason.data], current_user, comment=form.comment.data
+        )
+        flash(f"Le compte de l'utilisateur {user.email} ({user.id}) a été suspendu", "success")
+    else:
+        flash("Les données envoyées sont invalides", "warning")
+
+    return _redirect_to_user_page(user)
+
+
+@users_blueprint.route("/unsuspend", methods=["POST"])
+def unsuspend_user(user_id: int) -> utils.BackofficeResponse:
+    user = users_models.User.query.get_or_404(user_id)
+
+    form = user_forms.UnsuspendUserForm()
+    if form.validate():
+        users_api.unsuspend_account(user, current_user, comment=form.comment.data)
+        flash(f"Le compte de l'utilisateur {user.email} ({user.id}) a été réactivé", "success")
+    else:
+        flash("Les données envoyées sont invalides", "warning")
+
+    return _redirect_to_user_page(user)

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -106,7 +106,3 @@ def is_user_offerer_action_type(action: history_models.ActionHistory) -> bool:
         history_models.ActionType.USER_OFFERER_REJECTED,
     }
     return action.actionType in user_offerer_action_types
-
-
-def can_user_add_comment() -> bool:
-    return has_current_user_permission(perm_models.Permissions.MANAGE_PRO_ENTITY)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -30,7 +30,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "fraude-conformite": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
-        perm_models.Permissions.MANUAL_REVIEW_PUBLIC_ACCOUNT,
+        perm_models.Permissions.REVIEW_SUSPEND_USER,
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.VALIDATE_OFFERER,

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1096,7 +1096,7 @@ class PostManualReviewTest:
             user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.KO
         )
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1126,7 +1126,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1158,7 +1158,7 @@ class PostManualReviewTest:
             eligibilityType=users_models.EligibilityType.UNDERAGE,
         )
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1186,7 +1186,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1214,7 +1214,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory()
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.AdminFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1238,7 +1238,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1255,7 +1255,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1288,7 +1288,7 @@ class PostManualReviewTest:
         # given
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
-        auth_token = generate_token(users_factories.UserFactory.build(), [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(users_factories.UserFactory.build(), [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1311,7 +1311,7 @@ class PostManualReviewTest:
             resultContent=fraud_factories.UbbleContentFactory(birth_date=birth_date_15_yo.date().isoformat()),
         )
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1326,7 +1326,7 @@ class PostManualReviewTest:
     def test_cannot_review_unknown_account(self, client):
         # given
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1345,7 +1345,7 @@ class PostManualReviewTest:
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         DepositGrantFactory(user=user)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1362,7 +1362,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
 
         # when
         response = client.with_explicit_token(auth_token).post(

--- a/api/tests/routes/backoffice/blueprint_test.py
+++ b/api/tests/routes/backoffice/blueprint_test.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 def test_cors_allowed(client):
     # given
     user = users_factories.UserFactory()
-    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT])
+    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_SUSPEND_USER])
 
     # when
     response = client.with_explicit_token(auth_token).options(
@@ -28,7 +28,7 @@ def test_cors_allowed(client):
 def test_cors_disallowed(client):
     # given
     user = users_factories.UserFactory()
-    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT])
+    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_SUSPEND_USER])
 
     # when
     response = client.with_explicit_token(auth_token).options(

--- a/api/tests/routes/backoffice/permissions_test.py
+++ b/api/tests/routes/backoffice/permissions_test.py
@@ -164,7 +164,7 @@ class NewRoleTest:
         permissions = perm_models.Permission.query.filter(
             perm_models.Permission.name.in_(
                 (
-                    perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT.name,
+                    perm_models.Permissions.REVIEW_SUSPEND_USER.name,
                     perm_models.Permissions.READ_PUBLIC_ACCOUNT.name,
                 )
             )

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -20,6 +20,7 @@ from pcapi.notifications.sms import testing as sms_testing
 import pcapi.utils.email as email_utils
 
 from .helpers import accounts as accounts_helpers
+from .helpers import button as button_helpers
 from .helpers import html_parser
 from .helpers import search as search_helpers
 from .helpers import unauthorized as unauthorized_helpers
@@ -321,6 +322,24 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         endpoint = "backoffice_v3_web.public_accounts.get_public_account"
         endpoint_kwargs = {"user_id": 1}
         needed_permission = perm_models.Permissions.READ_PUBLIC_ACCOUNT
+
+    class SuspendButtonTest(button_helpers.ButtonHelper):
+        needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+        button_label = "Suspendre le compte"
+
+        @property
+        def path(self):
+            user = users_factories.UserFactory()
+            return url_for("backoffice_v3_web.public_accounts.get_public_account", user_id=user.id)
+
+    class UnsuspendButtonTest(button_helpers.ButtonHelper):
+        needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+        button_label = "Réactiver le compte"
+
+        @property
+        def path(self):
+            user = users_factories.UserFactory(isActive=False)
+            return url_for("backoffice_v3_web.public_accounts.get_public_account", user_id=user.id)
 
     @pytest.mark.parametrize(
         "index,expected_badge",

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -53,7 +53,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "fraude-conformite": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
-        perm_models.Permissions.MANUAL_REVIEW_PUBLIC_ACCOUNT,
+        perm_models.Permissions.REVIEW_SUSPEND_USER,
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.VALIDATE_OFFERER,

--- a/api/tests/routes/backoffice_v3/users_test.py
+++ b/api/tests/routes/backoffice_v3/users_test.py
@@ -1,0 +1,143 @@
+from flask import g
+from flask import url_for
+import pytest
+
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import factories as offerers_factories
+import pcapi.core.permissions.models as perm_models
+from pcapi.core.users import constants as users_constants
+from pcapi.core.users import factories as users_factories
+
+from .helpers import html_parser
+from .helpers import unauthorized as unauthorized_helpers
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
+
+
+class PostUserTestHelper(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+    method = "post"
+    endpoint_kwargs = {"user_id": 1}
+    needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+
+    def _post_request(self, authenticated_client, user_id, form):
+        # generate csrf token before request
+        authenticated_client.get(url_for("backoffice_v3_web.public_accounts.get_public_account", user_id=user_id))
+        form["csrf_token"] = g.get("csrf_token", "")
+        return authenticated_client.post(url_for(self.endpoint, user_id=user_id), form=form)
+
+
+class SuspendUserTest(PostUserTestHelper):
+    endpoint = "backoffice_v3_web.users.suspend_user"
+
+    def test_suspend_beneficiary_user(self, authenticated_client, legit_user):
+        user = users_factories.BeneficiaryGrant18Factory()
+
+        response = self._post_request(
+            authenticated_client,
+            user.id,
+            {
+                "reason": users_constants.SuspensionReason.FRAUD_RESELL_PRODUCT.name,
+                "comment": "Le jeune a mis en ligne des annonces de vente le lendemain",
+            },
+        )
+
+        assert response.status_code == 303
+        assert response.location == url_for(
+            "backoffice_v3_web.public_accounts.get_public_account", user_id=user.id, _external=True
+        )
+
+        assert not user.isActive
+        assert len(user.action_history) == 1
+        assert user.action_history[0].actionType == history_models.ActionType.USER_SUSPENDED
+        assert user.action_history[0].authorUser == legit_user
+        assert user.action_history[0].user == user
+        assert user.action_history[0].offererId is None
+        assert user.action_history[0].venueId is None
+        assert user.action_history[0].extraData["reason"] == users_constants.SuspensionReason.FRAUD_RESELL_PRODUCT.value
+        assert user.action_history[0].comment == "Le jeune a mis en ligne des annonces de vente le lendemain"
+
+    def test_suspend_pro_user(self, authenticated_client, legit_user):
+        user = offerers_factories.UserOffererFactory().user
+
+        response = self._post_request(
+            authenticated_client,
+            user.id,
+            {
+                "reason": users_constants.SuspensionReason.FRAUD_USURPATION_PRO.name,
+                "comment": "",  # optional, keep empty
+            },
+        )
+
+        assert response.status_code == 303
+        assert response.location == url_for("backoffice_v3_web.pro_user.get", user_id=user.id, _external=True)
+
+        assert not user.isActive
+        assert len(user.action_history) == 1
+        assert user.action_history[0].actionType == history_models.ActionType.USER_SUSPENDED
+        assert user.action_history[0].authorUser == legit_user
+        assert user.action_history[0].user == user
+        assert user.action_history[0].offererId is None
+        assert user.action_history[0].venueId is None
+        assert user.action_history[0].extraData["reason"] == users_constants.SuspensionReason.FRAUD_USURPATION_PRO.value
+        assert user.action_history[0].comment is None
+
+    def test_suspend_without_reason(self, authenticated_client, legit_user):
+        user = users_factories.UnderageBeneficiaryFactory()
+
+        response = self._post_request(authenticated_client, user.id, {"reason": "", "comment": ""})
+
+        assert response.status_code == 303
+        assert response.location == url_for(
+            "backoffice_v3_web.public_accounts.get_public_account", user_id=user.id, _external=True
+        )
+
+        redirected_response = authenticated_client.get(response.location)
+        assert "Les données envoyées sont invalides" in html_parser.extract_alert(redirected_response.data)
+
+        assert user.isActive
+        assert len(user.action_history) == 0
+
+
+class UnsuspendUserTest(PostUserTestHelper):
+    endpoint = "backoffice_v3_web.users.unsuspend_user"
+
+    def test_unsuspend_beneficiary_user(self, authenticated_client, legit_user):
+        user = users_factories.BeneficiaryGrant18Factory(isActive=False)
+
+        response = self._post_request(authenticated_client, user.id, {"comment": ""})
+
+        assert response.status_code == 303
+        assert response.location == url_for(
+            "backoffice_v3_web.public_accounts.get_public_account", user_id=user.id, _external=True
+        )
+
+        assert user.isActive
+        assert len(user.action_history) == 1
+        assert user.action_history[0].actionType == history_models.ActionType.USER_UNSUSPENDED
+        assert user.action_history[0].authorUser == legit_user
+        assert user.action_history[0].user == user
+        assert user.action_history[0].offererId is None
+        assert user.action_history[0].venueId is None
+        assert user.action_history[0].comment is None
+
+    def test_unsuspend_pro_user(self, authenticated_client, legit_user):
+        user = users_factories.ProFactory(isActive=False)
+        offerers_factories.UserOffererFactory(user=user)
+
+        response = self._post_request(authenticated_client, user.id, {"comment": "Réactivé suite à contact avec l'AC"})
+
+        assert response.status_code == 303
+        assert response.location == url_for("backoffice_v3_web.pro_user.get", user_id=user.id, _external=True)
+
+        assert user.isActive
+        assert len(user.action_history) == 1
+        assert user.action_history[0].actionType == history_models.ActionType.USER_UNSUSPENDED
+        assert user.action_history[0].authorUser == legit_user
+        assert user.action_history[0].user == user
+        assert user.action_history[0].offererId is None
+        assert user.action_history[0].venueId is None
+        assert user.action_history[0].comment == "Réactivé suite à contact avec l'AC"

--- a/backoffice/src/resources/PublicUsers/types.tsx
+++ b/backoffice/src/resources/PublicUsers/types.tsx
@@ -8,7 +8,7 @@ export enum PublicUserRolesEnum {
 export enum PermissionsEnum {
   managePermissions = 'MANAGE_PERMISSIONS',
   readPublicAccount = 'READ_PUBLIC_ACCOUNT',
-  reviewPublicAccount = 'REVIEW_PUBLIC_ACCOUNT',
+  reviewPublicAccount = 'REVIEW_SUSPEND_USER',
   managePublicAccount = 'MANAGE_PUBLIC_ACCOUNT',
   searchPublicAccount = 'SEARCH_PUBLIC_ACCOUNT',
   searchProAccount = 'SEARCH_PRO_ACCOUNT',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18475

## But de la pull request

Ajouter les boutons de suspension et réactivation de compte utilisateur dans le backoffice v3.
Fonctionnalité similaire à Flask-Admin et réservée à l'équipe Fraude & Conformité (comme la revue manuelle).

## Implémentation

Plus de détails sur les spécifications dans le ticket.

À noter : j'ai renommé une permission, qui se retrouvera donc nouvelle, et sera à réaffecter dans les rôles sur les différents environnements.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
