### PR TITLE
(BSR)[API] fix: Remove useless unique constraint on cashflow_pricing

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 af95cd1b1a41 (pre) (head)
-18e001e42fbd (post) (head)
+a24e2d695e7c (post) (head)

--- a/api/src/pcapi/alembic/versions/20230307T174719_a24e2d695e7c_delete_unique_cashflow_pricing_association_constraint.py
+++ b/api/src/pcapi/alembic/versions/20230307T174719_a24e2d695e7c_delete_unique_cashflow_pricing_association_constraint.py
@@ -1,0 +1,22 @@
+"""Delete `unique_cashflow_pricing_association` constraint """
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "a24e2d695e7c"
+down_revision = "18e001e42fbd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        ALTER TABLE "cashflow_pricing" DROP CONSTRAINT IF EXISTS "unique_cashflow_pricing_association"
+        """
+    )
+
+
+def downgrade():
+    pass  # the constraint is useless, no need to restore it

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -601,14 +601,6 @@ class CashflowPricing(Base, Model):
     cashflowId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("cashflow.id"), index=True, primary_key=True)
     pricingId: int = sqla.Column(sqla.BigInteger, sqla.ForeignKey("pricing.id"), index=True, primary_key=True)
 
-    __table_args__ = (
-        sqla.UniqueConstraint(
-            "cashflowId",
-            "pricingId",
-            name="unique_cashflow_pricing_association",
-        ),
-    )
-
 
 class CashflowBatch(Base, Model):
     """A cashflow batch groups cashflows that are sent to the bank at the


### PR DESCRIPTION
The composite primary key already enforces unicity.