### PR TITLE
(PC-20464)[API] fix: AttributeError: 'Venue' object has no attribute 'email' when venue is edited from PC Pro

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -97,7 +97,9 @@ def update_venue(
     venue_snapshot = history_api.ObjectUpdateSnapshot(venue, author)
 
     if contact_data:
-        venue_snapshot.trace_update(contact_data.dict(), target=venue.contact, field_name_template="contact.{}")
+        # target must not be None, otherwise contact_data fields will be compared to fields in Venue, which do not exist
+        target = venue.contact if venue.contact is not None else offerers_models.VenueContact()
+        venue_snapshot.trace_update(contact_data.dict(), target=target, field_name_template="contact.{}")
         upsert_venue_contact(venue, contact_data)
 
     if not modifications:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20464

## But de la pull request

Corriger l'exception remontée par Sentry :
AttributeError: 'Venue' object has no attribute 'email'
qui se produit lors de l'édition d'un lieu qui n'a pas encore d'info de contact.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
