### PR TITLE
(PC-20530)[API] fix: venue history filled with unchange value when us…

### DIFF
--- a/api/src/pcapi/core/history/api.py
+++ b/api/src/pcapi/core/history/api.py
@@ -1,4 +1,8 @@
+import decimal
+import enum
 import typing
+
+from sqlalchemy.ext.mutable import MutableDict
 
 from pcapi.core.history import models
 from pcapi.core.offerers import models as offerers_models
@@ -104,7 +108,14 @@ class ObjectUpdateSnapshot:
             data = {column: new_value for column, new_value in data.items() if hasattr(target, column)}
 
         for column, new_value in data.items():
-            old_value = getattr(target, column)
+            if isinstance(getattr(target, column), enum.Enum):
+                old_value = getattr(target, column).name
+            elif isinstance(getattr(target, column), decimal.Decimal):
+                old_value = float(getattr(target, column))
+            elif isinstance(getattr(target, column), MutableDict) and new_value is None:
+                old_value = None
+            else:
+                old_value = getattr(target, column)
 
             if old_value != new_value:
                 field_name = field_name_template.format(column)

--- a/api/tests/core/history/test_api.py
+++ b/api/tests/core/history/test_api.py
@@ -3,6 +3,7 @@ import pytest
 from pcapi.core.criteria import factories as criteria_factories
 from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
+from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import factories as users_factories
@@ -109,6 +110,24 @@ class ObjectUpdateSnapshotTest:
                 "siren": {"old_info": offerer.siren, "new_info": new_siren},
             }
         }
+
+    def test_trace_update_with_no_modification(self):
+        author = users_factories.UserFactory()
+        venue = offerers_factories.VenueFactory()
+
+        # Reproduce the same process as through the form
+        longitude = float(str(venue.longitude))
+        latitude = float(str(venue.latitude))
+        venue_type_code = venue.venueTypeCode.name
+
+        attrs = {
+            "longitude": longitude,
+            "latitude": latitude,
+            "venueTypeCode": venue_type_code,
+        }
+        offerers_api.update_venue(venue, author=author, contact_data=None, **attrs)
+
+        assert history_models.ActionHistory.query.count() == 0
 
     def test_log_update_without_saving(self):
         author = users_factories.UserFactory()


### PR DESCRIPTION
...ing pro

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20530

## But de la pull request

Ne plus avoir dans l'historique des données non modifiées. Ces données apparaissaient quand on modifiait le lieu via le portail pro.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
