### PR TITLE
(PC-20391)[PRO] refactor: move collective offer params away from the router

### DIFF
--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -1,43 +1,68 @@
 import cn from 'classnames'
 import React from 'react'
+import { useLocation, useParams } from 'react-router-dom'
 
-import CollectiveOfferBreadcrumb, {
-  CollectiveOfferBreadcrumbStep,
-} from 'components/CollectiveOfferBreadcrumb'
+import CollectiveOfferBreadcrumb from 'components/CollectiveOfferBreadcrumb'
 import HelpLink from 'components/HelpLink'
+import useCollectiveOfferRoute from 'hooks/useCollectiveOfferRoute'
+import { getActiveStep } from 'pages/CollectiveOfferRoutes/utils/getActiveStep'
 import { Tag, Title } from 'ui-kit'
 
 import styles from './CollectiveOfferLayout.module.scss'
 
-interface IBreadcrumbProps {
-  activeStep: CollectiveOfferBreadcrumbStep
-  isCreatingOffer: boolean
-  offerId?: string
-}
 interface ICollectiveOfferLayout {
   children: React.ReactNode | React.ReactNode[]
-  breadCrumpProps?: IBreadcrumbProps
-  isTemplate?: boolean
-  title: string
   subTitle?: string
+  isFromTemplate?: boolean
   haveStock?: boolean
 }
 
 const CollectiveOfferLayout = ({
   children,
-  breadCrumpProps,
-  isTemplate = false,
-  title,
   subTitle,
+  isFromTemplate = false,
   haveStock = false,
 }: ICollectiveOfferLayout): JSX.Element => {
+  const location = useLocation()
+  const isSummaryPage = location.pathname.includes('recapitulatif')
+  const { offerId: offerIdFromParams } = useParams<{
+    offerId: string
+  }>()
+  const { isCreation, isTemplate } = useCollectiveOfferRoute(
+    location.pathname,
+    offerIdFromParams
+  )
+  let title = ''
+  if (isCreation) {
+    if (isFromTemplate) {
+      title = 'Créer une offre pour un établissement scolaire'
+    } else {
+      title = 'Créer une nouvelle offre collective'
+    }
+  } else {
+    if (isSummaryPage) {
+      title = 'Récapitulatif'
+    } else {
+      title = 'Éditer une offre collective'
+    }
+  }
+
+  const breadCrumpProps = isSummaryPage
+    ? undefined
+    : {
+        activeStep: getActiveStep(location.pathname),
+        offerId: offerIdFromParams,
+        isCreatingOffer: isCreation,
+      }
   return (
     <div className={styles['eac-layout']}>
       <div className={styles['eac-layout-headings']}>
         {isTemplate && (
           <Tag label="Offre vitrine" className={styles['eac-layout-tag']} />
         )}
+        {}
         <Title level={1}>{title}</Title>
+
         {subTitle && (
           <Title level={4} className={styles['eac-layout-sub-heading']}>
             {subTitle}

--- a/pro/src/components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
+++ b/pro/src/components/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
@@ -1,54 +1,84 @@
+import '@testing-library/jest-dom'
 import { screen } from '@testing-library/react'
 import React from 'react'
+import * as router from 'react-router-dom'
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}))
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
+  },
+}))
 
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferLayout from '../CollectiveOfferLayout'
 
-const renderCollectiveOfferLayout = ({
-  isTemplate,
-  title,
-  subTitle,
-}: {
-  isTemplate?: boolean
-  title: string
-  subTitle?: string
-}) =>
+const renderCollectiveOfferLayout = (
+  path: string,
+  isFromTemplate?: boolean
+) => {
   renderWithProviders(
     <CollectiveOfferLayout
-      title={title}
-      subTitle={subTitle}
-      isTemplate={isTemplate}
+      subTitle="Ma super offre"
+      isFromTemplate={isFromTemplate}
     >
       Test
-    </CollectiveOfferLayout>
+    </CollectiveOfferLayout>,
+    { initialRouterEntries: [path] }
   )
+}
 
 describe('CollectiveOfferLayout', () => {
-  let props: { isTemplate?: boolean; title: string; subTitle?: string }
-  beforeEach(() => {
-    props = {
-      title: 'Offre collective',
-      subTitle: 'Ma super offre',
-    }
-  })
   it('should render subtitle if provided', () => {
-    renderCollectiveOfferLayout(props)
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveOfferLayout('/offre/A1/collectif/edition')
 
-    const offerTitle = screen.getByText('Offre collective')
     const offersubTitle = screen.getByText('Ma super offre')
     const tagOfferTemplate = screen.queryByText('Offre vitrine')
 
-    expect(offerTitle).toBeInTheDocument()
     expect(offersubTitle).toBeInTheDocument()
     expect(tagOfferTemplate).not.toBeInTheDocument()
   })
-  it("should render 'offer template' tag is offer is template", () => {
-    props.isTemplate = true
-    renderCollectiveOfferLayout(props)
+  it("should render 'Offre vitrine' tag if offer is template", () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'T-A1' })
+    renderCollectiveOfferLayout('/offre/T-A1/collectif/edition')
 
     const tagOfferTemplate = screen.getByText('Offre vitrine')
 
     expect(tagOfferTemplate).toBeInTheDocument()
+  })
+  it('should render summary page layout in edition', () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveOfferLayout('/offre/A1/collectif/recapitulatif')
+
+    const title = screen.getByRole('heading', { name: 'Récapitulatif' })
+
+    expect(title).toBeInTheDocument()
+  })
+  it('should display creation title', () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveOfferLayout('/offre/A1/collectif/')
+
+    const title = screen.getByRole('heading', {
+      name: 'Créer une nouvelle offre collective',
+    })
+
+    expect(title).toBeInTheDocument()
+  })
+  it('should display creation from template title', () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveOfferLayout('/offre/A1/collectif/', true)
+
+    const title = screen.getByRole('heading', {
+      name: 'Créer une offre pour un établissement scolaire',
+    })
+
+    expect(title).toBeInTheDocument()
   })
 })

--- a/pro/src/core/OfferEducational/adapters/getCollectiveOfferAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getCollectiveOfferAdapter.ts
@@ -3,7 +3,7 @@ import { api } from 'apiClient/api'
 import { CollectiveOffer } from '../types'
 
 type IPayloadFailure = null
-type GetCollectiveOfferAdapter = Adapter<
+export type GetCollectiveOfferAdapter = Adapter<
   string,
   CollectiveOffer,
   IPayloadFailure

--- a/pro/src/core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter.ts
+++ b/pro/src/core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter.ts
@@ -3,7 +3,7 @@ import { api } from 'apiClient/api'
 import { CollectiveOfferTemplate } from '../types'
 
 type IPayloadFailure = null
-type GetCollectiveOfferTemplateAdapter = Adapter<
+export type GetCollectiveOfferTemplateAdapter = Adapter<
   string,
   CollectiveOfferTemplate,
   IPayloadFailure

