### PR TITLE
(PC-21181)[API] feat: Add index for ean value in 

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 bf927d0e97e8 (pre) (head)
-26ae10b002ad (post) (head)
+7a48b353dd3e (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 bf927d0e97e8 (pre) (head)
-8eb478cb4014 (post) (head)
+26ae10b002ad (post) (head)

--- a/api/src/pcapi/alembic/versions/20230320T102144_26ae10b002ad_add_ean_index_offer.py
+++ b/api/src/pcapi/alembic/versions/20230320T102144_26ae10b002ad_add_ean_index_offer.py
@@ -1,0 +1,35 @@
+"""add_ean_index_offer
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "26ae10b002ad"
+down_revision = "8eb478cb4014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("""SET SESSION statement_timeout = '900s'""")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS offer_ean_idx
+        ON offer
+        USING btree ((("jsonData" ->> 'ean'::text)));
+        """
+    )
+    op.execute(f"""SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}""")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "offer_ean_idx"
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20230320T102832_7a48b353dd3e_add_ean_index_product.py
+++ b/api/src/pcapi/alembic/versions/20230320T102832_7a48b353dd3e_add_ean_index_product.py
@@ -1,0 +1,35 @@
+"""add_ean_index_product
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "7a48b353dd3e"
+down_revision = "26ae10b002ad"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("""SET SESSION statement_timeout = '900s'""")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS product_ean_idx
+        ON product
+        USING btree ((("jsonData" ->> 'ean'::text)));
+        """
+    )
+    op.execute(f"""SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}""")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "product_ean_idx"
+        """
+    )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -408,6 +408,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     sa.Index("idx_offer_trgm_name", name, postgresql_using="gin")
     sa.Index("offer_isbn_idx", extraData["isbn"].astext)
+    sa.Index("offer_ean_idx", extraData["ean"].astext)
     # FIXME: We shoud be able to remove the index on `venueId`, since this composite index
     #  can be used by PostgreSQL when filtering on the `venueId` column only.
     sa.Index("venueId_idAtProvider_index", venueId, idAtProvider, unique=True)

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -117,6 +117,7 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
     url = sa.Column(sa.String(255), nullable=True)
 
     sa.Index("product_isbn_idx", extraData["isbn"].astext)
+    sa.Index("product_ean_idx", extraData["ean"].astext)
 
     @property
     def subcategory(self) -> subcategories.Subcategory:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21181

1ere étape du ticket 21181
Add index to find offer/products by ean.
It will be usefull soon when we will block offer creation if another offer exists with this ean. Or getting/querying an offer by ean.
