### PR TITLE
(BSR)[API] demo: Turbo's turbo-frame usage

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -8,6 +8,7 @@ def install_routes(app: Flask) -> None:
     from . import auth
     from . import autocomplete
     from . import collective_bookings
+    from . import demo_component
     from . import filters
     from . import health_check
     from . import home

--- a/api/src/pcapi/routes/backoffice_v3/demo_component/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/demo_component/__init__.py
@@ -1,0 +1,2 @@
+from . import page
+from . import component

--- a/api/src/pcapi/routes/backoffice_v3/demo_component/component.py
+++ b/api/src/pcapi/routes/backoffice_v3/demo_component/component.py
@@ -1,0 +1,33 @@
+from flask import render_template
+
+from .. import blueprint
+from .. import utils
+from pcapi.core.bookings import models as bookings_models
+from pcapi.repository import repository
+
+
+
+@blueprint.backoffice_v3_web.route("/demo/component/<int:booking_id>/use", methods=["GET"])
+def demo_use_booking(booking_id: int) -> utils.BackofficeResponse:
+    booking = bookings_models.Booking.query.get(booking_id)
+
+    booking.status = bookings_models.BookingStatus.USED
+    repository.save(booking)
+
+    return render_template(
+        "demo_component/component.html",
+        booking = booking
+    )
+
+
+@blueprint.backoffice_v3_web.route("/demo/component/<int:booking_id>/cancel", methods=["GET"])
+def demo_cancel_booking(booking_id: int) -> utils.BackofficeResponse:
+    booking = bookings_models.Booking.query.get(booking_id)
+
+    booking.status = bookings_models.BookingStatus.CANCELLED
+    repository.save(booking)
+
+    return render_template(
+        "demo_component/component.html",
+        booking = booking
+    )

--- a/api/src/pcapi/routes/backoffice_v3/demo_component/page.py
+++ b/api/src/pcapi/routes/backoffice_v3/demo_component/page.py
@@ -1,0 +1,16 @@
+from flask import render_template
+
+from .. import blueprint
+from .. import utils
+from pcapi.core.bookings import models as bookings_models
+
+
+@blueprint.backoffice_v3_web.route("/demo/component", methods=["GET"])
+def demo_component() -> utils.BackofficeResponse:
+
+    bookings = bookings_models.Booking.query.limit(100).all()
+
+    return render_template(
+        "demo_component/page.html",
+        bookings = bookings
+    )

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/error.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/error.html
@@ -1,3 +1,3 @@
-<turbo-frame id="{{ turbo_frame_id }}">
+<turbo-frame data-turbo="false" id="{{ turbo_frame_id }}">
     <h6 class="lead">Une erreur est survenue, impossible de remonter les données</h6>
 </turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/templates/demo_component/component.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/demo_component/component.html
@@ -1,0 +1,19 @@
+<turbo-frame id="booking-component-{{booking.id}}">
+    <div class="card shadow m-2 p-2 d-flex flex-row justify-content-between">
+        <div>
+            <div>Booking id : {{ booking.id }}</div>
+            <div>Status : {{ booking.status }}</div>
+        </div>
+
+        {% if not booking.is_used_or_reimbursed %}
+        <a href="{{ url_for('.demo_use_booking', booking_id=booking.id) }}" class="btn btn-outline-primary">
+            USE
+        </a>
+
+        {% else %}
+        <a href="{{ url_for('.demo_cancel_booking', booking_id=booking.id) }}" class="btn btn-outline-primary">
+            CANCEL
+        </a>
+        {% endif %}
+    </div>
+</turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/templates/demo_component/component.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/demo_component/component.html
@@ -5,15 +5,26 @@
             <div>Status : {{ booking.status }}</div>
         </div>
 
-        {% if not booking.is_used_or_reimbursed %}
-        <a href="{{ url_for('.demo_use_booking', booking_id=booking.id) }}" class="btn btn-outline-primary">
-            USE
-        </a>
-
-        {% else %}
-        <a href="{{ url_for('.demo_cancel_booking', booking_id=booking.id) }}" class="btn btn-outline-primary">
-            CANCEL
-        </a>
-        {% endif %}
+        <div class="dropdown">
+            <button type="button" data-bs-toggle="dropdown" aria-expanded="false" class="btn p-0"><i
+                    class="bi bi-three-dots-vertical"></i></button>
+            <ul class="dropdown-menu">
+                {% if not booking.is_used_or_reimbursed %}
+                <li class="dropdown-item p-0">
+                    <a class="btn btn-sm d-block w-100 text-start px-3"
+                        href="{{ url_for('.demo_use_booking', booking_id=booking.id) }}">
+                        USE
+                    </a>
+                </li>
+                {% else %}
+                <li class="dropdown-item p-0">
+                    <a class="btn btn-sm d-block w-100 text-start px-3"
+                        href="{{ url_for('.demo_cancel_booking', booking_id=booking.id) }}">
+                        CANCEL
+                    </a>
+                </li>
+                {% endif %}
+            </ul>
+        </div>
     </div>
 </turbo-frame>

