### PR TITLE
(PC-20592)[PRO] feat: add trackers on click collective booking link

### DIFF
--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -2,11 +2,13 @@ import cn from 'classnames'
 import React from 'react'
 
 import { CollectiveBookingStatus, OfferStatus } from 'apiClient/v1'
+import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'
 import {
   CollectiveOffer,
   CollectiveOfferTemplate,
   isCollectiveOffer,
 } from 'core/OfferEducational'
+import useAnalytics from 'hooks/useAnalytics'
 import { CircleArrowIcon } from 'icons'
 import { getCollectiveStatusLabel } from 'pages/Offers/Offers/OfferItem/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell'
 import { Button, ButtonLink } from 'ui-kit'
@@ -36,6 +38,7 @@ const OfferEducationalActions = ({
   offer,
   setIsOfferActive,
 }: IOfferEducationalActions): JSX.Element => {
+  const { logEvent } = useAnalytics()
   const lastBookingId = isCollectiveOffer(offer) ? offer.lastBookingId : null
   const lastBookingStatus = isCollectiveOffer(offer)
     ? offer.lastBookingStatus
@@ -80,6 +83,14 @@ const OfferEducationalActions = ({
               link={{ isExternal: false, to: getBookingLink() }}
               Icon={CircleArrowIcon}
               iconPosition={IconPositionEnum.LEFT}
+              onClick={() =>
+                logEvent?.(
+                  CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
+                  {
+                    from: location.pathname,
+                  }
+                )
+              }
             >
               Voir la{' '}
               {lastBookingStatus == 'PENDING'

--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -67,6 +67,7 @@ export enum CollectiveBookingsEvents {
   CLICKED_EXPAND_COLLECTIVE_BOOKING_DETAILS = 'hasClickedExpandCollectiveBookingDetails',
   CLICKED_DETAILS_BUTTON_CELL = 'hasClickedDetailsButtonCell',
   CLICKED_MODIFY_BOOKING_LIMIT_DATE = 'hasClickedModifyBookingLimitDate',
+  CLICKED_SEE_COLLECTIVE_BOOKING = 'hasClickedSeeCollectiveBooking',
 }
 
 export enum OFFER_FORM_NAVIGATION_MEDIUM {

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/BookingLinkCell/BookingLinkCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/BookingLinkCell/BookingLinkCell.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { CollectiveBookingsEvents } from 'core/FirebaseEvents/constants'
+import useAnalytics from 'hooks/useAnalytics'
 import { ReactComponent as ArrowIcon } from 'icons/ico-arrow-right.svg'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
@@ -24,6 +26,7 @@ const BookingLinkCell = ({
   if (!offerEventDate) {
     return null
   }
+  const { logEvent } = useAnalytics()
   const eventDateFormated = formatBrowserTimezonedDateAsUTC(
     offerEventDate,
     FORMAT_ISO_DATE_ONLY
@@ -37,6 +40,11 @@ const BookingLinkCell = ({
         link={{ isExternal: false, to: bookingLink }}
         Icon={ArrowIcon}
         iconPosition={IconPositionEnum.CENTER}
+        onClick={() =>
+          logEvent?.(CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING, {
+            from: location.pathname,
+          })
+        }
         hasTooltip
       >
         Voir la {bookingStatus == 'PENDING' ? 'préréservation' : 'réservation'}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20592

## But de la pull request

Ajouter un tracker sur les boutons d'accès aux réservations collectives : 

- Depuis la liste des offres (filtrer sur une offre préservée ou réservée)
- Depuis la page récap d'une offre collective