### PR TITLE
(PC-19289)[API] feat: add route for e2e tests requireing educonnect login

### DIFF
--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -90,7 +90,7 @@ class ToDevSendinblueBackend(SendinblueBackend):
             staging_whitelisted_email_recipients = settings.IS_STAGING and recipient.endswith("@yeswehack.ninja")
             # Only for e2e, when IS_RUNNING_TESTS is true and EMAIL_BACKEND is pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend
             # This override can be seen in pass-culture-app-native/.github/workflows/e2e-*.yml
-            e2e_whitelisted_email_recipients = settings.IS_RUNNING_TESTS and is_e2e_recipient
+            e2e_whitelisted_email_recipients = settings.IS_E2E_TESTS and is_e2e_recipient
             if (
                 (user and user.has_test_role)
                 or recipient in settings.WHITELISTED_EMAIL_RECIPIENTS

--- a/api/src/pcapi/routes/serialization/educonnect.py
+++ b/api/src/pcapi/routes/serialization/educonnect.py
@@ -1,0 +1,9 @@
+import datetime
+
+from pcapi.routes.serialization import BaseModel
+
+
+class EduconnectUserE2ERequest(BaseModel):
+    birthDate: datetime.date
+    firstName: str
+    lastName: str

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -22,6 +22,7 @@ IS_PROD = ENV == "production"
 IS_TESTING = ENV == "testing"
 IS_RUNNING_TESTS = os.environ.get("RUN_ENV") == "tests"
 IS_PERFORMANCE_TESTS = bool(os.environ.get("IS_PERFORMANCE_TESTS", False))
+IS_E2E_TESTS = bool(os.environ.get("IS_E2E_TESTS", False))
 assert not (IS_PROD and IS_PERFORMANCE_TESTS)
 
 # Load configuration files

--- a/api/tests/core/mails/tests.py
+++ b/api/tests/core/mails/tests.py
@@ -153,8 +153,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert list(task_param.recipients) == [recipient]
         assert result.successful
 
-    @override_settings(IS_STAGING=True)
-    @override_settings(END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
+    @override_settings(IS_STAGING=True, IS_E2E_TESTS=True, END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail_whitelisted_qa_staging(self, mock_send_transactional_email_secondary_task):
         recipient = "qa-test+123@passculture.app"
@@ -168,8 +167,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert list(task_param.recipients) == [recipient]
         assert result.successful
 
-    @override_settings(IS_TESTING=True)
-    @override_settings(END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
+    @override_settings(IS_TESTING=True, IS_E2E_TESTS=True, END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_secondary_task.delay")
     def test_send_mail_whitelisted_qa_testing(
         self, mock_send_transactional_email_secondary_task, recipient="qa-test+123@passculture.app"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19289

## But de la pull request

Adaptation de la route login d'educonnect pour les tests e2e

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
