### PR TITLE
(PC-20243)[PRO] fix: refresh bug on price category deletion

### DIFF
--- a/pro/src/screens/OfferIndividual/PriceCategories/PriceCategories.tsx
+++ b/pro/src/screens/OfferIndividual/PriceCategories/PriceCategories.tsx
@@ -95,6 +95,7 @@ const PriceCategories = ({ offer }: IPriceCategories): JSX.Element => {
       )
     ) {
       setShowConfirmChangeOnPrice(true)
+      setIsClickingFromActionBar(false)
       return
     } else {
       setShowConfirmChangeOnPrice(false)
@@ -226,6 +227,8 @@ const PriceCategories = ({ offer }: IPriceCategories): JSX.Element => {
             offerId={offer.nonHumanizedId.toString()}
             mode={mode}
             stocks={offer.stocks}
+            setOffer={setOffer}
+            humanizedOfferId={offer.id}
           />
 
           <ActionBar

--- a/pro/src/screens/OfferIndividual/PriceCategories/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/screens/OfferIndividual/PriceCategories/__specs__/PriceCategoriesForm.spec.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 
 import { api } from 'apiClient/api'
 import { OFFER_WIZARD_MODE } from 'core/Offers'
+import { GetIndividualOfferFactory } from 'utils/apiFactories'
 import { individualStockFactory } from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
@@ -35,12 +36,17 @@ const renderPriceCategoriesForm = (
         offerId="42"
         mode={OFFER_WIZARD_MODE.DRAFT}
         stocks={[individualStockFactory({ priceCategoryId: 144 })]}
+        setOffer={jest.fn()}
+        humanizedOfferId="AA"
       />
     </Formik>
   )
 }
 
 describe('PriceCategories', () => {
+  beforeEach(() => {
+    jest.spyOn(api, 'getOffer').mockResolvedValue(GetIndividualOfferFactory())
+  })
   it('should render without error', () => {
     renderPriceCategoriesForm()
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20243

## But de la pull request

_Régler deux bugs (on avait besoin de refresh offer après avoir supprimer un price category)
1- le route leaving guard s'affichait après une suprression (qaund il reste deux éléments, le passage de 2 à 1 sera réglé ailleurs)
2- les tarifs supprimés apparaissaient encore

