### PR TITLE
(BSR)[API] fix: autocomplete reset button

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/postal_address_autocomplete.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/postal_address_autocomplete.html
@@ -6,7 +6,7 @@
         value="{{ field.data | empty_string_if_null }}"
         data-toggle="postal-address-autocomplete"
         data-limit="{{ field.limit }}"
-        {% if field.required %}required{% endif %}
+        {% if field.required %}required {% endif %}
         {% if field.has_reset %}data-has-reset="true"{% endif %}
         {% if field.has_manual_editing %}data-has-manual-editing="true"{% endif %}
         {# Bellow data are necessary to tell add on PcPostalAddressAutocomplete which field in the form to set on selection #}


### PR DESCRIPTION
## But de la pull request

l'attribut `required` étant collé à l'attribut `data-has-reset`, le `data-has-reset` était toujours null et le `required` toujours `false`

## Implémentation

NA

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
