### PR TITLE
(PC-21185)[API] feat: update settings for offers index at Algolia

### DIFF
--- a/api/src/pcapi/algolia_settings_offers.json
+++ b/api/src/pcapi/algolia_settings_offers.json
@@ -4,6 +4,16 @@
     "hitsPerPage": 20,
     "maxValuesPerFacet": 100,
     "version": 2,
+    "searchableAttributes": [
+        "unordered(offer.name)",
+        "unordered(venue.publicName)",
+        "unordered(offer.artist)",
+        "unordered(offer.subcategoryId)",
+        "unordered(venue.name)",
+        "unordered(offerer.name)",
+        "unordered(offer.description)",
+        "unordered(distinct)"
+    ],
     "attributesToRetrieve": null,
     "ignorePlurals": [
         "fr"
@@ -20,7 +30,9 @@
     "queryLanguages": [
         "fr"
     ],
-    "replicas": [],
+    "replicas": [
+        "virtual(PRODUCTION Top offres)"
+    ],
     "attributesForFaceting": [
         "offer.bookMacroSection",
         "filterOnly(offer.category)",
@@ -70,7 +82,6 @@
         "custom"
     ],
     "customRanking": [
-        "desc(offer.last30DaysBookings)",
         "desc(offer.rankingWeight)",
         "desc(offer.isEvent)"
     ],
@@ -96,16 +107,6 @@
         [
             "offer.searchGroupName:-CINEMA"
         ]
-    ],
-    "searchableAttributes": [
-        "unordered(offer.name)",
-        "unordered(venue.publicName)",
-        "unordered(offer.artist)",
-        "unordered(offer.subcategoryId)",
-        "unordered(venue.name)",
-        "unordered(offerer.name)",
-        "unordered(offer.description)",
-        "unordered(distinct)"
     ],
     "numericAttributesForFiltering": null
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21185

## But de la pull request

mise à jour des settings de l'index des offres chez Algolia:
- déclaration d'un replica virtuel **_PRODUCTION Top offres_** pour l'index des offres (le replica existe dans les environnements de prod et de testing chez Algolia)
- suppression du customRanking sur `offer.last30DaysBookings`

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
