### PR TITLE
(PC-19889)[BO] fix: autocomplete was accent-sensitive

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/autocomplete.py
+++ b/api/src/pcapi/routes/backoffice_v3/autocomplete.py
@@ -4,6 +4,7 @@ import sqlalchemy as sa
 from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.clean_accents import clean_accents
 
 from . import blueprint
 
@@ -28,7 +29,7 @@ def autocomplete_offerers() -> AutocompleteResponse:
     if len(query_string) < 2:
         return AutocompleteResponse(items=[])
 
-    filters = offerers_models.Offerer.name.ilike(f"%{query_string}%")
+    filters = sa.func.unaccent(offerers_models.Offerer.name).ilike(f"%{clean_accents(query_string)}%")
 
     if query_string.isnumeric() and len(query_string) <= 9:
         filters = sa.or_(filters, offerers_models.Offerer.siren.like(f"{query_string}%"))
@@ -56,7 +57,7 @@ def autocomplete_venues() -> AutocompleteResponse:
     if not query_string or len(query_string) < 2:
         return AutocompleteResponse(items=[])
 
-    filters = offerers_models.Venue.name.ilike(f"%{query_string}%")
+    filters = sa.func.unaccent(offerers_models.Venue.name).ilike(f"%{clean_accents(query_string)}%")
 
     if query_string.isnumeric() and len(query_string) <= 14:
         filters = sa.or_(filters, offerers_models.Venue.siret.like(f"{query_string}%"))

--- a/api/tests/routes/backoffice_v3/autocomplete_test.py
+++ b/api/tests/routes/backoffice_v3/autocomplete_test.py
@@ -23,6 +23,7 @@ class AutocompleteOffererTest:
             ("789", set()),
             ("100200301", set()),
             ("ciné", {"Le Cinéma (123456789)", "Cinéma concurrent (561234789)"}),
+            ("cinema", {"Le Cinéma (123456789)", "Cinéma concurrent (561234789)"}),
             ("ciné théâtre", set()),
         ],
     )
@@ -62,6 +63,7 @@ class AutocompleteVenueTest:
             ("789", set()),
             ("100200301", set()),
             ("ciné", {"Le Cinéma (12345678900018)", "Cinéma concurrent (56123478900023)"}),
+            ("cinema", {"Le Cinéma (12345678900018)", "Cinéma concurrent (56123478900023)"}),
             ("ciné théâtre", set()),
         ],
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19889

## But de la pull request

Dans l'autocomplétion des structures et lieux du backoffice v3, permettre de chercher indifféremment avec ou sans accents. « cinema » doit trouver des structures contenant « Cinéma ».

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
