### PR TITLE
(PC-20876)[API] fix: remove id from all html templates

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/credit.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/credit.html
@@ -74,7 +74,7 @@
     </div>
 
     <div class="col">
-        <div class="card" id="main-check-item">
+        <div class="card accounts-show-user-credit-card">
             <div class="card-body">
                 {% if latest_fraud_check %}
                     <h5 class="card-title mb-3">Dossier {{ latest_fraud_check.type | upper }} importé le</h5>
@@ -85,11 +85,11 @@
                     <h6 class="card-subtitle me-auto">
                         Statut: {{ latest_fraud_check.status | upper }}
                     </h6>
-                    
+
                     <a href="{{ latest_fraud_check | format_fraud_check_url }}" target="_blank" class="card-link btn lead px-0 py-0 fw-bold">
                         Accéder au dossier {{ latest_fraud_check.type | upper }}
                     </a>
-                
+
                 {% else %}
                     <h5 class="card-title mb-3">Pas de dossier DMS ou Ubble</h5>
                 {% endif %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
@@ -31,7 +31,7 @@
                 <td>{{ booking.status | format_booking_status_long | safe }}</td>
                 <td>{{ booking.token | empty_string_if_null }}</td>
             </tr>
-            <tr class="collapse accordion-collapse" id="b{{ booking.id }}" data-bs-parent=".table">
+            <tr class="collapse accordion-collapse" data-bs-parent=".table">
                 <td colspan="7">
                     <div class="card shadow-sm p-3">
                         {% if booking.stock.beginningDatetime %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
@@ -1,5 +1,5 @@
 <div class="card my-4 pc-personal-information-registration-view">
-    <div class="card-body" id="{{ history_type }}">
+    <div class="card-body {{ history_type }}">
         <h5 class="card-title text-bold fs-2 m-3">
             Parcours d'inscription
             <span class="badge rounded-pill text-bg-primary fs-6 align-middle mx-4">
@@ -32,7 +32,7 @@
     </div>
     <div class="row justify-content-evenly g-4 mb-4">
         {% for idCheckItem in history.idCheckHistory %}
-            <div class="card mx-1 shadow col-auto" id="{{ idCheckItem.thirdPartyId }}">
+            <div class="card mx-1 shadow col-auto {{ idCheckItem.thirdPartyId }}">
                 <div class="card-header bg-white">
                     <h5 class="card-title text-bold fs-3 m-3">
                         {{ idCheckItem.type }}
@@ -97,7 +97,7 @@
                                     </button>
                                 </div>
                                 <div class="col">
-                                    <div class="fs-6 collapse" id="collapse-details{{ idCheckItem.thirdPartyId }}">
+                                    <div class="fs-6 collapse collapse-details{{ idCheckItem.thirdPartyId }}">
                                     <pre>
                                          <code><br>{{ idCheckItem.technicalDetails  | tojson(indent=4) | safe | empty_string_if_null }}</code>
                                     </pre>

--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
@@ -8,7 +8,7 @@
                 <div class="card-header" data-bs-toggle="collapse" href="#{{ form.name }}">
                     {{ form.name }}
                 </div>
-                <div class="collapse card-collapse p-3 shadow" id="{{ form.name }}">
+                <div class="collapse card-collapse p-3 shadow">
                     <form action="{{ url_for(".update_role", role_id=form.id) }}" method="POST">
                         <div class="card-body">
                             <div class="row">

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
@@ -6,9 +6,17 @@
 {% extends "layouts/connected.html" %}
 
 {% block page %}
-    <div class="pt-3 px-5">
+    <div class="pt-3 px-5" data-toggle="filters" data-toggle-id="collective-bookings">
         <h2 class="fw-light">Réservations collectives</h2>
-        <div id="filters">
+        <div class="col-2">
+            <div class="py-2">
+                <button type="submit" class="btn btn-primary filters-toggle-button" disabled>
+                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                    <span class="visually-hidden">Chargement...</span>
+                </button>
+            </div>
+        </div>
+        <div class="filters-container">
             {{ forms.build_filters_form(form, dst) }}
         </div>
         <div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/bookings/extra_row.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/bookings/extra_row.html
@@ -4,14 +4,17 @@
             transform: rotate(90deg)
         }
     </style>
-    <button class="btn btn-sm btn-outline-primary pc-btn-chevron-toggle" data-bs-toggle="collapse"
-            data-bs-target="#b{{ booking.id }}">
+    <button
+        class="btn btn-sm btn-outline-primary pc-btn-chevron-toggle"
+        data-bs-toggle="collapse"
+        data-bs-target="#b{{ booking.id }}"
+    >
         <i class="bi bi-chevron-right"></i>
     </button>
 {% endmacro %}
 
 {% macro build_booking_extra_row(booking, stock, offer) %}
-    <tr class="collapse accordion-collapse" id="b{{ booking.id }}">
+    <tr class="collapse accordion-collapse">
         <td colspan="100%">
             <div class="row">
                 <div class="col-6">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/date_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/date_field.html
@@ -1,4 +1,9 @@
 <div class="form-floating">
-    <input type="date" id="{{ field.name }}" name="{{ field.name }}" class="form-control" value="{{ field.data if field.data else "" }}">
-    <label for="floatingInput">{{ field.label }}</label>
+    <input
+        type="date"
+        name="{{ field.name }}"
+        class="form-control"
+        value="{{ field.data if field.data else "" }}"
+    >
+    <label for="{{ field.name }}">{{ field.label }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/search_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/search_field.html
@@ -1,4 +1,10 @@
-<span class="input-group-text bg-white" id="search-icon"><i class="bi bi-search"></i></span>
-<input type="text" class="form-control col-8 border-start-0" id="{{ field.id }}" name="{{ field.name }}"
-        value="{{ field.data | empty_string_if_null }}" style="flex-grow:3!important;" aria-describedby="search-icon"
-        placeholder="{{ field.label.text }}"/>
+<span class="input-group-text bg-white"><i class="bi bi-search"></i></span>
+<input
+    type="text"
+    class="form-control col-8 border-start-0"
+    name="{{ field.name }}"
+    value="{{ field.data | empty_string_if_null }}"
+    style="flex-grow:3!important;"
+    aria-describedby="search-icon"
+    placeholder="{{ field.label.text }}"
+/>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_field.html
@@ -1,5 +1,5 @@
 <div class="form-floating dropdown">
-    <select class="form-select form-control" id="{{ field.name }}" name="{{ field.name }}"
+    <select class="form-select form-control" name="{{ field.name }}"
             aria-label="{{ field.name }}" style="flex-grow: 1!important;" {% if field.flags.required %}required{% endif %}>
         {% if not field.default %}
             <option value=""></option>

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -461,15 +461,16 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
 
         parsed_html = html_parser.get_soup(response.data)
-        main_dossier_card = str(parsed_html.find(id="main-check-item"))
+        print(parsed_html)
+        main_dossier_card = str(parsed_html.find("div", class_="accounts-show-user-credit-card"))
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{old_dms.source_data().procedure_number}/dossiers/{old_dms.thirdPartyId}"
             in main_dossier_card
         )
 
-        old_ubble_card = str(parsed_html.find(id=old_ubble.thirdPartyId))
+        old_ubble_card = str(parsed_html.find("div", class_=old_ubble.thirdPartyId))
         assert f"https://dashboard.ubble.ai/identifications/{old_ubble.thirdPartyId}" in old_ubble_card
-        old_dms_card = str(parsed_html.find(id=old_dms.thirdPartyId))
+        old_dms_card = str(parsed_html.find("div", class_=old_dms.thirdPartyId))
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{old_dms.source_data().procedure_number}/dossiers/{old_dms.thirdPartyId}"
             in old_dms_card
@@ -484,12 +485,12 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
 
         parsed_html = html_parser.get_soup(response.data)
-        main_dossier_card = str(parsed_html.find(id="main-check-item"))
+        main_dossier_card = str(parsed_html.find("div", class_="accounts-show-user-credit-card"))
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{new_dms.source_data().procedure_number}/dossiers/{new_dms.thirdPartyId}"
             in main_dossier_card
         )
