### PR TITLE
(PC-20708)[PRO] fix: csp sha for beamer

### DIFF
--- a/pro/public/index.html
+++ b/pro/public/index.html
@@ -13,7 +13,7 @@
       content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-TMqfN40yv4Oy3FCUUn4u+Oh+eomT/tIw0/9GHc52ino='; connect-src 'self' data: https: http: ws://*:3001 wss://*:3001; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'">
     <% } else { %>
       <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-a47g9sqV7LR3oNh5aE8P8wXhV2lEWrTnOXtd8En9wAQ='; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'">
+        content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-lsVG3dRRjbLAsQIz53z4zymQ5Vw0cFQnOqNnY5sCuSM='; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'">
       <% } %>
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
         <link rel="shortcut icon" href="%PUBLIC_URL%/icon/app-icon-iphone.png">


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20708

-on essaye avec le bon sha
```
echo -n 'var beamer_config={product_id:"vjbiYuMS52566"}' | openssl sha256 -binary | openssl base64
lsVG3dRRjbLAsQIz53z4zymQ5Vw0cFQnOqNnY5sCuSM=

```
![image](https://user-images.githubusercontent.com/15941528/222770416-4363b9d4-d2a9-4882-9858-7ebcd0c7110e.png)
