### PR TITLE
(BSR)[API] test: fix flaky unit test should_notify_users_after_sending_an_email

### DIFF
--- a/api/tests/core/mails/transactional/users/ubble_ko_reminder_test.py
+++ b/api/tests/core/mails/transactional/users/ubble_ko_reminder_test.py
@@ -245,9 +245,7 @@ class SendUbbleKoReminderEmailTest:
 
         assert len(push_testing.requests) == 1
 
-        assert push_testing.requests[0] == {
-            "can_be_asynchronously_retried": True,
-            "event_name": "has_ubble_ko_status",
-            "event_payload": {},
-            "user_ids": [user1.id, user2.id],
-        }
+        assert push_testing.requests[0]["can_be_asynchronously_retried"] is True
+        assert push_testing.requests[0]["event_name"] == "has_ubble_ko_status"
+        assert push_testing.requests[0]["event_payload"] == {}
+        assert set(push_testing.requests[0]["user_ids"]) == {user1.id, user2.id}


### PR DESCRIPTION
## But de la pull request

Correction d'un test unitaire instable.
C'est un test ajouté récemment : https://github.com/pass-culture/pass-culture-main/commit/11f73f75c8cc1035751cbbe50da7c00f204d0cff

Sur master : 
https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/38697/workflows/ffe75614-49f2-4124-865f-7b3265ce369d/jobs/318319

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
