### PR TITLE
(PC-21230)[API] fix: timeout when searching for offers by visa in backoffice v3

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 bf927d0e97e8 (pre) (head)
-474312bd6eaf (post) (head)
+2598542274a5 (post) (head)

--- a/api/src/pcapi/alembic/script.py.mako
+++ b/api/src/pcapi/alembic/script.py.mako
@@ -12,9 +12,9 @@ branch_labels = ${repr(branch_labels)}
 depends_on = ${repr(depends_on)}
 
 
-def upgrade():
+def upgrade() -> None:
     ${upgrades if upgrades else "pass"}
 
 
-def downgrade():
+def downgrade() -> None:
     ${downgrades if downgrades else "pass"}

--- a/api/src/pcapi/alembic/versions/20230322T132119_2598542274a5_add_visa_index_offer.py
+++ b/api/src/pcapi/alembic/versions/20230322T132119_2598542274a5_add_visa_index_offer.py
@@ -1,0 +1,31 @@
+"""add_visa_index_offer
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "2598542274a5"
+down_revision = "474312bd6eaf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS offer_visa_idx
+        ON offer
+        USING btree ((("jsonData" ->> 'visa'::text)));
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "offer_visa_idx"
+        """
+    )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -410,6 +410,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     sa.Index("idx_offer_trgm_name", name, postgresql_using="gin")
     sa.Index("offer_ean_idx", extraData["ean"].astext)
     sa.Index("offer_isbn_idx", extraData["isbn"].astext)
+    sa.Index("offer_visa_idx", extraData["visa"].astext)
     # FIXME: We shoud be able to remove the index on `venueId`, since this composite index
     #  can be used by PostgreSQL when filtering on the `venueId` column only.
     sa.Index("venueId_idAtProvider_index", venueId, idAtProvider, unique=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21230

## But de la pull request

Résoudre le problème de timeout dans le backoffice v3 lors de la recherche d'offres par visa d'exploitation.

## Implémentation

Création d'un index, similaire à celui ajouté par @mageoffray hier pour `ean`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
