### PR TITLE
(PC-21128)[PRO] fix: remove frame-ancestors from meta tag (not suppor…

### DIFF
--- a/pro/public/index.html
+++ b/pro/public/index.html
@@ -1,33 +1,46 @@
 <!DOCTYPE html>
 <html lang="fr">
-
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, shrink-to-fit=no">
-  <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="theme-color" content="#000000">
-  <meta name="version" content="%VERSION%">
-  <% if (process.env.NODE_ENV==='development' ) { %>
-    <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-TMqfN40yv4Oy3FCUUn4u+Oh+eomT/tIw0/9GHc52ino='; connect-src 'self' data: https: http: ws://*:3001 wss://*:3001; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, user-scalable=no, shrink-to-fit=no"
+    />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="version" content="%VERSION%" />
+    <% if (process.env.NODE_ENV==='development' ) { %>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-TMqfN40yv4Oy3FCUUn4u+Oh+eomT/tIw0/9GHc52ino='; connect-src 'self' data: https: http: ws://*:3001 wss://*:3001; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'"
+    />
     <% } else { %>
-      <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-lsVG3dRRjbLAsQIz53z4zymQ5Vw0cFQnOqNnY5sCuSM='; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline';frame-ancestors https://bv.ac-versailles.fr/">
-      <% } %>
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-        <link rel="shortcut icon" href="%PUBLIC_URL%/icon/app-icon-iphone.png">
-        <link rel="apple-touch-icon" href="%PUBLIC_URL%/icon/app-icon-iphone.png">
-        <title>pass Culture Pro</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <noscript>pass Culture Pro a besoin de JavaScript pour fonctionner.</noscript>
-  <% if (process.env.REACT_APP_ENVIRONMENT_NAME==='testing' ) { %>
-    <script>var beamer_config = { product_id: "vjbiYuMS52566" };</script>
-    <script type="text/javascript" src="https://app.getbeamer.com/js/beamer-embed.js" defer="defer"></script>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' blob: data: https: http: gap://ready https://*.hotjar.com:* https://*.hotjar.io wss://*.hotjar.com https://*.getbeamer.com/ 'sha256-lsVG3dRRjbLAsQIz53z4zymQ5Vw0cFQnOqNnY5sCuSM='; style-src 'self' https://app.getbeamer.com/styles/beamer-embed.css https://fonts.googleapis.com/css 'unsafe-inline'"
+    />
     <% } %>
-</body>
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/icon/app-icon-iphone.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/icon/app-icon-iphone.png" />
+    <title>pass Culture Pro</title>
+  </head>
 
+  <body>
+    <div id="root"></div>
+    <noscript
+      >pass Culture Pro a besoin de JavaScript pour fonctionner.</noscript
+    >
+    <% if (process.env.REACT_APP_ENVIRONMENT_NAME==='testing' ) { %>
+    <script>
+      var beamer_config = { product_id: 'vjbiYuMS52566' }
+    </script>
+    <script
+      type="text/javascript"
+      src="https://app.getbeamer.com/js/beamer-embed.js"
+      defer="defer"
+    ></script>
+    <% } %>
+  </body>
 </html>


### PR DESCRIPTION
…ted)

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21128

## But de la pull request

Enlever le frame-ancestors de la balise meta car il n'est pas supporté dans le tag <meta>. (On va surement déplacer ce paramétrage côté infra)
