### PR TITLE
(PC-21175)[BO] feat: show bookingEmail instead of contact.email in venue details

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -14,7 +14,7 @@ class EditVirtualVenueForm(utils.PCForm):
     tags = fields.PCAutocompleteSelectMultipleField(
         "Tags", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_criteria"
     )
-    email = fields.PCEmailField("Email")
+    booking_email = fields.PCEmailField("Email (notifications de réservation)")
     phone_number = fields.PCPhoneNumberField("Numéro de téléphone")  # match Venue.contact.postal_code case
 
 
@@ -66,7 +66,7 @@ class EditVenueForm(EditVirtualVenueForm):
         self.venue = venue
 
         # self._fields is a collections.OrderedDict
-        self._fields.move_to_end("email")
+        self._fields.move_to_end("booking_email")
         self._fields.move_to_end("phone_number")
         self._fields.move_to_end("is_permanent")
 

--- a/api/src/pcapi/routes/backoffice_v3/i18n.py
+++ b/api/src/pcapi/routes/backoffice_v3/i18n.py
@@ -65,8 +65,10 @@ def i18n_column_name(term: str) -> str:
             return "Ville"
         case "address":
             return "Adresse"
+        case "bookingemail":
+            return "E-mail"
         case "contact.email":
-            return "Email de contact"
+            return "E-mail de contact"
         case "contact.phone_number":
             return "Numéro de téléphone de contact"
         case "ispermanent":

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_card_venue.html
@@ -13,7 +13,7 @@
     <h6 class="card-subtitle mb-4 text-muted">SIRET : {{ row.siret | empty_string_if_null }}</h6>
     <div class="fs-6">
       <p class="mb-1">
-        <span class="fw-bold">E-mail :</span> {{ row.contact.email | empty_string_if_null }}
+        <span class="fw-bold">E-mail :</span> {{ row.bookingEmail | empty_string_if_null }}
       </p>
       <p>
         <span class="fw-bold">Tél :</span> {{ row.contact.phone_number | empty_string_if_null }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -128,13 +128,13 @@
                     {{ venue.latitude }} (latitude) / {{ venue.longitude }} (longitude)
                   </p>
                 {% endif %}
+                {% if venue.bookingEmail %}
+                  <p class="mb-1">
+                    <span class="fw-bold">E-mail :</span>
+                    {{ venue.bookingEmail }}
+                  </p>
+                {% endif %}
                 {% if venue.contact %}
-                  {% if venue.contact.email %}
-                    <p class="mb-1">
-                      <span class="fw-bold">E-mail :</span>
-                      {{ venue.contact.email }}
-                    </p>
-                  {% endif %}
                   {% if venue.contact.phone_number %}
                     <p class="mb-1">
                       <span class="fw-bold">Numéro de téléphone :</span>

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -103,7 +103,7 @@ def render_venue_details(
     if not edit_venue_form:
         if venue.isVirtual:
             edit_venue_form = forms.EditVirtualVenueForm(
-                email=venue.contact.email if venue.contact else None,
+                booking_email=venue.bookingEmail,
                 phone_number=venue.contact.phone_number if venue.contact else None,
             )
         else:
@@ -118,7 +118,7 @@ def render_venue_details(
                 else None,
                 postal_code=venue.postalCode,
                 address=venue.address,
-                email=venue.contact.email if venue.contact else None,
+                booking_email=venue.bookingEmail,
                 phone_number=venue.contact.phone_number if venue.contact else None,
                 is_permanent=venue.isPermanent,
                 latitude=venue.latitude,
@@ -274,14 +274,17 @@ def update_venue(venue_id: int) -> utils.BackofficeResponse:
         if field.name and hasattr(venue, to_camelcase(field.name))
     }
 
-    contact_data = serialize_base.VenueContactModel(
-        email=form.email.data,
-        phone_number=form.phone_number.data,
-        # Use existing values, if any, to ensure that no data (website
-        # for example) will be erased by mistake
-        website=venue.contact.website if venue.contact else None,
-        social_medias=venue.contact.social_medias if venue.contact else None,
-    )
+    if form.phone_number.data or venue.contact:
+        contact_data = serialize_base.VenueContactModel(
+            phone_number=form.phone_number.data,
+            # Use existing values, if any, to ensure that no data (website
+            # for example) will be erased by mistake
+            email=venue.contact.email if venue.contact else None,
+            website=venue.contact.website if venue.contact else None,
+            social_medias=venue.contact.social_medias if venue.contact else None,
+        )
+    else:
+        contact_data = None
 
     criteria = criteria_models.Criterion.query.filter(criteria_models.Criterion.id.in_(form.tags.data)).all()
 

--- a/api/tests/routes/backoffice_v3/pro_test.py
+++ b/api/tests/routes/backoffice_v3/pro_test.py
@@ -59,8 +59,8 @@ def assert_venue_equals(result_card_text: str, expected_venue: offerers_models.V
     assert f"{expected_venue.name.upper()} " in result_card_text
     assert f"Venue ID : {expected_venue.id} " in result_card_text
     assert f"SIRET : {expected_venue.siret} " in result_card_text
+    assert f"E-mail : {expected_venue.bookingEmail} " in result_card_text
     if expected_venue.contact:
-        assert f"E-mail : {expected_venue.contact.email} " in result_card_text
         assert f"Tél : {expected_venue.contact.phone_number} " in result_card_text
     if expected_venue.isPermanent:
         assert "Lieu permanent " in result_card_text


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21175

## But de la pull request

Afficher un modifier `venue.bookingEmail` plutôt que `venue.contact.email` dans la page de détails d'un lieu dans le backoffice. C'est cette adresse de « notifications de réservations » qui est utilisée de préférence dans nos communications avec les AC.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
