### PR TITLE
(PC-19409)[API] feat: do not cancel event booking on account suspension

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -143,7 +143,7 @@ addopts = [
     "--disable-socket",
     # FIXME (dbaty, 2022-12-01): use network range 172.16.0.0/12 once pytest-socket
     # supports it.
-    "--allow-hosts=127.0.0.1,172.18.0.2,::1,172.20.0.2",  # allow connections to local Redis
+    "--allow-hosts=127.0.0.1,::1,172.18.0.2,172.19.0.3,172.20.0.2",  # allow connections to local Redis
 ]
 filterwarnings = [
     # Mark warnings as errors

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -390,22 +390,23 @@ def get_qr_code_data(booking_token: str) -> str:
 def compute_cancellation_limit_date(
     event_beginning: datetime.datetime | None, booking_creation_or_event_edition: datetime.datetime
 ) -> datetime.datetime | None:
-    if event_beginning:
-        if event_beginning.tzinfo:
-            tz_naive_event_beginning = event_beginning.astimezone(pytz.utc)
-            tz_naive_event_beginning = tz_naive_event_beginning.replace(tzinfo=None)
-        else:
-            tz_naive_event_beginning = event_beginning
-        before_event_limit = tz_naive_event_beginning - constants.CONFIRM_BOOKING_BEFORE_EVENT_DELAY
-        after_booking_or_event_edition_limit = (
-            booking_creation_or_event_edition + constants.CONFIRM_BOOKING_AFTER_CREATION_DELAY
-        )
-        earliest_date_in_cancellation_period = min(before_event_limit, after_booking_or_event_edition_limit)
-        latest_date_between_earliest_date_in_cancellation_period_and_booking_creation_or_event_edition = max(
-            earliest_date_in_cancellation_period, booking_creation_or_event_edition
-        )
-        return latest_date_between_earliest_date_in_cancellation_period_and_booking_creation_or_event_edition
-    return None
+    if event_beginning is None:
+        return None
+
+    if event_beginning.tzinfo:
+        tz_naive_event_beginning = event_beginning.astimezone(pytz.utc)
+        tz_naive_event_beginning = tz_naive_event_beginning.replace(tzinfo=None)
+    else:
+        tz_naive_event_beginning = event_beginning
+    before_event_limit = tz_naive_event_beginning - constants.CONFIRM_BOOKING_BEFORE_EVENT_DELAY
+    after_booking_or_event_edition_limit = (
+        booking_creation_or_event_edition + constants.CONFIRM_BOOKING_AFTER_CREATION_DELAY
+    )
+    earliest_cancellation_limit_date = max(
+        booking_creation_or_event_edition,
+        min(after_booking_or_event_edition_limit, before_event_limit),
+    )
+    return earliest_cancellation_limit_date
 
 
 def update_cancellation_limit_dates(

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -343,14 +343,6 @@ def find_offers_booked_by_beneficiaries(users: list[User]) -> list[Offer]:
     )
 
 
-def find_cancellable_bookings_by_beneficiaries(users: list[User]) -> list[Booking]:
-    return (
-        Booking.query.filter(Booking.userId.in_(user.id for user in users))
-        .filter(Booking.status == BookingStatus.CONFIRMED)
-        .all()
-    )
-
-
 def find_cancellable_bookings_by_offerer(offerer_id: int) -> list[Booking]:
     return Booking.query.filter(
         Booking.offererId == offerer_id,

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -409,6 +409,10 @@ def _cancel_bookings_of_user_on_requested_account_suspension(
     bookings_to_cancel = bookings_models.Booking.query.filter(
         bookings_models.Booking.userId == user.id,
         bookings_models.Booking.status == bookings_models.BookingStatus.CONFIRMED,
+        sa.or_(
+            datetime.datetime.utcnow() < bookings_models.Booking.cancellationLimitDate,
+            bookings_models.Booking.cancellationLimitDate == None,
+        ),
     ).all()
 
     cancelled_bookings_count = 0

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -836,37 +836,37 @@ class MarkAsUnusedTest:
 
 
 @pytest.mark.parametrize(
-    "booking_date",
+    "booking_creation_date",
     [datetime(2020, 7, 14, 15, 30), datetime(2020, 10, 25, 1, 45), datetime.utcnow()],
     ids=["14 Jul", "Daylight Saving Switch", "Now"],
 )
 @pytest.mark.usefixtures("db_session")
 class ComputeCancellationDateTest:
-    def test_returns_none_if_no_event_beginning(self, booking_date):
+    def test_returns_none_if_no_event_beginning(self, booking_creation_date):
         event_beginning = None
-        booking_creation = booking_date
-        assert api.compute_cancellation_limit_date(event_beginning, booking_creation) is None
+        assert api.compute_cancellation_limit_date(event_beginning, booking_creation_date) is None
 
-    def test_returns_creation_date_if_event_begins_too_soon(self, booking_date):
-        event_date_too_close_to_cancel_booking = booking_date + timedelta(days=1)
-        booking_creation = booking_date
+    def test_returns_creation_date_if_event_begins_too_soon(self, booking_creation_date):
+        event_date_too_close_to_cancel_booking = booking_creation_date + timedelta(days=1)
         assert (
-            api.compute_cancellation_limit_date(event_date_too_close_to_cancel_booking, booking_creation)
-            == booking_creation
+            api.compute_cancellation_limit_date(event_date_too_close_to_cancel_booking, booking_creation_date)
+            == booking_creation_date
         )
 
-    def test_returns_two_days_after_booking_creation_if_event_begins_in_more_than_four_days(self, booking_date):
-        event_date_more_ten_days_from_now = booking_date + timedelta(days=6)
-        booking_creation = booking_date
+    def test_returns_two_days_after_booking_creation_if_event_begins_in_more_than_four_days(
+        self, booking_creation_date
+    ):
+        event_date_more_ten_days_from_now = booking_creation_date + timedelta(days=6)
         assert api.compute_cancellation_limit_date(
-            event_date_more_ten_days_from_now, booking_creation
-        ) == booking_creation + timedelta(days=2)
+            event_date_more_ten_days_from_now, booking_creation_date
+        ) == booking_creation_date + timedelta(days=2)
 
-    def test_returns_two_days_before_event_if_event_begins_between_two_and_four_days_from_now(self, booking_date):
-        event_date_four_days_from_now = booking_date + timedelta(days=4)
-        booking_creation = booking_date
+    def test_returns_two_days_before_event_if_event_begins_between_two_and_four_days_from_now(
+        self, booking_creation_date
+    ):
+        event_date_four_days_from_now = booking_creation_date + timedelta(days=4)
         assert api.compute_cancellation_limit_date(
-            event_date_four_days_from_now, booking_creation
+            event_date_four_days_from_now, booking_creation_date
         ) == event_date_four_days_from_now - timedelta(days=2)
 
 

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -2189,31 +2189,6 @@ class GetOffersBookedByFraudulentUsersTest:
         assert set(offers) == {offer_booked_by_both, offer_booked_by_fraudulent_users}
 
 
-class FindBookingsByFraudulentUsersTest:
-    def test_returns_only_bookings_by_fraudulent_users(self):
-        # Given
-        fraudulent_beneficiary_user = users_factories.BeneficiaryGrant18Factory(email="jesuisunefraude@example.com")
-        another_fraudulent_beneficiary_user = users_factories.BeneficiaryGrant18Factory(
-            email="jesuisuneautrefraude@example.com"
-        )
-        beneficiary_user = users_factories.BeneficiaryGrant18Factory(email="jenesuispasunefraude@EXAmple.com")
-
-        booking_booked_by_fraudulent_user = bookings_factories.BookingFactory(user=fraudulent_beneficiary_user)
-        another_booking_booked_by_fraudulent_user = bookings_factories.BookingFactory(
-            user=another_fraudulent_beneficiary_user
-        )
-        bookings_factories.BookingFactory(user=beneficiary_user, stock__price=1)
-
-        # When
-        bookings = booking_repository.find_cancellable_bookings_by_beneficiaries(
-            [fraudulent_beneficiary_user, another_fraudulent_beneficiary_user]
-        )
-
-        # Then
-        assert len(bookings) == 2
-        assert set(bookings) == {booking_booked_by_fraudulent_user, another_booking_booked_by_fraudulent_user}
-
-
 class FindExpiringBookingsTest:
     def test_find_expired_bookings_before_and_after_enabling_feature_flag(self):
         with freeze_time("2021-08-01 15:00:00") as frozen_time:

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -244,7 +244,7 @@ class CancelBeneficiaryBookingsOnSuspendAccountTest:
 
         assert booking_event.status is BookingStatus.CANCELLED
 
-    def should_cancel_event_when_cancellation_limit_date_is_past(self):
+    def should_not_cancel_event_when_cancellation_limit_date_is_past(self):
         """
         ---[        cancellable       ][         not cancellable        ]-->
         ---|---------------------------|--------------------------------|-->
@@ -267,7 +267,7 @@ class CancelBeneficiaryBookingsOnSuspendAccountTest:
 
         users_api.suspend_account(booking_event.user, reason, author)
 
-        assert booking_event.status is BookingStatus.CANCELLED
+        assert booking_event.status is BookingStatus.CONFIRMED
 
 
 @pytest.mark.usefixtures("db_session")
@@ -316,7 +316,7 @@ class SuspendAccountTest:
         assert _datetime_within_last_5sec(user.suspension_date)
 
         assert cancellable_booking.status is BookingStatus.CANCELLED
-        assert confirmed_booking.status is BookingStatus.CANCELLED
+        assert confirmed_booking.status is BookingStatus.CONFIRMED
         assert used_booking.status is BookingStatus.USED
 
         history = history_models.ActionHistory.query.filter_by(userId=user.id).all()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19409

## But de la pull request

Lors de la suspension de compte :

Ne plus annuler les réservations des événements qui ont été confirmées

## Informations supplémentaires

- quelques petits refactoring, tout est découpé en commits atomics
- en faisant la feature, j'ai découvert que l'on calcul la date à laquelle on peut annuler une réservation, cette date correspond à :
	- soit l'event à lieu dans un futur lointain : 48h après avoir fait la réservation elle est confirmée
	- soit l'event à lieu dans un futur proche : 48h avant l'event
	- sinon : la date de la réservation

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires

