### PR TITLE
(PC-21289)[BO] fix: checked offerer tags were lost in filter when using pagination

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -62,7 +62,7 @@ class EditOffererForm(FlaskForm):
     postal_code = fields.PCPostalCodeHiddenField("Code postal")
 
 
-class OffererValidationListForm(FlaskForm):
+class OffererValidationListForm(utils.PCForm):
     class Meta:
         csrf = False
 
@@ -96,7 +96,7 @@ class OffererValidationListForm(FlaskForm):
         return q
 
 
-class UserOffererValidationListForm(FlaskForm):
+class UserOffererValidationListForm(utils.PCForm):
     class Meta:
         csrf = False
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/utils.py
@@ -12,6 +12,10 @@ class PCForm(FlaskForm):
             return ""
         return email_utils.sanitize_email(raw_email)
 
+    @property
+    def raw_data(self) -> dict[str, typing.Any]:
+        return {field.name: field.raw_data for field in self}
+
 
 def choices_from_enum(
     enum_cls: typing.Type[enum.Enum], formatter: typing.Callable[[typing.Any], str] | None = None

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -353,7 +353,7 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
         per_page=int(form.data["per_page"]),
     )
 
-    next_page = partial(url_for, ".list_offerers_to_validate", **form.data)
+    next_page = partial(url_for, ".list_offerers_to_validate", **form.raw_data)
     next_pages_urls = search_utils.pagination_links(next_page, int(form.data["page"]), paginated_offerers.pages)
 
     form.page.data = 1  # Reset to first page when form is submitted ("Appliquer" clicked)
@@ -533,7 +533,7 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
         per_page=int(form.data["per_page"]),
     )
 
-    next_page = partial(url_for, ".list_offerers_attachments_to_validate", **form.data)
+    next_page = partial(url_for, ".list_offerers_attachments_to_validate", **form.raw_data)
     next_pages_urls = search_utils.pagination_links(next_page, int(form.data["page"]), paginated_users_offerers.pages)
 
     form.page.data = 1  # Reset to first page when form is submitted ("Appliquer" clicked)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21289

## But de la pull request

Bug en prod : Sur les pages “Structures à valider” et “Rattachements à valider”, lorsqu’on filtre sur un ou plusieurs tags et qu’on change de page, le tag disparaît et les résultats ne sont donc plus en adéquation avec la recherche effectuée

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