--- a/pro/src/hooks/__specs__/useCollectiveOfferRoute.spec.tsx
+++ b/pro/src/hooks/__specs__/useCollectiveOfferRoute.spec.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import * as getCollectiveOfferAdapter from 'core/OfferEducational/adapters/getCollectiveOfferAdapter'
+import * as getCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
+import useCollectiveOfferRoute from 'hooks/useCollectiveOfferRoute'
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
+  },
+}))
+
+describe('useCollectiveOfferRoute', () => {
+  it('should set the adapter and id for a template offer', async () => {
+    const pathName = '/offre/T-A1/collectif/edition'
+    const mockAdapter = jest.fn()
+    jest
+      .spyOn(getCollectiveOfferTemplateAdapter, 'default')
+      .mockImplementation(mockAdapter)
+    const { result } = renderHook(() =>
+      useCollectiveOfferRoute(pathName, 'T-A1')
+    )
+    expect(result.current.isTemplate).toEqual(true)
+    expect(result.current.offerId).toEqual('A1')
+    expect(mockAdapter).toHaveBeenCalledTimes(1)
+  })
+
+  it('should set the adapter and id for an offer that is not a template', async () => {
+    const pathName = '/offre/A1/collectif/edition'
+    const mockAdapter = jest.fn()
+    jest
+      .spyOn(getCollectiveOfferAdapter, 'default')
+      .mockImplementation(mockAdapter)
+    const { result } = renderHook(() => useCollectiveOfferRoute(pathName, 'A1'))
+    expect(result.current.isTemplate).toEqual(false)
+    expect(result.current.offerId).toEqual('A1')
+    result.current.loadCollectiveOffer?.('')
+    expect(mockAdapter).toHaveBeenCalledTimes(1)
+  })
+
+  it('should indicate if a route is part of creation', async () => {
+    const pathName = '/offre/creation/collectif/vitrine'
+    const { result } = renderHook(() => useCollectiveOfferRoute(pathName))
+    expect(result.current.isCreation).toEqual(true)
+  })
+
+  it('should indicate if a route is part of edition', async () => {
+    const pathName = '/offre/:offerId/collectif/recapitulatif'
+    const { result } = renderHook(() =>
+      useCollectiveOfferRoute(pathName, 'T-A1')
+    )
+    expect(result.current.isCreation).toEqual(false)
+  })
+})

--- a/pro/src/hooks/useCollectiveOfferRoute.ts
+++ b/pro/src/hooks/useCollectiveOfferRoute.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+import { matchPath } from 'react-router'
+
+import getCollectiveOfferAdapter, {
+  GetCollectiveOfferAdapter,
+} from 'core/OfferEducational/adapters/getCollectiveOfferAdapter'
+import getCollectiveOfferTemplateAdapter, {
+  GetCollectiveOfferTemplateAdapter,
+} from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
+
+const useCollectiveOfferRoute = (
+  pathname: string,
+  offerIdFromParam?: string
+) => {
+  const [loadCollectiveOffer, setLoadCollectiveOffer] = useState<
+    GetCollectiveOfferTemplateAdapter | GetCollectiveOfferAdapter
+  >()
+  const [offerId, setOfferId] = useState<string>()
+  const [isCreation, setIsCreation] = useState<boolean>(false)
+  const [isTemplate, setIsTemplate] = useState<boolean>(false)
+  useEffect(() => {
+    setIsCreation(
+      [
+        '/offre/:offerId/collectif/edition',
+        '/offre/:offerId/collectif/recapitulatif',
+        '/offre/:offerId/collectif/stocks/edition',
+        '/offre/:offerId/collectif/visibilite/edition',
+      ].find(route => matchPath(pathname, route)) === undefined
+    )
+    const splitOfferId = offerIdFromParam?.split('T-')
+
+    const isTemplate =
+      splitOfferId === undefined
+        ? pathname.includes('vitrine') // creation
+        : splitOfferId.length > 1 // edition
+
+    setOfferId(
+      splitOfferId && splitOfferId.length > 1
+        ? splitOfferId[1]
+        : offerIdFromParam
+    )
+    setIsTemplate(isTemplate)
+    setLoadCollectiveOffer(
+      isTemplate ? getCollectiveOfferTemplateAdapter : getCollectiveOfferAdapter
+    )
+  }, [])
+
+  return {
+    offerId,
+    isCreation,
+    isTemplate,
+    loadCollectiveOffer,
+  }
+}
+
+export default useCollectiveOfferRoute

--- a/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -15,7 +15,7 @@ import OfferEducationalScreen from 'screens/OfferEducational'
 import useOfferEducationalFormData from 'screens/OfferEducational/useOfferEducationalFormData'
 import Spinner from 'ui-kit/Spinner/Spinner'
 
