### PR TITLE
(PC-19603)[API] fix: move foreignKey creation to post migration

### DIFF
--- a/api/src/pcapi/alembic/versions/20230130T150624_1eab834f493d_addpricecategory.py
+++ b/api/src/pcapi/alembic/versions/20230130T150624_1eab834f493d_addpricecategory.py
@@ -29,7 +29,6 @@ def upgrade() -> None:
         sa.Column("offerId", sa.BigInteger(), nullable=False),
         sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=False),
         sa.Column("priceCategoryLabelId", sa.BigInteger(), nullable=False),
-        sa.ForeignKeyConstraint(["offerId"], ["offer.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(
             ["priceCategoryLabelId"],
             ["price_category_label.id"],

--- a/api/src/pcapi/alembic/versions/20230202T171059_930a602ac1af_add_stock_pricecategoryid_foreign_key.py
+++ b/api/src/pcapi/alembic/versions/20230202T171059_930a602ac1af_add_stock_pricecategoryid_foreign_key.py
@@ -20,10 +20,22 @@ def upgrade() -> None:
         ALTER TABLE stock ADD CONSTRAINT "stock_priceCategoryId_fkey" FOREIGN KEY ("priceCategoryId") REFERENCES "price_category" ("id") NOT VALID
         """
     )
+
+    op.execute(
+        """
+        ALTER TABLE price_category DROP CONSTRAINT IF EXISTS "price_category_offerId_fkey";
+        ALTER TABLE price_category ADD CONSTRAINT "price_category_offerId_fkey" FOREIGN KEY ("offerId") REFERENCES "offer" ("id") ON DELETE CASCADE NOT VALID;
+        """
+    )
     op.execute(f"""SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}""")
 
 
 def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE offer DROP CONSTRAINT IF EXISTS "price_category_offerId_fkey";
+        """
+    )
     op.execute(
         """
         ALTER TABLE stock DROP CONSTRAINT "stock_priceCategoryId_fkey"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19603
Both tables are locked during foreign key creation, to create it without downtime see [this article](https://travisofthenorth.com/blog/2017/2/2/postgres-adding-foreign-keys-with-zero-downtime). 
Note : **both** tables are locked during the creation of the fkey
Other foreign key created are : 
price_category -> venue (not many lines)
price_category -> price_category_label (no lines)