### PR TITLE
(BSR)[API] ci: Replace set-output by $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/mypy-cop.yml
+++ b/.github/workflows/mypy-cop.yml
@@ -29,19 +29,18 @@ jobs:
           git checkout master --quiet
           master_ignore_count="$(grep "type: ignore" -r src | wc -l)"
           git checkout - --quiet
-          echo "::set-output name=this_branch_ignore_count::$this_branch_ignore_count"
-          echo "::set-output name=master_ignore_count::$master_ignore_count"
+          echo "this_branch_ignore_count=$this_branch_ignore_count" >> $GITHUB_OUTPUT
+          echo "master_ignore_count=$master_ignore_count" >> $GITHUB_OUTPUT
       - name: Create mypy cop report
         id: mypy-cop
         run: |
           cd api
           body="$(./mypy_cop.sh ${{ steps.mypy-ignore-counter.outputs.master_ignore_count }} ${{ steps.mypy-ignore-counter.outputs.this_branch_ignore_count }} )"
-          # Escape output, otherwise only its first line will be stored by `set-ouput` below.
-          # See https://github.community/t/set-output-truncates-multiline-strings/16852
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=body::$body"
+          # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "body<<$EOF" >> $GITHUB_OUTPUT
+          echo "$body" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
       - name: Find Comment
         if: steps.changes.outputs.src == 'true'
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/update-api-client-template.yml
+++ b/.github/workflows/update-api-client-template.yml
@@ -39,7 +39,7 @@ jobs:
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [[ "$changed_file" == "pro/yarn.lock" || "$changed_file" == "adage-front/yarn.lock" || "$changed_file" == "api/requirements.txt" ]];
               then
-                echo ::set-output name=dependency-change::'true'
+                echo "dependency-change=true" >> $GITHUB_OUTPUT
             fi
           done
 
@@ -48,9 +48,9 @@ jobs:
         run: |
           if ${{ (!inputs.trigger-only-on-api-change && !inputs.trigger-only-on-dependency-change) || (inputs.trigger-only-on-api-change && steps.changes-api.outputs.src == 'true') || (inputs.trigger-only-on-dependency-change && steps.check-dependency-change.outputs.dependency-change == 'true') }};
             then
-              echo ::set-output name=should-run-cache::'true'
+              echo "should-run-cache=true" >> $GITHUB_OUTPUT
             else
-              echo ::set-output name=should-run-cache::'false'
+              echo "should-run-cache=false" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/setup-node@v2
@@ -128,9 +128,9 @@ jobs:
         run: |
           if [[ -z "$(git status --porcelain $STATUS_ARGS $PATHSPEC)" ]];
             then
-              echo ::set-output name=changed::'false'
+              echo "changed=false" >> $GITHUB_OUTPUT
             else
-              echo ::set-output name=changed::'true'
+              echo "changed=true" >> $GITHUB_OUTPUT
             fi
 
       - name: Commit


### PR DESCRIPTION
`set-output` is deprecated and is planned to stop working starting 1st
June: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

J'ai ajouté 2 commits déclenchant mypy-cop et update-api-client, pour vérifier que ces 2 actions fonctionnent;