### PR TITLE
(PC-21062)[API] feat: remove offer isDuo from bookings, and add booki…

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
@@ -24,7 +24,7 @@
                 <td>{{ links.build_offer_name_to_pc_pro_link(booking.stock.offer) }}</td>
                 <td>
                     {{ booking.amount | format_amount }}
-                    {% if booking.stock.offer.isDuo %}(Duo){% endif %}
+                    {% if booking.stock.offer.isDuo and booking.quantity == 2 %}(Duo){% endif %}
                 </td>
                 <td>{{ booking.dateCreated | format_date("Le %d/%m/%Y à %Hh%M") }}</td>
                 <td>{{ booking.status | format_booking_status_long | safe }}</td>

--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -28,7 +28,7 @@
                         <th scope="col">Bénéficiaire</th>
                         <th scope="col">Nom de l'offre</th>
                         <th scope="col">ID offre</th>
-                        <th scope="col">Offre duo</th>
+                        <th scope="col">Résa duo</th>
                         <th scope="col">Stock</th>
                         <th scope="col">Montant</th>
                         <th scope="col">Statut</th>
@@ -135,7 +135,7 @@
                             <td>{{ links.build_public_user_name_to_details_link(booking.user) }}</td>
                             <td>{{ links.build_offer_name_to_pc_pro_link(offer) }}</td>
                             <td>{{ links.a_offer_name_to_details(offer, text_attr="id") }}</td>
-                            <td>{{ offer.isDuo | format_bool }}</td>
+                            <td>{{ (offer.isDuo and booking.quantity == 2) | format_bool }}</td>
                             <td>{{ booking.stock.quantity }}</td>
                             <td>{{ booking.total_amount | format_amount }}</td>
                             <td>{{ booking.status | format_booking_status(with_badge=True) | safe }}</td>

--- a/api/tests/routes/backoffice_v3/individual_bookings_test.py
+++ b/api/tests/routes/backoffice_v3/individual_bookings_test.py
@@ -38,6 +38,7 @@ def bookings_fixture() -> tuple:
         token="WTRL00",
         stock__price="15.2",
         stock__quantity="212",
+        stock__offer__isDuo=True,
         stock__offer__product__name="Guide du Routard Sainte-Hélène",
         stock__offer__product__subcategoryId=subcategories_v2.LIVRE_PAPIER.id,
         dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4),
@@ -108,7 +109,7 @@ class ListIndividualBookingsTest:
         assert rows[0]["Bénéficiaire"].startswith("Napoléon Bonaparte (")
         assert rows[0]["Nom de l'offre"] == "Guide du Routard Sainte-Hélène"
         assert rows[0]["ID offre"].isdigit()
-        assert rows[0]["Offre duo"] == "Non"
+        assert rows[0]["Résa duo"] == "Oui"
         assert rows[0]["Stock"] == "212"
         assert rows[0]["Montant"] == "30,40 €"
         assert rows[0]["Statut"] == "Validée"
@@ -157,7 +158,7 @@ class ListIndividualBookingsTest:
         assert row["Contremarque"] == "ELBEIT"
         assert row["Bénéficiaire"].startswith("Napoléon Bonaparte (")
         assert row["Nom de l'offre"] == "Guide Ile d'Elbe 1814 Petit Futé"
-        assert row["Offre duo"] == "Non"
+        assert row["Résa duo"] == "Non"
         assert row["Stock"] == "2"
         assert row["Montant"] == "13,95 €"
         assert row["Statut"] == "Confirmée"


### PR DESCRIPTION
…ng isduo

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21062

## But de la pull request

Ajout de l'info Résa duo (offre duo ET quantité réservée = 2) dans la page des réservations individuelles.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
