### PR TITLE
(PC-20276)[PRO] feat: should disply booking link for expired offer wi…

### DIFF
--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -102,7 +102,8 @@ const OfferEducationalActions = ({
           )}
         {isImproveCollectiveStatusActive &&
           lastBookingId &&
-          lastBookingStatus != CollectiveBookingStatus.CANCELLED && (
+          (lastBookingStatus != CollectiveBookingStatus.CANCELLED ||
+            offer?.status == OfferStatus.EXPIRED) && (
             <ButtonLink
               variant={ButtonVariant.TERNARY}
               className={style['button-link']}

--- a/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
+++ b/pro/src/components/OfferEducationalActions/__specs__/OfferEducationalActions.spec.tsx
@@ -77,6 +77,22 @@ describe('OfferEducationalActions', () => {
     )
     expect(screen.getByText('réservée')).toBeInTheDocument()
   })
+  it('should display booking link for used booking', () => {
+    props.offer = collectiveOfferFactory({
+      status: OfferStatus.EXPIRED,
+      lastBookingId: 1,
+      lastBookingStatus: CollectiveBookingStatus.USED,
+    })
+    const storeOverride = {}
+    renderOfferEducationalActions(props, storeOverride)
+    expect(
+      screen.getByRole('link', { name: 'Voir la réservation' })
+    ).toHaveAttribute(
+      'href',
+      '/reservations/collectives?page=1&offerEventDate=2021-10-15&bookingStatusFilter=booked&offerType=all&offerVenueId=all&bookingId=1'
+    )
+    expect(screen.getByText('terminée')).toBeInTheDocument()
+  })
   it('should display cancel booking button if offer is cancelable', () => {
     const storeOverride = {
       features: {

--- a/pro/src/pages/Offers/Offers/OfferItem/CollectiveOfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/CollectiveOfferItem.tsx
@@ -70,7 +70,8 @@ const CollectiveOfferItem = ({
       )}
 
       {isImproveCollectiveStatusActive &&
-        offer.status == OfferStatus.SOLD_OUT &&
+        (offer.status == OfferStatus.SOLD_OUT ||
+          offer.status == OfferStatus.EXPIRED) &&
         offer.educationalBooking && (
           <BookingLinkCell
             bookingId={offer.educationalBooking?.id}


### PR DESCRIPTION
…th booking

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20276

## But de la pull request

Afficher un lien vers la réservation quand l'offre a le statut terminée  (offre expirée avec une réservation liée)

## Screenshot 

![Capture d’écran 2023-02-10 à 15 26 20](https://user-images.githubusercontent.com/71768799/218116176-a810b5bc-e124-451e-ab66-cde286847053.png)

