### PR TITLE
PC-20836 fix dms messaging spam

### DIFF
--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -403,15 +403,14 @@ def _process_user_not_found_error(
             latest_modification_datetime=latest_modification_datetime,
             email=email,
         )
-
-    if state == dms_models.GraphQLApplicationStates.draft:
-        dms_connector_api.DMSGraphQLClient().send_user_message(
-            application_scalar_id,
-            settings.DMS_INSTRUCTOR_ID,
-            dms_internal_mailing.DMS_ERROR_MESSAGE_USER_NOT_FOUND,
-        )
-    elif state == dms_models.GraphQLApplicationStates.accepted:
-        transactional_mails.send_create_account_after_dms_email(email)
+        if state == dms_models.GraphQLApplicationStates.draft:
+            dms_connector_api.DMSGraphQLClient().send_user_message(
+                application_scalar_id,
+                settings.DMS_INSTRUCTOR_ID,
+                dms_internal_mailing.DMS_ERROR_MESSAGE_USER_NOT_FOUND,
+            )
+        elif state == dms_models.GraphQLApplicationStates.accepted:
+            transactional_mails.send_create_account_after_dms_email(email)
 
 
 def _process_accepted_application(

--- a/api/src/pcapi/core/users/email/send.py
+++ b/api/src/pcapi/core/users/email/send.py
@@ -23,15 +23,15 @@ def _build_link_for_email_change(current_email: str, new_email: str, expiration_
     return generate_firebase_dynamic_link(path, params)
 
 
-def send_beneficiary_user_emails_for_email_change(user: User, new_email: str, expiration_date: datetime) -> None:
+def send_beneficiary_user_emails_for_email_change(user: User, new_email: str, expiration_date: datetime) -> bool:
     user_with_new_email = find_user_by_email(new_email)
     if user_with_new_email:
-        return True  # type: ignore [return-value]
+        return True
 
     success = transactional_mails.send_information_email_change_email(user)
     link_for_email_change = _build_link_for_email_change(user.email, new_email, expiration_date)
     success &= transactional_mails.send_confirmation_email_change_email(user, new_email, link_for_email_change)
-    return success  # type: ignore [return-value]
+    return success
 
 
 def build_pro_link_for_email_change(current_email: str, new_email: str, user_id: int, expiration_date: datetime) -> str:

--- a/api/src/pcapi/scripts/subscription/dms/__init__.py
+++ b/api/src/pcapi/scripts/subscription/dms/__init__.py
@@ -2,4 +2,3 @@ from .archive_dms_applications import archive_applications
 from .handle_deleted_dms_applications import handle_deleted_dms_applications
 from .handle_inactive_dms_applications import handle_inactive_dms_applications
 from .import_dms_applications import import_all_updated_dms_applications
-from .import_dms_applications import import_dms_accepted_applications

--- a/api/src/pcapi/scripts/subscription/dms/import_dms_applications.py
+++ b/api/src/pcapi/scripts/subscription/dms/import_dms_applications.py
@@ -11,33 +11,6 @@ from pcapi.repository import repository
 logger = logging.getLogger(__name__)
 
 
-def import_dms_accepted_applications(procedure_number: int) -> None:
-    logger.info(
-        "[DMS] Start import of accepted applications from Démarches Simplifiées for procedure %s", procedure_number
-    )
-
-    already_processed_applications_ids = dms_repository.get_already_processed_applications_ids(procedure_number)
-    client = dms_connector_api.DMSGraphQLClient()
-    processed_count = 0
-
-    for application_details in client.get_applications_with_details(
-        procedure_number, dms_models.GraphQLApplicationStates.accepted
-    ):
-        if application_details.number in already_processed_applications_ids:
-            continue
-        processed_count += 1
-        try:
-            dms_api.handle_dms_application(application_details)
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("[DMS] Error in script while importing application %s", application_details.number)
-
-    logger.info(
-        "[DMS] End import of accepted applications from Démarches Simplifiées for procedure %s - Processed %s applications",
-        procedure_number,
-        processed_count,
-    )
-
-
 def _import_all_dms_applications_initial_import(procedure_id: int) -> None:
     already_processed_applications_ids = dms_repository.get_already_processed_applications_ids(procedure_id)
     client = dms_connector_api.DMSGraphQLClient()

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -584,9 +584,8 @@ class DmsWebhookApplicationTest:
 
         # assert an OrphanApplication is not created again
         assert fraud_models.OrphanDmsApplication.query.count() == 1
-        # assert an email is sent to ask to create account
-        assert len(mails_testing.outbox) == 1
-        assert mails_testing.outbox[0].sent_data["template"]["id_prod"] == 678
+        # assert no email is sent to ask to create account (Already sent once when the application was created)
+        assert len(mails_testing.outbox) == 0
 
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
     @patch.object(api_dms.DMSGraphQLClient, "send_user_message")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20836

## But de la pull request

Arreter le spam de la messagerie DMS quand un email n'est pas encore attaché à un compte
On ne veut envoyer le msg qu'une fois

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
