### PR TITLE
(PC-20875)[API] fix: use name on all forms

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 import typing
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
@@ -238,6 +239,18 @@ def parse_referrer(url: str) -> str:
         return "/"
 
 
+def action_to_name(action_url: str) -> str:
+    """
+    Slugify a form action path to a name so form can be controlled with JS.
+    """
+    try:
+        if len(action_url) != 0:
+            return action_url[1:].replace("-", "_").replace("/", "_")
+        return format(random.getrandbits(128), "x")
+    except Exception:  # pylint: disable=broad-except
+        return action_url
+
+
 def install_template_filters(app: Flask) -> None:
     app.jinja_env.trim_blocks = True
     app.jinja_env.lstrip_blocks = True
@@ -265,6 +278,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_reason_label"] = format_reason_label
     app.jinja_env.filters["format_adage_referred"] = format_adage_referred
     app.jinja_env.filters["parse_referrer"] = parse_referrer
+    app.jinja_env.filters["action_to_name"] = action_to_name
     app.jinja_env.filters["pc_pro_offer_link"] = urls.build_pc_pro_offer_link
     app.jinja_env.filters["pc_pro_offerer_link"] = urls.build_pc_pro_offerer_link
     app.jinja_env.filters["pc_pro_venue_bookings_link"] = urls.build_pc_pro_venue_bookings_link

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/edit.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/edit.html
@@ -9,7 +9,11 @@
             <h5 class="lead fs-1 my-4">Éditer les informations</h5>
 
             <div class="mt-5 text-center">
