### PR TITLE
(PC-20964)[API] fix: Rendre le champs pondération optionnel

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -115,6 +115,13 @@ class PCEmailField(wtforms.EmailField):
     ]
 
 
+class PCOptIntegerField(wtforms.IntegerField):
+    widget = partial(widget, template="components/forms/string_field.html")
+    validators = [
+        validators.Optional(""),
+    ]
+
+
 class PCIntegerField(wtforms.IntegerField):
     widget = partial(widget, template="components/forms/string_field.html")
     validators = [

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
@@ -1,6 +1,6 @@
-<div class="form-floating my-3 {% if field.type == "PCIntegerField"  %} d-inline-block {% elif field.type == "PCOptHiddenField" or field.type == "PCPostalCodeHiddenField" or field.type == "PCOptPostalCodeHiddenField" or field.type == "PCHiddenField" %} d-none {% endif %}">
+<div class="form-floating my-3 {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField"  %} d-inline-block {% elif field.type == "PCOptHiddenField" or field.type == "PCPostalCodeHiddenField" or field.type == "PCOptPostalCodeHiddenField" or field.type == "PCHiddenField" %} d-none {% endif %}">
     <input
-        type="{% if field.type == "PCIntegerField" %}number{% else %}text{% endif %}"
+        type="{% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" %}number{% else %}text{% endif %}"
         id="{{ field.name }}"
         name="{{ field.name }}"
         class="form-control"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20964

## But de la pull request

Rendre optionnel le champ `rankingweight` du formulaire d'édition des offres. 

## Implémentation

Création d'un champs `PCOptIntegerField`
Mise en place des vérifications adéquates pour afficher le champs en tant que champs nombre. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
