### PR TITLE
(PC-21076)[API] feat: add showsubtype property to offer

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -622,6 +622,12 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         except ValueError:  # if no non-deleted stocks
             return 0
 
+    @property
+    def showSubType(self) -> str | None:  # used in validation rule, do not remove
+        if self.extraData:
+            return self.extraData.get("showSubType")
+        return None
+
     @hybrid_property
     def status(self) -> OfferStatus:
         if self.validation == OfferValidationStatus.REJECTED:

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -284,6 +284,15 @@ class OfferStatusTest:
         assert models.Offer.query.filter(models.Offer.status != offer_mixin.OfferStatus.SOLD_OUT.name).count() == 0
 
 
+class OfferShowSubTypeTest:
+    def test_show_sub_type_property(self):
+        offer_without_showsubtype = factories.OfferFactory()
+        offer_with_showsubtype = factories.OfferFactory(extraData={"showSubType": "1101"})
+
+        assert offer_without_showsubtype.showSubType is None
+        assert offer_with_showsubtype.showSubType == "1101"
+
+
 class StockBookingsQuantityTest:
     def test_bookings_quantity_without_bookings(self):
         offer = factories.OfferFactory()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21076

## But de la pull request

Ajout de la propriété showSubType à Offer, qui va chercher cette info dans extraData.
Le but est de pouvoir y accéder simplement pour l'utiliser dans les règles de fraude.
```
-   conditions:
    -   attribute: showSubType
        condition:
            comparated: "some string value"
            operator: ==
        model: Offer
    factor: 0
    name: "Vérification des offres avec ce sous type"
```

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
