### PR TITLE
(PC-20210)[API] feat: Profil jeune - Lien vers le second profil en cas de doublon

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -227,3 +227,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["pc_pro_venue_offers_link"] = urls.build_pc_pro_venue_offers_link
     app.jinja_env.filters["pc_pro_venue_link"] = urls.build_pc_pro_venue_link
     app.jinja_env.filters["pc_pro_user_email_validation_link"] = urls.build_pc_pro_user_email_validation_link
+    app.jinja_env.filters["pc_backoffice_public_account_link"] = urls.build_backoffice_public_account_link
+    app.jinja_env.filters[
+        "pc_backoffice_public_account_link_in_comment"
+    ] = urls.build_backoffice_public_account_link_in_comment

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details.html
@@ -4,17 +4,17 @@
 {% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
 
     {% call build_details_tabs_wrapper() %}
-        {{ build_details_tab("history", "Historique du compte", true) }}
-        {{ build_details_tab("personal-information", "Informations personnelles") }}
+        {{ build_details_tab("history", "Historique du compte") }}
+        {{ build_details_tab("personal-information", "Informations personnelles", true) }}
         {{ build_details_tab("bookings", "Suivi des réservations") }}
     {% endcall %}
 
     {% call build_details_tabs_content_wrapper() %}
-        {% call build_details_tab_content("history", true) %}
+        {% call build_details_tab_content("history") %}
             {% include "accounts/get/details/history.html" %}
         {% endcall %}
 
-        {% call build_details_tab_content("personal-information") %}
+        {% call build_details_tab_content("personal-information", true) %}
             {% include "accounts/get/details/personal_information_user_details.html" %}
             {% for history_type, history in eligibility_history.items() %}
                 {% include "accounts/get/details/personal_information_registration.html" %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
@@ -81,7 +81,7 @@
                             </p>
                             <p class="d-flex justify-content-between">
                                 <span class="fs-6">Explication</span>
-                                <span class="fs-6">{{ idCheckItem.reason | empty_string_if_null }}</span>
+                                <span class="fs-6">{{ idCheckItem.reason | empty_string_if_null | pc_backoffice_public_account_link_in_comment | safe }}</span>
                             </p>
                             <p class="d-flex justify-content-between">
                                 <span class="fs-6">Codes d'erreur</span>

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -6,7 +6,6 @@
             <div class="card-body">
                 <h5 class="card-title">
                     {{ user.firstName }} {{ user.lastName | upper }}
-
                     {% for role in user.roles %}
                         <span class="ms-5 me-2 badge rounded-pill text-bg-primary align-middle">
                             {{ role | format_role }}
@@ -16,6 +15,11 @@
                         <span class="badge rounded-pill text-bg-secondary align-middle">
                             {{ user.isActive | format_state }}
                         </span>
+                    {% endif %}
+                   {% if duplicate_user_id %}
+                        <br>
+                        <small><a href="{{ duplicate_user_id | pc_backoffice_public_account_link }}" target="_blank">User ID
+                            doublon : {{ duplicate_user_id }}</a></small>
                     {% endif %}
                 </h5>
 

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -216,7 +216,7 @@
             </tr>
             <tr>
                 <th scope="row">Explication</th>
-                <td>{{ review.reason }}</td>
+                <td>{{ review.reason | pc_backoffice_public_account_link_in_comment | safe }}</td>
             </tr>
         </table>
         {% endfor %}
@@ -347,7 +347,7 @@
                 </tr>
                 <tr>
                     <th scope="row">Explication</th>
-                    <td>{{ check.reason|default("Aucune") }}</td>
+                    <td>{{ check.reason|default("Aucune") | pc_backoffice_public_account_link_in_comment | safe }}</td>
                 </tr>
                 <tr>
                     <th>Codes d'erreurs</th>

--- a/api/src/pcapi/utils/urls.py
+++ b/api/src/pcapi/utils/urls.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import urlencode
 
 from pcapi import settings
@@ -60,3 +61,15 @@ def build_pc_pro_venue_offers_link(venue: offerers_models.Venue) -> str:
 
 def build_pc_pro_user_email_validation_link(user: users_models.User) -> str:
     return f"{settings.PRO_URL}/inscription/validation/{user.validationToken}"
+
+
+def build_backoffice_public_account_link(user_id: int) -> str:
+    return f"{settings.BACKOFFICE_URL}/public-accounts/{user_id}"
+
+
+def substitute_id_by_url_public_account(found_id: str) -> str:
+    return f'<a class="link-primary" href="{build_backoffice_public_account_link(int(found_id))}" target="_blank">{found_id}</a>'
+
+
+def build_backoffice_public_account_link_in_comment(comment: str) -> str:
+    return re.sub(r"(\d+)$", lambda m: substitute_id_by_url_public_account(m.group(1)), comment)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20210

## But de la pull request

En tant que support jeune
J'aimerais accéder au profil doublon depuis le profil d’un jeune
Afin de gagner du temps

## Implémentation

- L’onglet par défaut lorsqu’on arrive sur le profil jeune doit être “Informations personnelles” (et non plus “Historique du compte)
- Sur le profil jeune, lorsqu’un doublon est identifié par Ubble (ID doublon visible dans le bloc “ubble”) : 
    - Remonter l’information du second ID dans le bloc d’informations générales en haut de page => User ID doublon : xxxxx
        - L’afficher uniquement en cas de doublon
    - Rendre cliquable cet ID doublon pour rediriger l’utilisateur vers le profil du doublon

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

<img width="797" alt="Capture d’écran 2023-02-13 à 22 20 16" src="https://user-images.githubusercontent.com/9610732/218577049-b2eb266f-404f-45ea-b38a-c0ed26efdd97.png">

