### PR TITLE
(PC-20854)[API] fix: show subscription items only when they have frau…

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -27,11 +27,11 @@ import pcapi.core.subscription.api as subscription_api
 from pcapi.core.subscription.phone_validation import api as phone_validation_api
 from pcapi.core.subscription.phone_validation import exceptions as phone_validation_exceptions
 from pcapi.core.users import api as users_api
+from pcapi.core.users import constants as users_constants
 from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import models as users_models
-import pcapi.core.users.constants as users_constants
+from pcapi.core.users import utils as users_utils
 import pcapi.core.users.email.update as email_update
-import pcapi.core.users.utils as users_utils
 from pcapi.models import db
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
@@ -439,17 +439,22 @@ def get_eligibility_history(user: users_models.User) -> dict[str, accounts.Eligi
         subscription_api.get_user_profiling_subscription_item,
         subscription_api.get_honor_statement_subscription_item,
     ]
-
     # Do not show information about eligibility types which are not possible depending on known user age
     if user.birth_date:
         age_at_creation = users_utils.get_age_at_date(user.birth_date, user.dateCreated)
         if age_at_creation <= users_constants.ELIGIBILITY_AGE_18:
             if age_at_creation == users_constants.ELIGIBILITY_AGE_18:
                 eligibility_types.append(users_models.EligibilityType.AGE18)
+                if users_models.EligibilityType.UNDERAGE in [
+                    fraud_check.eligibilityType for fraud_check in user.beneficiaryFraudChecks
+                ]:
+                    eligibility_types.insert(0, users_models.EligibilityType.UNDERAGE)
             else:
                 eligibility_types.append(users_models.EligibilityType.UNDERAGE)
                 age_now = users_utils.get_age_from_birth_date(user.birth_date)
-                if age_now >= users_constants.ELIGIBILITY_AGE_18:
+                if age_now >= users_constants.ELIGIBILITY_AGE_18 or users_models.EligibilityType.AGE18 in [
+                    fraud_check.eligibilityType for fraud_check in user.beneficiaryFraudChecks
+                ]:
                     eligibility_types.append(users_models.EligibilityType.AGE18)
     else:
         # Profile completion step not reached yet; can't guess eligibility, display all

--- a/api/tests/routes/backoffice_v3/collective_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/collective_bookings_test.py
@@ -452,7 +452,7 @@ class CancelCollectiveBookingTest:
             "backoffice_v3_web.collective_bookings.mark_booking_as_cancelled", collective_booking_id=reimbursed.id
         )
         response = send_request(authenticated_client, url)
-        print(response.data.decode("utf8"))
+
         # then
         assert response.status_code == 303
 
@@ -480,7 +480,7 @@ class CancelCollectiveBookingTest:
         assert cancelled.status == old_status
 
         redirected_response = authenticated_client.get(response.headers["location"])
-        print(html_parser.extract_alert(redirected_response.data))
+
         assert "Impossible d'annuler une réservation déjà annulée" in html_parser.extract_alert(
             redirected_response.data
         )

--- a/api/tests/routes/backoffice_v3/individual_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/individual_bookings_test.py
@@ -424,7 +424,7 @@ class CancelBookingTest:
         # when
         url = url_for("backoffice_v3_web.individual_bookings.mark_booking_as_cancelled", booking_id=reimbursed.id)
         response = send_request(authenticated_client, url)
-        print(response.data.decode("utf8"))
+
         # then
         assert response.status_code == 303
 
@@ -452,7 +452,7 @@ class CancelBookingTest:
         assert cancelled.status == old_status
 
         redirected_response = authenticated_client.get(response.headers["location"])
-        print(html_parser.extract_alert(redirected_response.data))
+
         assert "Impossible d'annuler une réservation déjà annulée" in html_parser.extract_alert(
             redirected_response.data
         )


### PR DESCRIPTION
…d checks

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20854

## But de la pull request

Ne plus afficher les parcours d'inscription en fonction de l'âge, mais en fonction de s'ils contiennent des fraud checks

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
