### PR TITLE
(PC-20467)[BO] fix: status badge color on user bookings

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -131,13 +131,13 @@ def format_booking_cancellation_reason(reason: bookings_models.BookingCancellati
 def format_booking_status_long(status: bookings_models.BookingStatus) -> str:
     match status:
         case bookings_models.BookingStatus.CONFIRMED:
-            return "<span class='badge text-bg-success'>Réservation confirmée</span>"
+            return "Réservation confirmée"
         case bookings_models.BookingStatus.USED:
-            return "Le jeune a consommé l'offre"
+            return '<span class="badge text-bg-success">Le jeune a consommé l\'offre</span>'
         case bookings_models.BookingStatus.CANCELLED:
-            return "<span class='badge text-bg-danger'>L'offre n'a pas eu lieu</span>"
+            return "<span class=\"badge text-bg-danger\">L'offre n'a pas eu lieu</span>"
         case bookings_models.BookingStatus.REIMBURSED:
-            return "<span class='badge text-bg-success'>AC remboursé</span>"
+            return '<span class="badge text-bg-success">AC remboursé</span>'
         case _:
             return status.value
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20467

## But de la pull request

Corriger les couleurs des badges d'état de réservation pour coller à la demande résumée dans le ticket.

Détail : j'ai mis des guillemets dans les tags html, ensuite c'est black qui force tantôt des apostrophes, tantôt des guillemets selon les apostrophes dans la chaîne.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
