### PR TITLE
(PC-20158)[*] build: Add version number when building image for testing

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -58,6 +58,21 @@ jobs:
         registry: '${{ env.REGION }}-docker.pkg.dev'
         username: 'oauth2accesstoken'
         password: '${{ steps.openid-auth.outputs.access_token }}'
+    - name: Add version to api
+      run: |
+        cd api
+        echo "${{ inputs.tag }}" > version.txt
+        git add version.txt
+    - name: Add version to pro
+      run: |
+        cd pro
+        yarn version --new-version "${{ inputs.tag }}"
+        git add package.json
+    - name: Add version to adage
+      run: |
+        cd adage-front
+        yarn version --new-version "${{ inputs.tag }}"
+        git add package.json
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:


### PR DESCRIPTION
On the backend we used to have "master" as the version, which was not
very distinctive... Now we have the SHA of the latest commit, which is
a bit more helpful.


---

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20158