### PR TITLE
(PC-20702)[PRO] fix: space field field layout

### DIFF
--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
@@ -6,6 +6,7 @@
 
 .field-layout {
   width: 100%;
+  margin-bottom: rem.torem(16px);
 
   &-label {
     margin-bottom: rem.torem(forms.$label-space-before-input);


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20702

## But de la pull request

Remettre l'espace entre le select et la bannière qui affiche les informations selectionnées.

Avant :
<img width="451" alt="Capture d’écran 2023-03-02 à 15 59 20" src="https://user-images.githubusercontent.com/119043808/222465163-6007b630-f7ad-4169-a150-bd4894f1c504.png">

Après :
<img width="451" alt="Capture d’écran 2023-03-02 à 15 58 51" src="https://user-images.githubusercontent.com/119043808/222465006-780263dd-1dcd-4e08-b61e-651af7af0f52.png">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
