### PR TITLE
(PC-20621)[BO] fix: avoid http error 500 when bookings action fails because of SQL constraint

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
@@ -191,9 +191,13 @@ def mark_booking_as_used(collective_booking_id: int) -> utils.BackofficeResponse
         flash("Impossible de valider une réservation qui n'est pas annulée", "warning")
         return _redirect_after_collective_booking_action()
 
-    educational_api_booking.uncancel_collective_booking_by_id_from_support(collective_booking)
+    try:
+        educational_api_booking.uncancel_collective_booking_by_id_from_support(collective_booking)
+    except sa.exc.SQLAlchemyError as exc:
+        flash(f"Une erreur s'est produite : {str(exc)}", "warning")
+    else:
+        flash(f"La réservation {collective_booking.id} a été validée", "success")
 
-    flash(f"La réservation {collective_booking.id} a été validée", "success")
     return _redirect_after_collective_booking_action()
 
 
@@ -208,6 +212,8 @@ def mark_booking_as_cancelled(collective_booking_id: int) -> utils.BackofficeRes
         flash("Impossible d'annuler une réservation déjà annulée", "warning")
     except educational_exceptions.BookingIsAlreadyRefunded:
         flash("Impossible d'annuler une réservation remboursée", "warning")
+    except sa.exc.SQLAlchemyError as exc:
+        flash(f"Une erreur s'est produite : {str(exc)}", "warning")
     else:
         flash(f"La réservation {collective_booking.id} a été annulée", "success")
 

--- a/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
@@ -214,9 +214,13 @@ def mark_booking_as_used(booking_id: int) -> utils.BackofficeResponse:
         flash("Impossible de valider une réservation qui n'est pas annulée", "warning")
         return _redirect_after_individual_booking_action()
 
-    bookings_api.mark_as_used_with_uncancelling(booking)
+    try:
+        bookings_api.mark_as_used_with_uncancelling(booking)
+    except sa.exc.SQLAlchemyError as exc:
+        flash(f"Une erreur s'est produite : {str(exc)}", "warning")
+    else:
+        flash(f"La réservation {booking.token} a été validée", "success")
 
-    flash(f"La réservation {booking.token} a été validée", "success")
     return _redirect_after_individual_booking_action()
 
 
@@ -233,6 +237,8 @@ def mark_booking_as_cancelled(booking_id: int) -> utils.BackofficeResponse:
         flash("Impossible d'annuler une réservation remboursée", "warning")
     except bookings_exceptions.BookingIsAlreadyUsed:
         flash("Impossible d'annuler une réservation déjà utilisée", "warning")
+    except sa.exc.SQLAlchemyError as exc:
+        flash(f"Une erreur s'est produite : {str(exc)}", "warning")
     else:
         flash(f"La réservation {booking.token} a été annulée", "success")
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20621

## But de la pull request

Les actions sur les réservations dans le backoffice finissent avec la page d'erreur 500 si l'opération échoue à cause d'une contrainte SQL. Solution : capturer l'exception pour afficher un message d'erreur comme sur FA permet.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
