### PR TITLE
(PC-20393)[PRO] chore: move collective offers llist to react-router-v6

### DIFF
--- a/pro/src/app/AppRouter/routes_map.tsx
+++ b/pro/src/app/AppRouter/routes_map.tsx
@@ -235,6 +235,7 @@ const routes: IRoute[] = [
     exact: true,
     path: '/offres/collectives',
     title: 'Offres',
+    useV6Router: true,
   },
   {
     component: CollectiveOfferRoutes,

--- a/pro/src/core/Offers/hooks/useQuerySearchFilters.ts
+++ b/pro/src/core/Offers/hooks/useQuerySearchFilters.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 
 import { DEFAULT_PAGE, DEFAULT_SEARCH_FILTERS } from 'core/Offers/constants'
 import { parse } from 'utils/query-string'

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { api } from 'apiClient/api'
 import { filterEducationalCategories } from 'core/OfferEducational'
@@ -24,7 +24,7 @@ import { getFilteredCollectiveOffersAdapter } from './adapters'
 const CollectiveOffers = (): JSX.Element => {
   const [urlSearchFilters, urlPageNumber] = useQuerySearchFilters()
   const notify = useNotification()
-  const history = useHistory()
+  const navigate = useNavigate()
   const { currentUser } = useCurrentUser()
   const dispatch = useDispatch()
 
@@ -105,19 +105,15 @@ const CollectiveOffers = (): JSX.Element => {
     [notify]
   )
 
-  const redirectWithUrlFilters = useCallback(
-    (
-      filters: TSearchFilters & {
-        page?: number
-        audience?: Audience
-      }
-    ) => {
-      const newUrl = computeCollectiveOffersUrl(filters, filters.page)
-
-      history.push(newUrl)
-    },
-    [history]
-  )
+  const redirectWithUrlFilters = (
+    filters: TSearchFilters & {
+      page?: number
+      audience?: Audience
+    }
+  ) => {
+    const newUrl = computeCollectiveOffersUrl(filters, filters.page)
+    navigate(newUrl)
+  }
 
   useEffect(() => {
     const filters = { ...urlSearchFilters }

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
@@ -1,0 +1,372 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import * as router from 'react-router-dom-v5-compat'
+import type { Store } from 'redux'
+
+import { api } from 'apiClient/api'
+import { OfferStatus } from 'apiClient/v1'
+import {
+  ALL_CATEGORIES_OPTION,
+  DEFAULT_SEARCH_FILTERS,
+} from 'core/Offers/constants'
+import { Offer, TSearchFilters } from 'core/Offers/types'
+import { computeCollectiveOffersUrl } from 'core/Offers/utils'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveOffers from '../CollectiveOffers'
+import { collectiveOfferFactory } from '../utils/collectiveOffersFactories'
+
+//FIX ME : extract inital values and constant to reduce code duplication with CollectiveOffers.spec.tsx
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useNavigate: jest.fn(),
+}))
+
+const renderOffers = async (
+  storeOverrides: Store,
+  filters: Partial<TSearchFilters> & {
+    page?: number
+  } = DEFAULT_SEARCH_FILTERS
+) => {
+  const route = computeCollectiveOffersUrl(filters)
+  renderWithProviders(
+    <router.Routes>
+      <router.Route path="/offres/collectives" element={<CollectiveOffers />} />
+
+      <router.Route
+        path="/offres"
+        element={
+          <>
+            <h1>Offres individuelles</h1>
+          </>
+        }
+      ></router.Route>
+    </router.Routes>,
+    {
+      storeOverrides,
+      initialRouterEntries: [route],
+    }
+  )
+
+  await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+  return {
+    history,
+  }
+}
+
+const categoriesAndSubcategories = {
+  categories: [
+    { id: 'CINEMA', proLabel: 'Cinéma', isSelectable: true },
+    { id: 'JEU', proLabel: 'Jeux', isSelectable: true },
+    { id: 'TECHNIQUE', proLabel: 'Technique', isSelectable: false },
+  ],
+  subcategories: [
+    {
+      id: 'EVENEMENT_CINE',
+      proLabel: 'Evènement ciné',
+      canBeEducational: true,
+      categoryId: 'CINEMA',
+      isSelectable: true,
+    },
+    {
+      id: 'CONCOURS',
+      proLabel: 'Concours jeux',
+      canBeEducational: false,
+      categoryId: 'JEU',
+      isSelectable: true,
+    },
+  ],
+}
+
+const proVenues = [
+  {
+    id: 'JI',
+    name: 'Ma venue',
+    offererName: 'Mon offerer',
+    isVirtual: false,
+  },
+  {
+    id: 'JQ',
+    name: 'Ma venue virtuelle',
+    offererName: 'Mon offerer',
+    isVirtual: true,
+  },
+]
+
+jest.mock('repository/venuesService', () => ({
+  ...jest.requireActual('repository/venuesService'),
+}))
+
+jest.mock('apiClient/api', () => ({
+  api: {
+    listOffers: jest.fn(),
+    getCategories: jest.fn().mockResolvedValue(categoriesAndSubcategories),
+    getCollectiveOffers: jest.fn(),
+    getOfferer: jest.fn(),
+    getVenues: jest.fn().mockResolvedValue({ venues: proVenues }),
+  },
+}))
+
+jest.mock('utils/date', () => ({
+  ...jest.requireActual('utils/date'),
+  getToday: jest
+    .fn()
+    .mockImplementation(() => new Date('2020-12-15T12:00:00Z')),
+}))
+
+jest.mock('hooks/useActiveFeature', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(true),
+}))
+
+describe('route CollectiveOffers', () => {
+  let currentUser: {
+    id: string
+    isAdmin: boolean
+    name: string
+    publicName: string
+  }
+  let store: any
+  let offersRecap: Offer[]
+  const mockNavigate = jest.fn()
+
+  beforeEach(() => {
+    currentUser = {
+      id: 'EY',
+      isAdmin: false,
+      name: 'Current User',
+      publicName: 'USER',
+    }
+    store = {
+      user: {
+        initialized: true,
+        currentUser,
+      },
+      offers: {
+        searchFilters: DEFAULT_SEARCH_FILTERS,
+      },
+    }
+    offersRecap = [collectiveOfferFactory()]
+    jest
+      .spyOn(api, 'getCollectiveOffers')
+      // @ts-expect-error FIX ME
+      .mockResolvedValue(offersRecap)
+    jest.spyOn(router, 'useNavigate').mockReturnValue(mockNavigate)
+  })
+
+  describe('url query params', () => {
+    it('should have page value when page value is not first page', async () => {
+      // Given
+      const offersRecap = Array.from({ length: 11 }, () =>
+        collectiveOfferFactory()
+      )
+      jest
+        .spyOn(api, 'getCollectiveOffers')
+        // @ts-expect-error FIX ME
+        .mockResolvedValueOnce(offersRecap)
+      await renderOffers(store)
+      const nextPageIcon = screen.getByAltText('Page suivante')
+      // When
+      await userEvent.click(nextPageIcon)
+
+      expect(mockNavigate).toHaveBeenCalledWith('/offres/collectives?page=2')
+    })
+
+    it('should have offer name value when name search value is not an empty string', async () => {
+      // Given
+      await renderOffers(store)
+      // When
+      await userEvent.type(
+        screen.getByPlaceholderText('Rechercher par nom d’offre'),
+        'AnyWord'
+      )
+      await userEvent.click(screen.getByText('Lancer la recherche'))
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/offres/collectives?nom-ou-isbn=AnyWord'
+      )
+    })
+
+    it('should have offer name value be removed when name search value is an empty string', async () => {
+      // Given
+      await renderOffers(store)
+      // When
+      await userEvent.clear(
+        screen.getByPlaceholderText('Rechercher par nom d’offre')
+      )
+      await userEvent.click(screen.getByText('Lancer la recherche'))
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith('/offres/collectives')
+    })
+
+    it('should have venue value when user filters by venue', async () => {
+      // Given
+      await renderOffers(store)
+      const firstVenueOption = screen.getByRole('option', {
+        name: proVenues[0].name,
+      })
+      const venueSelect = screen.getByLabelText('Lieu')
+      // When
+      await userEvent.selectOptions(venueSelect, firstVenueOption)
+      await userEvent.click(screen.getByText('Lancer la recherche'))
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith('/offres/collectives?lieu=JI')
+    })
+
+    it('should have venue value be removed when user asks for all venues', async () => {
+      // Given
+      jest
+        .spyOn(api, 'getCollectiveOffers')
+        // @ts-expect-error FIX ME
+        .mockResolvedValueOnce(offersRecap)
+      jest.spyOn(api, 'getCategories').mockResolvedValue({
+        categories: [
+          { id: 'test_id_1', proLabel: 'My test value', isSelectable: true },
+          {
+            id: 'test_id_2',
+            proLabel: 'My second test value',
+            isSelectable: true,
+          },
+        ],
+        subcategories: [
+          // @ts-expect-error FIX ME
+          {
+            id: 'test_sub_id_1',
+            categoryId: 'test_id_1',
+            isSelectable: true,
+            canBeEducational: true,
+          },
+          // @ts-expect-error FIX ME
+          {
+            id: 'test_sub_id_2',
+            categoryId: 'test_id_2',
+            canBeEducational: true,
+            isSelectable: true,
+          },
+        ],
+      })
+      await renderOffers(store)
+      const firstTypeOption = screen.getByRole('option', {
+        name: 'My test value',
+      })
+      const typeSelect = screen.getByDisplayValue(
+        ALL_CATEGORIES_OPTION.displayName
+      )
+      // When
+      await userEvent.selectOptions(typeSelect, firstTypeOption)
+      await userEvent.click(screen.getByText('Lancer la recherche'))
+
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/offres/collectives?categorie=test_id_1'
+      )
+    })
+
+    it('should have status value when user filters by status', async () => {
+      // Given
+      jest.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce([
+        // @ts-expect-error FIX ME
+        collectiveOfferFactory(
+          {
+            id: 'KE',
+            availabilityMessage: 'Pas de stock',
+            status: OfferStatus.ACTIVE,
+          },
+          // @ts-expect-error collectiveOfferFactory is not typed and null throws an error but is accepted by the function
+          null
+        ),
+      ])
+      await renderOffers(store)
+      await userEvent.click(
+        screen.getByAltText('Afficher ou masquer le filtre par statut')
+      )
+      await userEvent.click(screen.getByLabelText('Réservée'))
+      // When
+      await userEvent.click(screen.getByText('Appliquer'))
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/offres/collectives?statut=reservee'
+      )
+    })
+
+    it('should have status value be removed when user ask for all status', async () => {
+      // Given
+      jest.spyOn(api, 'getCollectiveOffers').mockResolvedValueOnce([
+        // @ts-expect-error FIX ME
+        collectiveOfferFactory(
+          {
+            id: 'KE',
+            availabilityMessage: 'Pas de stock',
+            status: OfferStatus.ACTIVE,
+          },
+          // @ts-expect-error collectiveOfferFactory is not typed and null throws an error but is accepted by the function
+          null
+        ),
+      ])
+      await renderOffers(store)
+      await userEvent.click(
+        screen.getByAltText('Afficher ou masquer le filtre par statut')
+      )
+      await userEvent.click(screen.getByLabelText('Tous'))
+      // When
+      await userEvent.click(screen.getByText('Appliquer'))
+      // Then
+      expect(mockNavigate).toHaveBeenCalledWith('/offres/collectives')
+    })
+
+    it('should have offerer filter when user filters by offerer', async () => {
+      // Given
+      const filters = { offererId: 'A4' }
+      // @ts-expect-error FIX ME
+      jest.spyOn(api, 'getOfferer').mockResolvedValueOnce({
+        name: 'La structure',
+      })
+      // When
+      await renderOffers(store, filters)
+      // Then
+      const offererFilter = screen.getByText('La structure')
+      expect(offererFilter).toBeInTheDocument()
+    })
+
+    it('should have offerer value be removed when user removes offerer filter', async () => {
+      // Given
+      const filters = { offererId: 'A4' }
+      // @ts-expect-error FIX ME
+      jest.spyOn(api, 'getOfferer').mockResolvedValueOnce({
+        name: 'La structure',
+      })
+      await renderOffers(store, filters)
+      // When
+      await userEvent.click(
+        screen.getByAltText('Supprimer le filtre par structure')
+      )
+      // Then
+      expect(screen.queryByText('La structure')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('page navigation', () => {
+    it('should redirect to individual offers when user clicks on individual offers link', async () => {
+      // Given
+
+      jest.spyOn(api, 'getCollectiveOffers').mockResolvedValue(
+        // @ts-expect-error FIX ME
+        offersRecap
+      )
+      await renderOffers(store)
+      screen.getByText('Lancer la recherche')
+      const individualAudienceLink = screen.getByText('Offres individuelles', {
+        selector: 'span',
+      })
+
+      // When
+      await userEvent.click(individualAudienceLink)
+
+      // Then
+      expect(screen.getByRole('heading', { name: 'Offres individuelles' }))
+    })
+  })
+})

--- a/pro/src/screens/Offers/Offers.tsx
+++ b/pro/src/screens/Offers/Offers.tsx
@@ -202,6 +202,7 @@ const Offers = ({
   )
 
   const applyFilters = useCallback(() => {
+    // FIXME : this code's part seems to be useless
     if (!hasDifferentFiltersFromLastSearch(searchFilters)) {
       refreshOffers()
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20393

## But de la pull request

Rendre compatible la route de la liste des offres collectives avec le router react v6
