### PR TITLE
PC-20679-ne-pas-faire-rentrer-dans-le-process-jira-update-les-tickets-ops-task

### DIFF
--- a/.github/workflows/update-jira-issues.yml
+++ b/.github/workflows/update-jira-issues.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - master
 jobs:
-  update-jira-issues:
+  issue-number:
+    outputs:
+      status: ${{ steps.issue-check.outputs.status }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -40,13 +42,44 @@ jobs:
         with:
           from: commits
 
-      - name: Get jira previous commit number
-        id: get_previous_commit_number
+      # set the output with the issue number, only if the issue type is not equal to "OPS Task"
+      - id: issue-check
+        name: issue check
         if: ${{ steps.get_jira_key.outputs.issue != null }}
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+          chmod +x ./jq
+          issue_type=$(jira view ${{ steps.get_jira_key.outputs.issue }} -t json | ./jq -r '.fields.issuetype.name')
+          if [[ $issue_type != "OPS Task" ]]; then 
+            echo "status=${{ steps.get_jira_key.outputs.issue }}" >> $GITHUB_OUTPUT
+          fi
+
+  # run only if previous job issue-number has set his output to the issue number 
+  update-jira-issues:
+    runs-on: ubuntu-latest
+    needs: issue-number
+    if: needs.issue-number.outputs.status != null
+    steps:
+      - name: Setup gajira cli
+        uses: atlassian/gajira-cli@master
+        with:
+          version: 1.0.20
+
+      - name: Login
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Get jira previous commit number
+        id: get_previous_commit_number
+        env:
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         # The jira view command uses .jira.d/templates/view template by default
-        run: echo "::set-output name=value::$(jira view ${{ steps.get_jira_key.outputs.issue }})"
+        run: echo "::set-output name=value::$(jira view ${{ needs.issue-number.outputs.status }})"
 
       - name: Mark issue as not deployable
         env:
@@ -63,7 +96,6 @@ jobs:
           jira edit --query='"Numéro de commit[Number]" > ${{ steps.get_previous_commit_number.outputs.value }}' --override customfield_10044=true --noedit
 
       - name: Push commit number and commit hash to jira issue
-        if: ${{ steps.get_jira_key.outputs.issue != null }}
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         run: |


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20679

## But de la pull request

Si le ticket est de type `OPS Task`, alors on ne fait rien. En effet ce type d ticket ne comporte plus les champs qui sont update par cette action, notamment le champ impropre. 

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
