### PR TITLE
(PC-20399)[API] fix: Ajout du flash message lors de la réussite du traitement des rattachements

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -586,7 +586,8 @@ def add_user_offerer_and_validate(offerer_id: int) -> utils.BackofficeResponse:
 
 
 def _user_offerer_batch_action(
-    api_function: typing.Callable[[offerers_models.UserOfferer, users_models.User, str | None], None]
+    api_function: typing.Callable[[offerers_models.UserOfferer, users_models.User, str | None], None],
+    success_message: str,
 ) -> utils.BackofficeResponse:
     form = offerer_forms.BatchOptionalCommentForm()
     try:
@@ -599,23 +600,30 @@ def _user_offerer_batch_action(
 
     for user_offerer in user_offerers:
         api_function(user_offerer, current_user, form.comment.data)
+    flash(success_message, "success")
 
     return _redirect_after_offerer_validation_action()
 
 
 @validation_blueprint.route("/user-offerer/batch-pending", methods=["POST"])
 def batch_set_user_offerer_pending() -> utils.BackofficeResponse:
-    return _user_offerer_batch_action(offerers_api.set_offerer_attachment_pending)
+    return _user_offerer_batch_action(
+        offerers_api.set_offerer_attachment_pending, "Les rattachements ont été mis en attente avec succès"
+    )
 
 
 @validation_blueprint.route("/user-offerer/batch-reject", methods=["POST"])
 def batch_reject_user_offerer() -> utils.BackofficeResponse:
-    return _user_offerer_batch_action(offerers_api.reject_offerer_attachment)
+    return _user_offerer_batch_action(
+        offerers_api.reject_offerer_attachment, "Les rattachements sélectionnés ont été rejetés avec succès"
+    )
 
 
 @validation_blueprint.route("/user-offerer/batch-validate", methods=["POST"])
 def batch_validate_user_offerer() -> utils.BackofficeResponse:
-    return _user_offerer_batch_action(offerers_api.validate_offerer_attachment)
+    return _user_offerer_batch_action(
+        offerers_api.validate_offerer_attachment, "Les rattachements sélectionnés ont été validés avec succès"
+    )
 
 
 offerer_tag_blueprint = utils.child_backoffice_blueprint(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20399

## But de la pull request

Lors d’une validation/rejet/mise en attente en masse, il n’y a aucun message de type snack bar en haut de page pour confirmer à l’utilisateur que l’action a bien été réalisée (alors que c’est le cas pour une action sur une demande invididuelle) 

## Implémentation

- Ajout d'un message flash spécifique au type de traitement en batch effectué (validation, rejet, mise en attente)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
