### PR TITLE
(PC-20359)[PRO] fix: fix reset pre filters for collective bookings

### DIFF
--- a/pro/src/screens/Bookings/Bookings.tsx
+++ b/pro/src/screens/Bookings/Bookings.tsx
@@ -92,8 +92,8 @@ const Bookings = <
 
   const resetAndApplyPreFilters = useCallback(() => {
     resetPreFilters()
-    updateUrl(appliedPreFilters)
-  }, [appliedPreFilters])
+    updateUrl({ ...DEFAULT_PRE_FILTERS })
+  }, [resetPreFilters])
 
   const applyPreFilters = (filters: TPreFilters) => {
     setAppliedPreFilters(filters)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20359

## But de la pull request

Fix le comportement du bouton `Voir toutes les réservations` qui ne réinitialisait pas les filtres correctement. 

## Screenshot

![Capture d’écran 2023-02-08 à 10 25 11](https://user-images.githubusercontent.com/71768799/217489603-858db523-ed70-4acb-ba46-eab7902bdea4.png)
