### PR TITLE
(PC-21220)[API] feat: register date of acceptation for venues in adage

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-a8c91c7a2a9f (pre) (head)
+d1eb4e7db641 (pre) (head)
 2598542274a5 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230323T093430_d1eb4e7db641_register_adage_id_create_date.py
+++ b/api/src/pcapi/alembic/versions/20230323T093430_d1eb4e7db641_register_adage_id_create_date.py
@@ -1,0 +1,20 @@
+"""register_adage_id_create_date
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "d1eb4e7db641"
+down_revision = "a8c91c7a2a9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("venue", sa.Column("adageInscriptionDate", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("venue", "adageInscriptionDate")

--- a/api/src/pcapi/core/educational/api/adage.py
+++ b/api/src/pcapi/core/educational/api/adage.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import partial
 import json
 import typing
@@ -120,12 +121,14 @@ def synchronize_adage_ids_on_venues() -> None:
                 send_eac_offerer_activation_email(venue, list(emails))
 
         venue.adageId = str(filtered_cultural_partner_by_ids[venue.id].id)
+        venue.adageInscriptionDate = datetime.utcnow()
 
     db.session.commit()
 
 
 def _remove_venue_from_eac(venue: offerers_models.Venue) -> None:
     venue.adageId = None
+    venue.adageInscriptionDate = None
 
 
 def get_adage_educational_redactors_for_uai(uai: str, *, force_update: bool = False) -> list[dict[str, str]]:

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -233,6 +233,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
     bannerMeta: dict | None = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
     adageId = Column(Text, nullable=True)
+    adageInscriptionDate = Column(DateTime, nullable=True)
 
     thumb_path_component = "venues"
 

--- a/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
+++ b/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import requests_mock
@@ -18,8 +19,8 @@ def test_synchronize_adage_ids_on_venues(db_session):
     venue2 = offerers_factories.VenueFactory()
     venue3 = offerers_factories.VenueFactory()
     venue4 = offerers_factories.VenueFactory()
-    venue5 = offerers_factories.VenueFactory(adageId="11")
-    venue6 = offerers_factories.VenueFactory(adageId="1252")
+    venue5 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=datetime.utcnow())
+    venue6 = offerers_factories.VenueFactory(adageId="1252", adageInscriptionDate=datetime.utcnow())
 
     BASE_DATA = {
         "siret": "",
@@ -69,9 +70,15 @@ def test_synchronize_adage_ids_on_venues(db_session):
             educational_api_adage.synchronize_adage_ids_on_venues()
 
     assert venue1.adageId == "128028"
+    assert venue1.adageInscriptionDate != None
     assert venue2.adageId == "128029"
+    assert venue2.adageInscriptionDate != None
     assert venue3.adageId is None
+    assert venue3.adageInscriptionDate is None
     assert venue4.adageId is None
+    assert venue4.adageInscriptionDate is None
     assert venue5.adageId is None
+    assert venue5.adageInscriptionDate is None
     assert venue6.adageId is None
+    assert venue6.adageInscriptionDate is None
     mock_activation_mail.assert_called_with(venue2, list(email2))


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21220

## Modifications du schéma de la base de données

- ajout d'une colonne `adageInsccriptionDate` dans la table venue qui contient la date a laquelle adageId a été set (et None si adageId est None)
