### PR TITLE
(PC-20374)[API]feat: handle missing showtimes

### DIFF
--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -45,7 +45,7 @@ def get_offer(offer_id: str) -> serializers.OfferResponse:
     if is_external_ticket_applicable:
         cinema_venue_provider = external_bookings_api.get_active_cinema_venue_provider(offer.venueId)
         if check_offer_is_from_current_cinema_provider(offer):
-            api.update_stock_quantity_to_match_cinema_venue_provider_remaining_place(offer, cinema_venue_provider)
+            api.update_stock_quantity_to_match_cinema_venue_provider_remaining_places(offer, cinema_venue_provider)
 
     return serializers.OfferResponse.from_orm(offer)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20374

## But de la pull request

Ne plus proposer à la réservation un stock dont la séance correspondante côté cinéma n'est plus renvoyée par l'API.

## Implémentation

- Modification de `update_stock_quantity_to_match_cinema_venue_provider_remaining_places()`

## Informations supplémentaires

- Au passage, on met à jour la quantité du stock à 1 si on sait qu'il ne reste qu'une place, afin d'éviter un échec de réservation duo 
- Si un stock est épuisé, on en profite pour ré-indexer l'offre