### PR TITLE
(BSR)[API] fix: accounts button

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -115,58 +115,58 @@
                 {% endif %}
               </div>
             </div>
-            <div class="d-flex flex-column ms-auto align-items-end justify-content-around">
-              {% if has_permission("SUSPEND_USER") and user.isActive %}
-                <div>
-                  {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
-                </div>
-              {% elif has_permission("UNSUSPEND_USER") and not user.isActive %}
-                <div>
-                  {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
-                </div>
-              {% endif %}
-              {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
-                <button class="btn btn-outline-primary lead fw-bold mt-2 justify-content-end"
-                        data-bs-toggle="modal"
-                        data-bs-target="#review-public-account-modal"
-                        type="button">
-                  Revue manuelle
-                </button>
-                <div class="modal modal-lg fade"
-                     id="review-public-account-modal"
-                     tabindex="-1"
-                     aria-labelledby="review-public-account-modal-label"
-                     aria-hidden="true">
-                  <div class="modal-dialog modal-dialog-centered">
-                    <div class="modal-content">
-                      <form action="{{ url_for(".review_public_account", user_id=user.id) }}"
-                            name="{{ url_for(".review_public_account", user_id=user.id) | action_to_name }}"
-                            method="post">
-                        <div class="modal-header">
-                          <h5 class="modal-title">Revue manuelle</h5>
+          </div>
+          <div class="d-flex flex-column ms-auto align-items-end justify-content-around">
+            {% if has_permission("SUSPEND_USER") and user.isActive %}
+              <div>
+                {{ build_modal_form("suspend", suspension_dst, suspension_form, "Suspendre le compte", "Confirmer la suspension") }}
+              </div>
+            {% elif has_permission("UNSUSPEND_USER") and not user.isActive %}
+              <div>
+                {{ build_modal_form("unsuspend", suspension_dst, suspension_form, "Réactiver le compte", "Confirmer la réactivation") }}
+              </div>
+            {% endif %}
+            {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
+              <button class="btn btn-outline-primary lead fw-bold mt-2 justify-content-end"
+                      data-bs-toggle="modal"
+                      data-bs-target="#review-public-account-modal"
+                      type="button">
+                Revue manuelle
+              </button>
+              <div class="modal modal-lg fade"
+                   id="review-public-account-modal"
+                   tabindex="-1"
+                   aria-labelledby="review-public-account-modal-label"
+                   aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                  <div class="modal-content">
+                    <form action="{{ url_for(".review_public_account", user_id=user.id) }}"
+                          name="{{ url_for(".review_public_account", user_id=user.id) | action_to_name }}"
+                          method="post">
+                      <div class="modal-header">
+                        <h5 class="modal-title">Revue manuelle</h5>
+                      </div>
+                      <div class="modal-body">
+                        <div class="form-floating my-3">
+                          {{ build_form_fields_group(manual_review_form) }}
                         </div>
-                        <div class="modal-body">
-                          <div class="form-floating my-3">
-                            {{ build_form_fields_group(manual_review_form) }}
-                          </div>
-                        </div>
-                        <div class="modal-footer">
-                          <button type="button"
-                                  class="btn btn-outline-primary"
-                                  data-bs-dismiss="modal">
-                            Annuler
-                          </button>
-                          <button type="submit"
-                                  class="btn btn-primary">
-                            Enregistrer
-                          </button>
-                        </div>
-                      </form>
-                    </div>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button"
+                                class="btn btn-outline-primary"
+                                data-bs-dismiss="modal">
+                          Annuler
+                        </button>
+                        <button type="submit"
+                                class="btn btn-primary">
+                          Enregistrer
+                        </button>
+                      </div>
+                    </form>
                   </div>
                 </div>
-              {% endif %}
-            </div>
+              </div>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## But de la pull request

Suite à l'ajout de `djlint`, une balise manquante `</div>` a été fermé en pied de page, alors qu'elle aurait du l'etre au milieu provoquant cet affichage:

![image](https://user-images.githubusercontent.com/77674046/225700325-6a6d7c2a-12dd-4b2f-a22a-e491a06ec21f.png)


La PR corrige pour remettre comme c'est actuellement en production:

![image](https://user-images.githubusercontent.com/77674046/225700396-8a744a62-8e68-4727-8cc5-98adcd9301fb.png)


## Implémentation

NA

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
