### PR TITLE
(PC-20019)[API] feat: Prevent deregistered users from re-activating their deactivated offers

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -730,6 +730,22 @@ def get_collective_offer_by_id(offer_id: int) -> educational_models.CollectiveOf
         raise educational_exceptions.CollectiveOfferNotFound()
 
 
+def get_offerer_ids_from_collective_offers_ids(offers_ids: list[int]) -> set[int]:
+    query = db.session.query(offerers_models.Offerer.id)
+    query = query.join(offerers_models.Offerer, offerers_models.Venue.managingOfferer)
+    query = query.join(educational_models.CollectiveOffer, offerers_models.Venue.collectiveOffers)
+    query = query.filter(educational_models.CollectiveOffer.id.in_(offers_ids))
+    return {result[0] for result in query.all()}
+
+
+def get_offerer_ids_from_collective_offers_template_ids(offers_ids: list[int]) -> set[int]:
+    query = db.session.query(offerers_models.Offerer.id)
+    query = query.join(offerers_models.Offerer, offerers_models.Venue.managingOfferer)
+    query = query.join(educational_models.CollectiveOfferTemplate, offerers_models.Venue.collectiveOfferTemplates)
+    query = query.filter(educational_models.CollectiveOfferTemplate.id.in_(offers_ids))
+    return {result[0] for result in query.all()}
+
+
 def get_collective_offer_template_by_id(offer_id: int) -> educational_models.CollectiveOfferTemplate:
     try:
         query = educational_models.CollectiveOfferTemplate.query

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -318,6 +318,12 @@ def edit_collective_offer_template(
 def patch_all_collective_offers_active_status(
     body: collective_offers_serialize.PatchAllCollectiveOffersActiveStatusBodyModel,
 ) -> None:
+    if body.is_active:
+        try:
+            offerers_api.can_offerer_create_educational_offer(body.offerer_id)
+        except educational_exceptions.CulturalPartnerNotFoundException:
+            raise ApiErrors({"Partner": ["User not in Adage can't edit the offer"]}, status_code=403)
+
     filters = {
         "user_id": current_user.id,
         "is_user_admin": current_user.has_admin_role,
@@ -342,6 +348,14 @@ def patch_all_collective_offers_active_status(
 def patch_collective_offers_active_status(
     body: collective_offers_serialize.PatchCollectiveOfferActiveStatusBodyModel,
 ) -> None:
+    if body.is_active:
+        offerers_ids = educational_repository.get_offerer_ids_from_collective_offers_ids(body.ids)
+        for offerer_id in offerers_ids:
+            try:
+                offerers_api.can_offerer_create_educational_offer(offerer_id)
+            except educational_exceptions.CulturalPartnerNotFoundException:
+                raise ApiErrors({"Partner": ["User not in Adage can't edit the offer"]}, status_code=403)
+
     collective_query = educational_api_offer.get_query_for_collective_offers_by_ids_for_user(current_user, body.ids)
     offers_api.batch_update_collective_offers(collective_query, {"isActive": body.is_active})
 
@@ -355,6 +369,14 @@ def patch_collective_offers_active_status(
 def patch_collective_offers_template_active_status(
     body: collective_offers_serialize.PatchCollectiveOfferActiveStatusBodyModel,
 ) -> None:
+    if body.is_active:
+        offerers_ids = educational_repository.get_offerer_ids_from_collective_offers_template_ids(body.ids)
+        for offerer_id in offerers_ids:
+            try:
+                offerers_api.can_offerer_create_educational_offer(offerer_id)
+            except educational_exceptions.CulturalPartnerNotFoundException:
+                raise ApiErrors({"Partner": ["User not in Adage can't edit the offer"]}, status_code=403)
+
     collective_template_query = educational_api_offer.get_query_for_collective_offers_template_by_ids_for_user(
         current_user, body.ids
     )

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from freezegun import freeze_time
 import pytest
 
+from pcapi.core.educational.exceptions import CulturalPartnerNotFoundException
 from pcapi.core.educational.factories import CollectiveBookingFactory
 from pcapi.core.educational.factories import CollectiveOfferFactory
 from pcapi.core.educational.factories import CollectiveOfferTemplateFactory
@@ -400,6 +402,7 @@ class Returns400Test:
         assert response.status_code == 400
 
 
+@pytest.mark.usefixtures("db_session")
 class Returns403Test:
     def when_user_is_not_attached_to_offerer(self, app, client):
         # Given
@@ -483,6 +486,33 @@ class Returns403Test:
         # Then
         assert response.status_code == 403
         assert response.json == {"venueId": "New venue needs to have the same offerer"}
+
+    def test_when_activating_all_existing_offers_active_status_when_cultural_partners_not_found(self, client):
+        # Given
+        offer1 = CollectiveOfferFactory(isActive=False)
+        venue = offer1.venue
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+
+        # When
+        client = client.with_session_auth("pro@example.com")
+        data = {
+            "isActive": True,
+            "offererId": offerer.id,
+            "page": 1,
+            "venueId": humanize(venue.id),
+        }
+
+        with patch(
+            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
+            side_effect=CulturalPartnerNotFoundException,
+        ):
+            response = client.patch("/collective/offers/all-active-status", json=data)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json == {"Partner": ["User not in Adage can't edit the offer"]}
+        assert offer1.isActive == False
 
 
 class Returns404Test:

--- a/api/tests/routes/pro/patch_collective_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_active_status_test.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
 from pcapi.core import testing
+from pcapi.core.educational.exceptions import CulturalPartnerNotFoundException
 from pcapi.core.educational.factories import CollectiveOfferFactory
 from pcapi.core.educational.models import CollectiveOffer
 import pcapi.core.offerers.factories as offerers_factories
@@ -17,11 +20,15 @@ class Returns204Test:
         offer2 = CollectiveOfferFactory(venue=venue, isActive=False)
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+        client = client.with_session_auth("pro@example.com")
 
         # When
-        client = client.with_session_auth("pro@example.com")
         data = {"ids": [humanize(offer1.id), humanize(offer2.id)], "isActive": True}
-        response = client.patch("/collective/offers/active-status", json=data)
+
+        with patch(
+            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
+        ):
+            response = client.with_session_auth("pro@example.com").patch("/collective/offers/active-status", json=data)
 
         # Then
         assert response.status_code == 204
@@ -55,14 +62,44 @@ class Returns204Test:
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
 
-        client = client.with_session_auth("pro@example.com")
         data = {
             "ids": [humanize(approved_offer.id), humanize(pending_offer.id), humanize(rejected_offer.id)],
             "isActive": True,
         }
-        response = client.patch("/collective/offers/active-status", json=data)
+
+        with patch(
+            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
+        ):
+            client = client.with_session_auth("pro@example.com")
+            response = client.patch("/collective/offers/active-status", json=data)
 
         assert response.status_code == 204
         assert approved_offer.isActive
         assert not pending_offer.isActive
         assert not rejected_offer.isActive
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns403Test:
+    def test_when_activating_all_existing_offers_active_status_when_cultural_partners_not_found(self, client):
+        # Given
+        offer1 = CollectiveOfferFactory(isActive=False)
+        offer2 = CollectiveOfferFactory(isActive=False)
+        venue = offer1.venue
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+
+        # When
+        client = client.with_session_auth("pro@example.com")
+        data = {"ids": [humanize(offer1.id), humanize(offer2.id)], "isActive": True}
+
+        with patch(
+            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
+            side_effect=CulturalPartnerNotFoundException,
+        ):
+            response = client.patch("/collective/offers/active-status", json=data)
+
+        # Then
+        assert response.status_code == 403
+        assert response.json == {"Partner": ["User not in Adage can't edit the offer"]}
+        assert offer1.isActive == False


### PR DESCRIPTION
Prevent deregistered users from re-activating their deactivated offers

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20019

## But de la pull request

empecher les utilisateurs non enregistré de réactiver leur offre désactivé
