### PR TITLE
(PC-20523)[BO] fix: properly update roles at authentication

### DIFF
--- a/api/src/pcapi/core/users/backoffice/api.py
+++ b/api/src/pcapi/core/users/backoffice/api.py
@@ -17,7 +17,7 @@ def upsert_roles(
         user.backoffice_profile.roles = []
 
     concrete_roles = perm_api.get_concrete_roles(roles)
-    user.backoffice_profile.roles.extend(concrete_roles)
+    user.backoffice_profile.roles = concrete_roles
 
     return user.backoffice_profile
 

--- a/api/tests/core/users/backoffice/test_api.py
+++ b/api/tests/core/users/backoffice/test_api.py
@@ -1,18 +1,105 @@
 import pytest
 
+from pcapi.core.permissions import factories as perm_factories
+from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
 import pcapi.core.users.backoffice.api as backoffice_api
-
-from tests.routes.backoffice_v3.conftest import legit_user_fixture  # pylint: disable=unused-import
-from tests.routes.backoffice_v3.conftest import roles_with_permissions_fixture  # pylint: disable=unused-import
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-def test_fetch_user_with_profile(legit_user) -> None:
-    user_id = legit_user.id
+@pytest.fixture(scope="function", name="permissions")
+def permissions_fixture() -> list[perm_models.Permissions]:
+    return perm_models.Permission.query.order_by(perm_models.Permission.name).limit(5).all()
 
+
+@pytest.fixture(scope="function", name="roles")
+def roles_fixture(permissions) -> list[perm_models.Roles]:
+    return [
+        perm_factories.RoleFactory(  # 0
+            name=perm_models.Roles.SUPPORT_N1.value, permissions=[permissions[1], permissions[3]]
+        ),
+        perm_factories.RoleFactory(  # 1
+            name=perm_models.Roles.SUPPORT_N2.value, permissions=[permissions[2], permissions[3]]
+        ),
+        perm_factories.RoleFactory(  # 2
+            name=perm_models.Roles.SUPPORT_PRO.value, permissions=[permissions[0], permissions[1]]
+        ),
+    ]
+
+
+def test_update_roles_from_no_profile(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory()
+
+    backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_N1, perm_models.Roles.SUPPORT_PRO])
+
+    assert set(user.backoffice_profile.roles) == {roles[0], roles[2]}
+
+
+def test_update_roles_add_one_role(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory(
+        backoffice_profile=perm_models.BackOfficeUserProfile(roles=[roles[1]])
+    )
+
+    backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_N2, perm_models.Roles.SUPPORT_PRO])
+
+    assert set(user.backoffice_profile.roles) == {roles[1], roles[2]}
+
+
+def test_update_roles_remove_one_role(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory(
+        backoffice_profile=perm_models.BackOfficeUserProfile(roles=[roles[0], roles[1]])
+    )
+
+    backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_N2])
+
+    assert user.backoffice_profile.roles == [roles[1]]
+
+
+def test_update_roles_add_remove_role(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory(
+        backoffice_profile=perm_models.BackOfficeUserProfile(roles=[roles[0], roles[1]])
+    )
+
+    backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_N2, perm_models.Roles.SUPPORT_PRO])
+
+    assert set(user.backoffice_profile.roles) == {roles[1], roles[2]}
+
+
+def test_update_roles_clear_roles(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory(
+        backoffice_profile=perm_models.BackOfficeUserProfile(roles=[roles[0], roles[1]])
+    )
+
+    backoffice_api.upsert_roles(user, [])
+
+    assert user.backoffice_profile.roles == []
+
+
+def test_update_roles_keep_roles(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory(
+        backoffice_profile=perm_models.BackOfficeUserProfile(roles=[roles[1], roles[2]])
+    )
+
+    backoffice_api.upsert_roles(user, [perm_models.Roles.SUPPORT_N2, perm_models.Roles.SUPPORT_PRO])
+
+    assert set(user.backoffice_profile.roles) == {roles[1], roles[2]}
+
+
+def test_fetch_user_with_profile(permissions, roles) -> None:
+    user: users_models.User = users_factories.UserFactory(
+        backoffice_profile=perm_models.BackOfficeUserProfile(roles=[roles[0], roles[1]])
+    )
+
+    user_id = user.id
     with assert_num_queries(1):
         user_with_profile = backoffice_api.fetch_user_with_profile(user_id)
-        assert user_with_profile.backoffice_profile.permissions
+
+        # user_with_profile.backoffice_profile.permission contains Permissions enum items
+        # permissions contains Permission objects from database
+        assert set(perm.name for perm in user_with_profile.backoffice_profile.permissions) == set(
+            perm.name for perm in permissions[1:4]
+        )

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -757,7 +757,7 @@ class CommentOffererTest:
     class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf, unauthorized_helpers.MissingCSRFHelper):
         endpoint = "backoffice_v3_web.offerer.comment_offerer"
         endpoint_kwargs = {"offerer_id": 1}
-        needed_permission = perm_models.Permissions.VALIDATE_OFFERER
+        needed_permission = perm_models.Permissions.MANAGE_PRO_ENTITY
 
     def test_add_comment(self, authenticated_client, legit_user, offerer):
         comment = "Code APE non éligible"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20523

## But de la pull request

Mettre à jour correctement les rôles depuis ceux reçus de Google lors de l'authentification.

En effet un utilisateur retiré d'un groupe ne perdait pas le rôle dans la base de données, et donc conservait les permissions à vie.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
