### PR TITLE
(PC-20537)[BO] feat: Move SIRET from backoffice (Legal SIRET)

### DIFF
--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -5,11 +5,11 @@ import logging
 import click
 import sqlalchemy.orm as sqla_orm
 
+from pcapi.core.finance import siret_api
 import pcapi.core.finance.api as finance_api
 import pcapi.core.finance.utils as finance_utils
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
-from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 import pcapi.scheduled_tasks.decorators as cron_decorators
 from pcapi.utils import human_ids
@@ -128,41 +128,6 @@ def add_custom_offer_reimbursement_rule(
     print(f"Created new rule: {rule.id}")
 
 
-class CheckError(Exception):
-    pass
-
-
-def check_can_move_siret(source_id: int, target_id: int, siret: str, override_revenue_check: bool) -> None:
-    source = offerers_models.Venue.query.get(source_id)
-    target = offerers_models.Venue.query.get(target_id)
-    if source.managingOffererId != target.managingOffererId:
-        raise CheckError(f"Source {source_id} and target {target_id} do not have the same offerer")
-    offerer = target.managingOfferer
-    if offerer.siren != siret[:9]:
-        raise CheckError(f"SIRET {siret} does not match offerer SIREN {offerer.siren}")
-    if source.siret != siret:
-        raise CheckError(f"Source venue {source.id} has SIRET {source.siret}, not requested SIRET {siret}")
-    if target.siret is not None:
-        raise CheckError(f"Target venue {target.id} already has a siret: {target.siret}")
-
-    if not override_revenue_check:
-        # Calculate yearly revenue of target venue
-        query = """
-          select sum(booking.amount * booking.quantity) as "chiffre d'affaires"
-          from booking
-          where
-            "venueId" = :target_id
-            and "dateUsed" is not null
-            -- On ajoute 1 heure pour la conversion UTC -> CET afin de récupérer
-            -- le chiffre d'affaires de l'année en cours.
-            and DATE_PART('year', "dateUsed" + interval '1 hour') = date_part('year', now() + interval '1 hour');
-        """
-        rows = db.session.execute(query, {"target_id": target_id}).fetchone()
-        revenue = rows[0]
-        if revenue and revenue > 10_000:
-            raise CheckError("Target venue has an unexpectedly high yearly revenue.")
-
-
 @blueprint.cli.command("move_siret")
 @click.option("--src-venue-id", type=int, required=True)
 @click.option("--dst-venue-id", type=int, required=True)
@@ -178,68 +143,23 @@ def move_siret(
     apply_changes: bool = False,
     override_revenue_check: bool = False,
 ) -> None:
+    source = offerers_models.Venue.query.get(src_venue_id)
+    target = offerers_models.Venue.query.get(dst_venue_id)
+
     try:
-        check_can_move_siret(
-            source_id=src_venue_id,
-            target_id=dst_venue_id,
-            siret=siret,
+        siret_api.move_siret(
+            source,
+            target,
+            siret,
+            comment,
+            apply_changes=apply_changes,
             override_revenue_check=override_revenue_check,
         )
-    except CheckError as exc:
+    except siret_api.CheckError as exc:
         print(str(exc))
         return
 
-    db.session.rollback()  # discard any previous transaction to start a fresh new one.
-    queries = [
-        """
-        update pricing
-        set "pricingPointId" = :target_id
-        where "pricingPointId" = :source_id
-        """,
-        """
-        update venue_pricing_point_link
-        set "pricingPointId" = :target_id
-        where "pricingPointId" = :source_id
-        """,
-        """
-        update venue
-        set siret = NULL, comment = :comment
-        where id = :source_id and siret = :siret
-        """,
-        """
-        update venue
-        set siret = :siret, comment = NULL
-        where id = :target_id and siret IS NULL
-        """,
-        """
-        insert into venue_pricing_point_link ("venueId", "pricingPointId", timespan)
-        values (
-          :target_id,
-          :target_id,
-          tsrange(now()::timestamp, NULL, '[)')
-        )
-        -- If the pricing point of the target venue was the source venue before our changes,
-        -- the update above will have changed the existing row. Thus the source venue
-        -- now points to itself, which means that we don't need to execute this insert
-        -- (and it would raise an integrity error). Hence the "do nothing" below.
-        on conflict do nothing
-        """,
-    ]
-
-    db.session.begin()
-    for query in queries:
-        db.session.execute(
-            query,
-            {
-                "source_id": src_venue_id,
-                "target_id": dst_venue_id,
-                "siret": siret,
-                "comment": comment,
-            },
-        )
     if apply_changes:
-        db.session.commit()
         print("Siret has been moved.")
     else:
-        db.session.rollback()
         print("DRY RUN: NO CHANGES HAVE BEEN MADE")

--- a/api/src/pcapi/core/finance/siret_api.py
+++ b/api/src/pcapi/core/finance/siret_api.py
@@ -1,0 +1,149 @@
+from decimal import Decimal
+
+import pcapi.core.history.models as history_models
+import pcapi.core.offerers.models as offerers_models
+from pcapi.models import db
+
+
+class CheckError(Exception):
+    pass
+
+
+def get_yearly_revenue(venue_id: int) -> Decimal:
+    # Calculate yearly revenue of target venue
+    query = """
+      select sum(booking.amount * booking.quantity) as "chiffre d'affaires"
+      from booking
+      where
+        "venueId" = :venue_id
+        and "dateUsed" is not null
+        -- On ajoute 1 heure pour la conversion UTC -> CET afin de récupérer
+        -- le chiffre d'affaires de l'année en cours.
+        and DATE_PART('year', "dateUsed" + interval '1 hour') = date_part('year', now() + interval '1 hour');
+    """
+    rows = db.session.execute(query, {"venue_id": venue_id}).fetchone()
+    return rows[0]
+
+
+def check_can_move_siret(
+    source: offerers_models.Venue, target: offerers_models.Venue, siret: str, override_revenue_check: bool
+) -> None:
+    if source.managingOffererId != target.managingOffererId:
+        raise CheckError(f"Source {source.id} and target {target.id} do not have the same offerer")
+    offerer = target.managingOfferer
+    if offerer.siren != siret[:9]:
+        raise CheckError(f"SIRET {siret} does not match offerer SIREN {offerer.siren}")
+    if source.siret != siret:
+        raise CheckError(f"Source venue {source.id} has SIRET {source.siret}, not requested SIRET {siret}")
+    if target.siret is not None:
+        raise CheckError(f"Target venue {target.id} already has a siret: {target.siret}")
+
+    if not override_revenue_check:
+        revenue = get_yearly_revenue(target.id)
+        if revenue and revenue > 10_000:
+            raise CheckError(f"Target venue has an unexpectedly high yearly revenue: {revenue}")
+
+
+def move_siret(
+    source_venue: offerers_models.Venue,
+    target_venue: offerers_models.Venue,
+    siret: str,
+    comment: str,
+    apply_changes: bool = False,
+    override_revenue_check: bool = False,
+    author_user_id: int | None = None,
+) -> None:
+    check_can_move_siret(
+        source=source_venue,
+        target=target_venue,
+        siret=siret,
+        override_revenue_check=override_revenue_check,
+    )
+
+    db.session.rollback()  # discard any previous transaction to start a fresh new one.
+    queries = [
+        """
+        update pricing
+        set "pricingPointId" = :target_id
+        where "pricingPointId" = :source_id
+        """,
+        """
+        update venue_pricing_point_link
+        set "pricingPointId" = :target_id
+        where "pricingPointId" = :source_id
+        """,
+        """
+        update venue
+        set siret = NULL, comment = :comment
+        where id = :source_id and siret = :siret
+        """,
+        """
+        update venue
+        set siret = :siret, comment = NULL
+        where id = :target_id and siret IS NULL
+        """,
+        """
+        insert into venue_pricing_point_link ("venueId", "pricingPointId", timespan)
+        values (
+          :target_id,
+          :target_id,
+          tsrange(now()::timestamp, NULL, '[)')
+        )
+        -- If the pricing point of the target venue was the source venue before our changes,
+        -- the update above will have changed the existing row. Thus the source venue
+        -- now points to itself, which means that we don't need to execute this insert
+        -- (and it would raise an integrity error). Hence the "do nothing" below.
+        on conflict do nothing
+        """,
+    ]
+
+    try:
+        db.session.begin()
+        for query in queries:
+            db.session.execute(
+                query,
+                {
+                    "source_id": source_venue.id,
+                    "target_id": target_venue.id,
+                    "siret": siret,
+                    "comment": comment,
+                },
+            )
+
+        # Add actions in the history for both venues to track who/when it was changed
+        db.session.add(
+            history_models.ActionHistory(
+                actionType=history_models.ActionType.INFO_MODIFIED,
+                authorUserId=author_user_id,
+                offererId=source_venue.managingOffererId,
+                venueId=source_venue.id,
+                comment=comment,
+                extraData={
+                    "modified_info": {
+                        "siret": {"old_info": siret, "new_info": None},
+                    }
+                },
+            )
+        )
+        db.session.add(
+            history_models.ActionHistory(
+                actionType=history_models.ActionType.INFO_MODIFIED,
+                authorUserId=author_user_id,
+                offererId=target_venue.managingOffererId,
+                venueId=target_venue.id,
+                comment=comment,
+                extraData={
+                    "modified_info": {
+                        "siret": {"old_info": None, "new_info": siret},
+                    }
+                },
+            )
+        )
+    except Exception:
+        db.session.rollback()
+        raise
+
+    if apply_changes:
+        db.session.commit()
+    else:
+        db.session.rollback()

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -32,6 +32,7 @@ class Permissions(enum.Enum):
     READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"
     MANAGE_PRO_ENTITY = "gérer une structure, un lieu ou un compte pro"
     DELETE_PRO_ENTITY = "supprimer une structure ou un lieu"
+    ADVANCED_PRO_SUPPORT = "support pro avancé : déplacer un SIRET"
 
     MANAGE_BOOKINGS = "gérer les réservations"
     SEARCH_BOOKINGS = "rechercher les réservations"
@@ -117,6 +118,7 @@ class Roles(enum.Enum):
     SUPPORT_N1 = "support-N1"
     SUPPORT_N2 = "support-N2"
     SUPPORT_PRO = "support-PRO"
+    SUPPORT_PRO_N2 = "support-PRO-N2"
     FRAUDE_CONFORMITE = "fraude-conformite"
     DAF = "daf"
     BIZDEV = "bizdev"

--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -16,6 +16,7 @@ def install_routes(app: Flask) -> None:
     from . import offerers
     from . import offers
     from . import pro
+    from . import pro_support
     from . import pro_users
     from . import users
     from . import venues

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -82,6 +82,13 @@ class PCEmailField(wtforms.EmailField):
     ]
 
 
+class PCIntegerField(wtforms.IntegerField):
+    widget = partial(widget, template="components/forms/string_field.html")
+    validators = [
+        validators.InputRequired("Information obligatoire"),
+    ]
+
+
 class PCDateField(wtforms.DateField):
     widget = partial(widget, template="components/forms/date_field.html")
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/pro_support.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/pro_support.py
@@ -1,0 +1,19 @@
+from flask_wtf import FlaskForm
+import wtforms
+
+from . import fields
+
+
+class MoveSiretForm(FlaskForm):
+    source_venue = fields.PCIntegerField("Venue ID du lieu source")
+    target_venue = fields.PCIntegerField("Venue ID du lieu cible")
+    siret = fields.PCStringField(
+        "SIRET",
+        validators=[
+            wtforms.validators.InputRequired("SIRET obligatoire"),
+            wtforms.validators.Length(min=14, max=14, message="Le SIRET doit contenir exactement %(min)d chiffres"),
+            wtforms.validators.Regexp(r"^\d{14}$", message="Le SIRET doit contenir exactement 14 chiffres"),
+        ],
+    )
+    comment = fields.PCCommentField("Commentaire associé au lieu source, sans SIRET")
+    override_revenue_check = fields.PCSwitchBooleanField("Ignorer la limite de revenus annuels")

--- a/api/src/pcapi/routes/backoffice_v3/pro_support.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_support.py
@@ -1,0 +1,132 @@
+from flask import flash
+from flask import redirect
+from flask import render_template
+from flask import url_for
+from flask_login import current_user
+
+from pcapi.core.finance import siret_api
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.permissions import models as perm_models
+
+from . import utils
+from .forms import pro_support as pro_support_forms
+
+
+pro_support_blueprint = utils.child_backoffice_blueprint(
+    "pro_support",
+    __name__,
+    url_prefix="/pro/support",
+    permission=perm_models.Permissions.ADVANCED_PRO_SUPPORT,
+)
+
+
+def _validate_move_siret_form() -> (
+    tuple[pro_support_forms.MoveSiretForm, offerers_models.Venue | None, offerers_models.Venue | None]
+):
+    form = pro_support_forms.MoveSiretForm()
+    if not form.validate():
+        return form, None, None
+
+    if form.source_venue.data == form.target_venue.data:
+        flash("Les lieux source et destination doivent être différents", "warning")
+        return form, None, None
+
+    source_venue = offerers_models.Venue.query.filter_by(id=form.source_venue.data).one_or_none()
+    if not source_venue:
+        flash(f"Aucun lieu n'a été trouvé avec l'ID {form.source_venue.data}", "warning")
+        return form, None, None
+
+    target_venue = offerers_models.Venue.query.filter_by(id=form.target_venue.data).one_or_none()
+    if not target_venue:
+        flash(f"Aucun lieu n'a été trouvé avec l'ID {form.target_venue.data}", "warning")
+        return form, None, None
+
+    if source_venue.siret != form.siret.data:
+        flash(f"Le SIRET {form.siret.data} ne correspond pas au lieu {form.source_venue.data}", "warning")
+        return form, None, None
+
+    if target_venue.isVirtual:
+        flash(f"Le lieu cible {target_venue.name} (ID {target_venue.id}) est un lieu virtuel", "warning")
+        return form, None, None
+
+    return form, source_venue, target_venue
+
+
+def _render_form_page(form: pro_support_forms.MoveSiretForm, code: int = 200) -> utils.BackofficeResponse:
+    return render_template("pro/move_siret.html", form=form, dst=url_for(".post_move_siret")), code
+
+
+def _render_confirmation_page(
+    form: pro_support_forms.MoveSiretForm,
+    source_venue: offerers_models.Venue,
+    target_venue: offerers_models.Venue,
+    code: int = 200,
+) -> utils.BackofficeResponse:
+    return (
+        render_template(
+            "pro/move_siret_confirmation.html",
+            form=form,
+            dst=url_for(".apply_move_siret"),
+            source_venue=source_venue,
+            target_venue=target_venue,
+            target_yearly_revenue=siret_api.get_yearly_revenue(target_venue.id),
+        ),
+        code,
+    )
+
+
+@pro_support_blueprint.route("/move_siret", methods=["GET"])
+def move_siret() -> utils.BackofficeResponse:
+    form = pro_support_forms.MoveSiretForm()
+    return _render_form_page(form)
+
+
+@pro_support_blueprint.route("/move_siret", methods=["POST"])
+def post_move_siret() -> utils.BackofficeResponse:
+    form, source_venue, target_venue = _validate_move_siret_form()
+    if not source_venue or not target_venue:
+        return _render_form_page(form, code=400)
+
+    try:
+        siret_api.check_can_move_siret(
+            source_venue,
+            target_venue,
+            form.siret.data,
+            bool(form.override_revenue_check.data),
+        )
+    except siret_api.CheckError as exc:
+        flash(str(exc), "warning")
+        return _render_form_page(form, code=400)
+
+    return _render_confirmation_page(form, source_venue, target_venue)
+
+
+@pro_support_blueprint.route("/move_siret/apply", methods=["POST"])
+def apply_move_siret() -> utils.BackofficeResponse:
+    form, source_venue, target_venue = _validate_move_siret_form()
+    if not source_venue or not target_venue:
+        return _render_form_page(form, code=400)
+
+    try:
+        siret_api.move_siret(
+            source_venue,
+            target_venue,
+            form.siret.data,
+            form.comment.data,
+            apply_changes=True,
+            override_revenue_check=bool(form.override_revenue_check.data),
+            author_user_id=current_user.id,
+        )
+    except siret_api.CheckError as exc:
+        flash(f"La vérification a échoué : {str(exc)}", "warning")
+        return _render_confirmation_page(form, source_venue, target_venue, code=400)
+    except Exception as exc:  # pylint: disable=broad-except
+        flash(f"Une erreur s'est produite : {str(exc)}", "warning")
+        return _render_confirmation_page(form, source_venue, target_venue, code=400)
+
+    flash(
+        f"Le SIRET {form.siret.data} a été déplacé de {source_venue.name} ({source_venue.id}) "
+        f"vers {target_venue.name} ({target_venue.id})",
+        "success",
+    )
+    return redirect(url_for(".move_siret"), code=303)

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
@@ -1,6 +1,9 @@
 <div class="form-floating my-3">
-    <input type="text" id="{{ field.name }}" name="{{ field.name }}" class="form-control" value="{{ field.data | empty_string_if_null }}"
+    <input type="{% if field.type == "PCIntegerField" %}number{% else %}text{% endif %}"
+        id="{{ field.name }}" name="{{ field.name }}" class="form-control"
+        value="{{ field.data | empty_string_if_null }}"
         {% if field.flags.required %}required{% endif %}
+        {% if field.flags.pattern %}pattern="{{ field.flags.pattern }}"{% endif %}
         {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
         {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}/>
     <label for="floatingInput">{{ field.label }}</label>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/actions.html
@@ -1,41 +1,53 @@
-<table class="table table-hover my-4">
-    <thead>
-        <tr>
-            <th scope="col"></th>
-            <th scope="col">Type</th>
-            <th scope="col">Date/Heure</th>
-            <th scope="col">Commentaire</th>
-            <th scope="col">Auteur</th>
-        </tr>
-    </thead>
-    <tbody class="table-group-divider">
-        {% for action in actions %}
+{# This macro must be imported with context because of is_user_offerer_action_type() #}
+{% macro build_actions_table(actions, show_venue) %}
+    <table class="table table-hover my-4">
+        <thead>
             <tr>
-                <th scope="row"></th>
-                <td>{{ action.actionType.value }}</td>
-                <td>{{ action.actionDate | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
-                <td class="text-break">
-                    {% if action.userId and action.user.full_name and is_user_offerer_action_type(action) %}
-                        <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=action.userId) }}" class="link-primary">
-                            {{ action.user.full_name | empty_string_if_null }} - {{ action.userId }}
-                        </a>
-                    {% elif action.actionType.name == "INFO_MODIFIED" %}
-                        <p class="fw-bold">Informations modifiées</p>
-                        {% for info_name, modified_info in action.extraData.get('modified_info', {}).items() %}
-                            <p>
-                                <span class="text-decoration-underline">{{ info_name | i18n_column_name }} :</span>
-                                {{ modified_info['old_info'] | i18n_column_value | escape }} =&gt; {{ modified_info['new_info'] | i18n_column_value | escape }}
-                            </p>
-                        {% endfor %}
-                    {% elif action.actionType.name == "USER_SUSPENDED" %}
-                        <p>{{ action.extraData['reason'] | format_reason_label }}</p>
-                    {% endif %}
-                    {% if action.comment %}
-                        <p>{{ action.comment | empty_string_if_null | replace("\n", "<br/>"|safe) }}</p>
-                    {% endif %}
-                </td>
-                <td>{{ action.authorUser.full_name if action.authorUser else None | empty_string_if_null }}</td>
+                <th scope="col"></th>
+                <th scope="col">Type</th>
+                <th scope="col">Date/Heure</th>
+                <th scope="col">Commentaire</th>
+                <th scope="col">Auteur</th>
             </tr>
-        {% endfor %}
-    </tbody>
-</table>
+        </thead>
+        <tbody class="table-group-divider">
+            {% for action in actions %}
+                <tr>
+                    <th scope="row"></th>
+                    <td>{{ action.actionType.value }}</td>
+                    <td>{{ action.actionDate | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
+                    <td class="text-break">
+                        {% if action.userId and action.user.full_name and is_user_offerer_action_type(action) %}
+                            <a href="{{ url_for("backoffice_v3_web.pro_user.get", user_id=action.userId) }}" class="link-primary">
+                                {{ action.user.full_name | empty_string_if_null }} - {{ action.userId }}
+                            </a>
+                        {% elif action.actionType.name == "INFO_MODIFIED" %}
+                            <p>
+                                <span class="fw-bold">Informations modifiées</span>
+                                {% if show_venue and action.venueId %}
+                                    sur le lieu
+                                    <a href="{{ url_for("backoffice_v3_web.venue.get", venue_id=action.venueId) }}" class="link-primary">
+                                        {{ action.venue.name }}
+                                    </a>
+                                    ({{ action.venueId }})
+                                {% endif %}
+                            </p>
+                            {% for info_name, modified_info in action.extraData.get('modified_info', {}).items() %}
+                                <p>
+                                    <span class="text-decoration-underline">{{ info_name | i18n_column_name }} :</span>
+                                    {{ modified_info['old_info'] | i18n_column_value | escape }} =&gt; {{ modified_info['new_info'] | i18n_column_value | escape }}
+                                </p>
+                            {% endfor %}
+                        {% elif action.actionType.name == "USER_SUSPENDED" %}
+                            <p>{{ action.extraData['reason'] | format_reason_label }}</p>
+                        {% endif %}
+                        {% if action.comment %}
+                            <p>{{ action.comment | empty_string_if_null | replace("\n", "<br/>"|safe) }}</p>
+                        {% endif %}
+                    </td>
+                    <td>{{ action.authorUser.full_name if action.authorUser else None | empty_string_if_null }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/view.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/view.html
@@ -1,6 +1,7 @@
+{% from "components/history/actions.html" import build_actions_table with context %}
 {% from "components/history/comment.html" import build_comment_modal with context %}
 
-{% macro build_history_view(dst, form) %}
+{% macro build_history_view(dst, form, actions, show_venue) %}
     {% set modal_title %}
         {{ caller() }}
     {% endset %}
@@ -9,5 +10,5 @@
         {{ modal_title }}
     {% endcall %}
 
-    {% include "components/history/actions.html" %}
+    {{ build_actions_table(actions, show_venue) }}
 {% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -91,6 +91,14 @@
                                 {% endcall %}
                             </div>
                             <hr>
+                            {% if has_permission("ADVANCED_PRO_SUPPORT") %}
+                                <div class="nav nav-pills flex-column">
+                                    {% call menu_section("Support Pro") %}
+                                        {{ menu_section_item("Déplacer un SIRET", "backoffice_v3_web.pro_support.move_siret") }}
+                                    {% endcall %}
+                                </div>
+                                <hr>
+                            {% endif %}
                             {% if has_permission("READ_BOOKINGS") %}
                                 <div class="nav nav-pills flex-column">
                                     {% call menu_section("Réservations") %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/history.html
@@ -1,5 +1,5 @@
 {% from "components/history/view.html" import build_history_view with context %}
 
-{% call build_history_view(dst, form) %}
+{% call build_history_view(dst, form, actions, true) %}
     {{ offerer.name }}
 {% endcall %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret.html
@@ -1,0 +1,17 @@
+{% extends "layouts/connected.html" %}
+
+{% block page %}
+    <div class="pt-3 px-5">
+        <h2 class="fw-light">Déplacer un SIRET d’un lieu à un autre</h2>
+        <div class="col-12 py-4">
+            <form action="{{ dst }}" method="POST">
+                <div class="form-group">
+                    {% include "components/form_body.html" %}
+                </div>
+                <div class="d-flex justify-content-end">
+                    <button type="submit" class="btn btn-primary">Continuer</button>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret_confirmation.html
@@ -1,0 +1,76 @@
+{% extends "layouts/connected.html" %}
+{% from "components/badges.html" import build_venue_badges %}
+{% from "components/external_links.html" import build_siret_link %}
+
+{% macro build_venue_card(venue, yearly_revenue) %}
+    <div class="card">
+        <div class="card-body">
+            <h5 class="mb-3">
+                {{ build_venue_badges(venue) }}
+            </h5>
+            <h5 class="card-title">
+                {{ venue.name | upper }}
+            </h5>
+            <h6 class="card-subtitle mt-4 mb-3 text-muted">
+                Venue ID : {{ venue.id }}
+            </h6>
+            <h6 class="card-subtitle mb-4 text-muted">
+                SIRET : {{ venue.siret | empty_string_if_null }}
+            </h6>
+            <div class="row pt3">
+                {% if venue.publicName and venue.publicName != venue.name %}
+                    <p><span class="fw-bold">Nom d'usage :</span> {{ venue.publicName }}</p>
+                {% endif %}
+                <p><span class="fw-bold">Structure :</span> {{ venue.managingOfferer.name }}</p>
+                <p>
+                    {% if yearly_revenue is not false %}
+                        <span class="fw-bold">Revenu de l'année :</span>
+                        {{ yearly_revenue | format_amount }}
+                    {% else %}
+                        &nbsp;
+                    {% endif %}
+                </p>
+            </div>
+            <a href="{{ url_for("backoffice_v3_web.venue.get", venue_id=venue.id) }}" target="_blank"
+               class="card-link">
+                <button class="btn lead px-0 fw-bold mt-1">
+                    CONSULTER LE PROFIL
+                </button>
+            </a>
+        </div>
+    </div>
+{% endmacro %}
+
+{% block page %}
+    <div class="pt-3 px-5">
+        <h2 class="fw-light">Déplacer un SIRET d’un lieu à un autre</h2>
+
+        <div class="row mt-4">
+            <div class="col-6">
+                <p class="fw-bold">Source :</p>
+                {{ build_venue_card(source_venue, False) }}
+            </div>
+            <div class="col-6">
+                <p class="fw-bold">Cible :</p>
+                {{ build_venue_card(target_venue, target_yearly_revenue) }}
+            </div>
+        </div>
+
+        <div class="d-flex justify-content-end py-4">
+            <a href="{{ url_for(".move_siret") }}" class="btn btn-outline-primary mx-4" role="button">
+                Annuler
+            </a>
+            <div>
+                <form action="{{ dst }}" method="POST">
+                    {% for form_field in form %}
+                        <input type="hidden" name="{{ form_field.name }}" value="{{ form_field.data }}"/>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-primary">
+                        Confirmer
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details/history.html
@@ -1,5 +1,5 @@
 {% from "components/history/view.html" import build_history_view with context %}
 
-{% call build_history_view(dst, form) %}
+{% call build_history_view(dst, form, actions, false) %}
     {{ user.firstName }} {{ user.lastName | upper }}
 {% endcall %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details/history.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details/history.html
@@ -1,5 +1,5 @@
 {% from "components/history/view.html" import build_history_view with context %}
 
-{% call build_history_view(dst, form) %}
+{% call build_history_view(dst, form, actions, false) %}
     {{ venue.name }}
 {% endcall %}

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -28,6 +28,9 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.SEARCH_OFFERS,
         perm_models.Permissions.READ_OFFERS,
     ],
+    "support-PRO-N2": [
+        perm_models.Permissions.ADVANCED_PRO_SUPPORT,
+    ],
     "fraude-conformite": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -51,6 +51,9 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.SEARCH_OFFERS,
         perm_models.Permissions.READ_OFFERS,
     ],
+    "support-PRO-N2": [
+        perm_models.Permissions.ADVANCED_PRO_SUPPORT,
+    ],
     "fraude-conformite": [
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,

--- a/api/tests/routes/backoffice_v3/pro_support_test.py
+++ b/api/tests/routes/backoffice_v3/pro_support_test.py
@@ -1,0 +1,198 @@
+from flask import g
+from flask import url_for
+import pytest
+
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.users import factories as users_factories
+
+from tests.conftest import clean_database
+
+from .helpers import html_parser
+from .helpers import unauthorized as unauthorized_helpers
+
+
+pytestmark = [
+    pytest.mark.backoffice_v3,
+]
+
+
+class MoveSiretUnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+    endpoint = "backoffice_v3_web.pro_support.move_siret"
+    needed_permission = perm_models.Permissions.ADVANCED_PRO_SUPPORT
+
+
+class PostMoveSiretUnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+    endpoint = "backoffice_v3_web.pro_support.post_move_siret"
+    needed_permission = perm_models.Permissions.ADVANCED_PRO_SUPPORT
+
+
+class ApplyMoveSiretUnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+    endpoint = "backoffice_v3_web.pro_support.apply_move_siret"
+    needed_permission = perm_models.Permissions.ADVANCED_PRO_SUPPORT
+
+
+class MoveSiretTest:
+    def _post_request(self, authenticated_client, form: dict, apply: bool):
+        form_response = authenticated_client.get(url_for("backoffice_v3_web.pro_support.move_siret"))
+        assert form_response.status_code == 200
+
+        if apply:
+            endpoint = "backoffice_v3_web.pro_support.apply_move_siret"
+        else:
+            endpoint = "backoffice_v3_web.pro_support.post_move_siret"
+
+        form["csrf_token"] = g.get("csrf_token", "")
+        return authenticated_client.post(url_for(endpoint), form=form)
+
+    @clean_database
+    @pytest.mark.parametrize("override_revenue_check", ["", "on"])
+    def test_move_siret_ok(self, authenticated_client, override_revenue_check):
+        offerer = offerers_factories.OffererFactory(siren="123456789")
+        venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900001")
+        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, siret=None, comment="No SIRET")
+
+        if override_revenue_check:
+            rich_beneficiary = users_factories.BeneficiaryGrant18Factory(deposit__amount=100_000)
+            bookings_factories.ReimbursedBookingFactory(
+                user=rich_beneficiary, stock__price=10800, stock__offer__venue=venue2
+            )
+
+        form = {
+            "source_venue": str(venue1.id),
+            "target_venue": str(venue2.id),
+            "siret": venue1.siret,
+            "comment": 'lieu public, le SIRET est porté par le "Lieu administratif"',
+            "override_revenue_check": override_revenue_check,
+        }
+        response = self._post_request(authenticated_client, form, False)
+
+        assert response.status_code == 200
+        assert venue1.siret == form["siret"]
+        assert not venue2.siret
+        assert history_models.ActionHistory.query.count() == 0
+
+        response = self._post_request(authenticated_client, form, True)
+
+        assert response.status_code == 303
+        assert not venue1.siret
+        assert venue1.comment == form["comment"]
+        assert venue2.siret == form["siret"]
+        assert not venue2.comment
+
+        actions = history_models.ActionHistory.query.all()
+        assert len(actions) == 2
+        for action in actions:
+            assert action.actionType == history_models.ActionType.INFO_MODIFIED
+            assert action.offererId == offerer.id
+            assert action.venueId in (venue1.id, venue2.id)
+            assert action.extraData.get("modified_info")
+
+    def _assert_error_400(
+        self,
+        authenticated_client,
+        source_venue: offerers_models.Venue,
+        target_venue: offerers_models.Venue,
+        siret: str | None = None,
+        expected_alert: str | None = None,
+    ):
+        form = {
+            "source_venue": str(source_venue.id),
+            "target_venue": str(target_venue.id),
+            "siret": siret or source_venue.siret,
+            "comment": 'lieu public, le SIRET est porté par le "Lieu administratif"',
+            "override_revenue_check": "",
+        }
+        response = self._post_request(authenticated_client, form, False)
+        assert response.status_code == 400
+        assert expected_alert in html_parser.extract_alert(response.data)
+
+        response = self._post_request(authenticated_client, form, True)
+        assert response.status_code == 400
+        assert expected_alert in html_parser.extract_alert(response.data)
+
+        assert source_venue.siret == "12345678900001"
+        assert history_models.ActionHistory.query.count() == 0
+
+    @clean_database
+    def test_move_siret_same_venue(self, authenticated_client):
+        # given
+        offerer = offerers_factories.OffererFactory(siren="123456789")
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900001")
+
+        self._assert_error_400(
+            authenticated_client, venue, venue, expected_alert="Les lieux source et destination doivent être différents"
+        )
+
+    @clean_database
+    def test_move_siret_not_matching_venue(self, authenticated_client):
+        # given
+        offerer = offerers_factories.OffererFactory(siren="123456789")
+        venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900001")
+        venue2 = offerers_factories.VirtualVenueFactory(managingOfferer=offerer, siret=None)
+
+        self._assert_error_400(
+            authenticated_client,
+            venue1,
+            venue2,
+            siret="12345678900002",
+            expected_alert=f"Le SIRET 12345678900002 ne correspond pas au lieu {venue1.id}",
+        )
+
+    @clean_database
+    def test_move_siret_virtual_venue(self, authenticated_client):
+        offerer = offerers_factories.OffererFactory(siren="123456789")
+        venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900001")
+        venue2 = offerers_factories.VirtualVenueFactory(managingOfferer=offerer, siret=None)
+
+        self._assert_error_400(
+            authenticated_client,
+            venue1,
+            venue2,
+            expected_alert=f"Le lieu cible {venue2.name} (ID {venue2.id}) est un lieu virtuel",
+        )
+
+    @clean_database
+    def test_move_siret_different_offerer(self, authenticated_client):
+        venue1 = offerers_factories.VenueFactory(siret="12345678900001")
+        venue2 = offerers_factories.VenueFactory(siret=None, comment="No SIRET")
+
+        self._assert_error_400(
+            authenticated_client,
+            venue1,
+            venue2,
+            expected_alert=f"Source {venue1.id} and target {venue2.id} do not have the same offerer",
+        )
+
+    @clean_database
+    def test_move_siret_target_with_siret(self, authenticated_client):
+        offerer = offerers_factories.OffererFactory(siren="123456789")
+        venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900001")
+        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900003")
+
+        self._assert_error_400(
+            authenticated_client,
+            venue1,
+            venue2,
+            expected_alert=f"Target venue {venue2.id} already has a siret: {venue2.siret}",
+        )
+
+    @clean_database
+    def test_move_siret_high_revenue(self, authenticated_client):
+        offerer = offerers_factories.OffererFactory(siren="123456789")
+        venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, siret="12345678900001")
+        venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, siret=None, comment="No SIRET")
+        rich_beneficiary = users_factories.BeneficiaryGrant18Factory(deposit__amount=100_000)
+        bookings_factories.ReimbursedBookingFactory(
+            user=rich_beneficiary, stock__price=10200, stock__offer__venue=venue2
+        )
+
+        self._assert_error_400(
+            authenticated_client,
+            venue1,
+            venue2,
+            expected_alert=f"Target venue has an unexpectedly high yearly revenue: {10200.00}",
+        )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20537

## But de la pull request

Ajouter une page dans le backoffice afin de faire les déplacements de SIRET (lieu public vers lieu administratif), nombreux dans les demandes shérif. Le but est de pouvoir être fait directement côté support.

## Informations supplémentaires

Un nouveau rôle a été ajouté car la permission ne doit être donnée qu'à un nombre très restreint de personnes.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

![Screenshot_20230216_084704](https://user-images.githubusercontent.com/23212130/219300826-34e151c8-0c43-48c7-983f-f207127965ff.png)
![Screenshot_20230216_084717](https://user-images.githubusercontent.com/23212130/219300830-5bdff43d-a663-4245-ae6f-088345084621.png)
![Screenshot_20230216_084735](https://user-images.githubusercontent.com/23212130/219300831-a9fa7ab1-2040-4b0e-a884-d787644941e7.png)