### PR TITLE
(PC-20201)[API] feat: add procedure 47380 to handle inactive applications

### DIFF
--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -390,10 +390,11 @@ def delete_suspended_accounts_after_withdrawal_period() -> None:
 @blueprint.cli.command("handle_inactive_dms_applications_cron")
 @log_cron_with_transaction
 def handle_inactive_dms_applications_cron() -> None:
-    # DMS_ENROLLMENT_PROCEDURE_ID_v4_ET is excluded because the review delay is longer
-    # TESTING
     dms_script.handle_inactive_dms_applications(
         settings.DMS_ENROLLMENT_PROCEDURE_ID_v4_FR, with_never_eligible_applicant_rule=settings.IS_TESTING
+    )
+    dms_script.handle_inactive_dms_applications(
+        settings.DMS_ENROLLMENT_PROCEDURE_ID_v4_ET, with_never_eligible_applicant_rule=settings.IS_TESTING
     )
 
     if settings.IS_PROD:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20201

## But de la pull request

Ajouter la procédure DMS 'jeune de nationalité étrangère' à la liste des procédures pour lesquelles on gère l'inactivité.
En effet cette procédure a maintenant les mêmes délais que les autres

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
