### PR TITLE
(PC-20025)[API] feat: bov3: bookings: show pricing/cashflow information

### DIFF
--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -256,13 +256,13 @@ class Pricing(Base, Model):
     status: PricingStatus = sqla.Column(db_utils.MagicEnum(PricingStatus), index=True, nullable=False)
 
     bookingId = sqla.Column(sqla.BigInteger, sqla.ForeignKey("booking.id"), index=True, nullable=True)
-    booking: "bookings_models.Booking | None" = sqla_orm.relationship(
+    booking: sqla_orm.Mapped["bookings_models.Booking | None"] = sqla_orm.relationship(
         "Booking", foreign_keys=[bookingId], backref="pricings"
     )
     collectiveBookingId = sqla.Column(
         sqla.BigInteger, sqla.ForeignKey("collective_booking.id"), index=True, nullable=True
     )
-    collectiveBooking: "educational_models.CollectiveBooking | None" = sqla_orm.relationship(
+    collectiveBooking: sqla_orm.Mapped["educational_models.CollectiveBooking | None"] = sqla_orm.relationship(
         "CollectiveBooking", foreign_keys=[collectiveBookingId], backref="pricings"
     )
     # FIXME (dbaty 2022-08-03): make NOT NULLable once we have populated all rows.
@@ -333,6 +333,18 @@ class Pricing(Base, Model):
             name="reimbursement_rule_constraint_check",
         ),
     )
+
+    @property
+    def cashflow(self) -> "Cashflow | None":
+        """
+        The Pricing-Cashflow relation is implemented as a
+        many-to-many one but for now a Pricing can only have one
+        cashflow.
+        """
+        if not self.cashflows:
+            return None
+
+        return self.cashflows[0]
 
 
 class PricingLine(Base, Model):

--- a/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 
 from pcapi.core.categories import subcategories_v2
 from pcapi.core.educational import models as educational_models
+from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.utils import date as date_utils
@@ -45,6 +46,22 @@ def _get_collective_bookings(form: collective_booking_forms.GetCollectiveBooking
             sa.orm.joinedload(educational_models.CollectiveBooking.educationalInstitution).load_only(
                 educational_models.EducationalInstitution.id, educational_models.EducationalInstitution.name
             ),
+            sa.orm.joinedload(educational_models.CollectiveBooking.offerer).load_only(
+                offerers_models.Offerer.id, offerers_models.Offerer.name
+            ),
+            sa.orm.joinedload(educational_models.CollectiveBooking.venue).load_only(
+                # for name and link (build_pc_pro_venue_link)
+                offerers_models.Venue.id,
+                offerers_models.Venue.name,
+                offerers_models.Venue.isVirtual,
+                offerers_models.Venue.managingOffererId,
+            ),
+            sa.orm.joinedload(educational_models.CollectiveBooking.pricings)
+            .load_only(finance_models.Pricing.amount)
+            .joinedload(finance_models.Pricing.cashflows)
+            .load_only(finance_models.Cashflow.batchId)
+            .joinedload(finance_models.Cashflow.batch)
+            .load_only(finance_models.CashflowBatch.label),
         )
     )
 

--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -84,6 +84,13 @@ def format_amount(amount: float | None) -> str:
     return f"{amount:,.2f} €".replace(",", "\u202f").replace(".", ",")
 
 
+def format_cents(amount_in_cents: float | None) -> str:
+    if amount_in_cents is None:
+        amount_in_cents = 0.0
+
+    return format_amount(amount_in_cents / 100)
+
+
 def format_bool(data: bool | None) -> str:
     if data is None:
         return ""
@@ -201,6 +208,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_booking_status"] = format_booking_status
     app.jinja_env.filters["format_booking_status_long"] = format_booking_status_long
     app.jinja_env.filters["format_bool"] = format_bool
