### PR TITLE
PC-19821 track booking events in amplitude

### DIFF
--- a/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
+++ b/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 class AmplitudeEventType(enum.Enum):
     BOOKING_CANCELLED = "BOOKING_CANCELLED"
+    BOOKING_USED = "BOOKING_USED"
     DMS_ERROR = "DMS_ERROR"
     EDUCONNECT_ERROR = "EDUCONNECT_ERROR"
     OFFER_BOOKED = "OFFER_BOOKED"

--- a/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
+++ b/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
@@ -11,9 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 class AmplitudeEventType(enum.Enum):
+    DMS_ERROR = "DMS_ERROR"
     EDUCONNECT_ERROR = "EDUCONNECT_ERROR"
     UBBLE_ERROR = "UBBLE_ERROR"
-    DMS_ERROR = "DMS_ERROR"
 
 
 class AmplitudeBackend:

--- a/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
+++ b/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class AmplitudeEventType(enum.Enum):
     DMS_ERROR = "DMS_ERROR"
     EDUCONNECT_ERROR = "EDUCONNECT_ERROR"
+    OFFER_BOOKED = "OFFER_BOOKED"
     UBBLE_ERROR = "UBBLE_ERROR"
 
 

--- a/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
+++ b/api/src/pcapi/analytics/amplitude/backends/amplitude_connector.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class AmplitudeEventType(enum.Enum):
+    BOOKING_CANCELLED = "BOOKING_CANCELLED"
     DMS_ERROR = "DMS_ERROR"
     EDUCONNECT_ERROR = "EDUCONNECT_ERROR"
     OFFER_BOOKED = "OFFER_BOOKED"

--- a/api/src/pcapi/analytics/amplitude/events/booking_events.py
+++ b/api/src/pcapi/analytics/amplitude/events/booking_events.py
@@ -40,3 +40,21 @@ def track_cancel_booking_event(
             },
         )
     )
+
+
+def track_mark_as_used_event(booking: bookings_models.Booking) -> None:
+    amplitude_tasks.track_event.delay(
+        amplitude_tasks.TrackAmplitudeEventRequest(
+            user_id=booking.userId or 0,
+            event_name=amplitude_connector.AmplitudeEventType.BOOKING_USED,
+            event_properties={
+                "offer_id": booking.stock.offerId,
+                "price": float(booking.total_amount),
+                "booking_id": booking.id,
+                "category": booking.stock.offer.category.id,
+                "subcategory": booking.stock.offer.subcategoryId,
+                # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
+                # "offer_type": ???
+            },
+        )
+    )

--- a/api/src/pcapi/analytics/amplitude/events/booking_events.py
+++ b/api/src/pcapi/analytics/amplitude/events/booking_events.py
@@ -1,0 +1,20 @@
+from pcapi.analytics.amplitude.backends import amplitude_connector
+from pcapi.tasks import amplitude_tasks
+
+
+def track_book_offer_event(booking: bookings_models.Booking) -> None:
+    amplitude_tasks.track_event.delay(
+        amplitude_tasks.TrackAmplitudeEventRequest(
+            user_id=booking.userId or 0,
+            event_name=amplitude_connector.AmplitudeEventType.OFFER_BOOKED,
+            event_properties={
+                "offer_id": booking.stock.offerId,
+                "price": float(booking.total_amount),
+                "booking_id": booking.id,
+                "category": booking.stock.offer.category.id,
+                "subcategory": booking.stock.offer.subcategoryId,
+                # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
+                # "offer_type": ???
+            },
+        )
+    )

--- a/api/src/pcapi/analytics/amplitude/events/booking_events.py
+++ b/api/src/pcapi/analytics/amplitude/events/booking_events.py
@@ -1,4 +1,5 @@
 from pcapi.analytics.amplitude.backends import amplitude_connector
+from pcapi.core.bookings import models as bookings_models
 from pcapi.tasks import amplitude_tasks
 
 
