### PR TITLE
(PC-20686)[BO] fix: exception when a venue is updated with empty phone number

### DIFF
--- a/api/src/pcapi/routes/serialization/base.py
+++ b/api/src/pcapi/routes/serialization/base.py
@@ -27,9 +27,9 @@ class VenueContactModel(BaseModel):
     social_medias: SocialMedias | None
 
     @validator("phone_number")
-    def validate_phone_number(cls, phone_number: str) -> str:
-        if phone_number is None:
-            return phone_number
+    def validate_phone_number(cls, phone_number: str) -> str | None:
+        if not phone_number:
+            return None
 
         try:
             return phone_number_utils.ParsedPhoneNumber(phone_number).phone_number

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -534,6 +534,25 @@ class UpdateVenueTest:
         update_snapshot = venue.action_history[0].extraData["modified_info"]
         assert update_snapshot["contact.email"]["new_info"] == data["email"]
 
+    def test_update_venue_empty_phone_number(self, authenticated_client):
+        venue = offerers_factories.VenueFactory()
+
+        url = url_for("backoffice_v3_web.venue.update_venue", venue_id=venue.id)
+        data = {
+            "siret": venue.siret,
+            "city": venue.city,
+            "postalCode": venue.postalCode,
+            "address": venue.address,
+            "email": venue.contact.email,
+            "phone_number": "",
+        }
+
+        response = send_request(authenticated_client, venue.id, url, data)
+
+        assert response.status_code == 303
+        db.session.refresh(venue)
+        assert venue.contact.phone_number is None
+
     def test_update_virtual_venue(self, authenticated_client, offerer):
         venue = offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20686

## But de la pull request

Corriger une exception (erreur 500) qui se produit lors de la modification d'un lieu, si le numéro de téléphone n'est pas rempli.

https://sentry.passculture.team/organizations/sentry/issues/408130/?project=5

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
