### PR TITLE
(PC-20585)[PRO] feat: get price detail from offer template duplication

### DIFF
--- a/pro/src/core/OfferEducational/utils/__specs__/extractInitialStockValues.spec.ts
+++ b/pro/src/core/OfferEducational/utils/__specs__/extractInitialStockValues.spec.ts
@@ -1,0 +1,58 @@
+import { GetCollectiveOfferCollectiveStockResponseModel } from 'apiClient/v1'
+import { DEFAULT_EAC_STOCK_FORM_VALUES } from 'core/OfferEducational/constants'
+import {
+  CollectiveOffer,
+  CollectiveOfferTemplate,
+} from 'core/OfferEducational/types'
+
+import { extractInitialStockValues } from '../extractInitialStockValues'
+
+describe('extractInitialVisibilityValues', () => {
+  it('should return default values when collectiveStock is not defined', () => {
+    expect(
+      extractInitialStockValues({ collectiveStock: null } as CollectiveOffer)
+    ).toStrictEqual(DEFAULT_EAC_STOCK_FORM_VALUES)
+  })
+
+  it('should return stock details', () => {
+    const stockValues: GetCollectiveOfferCollectiveStockResponseModel = {
+      beginningDatetime: '2023-02-23T10:46:20Z',
+      bookingLimitDatetime: '2023-02-28T10:46:20Z',
+      educationalPriceDetail: 'test',
+      id: 'UM',
+      isBooked: false,
+      isCancellable: false,
+      isEducationalStockEditable: true,
+      numberOfTickets: 20,
+      price: 1200,
+    }
+    expect(
+      extractInitialStockValues({
+        venue: { departementCode: '75' },
+        collectiveStock: stockValues,
+      } as CollectiveOffer)
+    ).toStrictEqual({
+      bookingLimitDatetime: new Date('2023-02-28T11:46:20.000Z'),
+      eventDate: new Date('2023-02-23T11:46:20.000Z'),
+      eventTime: new Date('2023-02-23T11:46:20.000Z'),
+      educationalOfferType: 'CLASSIC',
+      numberOfPlaces: 20,
+      priceDetail: 'test',
+      totalPrice: 1200,
+    })
+  })
+
+  it('should return default values with educationPriceDetail when educationalPriceDetail is defined', () => {
+    expect(
+      extractInitialStockValues(
+        { collectiveStock: null } as CollectiveOffer,
+        {
+          educationalPriceDetail: 'initialStockValues',
+        } as CollectiveOfferTemplate
+      )
+    ).toStrictEqual({
+      ...DEFAULT_EAC_STOCK_FORM_VALUES,
+      priceDetail: 'initialStockValues',
+    })
+  })
+})

