### PR TITLE
(PC-20496) cine update stocks

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1064,7 +1064,7 @@ def update_stock_quantity_to_match_cinema_venue_provider_remaining_places(
         "Getting up-to-date show stock from booking provider on offer view",
         extra={"offer": offer.id, "venue_provider": venue_provider.id},
     )
-    offer_current_stocks = offer.activeStocks
+    offer_current_stocks = offer.bookableStocks
 
     match venue_provider.provider.localClass:
         case "CDSStocks":
@@ -1072,7 +1072,7 @@ def update_stock_quantity_to_match_cinema_venue_provider_remaining_places(
                 raise feature.DisabledFeatureError("ENABLE_CDS_IMPLEMENTATION is inactive")
             show_ids = [
                 cinema_providers_utils.get_cds_show_id_from_uuid(stock.idAtProviders)
-                for stock in offer.activeStocks
+                for stock in offer.bookableStocks
                 if stock.idAtProviders
             ]
             cleaned_show_ids = [s for s in show_ids if s is not None]

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1863,15 +1863,19 @@ class FormatExtraDataTest:
 
 @pytest.mark.usefixtures("db_session")
 class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
+    DATETIME_10_DAYS_AFTER = datetime.today() + timedelta(days=10)
+    DATETIME_10_DAYS_AGO = datetime.today() - timedelta(days=10)
+
     @override_features(ENABLE_CDS_IMPLEMENTATION=True)
     @pytest.mark.parametrize(
-        "show_id, api_return_value, expected_remaining_quantity",
+        "show_id, show_beginning_datetime, api_return_value, expected_remaining_quantity",
         [
-            (888, {888: 10}, 10),
-            (888, {888: 5}, 10),
-            (888, {888: 1}, 1),
-            (888, {888: 0}, 0),
-            (123, {888: 0}, 0),
+            (888, DATETIME_10_DAYS_AFTER, {888: 10}, 10),
+            (888, DATETIME_10_DAYS_AFTER, {888: 5}, 10),
+            (888, DATETIME_10_DAYS_AFTER, {888: 1}, 1),
+            (888, DATETIME_10_DAYS_AFTER, {888: 0}, 0),
+            (123, DATETIME_10_DAYS_AFTER, {888: 0}, 0),
+            (888, DATETIME_10_DAYS_AGO, None, 10),
         ],
     )
     @patch("pcapi.core.search.async_index_offer_ids")
@@ -1881,6 +1885,7 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
         mocked_get_shows_stock,
         mocked_async_index_offer_ids,
         show_id,
+        show_beginning_datetime,
         api_return_value,
         expected_remaining_quantity,
     ):
@@ -1894,6 +1899,7 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
             offer=offer,
             quantity=10,
             idAtProviders=f"{offer_id_at_provider}#{show_id}/{showtime}",
+            beginningDatetime=show_beginning_datetime,
         )
 
         mocked_get_shows_stock.return_value = api_return_value
@@ -1907,13 +1913,14 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
 
     @override_features(ENABLE_BOOST_API_INTEGRATION=True)
     @pytest.mark.parametrize(
-        "show_id, api_return_value, expected_remaining_quantity",
+        "show_id, show_beginning_datetime, api_return_value, expected_remaining_quantity",
         [
-            (888, {888: 10}, 10),
-            (888, {888: 5}, 10),
-            (888, {888: 1}, 1),
-            (888, {888: 0}, 0),
-            (123, {888: 0}, 0),
+            (888, DATETIME_10_DAYS_AFTER, {888: 10}, 10),
+            (888, DATETIME_10_DAYS_AFTER, {888: 5}, 10),
+            (888, DATETIME_10_DAYS_AFTER, {888: 1}, 1),
+            (888, DATETIME_10_DAYS_AFTER, {888: 0}, 0),
+            (123, DATETIME_10_DAYS_AFTER, {888: 0}, 0),
+            (888, DATETIME_10_DAYS_AGO, None, 10),
         ],
     )
     @patch("pcapi.core.search.async_index_offer_ids")
@@ -1923,6 +1930,7 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
         mocked_get_boost_movie_shows_stock,
         mocked_async_index_offer_ids,
         show_id,
+        show_beginning_datetime,
         api_return_value,
         expected_remaining_quantity,
     ):
@@ -1935,6 +1943,7 @@ class UpdateStockQuantityToMatchCinemaVenueProviderRemainingPlacesTest:
             offer=offer,
             quantity=10,
             idAtProviders=f"{offer_id_at_provider}#{show_id}",
+            beginningDatetime=show_beginning_datetime,
         )
 
         mocked_get_boost_movie_shows_stock.return_value = api_return_value


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20496

## But de la pull request
- Limiter la mise à jour des stocks synchronisés à 0 ou 1 seulement pour les séances qui sont encore réservables.
- Ajouter un retry lorsqu'une erreur est levée suite à la vérification sur la colonne dé-normalisée `Stock.dnBookedQuantity`


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
