### PR TITLE
(PC-19876)[PRO] feat: hide clg 5 and 6 if ff is not active

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -1,6 +1,7 @@
 import { useFormikContext } from 'formik'
 import React from 'react'
 
+import { StudentLevels } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout'
 import { IOfferEducationalFormValues } from 'core/OfferEducational'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -25,6 +26,14 @@ const FormParticipants = ({
 
   const isCLG6Active = useActiveFeature('WIP_ADD_CLG_6_5_COLLECTIVE_OFFER')
 
+  const filteredParticipantsOptions = isCLG6Active
+    ? participantsOptions
+    : participantsOptions.filter(
+        x =>
+          x.label !== StudentLevels.COLL_GE_6E &&
+          x.label !== StudentLevels.COLL_GE_5E
+      )
+
   return (
     <FormLayout.Section title="Participants">
       <FormLayout.Row
@@ -38,7 +47,7 @@ const FormParticipants = ({
         }
       >
         <CheckboxGroup
-          group={participantsOptions}
+          group={filteredParticipantsOptions}
           groupName="participants"
           legend="Cette offre s'adresse aux élèves de :"
           disabled={disableForm}

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -1,35 +1,54 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Formik } from 'formik'
 import React from 'react'
 
 import { StudentLevels } from 'apiClient/v1'
 import { buildStudentLevelsMapWithDefaultValue } from 'core/OfferEducational/utils/buildStudentLevelsMapWithDefaultValue'
+import { RootState } from 'store/reducers'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import FormParticipants from '../FormParticipants'
 import { ALL_STUDENTS_LABEL } from '../participantsOptions'
 
-const initialValues = {
-  participants: {
+const filteredParticipants = Object.values(StudentLevels).filter(
+  studentLevel =>
+    studentLevel !== StudentLevels.COLL_GE_6E &&
+    studentLevel !== StudentLevels.COLL_GE_5E
+)
+
+const renderFormParticipants = (
+  participants: Record<string, boolean>,
+  storeOverride?: Partial<RootState>
+) => {
+  const storeOverrides = {
+    features: {
+      initialized: true,
+      list: [
+        {
+          isActive: false,
+          nameKey: 'WIP_ADD_CLG_6_5_COLLECTIVE_OFFER',
+        },
+      ],
+    },
+    ...storeOverride,
+  }
+  return renderWithProviders(
+    <Formik initialValues={{ participants }} onSubmit={() => {}}>
+      <FormParticipants disableForm={false} />
+    </Formik>,
+    { storeOverrides }
+  )
+}
+
+describe('FormParticipants', () => {
+  let participants: Record<string, boolean> = {
     ...buildStudentLevelsMapWithDefaultValue(true),
     CAPAnnee2: false,
     all: false,
-  },
-}
-
-// TO FIX : remove when WIP_ADD_CLG_6_5_COLLECTIVE_OFFER is active in prod
-jest.mock('hooks/useActiveFeature', () => ({
-  __esModule: true,
-  default: jest.fn().mockReturnValue(false),
-}))
-
-describe('FormParticipants', () => {
+  }
   it('should render all options with default value', async () => {
-    render(
-      <Formik initialValues={initialValues} onSubmit={() => {}}>
-        <FormParticipants disableForm={false} />
-      </Formik>
-    )
+    renderFormParticipants(participants)
     expect(await screen.findAllByRole('checkbox')).toHaveLength(8)
     expect(
       screen.getByRole('checkbox', { name: StudentLevels.LYC_E_PREMI_RE })
@@ -38,18 +57,11 @@ describe('FormParticipants', () => {
 
   describe('useParticipantUpdates', () => {
     it('should set all participants to true when user selects "all"', async () => {
-      const initialValues = {
-        participants: {
-          ...buildStudentLevelsMapWithDefaultValue(false),
-          all: false,
-        },
+      participants = {
+        ...buildStudentLevelsMapWithDefaultValue(false),
+        all: false,
       }
-
-      render(
-        <Formik initialValues={initialValues} onSubmit={() => {}}>
-          <FormParticipants disableForm={false} />
-        </Formik>
-      )
+      renderFormParticipants(participants)
       const allStudentsCheckbox = screen.getByRole('checkbox', {
         name: ALL_STUDENTS_LABEL,
       })
@@ -58,7 +70,7 @@ describe('FormParticipants', () => {
       await waitFor(() =>
         expect(screen.getByLabelText(ALL_STUDENTS_LABEL)).toBeChecked()
       )
-      Object.values(StudentLevels).forEach(studentLevel => {
+      filteredParticipants.forEach(studentLevel => {
         const studentLevelCheckbox = screen.getByRole('checkbox', {
           name: studentLevel,
         })
@@ -67,18 +79,11 @@ describe('FormParticipants', () => {
     })
 
     it('should set all participants to false when user unselects "all"', async () => {
-      const initialValues = {
-        participants: {
-          ...buildStudentLevelsMapWithDefaultValue(true),
-          all: true,
-        },
+      participants = {
+        ...buildStudentLevelsMapWithDefaultValue(true),
+        all: true,
       }
-
-      render(
-        <Formik initialValues={initialValues} onSubmit={() => {}}>
-          <FormParticipants disableForm={false} />
-        </Formik>
-      )
+      renderFormParticipants(participants)
       const allStudentsCheckbox = screen.getByRole('checkbox', {
         name: ALL_STUDENTS_LABEL,
       })
@@ -87,7 +92,7 @@ describe('FormParticipants', () => {
       await waitFor(() =>
         expect(screen.getByLabelText(ALL_STUDENTS_LABEL)).not.toBeChecked()
       )
-      Object.values(StudentLevels).forEach(studentLevel => {
+      filteredParticipants.forEach(studentLevel => {
         const studentLevelCheckbox = screen.getByRole('checkbox', {
           name: studentLevel,
         })
@@ -96,19 +101,13 @@ describe('FormParticipants', () => {
     })
 
     it('should select "all" when user selects all participants', async () => {
-      const initialValues = {
-        participants: {
-          ...buildStudentLevelsMapWithDefaultValue(true),
-          [StudentLevels.CAP_2E_ANN_E]: false,
-          all: false,
-        },
+      participants = {
+        ...buildStudentLevelsMapWithDefaultValue(true),
+        [StudentLevels.CAP_2E_ANN_E]: false,
+        all: false,
       }
+      renderFormParticipants(participants)
 
-      render(
-        <Formik initialValues={initialValues} onSubmit={() => {}}>
-          <FormParticipants disableForm={false} />
-        </Formik>
-      )
       const allStudentsCheckbox = screen.getByRole('checkbox', {
         name: ALL_STUDENTS_LABEL,
       })
@@ -117,7 +116,7 @@ describe('FormParticipants', () => {
       await waitFor(() =>
         expect(screen.getByLabelText(ALL_STUDENTS_LABEL)).toBeChecked()
       )
-      Object.values(StudentLevels).forEach(studentLevel => {
+      filteredParticipants.forEach(studentLevel => {
         const studentLevelCheckbox = screen.getByRole('checkbox', {
           name: studentLevel,
         })
@@ -126,18 +125,12 @@ describe('FormParticipants', () => {
     })
 
     it('should unselect "all" when user deselects one participant', async () => {
-      const initialValues = {
-        participants: {
-          ...buildStudentLevelsMapWithDefaultValue(true),
-          all: true,
-        },
+      participants = {
+        ...buildStudentLevelsMapWithDefaultValue(true),
+        all: true,
       }
+      renderFormParticipants(participants)
 
-      render(
-        <Formik initialValues={initialValues} onSubmit={() => {}}>
-          <FormParticipants disableForm={false} />
-        </Formik>
-      )
       const quatriemeCheckbox = screen.getByRole('checkbox', {
         name: StudentLevels.COLL_GE_4E,
       })
@@ -148,7 +141,7 @@ describe('FormParticipants', () => {
           screen.getByLabelText(StudentLevels.COLL_GE_4E)
         ).not.toBeChecked()
       )
-      Object.values(StudentLevels)
+      filteredParticipants
         .filter(studentLevel => studentLevel !== StudentLevels.COLL_GE_4E)
         .forEach(studentLevel => {
           const studentLevelCheckbox = screen.getByRole('checkbox', {
@@ -160,20 +153,14 @@ describe('FormParticipants', () => {
     })
 
     it('should not change "all"', async () => {
-      const initialValues = {
-        participants: {
-          ...buildStudentLevelsMapWithDefaultValue(false),
-          [StudentLevels.COLL_GE_4E]: true,
-          [StudentLevels.COLL_GE_3E]: true,
-          all: false,
-        },
+      participants = {
+        ...buildStudentLevelsMapWithDefaultValue(false),
+        [StudentLevels.COLL_GE_4E]: true,
+        [StudentLevels.COLL_GE_3E]: true,
+        all: false,
       }
+      renderFormParticipants(participants)
 
-      render(
-        <Formik initialValues={initialValues} onSubmit={() => {}}>
-          <FormParticipants disableForm={false} />
-        </Formik>
-      )
       const secondeCheckbox = screen.getByRole('checkbox', {
         name: StudentLevels.LYC_E_SECONDE,
       })
@@ -186,6 +173,28 @@ describe('FormParticipants', () => {
         screen.getByLabelText(StudentLevels.CAP_1RE_ANN_E)
       ).not.toBeChecked()
       expect(screen.getByLabelText(ALL_STUDENTS_LABEL)).not.toBeChecked()
+    })
+
+    it('should display clg 6 & 5 if ff active', () => {
+      const storeOverride = {
+        features: {
+          initialized: true,
+          list: [
+            {
+              isActive: true,
+              nameKey: 'WIP_ADD_CLG_6_5_COLLECTIVE_OFFER',
+            },
+          ],
+        },
+      }
+      renderFormParticipants(participants, storeOverride)
+
+      expect(
+        screen.getByLabelText(StudentLevels.COLL_GE_6E)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByLabelText(StudentLevels.COLL_GE_5E)
+      ).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19876

## But de la pull request

Ne pas afficher les options 6e et 5e dans la création d'offres collectives si le FF `WIP_ADD_CLG_6_5_COLLECTIVE_OFFER` n'est pas actif