--- a/api/src/pcapi/routes/backoffice_v3/templates/demo_component/page.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/demo_component/page.html
@@ -1,0 +1,15 @@
+{% extends "layouts/connected.html" %}
+
+{% block page %}
+<div class="py-4 px-5">
+    <div class="d-flex justify-content-between mx-3">
+        <h1 class="text-muted">Démo approche par composants</h1>
+    </div>
+
+    <div class="container-fluid">
+        {% for booking in bookings %}
+        {% include "demo_component/component.html" %}
+        {% endfor %}
+    </div>
+</div>
+{% endblock %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/errors/csrf.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/errors/csrf.html
@@ -4,7 +4,7 @@
 <h1 class="display-1 fw-bold">Erreur</h1>
 
 <!-- this frame wrap errors in case the error call was made inside a turbo frame -->
-<turbo-frame id="{{ turbo_frame_id }}">
+<turbo-frame data-turbo="false" id="{{ turbo_frame_id }}">
     <p class="fs-3"> <span class="text-danger">Woops !</span> Token CSRF absent</p>
 </turbo-frame>
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/errors/generic.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/errors/generic.html
@@ -8,7 +8,7 @@
 </p>
 
 <!-- this frame wrap errors in case the error call was made inside a turbo frame -->
-<turbo-frame id="{{ turbo_frame_id }}">
+<turbo-frame data-turbo="false" id="{{ turbo_frame_id }}">
 
     {% for error_key, error_details in errors.items() %}
         {% for error_detail in error_details %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -21,17 +21,16 @@
 
     <!-- Useful for local script and styles modification per-view -->
     {% block head %}{% endblock %}
+
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
+            crossorigin="anonymous"></script>
 </head>
 
-{#  Navigation with turbolink is disabled because bootstrap is not reloaded and so is not working after navigation  #}
-<body data-turbo="false">
+<body>
 
 {% block content %}{% endblock %}
-
-<!-- Bootstrap JS -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
-        crossorigin="anonymous"></script>
 
 <!-- Our JS libs -->
 <script src="{{ url_for('static', filename='backoffice/js/pc-table-multi-select.js') }}"></script>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details.html
@@ -3,7 +3,7 @@
 {% from "components/presentation/details/tabs.html" import build_details_tab_content %}
 {% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
 
-<turbo-frame id="offerer_details_frame">
+<turbo-frame data-turbo="false" id="offerer_details_frame">
 
     {% call build_details_tabs_wrapper() %}
         {{ build_details_tab("history", "Historique du compte", active_tab == 'history') }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/stats.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/stats.html
@@ -1,4 +1,4 @@
-<turbo-frame id="total_revenue_frame">
+<turbo-frame data-turbo="false" id="total_revenue_frame">
     <div class="row">
         <div class="col-md-4">
             <div class="card h-100 shadow">

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -113,7 +113,7 @@
             </div>
         </div>
         <div class="mt-4">
-            <turbo-frame id="pro_user_details_frame" src="{{ url_for("backoffice_v3_web.pro_user.get_details", user_id=user.id, active_tab=request.args.get("active_tab", "history")) }}">
+            <turbo-frame data-turbo="false" id="pro_user_details_frame" src="{{ url_for("backoffice_v3_web.pro_user.get_details", user_id=user.id, active_tab=request.args.get("active_tab", "history")) }}">
                 <p class="text-center">
                     <span class="spinner-grow spinner-grow-sm" role="status">
                         <span class="visually-hidden">Chargement...</span>

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get/details.html
@@ -3,7 +3,7 @@
 {% from "components/presentation/details/tabs.html" import build_details_tab_content %}
 {% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
 
-<turbo-frame id="pro_user_details_frame">
+<turbo-frame data-turbo="false" id="pro_user_details_frame">
 
     {% call build_details_tabs_wrapper() %}
         {{ build_details_tab("history", "Historique du compte", active_tab == 'history') }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -252,7 +252,7 @@
         </div>
 
         <div class="mt-4">
-            <turbo-frame id="venue_total_revenue_frame" src="{{ url_for("backoffice_v3_web.venue.get_stats", venue_id=venue.id) }}">
+            <turbo-frame data-turbo="false" id="venue_total_revenue_frame" src="{{ url_for("backoffice_v3_web.venue.get_stats", venue_id=venue.id) }}">
                 <p class="text-center">
                     <span class="spinner-grow spinner-grow-sm" role="status">
                         <span class="visually-hidden">Chargement...</span>
@@ -263,7 +263,7 @@
         </div>
 
         <div class="mt-4">
-            <turbo-frame id="venue_details_frame" src="{{ url_for("backoffice_v3_web.venue.get_details", venue_id=venue.id) }}">
+            <turbo-frame data-turbo="false" id="venue_details_frame" src="{{ url_for("backoffice_v3_web.venue.get_details", venue_id=venue.id) }}">
                 <p class="text-center">
                     <span class="spinner-grow spinner-grow-sm" role="status">
                         <span class="visually-hidden">Chargement...</span>

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get/details.html
@@ -3,7 +3,7 @@
 {% from "components/presentation/details/tabs.html" import build_details_tab_content %}
 {% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
 
-<turbo-frame id="venue_details_frame">
+<turbo-frame data-turbo="false" id="venue_details_frame">
 
     {% call build_details_tabs_wrapper() %}
         {{ build_details_tab("history", "Historique du compte", true) }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get/stats.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get/stats.html
@@ -1,4 +1,4 @@
-<turbo-frame id="venue_total_revenue_frame">
+<turbo-frame data-turbo="false" id="venue_total_revenue_frame">
     <div class="row">
         <div class="col-4">
             <div class="card h-100 shadow">
@@ -50,4 +50,3 @@
         </div>
     </div>
 </turbo-frame>
-


### PR DESCRIPTION
!! Cette PR ne sera pas mergée !!

C'est une demo pour l'utilisation des turbo frames : un exemple d'utilisation sous le format d'un composant.
On voit comment on peut mettre à jour un objet en DB et sa représentation sur la page du backoffice sans faire un rechargement de toute la page, et ainsi conserver l'état du reste de la page (scroll par exemple)