### PR TITLE
(BSR)[API] chore: Provide stub for mypy to notice our monkeypatch of `logging`

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -38,8 +38,10 @@ multi_line_output = 3
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"
 use_parentheses = true
 
+
 [tool.mypy]
 python_version = "3.10"
+mypy_path = "stubs/"
 disallow_untyped_defs = true
 follow_imports = "silent"
 ignore_missing_imports = true

--- a/api/src/pcapi/admin/custom_views/offer_view.py
+++ b/api/src/pcapi/admin/custom_views/offer_view.py
@@ -312,7 +312,11 @@ class OfferView(BaseAdminView):
                 )
                 transactional_mails.send_offer_validation_status_update_email(offer, new_validation, recipients)
                 admin_emails.send_offer_validation_notification_to_administration(new_validation, offer)
-                logger.info("validation status updated", extra={"offer": offer.id, "offer_validation": offer.validation}, technical_message_id="offers.validation_updated")  # type: ignore [call-arg]
+                logger.info(
+                    "validation status updated",
+                    extra={"offer": offer.id, "offer_validation": offer.validation},
+                    technical_message_id="offers.validation_updated",
+                )
                 flash("Le statut de l'offre a bien été modifié", "success")
 
         search.async_index_offer_ids([offer.id])

--- a/api/src/pcapi/analytics/amplitude/backends/logger.py
+++ b/api/src/pcapi/analytics/amplitude/backends/logger.py
@@ -3,6 +3,9 @@ import logging
 from pcapi.analytics.amplitude.backends.amplitude_connector import AmplitudeEventType
 
 
+logger = logging.getLogger(__name__)
+
+
 class LoggerBackend:
     def track_event(
         self,
@@ -10,7 +13,7 @@ class LoggerBackend:
         event_name: AmplitudeEventType,
         event_properties: dict | None = None,
     ) -> None:
