### PR TITLE
(PC-20964)[API] fix: Rendre le champs pondération optionnel

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offer.py
@@ -36,4 +36,4 @@ class EditOfferForm(FlaskForm):
     criteria = fields.PCAutocompleteSelectMultipleField(
         "Tags", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_criteria"
     )
-    rankingWeight = fields.PCIntegerField("Pondération")
+    rankingWeight = fields.PCOptIntegerField("Pondération")

--- a/api/tests/routes/backoffice_v3/offers_test.py
+++ b/api/tests/routes/backoffice_v3/offers_test.py
@@ -227,9 +227,8 @@ class EditOffersTest:
         assert criteria[1].name in row[0]["Tag"]
         assert criteria[2].name not in row[0]["Tag"]
 
-        # New Update
-        choosenRankingWeight = 25
-        base_form = {"criteria": [criteria[2].id, criteria[1].id], "rankingWeight": choosenRankingWeight}
+        # New Update without rankingWeight
+        base_form = {"criteria": [criteria[2].id, criteria[1].id], "rankingWeight": ""}
         response = self._update_offerer(authenticated_client, offer_to_edit, base_form)
         assert response.status_code == 303
 
@@ -239,7 +238,7 @@ class EditOffersTest:
         assert response.status_code == 200
         row = html_parser.extract_table_rows(response.data)
         assert len(row) == 1
-        assert row[0]["Pondération"] == str(choosenRankingWeight)
+        assert row[0]["Pondération"] == ""
         assert criteria[2].name in row[0]["Tag"]
         assert criteria[1].name in row[0]["Tag"]
         assert criteria[0].name not in row[0]["Tag"]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20964

## But de la pull request

Rendre optionnel le champ `rankingweight` du formulaire d'édition des offres. 

## Implémentation

Création d'un champs `PCOptIntegerField`
Mise en place des vérifications adéquates pour afficher le champs en tant que champs nombre. 

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
