### PR TITLE
(PC-20767)[PRO] feat: reset filters when changing tab in adage iframe

### DIFF
--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -53,6 +53,9 @@ export const OffersSearchComponent = ({
   const uaiCodeShareWithMyInstitutionTab = userUAICode ? [userUAICode] : null
 
   const handleTabChange = (tab: OfferTab) => {
+    dispatchCurrentFilters({
+      type: 'RESET_CURRENT_FILTERS',
+    })
     setActiveTab(tab)
     setFacetFilters(
       populateFacetFilters({


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20767

## But de la pull request

Remettre à zéro les filtres quand on accède à l'onglet 'Partagé avec mon établissement' sur adage 

## Screenshot 
<img width="1384" alt="Capture d’écran 2023-02-27 à 17 07 54" src="https://user-images.githubusercontent.com/71768799/221617784-446051cd-d1a9-4567-a73b-e7304d4eea4b.png">

