### PR TITLE
(PC-21019)[PRO] feat: display reimbursment date in collective timeline

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/CollectiveTimeLine.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/CollectiveTimeLine.tsx
@@ -62,7 +62,7 @@ const CollectiveTimeLine = ({
   const eventDate = getDateToFrenchText(
     bookingRecap.stock.eventBeginningDatetime
   )
-  const cancelledDate = getDateToFrenchText(
+  const lastHistoryDate = getDateToFrenchText(
     bookingRecap.bookingStatusHistory[
       bookingRecap.bookingStatusHistory.length - 1
     ].date
@@ -229,7 +229,7 @@ const CollectiveTimeLine = ({
         <div className={styles['timeline-step-title']}>
           Remboursement effectué
         </div>
-        <div>{}</div>
+        <div>{lastHistoryDate}</div>
       </>
     ),
   }
@@ -274,7 +274,7 @@ const CollectiveTimeLine = ({
           {cancellationReasonTitle(bookingRecap)}
         </div>
         <div>
-          {cancelledDate}
+          {lastHistoryDate}
           <br />
           <br />
           {bookingRecap.bookingCancellationReason ===

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Table/Body/CollectiveTimeLine/__specs__/CollectiveTimeLine.spec.tsx
@@ -61,9 +61,15 @@ describe('collective timeline', () => {
   it('should render steps for reimbursed booking', () => {
     const bookingRecap = collectiveBookingRecapFactory({
       bookingStatus: BOOKING_STATUS.REIMBURSED,
+      bookingStatusHistory: [
+        { date: new Date().toISOString(), status: BOOKING_STATUS.PENDING },
+        { date: new Date().toISOString(), status: BOOKING_STATUS.CONFIRMED },
+        { date: '2023-03-25', status: BOOKING_STATUS.REIMBURSED },
+      ],
     })
     renderCollectiveTimeLine(bookingRecap, bookingDetails)
     expect(screen.getByText('Remboursement effectué')).toBeInTheDocument()
+    expect(screen.getByText('25 mars 2023')).toBeInTheDocument()
   })
   it('should render steps for cancelled booking', () => {
     const bookingRecap = collectiveBookingRecapFactory({


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21019

## But de la pull request

Afficher la date de remboursement pour les réservations collectives remboursées 

## Screenshot 

![Capture d’écran 2023-03-24 à 10 19 56](https://user-images.githubusercontent.com/71768799/227477941-8f9501ca-975e-4fa5-8397-432997dd6ed0.png)
