### PR TITLE
(PC-20783)[PRO] fix: check venue comment and withdrawal details max length

### DIFF
--- a/api/src/pcapi/routes/serialization/base.py
+++ b/api/src/pcapi/routes/serialization/base.py
@@ -93,6 +93,18 @@ class VenueSiret(RequiredStrippedString):
     max_length = 14
 
 
+class VenueComment(pydantic.ConstrainedStr):
+    strip_whitespace = True
+    # optional, hence no `min_length`
+    max_length = 500
+
+
+class VenueWithdrawalDetails(pydantic.ConstrainedStr):
+    strip_whitespace = True
+    # optional, hence no `min_length`
+    max_length = 500
+
+
 class BaseVenueResponse(BaseModel):
     isVirtual: bool
     name: str

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -36,7 +36,7 @@ class PostVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     address: base.VenueAddress
     bookingEmail: base.VenueBookingEmail
     city: base.VenueCity
-    comment: str | None
+    comment: base.VenueComment | None
     latitude: float
     longitude: float
     managingOffererId: str
@@ -46,7 +46,7 @@ class PostVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     siret: base.VenueSiret | None
     venueLabelId: str | None
     venueTypeCode: str
-    withdrawalDetails: str | None
+    withdrawalDetails: base.VenueWithdrawalDetails | None
     description: base.VenueDescription | None
     contact: base.VenueContactModel | None
 
@@ -293,10 +293,10 @@ class EditVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     postalCode: base.VenuePostalCode | None
     city: base.VenueCity | None
     publicName: base.VenuePublicName | None
-    comment: str | None
+    comment: base.VenueComment | None
     venueTypeCode: str | None
     venueLabelId: int | None
-    withdrawalDetails: str | None
+    withdrawalDetails: base.VenueWithdrawalDetails | None
     isAccessibilityAppliedOnAllOffers: bool | None
     isWithdrawalAppliedOnAllOffers: bool | None
     isEmailAppliedOnAllOffers: bool | None

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -173,6 +173,29 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json["siret"] == ["Veuillez saisir soit un SIRET soit un commentaire"]
 
+    def test_comment_too_long(self, client) -> None:
+        user = ProFactory()
+        client = client.with_session_auth(email=user.email)
+        venue_data = create_valid_venue_data(user)
+        venue_data["siret"] = None
+        venue_data["comment"] = "Pas de SIRET " * 40
+
+        response = client.post("/venues", json=venue_data)
+
+        assert response.status_code == 400
+        assert response.json["comment"] == ["ensure this value has at most 500 characters"]
+
+    def test_withdrawal_details_too_long(self, client) -> None:
+        user = ProFactory()
+        client = client.with_session_auth(email=user.email)
+        venue_data = create_valid_venue_data(user)
+        venue_data["withdrawalDetails"] = "Trop long " * 51
+
+        response = client.post("/venues", json=venue_data)
+
+        assert response.status_code == 400
+        assert response.json["withdrawalDetails"] == ["ensure this value has at most 500 characters"]
+
 
 class Returns403Test:
     def test_user_is_not_managing_offerer_create_venue(self, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20783

## But de la pull request

Corriger une erreur remontée par le Bug Bounty (YesWeHack) : un hacker malintentionné pourrait créer un compte pro, créer des lieux sans SIRET sur lesquels envoyer des millions de caractères. De manière automatisée, cela aurait un impact négatif sur la taille de notre base de données.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
