### PR TITLE
(BSR)[API] ci: fix flakiness in alembic conflict detection test

### DIFF
--- a/api/tests/alembic/alembic_version_conflict_detection_test.py
+++ b/api/tests/alembic/alembic_version_conflict_detection_test.py
@@ -1,13 +1,39 @@
-from pcapi.models import db
+import subprocess
 
 
 def test_versions_are_up_to_date():
-    version_num_rows = db.engine.execute("SELECT version_num FROM alembic_version").fetchall()
-    pre_version_num = version_num_rows[0][0]
-    post_version_num = version_num_rows[1][0]
+    alembic_heads_command = subprocess.run("alembic heads", capture_output=True, shell=True, text=True, check=True)
+    alembic_heads = alembic_heads_command.stdout.splitlines()
+
+    try:
+        pre_version_line = next(line for line in alembic_heads if "(pre)" in line)
+        post_version_line = next(line for line in alembic_heads if "(post)" in line)
+    except StopIteration:
+        raise AssertionError(
+            "`alembic heads` command did not return the expected output. (pre) or (post) version not found."
+        )
+
+    pre_version_num = pre_version_line.split(" ")[0]
+    post_version_num = post_version_line.split(" ")[0]
 
     with open("alembic_version_conflict_detection.txt", "r", encoding="utf-8") as content_file:
-        output = content_file.read()
+        output = content_file.read().splitlines()
+
+        try:
+            pre_version_line_in_file = next(line for line in output if "(pre)" in line)
+            post_version_line_in_file = next(line for line in output if "(post)" in line)
+        except StopIteration:
+            raise AssertionError(
+                "The alembic_version_conflict_detection.txt file is not up to date. (pre) or (post) version not found."
+            )
+
+        pre_version_num_in_file = pre_version_line_in_file.split(" ")[0]
+        post_version_num_in_file = post_version_line_in_file.split(" ")[0]
+
     assert (
-        output == f"""{pre_version_num} (pre) (head)\n{post_version_num} (post) (head)\n"""
-    ), "The alembic_version_conflict_detection.txt file is not up to date. Modify pre and/or post version to match the database state"
+        pre_version_num == pre_version_num_in_file
+    ), "The alembic_version_conflict_detection.txt file is not up to date. Modify pre version to match the database state"
+
+    assert (
+        post_version_num == post_version_num_in_file
+    ), "The alembic_version_conflict_detection.txt file is not up to date. Modify post version to match the database state"


### PR DESCRIPTION
## But de la pull request

Eviter les KO Flaky de la CI sur le test de conflit de migrations
Par exemple dans [ce workflow](https://app.circleci.com/pipelines/github/pass-culture/pass-culture-main/40186/workflows/c276d96d-43ec-4f90-a97f-7919b1df5d22/jobs/332228/tests#failed-test-0) le fichier est correct, mais un changement d'ordre casse le test. Apperment l'ordre n'est pas consistent d'un run à l'autre 

## Implémentation

Explicitement chercher pre et post au lieu de partir du principe qu'ils sont ordonnés

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
