### PR TITLE
Pc 20558 remonter valeur ispublicapi dans routes offer

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -110,6 +110,7 @@ class CollectiveOfferResponseModel(BaseModel):
     templateId: str | None
     imageCredit: str | None
     imageUrl: str | None
+    isPublicApi: bool
 
 
 class ListCollectiveOffersResponseModel(BaseModel):
@@ -159,6 +160,7 @@ def _serialize_offer_paginated(offer: CollectiveOffer | CollectiveOfferTemplate)
         templateId=templateId,
         imageCredit=offer.imageCredit,
         imageUrl=offer.imageUrl,
+        isPublicApi=offer.isPublicApi if not is_offer_template else False,
     )
 
 
@@ -357,6 +359,7 @@ class GetCollectiveOfferResponseModel(GetCollectiveOfferBaseResponseModel):
     lastBookingId: int | None
     teacher: EducationalRedactorResponseModel | None
     _humanize_templateId = humanize_field("templateId")
+    isPublicApi: bool
 
 
 class CollectiveOfferResponseIdModel(BaseModel):

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -44,6 +44,25 @@ class Returns200Test:
         assert response_json[0]["educationalInstitution"]["name"] == institution.name
         assert response_json[0]["imageCredit"] == None
         assert response_json[0]["imageUrl"] == None
+        assert response_json[0]["isPublicApi"] == False
+
+    def test_if_collective_offer_is_public_api(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        offerer = offerer_factories.OffererFactory()
+        offerer_factories.UserOffererFactory(user=user, offerer=offerer)
+        venue = offerer_factories.VenueFactory(managingOfferer=offerer)
+        institution = educational_factories.EducationalInstitutionFactory()
+        educational_factories.CollectiveOfferFactory(venue=venue, offerId=1, institution=institution, isPublicApi=True)
+
+        # When
+        client = TestClient(app.test_client()).with_session_auth(email=user.email)
+        response = client.get("/collective/offers")
+
+        # Then
+        response_json = response.json
+        assert response.status_code == 200
+        assert response_json[0]["isPublicApi"] == True
 
     def test_one_simple_collective_offer_template(self, app):
         # Given

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -39,6 +39,7 @@ class Returns200Test:
         assert response_json["nonHumanizedId"] == offer.id
         assert response_json["lastBookingStatus"] is None
         assert response_json["lastBookingId"] is None
+        assert response_json["isPublicApi"] == False
         assert response_json["teacher"] == {
             "email": offer.teacher.email,
             "firstName": offer.teacher.firstName,

--- a/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferResponseModel.ts
@@ -19,6 +19,7 @@ export type CollectiveOfferResponseModel = {
   isActive: boolean;
   isEditable: boolean;
   isEducational: boolean;
+  isPublicApi: boolean;
   isShowcase: boolean;
   name: string;
   nonHumanizedId: number;

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferResponseModel.ts
@@ -33,6 +33,7 @@ export type GetCollectiveOfferResponseModel = {
   isBookable: boolean;
   isCancellable: boolean;
   isEditable: boolean;
+  isPublicApi: boolean;
   isVisibilityEditable: boolean;
   lastBookingId?: number | null;
   lastBookingStatus?: CollectiveBookingStatus | null;

--- a/pro/src/utils/collectiveApiFactories.ts
+++ b/pro/src/utils/collectiveApiFactories.ts
@@ -44,6 +44,7 @@ const sharedCollectiveOfferData = {
   hasBookingLimitDatetimesPassed: false,
   interventionArea: ['mainland'],
   isEditable: true,
+  isPublicApi: false,
   nonHumanizedId: 123,
   offerVenue: {
     venueId: '',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20558

## But de la pull request

savoir si les offres ont été ajouter via l'api publique ou non 

## NOTE

la page de test dans test_api a été copié de master apres une erreur de ma part ( j'ai embarqué les info d'une autre branche et j'ai remis en modifiant.
