### PR TITLE
(PC-21224)[API] feat: Add index for ean value

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 bf927d0e97e8 (pre) (head)
-9b02e53e8369 (post) (head)
+061957688845 (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 bf927d0e97e8 (pre) (head)
-061957688845 (post) (head)
+474312bd6eaf (post) (head)

--- a/api/src/pcapi/alembic/versions/20230321T133811_061957688845_add_ean_index_offer.py
+++ b/api/src/pcapi/alembic/versions/20230321T133811_061957688845_add_ean_index_offer.py
@@ -1,0 +1,31 @@
+"""add_ean_index_offer
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "061957688845"
+down_revision = "9b02e53e8369"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS offer_ean_idx
+        ON offer
+        USING btree ((("jsonData" ->> 'ean'::text)));
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "offer_ean_idx"
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20230321T135100_474312bd6eaf_add_ean_index_product.py
+++ b/api/src/pcapi/alembic/versions/20230321T135100_474312bd6eaf_add_ean_index_product.py
@@ -1,0 +1,31 @@
+"""add_ean_index_product
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "474312bd6eaf"
+down_revision = "061957688845"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS product_ean_idx
+        ON product
+        USING btree ((("jsonData" ->> 'ean'::text)));
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "product_ean_idx"
+        """
+    )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -116,6 +116,7 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
     thumb_path_component = "products"
     url = sa.Column(sa.String(255), nullable=True)
 
+    sa.Index("product_ean_idx", extraData["ean"].astext)
     sa.Index("product_isbn_idx", extraData["isbn"].astext)
 
     @property

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -407,6 +407,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     withdrawalType = sa.Column(sa.Enum(WithdrawalTypeEnum), nullable=True)
 
     sa.Index("idx_offer_trgm_name", name, postgresql_using="gin")
+    sa.Index("offer_ean_idx", extraData["ean"].astext)
     sa.Index("offer_isbn_idx", extraData["isbn"].astext)
     # FIXME: We shoud be able to remove the index on `venueId`, since this composite index
     #  can be used by PostgreSQL when filtering on the `venueId` column only.


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21224

Add index to find offer/products by ean.
It will be usefull soon when we will block offer creation if another offer exists with this ean. Or getting/querying an offer by ean.

Duplicate of https://github.com/pass-culture/pass-culture-main/pull/5733 to have the right jira ticket name
