### PR TITLE
(PC-20797)[API] fix: accept parenthesis in city name and refactor profile validators

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Query
 
 from pcapi import settings
 import pcapi.core.finance.exceptions as finance_exceptions
-from pcapi.core.fraud.utils import is_latin
+import pcapi.core.fraud.utils as fraud_utils
 from pcapi.core.history import models as history_models
 import pcapi.core.mails.transactional as transaction_mails
 from pcapi.core.subscription import api as subscription_api
@@ -308,7 +308,12 @@ def is_subscription_name_valid(name: str | None) -> bool:
     if not name:
         return False
     stripped_name = name.strip()
-    return is_latin(stripped_name)
+    try:
+        fraud_utils.validate_name(stripped_name)
+    except ValueError:
+        return False
+
+    return True
 
 
 def _check_user_names_valid(first_name: str | None, last_name: str | None) -> models.FraudItem:

--- a/api/src/pcapi/core/fraud/utils.py
+++ b/api/src/pcapi/core/fraud/utils.py
@@ -1,11 +1,15 @@
 import unicodedata
 
 
-def is_latin(s: str) -> bool:
+ACCEPTED_CHARS_FOR_NAMES = [" ", "-", ".", ",", "'", "’"]
+ACCEPTED_CHARS_FOR_CITY = [" ", "-", "'", "(", ")"]
+
+
+def is_latin(s: str, accepted_chars: list[str]) -> bool:
     if s == "":
         return False
     for char in s:
-        if char in (" ", "-", ".", ",", "'", "’"):
+        if char in accepted_chars:
             continue
         try:
             if not "LATIN" in unicodedata.name(char):
@@ -16,10 +20,25 @@ def is_latin(s: str) -> bool:
     return True
 
 
-def has_latin_or_numeric_chars(address: str) -> bool:
+def validate_not_empty(value: str) -> None:
+    if not value:
+        raise ValueError("This field cannot be empty")
+
+
+def validate_name(name: str) -> None:
+    validate_not_empty(name)
+    if not is_latin(name, accepted_chars=ACCEPTED_CHARS_FOR_NAMES):
+        raise ValueError("Les champs textuels doivent contenir des caractères latins")
+
+
+def validate_address(address: str) -> None:
+    validate_not_empty(address)
     for char in address:
-        if char == " ":
-            continue
-        if not is_latin(char) and not char.isnumeric():
-            return False
-    return True
+        if not is_latin(char, accepted_chars=[" "]) and not char.isnumeric():
+            raise ValueError("L'adresse doit contenir des caractères alphanumériques")
+
+
+def validate_city(city: str) -> None:
+    validate_not_empty(city)
+    if not is_latin(city, accepted_chars=ACCEPTED_CHARS_FOR_CITY):
+        raise ValueError("Le champs city doit contenir des caractères latins")

--- a/api/tests/core/fraud/utils_test.py
+++ b/api/tests/core/fraud/utils_test.py
@@ -1,10 +1,61 @@
 import pytest
 
-from pcapi.core.fraud.utils import has_latin_or_numeric_chars
-from pcapi.core.fraud.utils import is_latin
+import pcapi.core.fraud.utils as fraud_utils
 
 
 class UtilsUnitTest:
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            ("", False),
+            ("a", True),
+            ("Verona", True),
+            ("მარიამ", False),
+            ("aé", True),
+            ("&", False),
+            ("a&", False),
+            ("1", False),
+        ],
+    )
+    def test_is_latin(self, test_input, expected):
+        assert fraud_utils.is_latin(test_input, accepted_chars=[]) == expected
+
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            ("a", True),
+            ("მარიამ", False),
+            ("1 allée des séqoïas", True),
+            ("&", False),
+            ("25 & 26 rue Duhesme", False),
+            ("1", True),
+        ],
+    )
+    def test_is_address_valid(self, test_input, expected):
+        if expected:
+            fraud_utils.validate_address(test_input)
+        else:
+            with pytest.raises(ValueError):
+                fraud_utils.validate_address(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input,expected",
+        [
+            ("a", True),
+            ("მარიამ", False),
+            ("Château-Chinon (Ville)", True),
+            ("Trucy-l'Orgueilleux", True),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_city_valid(self, test_input, expected):
+        if expected:
+            fraud_utils.validate_city(test_input)
+        else:
+            with pytest.raises(ValueError):
+                fraud_utils.validate_city(test_input)
+
     @pytest.mark.parametrize(
         "test_input,expected",
         [
@@ -22,19 +73,9 @@ class UtilsUnitTest:
             ("1", False),
         ],
     )
-    def test_is_latin(self, test_input, expected):
-        assert is_latin(test_input) == expected
-
-    @pytest.mark.parametrize(
-        "test_input,expected",
-        [
-            ("a", True),
-            ("მარიამ", False),
-            ("1 allée des séqoïas", True),
-            ("&", False),
-            ("25 & 26 rue Duhesme", False),
-            ("1", True),
-        ],
-    )
-    def test_is_address_valid(self, test_input, expected):
-        assert has_latin_or_numeric_chars(test_input) == expected
+    def test_is_name_valid(self, test_input, expected):
+        if expected:
+            fraud_utils.validate_name(test_input)
+        else:
+            with pytest.raises(ValueError):
+                fraud_utils.validate_name(test_input)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20797

## But de la pull request

- Accepter les `(` `)` dans le champ ville 

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
