### PR TITLE
(PC-20876)[API] fix: remove id from all html templates

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/blueprint.py
@@ -45,4 +45,5 @@ def extra_funcs() -> dict:
         "csrf_token": empty_forms.EmptyForm().csrf_token,
         "has_permission": utils.has_current_user_permission,
         "is_user_offerer_action_type": utils.is_user_offerer_action_type,
+        "random_hash": utils.random_hash,
     }

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/credit.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/credit.html
@@ -74,7 +74,7 @@
     </div>
 
     <div class="col">
-        <div class="card" id="main-check-item">
+        <div class="card pc-script-user-accounts-additional-data-main-fraud-check">
             <div class="card-body">
                 {% if latest_fraud_check %}
                     <h5 class="card-title mb-3">Dossier {{ latest_fraud_check.type | upper }} importé le</h5>
@@ -85,11 +85,11 @@
                     <h6 class="card-subtitle me-auto">
                         Statut: {{ latest_fraud_check.status | upper }}
                     </h6>
-                    
+
                     <a href="{{ latest_fraud_check | format_fraud_check_url }}" target="_blank" class="card-link btn lead px-0 py-0 fw-bold">
                         Accéder au dossier {{ latest_fraud_check.type | upper }}
                     </a>
-                
+
                 {% else %}
                     <h5 class="card-title mb-3">Pas de dossier DMS ou Ubble</h5>
                 {% endif %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
@@ -1,6 +1,5 @@
 {% import "components/links.html" as links %}
 {% from "components/bookings/extra_row.html" import build_booking_toggle_extra_row_button with context %}
-{% from "components/bookings/extra_row.html" import build_booking_extra_row with context %}
 
 {% if bookings %}
     <table class="table mb-4 get-details-bookings-view">
@@ -31,7 +30,7 @@
                 <td>{{ booking.status | format_booking_status_long | safe }}</td>
                 <td>{{ booking.token | empty_string_if_null }}</td>
             </tr>
-            <tr class="collapse accordion-collapse" id="b{{ booking.id }}" data-bs-parent=".table">
+            <tr class="collapse accordion-collapse pc-booking-{{ booking.id }}" data-bs-parent=".table">
                 <td colspan="7">
                     <div class="card shadow-sm p-3">
                         {% if booking.stock.beginningDatetime %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
@@ -1,5 +1,5 @@
 <div class="card my-4 pc-personal-information-registration-view">
-    <div class="card-body" id="{{ history_type }}">
+    <div class="card-body {{ history_type }}">
         <h5 class="card-title text-bold fs-2 m-3">
             Parcours d'inscription
             <span class="badge rounded-pill text-bg-primary fs-6 align-middle mx-4">
@@ -32,7 +32,7 @@
     </div>
     <div class="row justify-content-evenly g-4 mb-4">
         {% for idCheckItem in history.idCheckHistory %}
-            <div class="card mx-1 shadow col-auto" id="{{ idCheckItem.thirdPartyId }}">
+            <div class="card mx-1 shadow col-auto {{ idCheckItem.thirdPartyId }}">
                 <div class="card-header bg-white">
                     <h5 class="card-title text-bold fs-3 m-3">
                         {{ idCheckItem.type }}
@@ -92,12 +92,12 @@
                             <div>
                                 <div class="col justify-content-between">
                                     <button class="btn btn-primary fs-6" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#collapse-details{{ idCheckItem.thirdPartyId }}">
+                                            data-bs-target=".pc-collapse-details-{{ idCheckItem.thirdPartyId }}">
                                         Afficher les détails techniques
                                     </button>
                                 </div>
                                 <div class="col">
-                                    <div class="fs-6 collapse" id="collapse-details{{ idCheckItem.thirdPartyId }}">
+                                    <div class="fs-6 collapse pc-collapse-details-{{ idCheckItem.thirdPartyId }}">
                                     <pre>
                                          <code><br>{{ idCheckItem.technicalDetails  | tojson(indent=4) | safe | empty_string_if_null }}</code>
                                     </pre>

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -1,4 +1,4 @@
-{% from "components/generic_modal.html" import build_modal_form %}
+{% from "components/generic_modal.html" import build_modal_form with context %}
 
 <div class="row row-cols-1 g-4 py-3">
     <div class="col">

--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/roles.html
@@ -5,15 +5,15 @@
         <h2>Gestion des rôles</h2>
         {% for form in forms %}
             <div class="card mb-4">
-                <div class="card-header" data-bs-toggle="collapse" href=".{{ form.name }}">
+                <div class="card-header" data-bs-toggle="collapse" href=".pc-collapse-{{ form.name }}" role="button">
                     {{ form.name }}
                 </div>
-                <div class="collapse card-collapse p-3 shadow">
+                <div class="collapse card-collapse p-3 shadow pc-collapse-{{ form.name }}">
                     <form
                         class=".{{ form.name }}"
                         action="{{ url_for(".update_role", role_id=form.id) }}"
-                        name="{{ url_for(".update_role", role_id=form.id) | action_to_name }}"
                         method="POST"
+                        name="{{ url_for(".update_role", role_id=form.id) | action_to_name }}"
                     >
                         <div class="card-body">
                             <div class="row">

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_bookings/list.html
@@ -5,10 +5,21 @@
 
 {% extends "layouts/connected.html" %}
 
+{% set pc_validate_booking_modal_id = random_hash() %}
+{% set pc_cancel_booking_modal_id = random_hash() %}
+
 {% block page %}
-    <div class="pt-3 px-5">
+    <div class="pt-3 px-5" data-toggle="filters" data-toggle-id="collective-bookings">
         <h2 class="fw-light">Réservations collectives</h2>
-        <div id="filters">
+        <div class="col-2">
+            <div class="py-2">
+                <button type="submit" class="btn btn-primary filters-toggle-button" disabled>
+                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                    <span class="visually-hidden">Chargement...</span>
+                </button>
+            </div>
+        </div>
+        <div class="filters-container">
             {{ forms.build_filters_form(form, dst) }}
         </div>
         <div>
@@ -49,7 +60,7 @@
                                                 <li class="dropdown-item p-0">
                                                     <a class="btn btn-sm d-block w-100 text-start px-3"
                                                             data-bs-toggle="modal"
-                                                            data-bs-target="#validate-booking-modal-{{ collective_booking.id }}">
+                                                            data-bs-target=".pc-validate-booking-modal-{{ collective_booking.id }}">
                                                             Valider la réservation
                                                     </a>
                                                 </li>
@@ -57,15 +68,15 @@
                                                 <li class="dropdown-item p-0">
                                                     <a class="btn btn-sm d-block w-100 text-start px-3"
                                                             data-bs-toggle="modal"
-                                                            data-bs-target="#cancel-booking-modal-{{ collective_booking.id }}">
+                                                            data-bs-target=".pc-cancel-booking-modal-{{ collective_booking.id }}">
                                                             Annuler la réservation
                                                     </a>
                                                 </li>
                                             {% endif %}
                                         </ul>
                                         {% if collective_booking.isCancelled %}
-                                            <div class="modal modal-lg fade" id="validate-booking-modal-{{ collective_booking.id }}" tabindex="-1"
-                                                aria-labelledby="validate-booking-modal-{{ collective_booking.id }}-label" aria-hidden="true">
+                                            <div class="modal modal-lg fade pc-validate-booking-modal-{{ collective_booking.id }}" tabindex="-1"
+                                                aria-labelledby="{{ pc_validate_booking_modal_id }}" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
                                                         <form
@@ -74,7 +85,7 @@
                                                             method="POST"
                                                             data-turbo="false"
                                                         >
-                                                            <div class="modal-header" id="validate-booking-modal-{{ collective_booking.id }}-label">
+                                                            <div class="modal-header" id="{{ pc_validate_booking_modal_id }}">
                                                                 <h5 class="modal-title">Valider la réservation {{ collective_booking.id }}</h5>
                                                             </div>
                                                             <div class="modal-body row">
@@ -89,8 +100,8 @@
                                                 </div>
                                             </div>
                                         {% elif not collective_booking.isReimbursed %}
-                                            <div class="modal modal-lg fade" id="cancel-booking-modal-{{ collective_booking.id }}" tabindex="-1"
-                                                aria-labelledby="cancel-booking-modal-{{ collective_booking.id }}-label" aria-hidden="true">
+                                            <div class="modal modal-lg fade pc-cancel-booking-modal-{{ collective_booking.id }}" tabindex="-1"
+                                                aria-labelledby="{{ pc_cancel_booking_modal_id }}" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
                                                         <form
@@ -99,7 +110,7 @@
                                                             method="POST"
                                                             data-turbo="false"
                                                         >
-                                                            <div class="modal-header" id="cancel-booking-modal-{{ collective_booking.id }}-label">
+                                                            <div class="modal-header" id="{{ pc_cancel_booking_modal_id }}">
                                                                 <h5 class="modal-title">Annuler la réservation {{ collective_booking.id }}</h5>
                                                             </div>
                                                             <div class="modal-body row">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/bookings/extra_row.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/bookings/extra_row.html
@@ -4,14 +4,17 @@
             transform: rotate(90deg)
         }
     </style>
-    <button class="btn btn-sm btn-outline-primary pc-btn-chevron-toggle" data-bs-toggle="collapse"
-            data-bs-target="#b{{ booking.id }}">
+    <button
+        class="btn btn-sm btn-outline-primary pc-btn-chevron-toggle"
+        data-bs-toggle="collapse"
+        data-bs-target=".pc-booking-{{ booking.id }}"
+    >
         <i class="bi bi-chevron-right"></i>
     </button>
 {% endmacro %}
 
 {% macro build_booking_extra_row(booking, stock, offer) %}
-    <tr class="collapse accordion-collapse" id="b{{ booking.id }}">
+    <tr class="collapse accordion-collapse pc-booking-{{ booking.id }}">
         <td colspan="100%">
             <div class="row">
                 <div class="col-6">

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/date_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/date_field.html
@@ -1,4 +1,11 @@
 <div class="form-floating">
-    <input type="date" id="{{ field.name }}" name="{{ field.name }}" class="form-control" value="{{ field.data if field.data else "" }}">
-    <label for="floatingInput">{{ field.label }}</label>
+    {% set date_field_id = random_hash() %}
+    <input
+        type="date"
+        id="{{ date_field_id }}"
+        name="{{ field.name }}"
+        class="form-control"
+        value="{{ field.data if field.data else "" }}"
+    >
+    <label for="{{ date_field_id }}">{{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/postal_address_autocomplete.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/postal_address_autocomplete.html
@@ -6,17 +6,17 @@
         value="{{ field.data | empty_string_if_null }}"
         data-toggle="postal-address-autocomplete"
         data-limit="{{ field.limit }}"
-        {% if field.required %}required {% endif %}
-        {% if field.has_reset %}data-has-reset="true"{% endif %}
-        {% if field.has_manual_editing %}data-has-manual-editing="true"{% endif %}
+        {% if field.required %} required{% endif %}
+        {% if field.has_reset %} data-has-reset="true"{% endif %}
+        {% if field.has_manual_editing %} data-has-manual-editing="true"{% endif %}
         {# Bellow data are necessary to tell add on PcPostalAddressAutocomplete which field in the form to set on selection #}
-        {% if field.address %}data-address-input-name="{{ field.address }}"{% endif %}
-        {% if field.city %}data-city-input-name="{{ field.city }}"{% endif %}
-        {% if field.postal_code %}data-postal-code-input-name="{{ field.postal_code }}"{% endif %}
-        {% if field.latitude %}data-latitude-input-name="{{ field.latitude }}"{% endif %}
-        {% if field.longitude %}data-longitude-input-name="{{ field.longitude }}"{% endif %}
+        {% if field.address %} data-address-input-name="{{ field.address }}"{% endif %}
+        {% if field.city %} data-city-input-name="{{ field.city }}"{% endif %}
+        {% if field.postal_code %} data-postal-code-input-name="{{ field.postal_code }}"{% endif %}
+        {% if field.latitude %} data-latitude-input-name="{{ field.latitude }}"{% endif %}
+        {% if field.longitude %} data-longitude-input-name="{{ field.longitude }}"{% endif %}
     />
-    <label for="{{ field.name }}" style="z-index: 5">{{ field.label }}</label>
+    <label for="{{ field.name }}" style="z-index: 5">{{ field.label.text }}</label>
     {% if field.has_reset %}
         <button
             data-bs-toggle="tooltip"

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/search_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/search_field.html
@@ -1,4 +1,12 @@
-<span class="input-group-text bg-white" id="search-icon"><i class="bi bi-search"></i></span>
-<input type="text" class="form-control col-8 border-start-0" id="{{ field.id }}" name="{{ field.name }}"
-        value="{{ field.data | empty_string_if_null }}" style="flex-grow:3!important;" aria-describedby="search-icon"
-        placeholder="{{ field.label.text }}"/>
+<span class="input-group-text bg-white"><i class="bi bi-search"></i></span>
+{% set search_field_id = random_hash() %}
+<input
+    type="text"
+    class="form-control col-8 border-start-0"
+    id="{{ search_field_id }}"
+    name="{{ field.name }}"
+    value="{{ field.data | empty_string_if_null }}"
+    style="flex-grow:3!important;"
+    aria-describedby="search-icon"
+    placeholder="{{ field.label.text }}"
+/>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_field.html
@@ -1,6 +1,13 @@
 <div class="form-floating dropdown">
-    <select class="form-select form-control" id="{{ field.name }}" name="{{ field.name }}"
-            aria-label="{{ field.name }}" style="flex-grow: 1!important;" {% if field.flags.required %}required{% endif %}>
+    {% set select_field_id = random_hash() %}
+    <select
+        class="form-select form-control"
+        id="{{ select_field_id }}"
+        name="{{ field.name }}"
+        aria-label="{{ field.name }}"
+        style="flex-grow: 1!important;"
+        {% if field.flags.required %} required{% endif %}
+    >
         {% if not field.default %}
             <option value=""></option>
         {% endif %}
@@ -10,5 +17,5 @@
             </option>
         {% endfor %}
     </select>
-    <label for="{{ field.name }}">{{ field.label }}</label>
+    <label for="{{ select_field_id }}">{{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
@@ -9,10 +9,11 @@
     }
 </style>
 <div class="form-floating {{ field.name }}-container">
+    {% set select_multiple_field_id = random_hash() %}
     <select
         multiple
         class="form-select pc-select-multiple-field"
-        id="{{ field.name }}"
+        id="{{ select_multiple_field_id }}"
         name="{{ field.name }}"
         size="2"
     >
@@ -22,5 +23,5 @@
             </option>
         {% endfor %}
     </select>
-    <label class="pc-select-label" for="{{ field.name }}" id="{{ field.name }}-label"> {{ field.label }}</label>
+    <label class="pc-select-label" for="{{ select_multiple_field_id }}"> {{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field_autocomplete.html
@@ -6,15 +6,16 @@
     }
 </style>
 <div class="form-floating {{ field.name }}-container">
+    {% set select_multiple_field_autocomplete_id = random_hash() %}
     <select
         multiple
         data-tomselect-autocomplete-url="{{ field.tomselect_autocomplete_url }}"
         data-tomselect-options="{{ field.tomselect_options }}"
         data-tomselect-items="{{ field.tomselect_items }}"
         class="form-select pc-select-multiple-field pc-select-multiple-autocomplete-field"
-        id="{{ field.name }}"
+        id="{{ select_multiple_field_autocomplete_id }}"
         name="{{ field.name }}"
         size="2"
     ></select>
-    <label class="pc-select-label" for="{{ field.name }}" id="{{ field.name }}-label"> {{ field.label }}</label>
+    <label class="pc-select-label" for="{{ select_multiple_field_autocomplete_id }}"> {{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_with_placeholder_value_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_with_placeholder_value_field.html
@@ -1,5 +1,12 @@
 <div class="form-floating">
-    <select class="form-select" id="{{ field.name }}" name="{{ field.name }}" aria-label="{{ field.name }}" {% if field.flags.required %}required{% endif %}>
+    {% set select_with_placeholder_value_field_id = random_hash() %}
+    <select
+        id="{{ select_with_placeholder_value_field_id }}"
+        class="form-select"
+        name="{{ field.name }}"
+        aria-label="{{ field.name }}"
+        {% if field.flags.required %} required{% endif %}
+    >
         <option value="" selected>---Sélectionnez une valeur---</option>
         {% for choice_value, choice_label in field.choices %}
             <option value="{{ choice_value }}">
@@ -8,5 +15,5 @@
         {% endfor %}
     </select>
 
-    <label for="{{ field.name }}">{{ field.label }}</label>
+    <label for="{{ select_with_placeholder_value_field_id }}">{{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
@@ -1,13 +1,14 @@
-<div class="form-floating my-3 {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField"  %} d-inline-block {% elif field.type == "PCOptHiddenField" or field.type == "PCPostalCodeHiddenField" or field.type == "PCOptPostalCodeHiddenField" or field.type == "PCHiddenField" %} d-none {% endif %}">
+<div class="form-floating my-3 {% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" %} d-inline-block {% elif field.type == "PCOptHiddenField" or field.type == "PCPostalCodeHiddenField" or field.type == "PCOptPostalCodeHiddenField" or field.type == "PCHiddenField" %} d-none {% endif %}">
+    {% set string_field_id = random_hash() %}
     <input
         type="{% if field.type == "PCIntegerField" or field.type == "PCOptIntegerField" %}number{% else %}text{% endif %}"
-        id="{{ field.name }}"
+        id="{{ string_field_id }}"
         name="{{ field.name }}"
         class="form-control"
         value="{{ field.data | empty_string_if_null }}"
-        {% if field.flags.required %}required{% endif %}
-        {% if field.flags.pattern %}pattern="{{ field.flags.pattern }}"{% endif %}
-        {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
-        {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}/>
-    <label for="{{ field.name }}">{{ field.label }}</label>
+        {% if field.flags.required %} required{% endif %}
+        {% if field.flags.pattern %} pattern="{{ field.flags.pattern }}"{% endif %}
+        {% if field.flags.minlength %} minlength="{{ field.flags.minlength }}"{% endif %}
+        {% if field.flags.maxlength %} maxlength="{{ field.flags.maxlength }}"{% endif %}/>
+    <label for="{{ string_field_id }}">{{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/switch_boolean_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/switch_boolean_field.html
@@ -1,4 +1,13 @@
 <div class="col-6 form-check form-switch mb-2">
-    <input class="form-check-input " type="checkbox" role="switch" style="height: 1.7rem; width: 3rem; margin-right: .5rem" name="{{ field.name }}" id="{{ field.name }}" {{ "checked" if field.data }}>
-    <label class="form-check-label" for="{{ field.name }}">{{ field.label }}</label>
+    {% set switch_boolean_field_id = random_hash() %}
+    <input
+        class="form-check-input"
+        type="checkbox"
+        role="switch"
+        style="height: 1.7rem; width: 3rem; margin-right: .5rem"
+        name="{{ field.name }}"
+        id="{{ switch_boolean_field_id }}"
+        {{ " checked" if field.data }}
+    >
+    <label role="button" class="form-check-label pc-switch-boolean-field-label" for="{{ switch_boolean_field_id }}">{{ field.label.text }}</label>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/textarea_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/textarea_field.html
@@ -1,12 +1,13 @@
 <div class="form-floating col mb-4">
+    {% set textarea_field_id = random_hash() %}
     <textarea
         name="comment"
         class="form-control h-100 pc-override-custom-textarea-enter"
         rows="3"
-        {% if field.flags.required %}required{% endif %}
-        {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
-        {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}
+        {% if field.flags.required %} required{% endif %}
+        {% if field.flags.minlength %} minlength="{{ field.flags.minlength }}"{% endif %}
+        {% if field.flags.maxlength %} maxlength="{{ field.flags.maxlength }}"{% endif %}
     >{{ field.data | empty_string_if_null }}</textarea>
-    <label for="comment">{{ field.label }}</label>
+    <label for="{{ textarea_field_id }}">{{ field.label.text }}</label>
     <div class="text-muted text-end"><small>Maj+Entrée pour ajouter une nouvelle ligne</small></div>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
@@ -1,13 +1,18 @@
 {% macro build_modal_form(modal_id, dst, form, title, button_text) %}
-    <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-        data-bs-target="#{{ modal_id }}-modal" type="button">
+    {% set modal_aria_described_by_id = random_hash() %}
+    <button
+        class="btn btn-outline-primary lead fw-bold mt-2"
+        data-bs-toggle="modal"
+        data-bs-target=".pc-{{ modal_id }}-modal"
+        type="button"
+    >
         {{ title }}
     </button>
-    <div class="modal modal-lg fade" id="{{ modal_id }}-modal" tabindex="-1"
-        aria-describedby="{{ modal_id }}-modal-label" aria-hidden="true">
+    <div class="modal modal-lg fade pc-{{ modal_id }}-modal" tabindex="-1"
+        aria-describedby="{{ modal_aria_described_by_id }}" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
-                <div class="modal-header fs-5" id="{{ modal_id }}-modal-label">
+                <div class="modal-header fs-5" id="{{ modal_aria_described_by_id }}">
                     {{ title }}
                 </div>
                 <form

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/history/comment.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/history/comment.html
@@ -1,15 +1,24 @@
 {# This macro must be imported with context because of has_permission() #}
 {% macro build_comment_modal(dst, form) %}
+    {% set add_comment_modal_label_id = random_hash() %}
     {% if has_permission("MANAGE_PRO_ENTITY") %}
-        <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-            data-bs-target="#add-comment-pro-user-modal" type="button">
+        <button
+            class="btn btn-outline-primary lead fw-bold mt-2"
+            data-bs-toggle="modal"
+            data-bs-target=".pc-add-comment-pro-user-modal"
+            type="button"
+        >
             Ajouter un commentaire
         </button>
-        <div class="modal modal-lg fade" id="add-comment-pro-user-modal" tabindex="-1"
-            aria-describedby="add-comment-pro-user-modal-label" aria-hidden="true">
+        <div
+            class="modal modal-lg fade pc-add-comment-pro-user-modal"
+            tabindex="-1"
+            aria-describedby="{{ add_comment_modal_label_id }}"
+            aria-hidden="true"
+        >
             <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content">
-                    <div class="modal-header fs-5" id="add-comment-pro-user-modal-label">
+                    <div class="modal-header fs-5" id="{{ add_comment_modal_label_id }}">
                         {{ caller() }}
                     </div>
                     <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">
@@ -26,8 +35,11 @@
                             </div>
                         </div>
                         <div class="modal-footer">
-                            <button type="button" class="btn btn-outline-primary"
-                                    data-bs-dismiss="modal">
+                            <button
+                                type="button"
+                                class="btn btn-outline-primary"
+                                data-bs-dismiss="modal"
+                            >
                                 Annuler
                             </button>
                             <button type="submit" class="btn btn-primary">Commenter</button>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/presentation/details/tabs.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/presentation/details/tabs.html
@@ -4,7 +4,7 @@
             class="{{ 'nav-link active fw-bolder' if is_active else 'nav-link fw-bolder' }}"
             id="{{ name ~ '-tab' }}"
             data-bs-toggle="tab"
-            data-bs-target="{{ '#' ~ name ~ '-tab-pane' }}"
+            data-bs-target="{{ '.' ~ name ~ '-tab-pane' }}"
             type="button"
             role="tab"
             aria-controls="{{ name ~ 'tab-pane' }}"
@@ -17,7 +17,7 @@
 
 
 {% macro build_details_tabs_wrapper(name="details-tab") %}
-    <ul class="nav nav-tabs nav-fill mt-4" id="{{ name }}" role="tablist">
+    <ul class="nav nav-tabs nav-fill mt-4 {{ name }}" role="tablist">
         {{ caller() }}
     </ul>
 {% endmacro %}
@@ -25,8 +25,7 @@
 
 {% macro build_details_tab_content(name, is_active=False) %}
     <div
-        class="tab-pane fade p-4 {{ 'show active' if is_active }}"
-        id="{{ name ~ '-tab-pane' }}"
+        class="tab-pane fade p-4 {{ name ~ '-tab-pane' }} {{ 'show active' if is_active }}"
         role="tabpanel"
         aria-labelledby="{{ name ~ '-tab' }}"
         tabindex="0"
@@ -37,7 +36,7 @@
 
 
 {% macro build_details_tabs_content_wrapper() %}
-    <div class="tab-content bg-body border border-top-0 shadow-sm" id="account-details-tab-content">
+    <div class="tab-content bg-body border border-top-0 shadow-sm">
         {{ caller() }}
     </div>
 {% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -5,6 +5,9 @@
 
 {% extends "layouts/connected.html" %}
 
+{% set validate_booking_aria_described_by_id = random_hash() %}
+{% set cancel_booking_aria_described_by_id = random_hash() %}
+
 {% block page %}
     <div class="pt-3 px-5">
         <h2 class="fw-light">Réservations individuelles</h2>
@@ -44,15 +47,21 @@
                                     {{ build_booking_toggle_extra_row_button(booking) }}
                                     <div class="mx-2 dropdown">
                                     {% if has_permission("MANAGE_BOOKINGS") %}
-                                        <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
-                                                class="btn p-0"><i
-                                                class="bi bi-three-dots-vertical"></i></button>
+                                        <button
+                                            type="button"
+                                            data-bs-toggle="dropdown"
+                                            aria-expanded="false"
+                                            class="btn p-0"
+                                            {% if booking.isReimbursed %} disabled{% endif %}
+                                        >
+                                            <i class="bi bi-three-dots-vertical"></i>
+                                        </button>
                                         <ul class="dropdown-menu">
                                             {% if booking.isCancelled %}
                                                 <li class="dropdown-item p-0">
                                                     <a class="btn btn-sm d-block w-100 text-start px-3"
                                                             data-bs-toggle="modal"
-                                                            data-bs-target="#validate-booking-modal-{{ booking.id }}">
+                                                            data-bs-target=".pc-validate-booking-modal-{{ booking.id }}">
                                                             Valider la réservation
                                                     </a>
                                                 </li>
@@ -60,15 +69,15 @@
                                                 <li class="dropdown-item p-0">
                                                     <a class="btn btn-sm d-block w-100 text-start px-3"
                                                             data-bs-toggle="modal"
-                                                            data-bs-target="#cancel-booking-modal-{{ booking.id }}">
+                                                            data-bs-target=".pc-cancel-booking-modal-{{ booking.id }}">
                                                             Annuler la réservation
                                                     </a>
                                                 </li>
                                             {% endif %}
                                         </ul>
                                         {% if booking.isCancelled %}
-                                            <div class="modal modal-lg fade" id="validate-booking-modal-{{ booking.id }}" tabindex="-1"
-                                                aria-labelledby="validate-booking-modal-{{ booking.id }}-label" aria-hidden="true">
+                                            <div class="modal modal-lg fade pc-validate-booking-modal-{{ booking.id }}" tabindex="-1"
+                                                aria-labelledby="{{ validate_booking_aria_described_by_id }}" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
                                                         <form
@@ -77,7 +86,7 @@
                                                             method="POST"
                                                             data-turbo="false"
                                                         >
-                                                            <div class="modal-header" id="validate-booking-modal-{{ booking.id }}-label">
+                                                            <div class="modal-header" id="{{ validate_booking_aria_described_by_id }}">
                                                                 <h5 class="modal-title">Valider la réservation {{ booking.token }}</h5>
                                                             </div>
                                                             <div class="modal-body row">
@@ -92,8 +101,8 @@
                                                 </div>
                                             </div>
                                         {% elif not booking.isReimbursed %}
-                                            <div class="modal modal-lg fade" id="cancel-booking-modal-{{ booking.id }}" tabindex="-1"
-                                                aria-labelledby="cancel-booking-modal-{{ booking.id }}-label" aria-hidden="true">
+                                            <div class="modal modal-lg fade pc-cancel-booking-modal-{{ booking.id }}" tabindex="-1"
+                                                aria-labelledby="{{ cancel_booking_aria_described_by_id }}" aria-hidden="true">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                     <div class="modal-content">
                                                         <form
@@ -102,7 +111,7 @@
                                                             method="POST"
                                                             data-turbo="false"
                                                         >
-                                                            <div class="modal-header" id="cancel-booking-modal-{{ booking.id }}-label">
+                                                            <div class="modal-header" id="{{ cancel_booking_aria_described_by_id }}">
                                                                 <h5 class="modal-title">Annuler la réservation {{ booking.token }}</h5>
                                                             </div>
                                                             <div class="modal-body row">

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -33,10 +33,12 @@
 {% endmacro %}
 
 {% block content %}
-    <nav class="navbar text-bg-primary p-3" id="pc-header-top">
+    {% set pc_collapse_menu_id = random_hash() %}
+    {% set pc_collapse_menu_label_id = random_hash() %}
+    <nav class="navbar text-bg-primary p-3 pc-header-top">
         <button class="btn" type="button" data-bs-toggle="collapse"
-                data-bs-target="#collapse-menu"
-                aria-controls="collapse-menu"><i class="bi bi-list text-white h4"></i></button>
+                data-bs-target=".pc-collapse-menu"
+                aria-controls="{{ pc_collapse_menu_id }}"><i class="bi bi-list text-white h4"></i></button>
 
         <a href="{{ url_for('backoffice_v3_web.home') }}" class="card-link">
             <p class="my-0 ms-5 navbar-brand text-white btn">
@@ -63,10 +65,11 @@
     <div class="container-fluid row">
         <div class="row flex-nowrap">
             <div class="col-auto px-0">
-                <div class="collapse collapse-horizontal offcanvas-start{% if request.path == "/backofficev3/" %} show{% endif %}"
+                <div class="collapse collapse-horizontal offcanvas-start{% if request.path == "/backofficev3/" %} show{% endif %} pc-collapse-menu"
                      data-bs-scroll="true" tabindex="-1"
                      style="transition:none"
-                     id="collapse-menu" aria-labelledby="collapse-menu-label">
+                     id="{{ pc_collapse_menu_id }}"
+                     aria-labelledby="collapse-menu-label">
                     <div class="no-gutters">
                         <nav class="me-3 shadow bg-white rounded-1 rounded-start-0 rounded-top-0">
                             <div class="nav nav-pills flex-column">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -4,6 +4,9 @@
 
 {% extends "layouts/pro.html" %}
 
+{% set edit_offerer_aria_described_by_id = random_hash() %}
+{% set delete_offerer_aria_described_by_id = random_hash() %}
+
 {% block pro_main_content %}
 <div class="row row-cols-1 g-4 py-3">
     <div class="col">
@@ -17,11 +20,11 @@
                     <div class="d-flex row-reverse justify-content-end flex-grow-1">
                         {% if has_permission("MANAGE_PRO_ENTITY") %}
                             <button class="btn btn-outline-primary lead fw-bold mt-2 mx-3" data-bs-toggle="modal"
-                                    data-bs-target="#edit-offerer-modal" type="button">
+                                    data-bs-target=".pc-edit-offerer-modal" type="button">
                                 Modifier les informations
                             </button>
-                            <div class="modal modal-lg fade" id="edit-offerer-modal" tabindex="-1"
-                                aria-describedby="edit-offerer-modal-label" aria-hidden="true">
+                            <div class="modal modal-lg fade pc-edit-offerer-modal" tabindex="-1"
+                                aria-describedby="{{ edit_offerer_aria_described_by_id }}" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                                     <div class="modal-content">
                                         <form
@@ -29,7 +32,7 @@
                                             name="{{ url_for("backoffice_v3_web.offerer.update_offerer", offerer_id=offerer.id) | action_to_name }}"
                                             method="POST"
                                         >
-                                            <div class="modal-header">
+                                            <div class="modal-header" id="{{ edit_offerer_aria_described_by_id }}">
                                                 <h5 class="modal-title">Modifier les informations de la structure</h5>
                                             </div>
                                             <div class="modal-body pb-3">
@@ -48,12 +51,12 @@
                         {% endif %}
                         {% if has_permission("DELETE_PRO_ENTITY") %}
                             <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-                            data-bs-target="#delete-offerer-modal" type="button">
+                            data-bs-target=".pc-delete-offerer-modal" type="button">
                                 <i class="bi bi-trash3-fill"></i>
                                 Supprimer la structure
                             </button>
-                            <div class="modal modal-lg fade" id="delete-offerer-modal" tabindex="-1"
-                                aria-describedby="delete-offerer-modal-label" aria-hidden="true">
+                            <div class="modal modal-lg fade pc-delete-offerer-modal" tabindex="-1"
+                                aria-describedby="{{ delete_offerer_aria_described_by_id }}" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <form
@@ -62,7 +65,7 @@
                                             method="POST"
                                             data-turbo="false"
                                         >
-                                            <div class="modal-header" id="delete-offerer-modal-label">
+                                            <div class="modal-header" id="{{ delete_offerer_aria_described_by_id }}">
                                                 <h5 class="modal-title">Supprimer la structure {{ offerer.name }}</h5>
                                             </div>
                                             <div class="modal-body row">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
@@ -4,15 +4,20 @@
 
 {% if add_user_form %}
     {% if add_user_form.pro_user_id.choices | length > 0 %}
+        {% set add_pro_user_modal_label_id = random_hash() %}
         <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-            data-bs-target="#add-pro-user-modal" type="button">
+            data-bs-target=".pc-add-pro-user-modal" type="button">
             Ajouter un compte pro
         </button>
-        <div class="modal modal-lg fade" id="add-pro-user-modal" tabindex="-1"
-            aria-describedby="add-pro-user-modal-label" aria-hidden="true">
+        <div
+            class="modal modal-lg fade pc-add-pro-user-modal"
+            tabindex="-1"
+            aria-describedby="{{ add_pro_user_modal_label_id }}"
+            aria-hidden="true"
+        >
             <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content">
-                    <div class="modal-header fs-5" id="add-pro-user-modal-label">Ajouter un compte pro</div>
+                    <div class="modal-header fs-5" id="{{ add_pro_user_modal_label_id }}">Ajouter un compte pro</div>
                     <div class="mx-4 mt-4">Veuillez sélectionner le compte pro à rattacher à cette structure</div>
                     <form action="{{ add_user_dst }}" name="{{ add_user_dst | action_to_name }}" method="POST">
                         <div class="modal-body">

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/offerer_tag.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/offerer_tag.html
@@ -3,14 +3,25 @@
 {% extends "layouts/connected.html" %}
 
 {% block page %}
+    {% set create_offerer_tag_modal_label_id = random_hash() %}
+    {% set edit_offerer_tag_modal_label_id = random_hash() %}
+    {% set delete_offerer_tag_modal_label_id = random_hash() %}
     <div class="pt-3 px-5">
         <h2 class="fw-light">Tags structure</h2>
-        <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-                data-bs-target="#create-offerer-tag-modal" type="button">
+        <button
+            class="btn btn-outline-primary lead fw-bold mt-2"
+            data-bs-toggle="modal"
+            data-bs-target=".pc-create-offerer-tag-modal"
+            type="button"
+        >
             Créer un tag structure
         </button>
-        <div class="modal modal-lg fade" id="create-offerer-tag-modal" tabindex="-1"
-                aria-describedby="create-offerer-tag-modal-label" aria-hidden="true">
+        <div
+            class="modal modal-lg fade pc-create-offerer-tag-modal"
+            tabindex="-1"
+            aria-describedby="{{ create_offerer_tag_modal_label_id }}"
+            aria-hidden="true"
+        >
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
                     <form
@@ -19,7 +30,7 @@
                         method="POST"
                         data-turbo="false"
                     >
-                        <div class="modal-header" id="create-offerer-tag-modal-label">
+                        <div class="modal-header" id="{{ create_offerer_tag_modal_label_id }}">
                             <h5 class="modal-title">Créer un tag structure</h5>
                         </div>
                         <div class="modal-body row">
@@ -52,14 +63,21 @@
                     <tr>
                         <td>
                             <div class="dropdown">
-                                <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
-                                        class="btn p-0"><i
-                                        class="bi bi-three-dots-vertical"></i></button>
+                                <button
+                                    type="button"
+                                    data-bs-toggle="dropdown"
+                                    aria-expanded="false"
+                                    class="btn p-0"
+                                >
+                                    <i class="bi bi-three-dots-vertical"></i>
+                                </button>
                                 <ul class="dropdown-menu">
                                     <li class="dropdown-item p-0">
-                                        <a class="btn btn-sm d-block w-100 text-start px-3"
-                                                data-bs-toggle="modal"
-                                                data-bs-target="#edit-offerer-tag-modal-{{ offerer_tag.id }}">
+                                        <a
+                                            class="btn btn-sm d-block w-100 text-start px-3"
+                                            data-bs-toggle="modal"
+                                            data-bs-target=".pc-edit-offerer-tag-modal-{{ offerer_tag.id }}"
+                                        >
                                                 Modifier le tag structure
                                         </a>
                                     </li>
@@ -67,14 +85,18 @@
                                         <li class="dropdown-item p-0">
                                             <a class="btn btn-sm d-block w-100 text-start px-3"
                                                     data-bs-toggle="modal"
-                                                    data-bs-target="#delete-offerer-tag-modal-{{ offerer_tag.id }}">
+                                                    data-bs-target=".pc-delete-offerer-tag-modal-{{ offerer_tag.id }}">
                                                     Supprimer le tag structure
                                             </a>
                                         </li>
                                     {% endif %}
                                 </ul>
-                                <div class="modal modal-lg fade" id="edit-offerer-tag-modal-{{ offerer_tag.id }}" tabindex="-1"
-                                    aria-labelledby="edit-offerer-tag-modal-{{ offerer_tag.id }}-label" aria-hidden="true">
+                                <div
+                                    class="modal modal-lg fade pc-edit-offerer-tag-modal-{{ offerer_tag.id }}"
+                                    tabindex="-1"
+                                    aria-labelledby="{{ edit_offerer_tag_modal_label_id }}"
+                                    aria-hidden="true"
+                                >
                                     <div class="modal-dialog modal-dialog-centered">
                                         <div class="modal-content">
                                             <form
@@ -83,7 +105,7 @@
                                                 method="POST"
                                                 data-turbo="false"
                                             >
-                                                <div class="modal-header" id="edit-offerer-tag-modal-{{ offerer_tag.id }}-label">
+                                                <div class="modal-header" id="{{ edit_offerer_tag_modal_label_id }}">
                                                     <h5 class="modal-title">Modifier le tag {{ offerer_tag.name }}</h5>
                                                 </div>
                                                 <div class="modal-body row">
@@ -98,8 +120,12 @@
                                     </div>
                                 </div>
                                 {% if has_permission("DELETE_OFFERER_TAG") %}
-                                    <div class="modal modal-lg fade" id="delete-offerer-tag-modal-{{ offerer_tag.id }}" tabindex="-1"
-                                        aria-labelledby="delete-offerer-tag-modal-{{ offerer_tag.id }}-label" aria-hidden="true">
+                                    <div
+                                        class="modal modal-lg fade pc-delete-offerer-tag-modal-{{ offerer_tag.id }}"
+                                        tabindex="-1"
+                                        aria-labelledby="{{ delete_offerer_tag_modal_label_id }}"
+                                        aria-hidden="true"
+                                    >
                                         <div class="modal-dialog modal-dialog-centered">
                                             <div class="modal-content">
                                                 <form
@@ -108,7 +134,7 @@
                                                     method="POST"
                                                     data-turbo="false"
                                                 >
-                                                    <div class="modal-header" id="delete-offerer-tag-modal-{{ offerer_tag.id }}-label">
+                                                    <div class="modal-header" id="{{ delete_offerer_tag_modal_label_id }}">
                                                         <h5 class="modal-title">Supprimer le tag {{ offerer_tag.name }}</h5>
                                                     </div>
                                                     <div class="modal-body row">

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/comment.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/comment.html
@@ -1,13 +1,22 @@
 {% macro build_comment_modal(dst, form) %}
-    <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-        data-bs-target="#add-comment-pro-user-modal" type="button">
+    {% set add_comment_modal_label_id = random_hash() %}
+    <button
+        class="btn btn-outline-primary lead fw-bold mt-2"
+        data-bs-toggle="modal"
+        data-bs-target=".pc-add-comment-pro-user-modal"
+        type="button"
+    >
         Ajouter un commentaire
     </button>
-    <div class="modal modal-lg fade" id="add-comment-pro-user-modal" tabindex="-1"
-        aria-describedby="add-comment-pro-user-modal-label" aria-hidden="true">
+    <div
+        class="modal modal-lg fade pc-add-comment-pro-user-modal"
+        tabindex="-1"
+        aria-describedby="{{ add_comment_modal_label_id }}"
+        aria-hidden="true"
+    >
         <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
-                <div class="modal-header fs-5" id="add-comment-pro-user-modal-label">
+                <div class="modal-header fs-5" id="{{ add_comment_modal_label_id }}">
                     {{ caller() }}
                 </div>
                 <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">
@@ -24,8 +33,11 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-outline-primary"
-                                data-bs-dismiss="modal">
+                        <button
+                            type="button"
+                            class="btn btn-outline-primary"
+                            data-bs-dismiss="modal"
+                        >
                             Annuler
                         </button>
                         <button type="submit" class="btn btn-primary">Commenter</button>

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -1,5 +1,5 @@
 {% from "components/badges.html" import build_pro_user_status_badge %}
-{% from "components/generic_modal.html" import build_modal_form %}
+{% from "components/generic_modal.html" import build_modal_form with context %}
 {% from "components/forms.html" import build_form_fields_group with context %}
 
 {% extends "layouts/pro.html" %}
@@ -32,15 +32,24 @@
                     </div>
                     <div class="col-2">
                         {% if has_permission("MANAGE_PRO_ENTITY") %}
-                            <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-                                    data-bs-target="#edit-pro-user-modal" type="button">
+                            {% set edit_pro_user_information_label_id = random_hash() %}
+                            <button
+                                class="btn btn-outline-primary lead fw-bold mt-2"
+                                data-bs-toggle="modal"
+                                data-bs-target=".pc-edit-pro-user-modal"
+                                type="button"
+                            >
                                 Modifier les informations
                             </button>
-                            <div class="modal modal-lg fade" id="edit-pro-user-modal" tabindex="-1"
-                                aria-describedby="edit-pro-user-modal-label" aria-hidden="true">
+                            <div
+                                class="modal modal-lg fade pc-edit-pro-user-modal"
+                                tabindex="-1"
+                                aria-describedby="{{ edit_pro_user_information_label_id }}"
+                                aria-hidden="true"
+                            >
                                 <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                                     <div class="modal-content">
-                                        <div class="modal-header fs-5" id="edit-pro-user-modal-label">
+                                        <div class="modal-header fs-5" id="{{ edit_pro_user_information_label_id }}">
                                             Modification des informations
                                             de {{ user.firstName }} {{ user.lastName | upper }}</div>
                                         <form action="{{ dst }}" name="{{ dst | action_to_name }}" method="POST">

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -49,13 +49,22 @@
                             </div>
                         {% endif %}
                         {% if has_permission("DELETE_PRO_ENTITY") %}
-                            <button class="btn btn-outline-primary lead fw-bold mt-2" data-bs-toggle="modal"
-                            data-bs-target="#delete-venue-modal" type="button">
+                            {% set delete_venue_modal_label_id = random_hash() %}
+                            <button
+                                class="btn btn-outline-primary lead fw-bold mt-2"
+                                data-bs-toggle="modal"
+                                data-bs-target=".pc-delete-venue-modal"
+                                type="button"
+                            >
                                 <i class="bi bi-trash3-fill"></i>
                                 Supprimer le lieu
                             </button>
-                            <div class="modal modal-lg fade" id="delete-venue-modal" tabindex="-1"
-                                aria-describedby="delete-venue-modal-label" aria-hidden="true">
+                            <div
+                                class="modal modal-lg fade pc-delete-venue-modal"
+                                tabindex="-1"
+                                aria-describedby="{{ delete_venue_modal_label_id }}"
+                                aria-hidden="true"
+                            >
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div class="modal-content">
                                         <form
@@ -85,13 +94,13 @@
                         {% endif %}
                     </div>
                 </div>
-                
+
                 {% if venue.publicName != venue.name %}
                     <p class="card-subtitle text-muted mb-3 h5">
                         Nom d'usage : {{ venue.publicName }}
                     </p>
                 {% endif %}
-                
+
                 <p class="card-subtitle text-muted mb-3 h5">
                     Venue ID : {{ venue.id }}
                 </p>

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -1,5 +1,6 @@
 from functools import wraps
 import logging
+import random
 import typing
 
 from flask import Blueprint
@@ -106,3 +107,7 @@ def is_user_offerer_action_type(action: history_models.ActionHistory) -> bool:
         history_models.ActionType.USER_OFFERER_REJECTED,
     }
     return action.actionType in user_offerer_action_types
+
+
+def random_hash() -> str:
+    return format(random.getrandbits(128), "x")

--- a/api/src/pcapi/static/backoffice/css/base.css
+++ b/api/src/pcapi/static/backoffice/css/base.css
@@ -1,4 +1,4 @@
-#pc-header-top {
+.pc-header-top {
     background: linear-gradient(to right, rgb(var(--bs-primary-rgb)), rgb(var(--bs-secondary-rgb)));
 }
 

--- a/api/src/pcapi/static/backoffice/js/addons/pc-batch-confirm.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-batch-confirm.js
@@ -160,7 +160,7 @@ class PcBatchConfirm extends PcAddOn {
               data-form-name="user-offerer-validation-form-${identifier}"
               rows="3"
             ></textarea>
-            <label for=${identifier}-textarea"><label for="comment">Raison</label></label>
+            <label for="user-offerer-validation-form-textarea-${identifier}"><label for="comment">Raison</label></label>
             <div class="text-muted text-end"><small>Maj+Entrée pour ajouter une nouvelle ligne</small></div>
           </div>
         </div>

--- a/api/src/pcapi/templates/admin/booking.html
+++ b/api/src/pcapi/templates/admin/booking.html
@@ -30,7 +30,7 @@
     frauduleusement) alors qu'elle a en fait été utilisée, il est
     possible de la désannuler.
 </p>
-<form action={{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }} method="POST">
+<form action="{{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }}" method="POST">
     {{ forms.display_form(mark_as_used_form) }}
     <input class="btn btn-danger" type="submit" value="Désannuler">
 </form>
@@ -41,7 +41,7 @@
     Annuler cette réservation manuellement.
     <br>
 </p>
-<form action={{ url_for(".cancel", booking_id=booking.id) }} method="POST">
+<form action="{{ url_for(".cancel", booking_id=booking.id) }}" method="POST">
     {{ forms.display_form(cancel_form) }}
     <input class="btn btn-danger" type="submit" value="Marquer comme annulée"{% if booking.status.value == 'USED' %}
         onclick="return confirm('Êtes-vous sûr de vouloir annuler une réservation validée ?')" {% endif %}>

--- a/api/src/pcapi/templates/admin/collective_booking.html
+++ b/api/src/pcapi/templates/admin/collective_booking.html
@@ -31,7 +31,7 @@
     frauduleusement) alors qu'elle a en fait été utilisée, il est
     possible de la désannuler.
 </p>
-<form action={{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }} method="POST">
+<form action="{{ url_for(".uncancel_and_mark_as_used", booking_id=booking.id) }}" method="POST">
     {{ forms.display_form(mark_as_used_form) }}
     <input class="btn btn-danger" type="submit" value="Désannuler">
 </form>
@@ -42,7 +42,7 @@
     Annuler cette réservation manuellement.
     <br>
 </p>
-<form action={{ url_for(".cancel", booking_id=booking.id) }} method="POST">
+<form action="{{ url_for(".cancel", booking_id=booking.id) }}" method="POST">
     {{ forms.display_form(cancel_form) }}
     <input class="btn btn-danger" type="submit" value="Marquer comme annulée"{% if booking.status.value == 'USED' %}
         onclick="return confirm('Êtes-vous sûr de vouloir annuler une réservation validée ?')" {% endif %}>

--- a/api/src/pcapi/templates/admin/list_user_email_history.html
+++ b/api/src/pcapi/templates/admin/list_user_email_history.html
@@ -1,8 +1,8 @@
 {% extends 'admin/model/list.html' %}
 
-{% block list_row_actions %} 
+{% block list_row_actions %}
     {% if row.eventType.value == enum_update_request_value %}
-        <form action={{ url_for(".validate_user_email", entry_id=get_pk_value(row)) }} method="POST">
+        <form action="{{ url_for(".validate_user_email", entry_id=get_pk_value(row)) }}" method="POST">
             <button
                 class="btn btn-secondary"
                 onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ row.newEmail }}')"

--- a/api/src/pcapi/templates/admin/support_beneficiary_details.html
+++ b/api/src/pcapi/templates/admin/support_beneficiary_details.html
@@ -78,8 +78,8 @@
                 Revue manuelle non disponible (aucun fraud check avec nom, prénom, date de naissance)
             </button>
             {% endif %}
-        {% endif %}  
-        
+        {% endif %}
+
         {% if current_user.has_admin_role %}
         <button name="submit" form="validate_form_button" type="submit" class="btn btn-primary">Valider le n° de
             téléphone
@@ -296,12 +296,15 @@
             {% if current_user.is_super_admin() %}
             <td>
                 {% if email_history.eventType.value == enum_update_request_value %}
-                <form action={{ url_for(
-                "user_email_history.validate_user_email", entry_id=email_history.id,
-                next="support_beneficiary.details_view" , id=model.id) }} method="POST">
-                <button class="btn btn-secondary"
-                        onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
-                        title="Approve">
+                <form
+                    action="{{ url_for("user_email_history.validate_user_email", entry_id=email_history.id, next="support_beneficiary.details_view" , id=model.id) }}"
+                    method="POST"
+                >
+                <button
+                    class="btn btn-secondary"
+                    onclick="return confirm('Êtes-vous certain de vouloir valider l\'adresse email {{ email_history.newEmail }}')"
+                    title="Approve"
+                >
                     Valider
                 </button>
                 </form>

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -415,7 +415,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
 
         response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
 
-        bookings = html_parser.extract_table_rows(response.data, parent_id="bookings-tab-pane")
+        bookings = html_parser.extract_table_rows(response.data, parent_class="bookings-tab-pane")
         assert len(bookings) == 2
 
         assert bookings[0]["Offreur"] == b2.offerer.name
@@ -443,7 +443,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
 
         response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
 
-        assert not html_parser.extract_table_rows(response.data, parent_id="bookings-tab-pane")
+        assert not html_parser.extract_table_rows(response.data, parent_class="bookings-tab-pane")
         assert "Aucune réservation à ce jour" in response.data.decode("utf-8")
 
     def test_fraud_check_link(self, authenticated_client):
@@ -465,15 +465,18 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
 
         parsed_html = html_parser.get_soup(response.data)
-        main_dossier_card = str(parsed_html.find(id="main-check-item"))
+
+        main_dossier_card = str(
+            parsed_html.find("div", class_="pc-script-user-accounts-additional-data-main-fraud-check")
+        )
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{old_dms.source_data().procedure_number}/dossiers/{old_dms.thirdPartyId}"
             in main_dossier_card
         )
 
-        old_ubble_card = str(parsed_html.find(id=old_ubble.thirdPartyId))
+        old_ubble_card = str(parsed_html.find("div", class_=old_ubble.thirdPartyId))
         assert f"https://dashboard.ubble.ai/identifications/{old_ubble.thirdPartyId}" in old_ubble_card
-        old_dms_card = str(parsed_html.find(id=old_dms.thirdPartyId))
+        old_dms_card = str(parsed_html.find("div", class_=old_dms.thirdPartyId))
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{old_dms.source_data().procedure_number}/dossiers/{old_dms.thirdPartyId}"
             in old_dms_card
@@ -488,12 +491,14 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
 
         parsed_html = html_parser.get_soup(response.data)
-        main_dossier_card = str(parsed_html.find(id="main-check-item"))
+        main_dossier_card = str(
+            parsed_html.find("div", class_="pc-script-user-accounts-additional-data-main-fraud-check")
+        )
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{new_dms.source_data().procedure_number}/dossiers/{new_dms.thirdPartyId}"
             in main_dossier_card
         )
-        new_dms_card = str(parsed_html.find(id=new_dms.thirdPartyId))
+        new_dms_card = str(parsed_html.find("div", class_=new_dms.thirdPartyId))
         assert (
             f"https://www.demarches-simplifiees.fr/procedures/{new_dms.source_data().procedure_number}/dossiers/{new_dms.thirdPartyId}"
             in new_dms_card
@@ -531,7 +536,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
 
         # then
         assert response.status_code == 200
-        history_rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        history_rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(history_rows) == 5
 
         assert history_rows[0]["Type"] == "Étape de vérification"

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -237,7 +237,7 @@ class UpdateOffererTest:
         assert offerer_to_edit.postalCode == new_postal_code
         assert offerer_to_edit.address == new_address
 
-        history_rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        history_rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(history_rows) == 1
         assert history_rows[0]["Type"] == history_models.ActionType.INFO_MODIFIED.value
         assert f"Ville : {old_city} => {offerer_to_edit.city}" in history_rows[0]["Commentaire"]
@@ -272,7 +272,7 @@ class UpdateOffererTest:
         assert updated_offerer.postalCode == "29200"
         assert updated_offerer.address == "Place de la Liberté"
 
-        history_rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        history_rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(history_rows) == 1
         assert history_rows[0]["Type"] == history_models.ActionType.INFO_MODIFIED.value
         assert history_rows[0]["Auteur"] == legit_user.full_name
@@ -496,7 +496,7 @@ class GetOffererDetailsTest:
 
         assert response.status_code == 200
 
-        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(rows) == 1
         assert rows[0]["Type"] == history_models.ActionType.COMMENT.value
         assert rows[0]["Commentaire"] == action.comment
@@ -522,7 +522,7 @@ class GetOffererDetailsTest:
 
         assert response.status_code == 200
 
-        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(rows) == 1
         assert rows[0]["Type"] == history_models.ActionType.OFFERER_NEW.value
         assert rows[0]["Commentaire"] == action.comment
@@ -541,7 +541,7 @@ class GetOffererDetailsTest:
             response = authenticated_client.get(url)
 
         assert response.status_code == 200
-        assert html_parser.count_table_rows(response.data, parent_id="history-tab-pane") == 0
+        assert html_parser.count_table_rows(response.data, parent_class="history-tab-pane") == 0
 
     def test_action_name_depends_on_type(self, authenticated_client, offerer):
         admin_user = users_factories.AdminFactory()
@@ -628,7 +628,7 @@ class GetOffererDetailsTest:
 
         # then
         assert response.status_code == 200
-        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(rows) == 4
 
         assert rows[0]["Type"] == "Structure validée"
@@ -722,7 +722,7 @@ class GetOffererDetailsTest:
         assert response.status_code == 200
 
         parsed_html = html_parser.get_soup(response.data)
-        select = parsed_html.find(id="pro_user_id")
+        select = parsed_html.find("select", attrs={"name": "pro_user_id"})
         options = select.find_all("option")
         assert [option["value"] for option in options] == ["", str(user3.id), str(user2.id)]
 

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -206,7 +206,7 @@ class GetProUserHistoryTest:
             response = authenticated_client.get(url)
 
         assert response.status_code == 200
-        rows = html_parser.extract_table_rows(response.data, parent_id="history-tab-pane")
+        rows = html_parser.extract_table_rows(response.data, parent_class="history-tab-pane")
         assert len(rows) == 2
 
         assert rows[0]["Type"] == history_models.ActionType.USER_SUSPENDED.value
@@ -229,7 +229,7 @@ class GetProUserHistoryTest:
             response = authenticated_client.get(url)
 
         assert response.status_code == 200
-        assert html_parser.count_table_rows(response.data, parent_id="history-tab-pane") == 0
+        assert html_parser.count_table_rows(response.data, parent_class="history-tab-pane") == 0
 
 
 class CommentProUserTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20876

## But de la pull request

Actuellement, nous utilisons des id pour des composants réutilisable, ce qui empêche si l'on souhaite rester sémantiquement correct au yeux de la w3c, de réutiliser un composant.

Ceci peut également avoir un impact sur l'API du DOM, afin d'éviter l'accumulation de dette technique, ce nettoyage est nécessaire.

## Implémentation

- Éviter le risque d'avoir deux identifiant unique dans la page
- Suppression de tout les ids (sauf pour checkbox/radio/accessibility, mais nous n'avons encore rien de tel)
- TODO: remove `id` from csrf input

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
