### PR TITLE
(PC-20649)[PRO] feat: can't edit when offer from publicApi

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -5,6 +5,7 @@ import {
   CollectiveOffer,
   CollectiveOfferTemplate,
   EducationalCategories,
+  isCollectiveOffer,
 } from 'core/OfferEducational'
 
 import CollectiveOfferAccessibilitySection from './components/CollectiveOfferAccessibilitySection'
@@ -33,13 +34,14 @@ const CollectiveOfferSummary = ({
   stockEditLink,
   visibilityEditLink,
 }: ICollectiveOfferSummaryProps) => {
+  const offerManuallyCreated = isCollectiveOffer(offer) && !offer.isPublicApi
   return (
     <>
       <SummaryLayout>
         <SummaryLayout.Content fullWidth>
           <SummaryLayout.Section
             title="Détails de l’offre"
-            editLink={offerEditLink}
+            editLink={offerManuallyCreated ? offerEditLink : ''}
           >
             <CollectiveOfferVenueSection venue={offer.venue} />
             <CollectiveOfferTypeSection offer={offer} categories={categories} />

--- a/pro/src/core/Offers/types.ts
+++ b/pro/src/core/Offers/types.ts
@@ -54,6 +54,7 @@ export type Offer = {
   productIsbn?: string | null
   venue: Venue
   stocks: Stock[]
+  isPublicApi?: boolean | null
   isEditable: boolean
   isShowcase?: boolean | null
   educationalInstitution?: EducationalInstitutionResponseModel | null

--- a/pro/src/pages/CollectiveOffers/adapters/serializers.ts
+++ b/pro/src/pages/CollectiveOffers/adapters/serializers.ts
@@ -44,6 +44,7 @@ export const serializeOffers = (
     productIsbn: null,
     venue: serializeVenue(offer.venue),
     stocks: serializeStocks(offer.stocks),
+    isPublicApi: offer.isPublicApi,
     isEditable: offer.isEditable,
     isShowcase: offer.isShowcase,
     educationalInstitution: offer.educationalInstitution,

--- a/pro/src/pages/CollectiveOffers/utils/collectiveOffersFactories.ts
+++ b/pro/src/pages/CollectiveOffers/utils/collectiveOffersFactories.ts
@@ -14,6 +14,7 @@ export const collectiveOfferFactory = (customOffer = {}): Offer => ({
   venue: venueFactory(),
   stocks: [],
   isEditable: true,
+  isPublicApi: false,
   ...customOffer,
 })
 

--- a/pro/src/pages/Offers/Offers/OfferItem/CollectiveOfferItem.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/CollectiveOfferItem.tsx
@@ -71,7 +71,7 @@ const CollectiveOfferItem = ({
             offerEventDate={offer.stocks[0].beginningDatetime}
           />
         )}
-      {offer.isEditable && (
+      {offer.isEditable && !offer.isPublicApi && (
         <EditOfferCell
           offer={offer}
           isOfferEditable={isOfferEditable}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20649

## But de la pull request

Ne plus afficher le bouton crayon dans la liste des offres ni les bouton "Modifier" dans le récapitulatif pour une offre collective lorsque celle-ci provient de l'api public.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
