### PR TITLE
(PC-21101)[API] fix: Allocine sync when projection attribute is empty

### DIFF
--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -295,7 +295,9 @@ def retrieve_showtime_information(showtime_information: dict) -> dict:
 def _filter_only_digital_and_non_experience_showtimes(showtimes_information: list[dict]) -> list[dict]:
     return list(
         filter(
-            lambda showtime: showtime["projection"][0] == DIGITAL_PROJECTION and showtime["experience"] is None,
+            lambda showtime: showtime["projection"]
+            and showtime["projection"][0] == DIGITAL_PROJECTION
+            and showtime["experience"] is None,
             showtimes_information,
         )
     )

--- a/api/tests/local_providers/allocine_stocks_functions_test.py
+++ b/api/tests/local_providers/allocine_stocks_functions_test.py
@@ -279,6 +279,12 @@ class FilterOnlyDigitalAndNonExperiencedShowtimesTest:
                 "projection": ["NON DIGITAL"],
                 "experience": None,
             },
+            {
+                "startsAt": "2019-12-03T22:00:00",
+                "diffusionVersion": "LOCAL",
+                "projection": None,
+                "experience": None,
+            },
         ]
 
         # When


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21101

## But de la pull request

Corriger les erreurs de synchronisation Allociné lorsque l'attribut projection est vide

## Implémentation

dans _`filter_only_digital_and_non_experience_showtimes()`, ignorer les séances pour lesquelles `projection` est vide
