### PR TITLE
(PC-21011)[API] fix: fix validation error when stock remaingQuantity is "unlimited"

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -56,6 +56,11 @@ class OfferStockResponse(BaseModel):
     remainingQuantity: int | None
 
     _convert_price = validator("price", pre=True, allow_reuse=True)(convert_to_cent)
+    _convert_remainingQuantity = validator(
+        "remainingQuantity",
+        pre=True,
+        allow_reuse=True,
+    )(lambda quantity: quantity if quantity != "unlimited" else None)
 
     class Config:
         orm_mode = True
@@ -86,9 +91,6 @@ class OfferStockResponse(BaseModel):
 
         price_category = getattr(stock, "priceCategory", None)
         stock_response.priceCategoryLabel = price_category.priceCategoryLabel.label if price_category else None
-        stock_response.remainingQuantity = (
-            stock.remainingQuantity if stock.remainingQuantity != "unlimited" else None  # type: ignore [assignment]
-        )
 
         return stock_response
 

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -213,6 +213,17 @@ class OffersTest:
         }
         assert response.json["withdrawalDetails"] == "modalité de retrait"
 
+    def test_get_offer_with_unlimited_stock(self, client):
+        product = ProductFactory(thumbCount=1, subcategoryId=subcategories.ABO_MUSEE.id)
+        offer = OfferFactory(product=product, venue__isPermanent=True)
+        ThingStockFactory(offer=offer, price=12.34, quantity=None)
+
+        with assert_no_duplicated_queries():
+            response = client.get(f"/native/v1/offer/{offer.id}")
+
+        assert response.status_code == 200
+        assert response.json["stocks"][0]["remainingQuantity"] is None
+
     def test_get_thing_offer(self, app):
         product = ProductFactory(thumbCount=1, subcategoryId=subcategories.ABO_MUSEE.id)
         offer = OfferFactory(product=product, venue__isPermanent=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21011

## But de la pull request

corriger un bug intervenant quand on cherche à renvoyer le `remainingQuantity` d'une offre avec un stock illimité

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
