### PR TITLE
(PC-20156)[API] feat: Suivi des réservations - Code couleur et ajout d'informations

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -10,6 +10,7 @@ from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories_v2
 from pcapi.core.criteria import models as criteria_models
 from pcapi.core.educational import models as educational_models
+from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
@@ -41,6 +42,16 @@ def format_role(role: str | None) -> str:
             return "Pass 18"
         case users_models.UserRole.UNDERAGE_BENEFICIARY:
             return "Pass 15-17"
+        case _:
+            return "Aucune information"
+
+
+def format_deposit_type(deposit_type: finance_models.DepositType) -> str:
+    match deposit_type:
+        case finance_models.DepositType.GRANT_18:
+            return "<span class='badge text-bg-secondary'>Pass 18</span>"
+        case finance_models.DepositType.GRANT_15_17:
+            return "<span class='badge text-bg-secondary'>Pass 15-17</span>"
         case _:
             return "Aucune information"
 
@@ -111,13 +122,13 @@ def format_booking_cancellation_reason(reason: bookings_models.BookingCancellati
 def format_booking_status_long(status: bookings_models.BookingStatus) -> str:
     match status:
         case bookings_models.BookingStatus.CONFIRMED:
-            return "Réservation confirmée"
+            return "<span class='badge text-bg-success'>Réservation confirmée</span>"
         case bookings_models.BookingStatus.USED:
             return "Le jeune a consommé l'offre"
         case bookings_models.BookingStatus.CANCELLED:
-            return "L'offre n'a pas eu lieu"
+            return "<span class='badge text-bg-danger'>L'offre n'a pas eu lieu</span>"
         case bookings_models.BookingStatus.REIMBURSED:
-            return "AC remboursé"
+            return "<span class='badge text-bg-success'>AC remboursé</span>"
         case _:
             return status.value
 
@@ -192,6 +203,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_bool"] = format_bool
     app.jinja_env.filters["format_string_list"] = format_string_list
     app.jinja_env.filters["format_date"] = format_date
+    app.jinja_env.filters["format_deposit_type"] = format_deposit_type
     app.jinja_env.filters["format_offer_validation_status"] = format_offer_validation_status
     app.jinja_env.filters["format_offer_category"] = format_offer_category
     app.jinja_env.filters["format_criteria"] = format_criteria

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
@@ -1,67 +1,97 @@
 {% if bookings %}
-  <table class="table mb-4">
-    <thead>
-      <tr>
-        <th scope="col"></th>
-        <th scope="col">Offreur</th>
-        <th scope="col">Nom de l'offre</th>
-        <th scope="col">Prix</th>
-        <th scope="col">Date de résa</th>
-        <th scope="col">État</th>
-        <th scope="col">Contremarque</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for booking in bookings %}
+    <table class="table mb-4">
+        <thead>
         <tr>