-        logging.info(
+        logger.info(
             "A request to track Amplitude event=%s would be sent for user with id=%d",
             event_name,
             user_id,

--- a/api/src/pcapi/connectors/beneficiaries/outscale.py
+++ b/api/src/pcapi/connectors/beneficiaries/outscale.py
@@ -29,10 +29,10 @@ def upload_file(user_id: str, file_path: str, file_name: str) -> bool:
         )
 
     except FileNotFoundError as e:
-        logging.warning(e)
+        logger.warning(e)
         return False
     except ClientError as e:
-        logging.exception(
+        logger.exception(
             "Could not upload file to Outscale bucket",
             extra={
                 "original_error_msg": e.msg,

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -217,7 +217,7 @@ def _cancel_booking(
         stock.dnBookedQuantity -= booking.quantity
         repository.save(booking, stock)
 
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         "Booking has been cancelled",
         extra={"booking_id": booking.id, "reason": str(reason)},
         technical_message_id="booking.cancelled",
@@ -325,7 +325,7 @@ def mark_as_used(booking: Booking) -> None:
     booking.mark_as_used()
     repository.save(booking)
 
-    logger.info("Booking was marked as used", extra={"booking_id": booking.id}, technical_message_id="booking.used")  # type: ignore [call-arg]
+    logger.info("Booking was marked as used", extra={"booking_id": booking.id}, technical_message_id="booking.used")
 
     update_external_user(booking.user)
 
@@ -381,7 +381,7 @@ def mark_as_unused(booking: Booking) -> None:
     booking.mark_as_unused_set_confirmed()
     repository.save(booking)
 
-    logger.info("Booking was marked as unused", extra={"booking_id": booking.id}, technical_message_id="booking.unused")  # type: ignore [call-arg]
+    logger.info("Booking was marked as unused", extra={"booking_id": booking.id}, technical_message_id="booking.unused")
 
     update_external_user(booking.user)
     update_external_pro(booking.venue.bookingEmail)

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -47,7 +47,7 @@ def log_information_for_data_purpose(
         user_id = get_hashed_user_id(user_email)
         extra_data["userId"] = user_id
 
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         event_name,
         extra={"analyticsSource": "adage", **extra_data},
         technical_message_id="collective_analytics_event",

--- a/api/src/pcapi/core/external/zendesk_sell.py
+++ b/api/src/pcapi/core/external/zendesk_sell.py
@@ -598,7 +598,7 @@ def do_update_offerer(offerer_id: int) -> None:
         try:
             zendesk_offerer_data = get_offerer_by_id(offerer)
         except ContactFoundMoreThanOneError as err:
-            logging.warning("Error while updating offerer in Zendesk Sell: %s", err, extra={"offerer_id": offerer.id})
+            logger.warning("Error while updating offerer in Zendesk Sell: %s", err, extra={"offerer_id": offerer.id})
         except ContactNotFoundError:
             if FeatureToggle.ENABLE_ZENDESK_SELL_CREATION.is_active():
                 zendesk_create_offerer(offerer)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -182,7 +182,7 @@ def create_offer(
 
     repository.add_to_session(offer)
 
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         "models.Offer has been created",
         extra={"offer_id": offer.id, "venue_id": venue.id, "product_id": offer.productId},
         technical_message_id="offer.created",
@@ -268,7 +268,7 @@ def update_offer(
     else:
         product_has_been_updated = False
 
-    logger.info("Offer has been updated", extra={"offer_id": offer.id}, technical_message_id="offer.updated")  # type: ignore [call-arg]
+    logger.info("Offer has been updated", extra={"offer_id": offer.id}, technical_message_id="offer.updated")
     if product_has_been_updated:
         logger.info("Product has been updated", extra={"product": offer.product.id})
 
@@ -364,7 +364,7 @@ def batch_update_offers(query: BaseQuery, update_fields: dict, send_email_notifi
     if "isActive" in update_fields.keys():
         message = "Offers has been activated" if update_fields["isActive"] else "Offers has been deactivated"
         technical_message_id = "offers.activated" if update_fields["isActive"] else "offers.deactivated"
-        logger.info(  # type: ignore [call-arg]
+        logger.info(
             message,
             extra={"offer_ids": offer_ids, "venue_id": venue_ids},
             technical_message_id=technical_message_id,
@@ -626,7 +626,7 @@ def publish_offer(offer: models.Offer, user: users_models.User | None) -> models
     offer.isActive = True
     update_offer_fraud_information(offer, user)
     search.async_index_offer_ids([offer.id])
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         "Offer has been published",
         extra={"offer_id": offer.id, "venue_id": offer.venueId, "offer_status": offer.status},
         technical_message_id="offer.published",
@@ -991,7 +991,11 @@ def update_pending_offer_validation(offer: models.Offer, validation_status: mode
     elif isinstance(offer, educational_models.CollectiveOfferTemplate):
         search.async_index_collective_offer_template_ids([offer.id])
     template = f"{type(offer)} validation status updated"
-    logger.info(template, extra={"offer": offer.id, "offer_validation": offer.validation}, technical_message_id="offers.validation_updated")  # type: ignore [call-arg]
+    logger.info(
+        template,
+        extra={"offer": offer.id, "offer_validation": offer.validation},
+        technical_message_id="offers.validation_updated",
+    )
     return True
 
 

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -62,7 +62,7 @@ def create_venue_provider(
         venue.isPermanent = True
         repository.save(venue)
 
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         "La synchronisation d'offre a été activée",
         extra={"venue_id": venue_id, "provider_id": provider_id},
         technical_message_id="offer.sync.activated",
@@ -135,7 +135,7 @@ def delete_venue_provider(venue_provider: providers_models.VenueProvider) -> Non
     venue_id = venue_provider.venueId
     provider_name = venue_provider.provider.name
     repository.delete(venue_provider)
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         "Deleted VenueProvider for venue %d",
         venue_id,
         extra={"venue_id": venue_id, "provider_name": provider_name},
@@ -153,7 +153,7 @@ def update_venue_provider(
         update_venue_synchronized_offers_active_status_job.delay(
             venue_provider.venueId, venue_provider.providerId, venue_provider.isActive
         )
-        logger.info(  # type: ignore [call-arg]
+        logger.info(
             "Updated VenueProvider %s isActive attribut to %s",
             venue_provider.id,
             venue_provider.isActive,

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -33,7 +33,7 @@ def check_user_and_credentials(user: models.User | None, password: str, allow_in
         crypto.check_password(password, HASHED_PLACEHOLDER)
         raise exceptions.InvalidIdentifier()
     if not (user.checkPassword(password) and (user.isActive or allow_inactive)):
-        logging.info(  # type: ignore [call-arg]
+        logger.info(  # type: ignore [call-arg]
             "Failed authentication attempt",
             extra={"user": user.id, "avoid_current_user": True, "success": False},
             technical_message_id="users.login",
@@ -47,7 +47,7 @@ def get_user_with_credentials(identifier: str, password: str, allow_inactive: bo
     user = find_user_by_email(identifier)
     check_user_and_credentials(user, password, allow_inactive)
     if user:
-        logging.info(  # type: ignore [call-arg]
+        logger.info(  # type: ignore [call-arg]
             "Successful authentication attempt",
             extra={"user": user.id, "avoid_current_user": True, "success": True},
             technical_message_id="users.login",

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -33,7 +33,7 @@ def check_user_and_credentials(user: models.User | None, password: str, allow_in
         crypto.check_password(password, HASHED_PLACEHOLDER)
         raise exceptions.InvalidIdentifier()
     if not (user.checkPassword(password) and (user.isActive or allow_inactive)):
-        logger.info(  # type: ignore [call-arg]
+        logger.info(
             "Failed authentication attempt",
             extra={"user": user.id, "avoid_current_user": True, "success": False},
             technical_message_id="users.login",
@@ -47,7 +47,7 @@ def get_user_with_credentials(identifier: str, password: str, allow_inactive: bo
     user = find_user_by_email(identifier)
     check_user_and_credentials(user, password, allow_inactive)
     if user:
-        logger.info(  # type: ignore [call-arg]
+        logger.info(
             "Successful authentication attempt",
             extra={"user": user.id, "avoid_current_user": True, "success": True},
             technical_message_id="users.login",

--- a/api/src/pcapi/routes/native/v1/cookies_consent.py
+++ b/api/src/pcapi/routes/native/v1/cookies_consent.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
     api=blueprint.api,
 )
 def cookies_consent(body: serializers.CookieConsentRequest) -> None:
-    logger.info(  # type: ignore [call-arg]
+    logger.info(
         "Cookies consent",
         extra={"analyticsSource": "app-native", **body.dict()},
         technical_message_id="cookies_consent",

--- a/api/stubs/logging/__init__.pyi
+++ b/api/stubs/logging/__init__.pyi
@@ -1,0 +1,896 @@
+# isort: off
+
+# We monkey-patch `Logger._log` (see `pcapi.core.logging` module).
+# mypy does not detect that and wrongly reports errors when we call
+# `info()`, `warning()`, etc. with our `technical_message_id`
+# argument.
+#
+# Here we just want to override the signature of `Logger.info`,
+# `.warning`, etc. methods, but this file completely overrides what
+# mypy would normally use. So we have to provide typing annotations
+# for everything we use in our code. As such, this file is a full copy
+# of `mypy/typeshed/stdlib/logging/__init__.pyi` (version 1.1.1). Our
+# changes are within the "custom pcapi signature" markers.
+
+import sys
+import threading
+from _typeshed import StrPath, SupportsWrite
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from io import TextIOWrapper
+from re import Pattern
+from string import Template
+from time import struct_time
+from types import FrameType, TracebackType
+from typing import Any, ClassVar, Generic, TextIO, TypeVar, overload
+from typing_extensions import Literal, Self, TypeAlias
+
+if sys.version_info >= (3, 11):
+    from types import GenericAlias
+
+__all__ = [
+    "BASIC_FORMAT",
+    "BufferingFormatter",
+    "CRITICAL",
+    "DEBUG",
+    "ERROR",
+    "FATAL",
+    "FileHandler",
+    "Filter",
+    "Formatter",
+    "Handler",
+    "INFO",
+    "LogRecord",
+    "Logger",
+    "LoggerAdapter",
+    "NOTSET",
+    "NullHandler",
+    "StreamHandler",
+    "WARN",
+    "WARNING",
+    "addLevelName",
+    "basicConfig",
+    "captureWarnings",
+    "critical",
+    "debug",
+    "disable",
+    "error",
+    "exception",
+    "fatal",
+    "getLevelName",
+    "getLogger",
+    "getLoggerClass",
+    "info",
+    "log",
+    "makeLogRecord",
+    "setLoggerClass",
+    "shutdown",
+    "warn",
+    "warning",
+    "getLogRecordFactory",
+    "setLogRecordFactory",
+    "lastResort",
+    "raiseExceptions",
+]
+
+if sys.version_info >= (3, 11):
+    __all__ += ["getLevelNamesMapping"]
+
+_SysExcInfoType: TypeAlias = tuple[type[BaseException], BaseException, TracebackType | None] | tuple[None, None, None]
+_ExcInfoType: TypeAlias = None | bool | _SysExcInfoType | BaseException
+_ArgsType: TypeAlias = tuple[object, ...] | Mapping[str, object]
+_FilterType: TypeAlias = Filter | Callable[[LogRecord], bool]
+_Level: TypeAlias = int | str
+_FormatStyle: TypeAlias = Literal["%", "{", "$"]
+
+raiseExceptions: bool
+logThreads: bool
+logMultiprocessing: bool
+logProcesses: bool
+_srcfile: str | None
+
+def currentframe() -> FrameType: ...
+
+_levelToName: dict[int, str]
+_nameToLevel: dict[str, int]
+
+class Filterer:
+    filters: list[Filter]
+    def addFilter(self, filter: _FilterType) -> None: ...
+    def removeFilter(self, filter: _FilterType) -> None: ...
+    def filter(self, record: LogRecord) -> bool: ...
+
+class Manager:  # undocumented
+    root: RootLogger
+    disable: int
+    emittedNoHandlerWarning: bool
+    loggerDict: dict[str, Logger | PlaceHolder]
+    loggerClass: type[Logger] | None
+    logRecordFactory: Callable[..., LogRecord] | None
+    def __init__(self, rootnode: RootLogger) -> None: ...
+    def getLogger(self, name: str) -> Logger: ...
+    def setLoggerClass(self, klass: type[Logger]) -> None: ...
+    def setLogRecordFactory(self, factory: Callable[..., LogRecord]) -> None: ...
+
+class Logger(Filterer):
+    name: str  # undocumented
+    level: int  # undocumented
+    parent: Logger | None  # undocumented
+    propagate: bool
+    handlers: list[Handler]  # undocumented
+    disabled: bool  # undocumented
+    root: ClassVar[RootLogger]  # undocumented
+    manager: Manager  # undocumented
+    def __init__(self, name: str, level: _Level = 0) -> None: ...
+    def setLevel(self, level: _Level) -> None: ...
+    def isEnabledFor(self, level: int) -> bool: ...
+    def getEffectiveLevel(self) -> int: ...
+    def getChild(self, suffix: str) -> Self: ...  # see python/typing#980
+    if sys.version_info >= (3, 8):
+        # --- 8-> "custom pcapi signature"
+        def debug(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def info(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def warning(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def warn(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def error(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def exception(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = True,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def critical(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            technical_message_id: str | None = None,
+        ) -> None: ...
+        def log(
+            self,
+            level: int,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def _log(
+            self,
+            level: int,
+            msg: object,
+            args: _ArgsType,
+            exc_info: _ExcInfoType | None = None,
+            extra: Mapping[str, object] | None = None,
+            stack_info: bool = False,
+            stacklevel: int = 1,
+            technical_message_id: str | None = None,
+        ) -> None: ...  # undocumented
+        # --- 8-> end of "custom pcapi signature"
+    else:
+        def debug(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def info(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def warning(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def warn(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def error(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def critical(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def log(
+            self,
+            level: int,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def exception(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = True,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+        ) -> None: ...
+        def _log(
+            self,
+            level: int,
+            msg: object,
+            args: _ArgsType,
+            exc_info: _ExcInfoType | None = None,
+            extra: Mapping[str, object] | None = None,
+            stack_info: bool = False,
+        ) -> None: ...  # undocumented
+    fatal = critical
+    def addHandler(self, hdlr: Handler) -> None: ...
+    def removeHandler(self, hdlr: Handler) -> None: ...
+    if sys.version_info >= (3, 8):
+        def findCaller(self, stack_info: bool = False, stacklevel: int = 1) -> tuple[str, int, str, str | None]: ...
+    else:
+        def findCaller(self, stack_info: bool = False) -> tuple[str, int, str, str | None]: ...
+
+    def handle(self, record: LogRecord) -> None: ...
+    def makeRecord(
+        self,
+        name: str,
+        level: int,
+        fn: str,
+        lno: int,
+        msg: object,
+        args: _ArgsType,
+        exc_info: _SysExcInfoType | None,
+        func: str | None = None,
+        extra: Mapping[str, object] | None = None,
+        sinfo: str | None = None,
+    ) -> LogRecord: ...
+    def hasHandlers(self) -> bool: ...
+    def callHandlers(self, record: LogRecord) -> None: ...  # undocumented
+
+CRITICAL: int
+FATAL: int
+ERROR: int
+WARNING: int
+WARN: int
+INFO: int
+DEBUG: int
+NOTSET: int
+
+class Handler(Filterer):
+    level: int  # undocumented
+    formatter: Formatter | None  # undocumented
+    lock: threading.Lock | None  # undocumented
+    name: str | None  # undocumented
+    def __init__(self, level: _Level = 0) -> None: ...
+    def get_name(self) -> str: ...  # undocumented
+    def set_name(self, name: str) -> None: ...  # undocumented
+    def createLock(self) -> None: ...
+    def acquire(self) -> None: ...
+    def release(self) -> None: ...
+    def setLevel(self, level: _Level) -> None: ...
+    def setFormatter(self, fmt: Formatter | None) -> None: ...
+    def flush(self) -> None: ...
+    def close(self) -> None: ...
+    def handle(self, record: LogRecord) -> bool: ...
+    def handleError(self, record: LogRecord) -> None: ...
+    def format(self, record: LogRecord) -> str: ...
+    def emit(self, record: LogRecord) -> None: ...
+
+class Formatter:
+    converter: Callable[[float | None], struct_time]
+    _fmt: str | None  # undocumented
+    datefmt: str | None  # undocumented
+    _style: PercentStyle  # undocumented
+    default_time_format: str
+    if sys.version_info >= (3, 9):
+        default_msec_format: str | None
+    else:
+        default_msec_format: str
+
+    if sys.version_info >= (3, 10):
+        def __init__(
+            self,
+            fmt: str | None = None,
+            datefmt: str | None = None,
+            style: _FormatStyle = "%",
+            validate: bool = True,
+            *,
+            defaults: Mapping[str, Any] | None = None,
+        ) -> None: ...
+    elif sys.version_info >= (3, 8):
+        def __init__(
+            self, fmt: str | None = None, datefmt: str | None = None, style: _FormatStyle = "%", validate: bool = True
+        ) -> None: ...
+    else:
+        def __init__(self, fmt: str | None = None, datefmt: str | None = None, style: _FormatStyle = "%") -> None: ...
+
+    def format(self, record: LogRecord) -> str: ...
+    def formatTime(self, record: LogRecord, datefmt: str | None = None) -> str: ...
+    def formatException(self, ei: _SysExcInfoType) -> str: ...
+    def formatMessage(self, record: LogRecord) -> str: ...  # undocumented
+    def formatStack(self, stack_info: str) -> str: ...
+    def usesTime(self) -> bool: ...  # undocumented
+
+class BufferingFormatter:
+    linefmt: Formatter
+    def __init__(self, linefmt: Formatter | None = None) -> None: ...
+    def formatHeader(self, records: Sequence[LogRecord]) -> str: ...
+    def formatFooter(self, records: Sequence[LogRecord]) -> str: ...
+    def format(self, records: Sequence[LogRecord]) -> str: ...
+
+class Filter:
+    name: str  # undocumented
+    nlen: int  # undocumented
+    def __init__(self, name: str = "") -> None: ...
+    def filter(self, record: LogRecord) -> bool: ...
+
+class LogRecord:
+    # args can be set to None by logging.handlers.QueueHandler
+    # (see https://bugs.python.org/issue44473)
+    args: _ArgsType | None
+    asctime: str
+    created: float
+    exc_info: _SysExcInfoType | None
+    exc_text: str | None
+    filename: str
+    funcName: str
+    levelname: str
+    levelno: int
+    lineno: int
+    module: str
+    msecs: float
+    # Only created when logging.Formatter.format is called. See #6132.
+    message: str
+    msg: str
+    name: str
+    pathname: str
+    process: int | None
+    processName: str | None
+    relativeCreated: float
+    stack_info: str | None
+    thread: int | None
+    threadName: str | None
+    def __init__(
+        self,
+        name: str,
+        level: int,
+        pathname: str,
+        lineno: int,
+        msg: object,
+        args: _ArgsType | None,
+        exc_info: _SysExcInfoType | None,
+        func: str | None = None,
+        sinfo: str | None = None,
+    ) -> None: ...
+    def getMessage(self) -> str: ...
+    # Allows setting contextual information on LogRecord objects as per the docs, see #7833
+    def __setattr__(self, __name: str, __value: Any) -> None: ...
+
+_L = TypeVar("_L", bound=Logger | LoggerAdapter[Any])
+
+class LoggerAdapter(Generic[_L]):
+    logger: _L
+    manager: Manager  # undocumented
+    if sys.version_info >= (3, 10):
+        extra: Mapping[str, object] | None
+        def __init__(self, logger: _L, extra: Mapping[str, object] | None = None) -> None: ...
+    else:
+        extra: Mapping[str, object]
+        def __init__(self, logger: _L, extra: Mapping[str, object]) -> None: ...
+
+    def process(self, msg: Any, kwargs: MutableMapping[str, Any]) -> tuple[Any, MutableMapping[str, Any]]: ...
+    if sys.version_info >= (3, 8):
+        def debug(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def info(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def warning(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def warn(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def error(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def exception(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = True,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def critical(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def log(
+            self,
+            level: int,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            stacklevel: int = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+    else:
+        def debug(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def info(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def warning(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def warn(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def error(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def exception(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = True,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def critical(
+            self,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+        def log(
+            self,
+            level: int,
+            msg: object,
+            *args: object,
+            exc_info: _ExcInfoType = ...,
+            stack_info: bool = ...,
+            extra: Mapping[str, object] | None = ...,
+            **kwargs: object,
+        ) -> None: ...
+
+    def isEnabledFor(self, level: int) -> bool: ...
+    def getEffectiveLevel(self) -> int: ...
+    def setLevel(self, level: _Level) -> None: ...
+    def hasHandlers(self) -> bool: ...
+    def _log(
+        self,
+        level: int,
+        msg: object,
+        args: _ArgsType,
+        exc_info: _ExcInfoType | None = None,
+        extra: Mapping[str, object] | None = None,
+        stack_info: bool = False,
+    ) -> None: ...  # undocumented
+    @property
+    def name(self) -> str: ...  # undocumented
+    if sys.version_info >= (3, 11):
+        def __class_getitem__(cls, item: Any) -> GenericAlias: ...
+
+def getLogger(name: str | None = None) -> Logger: ...
+def getLoggerClass() -> type[Logger]: ...
+def getLogRecordFactory() -> Callable[..., LogRecord]: ...
+
+if sys.version_info >= (3, 8):
+    def debug(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def info(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def warning(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def warn(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def error(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def critical(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def exception(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = True,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def log(
+        level: int,
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        stacklevel: int = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+
+else:
+    def debug(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def info(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def warning(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def warn(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def error(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def critical(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def exception(
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = True,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+    def log(
+        level: int,
+        msg: object,
+        *args: object,
+        exc_info: _ExcInfoType = ...,
+        stack_info: bool = ...,
+        extra: Mapping[str, object] | None = ...,
+    ) -> None: ...
+
+fatal = critical
+
+def disable(level: int = 50) -> None: ...
+def addLevelName(level: int, levelName: str) -> None: ...
+def getLevelName(level: _Level) -> Any: ...
+
+if sys.version_info >= (3, 11):
+    def getLevelNamesMapping() -> dict[str, int]: ...
+
+def makeLogRecord(dict: Mapping[str, object]) -> LogRecord: ...
+
+if sys.version_info >= (3, 9):
+    def basicConfig(
+        *,
+        filename: StrPath | None = ...,
+        filemode: str = ...,
+        format: str = ...,
+        datefmt: str | None = ...,
+        style: _FormatStyle = ...,
+        level: _Level | None = ...,
+        stream: SupportsWrite[str] | None = ...,
+        handlers: Iterable[Handler] | None = ...,
+        force: bool | None = ...,
+        encoding: str | None = ...,
+        errors: str | None = ...,
+    ) -> None: ...
+
+elif sys.version_info >= (3, 8):
+    def basicConfig(
+        *,
+        filename: StrPath | None = ...,
+        filemode: str = ...,
+        format: str = ...,
+        datefmt: str | None = ...,
+        style: _FormatStyle = ...,
+        level: _Level | None = ...,
+        stream: SupportsWrite[str] | None = ...,
+        handlers: Iterable[Handler] | None = ...,
+        force: bool = ...,
+    ) -> None: ...
+
+else:
+    def basicConfig(
+        *,
+        filename: StrPath | None = ...,
+        filemode: str = ...,
+        format: str = ...,
+        datefmt: str | None = ...,
+        style: _FormatStyle = ...,
+        level: _Level | None = ...,
+        stream: SupportsWrite[str] | None = ...,
+        handlers: Iterable[Handler] | None = ...,
+    ) -> None: ...
+
+def shutdown(handlerList: Sequence[Any] = ...) -> None: ...  # handlerList is undocumented
+def setLoggerClass(klass: type[Logger]) -> None: ...
+def captureWarnings(capture: bool) -> None: ...
+def setLogRecordFactory(factory: Callable[..., LogRecord]) -> None: ...
+
+lastResort: StreamHandler[Any] | None
+
+_StreamT = TypeVar("_StreamT", bound=SupportsWrite[str])
+
+class StreamHandler(Handler, Generic[_StreamT]):
+    stream: _StreamT  # undocumented
+    terminator: str
+    @overload
+    def __init__(self: StreamHandler[TextIO], stream: None = None) -> None: ...
+    @overload
+    def __init__(self: StreamHandler[_StreamT], stream: _StreamT) -> None: ...
+    def setStream(self, stream: _StreamT) -> _StreamT | None: ...
+    if sys.version_info >= (3, 11):
+        def __class_getitem__(cls, item: Any) -> GenericAlias: ...
+
+class FileHandler(StreamHandler[TextIOWrapper]):
+    baseFilename: str  # undocumented
+    mode: str  # undocumented
+    encoding: str | None  # undocumented
+    delay: bool  # undocumented
+    if sys.version_info >= (3, 9):
+        errors: str | None  # undocumented
+        def __init__(
+            self,
+            filename: StrPath,
+            mode: str = "a",
+            encoding: str | None = None,
+            delay: bool = False,
+            errors: str | None = None,
+        ) -> None: ...
+    else:
+        def __init__(
+            self, filename: StrPath, mode: str = "a", encoding: str | None = None, delay: bool = False
+        ) -> None: ...
+
+    def _open(self) -> TextIOWrapper: ...  # undocumented
+
+class NullHandler(Handler): ...
+
+class PlaceHolder:  # undocumented
+    loggerMap: dict[Logger, None]
+    def __init__(self, alogger: Logger) -> None: ...
+    def append(self, alogger: Logger) -> None: ...
+
+# Below aren't in module docs but still visible
+
+class RootLogger(Logger):
+    def __init__(self, level: int) -> None: ...
+
+root: RootLogger
+
+class PercentStyle:  # undocumented
+    default_format: str
+    asctime_format: str
+    asctime_search: str
+    if sys.version_info >= (3, 8):
+        validation_pattern: Pattern[str]
+    _fmt: str
+    if sys.version_info >= (3, 10):
+        def __init__(self, fmt: str, *, defaults: Mapping[str, Any] | None = None) -> None: ...
+    else:
+        def __init__(self, fmt: str) -> None: ...
+
+    def usesTime(self) -> bool: ...
+    if sys.version_info >= (3, 8):
+        def validate(self) -> None: ...
+
+    def format(self, record: Any) -> str: ...
+
+class StrFormatStyle(PercentStyle):  # undocumented
+    fmt_spec: Pattern[str]
+    field_spec: Pattern[str]
+
+class StringTemplateStyle(PercentStyle):  # undocumented
+    _tpl: Template
+
+_STYLES: dict[str, tuple[PercentStyle, str]]
+
+BASIC_FORMAT: str


### PR DESCRIPTION
... + 1 commit de correction de `logging.info()` -> `logger.info()

---

We monkey patch `logging.Logger._log()` to allow us to provide an
additional argument (`technical_message_id`). mypy does not detect
that and reports an error when we call `info()`, `warning()`, etc.
with this argument.

Defining our own stub for the `logging` module solves the issue.