### PR TITLE
(PC-20945)[API] feat: split user suspension and unsuspension permission

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -26,7 +26,8 @@ class Permissions(enum.Enum):
     REVIEW_PUBLIC_ACCOUNT = "faire une revue manuelle d'un compte bénéficiaire/grand public"
     MANAGE_PUBLIC_ACCOUNT = "gérer un compte bénéficiaire/grand public"
 
-    SUSPEND_USER = "suspendre ou réactiver un compte utilisateur"
+    SUSPEND_USER = "suspendre un compte utilisateur"
+    UNSUSPEND_USER = "réactiver un compte utilisateur"
 
     SEARCH_PRO_ACCOUNT = "rechercher un acteur culturel"
     READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"

--- a/api/src/pcapi/routes/backoffice_v3/forms/user.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/user.py
@@ -27,16 +27,15 @@ def get_toggle_suspension_args(user: users_models.User) -> dict:
     """
     Additional arguments which must be passed to render_template when the page may show suspend/unsuspend button.
     """
-    if not has_current_user_permission(perm_models.Permissions.SUSPEND_USER):
-        return {}
 
-    if user.isActive:
+    if user.isActive and has_current_user_permission(perm_models.Permissions.SUSPEND_USER):
         return {
             "suspension_form": SuspendUserForm(),
             "suspension_dst": url_for("backoffice_v3_web.users.suspend_user", user_id=user.id),
         }
-
-    return {
-        "suspension_form": UnsuspendUserForm(),
-        "suspension_dst": url_for("backoffice_v3_web.users.unsuspend_user", user_id=user.id),
-    }
+    if not user.isActive and has_current_user_permission(perm_models.Permissions.UNSUSPEND_USER):
+        return {
+            "suspension_form": UnsuspendUserForm(),
+            "suspension_dst": url_for("backoffice_v3_web.users.unsuspend_user", user_id=user.id),
+        }
+    return {}

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -143,14 +143,16 @@
 
                     </div>
                     <div class="d-flex flex-column ms-auto align-items-end justify-content-around">
-                        {% if has_permission("SUSPEND_USER") %}
+                        {% if has_permission("SUSPEND_USER") and user.isActive %}
                             <div>
