### PR TITLE
(PC-19889)[BO] feat: Filter bookings on offerers and venues

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -6,6 +6,7 @@ def install_routes(app: Flask) -> None:
     from . import accounts
     from . import admin
     from . import auth
+    from . import autocomplete
     from . import collective_bookings
     from . import filters
     from . import health_check

--- a/api/src/pcapi/routes/backoffice_v3/autocomplete.py
+++ b/api/src/pcapi/routes/backoffice_v3/autocomplete.py
@@ -1,0 +1,79 @@
+from flask import request
+import sqlalchemy as sa
+
+from pcapi.core.offerers import models as offerers_models
+from pcapi.routes.serialization import BaseModel
+from pcapi.serialization.decorator import spectree_serialize
+
+from . import blueprint
+
+
+NUM_RESULTS = 20
+
+
+class AutocompleteItem(BaseModel):
+    id: int
+    text: str
+
+
+class AutocompleteResponse(BaseModel):
+    items: list[AutocompleteItem]
+
+
+@blueprint.backoffice_v3_web.route("/autocomplete/offerers", methods=["GET"])
+@spectree_serialize(response_model=AutocompleteResponse, api=blueprint.backoffice_v3_web_schema)
+def autocomplete_offerers() -> AutocompleteResponse:
+    query_string = request.args.get("q", "").strip()
+
+    if len(query_string) < 2:
+        return AutocompleteResponse(items=[])
+
+    filters = offerers_models.Offerer.name.ilike(f"%{query_string}%")
+
+    if query_string.isnumeric() and len(query_string) <= 9:
+        filters = sa.or_(filters, offerers_models.Offerer.siren.like(f"{query_string}%"))
+
+    offerers = (
+        offerers_models.Offerer.query.filter(filters)
+        .limit(NUM_RESULTS)
+        .with_entities(
+            offerers_models.Offerer.id,
+            offerers_models.Offerer.name,
+            offerers_models.Offerer.siren,
+        )
+    )
+
+    return AutocompleteResponse(
+        items=[AutocompleteItem(id=offerer_id, text=f"{name} ({siren})") for offerer_id, name, siren in offerers]
+    )
+
+
+@blueprint.backoffice_v3_web.route("/autocomplete/venues", methods=["GET"])
+@spectree_serialize(response_model=AutocompleteResponse, api=blueprint.backoffice_v3_web_schema)
+def autocomplete_venues() -> AutocompleteResponse:
+    query_string = request.args.get("q", "").strip()
+
+    if not query_string or len(query_string) < 2:
+        return AutocompleteResponse(items=[])
+
+    filters = offerers_models.Venue.name.ilike(f"%{query_string}%")
+
+    if query_string.isnumeric() and len(query_string) <= 14:
+        filters = sa.or_(filters, offerers_models.Venue.siret.like(f"{query_string}%"))
+
+    venues = (
+        offerers_models.Venue.query.filter(filters)
+        .limit(NUM_RESULTS)
+        .with_entities(
+            offerers_models.Venue.id,
+            offerers_models.Venue.name,
+            offerers_models.Venue.siret,
+        )
+    )
+
+    return AutocompleteResponse(
+        items=[
+            AutocompleteItem(id=venue_id, text=f"{name} ({siret or 'Pas de SIRET'})")
+            for venue_id, name, siret in venues
+        ]
+    )

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
@@ -14,6 +14,12 @@ class GetCollectiveBookingListForm(FlaskForm):
         csrf = False
 
     q = fields.PCOptSearchField("ID réservation collective, ID offre, Nom ou ID de l'établissement")
+    offerer = fields.PCAutocompleteSelectMultipleField(
+        "Structures", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_offerers"
+    )
+    venue = fields.PCAutocompleteSelectMultipleField(
+        "Lieux", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_venues"
+    )
     category = fields.PCSelectMultipleField(
         "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)
     )
@@ -34,3 +40,16 @@ class GetCollectiveBookingListForm(FlaskForm):
         if q.data:
             q.data = q.data.strip()
         return q
+
+    def is_empty(self) -> bool:
+        return not any(
+            (
+                self.q.data,
+                self.offerer.data,
+                self.venue.data,
+                self.category.data,
+                self.status.data,
+                self.from_date.data,
+                self.to_date.data,
+            )
+        )

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -2,6 +2,7 @@ from functools import partial
 import typing
 
 from flask import render_template
+from flask import url_for
 import wtforms
 from wtforms import validators
 import wtforms_sqlalchemy.fields
@@ -105,6 +106,14 @@ class PCSelectWithPlaceholderValueField(wtforms.SelectField):
 class PCSelectMultipleField(wtforms.SelectMultipleField):
     widget = partial(widget, template="components/forms/select_multiple_field.html")
     validators = [validators.Optional()]
