### PR TITLE
(BSR)[API] fix: flaky log test

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -357,9 +357,10 @@ def batch_update_offers(query: BaseQuery, update_fields: dict, send_email_notifi
     if raw_results:
         offer_ids, venue_ids = zip(*raw_results)
     venue_ids = sorted(set(venue_ids))
+    number_of_offers_to_update = len(offer_ids)
     logger.info(
         "Batch update of offers",
-        extra={"updated_fields": update_fields, "nb_offers": len(offer_ids), "venue_ids": venue_ids},
+        extra={"updated_fields": update_fields, "nb_offers": number_of_offers_to_update, "venue_ids": venue_ids},
     )
     if "isActive" in update_fields.keys():
         message = "Offers has been activated" if update_fields["isActive"] else "Offers has been deactivated"
@@ -370,7 +371,6 @@ def batch_update_offers(query: BaseQuery, update_fields: dict, send_email_notifi
             technical_message_id=technical_message_id,
         )
 
-    number_of_offers_to_update = len(offer_ids)
     batch_size = 1000
     for current_start_index in range(0, number_of_offers_to_update, batch_size):
         offer_ids_batch = offer_ids[

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1078,10 +1078,9 @@ class BatchUpdateOffersTest:
             "venue_ids": [offer1.venueId, offer2.venueId],
         }
         assert second_record.message == "Offers has been activated"
-        assert second_record.extra == {
-            "offer_ids": (offer1.id, offer2.id),
-            "venue_id": [offer1.venueId, offer2.venueId],
-        }
+        assert second_record.extra.keys() == {"offer_ids", "venue_id"}
+        assert set(second_record.extra["offer_ids"]) == {offer1.id, offer2.id}
+        assert second_record.extra["venue_id"] == [offer1.venueId, offer2.venueId]
 
     def test_deactivate(self, caplog):
         offer1 = factories.OfferFactory()
@@ -1107,10 +1106,9 @@ class BatchUpdateOffersTest:
             "venue_ids": [offer1.venueId, offer2.venueId],
         }
         assert second_record.message == "Offers has been deactivated"
-        assert second_record.extra == {
-            "offer_ids": (offer1.id, offer2.id),
-            "venue_id": [offer1.venueId, offer2.venueId],
-        }
+        assert second_record.extra.keys() == {"offer_ids", "venue_id"}
+        assert set(second_record.extra["offer_ids"]) == {offer1.id, offer2.id}
+        assert second_record.extra["venue_id"] == [offer1.venueId, offer2.venueId]
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
## Implémentation

L'ordre des id n'est pas garanti en sortie d'une requête sql qui ne contient pas d'`order by`
