### PR TITLE
(PC-20781)[PRO] refactor: migrate generic component

### DIFF
--- a/pro/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom-v5-compat'
 
 import Stepper from 'components/Stepper'
 import { ReactComponent as BreadcumbSeparator } from 'icons/ico-breadcrumb-arrow-right.svg'

--- a/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
+++ b/pro/src/components/Breadcrumb/__specs__/Breadcrumb.spec.tsx
@@ -1,18 +1,14 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
-import { MemoryRouter } from 'react-router-dom'
 
 import type { Step } from 'components/Breadcrumb'
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Breadcrumb, { BreadcrumbStyle, IBreadcrumb } from '../Breadcrumb'
 
 const renderBreadcrumb = (props: IBreadcrumb) => {
-  return render(
-    <MemoryRouter>
-      <Breadcrumb {...props} />
-    </MemoryRouter>
-  )
+  renderWithProviders(<Breadcrumb {...props} />)
 }
 
 const onClick = jest.fn()

--- a/pro/src/components/DomainNameBanner/DomainNameBanner.jsx
+++ b/pro/src/components/DomainNameBanner/DomainNameBanner.jsx
@@ -23,7 +23,7 @@ export const DomainNameBanner = () => {
 
   const closeBanner = useCallback(() => {
     delete queryParams['redirect']
-    navigate({ search: stringify(queryParams), replace: true })
+    navigate({ search: stringify(queryParams) }, { replace: true })
 
     dispatch(setDisplayDomainBanner(false))
   }, [dispatch, history, queryParams])

--- a/pro/src/components/DomainNameBanner/DomainNameBanner.jsx
+++ b/pro/src/components/DomainNameBanner/DomainNameBanner.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat'
 
 import { setDisplayDomainBanner } from 'store/app/actions'
 import { Banner } from 'ui-kit'
@@ -8,7 +8,7 @@ import { parse, stringify } from 'utils/query-string'
 
 export const DomainNameBanner = () => {
   const dispatch = useDispatch()
-  const history = useHistory()
+  const navigate = useNavigate()
   const location = useLocation()
   const queryParams = parse(location.search)
   const shouldDisplayBanner = useSelector(
@@ -23,7 +23,7 @@ export const DomainNameBanner = () => {
 
   const closeBanner = useCallback(() => {
     delete queryParams['redirect']
-    history.replace({ search: stringify(queryParams) })
+    navigate({ search: stringify(queryParams), replace: true })
 
     dispatch(setDisplayDomainBanner(false))
   }, [dispatch, history, queryParams])

--- a/pro/src/components/Header/Header.jsx
+++ b/pro/src/components/Header/Header.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react'
-import { useDispatch } from 'react-redux'
-import { NavLink, useHistory, useLocation } from 'react-router-dom'
+import { NavLink, useNavigate, useLocation } from 'react-router-dom-v5-compat'
 
 import { Events } from 'core/FirebaseEvents/constants'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -17,16 +16,15 @@ import Logo from 'ui-kit/Logo/Logo'
 
 const Header = () => {
   const { currentUser } = useCurrentUser()
-  const dispatch = useDispatch()
-  const history = useHistory()
+  const navigate = useNavigate()
   const { logEvent } = useAnalytics()
   const location = useLocation()
   const isOffererStatsActive = useActiveFeature('ENABLE_OFFERER_STATS')
 
   const onSignoutClick = useCallback(() => {
     logEvent?.(Events.CLICKED_LOGOUT, { from: location.pathname })
-    history.push('/logout')
-  }, [dispatch, history, logEvent, location.pathname])
+    navigate('/logout')
+  }, [navigate, logEvent, location.pathname])
   return (
     <header className="menu-v2">
       <nav>

--- a/pro/src/hooks/__specs__/useAnalytics.spec.tsx
+++ b/pro/src/hooks/__specs__/useAnalytics.spec.tsx
@@ -10,7 +10,6 @@ import { useConfigureFirebase } from '../useAnalytics'
 
 const mockSetLogEvent = jest.fn()
 
-
 jest.mock('@firebase/analytics', () => {
   return {
     getAnalytics: jest.fn().mockReturnValue('getAnalyticsReturn'),

--- a/pro/src/hooks/__specs__/useAnalytics.spec.tsx
+++ b/pro/src/hooks/__specs__/useAnalytics.spec.tsx
@@ -2,21 +2,14 @@ import * as firebaseAnalytics from '@firebase/analytics'
 import * as firebase from '@firebase/app'
 import { render, waitFor } from '@testing-library/react'
 import React from 'react'
-import { MemoryRouter, Route } from 'react-router'
+import { MemoryRouter } from 'react-router'
 
 import { firebaseConfig } from 'config/firebase'
-import { AnalyticsContextProvider } from 'context/analyticsContext'
-import { Events } from 'core/FirebaseEvents/constants'
-import useLogNavigation from 'hooks/useLogNavigation'
 
 import { useConfigureFirebase } from '../useAnalytics'
 
 const mockSetLogEvent = jest.fn()
 
-const NavigationLogger = (): null => {
-  useLogNavigation()
-  return null
-}
 
 jest.mock('@firebase/analytics', () => {
   return {
@@ -83,50 +76,4 @@ test('should set logEvent and userId', async () => {
     expect(mockSetLogEvent).toHaveBeenCalledTimes(1)
     expect(mockSetLogEvent).toHaveBeenNthCalledWith(1, expect.any(Function))
   })
-})
-
-const renderFakeAppWithTrackedLinks = () => {
-  return render(
-    <AnalyticsContextProvider>
-      <MemoryRouter
-        initialEntries={[
-          '/structures?utm_campaign=push_offre_local&utm_medium=batch&utm_source=push',
-        ]}
-      >
-        <NavigationLogger />
-        <FakeAppWithTrackedLinks>
-          <Route path="/structures">
-            <h1>Fake Structure</h1>
-          </Route>
-        </FakeAppWithTrackedLinks>
-      </MemoryRouter>
-    </AnalyticsContextProvider>
-  )
-}
-
-interface IFakeAppProps {
-  children: JSX.Element
-}
-const FakeAppWithTrackedLinks = ({ children }: IFakeAppProps): JSX.Element => {
-  useConfigureFirebase('userId')
-  return children
-}
-
-test('should trigger a logEvent', async () => {
-  await renderFakeAppWithTrackedLinks()
-  await waitFor(() => {
-    expect(firebaseAnalytics.logEvent).toHaveBeenNthCalledWith(
-      1,
-      'getAnalyticsReturn',
-      Events.PAGE_VIEW,
-      {
-        from: '/structures',
-        traffic_campaign: 'push_offre_local',
-        traffic_medium: 'batch',
-        traffic_source: 'push',
-        A: 'true',
-      }
-    )
-  })
-  expect(firebaseAnalytics.logEvent).toHaveBeenCalledTimes(1)
 })

--- a/pro/src/hooks/useLogNavigation.ts
+++ b/pro/src/hooks/useLogNavigation.ts
@@ -1,30 +1,20 @@
-import type { Location, LocationListener } from 'history'
 import { useEffect } from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import { Events } from 'core/FirebaseEvents/constants'
 
 import useAnalytics from './useAnalytics'
 
-const useLogNavigation = (): LocationListener | void => {
-  const history = useHistory()
+const useLogNavigation = (): void => {
   const location = useLocation()
   const { logEvent } = useAnalytics()
+
   useEffect(() => {
     if (logEvent) {
       logEvent?.(Events.PAGE_VIEW, { from: location.pathname })
     }
-  }, [logEvent])
-
-  useEffect(() => {
-    if (logEvent) {
-      const unlisten = history.listen((nextLocation: Location) => {
-        logEvent?.(Events.PAGE_VIEW, { from: nextLocation.pathname })
-      })
-      return unlisten
-    }
     return
-  }, [location, history, logEvent])
+  }, [location, logEvent])
 }
 
 export default useLogNavigation

--- a/pro/src/screens/CsvTable/CsvTable.tsx
+++ b/pro/src/screens/CsvTable/CsvTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom-v5-compat'
 
 import type { ITableData } from 'screens/CsvTable'
 import Spinner from 'ui-kit/Spinner/Spinner'

--- a/pro/src/screens/EmailChangeValidation/__specs__/EmailChangeValidation.spec.tsx
+++ b/pro/src/screens/EmailChangeValidation/__specs__/EmailChangeValidation.spec.tsx
@@ -1,18 +1,15 @@
 // react-testing-library doc: https://testing-library.com/docs/react-testing-library/api
 
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { MemoryRouter } from 'react-router'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { EmailChangeValidationScreen } from '../'
 
 describe('screens:EmailChangeValidation', () => {
   it('renders component successfully when success', async () => {
-    render(
-      <MemoryRouter>
-        <EmailChangeValidationScreen isSuccess={true} />
-      </MemoryRouter>
-    )
+    renderWithProviders(<EmailChangeValidationScreen isSuccess={true} />)
 
     expect(
       screen.getByText('Et voilà !', {
@@ -21,11 +18,7 @@ describe('screens:EmailChangeValidation', () => {
     ).toBeInTheDocument()
   })
   it('renders component successfully when not success', () => {
-    render(
-      <MemoryRouter>
-        <EmailChangeValidationScreen isSuccess={false} />
-      </MemoryRouter>
-    )
+    renderWithProviders(<EmailChangeValidationScreen isSuccess={false} />)
     expect(
       screen.getByText('Votre lien a expiré !', {
         selector: 'h1',

--- a/pro/src/ui-kit/Hero/Hero.tsx
+++ b/pro/src/ui-kit/Hero/Hero.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom-v5-compat'
 
 import styles from './Hero.module.scss'
 

--- a/pro/src/ui-kit/Logo/Logo.jsx
+++ b/pro/src/ui-kit/Logo/Logo.jsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router-dom-v5-compat'
 
 import { ROOT_PATH } from 'utils/config'
 

--- a/pro/src/ui-kit/Logo/__specs__/Logo.spec.jsx
+++ b/pro/src/ui-kit/Logo/__specs__/Logo.spec.jsx
@@ -1,15 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
-import { MemoryRouter } from 'react-router'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
 
 import Logo from '../Logo'
 
 const renderLogo = props => {
-  return render(
-    <MemoryRouter>
-      <Logo {...props} />
-    </MemoryRouter>
-  )
+  return renderWithProviders(<Logo {...props} />)
 }
 
 describe('header logo', () => {

--- a/pro/src/ui-kit/Logo/__specs__/Logo.spec.jsx
+++ b/pro/src/ui-kit/Logo/__specs__/Logo.spec.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
 
 import { renderWithProviders } from 'utils/renderWithProviders'


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20781

## But de la pull request

- Migration de plusieurs composants génériques pour utiliser route v6

## Implémentation

- pro/src/components/Header/Header.jsx
- pro/src/components/Breadcrumb/Breadcrumb.tsx
- pro/src/hooks/useLogNavigation.ts
- pro/src/components/DomainNameBanner/DomainNameBanner.jsx
- pro/src/ui-kit/Logo/Logo.jsx
- pro/src/ui-kit/Hero/Hero.tsx
- pro/src/screens/CsvTable/CsvTable.tsx
- Tests