### PR TITLE
(PC-20974)[API] fix: convert stock price to cents in response

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v1/serialization/bookings.py
@@ -76,6 +76,8 @@ class BookingStockResponse(BaseModel):
     price: int
     priceCategoryLabel: str | None
 
+    _convert_price = validator("price", pre=True, allow_reuse=True)(convert_to_cent)
+
     class Config:
         orm_mode = True
 

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -199,7 +199,7 @@ class GetBookingsTest:
             "stock": {
                 "beginningDatetime": None,
                 "id": used2.stock.id,
-                "price": used2.stock.price,
+                "price": used2.stock.price * 100,
                 "priceCategoryLabel": None,
                 "offer": {
                     "subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id,
@@ -246,12 +246,12 @@ class GetBookingsTest:
             response.json["ended_bookings"][0]["stock"]["priceCategoryLabel"]
             == stock.priceCategory.priceCategoryLabel.label
         )
-        assert response.json["ended_bookings"][0]["stock"]["price"] == stock.price
+        assert response.json["ended_bookings"][0]["stock"]["price"] == stock.price * 100
         assert (
             response.json["ongoing_bookings"][0]["stock"]["priceCategoryLabel"]
             == stock.priceCategory.priceCategoryLabel.label
         )
-        assert response.json["ongoing_bookings"][0]["stock"]["price"] == stock.price
+        assert response.json["ongoing_bookings"][0]["stock"]["price"] == stock.price * 100
 
     @freeze_time("2021-03-12")
     def test_get_bookings_15_17_user(self, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20974

## But de la pull request

lorsque l'app native récupère la liste des réservations, elle attend que le prix des stock soient en centimes, hors le back renvoie des euros. cette PR corrige ça

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ x J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