+    app.jinja_env.filters["format_cents"] = format_cents
     app.jinja_env.filters["format_string_list"] = format_string_list
     app.jinja_env.filters["format_date"] = format_date
     app.jinja_env.filters["format_deposit_type"] = format_deposit_type

--- a/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories_v2
+from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
@@ -45,6 +46,22 @@ def _get_individual_bookings(form: individual_booking_forms.GetIndividualBooking
             sa.orm.joinedload(bookings_models.Booking.user).load_only(
                 users_models.User.id, users_models.User.firstName, users_models.User.lastName
             ),
+            sa.orm.joinedload(bookings_models.Booking.offerer).load_only(
+                offerers_models.Offerer.id, offerers_models.Offerer.name
+            ),
+            sa.orm.joinedload(bookings_models.Booking.venue).load_only(
+                # for name and link (build_pc_pro_venue_link)
+                offerers_models.Venue.id,
+                offerers_models.Venue.name,
+                offerers_models.Venue.isVirtual,
+                offerers_models.Venue.managingOffererId,
+            ),
+            sa.orm.joinedload(bookings_models.Booking.pricings)
+            .load_only(finance_models.Pricing.amount)
+            .joinedload(finance_models.Pricing.cashflows)
+            .load_only(finance_models.Cashflow.batchId)
+            .joinedload(finance_models.Cashflow.batch)
+            .load_only(finance_models.CashflowBatch.label),
         )
     )
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
@@ -1,3 +1,6 @@
+{% from "components/bookings/reimbursed.html" import build_reimbursed_td_content with context %}
+{% from "components/bookings/reimbursed.html" import build_reimbursed_extra_tr with context %}
+
 {% extends "layouts/connected.html" %}
 
 {% block page %}
@@ -57,11 +60,15 @@
                             <td>{{ collective_offer.id }}</td>
                             <td>{{ collective_offer.subcategory.category.pro_label }}</td>
                             <td>{{ collective_offer.subcategory.pro_label }}</td>
-                            <td>{{ collective_booking.status | format_booking_status }}</td>
+                            <td>
+                                {{ build_reimbursed_td_content(collective_booking) }}
+                            </td>
                             <td>{{ collective_booking.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ collective_booking.confirmationDate | format_date("%d/%m/%Y") }}</td>
                             <td>{{ collective_booking.cancellationDate | format_date("%d/%m/%Y") }}</td>
                         </tr>
+
+                        {{ build_reimbursed_extra_tr(collective_booking) }}
                     {% endfor %}
                     </tbody>
                 </table>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/bookings/reimbursed.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/bookings/reimbursed.html