-interface CollectiveOfferCreationProps {
+export interface CollectiveOfferCreationProps {
   offer?: CollectiveOffer | CollectiveOfferTemplate
   setOffer: (offer: CollectiveOffer | CollectiveOfferTemplate) => void
   isTemplate?: boolean

--- a/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 
+import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
   CollectiveOffer,
   CollectiveOfferTemplate,
   Mode,
+  isCollectiveOffer,
 } from 'core/OfferEducational'
 import canOffererCreateCollectiveOfferAdapter from 'core/OfferEducational/adapters/canOffererCreateCollectiveOfferAdapter'
 import { queryParamsFromOfferer } from 'pages/Offers/utils/queryParamsFromOfferer'
@@ -36,7 +38,10 @@ const CollectiveOfferCreation = ({
   }
 
   return (
-    <>
+    <CollectiveOfferLayout
+      subTitle={offer?.name}
+      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+    >
       <OfferEducationalScreen
         categories={offerEducationalFormData.categories}
         userOfferers={offerEducationalFormData.offerers}
@@ -48,7 +53,7 @@ const CollectiveOfferCreation = ({
         isTemplate={isTemplate}
       />
       <RouteLeavingGuardCollectiveOfferCreation />
-    </>
+    </CollectiveOfferLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferCreation/__specs__/CollectiveOfferCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferCreation/__specs__/CollectiveOfferCreation.spec.tsx
@@ -1,0 +1,72 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+import * as router from 'react-router-dom'
+
+import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveOfferCreation, {
+  CollectiveOfferCreationProps,
+} from '../CollectiveOfferCreation'
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getCategories: jest.fn(),
+    listEducationalDomains: jest.fn(),
+    listEducationalOfferers: jest.fn(),
+    canOffererCreateEducationalOffer: jest.fn(),
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
+  },
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}))
+
+const renderCollectiveOfferCreation = (
+  path: string,
+  props: CollectiveOfferCreationProps
+) => {
+  renderWithProviders(<CollectiveOfferCreation {...props} />, {
+    initialRouterEntries: [path],
+  })
+}
+
+const defaultProps = {
+  offer: collectiveOfferFactory(),
+  setOffer: jest.fn(),
+}
+
+describe('CollectiveOfferCreation', () => {
+  it('should render collective offer creation form', async () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveOfferCreation('/offre/creation/collectif', defaultProps)
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Créer une nouvelle offre collective',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'Lieu de rattachement de votre offre',
+      })
+    ).toBeInTheDocument()
+  })
+  it('should render with template tag', async () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'T-A1' })
+    renderCollectiveOfferCreation('/offre/creation/collectif/vitrine', {
+      ...defaultProps,
+      isTemplate: true,
+    })
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Créer une nouvelle offre collective',
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Offre vitrine')).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferCreationRoutes/CollectiveOfferCreationRoutes.tsx
+++ b/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferCreationRoutes/CollectiveOfferCreationRoutes.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react'
 import { Route, Switch, useLocation } from 'react-router-dom'
 
