### PR TITLE
(BSR)[API] fix: force disable jQuery by bootstrap

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -24,7 +24,7 @@
 </head>
 
 {#  Navigation with turbolink is disabled because bootstrap is not reloaded and so is not working after navigation  #}
-<body data-turbo="false">
+<body data-turbo="false" class="data-bs-no-jquery">
 
 {% block content %}{% endblock %}
 


### PR DESCRIPTION
## But de la pull request

Sources: 

- https://github.com/twbs/bootstrap/blob/main/js/src/util/index.js#L180
- https://github.com/twbs/bootstrap/blob/main/js/src/dom/event-handler.js#L264
- https://getbootstrap.com/docs/5.0/getting-started/javascript/#events
![image](https://user-images.githubusercontent.com/77674046/220413290-8a5485a8-5b90-47d5-b405-5e06a935b990.png)

## Implémentation

Cette class sur le `body` interdit l'usage de jQuery par bootstrap si présente dans le DOM

## Informations supplémentaires

Ceci évitera les erreurs lié à un ajout accidentel de jQuery par un dev

## Modifications du schéma de la base de données

NA 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