--- a/pro/src/core/OfferEducational/utils/extractInitialStockValues.ts
+++ b/pro/src/core/OfferEducational/utils/extractInitialStockValues.ts
@@ -2,15 +2,24 @@ import {
   DEFAULT_EAC_STOCK_FORM_VALUES,
   EducationalOfferType,
   CollectiveOffer,
+  CollectiveOfferTemplate,
   OfferEducationalStockFormValues,
 } from 'core/OfferEducational'
 import { getLocalDepartementDateTimeFromUtc } from 'utils/timezone'
 
 export const extractInitialStockValues = (
-  offer: CollectiveOffer
+  offer: CollectiveOffer,
+  offerTemplate?: CollectiveOfferTemplate
 ): OfferEducationalStockFormValues => {
   const { collectiveStock } = offer
+
   if (!collectiveStock) {
+    if (offerTemplate?.educationalPriceDetail) {
+      return {
+        ...DEFAULT_EAC_STOCK_FORM_VALUES,
+        priceDetail: offerTemplate.educationalPriceDetail,
+      }
+    }
     return DEFAULT_EAC_STOCK_FORM_VALUES
   }
 

--- a/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -1,16 +1,18 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import CollectiveOfferLayout from 'components/CollectiveOfferLayout'
 import RouteLeavingGuardCollectiveOfferCreation from 'components/RouteLeavingGuardCollectiveOfferCreation'
 import {
   CollectiveOffer,
+  CollectiveOfferTemplate,
   EducationalOfferType,
   extractInitialStockValues,
   isCollectiveOffer,
   Mode,
   OfferEducationalStockFormValues,
 } from 'core/OfferEducational'
+import getCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
 import { computeURLCollectiveOfferId } from 'core/OfferEducational/utils/computeURLCollectiveOfferId'
 import useNotification from 'hooks/useNotification'
 import patchCollectiveStockAdapter from 'pages/CollectiveOfferStockEdition/adapters/patchCollectiveStockAdapter'
@@ -31,7 +33,24 @@ const CollectiveOfferStockCreation = ({
   const notify = useNotification()
   const history = useHistory()
 
-  const initialValues = extractInitialStockValues(offer)
+  const [offerTemplate, setOfferTemplate] = useState<CollectiveOfferTemplate>()
+
+  useEffect(() => {
+    const fetchOfferTemplateDetails = async () => {
+      if (!(isCollectiveOffer(offer) && offer.templateId)) {
+        return null
+      }
+      const { isOk, payload, message } =
+        await getCollectiveOfferTemplateAdapter(offer.templateId)
+      if (!isOk) {
+        return notify.error(message)
+      }
+      setOfferTemplate(payload)
+    }
+    fetchOfferTemplateDetails()
+  }, [])
+
+  const initialValues = extractInitialStockValues(offer, offerTemplate)
 
   const handleSubmitStock = async (
     offer: CollectiveOffer,

--- a/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOfferStockCreation/__specs__/CollectiveOfferStockCreation.spec.tsx
@@ -1,8 +1,15 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import * as router from 'react-router-dom'
 
-import { collectiveOfferFactory } from 'utils/collectiveApiFactories'
+import { api } from 'apiClient/api'
+import getCollectiveOfferTemplateAdapter from 'core/OfferEducational/adapters/getCollectiveOfferTemplateAdapter'
+import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
+import * as useNotification from 'hooks/useNotification'
+import {
+  collectiveOfferFactory,
+  collectiveOfferTemplateFactory,
+} from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferStockCreation from '..'
@@ -35,8 +42,11 @@ const defaultProps = {
 }
 
 describe('CollectiveOfferStockCreation', () => {
-  it('should render collective offer stock form', async () => {
+  beforeEach(() => {
     jest.spyOn(router, 'useParams').mockReturnValue({ offerId: 'A1' })
+  })
+
+  it('should render collective offer stock form', async () => {
     renderCollectiveStockCreation('/offre/A1/collectif/stocks', defaultProps)
 
     expect(
@@ -49,5 +59,53 @@ describe('CollectiveOfferStockCreation', () => {
         name: 'Date et prix',
       })
     ).toBeInTheDocument()
+  })
+
+  it('should render collective offer stock form from template', async () => {
+    const props = {
+      offer: { ...defaultProps.offer, templateId: 'FM' },
+      setOffer: jest.fn(),
+    }
+    const offerTemplate = collectiveOfferTemplateFactory({
+      educationalPriceDetail: 'Details from template',
+    })
+    jest
+      .spyOn(api, 'getCollectiveOfferTemplate')
+      .mockResolvedValue(offerTemplate)
+    renderCollectiveStockCreation('/offre/A1/collectif/stocks', props)
+    await waitFor(() => {
+      expect(api.getCollectiveOfferTemplate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should failed render collective offer stock form from template', async () => {
+    const props = {
+      offer: { ...defaultProps.offer, templateId: 'FM' },
+      setOffer: jest.fn(),
+    }
+    jest.spyOn(api, 'getCollectiveOfferTemplate').mockRejectedValue({
+      isOk: false,
+      message: 'Une erreur est survenue lors de la récupération de votre offre',
+      payload: null,
+    })
+    const notifyError = jest.fn()
+    // @ts-expect-error
+    jest.spyOn(useNotification, 'default').mockImplementation(() => ({
+      error: notifyError,
+    }))
+    renderCollectiveStockCreation('/offre/A1/collectif/stocks', props)
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Créer une offre pour un établissement scolaire',
+      })
+    ).toBeInTheDocument()
+
+    const response = await getCollectiveOfferTemplateAdapter(
+      props.offer.templateId
+    )
+    expect(response.isOk).toBeFalsy()
+    await waitFor(() => {
+      expect(notifyError).toHaveBeenCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20585

## But de la pull request

Lorsqu'on créée une offre vitrine on a la possibilité de mettre une description pour le prix sauf qu'on ne l'a récupérait pas si on dupliquait l'offre vitrine en question. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires