### PR TITLE
(BSR)[API] feat: Log what we get from Provider API

### DIFF
--- a/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
+++ b/api/src/pcapi/infrastructure/repository/stock_provider/provider_api.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import logging
 
 from requests.exceptions import RequestException
@@ -91,16 +90,12 @@ class ProviderAPI:
                 continue
 
             if "price" not in stock_response:
-                # FIXME (jsdupuis, 2022-05-24) : to be removed after the start_blocking_date
-                start_blocking_date = datetime.strptime("2022-06-01 00:00:00", "%Y-%m-%d %H:%M:%S")
-
-                if datetime.utcnow() > start_blocking_date:
-                    logger.error(
-                        "[%s SYNC] missing price key in response with ref %s",
-                        self.name,
-                        stock_response_ref,
-                    )
-                    continue
+                logger.error(
+                    "[%s SYNC] missing price key in response with ref %s",
+                    self.name,
+                    stock_response_ref,
+                )
+                continue
 
             validated_stock_responses.append(stock_response)
 


### PR DESCRIPTION
... + 2 commits de nettoyage et amélioration mineure. Message du 1er commit ci-dessous :

---

Until now, we only logged the number of offers/stocks that were added
or updated. This is not enough when we want to know why a particular
reference is not up-to-date.

Now we log what we get from the Provider API, i.e. the reference,
quantity and price of each addition/update. We use multiple logs
because there is a 256 KB size limit in Google Cloud Logging above
which the log will be rejected.