@@ -1,0 +1,75 @@
+{% macro build_reimbursed_td_content(booking) %}
+    {% if booking.isReimbursed %}
+        <button class="mx-2 btn btn-outline-primary"
+                data-bs-toggle="collapse"
+                data-bs-target="#b{{ booking.id }}"
+        >
+            {{ booking.status | format_booking_status }}
+        </button>
+    {% else %}
+        {{ booking.status | format_booking_status }}
+    {% endif %}
+{% endmacro %}
+
+{% macro build_reimbursed_extra_tr(booking) %}
+    {% if booking.isReimbursed %}
+        <tr class="collapse accordion-collapse" id="b{{ booking.id }}" data-bs-parent=".table">
+            <td colspan="12">
+                <div class="row">
+                    <div class="col-6">
+                        <div class="card shadow-sm p-4 mx-2">
+                            <ul>
+                                <li>
+                                    Total payé par l'utilisateur : {{ booking.total_amount | format_amount }}
+                                </li>
+
+                                <li>
+                                    Date de remboursement : 
+                                    {{ booking.reimbursementDate | format_date }}
+                                </li>
+
+                                <li>
+                                    Nom de la structure : 
+                                    <a href="{{ booking.offerer | pc_pro_offerer_link }}" target="_blank">
+                                        {{ booking.offerer.name }}
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="col-6">
+                        <div class="card shadow-sm p-3">
+                            <ul>
+                                <li>
+                                    Nom du lieu :
+                                    <a href="{{ booking.venue | pc_pro_venue_link }}" target="_blank">
+                                        {{ booking.venue.name }}
+                                    </a>
+                                </li>
+
+                                <li>
+                                    Montant remboursé :
+                                    {% if booking.pricing %}
+                                        {{ -booking.pricing.amount | format_cents }}
+                                    {% endif %}
+                                </li>
+
+                                <li>
+                                    N° de virement :
+                                    {% if booking.cashflow_batch %}
+                                        {{ booking.cashflow_batch.label }}
+                                    {% endif %}
+                                </li>
+
+                                <li>
+                                    Taux de remboursement : {{ booking.reimbursement_rate | empty_string_if_null }}%
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </td>
+        </tr>
+    {% endif %}
+{% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -1,3 +1,6 @@
+{% from "components/bookings/reimbursed.html" import build_reimbursed_td_content with context %}
+{% from "components/bookings/reimbursed.html" import build_reimbursed_extra_tr with context %}
+
 {% extends "layouts/connected.html" %}
 
 {% block page %}
@@ -62,11 +65,14 @@
                             <td>{{ offer.category.pro_label }}</td>
                             <td>{{ offer.subcategory.pro_label }}</td>
                             <td>{{ booking.stock.quantity }}</td>
-                            <td>{{ booking.status | format_booking_status }}</td>
+                            <td>{{ build_reimbursed_td_content(booking) }}</td>
                             <td>{{ booking.dateCreated | format_date("%d/%m/%Y") }}</td>
                             <td>{{ booking.dateUsed | format_date("%d/%m/%Y") }}</td>
                             <td>{{ booking.cancellationDate | format_date("%d/%m/%Y") }}</td>
                         </tr>
+
+						{{ build_reimbursed_extra_tr(booking) }}
+
                     {% endfor %}
                     </tbody>
                 </table>

--- a/api/tests/routes/backoffice_v3/collective_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/collective_bookings_test.py
@@ -10,6 +10,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
 import pcapi.core.permissions.models as perm_models
 from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import assert_num_queries
 
 from .helpers import html_parser
 from .helpers import unauthorized as unauthorized_helpers
@@ -192,7 +193,12 @@ class ListCollectiveBookingsTest:
     )
     def test_list_bookings_by_status(self, authenticated_client, collective_bookings, status, expected_idx):
         # when
-        with assert_no_duplicated_queries():
+
+        # fetch session (1 query)
+        # fetch user (1 query)
+        # fetch individual bookings with extra data (1 query)
+        # count for pagination (1 pagination)
+        with assert_num_queries(4):
             response = authenticated_client.get(url_for(self.endpoint, status=status))
 
         # then

--- a/api/tests/routes/backoffice_v3/individual_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/individual_bookings_test.py
@@ -9,6 +9,7 @@ from pcapi.core.categories import categories
 from pcapi.core.categories import subcategories_v2
 import pcapi.core.permissions.models as perm_models
 from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 
 from .helpers import html_parser
@@ -168,7 +169,12 @@ class ListIndividualBookingsTest:
 
     def test_list_bookings_by_category(self, authenticated_client, bookings):
         # when
-        with assert_no_duplicated_queries():
+
+        # fetch session (1 query)
+        # fetch user (1 query)
+        # fetch individual bookings with extra data (1 query)
+        # count for pagination (1 pagination)
+        with assert_num_queries(4):
             response = authenticated_client.get(url_for(self.endpoint, category=categories.SPECTACLE.id))
 
         # then


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20025

## But de la pull request

Ajouter une ligne qui se déplie dans les tableaux des réservations individuelles et collectives. Celles-ci ne concernent que les réservations remboursées et contiennent des informations liées au remboursement (montant, rappel du lieu et de l'AC, informations concernant le virement...).