+
+
+class PCAutocompleteSelectMultipleField(PCSelectMultipleField):
+    widget = partial(widget, template="components/forms/select_multiple_field_autocomplete.html")
+
+    def __init__(self, label: str, endpoint: str, **kwargs: typing.Any):
+        super().__init__(label, **kwargs)
+        self.autocomplete_url = url_for(endpoint)
 
 
 class PCQuerySelectMultipleField(wtforms_sqlalchemy.fields.QuerySelectMultipleField):

--- a/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
@@ -14,6 +14,12 @@ class GetIndividualBookingListForm(FlaskForm):
         csrf = False
 
     q = fields.PCOptSearchField("Code contremarque, ID offre, Nom ou ID du bénéficiaire")
+    offerer = fields.PCAutocompleteSelectMultipleField(
+        "Structures", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_offerers"
+    )
+    venue = fields.PCAutocompleteSelectMultipleField(
+        "Lieux", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_venues"
+    )
     category = fields.PCSelectMultipleField(
         "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)
     )
@@ -34,3 +40,16 @@ class GetIndividualBookingListForm(FlaskForm):
         if q.data:
             q.data = q.data.strip()
         return q
+
+    def is_empty(self) -> bool:
+        return not any(
+            (
+                self.q.data,
+                self.offerer.data,
+                self.venue.data,
+                self.category.data,
+                self.status.data,
+                self.from_date.data,
+                self.to_date.data,
+            )
+        )

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/filters_form.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/filters_form.html
@@ -5,13 +5,13 @@
             {% for form_field in form %}
                 {% if form_field.type == "HiddenField" %}
                     {{ form_field }}
-                {% elif form_field.type == 'PCSelectMultipleField' or form_field.type == "PCQuerySelectMultipleField" %}
+                {% elif form_field.type in ('PCSelectMultipleField', "PCQuerySelectMultipleField", "PCAutocompleteSelectMultipleField") %}
                     {% set _ = select_multiple.append(form_field) %}
                 {% endif %}
             {% endfor %}
             <div class="input-group mb-3 px-1">
                 {% for form_field in form %}
