### PR TITLE
(PC-20880)[API] feat:Add a log for successful authentications

### DIFF
--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -32,7 +32,11 @@ def check_user_and_credentials(user: models.User | None, password: str, allow_in
         crypto.check_password(password, HASHED_PLACEHOLDER)
         raise exceptions.InvalidIdentifier()
     if not (user.checkPassword(password) and (user.isActive or allow_inactive)):
-        logging.info("Failed authentication attempt", extra={"user": user.id, "avoid_current_user": True})
+        logging.info(  # type: ignore [call-arg]
+            "Failed authentication attempt",
+            extra={"user": user.id, "avoid_current_user": True, "success": False},
+            technical_message_id="users.login",
+        )
         raise exceptions.InvalidIdentifier()
     if not user.isValidated or not user.isEmailValidated:
         raise exceptions.UnvalidatedAccount()
@@ -41,6 +45,12 @@ def check_user_and_credentials(user: models.User | None, password: str, allow_in
 def get_user_with_credentials(identifier: str, password: str, allow_inactive: bool = False) -> models.User:
     user = find_user_by_email(identifier)
     check_user_and_credentials(user, password, allow_inactive)
+    if user:
+        logging.info(  # type: ignore [call-arg]
+            "Successful authentication attempt",
+            extra={"user": user.id, "avoid_current_user": True, "success": True},
+            technical_message_id="users.login",
+        )
     return typing.cast(models.User, user)
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20880

## But de la pull request

Lors d'une connexion réussie, nous ne savons pas quel utilisateur s'est loggé.
Cette manque d'information est particulièrement dommageable pendant les attaques sur les routes signin : nous ne pouvons pas identifer quels comptes ont été signin avec succès (peut être par l'attaquant).

## Implémentation

Ajout d'un log lors d'un signin avec succès.
Utilisation du même format que le signin raté.
Ajout d'un technical_message_id pour exporter ces deux informations.

## Informations supplémentaires

Le log lors du signin avec succès n'est pas placé dans la même fonction (`check_user_and_credentials`) que celui du signin raté.
En effet cette fonction sert également à l'authentification forte lors des changement d'email ou de mot de passe, actions qui se font soit en possession d'un token ou autres credentials, et pour lesquelles le check_user_and_credentials ne sert pas à signin.

## Modifications du schéma de la base de données

NA

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
