### PR TITLE
(PC-20819)[API] feat: Allocine remove Product.thumbCount initialization

### DIFF
--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -139,7 +139,6 @@ class AllocineStocks(LocalProvider):
     def fill_product_attributes(self, allocine_product: offers_models.Product) -> None:
         allocine_product.name = self.movie_information["title"]  # type: ignore [index]
         allocine_product.subcategoryId = subcategories.SEANCE_CINE.id
-        allocine_product.thumbCount = 0
 
         self.update_from_movie_information(allocine_product, self.movie_information)  # type: ignore [arg-type]
 

--- a/api/tests/local_providers/allocine_stocks_test.py
+++ b/api/tests/local_providers/allocine_stocks_test.py
@@ -740,7 +740,7 @@ class UpdateObjectsTest:
     @patch("pcapi.local_providers.allocine.allocine_stocks.AllocineStocks.get_object_thumb")
     @patch("pcapi.settings.ALLOCINE_API_KEY", "token")
     @pytest.mark.usefixtures("db_session")
-    def test_should_replace_product_thumb_when_product_has_already_one_thumb(
+    def test_should_add_product_thumb_when_product_has_already_one_thumb(
         self, mock_get_object_thumb, mock_call_allocine_api, mock_api_poster
     ):
         # Given
@@ -790,8 +790,10 @@ class UpdateObjectsTest:
 
         # Then
         existing_product = offers_models.Product.query.one()
-        assert existing_product.thumbUrl == f"http://localhost/storage/thumbs/products/{humanize(existing_product.id)}"
-        assert existing_product.thumbCount == 1
+        assert (
+            existing_product.thumbUrl == f"http://localhost/storage/thumbs/products/{humanize(existing_product.id)}_1"
+        )
+        assert existing_product.thumbCount == 2
 
     @patch("pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes")
     @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
@@ -1543,6 +1545,54 @@ class UpdateObjectsTest:
             # Then
             stock = offers_models.Stock.query.one()
             assert stock.quantity == 50
+
+    @patch("pcapi.local_providers.allocine.allocine_stocks.get_movie_poster")
+    @patch("pcapi.local_providers.allocine.allocine_stocks.get_movies_showtimes")
+    @patch("pcapi.local_providers.allocine.allocine_stocks.AllocineStocks.get_object_thumb")
+    @patch("pcapi.settings.ALLOCINE_API_KEY", "token")
+    @pytest.mark.usefixtures("db_session")
+    def should_not_update_thumbnail_more_then_once_a_day(
+        self, mock_get_object_thumb, mock_call_allocine_api, mock_api_poster
+    ):
+        mock_call_allocine_api.return_value = iter(
+            [
+                {
+                    "node": {
+                        "movie": MOVIE_INFO,
+                        "showtimes": [
+                            {
+                                "startsAt": "2019-10-29T10:30:00",
+                                "diffusionVersion": "LOCAL",
+                                "projection": ["DIGITAL"],
+                                "experience": None,
+                            }
+                        ],
+                    }
+                }
+            ]
+        )
+        file_path = Path(tests.__path__[0]) / "files" / "mouette_portrait.jpg"
+        with open(file_path, "rb") as thumb_file:
+            mock_get_object_thumb.return_value = thumb_file.read()
+
+        allocine_venue_provider = providers_factories.AllocineVenueProviderFactory()
+        providers_factories.AllocineVenueProviderPriceRuleFactory(allocineVenueProvider=allocine_venue_provider)
+        allocine_stocks_provider = AllocineStocks(allocine_venue_provider)
+
+        allocine_stocks_provider.updateObjects()
+
+        created_product = offers_models.Product.query.one()
+
+        assert created_product.thumbUrl == f"http://localhost/storage/thumbs/products/{humanize(created_product.id)}"
+        assert created_product.thumbCount == 1
+        assert mock_get_object_thumb.call_count == 1
+
+        allocine_stocks_provider.updateObjects()
+        created_product = offers_models.Product.query.one()
+
+        assert created_product.thumbUrl == f"http://localhost/storage/thumbs/products/{humanize(created_product.id)}"
+        assert created_product.thumbCount == 1
+        assert mock_get_object_thumb.call_count == 1
 
 
 class GetObjectThumbTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20819

## But de la pull request
Supprimer l'initialisation du `Product.thumbCount` à 0 pour la synchro Allociné

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
