### PR TITLE
(PC-20924)[BO] fix: TypeError in public account history

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1121,7 +1121,7 @@ def public_account_history(user: models.User) -> list[dict]:
 
     history = sorted(
         email_changes_history + user_suspension_history + fraud_checks_history + reviews_history + imports_history,
-        key=lambda item: item["datetime"],
+        key=lambda item: item["datetime"] or datetime.datetime.min,
         reverse=True,
     )
 


### PR DESCRIPTION
TypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20924

## But de la pull request

Empêcher une exception (erreur 500) lorsque l'historique contient une action sans date (cela se produit sur les actions anciennes recréées à partir de l'existant)

Erreur Sentry : 
https://sentry.passculture.team/organizations/sentry/issues/407715/

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
