### PR TITLE
(PC-19878)[PRO] feat: change info message if ff CLG 6 active

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import FormLayout from 'components/FormLayout'
 import { IOfferEducationalFormValues } from 'core/OfferEducational'
+import useActiveFeature from 'hooks/useActiveFeature'
 import { CheckboxGroup, InfoBox } from 'ui-kit'
 
 import { participantsOptions } from './participantsOptions'
@@ -22,13 +23,17 @@ const FormParticipants = ({
 
   useParicipantUpdates(values.participants, handleParticipantsChange)
 
+  const isCLG6Active = useActiveFeature('WIP_ADD_CLG_6_5_COLLECTIVE_OFFER')
+
   return (
     <FormLayout.Section title="Participants">
       <FormLayout.Row
         sideComponent={
           <InfoBox
             type="info"
-            text="Le pass Culture à destination du public scolaire s’adresse aux élèves de la quatrième à la terminale des établissements publics et privés sous contrat."
+            text={`Le pass Culture à destination du public scolaire s’adresse aux élèves de la ${
+              isCLG6Active ? 'sixième' : 'quatrième'
+            } à la terminale des établissements publics et privés sous contrat.`}
           />
         }
       >

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -17,6 +17,12 @@ const initialValues = {
   },
 }
 
+// TO FIX : remove when WIP_ADD_CLG_6_5_COLLECTIVE_OFFER is active in prod
+jest.mock('hooks/useActiveFeature', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(false),
+}))
+
 describe('FormParticipants', () => {
   it('should render all options with default value', async () => {
     render(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19878

## But de la pull request

Changer le wording de l'info box concernant les participants d'une offre collective quand le FF `WIP_ADD_CLG_6_5_COLLECTIVE_OFFER` est actif 