-        new_dms_card = str(parsed_html.find(id=new_dms.thirdPartyId))
+        new_dms_card = str(parsed_html.find("div", class_=new_dms.thirdPartyId))
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{new_dms.source_data().procedure_number}/dossiers/{new_dms.thirdPartyId}"
             in new_dms_card

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -722,7 +722,7 @@ class GetOffererDetailsTest:
         assert response.status_code == 200
 
         parsed_html = html_parser.get_soup(response.data)
-        select = parsed_html.find(id="pro_user_id")
+        select = parsed_html.find("select", attrs={"name": "pro_user_id"})
         options = select.find_all("option")
         assert [option["value"] for option in options] == ["", str(user3.id), str(user2.id)]
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20876

## But de la pull request

Actuellement, nous utilisons des id pour des composants réutilisable, ce qui empêche si l'on souhaite rester sémantiquement correct au yeux de la w3c, de réutiliser un composant.

Ceci peut également avoir un impact sur l'API du DOM, afin d'éviter l'accumulation de dette technique, ce nettoyage est nécessaire.

## Implémentation

- Éviter le risque d'avoir deux identifiant unique dans la page
- Suppression de tout les ids (sauf pour checkbox/radio/accessibility, mais nous n'avons encore rien de tel)
- TODO: remove `id` from csrf input

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