-                <form action="{{ dst }}" method="POST">
+                <form
+                    action="{{ dst }}"
+                    name="{{ dst | action_to_name }}"
+                    method="POST"
+                >
                     {% for form_field in form %}
                         <div class="w-100 my-4">
                             {% for error in form_field.errors %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/edit_review.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/edit_review.html
@@ -9,7 +9,11 @@
             <h5 class="lead fs-1 my-4">Revue manuelle</h5>
 
             <div class="mt-5 text-center">
-                <form action="{{ url_for(".review_public_account", user_id=user.id) }}" method="POST">
+                <form
+                    action="{{ url_for(".review_public_account", user_id=user.id) }}"
+                    name="{{ url_for(".review_public_account", user_id=user.id) | action_to_name }}"
+                    method="POST"
+                >
                     {% for form_field in form %}
                         <div class="w-100 my-4">
                             {% for error in form_field.errors %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -66,7 +66,11 @@
                             <span class="fw-bold">E-mail :</span> {{ user.email }}
                             {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
                                 <br>
-                                <form action="{{ url_for('.resend_validation_email', user_id=user.id) }}" method="POST">
+                                <form
+                                    action="{{ url_for('.resend_validation_email', user_id=user.id) }}"
+                                    name="{{ url_for('.resend_validation_email', user_id=user.id) | action_to_name }}"
+                                    method="POST"
+                                >
                                     {{ resend_email_validation_form.csrf_token }}
 
                                     <button class="btn btn-outline-secondary btn-sm fw-bold mt-1">
@@ -81,8 +85,11 @@
                             {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
                                 <div class="d-flex">
                                     <div class="me-1">
-                                        <form action="{{ url_for('.send_validation_code', user_id=user.id) }}"
-                                              method="POST">
+                                        <form
+                                            action="{{ url_for('.send_validation_code', user_id=user.id) }}"
+                                            name="{{ url_for('.send_validation_code', user_id=user.id) | action_to_name }}"
+                                            method="POST"
+                                        >
                                             {{ send_validation_code_form.csrf_token }}
 
                                             <button class="btn btn-outline-secondary btn-sm fw-bold mt-1">
@@ -91,8 +98,11 @@
                                         </form>
                                     </div>
 
-                                    <form action="{{ url_for('.manually_validate_phone_number', user_id=user.id) }}"
-                                          method="POST">
+                                    <form
+                                        action="{{ url_for('.manually_validate_phone_number', user_id=user.id) }}"
+                                        name="{{ url_for('.manually_validate_phone_number', user_id=user.id) | action_to_name }}"
+                                        method="POST"
+                                    >
                                         {{ manual_validation_form.csrf_token }}
 
                                         <button class="btn btn-outline-secondary btn-sm fw-bold mt-1">

--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
@@ -5,11 +5,16 @@
         <h2>Gestion des rôles</h2>
         {% for form in forms %}
             <div class="card mb-4">
-                <div class="card-header" data-bs-toggle="collapse" href="#{{ form.name }}">
+                <div class="card-header" data-bs-toggle="collapse" href=".{{ form.name }}">
                     {{ form.name }}
                 </div>
-                <div class="collapse card-collapse p-3 shadow" id="{{ form.name }}">
-                    <form action="{{ url_for(".update_role", role_id=form.id) }}" method="POST">
+                <div class="collapse card-collapse p-3 shadow">
+                    <form
+                        class=".{{ form.name }}"
+                        action="{{ url_for(".update_role", role_id=form.id) }}"
+                        name="{{ url_for(".update_role", role_id=form.id) | action_to_name }}"
+                        method="POST"
+                    >
                         <div class="card-body">
                             <div class="row">
                                 {% for form_field in forms[form] %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
@@ -68,8 +68,12 @@
                                                 aria-labelledby="validate-booking-modal-{{ collective_booking.id }}-label" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
-                                                        <form action="{{ url_for("backoffice_v3_web.collective_bookings.mark_booking_as_used", collective_booking_id=collective_booking.id) }}"
-                                                            method="POST" data-turbo="false">
+                                                        <form
+                                                            action="{{ url_for("backoffice_v3_web.collective_bookings.mark_booking_as_used", collective_booking_id=collective_booking.id) }}"
+                                                            name="{{ url_for("backoffice_v3_web.collective_bookings.mark_booking_as_used", collective_booking_id=collective_booking.id) | action_to_name }}"
+                                                            method="POST"
+                                                            data-turbo="false"
+                                                        >
                                                             <div class="modal-header" id="validate-booking-modal-{{ collective_booking.id }}-label">
                                                                 <h5 class="modal-title">Valider la réservation {{ collective_booking.id }}</h5>
                                                             </div>
@@ -89,8 +93,12 @@
                                                 aria-labelledby="cancel-booking-modal-{{ collective_booking.id }}-label" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
-                                                        <form action="{{ url_for("backoffice_v3_web.collective_bookings.mark_booking_as_cancelled", collective_booking_id=collective_booking.id) }}"
-                                                            method="POST" data-turbo="false">
+                                                        <form
+                                                            action="{{ url_for("backoffice_v3_web.collective_bookings.mark_booking_as_cancelled", collective_booking_id=collective_booking.id) }}"
+                                                            name="{{ url_for("backoffice_v3_web.collective_bookings.mark_booking_as_cancelled", collective_booking_id=collective_booking.id) | action_to_name }}"
+                                                            method="POST"
+                                                            data-turbo="false"
+                                                        >
                                                             <div class="modal-header" id="cancel-booking-modal-{{ collective_booking.id }}-label">
                                                                 <h5 class="modal-title">Annuler la réservation {{ collective_booking.id }}</h5>
                                                             </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms.html
@@ -1,5 +1,5 @@
 {% macro build_filters_form(form, action) %}
-    <form action="{{ action }}" method="GET" class="mb-4 mt-3">
+    <form action="{{ action }}" name="{{ action | action_to_name }}" method="GET" class="mb-4 mt-3">
         <div class="row">
             <div class="col-10">
                 {% set select_multiple = [] %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
@@ -10,7 +10,11 @@
                 <div class="modal-header fs-5" id="{{ modal_id }}-modal-label">
                     {{ title }}
                 </div>
-                <form action="{{ dst }}" method="POST">
+                <form
+                    action="{{ dst }}"
+                    name="{{ dst | action_to_name }}"
+                    method="POST"
+                >
                     <div class="modal-body">
                         <div class="form-group">
                             {% for form_field in form %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/comment.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/comment.html
@@ -12,7 +12,7 @@
                     <div class="modal-header fs-5" id="add-comment-pro-user-modal-label">
                         {{ caller() }}
                     </div>
-                    <form action="{{ dst }}" method="POST">
+                    <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">
                         <div class="modal-body">
                             <div class="form-group">
                                 {% for form_field in form %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/base.html
@@ -21,7 +21,7 @@
                     {% endfor %}
                 </div>
 
-                <form action="{{ dst }}" method="GET">
+                <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="GET">
                     <div class="row col-10 translate-middle-x position-relative start-50 ">
 
                         <div class="input-group mb-3">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
@@ -8,7 +8,7 @@
     {% endif %}
 {% endmacro %}
 
-<form action="{{ dst }}" method="GET">
+<form action="{{ dst }}" name="{{ dst | action_to_name }}" method="GET">
     <div class="col-8 row">
         <div class="col-8">
             <div class="input-group mb-3">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/turbo/modal_form.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/turbo/modal_form.html
@@ -1,6 +1,12 @@
 <turbo-frame id="turbo-{{ div_id }}">
-    <form action="{{ dst }}" method="POST" target="_top" data-turbo="false"
-          class="modal-content" name="modal-form-{{ div_id }}">
+    <form
+        action="{{ dst }}"
+        name="{{ dst | action_to_name }}"
+        method="POST"
+        target="_top"
+        data-turbo="false"
+        class="modal-content"
+    >
         {{ csrf_token }}
         <div class="modal-header">
             <h5 class="modal-title">{{ title }}</h5>

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -71,8 +71,12 @@
                                                 aria-labelledby="validate-booking-modal-{{ booking.id }}-label" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
-                                                        <form action="{{ url_for("backoffice_v3_web.individual_bookings.mark_booking_as_used", booking_id=booking.id) }}"
-                                                            method="POST" data-turbo="false">
+                                                        <form
+                                                            action="{{ url_for("backoffice_v3_web.individual_bookings.mark_booking_as_used", booking_id=booking.id) }}"
+                                                            name="{{ url_for("backoffice_v3_web.individual_bookings.mark_booking_as_used", booking_id=booking.id) | action_to_name }}"
+                                                            method="POST"
+                                                            data-turbo="false"
+                                                        >
                                                             <div class="modal-header" id="validate-booking-modal-{{ booking.id }}-label">
                                                                 <h5 class="modal-title">Valider la réservation {{ booking.token }}</h5>
                                                             </div>
@@ -92,8 +96,12 @@
                                                 aria-labelledby="cancel-booking-modal-{{ booking.id }}-label" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
-                                                        <form action="{{ url_for("backoffice_v3_web.individual_bookings.mark_booking_as_cancelled", booking_id=booking.id) }}"
-                                                            method="POST" data-turbo="false">
+                                                        <form
+                                                            action="{{ url_for("backoffice_v3_web.individual_bookings.mark_booking_as_cancelled", booking_id=booking.id) }}"
+                                                            name="{{ url_for("backoffice_v3_web.individual_bookings.mark_booking_as_cancelled", booking_id=booking.id) | action_to_name }}"
+                                                            method="POST"
+                                                            data-turbo="false"
+                                                        >
                                                             <div class="modal-header" id="cancel-booking-modal-{{ booking.id }}-label">
                                                                 <h5 class="modal-title">Annuler la réservation {{ booking.token }}</h5>
                                                             </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -48,7 +48,11 @@
             </p>
         </a>
 
-        <form action="{{ url_for('backoffice_v3_web.logout') }}" method="POST">
+        <form
+            action="{{ url_for('backoffice_v3_web.logout') }}"
+            name="{{ url_for('backoffice_v3_web.logout') | action_to_name }}"
+            method="POST"
+        >
             {{ csrf_token }}
 
             <button type="submit" class="btn btn-link text-white">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -24,7 +24,11 @@
                                 aria-describedby="edit-offerer-modal-label" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                                     <div class="modal-content">
-                                        <form action="{{ url_for("backoffice_v3_web.offerer.update_offerer", offerer_id=offerer.id) }}" method="POST">
+                                        <form
+                                            action="{{ url_for("backoffice_v3_web.offerer.update_offerer", offerer_id=offerer.id) }}"
+                                            name="{{ url_for("backoffice_v3_web.offerer.update_offerer", offerer_id=offerer.id) | action_to_name }}"
+                                            method="POST"
+                                        >
                                             <div class="modal-header">
                                                 <h5 class="modal-title">Modifier les informations de la structure</h5>
                                             </div>
@@ -52,8 +56,12 @@
                                 aria-describedby="delete-offerer-modal-label" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
-                                        <form action="{{ url_for("backoffice_v3_web.offerer.delete_offerer", offerer_id=offerer.id) }}"
-                                            method="POST" data-turbo="false">
+                                        <form
+                                            action="{{ url_for("backoffice_v3_web.offerer.delete_offerer", offerer_id=offerer.id) }}"
+                                            name="{{ url_for("backoffice_v3_web.offerer.delete_offerer", offerer_id=offerer.id) | action_to_name }}"
+                                            method="POST"
+                                            data-turbo="false"
+                                        >
                                             <div class="modal-header" id="delete-offerer-modal-label">
                                                 <h5 class="modal-title">Supprimer la structure {{ offerer.name }}</h5>
                                             </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
@@ -14,7 +14,7 @@
                 <div class="modal-content">
                     <div class="modal-header fs-5" id="add-pro-user-modal-label">Ajouter un compte pro</div>
                     <div class="mx-4 mt-4">Veuillez sélectionner le compte pro à rattacher à cette structure</div>
-                    <form action="{{ add_user_dst }}" method="POST">
+                    <form action="{{ add_user_dst }}" name="{{ add_user_dst | action_to_name }}" method="POST">
                         <div class="modal-body">
                             <div class="form-group">
                                 {% for form_field in add_user_form %}
@@ -66,11 +66,10 @@
                     <ul class="dropdown-menu">
                         <li class="dropdown-item p-0">
                             <form
-                                    action="
-
-                                            {{ url_for("backoffice_v3_web.validation.validate_user_offerer",user_offerer_id=user_offerer.id,
-                                                    ) }}"
-                                    method="POST">
+                                action="{{ url_for("backoffice_v3_web.validation.validate_user_offerer",user_offerer_id=user_offerer.id) }}"
+                                name="{{ url_for("backoffice_v3_web.validation.validate_user_offerer",user_offerer_id=user_offerer.id) | action_to_name }}"
+                                method="POST"
+                            >
                                 {{ csrf_token }}
 
                                 <button type="submit" class="btn btn-sm d-block w-100 text-start px-3">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/offerer_tag.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/offerer_tag.html
@@ -13,7 +13,12 @@
                 aria-describedby="create-offerer-tag-modal-label" aria-hidden="true">
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
-                    <form action="{{ url_for("backoffice_v3_web.offerer_tag.create_offerer_tag") }}" method="POST" data-turbo="false">
+                    <form
+                        action="{{ url_for("backoffice_v3_web.offerer_tag.create_offerer_tag") }}"
+                        name="{{ url_for("backoffice_v3_web.offerer_tag.create_offerer_tag") | action_to_name }}"
+                        method="POST"
+                        data-turbo="false"
+                    >
                         <div class="modal-header" id="create-offerer-tag-modal-label">
                             <h5 class="modal-title">Créer un tag structure</h5>
                         </div>
@@ -72,8 +77,12 @@
                                     aria-labelledby="edit-offerer-tag-modal-{{ offerer_tag.id }}-label" aria-hidden="true">
                                     <div class="modal-dialog modal-dialog-centered">
                                         <div class="modal-content">
-                                            <form action="{{ url_for("backoffice_v3_web.offerer_tag.update_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
-                                                method="POST" data-turbo="false">
+                                            <form
+                                                action="{{ url_for("backoffice_v3_web.offerer_tag.update_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
+                                                action="{{ url_for("backoffice_v3_web.offerer_tag.update_offerer_tag", offerer_tag_id=offerer_tag.id) | action_to_name }}"
+                                                method="POST"
+                                                data-turbo="false"
+                                            >
                                                 <div class="modal-header" id="edit-offerer-tag-modal-{{ offerer_tag.id }}-label">
                                                     <h5 class="modal-title">Modifier le tag {{ offerer_tag.name }}</h5>
                                                 </div>
@@ -93,8 +102,12 @@
                                         aria-labelledby="delete-offerer-tag-modal-{{ offerer_tag.id }}-label" aria-hidden="true">
                                         <div class="modal-dialog modal-dialog-centered">
                                             <div class="modal-content">
-                                                <form action="{{ url_for("backoffice_v3_web.offerer_tag.delete_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
-                                                    method="POST" data-turbo="false">
+                                                <form
+                                                    action="{{ url_for("backoffice_v3_web.offerer_tag.delete_offerer_tag", offerer_tag_id=offerer_tag.id) }}"
+                                                    action="{{ url_for("backoffice_v3_web.offerer_tag.delete_offerer_tag", offerer_tag_id=offerer_tag.id) | action_to_name }}"
+                                                    method="POST"
+                                                    data-turbo="false"
+                                                >
                                                     <div class="modal-header" id="delete-offerer-tag-modal-{{ offerer_tag.id }}-label">
                                                         <h5 class="modal-title">Supprimer le tag {{ offerer_tag.name }}</h5>
                                                     </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -118,7 +118,14 @@
                                                     offerer_id=offerer.id,
                                                     user_offerer_id=user_offerer.id
                                                 ) }}"
-                                                    method="POST">
+                                                name="{{
+                                                url_for(
+                                                    "backoffice_v3_web.validation.validate_user_offerer",
+                                                    offerer_id=offerer.id,
+                                                    user_offerer_id=user_offerer.id
+                                                ) | action_to_name }}"
+                                                method="POST"
+                                            >
                                                 {{ csrf_token }}
                                                 <button type="submit" class="btn btn-sm d-block w-100 text-start px-3">
                                                     Valider

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/validation.html
@@ -73,11 +73,10 @@
                                     <ul class="dropdown-menu">
                                         <li class="dropdown-item p-0">
                                             <form
-                                                    action="{{ url_for(
-                                                    "backoffice_v3_web.validation.validate_offerer",
-                                                    offerer_id=offerer.id
-                                                ) }}"
-                                                    method="POST">
+                                                action="{{ url_for("backoffice_v3_web.validation.validate_offerer", offerer_id=offerer.id) }}"
+                                                name="{{ url_for("backoffice_v3_web.validation.validate_offerer", offerer_id=offerer.id) | action_to_name }}"
+                                                method="POST"
+                                            >
                                                 {{ csrf_token }}
                                                 <button type="submit" class="btn btn-sm d-block w-100 text-start px-3">
                                                     Valider
