### PR TITLE
(BSR)[API] ci: fix slack failures colors

### DIFF
--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -72,13 +72,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "Api tests",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests quality-checks échouent sur `master` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Les tests quality-checks échouent sur `master` :boom:"
               }
             ],
             "unfurl_links": false,
@@ -131,13 +131,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "Api tests",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests pylint-checks échouent sur `master` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Les tests pylint-checks échouent sur `master` :boom:"
               }
             ],
             "unfurl_links": false,
@@ -241,13 +241,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "Api tests",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests database échouent sur `master` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Les tests database échouent sur `master` :boom:"
               }
             ],
             "unfurl_links": false,
@@ -364,13 +364,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "Api tests",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests pytest échouent sur `master` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Les tests pytest échouent sur `master` :boom:"
               }
             ],
             "unfurl_links": false,

--- a/.github/workflows/tests-backoffice-v3.yml
+++ b/.github/workflows/tests-backoffice-v3.yml
@@ -134,13 +134,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "Backoffice tests",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests backoffice échouent sur `master` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Les tests backoffice échouent sur `master` :boom:"
               }
             ],
             "unfurl_links": false,


### PR DESCRIPTION
## But de la pull request

![image](https://user-images.githubusercontent.com/77674046/223469281-559405ed-6b53-404d-bc19-3eedf26ae2b4.png)

Ne plus montrer ses gros bras avec une couleur de succès quand on échoue

## Implémentation

Suppression du if else car toutes ces notifications ne tournent qu'en cas d'échec.

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