-                                {% if user.isActive %}
-                                    {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
-                                {% else %}
-                                    {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
-                                {% endif %}
+                                {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
                             </div>
+                        {% elif has_permission("UNSUSPEND_USER") and not user.isActive %}
+                            <div>
+                                {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
+                            </div>
+                        {% endif %}
+                        {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
                             <button class="btn btn-outline-primary lead fw-bold mt-2 justify-content-end" data-bs-toggle="modal"
                                     data-bs-target="#review-public-account-modal" type="button">
                                 Revue manuelle

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -68,12 +68,10 @@
                                 </div>
                             </div>
                         {% endif %}
-                        {% if has_permission("SUSPEND_USER") %}
-                            {% if user.isActive %}
-                                {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
-                            {% else %}
-                                {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
-                            {% endif %}
+                        {% if has_permission("SUSPEND_USER") and user.isActive %}
+                            {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
+                        {% elif has_permission("UNSUSPEND_USER") and not user.isActive %}
+                            {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
                         {% endif %}
                     </div>
                 </div>

--- a/api/src/pcapi/routes/backoffice_v3/users.py
+++ b/api/src/pcapi/routes/backoffice_v3/users.py
@@ -19,7 +19,6 @@ users_blueprint = utils.child_backoffice_blueprint(
     "users",
     __name__,
     url_prefix="/users/<int:user_id>",
-    permission=perm_models.Permissions.SUSPEND_USER,
 )
 
 
@@ -36,6 +35,7 @@ def _redirect_to_user_page(user: users_models.User) -> utils.BackofficeResponse:
 
 
 @users_blueprint.route("/suspend", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.SUSPEND_USER)
 def suspend_user(user_id: int) -> utils.BackofficeResponse:
     user = users_models.User.query.get_or_404(user_id)
 
@@ -52,6 +52,7 @@ def suspend_user(user_id: int) -> utils.BackofficeResponse:
 
 
 @users_blueprint.route("/unsuspend", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.UNSUSPEND_USER)
 def unsuspend_user(user_id: int) -> utils.BackofficeResponse:
     user = users_models.User.query.get_or_404(user_id)
 

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -74,14 +74,15 @@ def permission_required(permission: perm_models.Permissions) -> typing.Callable:
 
 
 def child_backoffice_blueprint(
-    name: str, import_name: str, url_prefix: str, permission: perm_models.Permissions
+    name: str, import_name: str, url_prefix: str, permission: perm_models.Permissions | None = None
 ) -> Blueprint:
     child_blueprint = Blueprint(name, import_name, url_prefix=url_prefix)
     blueprint.backoffice_v3_web.register_blueprint(child_blueprint)
 
     @child_blueprint.before_request
     def check_permission() -> None:
-        _check_permission(permission)
+        if permission:
+            _check_permission(permission)
 
     return child_blueprint
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -16,6 +16,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT,
+        perm_models.Permissions.SUSPEND_USER,
     ],
     "support-PRO": [
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
@@ -37,6 +38,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT,
         perm_models.Permissions.SUSPEND_USER,
+        perm_models.Permissions.UNSUSPEND_USER,
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.VALIDATE_OFFERER,

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -341,7 +341,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
             return url_for("backoffice_v3_web.public_accounts.get_public_account", user_id=user.id)
 
     class UnsuspendButtonTest(button_helpers.ButtonHelper):
-        needed_permission = perm_models.Permissions.SUSPEND_USER
+        needed_permission = perm_models.Permissions.UNSUSPEND_USER
         button_label = "Réactiver le compte"
 
         @property

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -39,6 +39,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.SEARCH_PUBLIC_ACCOUNT,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT,
+        perm_models.Permissions.SUSPEND_USER,
     ],
     "support-PRO": [
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
@@ -60,6 +61,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.REVIEW_PUBLIC_ACCOUNT,
         perm_models.Permissions.SUSPEND_USER,
+        perm_models.Permissions.UNSUSPEND_USER,
         perm_models.Permissions.SEARCH_PRO_ACCOUNT,
         perm_models.Permissions.READ_PRO_ENTITY,
         perm_models.Permissions.VALIDATE_OFFERER,

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -71,7 +71,7 @@ class GetProUserTest:
             return url_for("backoffice_v3_web.pro_user.get", user_id=user.id)
 
     class UnsuspendButtonTest(button_helpers.ButtonHelper):
-        needed_permission = perm_models.Permissions.SUSPEND_USER
+        needed_permission = perm_models.Permissions.UNSUSPEND_USER
         button_label = "Réactiver le compte"
 
         @property

--- a/api/tests/routes/backoffice_v3/users_test.py
+++ b/api/tests/routes/backoffice_v3/users_test.py
@@ -21,7 +21,6 @@ pytestmark = [
 class PostUserTestHelper(unauthorized_helpers.UnauthorizedHelperWithCsrf):
     method = "post"
     endpoint_kwargs = {"user_id": 1}
-    needed_permission = perm_models.Permissions.SUSPEND_USER
 
     def _post_request(self, authenticated_client, user_id, form):
         # generate csrf token before request
@@ -32,6 +31,7 @@ class PostUserTestHelper(unauthorized_helpers.UnauthorizedHelperWithCsrf):
 
 class SuspendUserTest(PostUserTestHelper):
     endpoint = "backoffice_v3_web.users.suspend_user"
+    needed_permission = perm_models.Permissions.SUSPEND_USER
 
     def test_suspend_beneficiary_user(self, authenticated_client, legit_user):
         user = users_factories.BeneficiaryGrant18Factory()
@@ -104,6 +104,7 @@ class SuspendUserTest(PostUserTestHelper):
 
 class UnsuspendUserTest(PostUserTestHelper):
     endpoint = "backoffice_v3_web.users.unsuspend_user"
+    needed_permission = perm_models.Permissions.UNSUSPEND_USER
 
     def test_unsuspend_beneficiary_user(self, authenticated_client, legit_user):
         user = users_factories.BeneficiaryGrant18Factory(isActive=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20945

## But de la pull request

Séparation de la permission de suspension et réactivation de compte en deux permissions (une action chacune)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
