### PR TITLE
(PC-20870)[BO] feat: show declared birth date when different

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -66,6 +66,12 @@
                 <span>{{ user.birth_date | format_date }} ({{ user.age | empty_string_if_null }} ans)</span>
               {% endif %}
             </p>
+            {% if user.dateOfBirth and user.dateOfBirth.date() != user.birth_date %}
+              <p class="my-1 ">
+                <span class="fw-bold">Date de naissance déclarée à l'inscription</span>
+                <span>{{ user.dateOfBirth | format_date }}</span>
+              </p>
+            {% endif %}
             <p class="mb-1">
               <span class="fw-bold">Crédité le :</span> {{ user.deposit_activation_date | format_date }}
             </p>
@@ -144,7 +150,9 @@
                           name="{{ url_for(".review_public_account", user_id=user.id) | action_to_name }}"
                           method="post">
                       <div class="modal-header">
-                        <h5 class="modal-title">Revue manuelle</h5>
+                        <h5 class="modal-title">
+                          Revue manuelle
+                        </h5>
                       </div>
                       <div class="modal-body">
                         <div class="form-floating my-3">

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -369,10 +369,27 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         assert f"Tél : {user.phoneNumber} " in content
         if user.dateOfBirth:
             assert f"Date de naissance {user.dateOfBirth.strftime('%d/%m/%Y')} " in content
+        assert "Date de naissance déclarée à l'inscription" not in content
         assert f"Adresse {user.address} " in content
         if expected_badge:
             assert expected_badge in content
         assert "Suspendu" not in content
+
+    def test_get_public_account_birth_dates(self, authenticated_client):
+        # given
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, days=15),
+            validatedBirthDate=datetime.datetime.utcnow() - relativedelta(years=17, days=15),
+        )
+
+        # when
+        response = authenticated_client.get(url_for(self.endpoint, user_id=user.id))
+
+        # then
+        assert response.status_code == 200
+        content = html_parser.content_as_text(response.data)
+        assert f"Date de naissance {user.validatedBirthDate.strftime('%d/%m/%Y')} " in content
+        assert f"Date de naissance déclarée à l'inscription {user.dateOfBirth.strftime('%d/%m/%Y')} " in content
 
     def test_get_beneficiary_credit(self, authenticated_client):
         # given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20870

## But de la pull request

Sur le profil d’un jeune, ajouter, sous la date de naissance d’aujourd’hui la “Date de naissance déclarée à l’inscription” si elle est différente de la “vraie” date de naissance, celle retournée par les vérifications d’identité

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