-import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import PageTitle from 'components/PageTitle/PageTitle'
 import {
   CollectiveOffer,
@@ -18,8 +17,6 @@ import CollectiveOfferSummaryCreation from 'pages/CollectiveOfferSummaryCreation
 import CollectiveOfferVisibilityCreation from 'pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility'
 import CollectiveOfferSelectionDuplication from 'screens/CollectiveOfferSelectionDuplication'
 import Spinner from 'ui-kit/Spinner/Spinner'
-
-import { getActiveStep } from '../utils/getActiveStep'
 
 interface CollectiveOfferCreationRoutesProps {
   offerId?: string
@@ -57,8 +54,6 @@ const CollectiveOfferCreationRoutes = ({
     loadCollectiveOffer(offerId)
   }, [offerId])
 
-  const activeStep = getActiveStep(location.pathname)
-
   return (
     <Switch>
       <Route
@@ -84,90 +79,71 @@ const CollectiveOfferCreationRoutes = ({
         exact={false}
       >
         <PageTitle title="Détails de l'offre" />
-        <CollectiveOfferLayout
-          title={
-            isCollectiveOffer(offer) && offer?.templateId
-              ? 'Créer une offre pour un établissement scolaire'
-              : 'Créer une nouvelle offre collective'
-          }
-          subTitle={offer?.name}
-          breadCrumpProps={{
-            activeStep: activeStep,
-            isCreatingOffer: true,
-            offerId,
-          }}
-          isTemplate={shouldRenderTemplateOffer}
-          haveStock={isCollectiveOffer(offer) && Boolean(offer.collectiveStock)}
-        >
-          <Switch>
-            <Route path="/offre/creation/collectif/vitrine">
+        <Switch>
+          <Route path="/offre/creation/collectif/vitrine">
+            <CollectiveOfferCreation
+              offer={offer}
+              setOffer={setOffer}
+              isTemplate
+            />
+          </Route>
+          <Route path="/offre/creation/collectif">
+            <CollectiveOfferCreation offer={offer} setOffer={setOffer} />
+          </Route>
+          <Route path="/offre/collectif/:offerId/creation">
+            {offer ? (
+              <CollectiveOfferCreation offer={offer} setOffer={setOffer} />
+            ) : (
+              <Spinner />
+            )}
+          </Route>
+          <Route path="/offre/collectif/vitrine/:offerId/creation">
+            {offer ? (
               <CollectiveOfferCreation
                 offer={offer}
                 setOffer={setOffer}
                 isTemplate
               />
-            </Route>
-            <Route path="/offre/creation/collectif">
-              <CollectiveOfferCreation offer={offer} setOffer={setOffer} />
-            </Route>
-            <Route path="/offre/collectif/:offerId/creation">
-              {offer ? (
-                <CollectiveOfferCreation offer={offer} setOffer={setOffer} />
-              ) : (
-                <Spinner />
-              )}
-            </Route>
-            <Route path="/offre/collectif/vitrine/:offerId/creation">
-              {offer ? (
-                <CollectiveOfferCreation
-                  offer={offer}
-                  setOffer={setOffer}
-                  isTemplate
-                />
-              ) : (
-                <Spinner />
-              )}
-            </Route>
-            <Route path="/offre/:offerId/collectif/stocks">
-              <PageTitle title="Date et prix" />
-              {offer && isCollectiveOffer(offer) ? (
-                <CollectiveOfferStockCreation
-                  offer={offer}
-                  setOffer={setOffer}
-                />
-              ) : (
-                <Spinner />
-              )}
-            </Route>
-            <Route path="/offre/:offerId/collectif/visibilite">
-              <PageTitle title="Visibilité" />
-              {offer && isCollectiveOffer(offer) ? (
-                <CollectiveOfferVisibilityCreation
-                  offer={offer}
-                  setOffer={setOffer}
-                />
-              ) : (
-                <Spinner />
-              )}
-            </Route>
-            <Route
-              path={[
-                '/offre/:offerId/collectif/creation/recapitulatif',
-                '/offre/:offerId/collectif/vitrine/creation/recapitulatif',
-              ]}
-            >
-              <PageTitle title="Récapitulatif" />
-              {offer ? (
-                <CollectiveOfferSummaryCreation
-                  offer={offer}
-                  setOffer={setOffer}
-                />
-              ) : (
-                <Spinner />
-              )}
-            </Route>
-          </Switch>
-        </CollectiveOfferLayout>
+            ) : (
+              <Spinner />
+            )}
+          </Route>
+          <Route path="/offre/:offerId/collectif/stocks">
+            <PageTitle title="Date et prix" />
+            {offer && isCollectiveOffer(offer) ? (
+              <CollectiveOfferStockCreation offer={offer} setOffer={setOffer} />
+            ) : (
+              <Spinner />
+            )}
+          </Route>
+          <Route path="/offre/:offerId/collectif/visibilite">
+            <PageTitle title="Visibilité" />
+            {offer && isCollectiveOffer(offer) ? (
+              <CollectiveOfferVisibilityCreation
+                offer={offer}
+                setOffer={setOffer}
+              />
+            ) : (
+              <Spinner />
+            )}
+          </Route>
+          <Route
+            path={[
+              '/offre/:offerId/collectif/creation/recapitulatif',
+              '/offre/:offerId/collectif/vitrine/creation/recapitulatif',
+            ]}
+          >
+            <PageTitle title="Récapitulatif" />
+            {offer ? (
+              <CollectiveOfferSummaryCreation
+                offer={offer}
+                setOffer={setOffer}
+              />
+            ) : (
+              <Spinner />
+            )}
+          </Route>
+        </Switch>
       </Route>
     </Switch>
   )

--- a/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferEditionRoutes/CollectiveOfferEditionRoutes.tsx
+++ b/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferEditionRoutes/CollectiveOfferEditionRoutes.tsx
@@ -1,6 +1,6 @@
 /* istanbul ignore file: DEBT, TO FIX*/
 import React, { useCallback, useEffect, useState } from 'react'
-import { Route, Switch, useLocation } from 'react-router-dom'
+import { Route, Switch } from 'react-router-dom'
 
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import PageTitle from 'components/PageTitle/PageTitle'
@@ -11,14 +11,11 @@ import {
 } from 'core/OfferEducational'
 import getCollectiveOfferAdapter from 'core/OfferEducational/adapters/getCollectiveOfferAdapter'
 import getCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
-import { computeURLCollectiveOfferId } from 'core/OfferEducational/utils/computeURLCollectiveOfferId'
 import CollectiveOfferEdition from 'pages/CollectiveOfferEdition'
 import CollectiveOfferStockEdition from 'pages/CollectiveOfferStockEdition'
 import CollectiveOfferSummaryEdition from 'pages/CollectiveOfferSummaryEdition'
 import CollectiveOfferVisibility from 'pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility'
 import Spinner from 'ui-kit/Spinner/Spinner'
-
-import { getActiveStep } from '../utils/getActiveStep'
 
 interface CollectiveOfferEditionRoutesProps {
   offerId: string
@@ -29,8 +26,6 @@ const CollectiveOfferEditionRoutes = ({
   offerId,
   isTemplate,
 }: CollectiveOfferEditionRoutesProps): JSX.Element => {
-  const location = useLocation()
-
   const [offer, setOffer] = useState<
     CollectiveOffer | CollectiveOfferTemplate
   >()
@@ -53,23 +48,8 @@ const CollectiveOfferEditionRoutes = ({
     return <Spinner />
   }
 
-  const isSummaryPage = location.pathname.includes('recapitulatif')
-
   return (
-    <CollectiveOfferLayout
-      isTemplate={isTemplate}
-      title={isSummaryPage ? 'Récapitulatif' : 'Éditer une offre collective'}
-      subTitle={offer.name}
-      breadCrumpProps={
-        isSummaryPage
-          ? undefined
-          : {
-              activeStep: getActiveStep(location.pathname),
-              offerId: computeURLCollectiveOfferId(offerId, isTemplate),
-              isCreatingOffer: false,
-            }
-      }
-    >
+    <CollectiveOfferLayout subTitle={offer.name}>
       <Switch>
         <Route path="/offre/:offerId/collectif/edition">
           <PageTitle title="Détails de l'offre" />

--- a/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferRoutes.tsx
+++ b/pro/src/pages/CollectiveOfferRoutes/CollectiveOfferRoutes.tsx
@@ -14,8 +14,6 @@ const CollectiveOfferRoutes = (): JSX.Element => {
   const { offerId, isTemplate } =
     extractOfferIdAndOfferTypeFromRouteParams(offerIdFromParams)
 
-  const formattedOfferId = offerId !== 'creation' ? offerId : undefined
-
   return (
     <Switch>
       <Route
@@ -31,9 +29,14 @@ const CollectiveOfferRoutes = (): JSX.Element => {
           isTemplate={isTemplate}
         />
       </Route>
+      <Route path={['/offre/creation/collectif']}>
+        <CollectiveOfferCreationRoutes
+          offerId={undefined}
+          isTemplate={isTemplate}
+        />
+      </Route>
       <Route
         path={[
-          '/offre/creation/collectif',
           '/offre/collectif/:offerId/creation',
           '/offre/collectif/vitrine/:offerId/creation',
           '/offre/:offerId/collectif/stocks',
@@ -45,7 +48,7 @@ const CollectiveOfferRoutes = (): JSX.Element => {
         ]}
       >
         <CollectiveOfferCreationRoutes
-          offerId={formattedOfferId}
+          offerId={offerId}
           isTemplate={isTemplate}
         />
       </Route>

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
 
+import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
   CollectiveOffer,
   EducationalOfferType,
   extractInitialStockValues,
+  isCollectiveOffer,
   Mode,
   OfferEducationalStockFormValues,
 } from 'core/OfferEducational'
@@ -96,7 +98,10 @@ const CollectiveOfferStockCreation = ({
   }
 
   return (
-    <>
+    <CollectiveOfferLayout
+      subTitle={offer?.name}
+      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+    >
       <OfferEducationalStockScreen
         initialValues={initialValues}
         mode={Mode.CREATION}
@@ -104,7 +109,7 @@ const CollectiveOfferStockCreation = ({
         onSubmit={handleSubmitStock}
       />
       <RouteLeavingGuardCollectiveOfferCreation />
-    </>
+    </CollectiveOfferLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -19,7 +19,7 @@ import OfferEducationalStockScreen from 'screens/OfferEducationalStock'
 import postCollectiveOfferTemplateAdapter from './adapters/postCollectiveOfferTemplate'
 import postCollectiveStockAdapter from './adapters/postCollectiveStock'
 
-interface OfferEducationalStockCreationProps {
+export interface OfferEducationalStockCreationProps {
   offer: CollectiveOffer
   setOffer: (offer: CollectiveOffer) => void
 }

--- a/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
@@ -1,0 +1,53 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+import * as router from 'react-router-dom'
+
+import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveOfferStockCreation from '..'
+import { OfferEducationalStockCreationProps } from '../CollectiveOfferStockCreation'
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
+  },
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}))
+
+const renderCollectiveStockCreation = (
+  path: string,
+  props: OfferEducationalStockCreationProps
+) => {
+  renderWithProviders(<CollectiveOfferStockCreation {...props} />, {
+    initialRouterEntries: [path],
+  })
+}
+
+const defaultProps = {
+  offer: collectiveOfferFactory(),
+  setOffer: jest.fn(),
+}
+
+describe('CollectiveOfferStockCreation', () => {
+  it('should render collective offer stock form', async () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveStockCreation('/offre/A1/collectif/stocks', defaultProps)
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Créer une nouvelle offre collective',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'Date et prix',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -13,7 +13,7 @@ import useNotification from 'hooks/useNotification'
 import CollectiveOfferSummaryCreationScreen from 'screens/CollectiveOfferSummaryCreation'
 import Spinner from 'ui-kit/Spinner/Spinner'
 
-interface CollectiveOfferSummaryCreationProps {
+export interface CollectiveOfferSummaryCreationProps {
   offer: CollectiveOffer | CollectiveOfferTemplate
   setOffer: (offer: CollectiveOffer | CollectiveOfferTemplate) => void
 }

--- a/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 
+import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
   getEducationalCategoriesAdapter,
   CollectiveOffer,
   CollectiveOfferTemplate,
+  isCollectiveOffer,
 } from 'core/OfferEducational'
 import { useAdapter } from 'hooks'
 import useNotification from 'hooks/useNotification'
@@ -36,14 +38,17 @@ const CollectiveOfferSummaryCreation = ({
   return isLoading ? (
     <Spinner />
   ) : (
-    <>
+    <CollectiveOfferLayout
+      subTitle={offer?.name}
+      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+    >
       <CollectiveOfferSummaryCreationScreen
         offer={offer}
         categories={categories}
         setOffer={setOffer}
       />
       <RouteLeavingGuardCollectiveOfferCreation />
-    </>
+    </CollectiveOfferLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferSummaryCreation/__specs__/CollectiveOfferSummaryCreation.spec.tsx
@@ -1,0 +1,62 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import React from 'react'
+import * as router from 'react-router-dom'
+
+import { api } from 'apiClient/api'
+import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveOfferSummaryCreation, {
+  CollectiveOfferSummaryCreationProps,
+} from '../CollectiveOfferSummaryCreation'
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getCategories: jest.fn(),
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
+  },
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}))
+
+const renderCollectiveOfferSummaryCreation = async (
+  path: string,
+  props: CollectiveOfferSummaryCreationProps
+) => {
+  renderWithProviders(<CollectiveOfferSummaryCreation {...props} />, {
+    initialRouterEntries: [path],
+  })
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+}
+
+const defaultProps = {
+  offer: collectiveOfferFactory(),
+  setOffer: jest.fn(),
+}
+
+describe('CollectiveOfferSummaryCreation', () => {
+  it('should render collective offer summary ', async () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    jest
+      .spyOn(api, 'getCategories')
+      .mockResolvedValue({ categories: [], subcategories: [] })
+    await renderCollectiveOfferSummaryCreation(
+      '/offre/A1/collectif/creation/recapitulatif',
+      defaultProps
+    )
+    expect(
+      screen.getByRole('heading', {
+        name: 'Créer une nouvelle offre collective',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'Détails de l’offre',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router'
 
 import { EducationalInstitutionResponseModel } from 'apiClient/v1'
+import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
   CollectiveOffer,
   DEFAULT_VISIBILITY_FORM_VALUES,
   Mode,
+  isCollectiveOffer,
 } from 'core/OfferEducational'
 import { extractInitialVisibilityValues } from 'core/OfferEducational/utils/extractInitialVisibilityValues'
 import CollectiveOfferVisibilityScreen from 'screens/CollectiveOfferVisibility'
@@ -54,7 +56,10 @@ const CollectiveOfferVisibility = ({
     ? extractInitialVisibilityValues(offer.institution)
     : DEFAULT_VISIBILITY_FORM_VALUES
   return (
-    <>
+    <CollectiveOfferLayout
+      subTitle={offer?.name}
+      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
+    >
       <CollectiveOfferVisibilityScreen
         mode={Mode.CREATION}
         patchInstitution={patchEducationalInstitutionAdapter}
@@ -64,7 +69,7 @@ const CollectiveOfferVisibility = ({
         isLoadingInstitutions={isLoadingInstitutions}
       />
       <RouteLeavingGuardCollectiveOfferCreation />
-    </>
+    </CollectiveOfferLayout>
   )
 }
 

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -16,7 +16,7 @@ import CollectiveOfferVisibilityScreen from 'screens/CollectiveOfferVisibility'
 import getEducationalInstitutionsAdapter from './adapters/getEducationalInstitutionsAdapter'
 import patchEducationalInstitutionAdapter from './adapters/patchEducationalInstitutionAdapter'
 
-interface CollectiveOfferVisibilityProps {
+export interface CollectiveOfferVisibilityProps {
   setOffer: (offer: CollectiveOffer) => void
   offer: CollectiveOffer
 }

--- a/pro/src/pages/CollectiveOfferVisibility/__specs__/CollectiveOfferCreationVisibility.spec.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/__specs__/CollectiveOfferCreationVisibility.spec.tsx
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+import * as router from 'react-router-dom'
+
+import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveOfferCreationVisibility, {
+  CollectiveOfferVisibilityProps,
+} from '../CollectiveOfferCreationVisibility'
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    getEducationalInstitutions: jest.fn(),
+    getCollectiveOffer: jest.fn(),
+    getCollectiveOfferTemplate: jest.fn(),
+  },
+}))
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}))
+
+const renderCollectiveOfferCreationVisibility = (
+  path: string,
+  props: CollectiveOfferVisibilityProps
+) => {
+  renderWithProviders(<CollectiveOfferCreationVisibility {...props} />, {
+    initialRouterEntries: [path],
+  })
+}
+
+const defaultProps = {
+  offer: collectiveOfferFactory(),
+  setOffer: jest.fn(),
+}
+
+describe('CollectiveOfferCreationVisibility', () => {
+  it('should render collective offer visibility form', async () => {
+    jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+    renderCollectiveOfferCreationVisibility(
+      '/offre/A1/collectif/visibilite',
+      defaultProps
+    )
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Créer une nouvelle offre collective',
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        name: 'Visibilité de l’offre',
+      })
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20391

## But de la pull request

Supprimer les paramètres passés aux routes pour les déplacer plus bas dans l'architecture

## Implémentation

Ajout d'un hook qui récupère les paramètres d'une offre collective

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires