### PR TITLE
(BSR)[API] fix: Handle Amplitude events in logs

### DIFF
--- a/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
+++ b/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
@@ -7,6 +7,7 @@ from pcapi import settings
 
 
 AMPLITUDE_API_PUBLIC_KEY = settings.AMPLITUDE_API_PUBLIC_KEY
+logger = logging.getLogger(__name__)
 
 
 class AmplitudeEventType(enum.Enum):
@@ -20,7 +21,7 @@ class AmplitudeBackend:
 
     def __init__(self) -> None:
         client = amplitude_sdk.Amplitude(AMPLITUDE_API_PUBLIC_KEY)
-        client.configuration.logger = logging.getLogger(__name__)
+        client.configuration.logger = logger
         client.configuration.min_id_length = 1
         client.configuration.server_zone = "EU"
         client.configuration.use_batch = True

--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -10,6 +10,7 @@ import time
 import typing
 import uuid
 
+import amplitude
 import flask
 from flask_login import current_user
 
@@ -135,7 +136,7 @@ def monkey_patch_logger_log() -> None:
 
 
 class JsonLogEncoder(json.JSONEncoder):
-    def default(self, obj: typing.Any) -> str | float | list[str | float]:
+    def default(self, obj: typing.Any) -> str | float | list[str | float] | dict:
         if isinstance(obj, decimal.Decimal):
             return float(obj)
         if isinstance(obj, enum.Enum):
@@ -152,6 +153,8 @@ class JsonLogEncoder(json.JSONEncoder):
             return obj.isoformat()
         if isinstance(obj, Exception):
             return str(obj)
+        if isinstance(obj, amplitude.BaseEvent):
+            return {"event_type": obj.event_type}
         return super().default(obj)
 
 

--- a/api/tests/core/logging/tests.py
+++ b/api/tests/core/logging/tests.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 
+import amplitude
 from flask import g
 from flask_login import login_user
 import pytest
@@ -102,6 +103,7 @@ class JsonFormatterTest:
                 "user": user,
                 "bytes": b"encod\xc3\xa9",
                 "nested_complex_object": [{"foo": ["bar"]}],
+                "event": amplitude.BaseEvent(event_type="event type"),
             },
         )
         serialized = formatter.format(record)
@@ -117,6 +119,7 @@ class JsonFormatterTest:
             "user": 7,
             "bytes": "encodé",
             "nested_complex_object": [{"foo": ["bar"]}],
+            "event": {"event_type": "event type"},
         }
 
         # gracefully handle non-serializable objects


### PR DESCRIPTION
Amplitude SDK logs its events through the `extra` log argument [1].

Another workaround could be to just ignore INFO level for the logger
that is used by Amplitude SDK, but the SDK uses the INFO level for
errors, too [2]. It seems useful to keep those.

[1] https://github.com/amplitude/Amplitude-Python/blob/ec790705394ed180079e198099149574a402c614/src/amplitude/processor.py#L83

[2] e.g. https://github.com/amplitude/Amplitude-Python/blob/ec790705394ed180079e198099149574a402c614/src/amplitude/processor.py#L32

---

Exemple dans Sentry : https://sentry.passculture.team/organizations/sentry/issues/406635