### PR TITLE
(BSR)[API] test: Fix ZendeskWebhookTest.test_webhook_update_user_by_phone

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -7,7 +7,6 @@ import sentry_sdk
 import sqlalchemy as sa
 
 from pcapi.core import search
-from pcapi.core.bookings import constants
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -97,7 +97,7 @@ class ZendeskWebhookTest:
             "user": {
                 "email": user.email,
                 "phone": "+33634567890",
-                "tags": ["suspendu", "éligible"],
+                "tags": ["suspendu"],
                 "user_fields": {
                     "backoffice_url": f"{settings.BACKOFFICE_URL}/public-accounts/{user.id}",
                     "user_id": user.id,


### PR DESCRIPTION
Since the user is born more than 19 years ago (today!), they're not
eligible anymore. That's not what we're testing, so we can just adapt
the tags.