### PR TITLE
(PC-20398)[BO] fix: distinct permissions for review and suspend, finally

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 0272ad68e89d (pre) (head)
-62bea1f33bcf (post) (head)
+b8b34e5a2e5b (post) (head)

--- a/api/src/pcapi/alembic/versions/20230208T093931_62bea1f33bcf_rename_permission_review_public_account.py
+++ b/api/src/pcapi/alembic/versions/20230208T093931_62bea1f33bcf_rename_permission_review_public_account.py
@@ -1,7 +1,5 @@
 """Rename_permission_REVIEW_PUBLIC_ACCOUNT
 """
-from alembic import op
-
 
 # pre/post deployment: post
 # revision identifiers, used by Alembic.
@@ -12,8 +10,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("UPDATE permission SET name = 'REVIEW_SUSPEND_USER' WHERE name = 'REVIEW_PUBLIC_ACCOUNT'")
+    # migration reverted
+    pass
 
 
 def downgrade() -> None:
-    op.execute("UPDATE permission SET name = 'REVIEW_PUBLIC_ACCOUNT' WHERE name = 'REVIEW_SUSPEND_USER'")
+    # migration reverted
+    pass

--- a/api/src/pcapi/alembic/versions/20230209T152624_b8b34e5a2e5b_remove_permission_review_suspend_user.py
+++ b/api/src/pcapi/alembic/versions/20230209T152624_b8b34e5a2e5b_remove_permission_review_suspend_user.py
@@ -1,0 +1,20 @@
+"""Remove_permission_REVIEW_SUSPEND_USER
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "b8b34e5a2e5b"
+down_revision = "62bea1f33bcf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # REVIEW_SUSPEND_USER was added but never deployed until production
+    op.execute("DELETE FROM permission WHERE name = 'REVIEW_SUSPEND_USER'")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -23,9 +23,10 @@ class Permissions(enum.Enum):
 
     SEARCH_PUBLIC_ACCOUNT = "rechercher un compte bénéficiaire/grand public"
     READ_PUBLIC_ACCOUNT = "visualiser un compte bénéficiaire/grand public"
+    REVIEW_PUBLIC_ACCOUNT = "faire une revue manuelle d'un compte bénéficiaire/grand public"
     MANAGE_PUBLIC_ACCOUNT = "gérer un compte bénéficiaire/grand public"
 
-    REVIEW_SUSPEND_USER = "faire une revue manuelle, suspendre un compte utilisateur"
+    SUSPEND_USER = "suspendre ou réactiver un compte utilisateur"
 
     SEARCH_PRO_ACCOUNT = "rechercher un acteur culturel"
     READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"

--- a/api/src/pcapi/routes/backoffice/accounts.py
+++ b/api/src/pcapi/routes/backoffice/accounts.py
@@ -191,7 +191,7 @@ def get_user_subscription_history(user_id: int) -> serialization.GetUserSubscrip
     on_success_status=200,
     api=blueprint.api,
 )
-@perm_utils.permission_required(perm_models.Permissions.REVIEW_SUSPEND_USER)
+@perm_utils.permission_required(perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT)
 def review_public_account(
     user_id: int, body: serialization.BeneficiaryReviewRequestModel
 ) -> serialization.BeneficiaryReviewResponseModel:

--- a/api/src/pcapi/routes/backoffice_v3/forms/user.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/user.py
@@ -27,7 +27,7 @@ def get_toggle_suspension_args(user: users_models.User) -> dict:
     """
     Additional arguments which must be passed to render_template when the page may show suspend/unsuspend button.
     """
-    if not has_current_user_permission(perm_models.Permissions.REVIEW_SUSPEND_USER):
+    if not has_current_user_permission(perm_models.Permissions.SUSPEND_USER):
         return {}
 
     if user.isActive:

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -39,7 +39,7 @@
                             }} </p>
                     </div>
 
-                    {% if has_permission("REVIEW_SUSPEND_USER") %}
+                    {% if has_permission("SUSPEND_USER") %}
                         <div class="col-4">
                             <div>
                                 {% if user.isActive %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -60,7 +60,7 @@
                                 </div>
                             </div>
                         {% endif %}
-                        {% if has_permission("REVIEW_SUSPEND_USER") %}
+                        {% if has_permission("SUSPEND_USER") %}
                             {% if user.isActive %}
                                 {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
                             {% else %}

--- a/api/src/pcapi/routes/backoffice_v3/users.py
+++ b/api/src/pcapi/routes/backoffice_v3/users.py
@@ -19,7 +19,7 @@ users_blueprint = utils.child_backoffice_blueprint(
     "users",
     __name__,
     url_prefix="/users/<int:user_id>",
-    permission=perm_models.Permissions.REVIEW_SUSPEND_USER,
+    permission=perm_models.Permissions.SUSPEND_USER,
 )
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -30,7 +30,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "fraude-conformite": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
-        perm_models.Permissions.REVIEW_SUSPEND_USER,
+        perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT,
+        perm_models.Permissions.SUSPEND_USER,
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.VALIDATE_OFFERER,

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -1096,7 +1096,7 @@ class PostManualReviewTest:
             user=user, type=fraud_models.FraudCheckType.DMS, status=fraud_models.FraudCheckStatus.KO
         )
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1126,7 +1126,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1158,7 +1158,7 @@ class PostManualReviewTest:
             eligibilityType=users_models.EligibilityType.UNDERAGE,
         )
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1186,7 +1186,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1214,7 +1214,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory()
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.AdminFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1238,7 +1238,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1255,7 +1255,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1288,7 +1288,7 @@ class PostManualReviewTest:
         # given
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
-        auth_token = generate_token(users_factories.UserFactory.build(), [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(users_factories.UserFactory.build(), [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1311,7 +1311,7 @@ class PostManualReviewTest:
             resultContent=fraud_factories.UbbleContentFactory(birth_date=birth_date_15_yo.date().isoformat()),
         )
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1326,7 +1326,7 @@ class PostManualReviewTest:
     def test_cannot_review_unknown_account(self, client):
         # given
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1345,7 +1345,7 @@ class PostManualReviewTest:
         fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.UBBLE)
         DepositGrantFactory(user=user)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(
@@ -1362,7 +1362,7 @@ class PostManualReviewTest:
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2))
         check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, type=fraud_models.FraudCheckType.DMS)
         reviewer = users_factories.UserFactory()
-        auth_token = generate_token(reviewer, [Permissions.REVIEW_SUSPEND_USER])
+        auth_token = generate_token(reviewer, [Permissions.REVIEW_PUBLIC_ACCOUNT])
 
         # when
         response = client.with_explicit_token(auth_token).post(

--- a/api/tests/routes/backoffice/blueprint_test.py
+++ b/api/tests/routes/backoffice/blueprint_test.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 def test_cors_allowed(client):
     # given
     user = users_factories.UserFactory()
-    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_SUSPEND_USER])
+    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT])
 
     # when
     response = client.with_explicit_token(auth_token).options(
@@ -28,7 +28,7 @@ def test_cors_allowed(client):
 def test_cors_disallowed(client):
     # given
     user = users_factories.UserFactory()
-    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_SUSPEND_USER])
+    auth_token = generate_token(user, [perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT])
 
     # when
     response = client.with_explicit_token(auth_token).options(

--- a/api/tests/routes/backoffice/permissions_test.py
+++ b/api/tests/routes/backoffice/permissions_test.py
@@ -164,7 +164,7 @@ class NewRoleTest:
         permissions = perm_models.Permission.query.filter(
             perm_models.Permission.name.in_(
                 (
-                    perm_models.Permissions.REVIEW_SUSPEND_USER.name,
+                    perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT.name,
                     perm_models.Permissions.READ_PUBLIC_ACCOUNT.name,
                 )
             )

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -324,7 +324,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         needed_permission = perm_models.Permissions.READ_PUBLIC_ACCOUNT
 
     class SuspendButtonTest(button_helpers.ButtonHelper):
-        needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+        needed_permission = perm_models.Permissions.SUSPEND_USER
         button_label = "Suspendre le compte"
 
         @property
@@ -333,7 +333,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
             return url_for("backoffice_v3_web.public_accounts.get_public_account", user_id=user.id)
 
     class UnsuspendButtonTest(button_helpers.ButtonHelper):
-        needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+        needed_permission = perm_models.Permissions.SUSPEND_USER
         button_label = "Réactiver le compte"
 
         @property

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -53,7 +53,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
     "fraude-conformite": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
-        perm_models.Permissions.REVIEW_SUSPEND_USER,
+        perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT,
+        perm_models.Permissions.SUSPEND_USER,
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.VALIDATE_OFFERER,

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -63,7 +63,7 @@ class GetProUserTest:
             assert self.button_label not in response.data.decode("utf-8")
 
     class SuspendButtonTest(button_helpers.ButtonHelper):
-        needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+        needed_permission = perm_models.Permissions.SUSPEND_USER
         button_label = "Suspendre le compte"
 
         @property
@@ -72,7 +72,7 @@ class GetProUserTest:
             return url_for("backoffice_v3_web.pro_user.get", user_id=user.id)
 
     class UnsuspendButtonTest(button_helpers.ButtonHelper):
-        needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+        needed_permission = perm_models.Permissions.SUSPEND_USER
         button_label = "Réactiver le compte"
 
         @property

--- a/api/tests/routes/backoffice_v3/users_test.py
+++ b/api/tests/routes/backoffice_v3/users_test.py
@@ -21,7 +21,7 @@ pytestmark = [
 class PostUserTestHelper(unauthorized_helpers.UnauthorizedHelperWithCsrf):
     method = "post"
     endpoint_kwargs = {"user_id": 1}
-    needed_permission = perm_models.Permissions.REVIEW_SUSPEND_USER
+    needed_permission = perm_models.Permissions.SUSPEND_USER
 
     def _post_request(self, authenticated_client, user_id, form):
         # generate csrf token before request

--- a/backoffice/src/resources/PublicUsers/types.tsx
+++ b/backoffice/src/resources/PublicUsers/types.tsx
@@ -8,7 +8,7 @@ export enum PublicUserRolesEnum {
 export enum PermissionsEnum {
   managePermissions = 'MANAGE_PERMISSIONS',
   readPublicAccount = 'READ_PUBLIC_ACCOUNT',
-  reviewPublicAccount = 'REVIEW_SUSPEND_USER',
+  reviewPublicAccount = 'REVIEW_PUBLIC_ACCOUNT',
   managePublicAccount = 'MANAGE_PUBLIC_ACCOUNT',
   searchPublicAccount = 'SEARCH_PUBLIC_ACCOUNT',
   searchProAccount = 'SEARCH_PRO_ACCOUNT',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20398

## But de la pull request

Finalement, on veut deux permissions distinctes pour la revue manuelle et pour suspendre ou réactiver des utilisateurs.
Cette PR rétablit donc l'ancienne permission et crée la nouvelle distincte ; la fusion n'était pas encore en prod.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
