### PR TITLE
(PC-20903)[PRO] fix: patch offers bookingEmail should be null

### DIFF
--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
@@ -127,7 +127,7 @@ describe('test updateIndividualOffer::serializers', () => {
       }
       patchBody = {
         ...patchBody,
-        bookingEmail: undefined,
+        bookingEmail: null,
         durationMinutes: undefined,
         externalTicketOfficeUrl: undefined,
         url: undefined,

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
@@ -140,7 +140,7 @@ describe('updateIndividualOffer', () => {
 
     const expectedBody: PatchOfferBodyModel = {
       audioDisabilityCompliant: true,
-      bookingEmail: undefined,
+      bookingEmail: null,
       description: undefined,
       durationMinutes: undefined,
       externalTicketOfficeUrl: 'https://example.com',

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -93,7 +93,7 @@ export const serializePatchOffer = ({
     durationMinutes: serializeDurationMinutes(sentValues.durationMinutes || ''),
     bookingEmail: sentValues.receiveNotificationEmails
       ? sentValues.bookingEmail
-      : undefined,
+      : null,
     externalTicketOfficeUrl: sentValues.externalTicketOfficeUrl || undefined,
     url: sentValues.url || undefined,
   }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20903

## But de la pull request

_Bug fix création d'offre, la serialization doit renvoyer null et pas undefined

