### PR TITLE
(PC-20543)[API] fix: expired event stock price edition when editing price category

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -733,8 +733,13 @@ def patch_event_price_categories(
     event_offer = (
         _retrieve_offer_query(event_id)
         .filter(offers_models.Offer.isEvent == True)
-        .options(sqla_orm.joinedload(offers_models.Offer.priceCategories))
-        .options(sqla_orm.joinedload(offers_models.Offer.stocks))
+        .outerjoin(offers_models.Offer.stocks.and_(offers_models.Stock.isEventExpired == False))
+        .options(sqla_orm.contains_eager(offers_models.Offer.stocks))
+        .options(
+            sqla_orm.joinedload(offers_models.Offer.priceCategories).joinedload(
+                offers_models.PriceCategory.priceCategoryLabel
+            )
+        )
         .one_or_none()
     )
     if not event_offer:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20543

## Implémentation

La sélection des stocks non expirés se fait directement dans la requête sqlalchemy.

`.first_or_404()` a été remplacé par un `.one_or_none()` parce que le `first` rajoute un `LIMIT 1` dans la requête SQL ce qui empêche les enfants (`stocks` et `priceCategories`) d'être peuplés par plus qu'un seul élément