### PR TITLE
(PC-20866)[API] fix: FA: venues: reindex on multi update

### DIFF
--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -410,6 +410,15 @@ class VenueView(BaseAdminView):
             criteria_ids = [crit.id for crit in criteria]
             criteria_api.VenueUpdate(venue_ids, criteria_ids, replace_tags=remove_other_tags).run()
 
+            # Immediately index venues if tags (criteria) are involved:
+            # tags are used by other tools (eg. building playlists for the
+            # home page) and waiting N minutes for the next indexing
+            # cron tasks is painful.
+            if criteria or remove_other_tags:
+                search.reindex_venue_ids(venue_ids)
+            else:
+                search.async_index_venue_ids(venue_ids)
+
             db.session.commit()
             return redirect(url)
 


### PR DESCRIPTION
## But de la pull request

Avant : l'index des lieux permet d'éditer (est permanent et tags) plusieurs lieux en même temps, via une modale. Mais la route appelée ne lançait aucune indexation, donc si on passe un lieu de permanent à non permanent de cette manière, celui-ci reste indexé.

Après : lancer l'indexation des lieux et faire en sorte d'avoir le même comportement que lors de l'édition d'un lieu spécifique.