### PR TITLE
(BSR)[API] fix: Fix `send_booking_cancellation_by_beneficiary_email` and test

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation.py
@@ -47,6 +47,12 @@ def get_booking_cancellation_confirmation_by_pro_email_data(
         stock_name, venue.name
     )
     ongoing_stock_bookings = find_ongoing_bookings_by_stock(booking.stock.id)
+    try:
+        # Booking is (being) cancelled, but the query here may still
+        # return it if changes have not been saved yet.
+        ongoing_stock_bookings.remove(booking)
+    except ValueError:
+        pass
     stock_date_time = None
     booking_is_on_event = booking.stock.beginningDatetime is not None
     if booking_is_on_event:

--- a/api/tests/emails/offer_cancellation_test.py
+++ b/api/tests/emails/offer_cancellation_test.py
@@ -49,9 +49,8 @@ class MakeOffererDrivenCancellationEmailForOffererTest:
             email.subject
             == f"Confirmation de votre annulation de réservation pour {stock.offer.name}, proposé par {venue.name}"
         )
-        # FIXME (tgabin, 2022-01-27): test below should work but html_no_recap return None
-        # html_no_recap = str(email_html.find("p", {"id": "no-recap"}))
-        # assert "Aucune réservation" in html_no_recap
+        html_no_recap = str(email_html.find("p", {"id": "no-recap"}))
+        assert "Aucune réservation" in html_no_recap
 
     @pytest.mark.usefixtures("db_session")
     def test_offer_cancellation_confirmation_by_offerer_event_when_other_booking(self, app):


### PR DESCRIPTION
This function is (usually) called by an asynchronous task. When the
task is performed, the status of the booking has been changed in the
database, so the booking does not appear in the e-mail. But it does in
the rare cases where the function is not called by an asynchronous
task.