### PR TITLE
Pc 20441 archive old digital bookings

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -4,7 +4,7 @@ import typing
 
 import pytz
 import sentry_sdk
-from sqlalchemy.orm import Query
+import sqlalchemy as sa
 
 from pcapi.core import search
 from pcapi.core.bookings import constants
@@ -442,7 +442,7 @@ def recompute_dnBookedQuantity(stock_ids: list[int]) -> None:
     db.session.execute(query, {"stock_ids": tuple(stock_ids)})
 
 
-def _logs_for_data_purpose(collective_bookings_subquery: Query) -> None:
+def _logs_for_data_purpose(collective_bookings_subquery: sa.orm.Query) -> None:
     bookings_information_tuple = collective_bookings_subquery.with_entities(
         CollectiveBooking.id, CollectiveBooking.collectiveStockId
     )

--- a/api/src/pcapi/core/bookings/commands.py
+++ b/api/src/pcapi/core/bookings/commands.py
@@ -1,0 +1,16 @@
+import logging
+
+import pcapi.scheduled_tasks.decorators as cron_decorators
+from pcapi.utils.blueprint import Blueprint
+
+from . import api
+
+
+blueprint = Blueprint(__name__, __name__)
+logger = logging.getLogger(__name__)
+
+
+@blueprint.cli.command("archive_old_activation_code_bookings")
+@cron_decorators.log_cron_with_transaction
+def archive_old_activation_code_bookings() -> None:
+    api.archive_old_activation_code_bookings()

--- a/api/src/pcapi/core/bookings/constants.py
+++ b/api/src/pcapi/core/bookings/constants.py
@@ -1,6 +1,7 @@
 import datetime
 
 
+ARCHIVE_DELAY = datetime.timedelta(days=30)
 CONFIRM_BOOKING_AFTER_CREATION_DELAY = datetime.timedelta(hours=48)
 CONFIRM_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(hours=48)
 BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=30)

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -180,7 +180,7 @@ def is_ended_booking(booking: Booking) -> bool:
         and booking.status != BookingStatus.CANCELLED
         and booking.stock.beginningDatetime >= datetime.utcnow()
     ):
-        # consider future events events as "ongoing" even if they are used
+        # consider future events as "ongoing" even if they are used
         return False
 
     if booking.stock.canHaveActivationCodes and booking.activationCode:

--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -5,6 +5,7 @@ import flask
 
 def install_commands(app: flask.Flask) -> None:
     module_paths = (
+        "pcapi.core.bookings.commands",
         "pcapi.core.educational.commands",
         "pcapi.core.external.commands.update_sendinblue_batch_attributes",
         "pcapi.core.finance.commands",

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -1,0 +1,34 @@
+import datetime
+
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.offers import factories as offers_factories
+
+from tests.conftest import clean_database
+from tests.test_utils import run_command
+
+
+class ArchiveOldDigitalBookingsTest:
+    @clean_database
+    def test_basics(self, app):
+        # given
+        now = datetime.datetime.utcnow()
+        recent = now - datetime.timedelta(days=29, hours=23)
+        old = now - datetime.timedelta(days=30, hours=1)
+        offer = offers_factories.OfferFactory(url="http://example.com")
+        stock = offers_factories.StockFactory(offer=offer)
+        recent_booking = bookings_factories.BookingFactory(stock=stock, dateCreated=recent)
+        old_booking = bookings_factories.BookingFactory(stock=stock, dateCreated=old)
+        offers_factories.ActivationCodeFactory(booking=recent_booking, stock=stock)
+        offers_factories.ActivationCodeFactory(booking=old_booking, stock=stock)
+        recent_booking_id = recent_booking.id
+        old_booking_id = old_booking.id
+
+        # when
+        run_command(app, "archive_old_activation_code_bookings")
+
+        # then
+        old_booking = bookings_models.Booking.query.get(old_booking_id)
+        recent_booking = bookings_models.Booking.query.get(recent_booking_id)
+        assert old_booking.displayAsEnded
+        assert not recent_booking.displayAsEnded

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -7,12 +7,7 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.utils import human_ids
 
 from tests.conftest import clean_database
-
-
-def run_command(app, command_name, *args):
-    runner = app.test_cli_runner()
-    args = (command_name, *args)
-    return runner.invoke(args=args)
+from tests.test_utils import run_command
 
 
 class AddCustomOfferReimbursementRuleTest:

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -23,3 +23,9 @@ def gen_offerer_tags():
     tags = [offerers_factories.OffererTagFactory(label=label) for label in ("Collectivité", "Établissement public")]
     tags.append(offerers_factories.OffererTagFactory(name="partenaire-national", label="Partenaire national"))
     return tags
+
+
+def run_command(app, command_name, *args):
+    runner = app.test_cli_runner()
+    args = (command_name, *args)
+    return runner.invoke(args=args)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20441

## But de la pull request

archiver les réservations avec code d'activation qui ont plus de 30 jours dans (càd. les renvoyer dans la liste des réservations terminées)

## Implémentation

ajout d'une commande `archive_old_activation_code_bookings` pour passer l'attribut `Booking.displayAsEnded` à `True` pour les réservations avec code d'activation qui ont plus de 30 jours

[cette commande sera exécutée par un CRON](https://github.com/pass-culture/pass-culture-deployment/pull/199)

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
