### PR TITLE
(PC-20388)[PRO] fix: warning setting selected on options

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/FilterByOmniSearch/FilterByOmniSearch.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/FilterByOmniSearch/FilterByOmniSearch.tsx
@@ -93,13 +93,10 @@ const FilterByOmniSearch = ({
         disabled={isDisabled}
         onBlur={handleOmniSearchCriteriaChange}
         onChange={handleOmniSearchCriteriaChange}
+        value={selectedOmniSearchCriteria}
       >
         {omnisearchFilters.map(selectOption => (
-          <option
-            key={selectOption.id}
-            selected={selectOption.id === selectedOmniSearchCriteria}
-            value={selectOption.id}
-          >
+          <option key={selectOption.id} value={selectOption.id}>
             {selectOption.selectOptionText}
           </option>
         ))}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20388

## But de la pull request

- Retirer le warning: "Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>"

## Implémentation

- Gestion par "value" dans le select plutôt que par selected sur les options.