### PR TITLE
(BSR)[API] fix: fix multiselect border radius

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
@@ -2,6 +2,7 @@
     select.form-select.pc-select-multiple-field:not(.pc-select-multiple-autocomplete-field) {
         height: 1em;
         overflow: hidden;
+        border-radius: 1rem;
     }
     select.form-select.pc-select-multiple-field:not(.tomselected):not(.pc-select-multiple-autocomplete-field) > option {
         display: none;
@@ -10,7 +11,7 @@
 <div class="form-floating {{ field.name }}-container">
     <select
         multiple
-        class="rounded-pill form-select pc-select-multiple-field"
+        class="form-select pc-select-multiple-field"
         id="{{ field.name }}"
         name="{{ field.name }}"
         size="2"

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
@@ -2,6 +2,7 @@
     select.form-select.pc-select-multiple-field.pc-select-multiple-autocomplete-field {
         height: 1em;
         overflow: hidden;
+        border-radius: 1rem;
     }
 </style>
 <div class="form-floating {{ field.name }}-container">
@@ -10,7 +11,7 @@
         data-tomselect-autocomplete-url="{{ field.tomselect_autocomplete_url }}"
         data-tomselect-options="{{ field.tomselect_options }}"
         data-tomselect-items="{{ field.tomselect_items }}"
-        class="rounded-pill form-select pc-select-multiple-field pc-select-multiple-autocomplete-field"
+        class="form-select pc-select-multiple-field pc-select-multiple-autocomplete-field"
         id="{{ field.name }}"
         name="{{ field.name }}"
         size="2"


### PR DESCRIPTION
## But de la pull request

Retrait de la class css `border-rounded` pour repasser a un style `border-radius: 1rem`.

Le passage a la class `border-rounded` ne fonctionne pas bien si on séléctionne beaucoup d'élément dans le mutli select

## Implémentation

Avant

![image](https://user-images.githubusercontent.com/77674046/223463656-cf1ac371-9e7c-4c11-83b2-528b30d05a0d.png)


Après

![image](https://user-images.githubusercontent.com/77674046/223463704-3d8ff5d8-5eb2-4da2-87cf-f12962a93618.png)


## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
