### PR TITLE
(BSR)[API] feat: Remove is_eligible_for_strict_search for old apps

### DIFF
--- a/api/src/pcapi/algolia_settings_venues.json
+++ b/api/src/pcapi/algolia_settings_venues.json
@@ -18,7 +18,6 @@
     ],
     "attributesForFaceting": [
         "filterOnly(has_at_least_one_bookable_offer)",
-        "filterOnly(is_eligible_for_strict_search)",
         "filterOnly(tags)",
         "filterOnly(venue_type)"
     ],

--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -492,8 +492,6 @@ class AlgoliaBackend(base.SearchBackend):
             "tags": [criterion.name for criterion in venue.criteria],
             "banner_url": venue.bannerUrl,
             "_geoloc": position(venue),
-            # TODO: remove "is_eligible_for_strict_search" key when the app does not use it anymore
-            "is_eligible_for_strict_search": has_at_least_one_bookable_offer,
             "has_at_least_one_bookable_offer": has_at_least_one_bookable_offer,
         }
 

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -42,7 +42,6 @@ def get_settings() -> serializers.SettingsResponse:
         enable_phone_validation=features[FeatureToggle.ENABLE_PHONE_VALIDATION],
         id_check_address_autocompletion=features[FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION],
         is_recaptcha_enabled=features[FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA],
-        # TODO(antoinewg): remove this after next forced release (> v1.166.3)
         object_storage_url=OBJECT_STORAGE_URL,
         pro_disable_events_qrcode=features[FeatureToggle.PRO_DISABLE_EVENTS_QRCODE],
         account_unsuspension_limit=constants.ACCOUNT_UNSUSPENSION_DELAY,

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -250,17 +250,18 @@ def test_serialize_venue():
         "tags": [],
         "banner_url": venue.bannerUrl,
         "_geoloc": {"lng": float(venue.longitude), "lat": float(venue.latitude)},
-        "is_eligible_for_strict_search": False,
         "has_at_least_one_bookable_offer": False,
     }
 
 
 def test_serialize_venue_with_one_bookable_offer():
     venue = offerers_factories.VenueFactory(isPermanent=True)
-    offers_factories.EventStockFactory(offer__venue=venue)
 
     serialized = algolia.AlgoliaBackend().serialize_venue(venue)
-    assert serialized["is_eligible_for_strict_search"]
+    assert not serialized["has_at_least_one_bookable_offer"]
+
+    offers_factories.EventStockFactory(offer__venue=venue)
+    serialized = algolia.AlgoliaBackend().serialize_venue(venue)
     assert serialized["has_at_least_one_bookable_offer"]
 
 


### PR DESCRIPTION
The `is_eligible_for_strict_search` attribute has been renamed as
`has_at_least_one_bookable_offer` in app since pass-culture/pass-culture-app-native@f78fff6b3ff4c44e13a8a9773ea2631a13b82434,
which was first released in app version 194. The minimal version is
way past that, we can stop indexing data under the old name.

---

+ 1 commit bonus de suppression d'un FIXME oublié, cf. détail dans le message de commit. ;)