### PR TITLE
Pc 20284 add price category label to offer stocks

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -7,7 +7,6 @@ import sentry_sdk
 import sqlalchemy as sa
 
 from pcapi.core import search
-from pcapi.core.bookings import constants
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
@@ -105,6 +104,9 @@ def book_offer(
             token=generate_booking_token(),
             venueId=stock.offer.venueId,
             offererId=stock.offer.venue.managingOffererId,
+            priceCategoryLabel=(
+                stock.priceCategory.priceCategoryLabel.label if getattr(stock, "priceCategory") else None
+            ),
             status=BookingStatus.CONFIRMED,
             depositId=beneficiary.deposit.id if beneficiary.has_active_deposit else None,  # type: ignore [union-attr]
         )

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -136,6 +136,7 @@ class EventStockFactory(StockFactory):
     priceCategory = factory.SubFactory(
         PriceCategoryFactory,
         offer=factory.SelfAttribute("..offer"),
+        price=factory.SelfAttribute("..price"),
         priceCategoryLabel__venue=factory.SelfAttribute("..offer.venue"),
     )
 

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -658,10 +658,7 @@ def get_offer_by_id(offer_id: int) -> models.Offer:
             .options(joinedload(models.Offer.product, innerjoin=True))
             .options(joinedload(models.Offer.priceCategories).joinedload(models.PriceCategory.priceCategoryLabel))
             .options(
-                joinedload(
-                    models.Offer.venue,
-                    innerjoin=True,
-                ).joinedload(
+                joinedload(models.Offer.venue, innerjoin=True).joinedload(
                     Venue.managingOfferer,
                     innerjoin=True,
                 )

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -9,8 +9,10 @@ from pcapi.core.offerers.models import Venue
 from pcapi.core.offers import api
 from pcapi.core.offers.exceptions import OfferReportError
 from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import PriceCategory
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import Reason
+from pcapi.core.offers.models import Stock
 from pcapi.core.offers.validation import check_offer_is_from_current_cinema_provider
 import pcapi.core.providers.repository as providers_repository
 from pcapi.core.users.models import User
@@ -29,7 +31,9 @@ from .serialization import subcategories_v2 as subcategories_v2_serializers
 @spectree_serialize(response_model=serializers.OfferResponse, api=blueprint.api, on_error_statuses=[404])
 def get_offer(offer_id: str) -> serializers.OfferResponse:
     offer: Offer = (
-        Offer.query.options(joinedload(Offer.stocks))
+        Offer.query.options(
+            joinedload(Offer.stocks).joinedload(Stock.priceCategory).joinedload(PriceCategory.priceCategoryLabel)
+        )
         .options(
             joinedload(Offer.venue)
             .joinedload(Venue.managingOfferer)

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -160,6 +160,7 @@ class BookOfferTest:
         assert len(booking.token) == 6
         assert booking.status is BookingStatus.CONFIRMED
         assert booking.cancellationLimitDate is None
+        assert booking.priceCategoryLabel is None
         assert stock.dnBookedQuantity == 7
 
         mocked_async_index_offer_ids.assert_called_once_with([stock.offer.id])
@@ -243,7 +244,7 @@ class BookOfferTest:
     def test_create_event_booking(self):
         ten_days_from_now = datetime.utcnow() + timedelta(days=10)
         beneficiary = users_factories.BeneficiaryGrant18Factory()
-        stock = offers_factories.StockFactory(price=10, beginningDatetime=ten_days_from_now, dnBookedQuantity=5)
+        stock = offers_factories.EventStockFactory(price=10, beginningDatetime=ten_days_from_now, dnBookedQuantity=5)
 
         booking = api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
@@ -265,6 +266,7 @@ class BookOfferTest:
         assert len(booking.token) == 6
         assert booking.status is BookingStatus.CONFIRMED
         assert booking.cancellationLimitDate == two_days_after_booking
+        assert booking.priceCategoryLabel == "Tarif unique"
 
     def test_book_stock_with_unlimited_quantity(self):
         beneficiary = users_factories.BeneficiaryGrant18Factory()

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -938,6 +938,8 @@ def test_public_api(client):
                         "isForbiddenToUnderage": {"title": "Isforbiddentounderage", "type": "boolean"},
                         "isSoldOut": {"title": "Issoldout", "type": "boolean"},
                         "price": {"title": "Price", "type": "integer"},
+                        "priceCategoryLabel": {"nullable": True, "title": "Pricecategorylabel", "type": "string"},
+                        "remainingQuantity": {"nullable": True, "title": "Remainingquantity", "type": "integer"},
                     },
                     "required": ["id", "isBookable", "isForbiddenToUnderage", "isSoldOut", "isExpired", "price"],
                     "title": "OfferStockResponse",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20284

## But de la pull request

- ajout d'une nouvelle route native `GET /offer/<int:offer_id>/with-price-categories` pour ajouter à la réponse le `priceCategoryLabel` et la `remainingQuantity` de chaque stock
- enregistrement du `priceCategoryLabel` dans chaque nouvelle réservation

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
