### PR TITLE
(PC-20839)[PRO] fix: display edit link for template offer

### DIFF
--- a/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
+++ b/pro/src/components/CollectiveOfferSummary/CollectiveOfferSummary.tsx
@@ -50,7 +50,9 @@ const CollectiveOfferSummary = ({
           )}
           <SummaryLayout.Section
             title="Détails de l’offre"
-            editLink={offerManuallyCreated ? offerEditLink : ''}
+            editLink={
+              offerManuallyCreated || offer.isTemplate ? offerEditLink : ''
+            }
           >
             <CollectiveOfferVenueSection venue={offer.venue} />
             <CollectiveOfferTypeSection offer={offer} categories={categories} />


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20839

## But de la pull request

Fix : remettre le bouton d'édition sur la page récap pour les offres vitrines
