### PR TITLE
(PC-20466)[API] feat: Local provider handle thumb update only once per day

### DIFF
--- a/api/src/pcapi/local_providers/local_provider.py
+++ b/api/src/pcapi/local_providers/local_provider.py
@@ -193,6 +193,7 @@ class LocalProvider(Iterator):
             for providable_info in providable_infos:
                 chunk_key = providable_info.id_at_providers + "|" + str(providable_info.type.__name__)
                 pc_object = get_existing_pc_obj(providable_info, chunk_to_insert, chunk_to_update)
+                last_update_for_current_provider = get_last_update_for_provider(self.provider.id, pc_object)
 
                 if pc_object is None:
                     if not self.can_create:
@@ -204,7 +205,6 @@ class LocalProvider(Iterator):
                     except ApiErrors:
                         continue
                 else:
-                    last_update_for_current_provider = get_last_update_for_provider(self.provider.id, pc_object)
                     object_need_update = (
                         last_update_for_current_provider is None
                         or last_update_for_current_provider < providable_info.date_modified_at_provider
@@ -220,7 +220,10 @@ class LocalProvider(Iterator):
                         except ApiErrors:
                             continue
 
-                if isinstance(pc_object, HasThumbMixin):
+                if isinstance(pc_object, HasThumbMixin) and (
+                    not last_update_for_current_provider
+                    or last_update_for_current_provider.date() != datetime.today().date()
+                ):
                     initial_thumb_count = pc_object.thumbCount
                     try:
                         self._handle_thumb(pc_object)

--- a/api/src/pcapi/repository/providable_queries.py
+++ b/api/src/pcapi/repository/providable_queries.py
@@ -56,9 +56,9 @@ def get_existing_object(
 
 def get_last_update_for_provider(
     provider_id: int,
-    pc_obj: offers_models.Product | offers_models.Offer | offers_models.Stock,
+    pc_obj: offers_models.Product | offers_models.Offer | offers_models.Stock | None,
 ) -> datetime.datetime | None:
-    if pc_obj.lastProviderId == provider_id:
+    if pc_obj and pc_obj.lastProviderId == provider_id:
         return pc_obj.dateModifiedAtLastProvider
     return None
 

--- a/api/tests/local_providers/allocine_stocks_test.py
+++ b/api/tests/local_providers/allocine_stocks_test.py
@@ -1123,7 +1123,7 @@ class UpdateObjectsTest:
             created_offer = Offer.query.all()
             created_stock = Stock.query.all()
 
-            assert mock_poster_get_allocine.call_count == 2
+            assert mock_poster_get_allocine.call_count == 1
             assert len(created_product) == 1
             assert len(created_offer) == 2
             assert Offer.query.filter(Offer.venueId == venue1.id).count() == 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20466

## But de la pull request

Adapter `LocalProvider` pour ne mettre à jour les affiches qu'une seule fois par jour.

Comparaison en local et sandbox Boost:
- Avec mise à jour des affiches:
![image](https://user-images.githubusercontent.com/77629406/220586172-44a2b74e-ccea-442c-90a4-48d1bd1e0d3c.png)
- Sans mise à jour des affiches:
![image](https://user-images.githubusercontent.com/77629406/220586329-2e7e4f76-846d-4661-8980-e5debc885978.png)


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
