### PR TITLE
(PC-21088)[PRO] feat: should display public name for adage offer venue

### DIFF
--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/OfferVenue.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/OfferVenue.tsx
@@ -16,7 +16,7 @@ const OfferVenue = ({ offerVenue }: IOfferVenue): JSX.Element => {
 
   return (
     <div>
-      <div>{offerVenue.name ?? offerVenue.publicName}</div>
+      <div>{offerVenue.publicName || offerVenue.name}</div>
       <div>
         {offerVenue.address}, {offerVenue.postalCode} {offerVenue.city}
       </div>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/OfferVenue.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/OfferVenue.tsx
@@ -16,7 +16,7 @@ const OfferVenue = ({ offerVenue }: IOfferVenue): JSX.Element => {
 
   return (
     <div>
-      <div>{offerVenue.name ?? offerVenue.publicName}</div>
+      <div>{offerVenue.publicName || offerVenue.name}</div>
       <div>
         {offerVenue.address}, {offerVenue.postalCode} {offerVenue.city}
       </div>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/__specs__/OfferVenue.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/__specs__/OfferVenue.spec.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { CollectiveOfferOfferVenue, OfferAddressType } from 'apiClient/adage'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import OfferVenue from '../OfferVenue'
+
+const renderOfferVenue = (offerVenue: CollectiveOfferOfferVenue) => {
+  return renderWithProviders(<OfferVenue offerVenue={offerVenue} />)
+}
+
+describe('OfferVenue', () => {
+  const defaultOfferVenue = {
+    addressType: OfferAddressType.OFFERER_VENUE,
+    venueId: 'VENUE_ID',
+    name: 'Nom juridique',
+    publicName: 'Mon petit cinema',
+    otherAddress: '',
+  }
+
+  it('should display public name(if valued) of the venue when addressType is OFFERER_VENUE', () => {
+    renderOfferVenue(defaultOfferVenue)
+
+    expect(screen.getByText('Mon petit cinema')).toBeInTheDocument()
+  })
+
+  it('should display name (if public name not valued) of the venue when addressType is OFFERER_VENUE', () => {
+    renderOfferVenue({
+      ...defaultOfferVenue,
+      publicName: '',
+    })
+
+    expect(screen.getByText('Nom juridique')).toBeInTheDocument()
+  })
+
+  it('should display other address when addressType is OTHER', () => {
+    renderOfferVenue({
+      ...defaultOfferVenue,
+      addressType: OfferAddressType.OTHER,
+      otherAddress: 'Mon autre adresse',
+    })
+
+    expect(screen.getByText('Mon autre adresse')).toBeInTheDocument()
+  })
+
+  it('should display in school message when addressType is IN_SCHOOL', () => {
+    renderOfferVenue({
+      ...defaultOfferVenue,
+      addressType: OfferAddressType.SCHOOL,
+    })
+
+    expect(
+      screen.getByText('Dans l’établissement scolaire')
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21088

## But de la pull request

- Afficher le nom public (si valorisé) au lieu du nom juridique dans l'iframe adage dans la section 'Adresse où se déroulera l’évènement' 
- Ajout de tests pour le coverage

## Screenshot 

![Capture d’écran 2023-03-20 à 17 46 47](https://user-images.githubusercontent.com/71768799/226410480-6b83fde3-e7f4-4f1d-8103-db32701746d1.png)