@@ -109,11 +108,10 @@
                                 {% set top_actor_checked = is_top_actor_func(offerer) %}
                                 <div class="form-check form-switch">
                                     <form
-                                            action="{{ url_for(
-                                                "backoffice_v3_web.validation.toggle_top_actor",
-                                                offerer_id=offerer.id
-                                            ) }}"
-                                            method="POST">
+                                        action="{{ url_for("backoffice_v3_web.validation.toggle_top_actor", offerer_id=offerer.id) }}"
+                                        name="{{ url_for("backoffice_v3_web.validation.toggle_top_actor", offerer_id=offerer.id) | action_to_name }}"
+                                        method="POST"
+                                    >
                                         {{ csrf_token }}
 
                                         <input class="form-check-input" type="checkbox" role="switch"

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret.html
@@ -6,7 +6,7 @@
     <div class="pt-3 px-5">
         <h2 class="fw-light">Déplacer un SIRET d’un lieu à un autre</h2>
         <div class="col-12 py-4">
-            <form action="{{ dst }}" method="POST">
+            <form action="{{ dst }}" name={{ dst | action_to_name }} method="POST">
                 {{ build_form_fields_group(form) }}
                 <div class="d-flex justify-content-end">
                     <button type="submit" class="btn btn-primary">Continuer</button>

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro/move_siret_confirmation.html
@@ -60,7 +60,7 @@
                 Annuler
             </a>
             <div>
