### PR TITLE
:wrench: Remove boolean from the function type

### DIFF
--- a/adage-front/src/app/hooks/useActiveFeature.ts
+++ b/adage-front/src/app/hooks/useActiveFeature.ts
@@ -1,11 +1,11 @@
-import { useContext } from 'react'
+import { useContext } from "react";
 
-import { FeaturesContext } from 'app/providers/FeaturesContextProvider'
+import { FeaturesContext } from "app/providers/FeaturesContextProvider";
 
-export const useActiveFeature = (featureName: string): boolean => {
-  const features = useContext(FeaturesContext)
+export const useActiveFeature = (featureName: string) => {
+  const features = useContext(FeaturesContext);
 
   return Boolean(
-    features.find(feature => feature.name === featureName)?.isActive
-  )
-}
+    features.find((feature) => feature.name === featureName)?.isActive
+  );
+};


### PR DESCRIPTION
### Why?

In typescript, it is not mandatory  to set types **explicitly** to our functions, because Typescript has a feature of  **Inference** based on the returned result ( expression );

### Proven by example

```typescript
const getString = ( str: string) => return str;
```
In the code above,  the return type of a function is also inferred by the returning value, which means we don't need to set the type `string` to our function:

```typescript
const getString = ( str: string): string => return str;
```
