### PR TITLE
(PC-20537)[BO] fix: move siret form

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret.html
@@ -1,3 +1,5 @@
+{% from "components/form_body.html" import build_form_body with context %}
+
 {% extends "layouts/connected.html" %}
 
 {% block page %}
@@ -6,7 +8,7 @@
         <div class="col-12 py-4">
             <form action="{{ dst }}" method="POST">
                 <div class="form-group">
-                    {% include "components/form_body.html" %}
+                    {{ build_form_body(form) }}
                 </div>
                 <div class="d-flex justify-content-end">
                     <button type="submit" class="btn btn-primary">Continuer</button>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20537

## But de la pull request

Corriger le formulaire de déplacement de SIRET.
Dû à un _merge_ entre le codage et le _merge_ de ce ticket.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
