### PR TITLE
(PC-20399)[BO] feat: bypass user offerer validation on validate

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -192,32 +192,35 @@
 
           bindEvents = () => {
             this.$batchPendingButton.addEventListener('click', () => {
-              this.onModalOpen({
+              this.onBatchButtonClick({
                 url: "{{ url_for("backoffice_v3_web.validation.batch_set_user_offerer_pending") }}",
                 title: "Mettre en attente le(s) rattachement(s)",
                 divId: "pending-modal",
                 buttonText: "Mettre en attente",
+                useConfirmationModal: true,
               })
             })
             this.$batchValidationButton.addEventListener('click', () => {
-              this.onModalOpen({
+              this.onBatchButtonClick({
                 url: "{{ url_for("backoffice_v3_web.validation.batch_validate_user_offerer") }}",
                 title: "Valider le(s) rattachement(s)",
                 divId: "validating-modal",
-                buttonText: "Valider"
+                buttonText: "Valider",
+                useConfirmationModal: false,
               })
             })
             this.$batchRejectingButton.addEventListener('click', () => {
-              this.onModalOpen({
+              this.onBatchButtonClick({
                 url: "{{ url_for("backoffice_v3_web.validation.batch_reject_user_offerer") }}",
                 title: "Rejeter le(s) rattachement(s)",
                 divId: "rejecting-modal",
                 buttonText: "Rejeter",
+                useConfirmationModal: true,
               })
             })
           }
 
-          onModalOpen = ({ url, title, divId, buttonText }) => {
+          onBatchButtonClick = ({ url, title, divId, buttonText, useConfirmationModal }) => {
             const csrfToken = '{{ csrf_token }}'
             this.$modalContent.innerHTML = `
             <form action="${url}" method="POST" class="modal-content" id="${divId}-form" data-turbo="false" name="user-offerer-validation-form-modal">
@@ -241,7 +244,11 @@
                 </div>
             </form>`
 
-            this.modal.show()
+            if (useConfirmationModal) {
+              this.modal.show()
+              return
+            }
+            this.$modalContent.querySelector('form').submit()
           }
         }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20399

## But de la pull request

Ne pas afficher la modal quand on valide des offerer validation

## Implémentation

Ajout d'une option pour valider sans confirmation

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
