### PR TITLE
(PC-21064)[API] fix: show email on bookings details

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -260,6 +260,15 @@ class Booking(PcObject, Base, Model):
     def email(self) -> str:
         return self.user.email
 
+    @property
+    def emailAtDateCreated(self) -> str:
+        email = self.user.email
+        for email_history in sorted(self.user.email_history, key=lambda history: history.creationDate):
+            if self.dateCreated < email_history.creationDate:
+                email = email_history.oldEmail
+                break
+        return email
+
     @hybrid_property
     def isExternal(self) -> bool:
         return any(externalBooking.id for externalBooking in self.externalBookings)

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
@@ -68,6 +68,10 @@
                 <span class="fw-bold">Crédit utilisé par le jeune :</span>
                 {{ booking.deposit.type | format_deposit_type | safe }}
               </p>
+              <p class="mb-1">
+                <span class="fw-bold">E-mail à la réservation :</span>
+                {{ booking.emailAtDateCreated }}
+              </p>
             </div>
           </td>
         </tr>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21064

## But de la pull request

Affiche l'email lié à la résas dans le détails d'une réservations

## Implémentation

La jointure étant déjà présente, ceci ne fait qu'afficher l'email.

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
