### PR TITLE
(PC-20298)[PRO] fix: ui return on activity form

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Activity/Activity.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/Activity.tsx
@@ -67,6 +67,7 @@ const Activity = (): JSX.Element => {
     <FormLayout>
       <FormikProvider value={formik}>
         <form onSubmit={formik.handleSubmit} data-testid="signup-activity-form">
+          <FormLayout.MandatoryInfo />
           <ActivityForm venueTypes={venueTypes} />
           <ActionBar
             onClickPrevious={handlePreviousStep}

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
@@ -11,10 +11,8 @@
 }
 
 .first-row {
-  display: flex;
-  align-items: center;
   margin-top: calc(
-    #{forms.$label-space-before-input} + #{fonts.$caption-line-height} + #{forms.$input-border-width-focus}
+    #{forms.$label-space-before-input} + #{forms.$input-space-before-error} + #{fonts.$caption-line-height} + #{forms.$input-border-width-focus * 2}
   );
 }
 

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -28,7 +28,6 @@ const ActivityForm = ({ venueTypes }: IActivityFormProps): JSX.Element => {
 
   return (
     <FormLayout.Section title="Activité">
-      <FormLayout.MandatoryInfo />
       <FormLayout.Row>
         <Select
           options={[

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -96,11 +96,6 @@ describe('screens:SignupJourney::Activity', () => {
       contextValue,
     })
     expect(await screen.findByText('Activité')).toBeInTheDocument()
-    expect(
-      await screen.getByText(
-        'Tous les champs sont obligatoires sauf mention contraire.'
-      )
-    ).toBeInTheDocument()
     expect(await screen.getByLabelText('Activité principale')).toHaveValue('')
     expect(
       await screen.getAllByText('Site internet, réseau social')
@@ -177,6 +172,9 @@ describe('screens:SignupJourney::Activity', () => {
     ).toBeInTheDocument()
     expect(
       await screen.findByText('Veuillez sélectionner un type de lieu')
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText('Veuillez renseigner une URL valide')
     ).toBeInTheDocument()
   })
 

--- a/pro/src/screens/SignupJourneyForm/Activity/validationSchema.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/validationSchema.tsx
@@ -4,7 +4,10 @@ import { TargetCustomerTypeEnum } from './constants'
 
 export const validationSchema = yup.object().shape({
   venueType: yup.string().required('Veuillez sélectionner un type de lieu'),
-  socialUrls: yup.array().of(yup.string()).nullable(),
+  socialUrls: yup
+    .array()
+    .of(yup.string().url('Veuillez renseigner une URL valide'))
+    .nullable(),
   targetCustomer: yup
     .string()
     .oneOf(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20298

## But de la pull request

- Inverser le titre “Activité” et “Tous les champs sont obligatoires sauf mention contraire.”
- Espacement entre “Activité” et le champ “Activité principale” : 24px 
- Comportement d’erreur manquant sur le champ “Site internet, réseau social” : Lorsqu’on le format de l’url n’est pas respecté → Indiquer sous le champ comme message d’erreur :  “Veuillez renseigner une URL valide. Ex : https://exemple.com/”

## Implémentation

![image](https://user-images.githubusercontent.com/106379750/223077175-8613175a-e100-4082-9c8c-e838f475555d.png)