### PR TITLE
(PC-20986)[PRO] feat: handle max price validation in yup schema for c…

### DIFF
--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
@@ -23,9 +23,8 @@ export interface IFormStockProps {
 const FormStock = ({
   mode,
   disablePriceAndParticipantInputs,
-  preventPriceIncrease,
 }: IFormStockProps): JSX.Element => {
-  const { values, setFieldValue, initialValues } =
+  const { values, setFieldValue } =
     useFormikContext<OfferEducationalStockFormValues>()
 
   return (
@@ -63,7 +62,6 @@ const FormStock = ({
         smallLabel
         step={0.01} // allow user to enter a price with cents
         type="number"
-        {...(preventPriceIncrease ? { max: initialValues.totalPrice } : {})}
         rightIcon={() => <EuroIcon />}
       />
       <DatePicker

--- a/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
@@ -10,7 +10,7 @@ import {
   Mode,
   OfferEducationalStockFormValues,
 } from 'core/OfferEducational'
-import { validationSchema } from 'screens/OfferEducationalStock/validationSchema'
+import { generateValidationSchema } from 'screens/OfferEducationalStock/validationSchema'
 import { SubmitButton } from 'ui-kit'
 
 import FormStock, { IFormStockProps } from '../FormStock'
@@ -28,7 +28,10 @@ const renderFormStock = ({
     <Formik
       initialValues={initialValues}
       onSubmit={onSubmit}
-      validationSchema={validationSchema}
+      validationSchema={generateValidationSchema(
+        props.preventPriceIncrease,
+        initialValues.totalPrice
+      )}
     >
       <Form>
         <FormStock {...props} />
@@ -123,7 +126,13 @@ describe('TimePicker', () => {
     const priceInput = screen.getByLabelText('Prix global TTC')
     await userEvent.clear(priceInput)
     await userEvent.type(priceInput, '10000')
+    const saveButton = screen.getByText('Enregistrer')
+
+    await userEvent.click(saveButton)
 
     expect(priceInput).toBeInvalid()
+    expect(
+      screen.getByText('Vous ne pouvez pas définir un prix plus élevé.')
+    ).toBeInTheDocument()
   })
 })

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -28,8 +28,8 @@ import FormStock from './FormStock'
 import styles from './OfferEducationalStock.module.scss'
 import ShowcaseBannerInfo from './ShowcaseBannerInfo'
 import {
+  generateValidationSchema,
   showcaseOfferValidationSchema,
-  validationSchema,
 } from './validationSchema'
 
 export interface IOfferEducationalStockProps<
@@ -61,9 +61,10 @@ const OfferEducationalStock = <
 
   const preventPriceIncrease = Boolean(
     isCollectiveOffer(offer) &&
-      offer.lastBookingStatus === CollectiveBookingStatus.USED &&
-      beginningDatetime &&
-      isBefore(new Date(), addDays(new Date(beginningDatetime), 2))
+      (offer.lastBookingStatus === CollectiveBookingStatus.CONFIRMED ||
+        (offer.lastBookingStatus === CollectiveBookingStatus.USED &&
+          beginningDatetime &&
+          isBefore(new Date(), addDays(new Date(beginningDatetime), 2))))
   )
 
   const disablePriceAndParticipantInputs =
@@ -88,8 +89,13 @@ const OfferEducationalStock = <
     validationSchema: yup.lazy((values: OfferEducationalStockFormValues) => {
       const isShowcase =
         values.educationalOfferType === EducationalOfferType.SHOWCASE
-
-      return isShowcase ? showcaseOfferValidationSchema : validationSchema
+      /* istanbul ignore next: TO FIX remove this condition as we should not have template offer here */
+      return isShowcase
+        ? showcaseOfferValidationSchema
+        : generateValidationSchema(
+            preventPriceIncrease,
+            initialValues.totalPrice
+          )
     }),
   })
 

--- a/pro/src/screens/OfferEducationalStock/validationSchema.ts
+++ b/pro/src/screens/OfferEducationalStock/validationSchema.ts
@@ -26,38 +26,57 @@ const isBeforeEventDate = (
   return bookingLimitDatetime < context.parent.eventDate
 }
 
-export const validationSchema = yup.object().shape({
-  eventDate: yup
-    .date()
+export const generateValidationSchema = (
+  preventPriceIncrease: boolean,
+  initialPrice: number | ''
+) => {
+  let totalPriceValidation = yup
+    .number()
     .nullable()
+    .min(0, 'Nombre positif attendu')
     .required('Champ requis')
-    .min(
-      todayAtMidnight(),
-      "La date de l’évènement doit être supérieure à aujourd'hui"
-    ),
-  eventTime: yup.string().nullable().required('Champ requis'),
-  numberOfPlaces: yup
-    .number()
-    .nullable()
-    .min(0, 'Nombre positif attendu')
-    .required('Champ requis'),
-  totalPrice: yup
-    .number()
-    .nullable()
-    .min(0, 'Nombre positif attendu')
-    .required('Champ requis'),
-  bookingLimitDatetime: yup
-    .date()
-    .notRequired()
-    .test({
-      name: 'is-one-true',
-      message:
-        'La date limite de réservation doit être fixée au plus tard le jour de l’évènement',
-      test: isBeforeEventDate,
-    })
-    .nullable(),
-  priceDetail: yup.string().nullable().max(MAX_DETAILS_LENGTH),
-})
+  if (preventPriceIncrease && initialPrice) {
+    totalPriceValidation = totalPriceValidation.max(
+      initialPrice,
+      'Vous ne pouvez pas définir un prix plus élevé.'
+    )
+  }
+
+  return yup.object().shape({
+    eventDate: yup
+      .date()
+      .nullable()
+      .required('Champ requis')
+      .when([], {
+        is: () => preventPriceIncrease === false,
+        then: yup
+          .date()
+          .min(
+            todayAtMidnight(),
+            "La date de l’évènement doit être supérieure à aujourd'hui"
+          ),
+        otherwise: yup.date(),
+      }),
+    eventTime: yup.string().nullable().required('Champ requis'),
+    numberOfPlaces: yup
+      .number()
+      .nullable()
+      .min(0, 'Nombre positif attendu')
+      .required('Champ requis'),
+    totalPrice: totalPriceValidation,
+    bookingLimitDatetime: yup
+      .date()
+      .notRequired()
+      .test({
+        name: 'is-one-true',
+        message:
+          'La date limite de réservation doit être fixée au plus tard le jour de l’évènement',
+        test: isBeforeEventDate,
+      })
+      .nullable(),
+    priceDetail: yup.string().nullable().max(MAX_DETAILS_LENGTH),
+  })
+}
 
 export const showcaseOfferValidationSchema = yup
   .object()


### PR DESCRIPTION
…ollective stock

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20986

## But de la pull request

Valider le changement de prix d'une offre collective via yup plutôt que la validation directement sur l'input. 

Contexte : 

Il est désormais possible de modifier le **prix seulement à la baisse** pour les offres collectives associés à une réservation confirmée ou terminée + 48h 