### PR TITLE
(BSR)[API] fix: multiselect preload style glitch fix

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
@@ -1,6 +1,20 @@
+<style>
+    select.form-select.pc-select-multiple-field:not(.pc-select-multiple-autocomplete-field) {
+        height: 1em;
+        overflow: hidden;
+    }
+    select.form-select.pc-select-multiple-field:not(.tomselected):not(.pc-select-multiple-autocomplete-field) > option {
+        display: none;
+    }
+</style>
 <div class="form-floating {{ field.name }}-container">
-    <select multiple class="form-select pc-select-multiple-field" id="{{ field.name }}" name="{{ field.name }}" size="2"
-            style="border-radius: 1rem!important;">
+    <select
+        multiple
+        class="rounded-pill form-select pc-select-multiple-field"
+        id="{{ field.name }}"
+        name="{{ field.name }}"
+        size="2"
+    >
         {% for value, label, selected in field.iter_choices() %}
             <option value="{{ value }}" {{ "selected" if selected else "" }}>
                 {{ label | i18n_public_account }}
@@ -9,4 +23,3 @@
     </select>
     <label class="pc-select-label" for="{{ field.name }}" id="{{ field.name }}-label"> {{ field.label }}</label>
 </div>
-

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
@@ -1,13 +1,19 @@
+<style>
+    select.form-select.pc-select-multiple-field.pc-select-multiple-autocomplete-field {
+        height: 1em;
+        overflow: hidden;
+    }
+</style>
 <div class="form-floating {{ field.name }}-container">
     <select
         multiple
         data-tomselect-autocomplete-url="{{ field.tomselect_autocomplete_url }}"
         data-tomselect-options="{{ field.tomselect_options }}"
         data-tomselect-items="{{ field.tomselect_items }}"
-        class="form-select pc-select-multiple-field pc-select-multiple-autocomplete-field"
+        class="rounded-pill form-select pc-select-multiple-field pc-select-multiple-autocomplete-field"
         id="{{ field.name }}"
         name="{{ field.name }}"
         size="2"
-        style="border-radius: 1rem!important;"></select>
+    ></select>
     <label class="pc-select-label" for="{{ field.name }}" id="{{ field.name }}-label"> {{ field.label }}</label>
 </div>


### PR DESCRIPTION
## But de la pull request

Pendant le chargement de la page, jusqu'à ce que l'event `window.onload` soit dispatch, le styling du select est différent, ceci arrange le style jusqu'au onload pour éviter le glitch visuel

## Implémentation

Court terme: ajout de style dans le template de l'input multiselect
Long terme: a déplacer dans nos feuilles de styles (via ticket PC-20877)

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
