### PR TITLE
(BSR)[API] fix: history: handle venue without existing contact

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -181,16 +181,18 @@ def upsert_venue_contact(venue: models.Venue, contact_data: serialize_base.Venue
     """
     venue_contact = venue.contact
     if not venue_contact:
-        venue_contact = models.VenueContact(venue=venue)
+        venue_contact = models.VenueContact()
 
     modifications = {
         field: value
         for field, value in contact_data.dict().items()
         if venue_contact.field_exists_and_has_changed(field, value)
     }
+
     if not modifications:
         return venue
 
+    venue_contact.venue = venue
     venue_contact.email = contact_data.email
     venue_contact.website = contact_data.website
     venue_contact.phone_number = contact_data.phone_number

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -299,7 +299,7 @@ class EditVenueTest:
         user_offerer = offerers_factories.UserOffererFactory(
             user__email="user.pro@test.com",
         )
-        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, contact=None)
 
         contact_data = serialize_base.VenueContactModel(email="other.contact@venue.com", phone_number="0788888888")
 
@@ -309,6 +309,17 @@ class EditVenueTest:
         assert venue.contact
         assert venue.contact.phone_number == contact_data.phone_number
         assert venue.contact.email == contact_data.email
+
+    def test_no_venue_contact_created_if_no_data(self, app):
+        user_offerer = offerers_factories.UserOffererFactory(
+            user__email="user.pro@test.com",
+        )
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, contact=None)
+        empty_contact_data = serialize_base.VenueContactModel()
+
+        offerers_api.update_venue(venue, contact_data=empty_contact_data, author=user_offerer.user)
+
+        assert offerers_models.VenueContact.query.count() == 0
 
     def test_cannot_update_virtual_venue_name(self):
         user = users_factories.UserFactory()


### PR DESCRIPTION
## But de la pull request

Ne pas appeler `trace_update` pour les informations de contact d'un lieu si celui-ci n'as pas de `VenueContact` associé. Sinon, la fonction utilise la cible par défaut, donc ici le lieu ce qui génère des erreurs du style : un lieu n'a pas de champ email.