-                <form action="{{ dst }}" method="POST">
+                <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">
                     {% for form_field in form %}
                         <input type="hidden" name="{{ form_field.name }}" value="{{ form_field.data }}"/>
                     {% endfor %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/comment.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/comment.html
@@ -10,7 +10,7 @@
                 <div class="modal-header fs-5" id="add-comment-pro-user-modal-label">
                     {{ caller() }}
                 </div>
-                <form action="{{ dst }}" method="POST">
+                <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">
                     <div class="modal-body">
                         <div class="form-group">
                             {% for form_field in form %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -43,7 +43,7 @@
                                         <div class="modal-header fs-5" id="edit-pro-user-modal-label">
                                             Modification des informations
                                             de {{ user.firstName }} {{ user.lastName | upper }}</div>
-                                        <form action="{{ dst }}" method="POST">
+                                        <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">
                                             <div class="modal-body">
                                                 {{ build_form_fields_group(form) }}
                                             </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -24,7 +24,11 @@
                                 aria-labelledby="edit-venue-modal-label" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
-                                        <form action="{{ url_for("backoffice_v3_web.venue.update_venue", venue_id=venue.id) }}" method="POST">
+                                        <form
+                                            action="{{ url_for("backoffice_v3_web.venue.update_venue", venue_id=venue.id) }}"
+                                            name="{{ url_for("backoffice_v3_web.venue.update_venue", venue_id=venue.id) | action_to_name }}"
+                                            method="POST"
+                                        >
                                             <div class="modal-header">
                                                 <h5 class="modal-title">Modifier les informations du lieu</h5>
                                             </div>
@@ -54,8 +58,12 @@
                                 aria-describedby="delete-venue-modal-label" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
-                                        <form action="{{ url_for("backoffice_v3_web.venue.delete_venue", venue_id=venue.id) }}"
-                                            method="POST" data-turbo="false">
+                                        <form
+                                            action="{{ url_for("backoffice_v3_web.venue.delete_venue", venue_id=venue.id) }}"
+                                            name="{{ url_for("backoffice_v3_web.venue.delete_venue", venue_id=venue.id) | action_to_name }}"
+                                            method="POST"
+                                            data-turbo="false"
+                                        >
                                             <div class="modal-header" id="delete-venue-modal-label">
                                                 <h5 class="modal-title">Supprimer le lieu {{ venue.name }}</h5>
                                             </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20875

## But de la pull request

Actuellement, nos formulaires n'ont pas d'attribut `name` systématiquement, ce qui rend compliqué le traversing des forms en JavaScript. 

Cette PR à pour but de rajouter un name a tout les forms.

Nous avons d'obligatoire l'attribut `action`, la stratégie pour le name est:

- Si action -> slugification de l'action en name
- Si pas d'action -> random hash en name

## Implémentation

- Ajout d'un filter jinja `action_to_name`, ex:
  - Si action `/backofficev3/public-accounts/127/update` alors name `backofficev3_public_accounts_127_update`
  - Si action `` alors name `78978921ef91d39b8d531375d78961c1` (random)

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
