### PR TITLE
(BSR)[API] fix: revert algolia replica to unblock deployement

### DIFF
--- a/api/src/pcapi/algolia_settings_offers.json
+++ b/api/src/pcapi/algolia_settings_offers.json
@@ -30,9 +30,7 @@
     "queryLanguages": [
         "fr"
     ],
-    "replicas": [
-        "virtual(PRODUCTION Top offres)"
-    ],
+    "replicas": [],
     "attributesForFaceting": [
         "offer.bookMacroSection",
         "filterOnly(offer.category)",


### PR DESCRIPTION
Revert pour débloquer le déploiement en staging.

Fix temporaire, on veut pouvoir laisser un replica sans casser les déploiements