### PR TITLE
(PC-21210)[PRO] feat: add dms collective timeline in venue form

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
@@ -1,0 +1,40 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_colors.scss" as colors;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.timeline {
+  &-step-title {
+    @include fonts.body;
+
+    font-weight: 700;
+  }
+
+  &-step-title-passed {
+    @include fonts.body;
+
+    font-weight: 700;
+    color: colors.$grey-dark;
+  }
+
+  &-step-title-disabled {
+    @include fonts.body-important;
+
+    line-height: rem.torem(20px);
+    color: colors.$grey-dark;
+  }
+
+  &-infobox {
+    border-radius: rem.torem(5px);
+    padding: rem.torem(16px);
+    background-color: colors.$light-pink;
+    margin-top: rem.torem(16px);
+
+    &-text {
+      margin-bottom: rem.torem(16px);
+    }
+
+    &-accent {
+      font-weight: 500;
+    }
+  }
+}

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+
+import { ExternalLinkIcon } from 'icons'
+import { ButtonLink } from 'ui-kit'
+import { ButtonVariant } from 'ui-kit/Button/types'
+import Timeline, { TimelineStepType } from 'ui-kit/Timeline/Timeline'
+
+import styles from './CollectiveDmsTimeline.module.scss'
+
+const CollectiveDmsTimeline = () => {
+  //const collectiveDmsStatus = venue.collectiveDmsStatus // FIX ME : collectiveDmsStatus is not yet a property of IVenue
+  const collectiveDmsStatus = 'DRAFT'
+  // const collectiveDmsApplicationLink = link to venue.collectiveDmsApplicationId // FIX ME : collectiveDmsApplicationId is not yet a property of IVenue
+  const collectiveDmsApplicationLink = 'todo'
+  const waitingDraftStep = {
+    type: TimelineStepType.WAITING,
+    content: (
+      <>
+        <div className={styles['timeline-step-title']}>
+          Déposez votre demande de référencement
+        </div>
+        <div className={styles['timeline-infobox']}>
+          <div className={styles['timeline-infobox-text']}>
+            Votre dossier est au statut “brouillon”. Vous devez le publier si
+            vous souhaitez qu’il soit traité.
+          </div>
+          <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            link={{
+              to: collectiveDmsApplicationLink,
+              isExternal: true,
+            }}
+            Icon={ExternalLinkIcon}
+          >
+            Modifier mon dossier sur Démarches Simplifiées
+          </ButtonLink>
+        </div>
+      </>
+    ),
+  }
+  const disabledInstructionStep = {
+    type: TimelineStepType.DISABLED,
+    content: (
+      <div className={styles['timeline-step-title-disabled']}>
+        Votre dossier est passé en instruction
+      </div>
+    ),
+  }
+  const disabledDoneStep = {
+    type: TimelineStepType.DISABLED,
+    content: (
+      <div className={styles['timeline-step-title-disabled']}>
+        Votre dossier a été traité
+      </div>
+    ),
+  }
+  const disabledAcceptedAdageStep = {
+    type: TimelineStepType.DISABLED,
+    content: (
+      <div className={styles['timeline-step-title-disabled']}>
+        Votre lieu a été ajouté dans ADAGE
+      </div>
+    ),
+  }
+
+  switch (collectiveDmsStatus) {
+    case 'DRAFT':
+      return (
+        <Timeline
+          steps={[
+            waitingDraftStep,
+            disabledInstructionStep,
+            disabledDoneStep,
+            disabledAcceptedAdageStep,
+          ]}
+        />
+      )
+    // istanbul ignore next: FIX ME not implemented yet
+    default:
+      throw new Error('Invalid dms status')
+  }
+}
+
+export default CollectiveDmsTimeline

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -1,0 +1,20 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveDmsTimeline from '..'
+
+const renderCollectiveDmsTimeline = () => {
+  renderWithProviders(<CollectiveDmsTimeline />)
+}
+
+describe('CollectiveDmsTimeline', () => {
+  it('should render draft state', () => {
+    renderCollectiveDmsTimeline()
+
+    expect(
+      screen.getByText('Déposez votre demande de référencement')
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/index.ts
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CollectiveDmsTimeline'

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import FormLayout from 'components/FormLayout'
+import { IVenue } from 'core/Venue'
+
+import { EACInformation } from '../EACInformation'
+
+import CollectiveDmsTimeline from './CollectiveDmsTimeline/CollectiveDmsTimeline'
+
+export interface ICollectiveVenueInformationsProps {
+  venue?: IVenue | null
+  isCreatingVenue: boolean
+}
+
+const CollectiveVenueInformations = ({
+  venue,
+  isCreatingVenue,
+}: ICollectiveVenueInformationsProps) => {
+  //const isAcceptedOnAdage = venue.adageId !== null // TO FIX : venue.adageId is not yet a property of IVenue
+  const isAcceptedOnAdage = false
+  return (
+    <FormLayout.Section
+      title="A destination des scolaires"
+      description={
+        // istanbul ignore next: FIX ME not yet implemented
+        isAcceptedOnAdage
+          ? ''
+          : 'Pour publier des offres à destination des scolaires, votre lieu doit être référencé sur ADAGE, la plateforme dédiée aux enseignants et aux chefs d’établissements.'
+      }
+    >
+      {
+        // istanbul ignore next: FIX ME not yet implemented
+        isAcceptedOnAdage ? (
+          <EACInformation venue={venue} isCreatingVenue={isCreatingVenue} />
+        ) : (
+          <CollectiveDmsTimeline />
+        )
+      }
+    </FormLayout.Section>
+  )
+}
+
+export default CollectiveVenueInformations

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/__specs__/CollectiveVenueInformations.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/__specs__/CollectiveVenueInformations.spec.tsx
@@ -1,0 +1,27 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import CollectiveVenueInformations, {
+  ICollectiveVenueInformationsProps,
+} from '../CollectiveVenueInformations'
+
+const renderCollectiveVenueInformations = (
+  props: ICollectiveVenueInformationsProps
+) => {
+  renderWithProviders(<CollectiveVenueInformations {...props} />)
+}
+
+describe('CollectiveVenueInformations', () => {
+  it('should display description when venue is not accepted on adage', () => {
+    renderCollectiveVenueInformations({
+      isCreatingVenue: false,
+    })
+    expect(
+      screen.getByText(
+        'Pour publier des offres à destination des scolaires, votre lieu doit être référencé sur ADAGE, la plateforme dédiée aux enseignants et aux chefs d’établissements.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/index.ts
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CollectiveVenueInformations'

--- a/pro/src/components/VenueForm/VenueForm.tsx
+++ b/pro/src/components/VenueForm/VenueForm.tsx
@@ -11,6 +11,7 @@ import {
   useNewOfferCreationJourney,
   useScrollToFirstErrorAfterSubmit,
 } from 'hooks'
+import useActiveFeature from 'hooks/useActiveFeature'
 import ReimbursementFields from 'pages/Offerers/Offerer/VenueV1/fields/ReimbursementFields/ReimbursementFields'
 import { venueSubmitRedirectUrl } from 'screens/VenueForm/utils/venueSubmitRedirectUrl'
 
@@ -20,6 +21,7 @@ import RouteLeavingGuard, { BlockerFunction } from '../RouteLeavingGuard'
 import { Accessibility } from './Accessibility'
 import { Activity } from './Activity'
 import { Address } from './Address'
+import CollectiveVenueInformations from './CollectiveVenueInformations/CollectiveVenueInformations'
 import { Contact } from './Contact'
 import { EACInformation } from './EACInformation'
 import { ImageUploaderVenue } from './ImageUploaderVenue'
@@ -30,7 +32,7 @@ import { WithdrawalDetails } from './WithdrawalDetails'
 
 import { IVenueFormValues } from '.'
 
-interface IVenueForm {
+export interface IVenueForm {
   isCreatingVenue: boolean
   offerer: IOfferer
   updateIsSiretValued: (isSiretValued: boolean) => void
@@ -76,6 +78,9 @@ const VenueForm = ({
   }, [])
 
   const isNewOfferCreationJourney = useNewOfferCreationJourney()
+  const isCollectiveDmsTrackingActive = useActiveFeature(
+    'WIP_ENABLE_COLLECTIVE_DMS_TRACKING'
+  )
 
   const shouldBlockNavigation: BlockerFunction = ({ nextLocation }) => {
     if (!isCreatingVenue) {
@@ -152,8 +157,19 @@ const VenueForm = ({
         />
         {
           /* istanbul ignore next: DEBT, TO FIX */ canOffererCreateCollectiveOffer &&
+            !isCollectiveDmsTrackingActive &&
             ((isCreatingVenue && isSiretValued) || !isCreatingVenue) && (
               <EACInformation isCreatingVenue={isCreatingVenue} venue={venue} />
+            )
+        }
+        {
+          /* istanbul ignore next: DEBT, TO FIX */
+          isCollectiveDmsTrackingActive &&
+            ((isCreatingVenue && isSiretValued) || !isCreatingVenue) && (
+              <CollectiveVenueInformations
+                venue={venue}
+                isCreatingVenue={isCreatingVenue}
+              />
             )
         }
         {!isCreatingVenue && venue && (


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21210

## But de la pull request

Ajouter un schéma visuel pour le référencement DMS sur la page lieu quand le FF WIP_ENABLE_COLLECTIVE_DMS_TRACKING est activé

ℹ️  _C'est simplement des briques placées sans logique pour l'instant, on implémentera tout ça dans un autre ticket quand le back sera implémenté_

## Screenshot 

![Capture d’écran 2023-03-21 à 09 59 10](https://user-images.githubusercontent.com/71768799/226845904-3e41285f-cf27-4c18-a8da-58e86671cc07.png)

