### PR TITLE
(PC-20857)[PRO] fix: fix stepper bug when template offer

### DIFF
--- a/pro/src/hooks/useCollectiveOfferRoute.ts
+++ b/pro/src/hooks/useCollectiveOfferRoute.ts
@@ -30,9 +30,9 @@ const useCollectiveOfferRoute = (
     const splitOfferId = offerIdFromParam?.split('T-')
 
     const isTemplate =
-      splitOfferId === undefined
+      splitOfferId && splitOfferId.length === 1
         ? pathname.includes('vitrine') // creation
-        : splitOfferId.length > 1 // edition
+        : true // edition
 
     setOfferId(
       splitOfferId && splitOfferId.length > 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20857

## But de la pull request

Lorsqu'on remplit le formulaire de création d'offre vitrine et que l'on arrive sur la page de récapitulatif et que l'on clique sur "Étape précédente" on revient sur le formulaire de création d'offre mais le stepper pour une offre réservable apparaît. Il ne faut afficher le stepper de l'offre vitrine.

Avant : 
<img width="763" alt="Capture d’écran 2023-03-02 à 17 02 06" src="https://user-images.githubusercontent.com/119043808/222482991-6e50f3c0-782c-444c-ada1-299b13f89814.png">
Après : 
<img width="763" alt="Capture d’écran 2023-03-02 à 17 01 18" src="https://user-images.githubusercontent.com/119043808/222483020-0307cee6-1547-4751-b02c-c3793bf4074e.png">

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
