### PR TITLE
(BSR)[*] ci: Fix color in Slack notification on build failure

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -128,13 +128,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "PCAPI Deployment",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Le déploiement de la version `master` a ${{ fromJSON('["réussi", "échoué"]')[env.WORKFLOW_CONCLUSION == 'failure'] }} sur `testing` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Le déploiement de la version `master` a échoué sur `testing` :boom:"
               }
             ],
             "unfurl_links": false,

--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -130,13 +130,13 @@ jobs:
             "attachments": [
               {
                 "mrkdwn_in": ["text"],
-                "color": "${{ fromJSON('["#36a64f", "#A30002"]')[ env.WORKFLOW_CONCLUSION == 'failure'] }}",
+                "color": "#A30002",
                 "author_name": "${{github.actor}}",
                 "author_link": "https://github.com/${{github.actor}}",
                 "author_icon": "https://github.com/${{github.actor}}.png",
                 "title": "Pro tests",
                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests unitaires de pro échouent sur `master` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                "text": "Les tests unitaires de pro échouent sur `master` :boom:"
               }
             ],
             "unfurl_links": false,


### PR DESCRIPTION
... and simplify code for deployment failure. In both cases, we're in
a block that is only triggered on a failure.

Same as e70c38d94acb964671d732d11a7ada863df14578.