### PR TITLE
(PC-20533)[BO] fix: filter bookings performance

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
@@ -28,11 +28,11 @@ class GetCollectiveBookingListForm(FlaskForm):
     )
     from_date = fields.PCDateField("À partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
-    page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
-    per_page = fields.PCSelectField(
-        "Par page",
-        choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
+    limit = fields.PCSelectField(
+        "Nombre maximum",
+        choices=((20, "20"), (100, "100"), (500, "500"), (1000, "1000")),
         default="100",
+        coerce=int,
         validators=(wtforms.validators.Optional(),),
     )
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
@@ -13,7 +13,7 @@ class GetIndividualBookingListForm(FlaskForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Code contremarque, ID offre, Nom ou ID du bénéficiaire")
+    q = fields.PCOptSearchField("Code contremarque, ID offre, Nom, email ou ID du bénéficiaire")
     offerer = fields.PCAutocompleteSelectMultipleField(
         "Structures", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_offerers"
     )
@@ -28,11 +28,11 @@ class GetIndividualBookingListForm(FlaskForm):
     )
     from_date = fields.PCDateField("À partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
-    page = wtforms.HiddenField("page", default="1", validators=(wtforms.validators.Optional(),))
-    per_page = fields.PCSelectField(
-        "Par page",
-        choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
+    limit = fields.PCSelectField(
+        "Nombre maximum",
+        choices=((20, "20"), (100, "100"), (500, "500"), (1000, "1000")),
         default="100",
+        coerce=int,
         validators=(wtforms.validators.Optional(),),
     )
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
@@ -10,12 +10,9 @@
             {% include "components/filters_form.html" %}
         </div>
         <div>
-            {% if rows and rows.total > 0 %}
+            {% if rows %}
                 <div class="d-flex justify-content-between">
-                    <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
-                    <div>
-                        {% include 'components/search/pagination.html' %}
-                    </div>
+                    <p class="lead num-results">{{ rows|length }} résultat{{ "s" if rows|length > 1 else "" }}</p>
                 </div>
                 <table class="table mb-4">
                     <thead>
@@ -34,7 +31,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for collective_booking in rows.items %}
+                    {% for collective_booking in rows %}
                         {% set collective_offer = collective_booking.collectiveStock.collectiveOffer %}
                         <tr>
                             <td>

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -10,12 +10,9 @@
             {% include "components/filters_form.html" %}
         </div>
         <div>
-            {% if rows and rows.total > 0 %}
+            {% if rows %}
                 <div class="d-flex justify-content-between">
-                    <p class="lead num-results">{{ rows.total }} résultat{{ "s" if rows.total > 1 else "" }}</p>
-                    <div>
-                        {% include 'components/search/pagination.html' %}
-                    </div>
+                    <p class="lead num-results">{{ rows|length }} résultat{{ "s" if rows|length > 1 else "" }}</p>
                 </div>
                 <table class="table mb-4">
                     <thead>
@@ -35,7 +32,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for booking in rows.items %}
+                    {% for booking in rows %}
                         {% set offer = booking.stock.offer %}
                         <tr>
                             <td>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20533

## But de la pull request

Améliorer les performances de la recherche des réservations individuelles ou collectives dans le backoffice.

- utilisation d'une `union` de deux sous-requêtes ayant chacune une seule clause `where`, plutôt qu'une seule requête avec un `or` de plusieurs conditions sur des tables différentes : gain sur staging : de 19 minutes à 0,15 seconde ;
- abandon de la pagination, remplacée par un nombre max de résultats, ce qui évite de trouver tous les résultats, les trier et les compter : gain sur staging : de 4-5 minutes à 0,1 seconde pour un filtre sur la catégorie "CINEMA" ;
- message affiché en cas de nombre de résultats au-delà du maximum pour inviter à affiner la recherche ;
- ajout d'un filtre par adresse email du bénéficiaire.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