-          <th scope="row" data-bs-toggle="collapse" data-bs-target="#b{{ booking.id }}">
-            <i class="bi bi-chevron-down"></i>
-          </th>
-          <td>{{ booking.offerer.name | escape }}</td>
-          <td>
-            <a href="{{ booking.stock.offer | pc_pro_offer_link }}" target="_blank" class="link-primary">
-              {{ booking.stock.offer.name | escape }}
-            </a>
-          </td>
-          <td>
-            {{ booking.amount | format_amount }}
-            {% if booking.stock.offer.isDuo %}(Duo){% endif %}
-          </td>
-          <td>{{ booking.dateCreated | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
-          <td>{{ booking.status | format_booking_status_long }}</td>
-          <td>{{ booking.token | empty_string_if_null }}</td>
+            <th scope="col"></th>
+            <th scope="col">Offreur</th>
+            <th scope="col">Nom de l'offre</th>
+            <th scope="col">Prix</th>
+            <th scope="col">Date de résa</th>
+            <th scope="col">État</th>
+            <th scope="col">Contremarque</th>
         </tr>
-        <tr class="collapse accordion-collapse" id="b{{ booking.id }}" data-bs-parent=".table">
-          <td colspan="7">
-            <div class="card shadow-sm p-3">
-              {% if booking.is_used_or_reimbursed %}
-                <p class="mb-1">
-                  <span class="fw-bold">Utilisée le :</span>
-                  {{ booking.dateUsed | format_date("%d/%m/%Y à %Hh%M") }}
-                </p>
-              {% elif booking.is_cancelled %}
-                <p class="mb-1">
-                  <span class="fw-bold">Annulée le :</span>
-                  {{ booking.cancellationDate | format_date("%d/%m/%Y à %Hh%M") }}
-                </p>
-                <p class="mb-1">
-                  <span class="fw-bold">Motif d'annulation :</span>
-                  {{ booking.cancellationReason | format_booking_cancellation_reason }}
-                </p>
-              {% endif %}
-              <p class="mb-1">
-                <span class="fw-bold">Type d'offre :</span>
-                {% if booking.stock.offer.isDigital %}Numérique{% else %}Physique{% endif %}
-              </p>
-              <p class="mb-1">
-                <span class="fw-bold">Catégorie :</span>
-                {{ booking.stock.offer.subcategoryId | format_offer_category }}
-              </p>
-            </div>
-          </td>
-        </tr>
-      {% endfor %}
-  </table>
+        </thead>
+        <tbody>
+        {% for booking in bookings %}
+            <tr>
+                <th scope="row">
+                    <button class="btn btn-sm btn-outline-primary " data-bs-toggle="collapse"
+                            data-bs-target="#b{{ booking.id }}"><i
+                            class="bi bi-chevron-right"
+                            id="#icn-{{ booking.id }}"></i>
+                    </button>
+                </th>
+                <td>{{ booking.offerer.name | escape }}</td>
+                <td>
+                    <a href="{{ booking.stock.offer | pc_pro_offer_link }}" target="_blank" class="link-primary">
+                        {{ booking.stock.offer.name | escape }}
+                    </a>
+                </td>
+                <td>
+                    {{ booking.amount | format_amount }}
+                    {% if booking.stock.offer.isDuo %}(Duo){% endif %}
+                </td>
+                <td>{{ booking.dateCreated | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
+                <td>{{ booking.status | format_booking_status_long | safe }}</td>
+                <td>{{ booking.token | empty_string_if_null }}</td>
+            </tr>
+            <tr class="collapse accordion-collapse" id="b{{ booking.id }}" data-bs-parent=".table">
+                <td colspan="7">
+                    <div class="card shadow-sm p-3">
+                        {% if booking.stock.beginningDatetime %}
+                            <p class="mb-1">
+                                <span class="fw-bold">Date de l'évènement :</span>
+                                {{ booking.stock.beginningDatetime | format_date("%d/%m/%Y à %Hh%M") }}
+                            </p>
+                        {% endif %}
+                        {% if booking.is_used_or_reimbursed %}
+                            <p class="mb-1">
+                                <span class="fw-bold">Utilisée le :</span>
+                                {{ booking.dateUsed | format_date("%d/%m/%Y à %Hh%M") }}
+                            </p>
+                        {% elif booking.is_cancelled %}
+                            <p class="mb-1">
+                                <span class="fw-bold">Annulée le :</span>
+                                {{ booking.cancellationDate | format_date("%d/%m/%Y à %Hh%M") }}
+                            </p>
+                            <p class="mb-1">
+                                <span class="fw-bold">Motif d'annulation :</span>
+                                {{ booking.cancellationReason | format_booking_cancellation_reason }}
+                            </p>
+                        {% endif %}
+                        <p class="mb-1">
+                            <span class="fw-bold">Type d'offre :</span>
+                            {% if booking.stock.offer.isDigital %}Numérique{% else %}Physique{% endif %}
+                        </p>
+                        <p class="mb-1">
+                            <span class="fw-bold">Catégorie :</span>
+                            {{ booking.stock.offer.subcategoryId | format_offer_category }}
+                        </p>
+                        <p class="mb-1">
+                            <span class="fw-bold">Crédit utilisé par le jeune :</span>
+                            {{ booking.deposit.type | format_deposit_type | safe }}
+                        </p>
+
+                    </div>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
 {% else %}
-  <p class="m-5">Aucune réservation à ce jour</p>
+    <p class="m-5">Aucune réservation à ce jour</p>
 {% endif %}
+
+{% block scripts %}
+    <script>
+        document.querySelectorAll("[data-bs-toggle= 'collapse']").forEach((el) => {
+            el.addEventListener('click', (event) => {
+                //**
+                // check if the event target is `<button> <i></i> </button>` or is simply `<i></i>`
+                // */
+                var icon = event.target.children[0] ? event.target.children[0] : event.target
+                icon.classList.toggle("bi-chevron-down")
+                icon.classList.toggle("bi-chevron-right")
+            })
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20156

## But de la pull request

- Sur l’onglet “Suivi des réservations” sur le profil jeune, ajout d’un code couleur sur la colonne statut : 
    - Surligner la ligne en vert si le statut = validée ou remboursée
    - Surligner la ligne en rouge si statut = annulée
    - Ne pas surligner la ligne si statut autre
- La flèche pointe vers la droite lorsque la sous ligne masquée, elle pointe vers le bas lorsqu’elle est ouverte 
    - Mettre la flèche en rouge pour indiquer à l’utilisateur qu’elle est cliquable 
- Sur la sous ligne d’une réservation, ajout des informations suivantes : 
    - Date de l’événement (s’il s’agit d’un événement daté, sinon on ne l’affiche pas)
    - Le crédit utilisé par le jeune (Pass 15-17 ou Pass 18)

## Implémentation

- Changement du bouton de développement de la rangée du tableau
- Ajout d'informations dans la rangée développée 
- Ajout d'un filtre de type de _deposit_ pour le template jinja

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

<img width="1835" alt="Capture d’écran 2023-02-06 à 15 14 30" src="https://user-images.githubusercontent.com/9610732/216994355-6f6b079a-1229-4246-9c14-0687bc19f8f6.png">
<img width="1849" alt="Capture d’écran 2023-02-06 à 15 14 46" src="https://user-images.githubusercontent.com/9610732/216994366-72567989-4b1a-4c2b-a436-148355e8230f.png">
<img width="1833" alt="Capture d’écran 2023-02-06 à 11 33 18" src="https://user-images.githubusercontent.com/9610732/216994369-1c60af14-92e4-4251-bdcc-35436b28f589.png">