@@ -13,6 +14,27 @@ def track_book_offer_event(booking: bookings_models.Booking) -> None:
                 "booking_id": booking.id,
                 "category": booking.stock.offer.category.id,
                 "subcategory": booking.stock.offer.subcategoryId,
+                # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
+                # "offer_type": ???
+            },
+        )
+    )
+
+
+def track_cancel_booking_event(
+    booking: bookings_models.Booking, reason: bookings_models.BookingCancellationReasons
+) -> None:
+    amplitude_tasks.track_event.delay(
+        amplitude_tasks.TrackAmplitudeEventRequest(
+            user_id=booking.userId or 0,
+            event_name=amplitude_connector.AmplitudeEventType.BOOKING_CANCELED,
+            event_properties={
+                "offer_id": booking.stock.offerId,
+                "price": float(booking.total_amount),
+                "booking_id": booking.id,
+                "category": booking.stock.offer.category.id,
+                "subcategory": booking.stock.offer.subcategoryId,
+                "reason": reason,
                 # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
                 # "offer_type": ???
             },

--- a/api/src/pcapi/analytics/amplitude/events/booking_events.py
+++ b/api/src/pcapi/analytics/amplitude/events/booking_events.py
@@ -4,57 +4,44 @@ from pcapi.tasks import amplitude_tasks
 
 
 def track_book_offer_event(booking: bookings_models.Booking) -> None:
-    amplitude_tasks.track_event.delay(
-        amplitude_tasks.TrackAmplitudeEventRequest(
-            user_id=booking.userId or 0,
-            event_name=amplitude_connector.AmplitudeEventType.OFFER_BOOKED,
-            event_properties={
-                "offer_id": booking.stock.offerId,
-                "price": float(booking.total_amount),
-                "booking_id": booking.id,
-                "category": booking.stock.offer.category.id,
-                "subcategory": booking.stock.offer.subcategoryId,
-                # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
-                # "offer_type": ???
-            },
-        )
-    )
+    _track_booking_event(booking, amplitude_connector.AmplitudeEventType.OFFER_BOOKED)
 
 
 def track_cancel_booking_event(
     booking: bookings_models.Booking, reason: bookings_models.BookingCancellationReasons
 ) -> None:
-    amplitude_tasks.track_event.delay(
-        amplitude_tasks.TrackAmplitudeEventRequest(
-            user_id=booking.userId or 0,
-            event_name=amplitude_connector.AmplitudeEventType.BOOKING_CANCELED,
-            event_properties={
-                "offer_id": booking.stock.offerId,
-                "price": float(booking.total_amount),
-                "booking_id": booking.id,
-                "category": booking.stock.offer.category.id,
-                "subcategory": booking.stock.offer.subcategoryId,
-                "reason": reason,
-                # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
-                # "offer_type": ???
-            },
-        )
-    )
+    _track_booking_event(booking, amplitude_connector.AmplitudeEventType.BOOKING_CANCELLED, reason)
 
 
 def track_mark_as_used_event(booking: bookings_models.Booking) -> None:
+    _track_booking_event(booking, amplitude_connector.AmplitudeEventType.BOOKING_USED)
+
+
+def _track_booking_event(
+    booking: bookings_models.Booking,
+    event_name: amplitude_connector.AmplitudeEventType,
+    reason: bookings_models.BookingCancellationReasons | None = None,
+) -> None:
+    # TODO: (lixxday) remove this when userId is not null in Booking
+    if not booking.userId:
+        return
+    event_properties = _get_booking_event_properties(booking)
+    if reason:
+        event_properties["reason"] = reason.value
     amplitude_tasks.track_event.delay(
         amplitude_tasks.TrackAmplitudeEventRequest(
-            user_id=booking.userId or 0,
-            event_name=amplitude_connector.AmplitudeEventType.BOOKING_USED,
-            event_properties={
-                "offer_id": booking.stock.offerId,
-                "price": float(booking.total_amount),
-                "booking_id": booking.id,
-                "category": booking.stock.offer.category.id,
-                "subcategory": booking.stock.offer.subcategoryId,
-                # TODO: add offer type (showType, musicType, BookMacroSection, MovieGenre, ...)
-                # "offer_type": ???
-            },
+            user_id=booking.userId,
+            event_name=event_name,
+            event_properties=event_properties,
         )
     )
+
+
+def _get_booking_event_properties(booking: bookings_models.Booking) -> dict:
+    return {
+        "offer_id": booking.stock.offerId,
+        "price": float(booking.total_amount),
+        "booking_id": booking.id,
+        "category": booking.stock.offer.category.id,
+        "subcategory": booking.stock.offer.subcategoryId,
+    }

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -329,6 +329,7 @@ def mark_as_used(booking: Booking) -> None:
     repository.save(booking)
 
     logger.info("Booking was marked as used", extra={"booking_id": booking.id}, technical_message_id="booking.used")
+    booking_events.track_mark_as_used_event(booking)
 
     update_external_user(booking.user)
 

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -224,6 +224,7 @@ def _cancel_booking(
         extra={"booking_id": booking.id, "reason": str(reason)},
         technical_message_id="booking.cancelled",
     )
+    booking_events.track_cancel_booking_event(booking, reason)
 
     update_external_user(booking.user)
     update_external_pro(booking.venue.bookingEmail)

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -5,6 +5,7 @@ import typing
 import sentry_sdk
 import sqlalchemy as sa
 
+from pcapi.analytics.amplitude.events import booking_events
 from pcapi.core import search
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
@@ -141,6 +142,7 @@ def book_offer(
             "used": booking.is_used_or_reimbursed,
         },
     )
+    booking_events.track_book_offer_event(booking)
 
     if not transactional_mails.send_user_new_booking_to_pro_email(booking, first_venue_booking):
         logger.warning(

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -660,6 +660,24 @@ class CancelByBeneficiaryTest:
 
         mocked_cancel_booking.assert_called()
 
+    def test_cancel_booking_tracked_in_amplitude(self):
+        booking = bookings_factories.BookingFactory()
+
+        api.cancel_booking_by_beneficiary(booking.user, booking)
+
+        assert amplitude_testing.requests[0] == {
+            "event_name": "BOOKING_CANCELLED",
+            "event_properties": {
+                "booking_id": booking.id,
+                "category": "FILM",
+                "offer_id": booking.stock.offerId,
+                "price": 10.00,
+                "reason": BookingCancellationReasons.BENEFICIARY,
+                "subcategory": "SUPPORT_PHYSIQUE_FILM",
+            },
+            "user_id": str(booking.userId),
+        }
+
 
 @pytest.mark.usefixtures("db_session")
 class CancelByOffererTest:

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -672,7 +672,7 @@ class CancelByBeneficiaryTest:
                 "category": "FILM",
                 "offer_id": booking.stock.offerId,
                 "price": 10.00,
-                "reason": BookingCancellationReasons.BENEFICIARY,
+                "reason": BookingCancellationReasons.BENEFICIARY.value,
                 "subcategory": "SUPPORT_PHYSIQUE_FILM",
             },
             "user_id": str(booking.userId),

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -834,6 +834,22 @@ class MarkAsUsedTest:
             api.mark_as_used(booking)
         assert booking.status is not BookingStatus.USED
 
+    def test_mark_as_used_tracked_to_amplitude(self):
+        booking = bookings_factories.BookingFactory()
+        api.mark_as_used(booking)
+        assert len(amplitude_testing.requests) == 1
+        assert amplitude_testing.requests[0] == {
+            "event_name": "BOOKING_USED",
+            "event_properties": {
+                "booking_id": booking.id,
+                "category": "FILM",
+                "offer_id": booking.stock.offerId,
+                "price": 10.00,
+                "subcategory": "SUPPORT_PHYSIQUE_FILM",
+            },
+            "user_id": str(booking.userId),
+        }
+
 
 @pytest.mark.usefixtures("db_session")
 class MarkAsUnusedTest:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19821

## But de la pull request

Répertorier ces events dans Amplitude
Cf. ticket

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