-                    {% if form_field.type != "HiddenField" and form_field.type != "PCSelectMultipleField" and form_field.type != "PCQuerySelectMultipleField" %}
+                    {% if form_field.type not in ("HiddenField", "PCSelectMultipleField", "PCQuerySelectMultipleField", "PCAutocompleteSelectMultipleField") %}
                         {{ form_field }}
                     {% endif %}
                 {% endfor %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
@@ -1,0 +1,76 @@
+<div class="form-floating">
+    <select multiple class="form-select pc-select-autocomplete" id="{{ field.name }}" name="{{ field.name }}" size="2"
+            style="border-radius: 1rem!important;">
+    </select>
+    <label class="pc-select-label" for="{{ field.name }}" id="{{ field.name }}-label"> {{ field.label }}</label>
+</div>
+
+{% block scripts %}
+    <script>
+        new TomSelect('#{{ field.name }}', {
+            plugins: ['dropdown_input', 'clear_button', 'checkbox_options'],
+            persist: false,
+            create: false,
+            valueField: 'id',
+            labelField: 'text',
+            {% if field.choices %}
+                options: [
+                    {% for choice_value, choice_label in field.choices %}
+                        {id: '{{ choice_value }}', text: '{{ choice_label }}'},
+                    {% endfor %}
+                ],
+                items: [{% for choice_value, _ in field.choices %}'{{ choice_value }}',{% endfor %}],
+            {% endif %}
+            load: function(query, callback) {
+                const url = '{{ field.autocomplete_url }}?q=' + encodeURIComponent(query);
+                fetch(url)
+                    .then(response => response.json())
+                    .then(json => {
+                        callback(json.items);
+                    }).catch(()=>{
+                        callback();
+                    });
+            }
+        });
+
+        document.getElementById('{{ field.name }}').onmousedown = function (e) {
+            e.preventDefault()
+            var select = this;
+            var scroll = select.scrollTop;
+
+            e.target.selected = !e.target.selected
+            setTimeout(function () {
+                select.scrollTop = scroll;
+            }, 0);
+            document.getElementById('{{field.name}}').focus()
+        }
+        document.getElementById('{{ field.name }}').onmousemove = function (e) {
+            e.preventDefault();
+        };
+
+       ['change', 'scroll'].forEach(function (event) {
+            document.getElementById('{{field.name}}').addEventListener(event, () => {
+                var select = document.getElementById('{{field.name}}')
+                var selected = [...select.options]
+                    .filter(option => option.selected)
+                const label = document.querySelector('label#{{ field.name }}-label');
+
+                if (selected.length > 0) {
+                    label.classList.add('is-hidden')
+                } else {
+                    label.classList.remove('is-hidden')
+                }
+            })
+        })
+
+    </script>
+{% endblock %}
+
+{% block styles %}
+    <style>
+        .is-hidden {
+            display: none;
+        }
+
+    </style>
+{% endblock %}

--- a/api/tests/routes/backoffice_v3/autocomplete_test.py
+++ b/api/tests/routes/backoffice_v3/autocomplete_test.py
@@ -1,0 +1,85 @@
+from flask import url_for
+import pytest
+
+from pcapi.core.offerers import factories as offerers_factories
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
+
+
+class AutocompleteOffererTest:
+    @pytest.mark.parametrize(
+        "search_query, expected_texts",
+        [
+            ("", set()),
+            ("1", set()),
+            ("12", {"Le Cinéma (123456789)", "La Librairie (123444556)"}),
+            ("1234", {"Le Cinéma (123456789)", "La Librairie (123444556)"}),
+            ("12345", {"Le Cinéma (123456789)"}),
+            ("123444556", {"La Librairie (123444556)"}),
+            ("789", set()),
+            ("100200301", set()),
+            ("ciné", {"Le Cinéma (123456789)", "Cinéma concurrent (561234789)"}),
+            ("ciné théâtre", set()),
+        ],
+    )
+    def test_autocomplete_offerers(self, authenticated_client, search_query, expected_texts):
+        # given
+        offerers_factories.OffererFactory(siren="100200300", name="Le Théâtre")
+        offerers_factories.OffererFactory(siren="123456789", name="Le Cinéma")
+        offerers_factories.OffererFactory(siren="123444556", name="La Librairie")
+        offerers_factories.OffererFactory(siren="561234789", name="Cinéma concurrent")
+
+        # when
+        response = authenticated_client.get(url_for("backoffice_v3_web.autocomplete_offerers", q=search_query))
+
+        # then
+        assert response.status_code == 200
+        items = response.json["items"]
+        for item in items:
+            assert isinstance(item["id"], int)
+            assert isinstance(item["text"], str)
+        assert {item["text"] for item in items} == expected_texts
+
+
+class AutocompleteVenueTest:
+    @pytest.mark.parametrize(
+        "search_query, expected_texts",
+        [
+            ("", set()),
+            ("1", set()),
+            ("12", {"Le Cinéma (12345678900018)", "La Librairie (12344455600012)", "La Médiathèque (12345678900011)"}),
+            (
+                "1234",
+                {"Le Cinéma (12345678900018)", "La Librairie (12344455600012)", "La Médiathèque (12345678900011)"},
+            ),
+            ("12345", {"Le Cinéma (12345678900018)", "La Médiathèque (12345678900011)"}),
+            ("123456789", {"Le Cinéma (12345678900018)", "La Médiathèque (12345678900011)"}),
+            ("12345678900011", {"La Médiathèque (12345678900011)"}),
+            ("789", set()),
+            ("100200301", set()),
+            ("ciné", {"Le Cinéma (12345678900018)", "Cinéma concurrent (56123478900023)"}),
+            ("ciné théâtre", set()),
+        ],
+    )
+    def test_autocomplete_venues(self, authenticated_client, search_query, expected_texts):
+        # given
+        offerers_factories.VenueFactory(siret="10020030000021", name="Le Théâtre")
+        offerers_factories.VenueFactory(siret="12345678900018", name="Le Cinéma")
+        offerers_factories.VenueFactory(siret="12344455600012", name="La Librairie")
+        offerers_factories.VenueFactory(siret="12345678900011", name="La Médiathèque")
+        offerers_factories.VenueFactory(siret="56123478900023", name="Cinéma concurrent")
+
+        # when
+        response = authenticated_client.get(url_for("backoffice_v3_web.autocomplete_venues", q=search_query))
+
+        # then
+        assert response.status_code == 200
+        items = response.json["items"]
+        for item in items:
+            assert isinstance(item["id"], int)
+            assert isinstance(item["text"], str)
+        assert {item["text"] for item in items} == expected_texts

--- a/api/tests/routes/backoffice_v3/individual_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/individual_bookings_test.py
@@ -214,3 +214,25 @@ class ListIndividualBookingsTest:
         assert response.status_code == 200
         rows = html_parser.extract_table_rows(response.data)
         assert set(row["Contremarque"] for row in rows) == {"CNCL02", "ELBEIT"}
+
+    def test_list_bookings_by_offerer(self, authenticated_client, bookings):
+        # when
+        offerer_id = bookings[1].offererId
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, offerer=offerer_id))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert rows[0]["Contremarque"] == bookings[1].token
+
+    def test_list_bookings_by_venue(self, authenticated_client, bookings):
+        # when
+        venue_ids = [bookings[0].venueId, bookings[2].venueId]
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint, venue=venue_ids))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(row["Contremarque"] for row in rows) == {bookings[0].token, bookings[2].token}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19889

## But de la pull request

Filtrage des réservations individuelles et collectives par structure(s) et par lieu(x) dans le nouveau backoffice.

## Implémentation

## Informations supplémentaires

Il serait souhaitable de factoriser le code entre les deux pages de réservations. On garde l'idée pour plus tard :)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
