### PR TITLE
(PC-20857)[PRO] fix: fix stepper bug when template offer

### DIFF
--- a/pro/src/hooks/useCollectiveOfferRoute.ts
+++ b/pro/src/hooks/useCollectiveOfferRoute.ts
@@ -30,9 +30,8 @@ const useCollectiveOfferRoute = (
     const splitOfferId = offerIdFromParam?.split('T-')
 
     const isTemplate =
-      splitOfferId && splitOfferId.length === 1
-        ? pathname.includes('vitrine') // creation
-        : true // edition
+      (splitOfferId === undefined && pathname.includes('vitrine')) ||
+      Boolean(offerIdFromParam?.includes('T-'))
 
     setOfferId(
       splitOfferId && splitOfferId.length > 1


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20857

## But de la pull request

Lorsqu'on remplit le formulaire de création d'offre vitrine et que l'on arrive sur la page de récapitulatif et que l'on clique sur "Étape précédente" on revient sur le formulaire de création d'offre mais le stepper pour une offre réservable apparaît. Il ne faut afficher le stepper de l'offre vitrine.

Avant: 
![image](https://user-images.githubusercontent.com/119043808/223091949-a6f2a84b-0d88-4e8c-89cf-bdf22271f542.png)
Après:
![image](https://user-images.githubusercontent.com/119043808/223091969-e79f13ac-9681-4c7b-9318-90f86ccdc455.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
