### PR TITLE
(PC-20984)[CI] Fix: values not passed to sub job

### DIFF
--- a/.github/update-jira-issues.sh
+++ b/.github/update-jira-issues.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Iterate over a list of commits. For each commits, grab the github commit number and update the jira ticket
+# to get all commits since last run use the command : 
+# `git log XXX..  --pretty=format:"%H" --reverse >> file.txt`
+# where XXX is the last commit
 
 JIRA_BINARY="$HOME/go/bin/jira"
 

--- a/.github/workflows/update-jira-issues.yml
+++ b/.github/workflows/update-jira-issues.yml
@@ -22,10 +22,8 @@ jobs:
       - name: Get commit info
         id: get_commit_info
         run: |
-          COMMIT_NUMBER=$(git rev-list --count HEAD)
-          COMMIT_HASH=$(git rev-parse HEAD)
-          echo "::set-output name=number::$COMMIT_NUMBER"
-          echo "::set-output name=hash::$COMMIT_HASH"
+          echo "commit-number=$(git rev-list --count HEAD)" >> $GITHUB_OUTPUT
+          echo "commit-hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Setup gajira cli
         uses: atlassian/gajira-cli@master
@@ -86,7 +84,8 @@ jobs:
         env:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         # The jira view command uses .jira.d/templates/view template by default
-        run: echo "::set-output name=value::$(jira view ${{ needs.issue-number.outputs.status }})"
+        run: |
+          echo "value=$(jira view ${{ needs.issue-number.outputs.status }})" >> $GITHUB_OUTPUT
 
       - name: Mark issue as not deployable
         env:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20984

## But de la pull request

Les deux valeurs de `needs.issue-number.outputs.commit-number ` et `${{ needs.issue-number.outputs.commit-hash }}` ne sont pas bine passées au sous job. 

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
