### PR TITLE
(PC-21177)[API] fix: add pro user email validation from bov3

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -38,6 +38,7 @@ class ActionType(enum.Enum):
     USER_SUSPENDED = "Compte suspendu"
     USER_UNSUSPENDED = "Compte réactivé"
     USER_PHONE_VALIDATED = "Validation manuelle du numéro de téléphone"
+    USER_EMAIL_VALIDATED = "Validation manuelle de l'e-mail"
 
 
 class ActionHistory(PcObject, Base, Model):

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/generic_modal.html
@@ -1,4 +1,4 @@
-{% macro build_modal_form(modal_id, dst, form, title, button_text) %}
+{% macro build_modal_form(modal_id, dst, form, title, button_text, description) %}
   {% set modal_aria_described_by_id = random_hash() %}
   <button class="btn btn-outline-primary lead fw-bold mt-2"
           data-bs-toggle="modal"
@@ -18,11 +18,18 @@
               name="{{ dst | action_to_name }}"
               method="post">
           <div class="modal-body">
+            {% if description %}
+              <p>
+                {{ description }}
+              </p>
+            {% endif %}
             <div class="form-group">
               {% for form_field in form %}
-                <div class="w-100 my-4">
-                  {% for error in form_field.errors %}<p class="text-warning lead">{{ error }}</p>{% endfor %}
-                </div>
+                  {% if form_field.errors %}
+                    <div class="w-100 my-4">
+                      {% for error in form_field.errors %}<p class="text-warning lead">{{ error }}</p>{% endfor %}
+                    </div>
+                  {% endif %}
                 {{ form_field }}
               {% endfor %}
             </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/pro_user/get.html
@@ -1,6 +1,7 @@
 {% from "components/badges.html" import build_pro_user_status_badge %}
 {% from "components/generic_modal.html" import build_modal_form with context %}
 {% from "components/forms.html" import build_form_fields_group with context %}
+{% from "components/generic_modal.html" import build_modal_form with context %}
 {% extends "layouts/pro.html" %}
 {% block pro_main_content %}
   <div class="row row-cols-1 g-4 py-3">
@@ -92,12 +93,7 @@
                 </p>
                 {% if not user.isEmailValidated and has_permission("MANAGE_PRO_ENTITY") %}
                   <p class="mb-1">
-                    <a href="{{ user | pc_pro_user_email_validation_link }}"
-                       target="_blank"
-                       class="btn btn-outline-primary fw-bold"
-                       role="button">
-                      Valider l'email
-                    </a>
+                    {{ build_modal_form("validate-email", url_for("backoffice_v3_web.pro_user.validate_pro_user_email", user_id=user.id), empty_form, "Valider l'adresse e-mail", "Confirmer la validation de l'adresse e-mail", "Vous êtes sur le point de valider l'adresse e-mail, êtes-vous sûr ?") }}
                   </p>
                 {% endif %}
               </div>

--- a/api/src/pcapi/routes/pro/validate.py
+++ b/api/src/pcapi/routes/pro/validate.py
@@ -1,10 +1,6 @@
 import logging
 
-from pcapi.connectors import sirene
-import pcapi.core.mails.transactional as transactional_mails
-import pcapi.core.offerers.models as offerers_models
-from pcapi.domain.admin_emails import maybe_send_offerer_validation_email
-from pcapi.repository import repository
+from pcapi.core.users import api as users_api
 from pcapi.repository import user_queries
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.validation.routes.validate import check_valid_token_for_user_validation
@@ -20,31 +16,4 @@ logger = logging.getLogger(__name__)
 def validate_user(token: str) -> None:
     user_to_validate = user_queries.find_by_validation_token(token)
     check_valid_token_for_user_validation(user_to_validate)
-
-    user_to_validate.validationToken = None
-    user_to_validate.isEmailValidated = True
-    repository.save(user_to_validate)
-
-    if not transactional_mails.send_welcome_to_pro_email(user_to_validate):
-        logger.warning(
-            "Could not send welcome email when pro user is valid",
-            extra={"user": user_to_validate.id},
-        )
-
-    user_offerer = offerers_models.UserOfferer.query.filter_by(userId=user_to_validate.id).one_or_none()
-
-    if user_offerer:
-        offerer = user_offerer.offerer
-
-        assert offerer.siren  # helps mypy until Offerer.siren is set as NOT NULL
-        try:
-            siren_info = sirene.get_siren(offerer.siren)
-        except sirene.SireneException as exc:
-            logger.info("Could not fetch info from Sirene API", extra={"exc": exc})
-            siren_info = None
-
-        if not maybe_send_offerer_validation_email(offerer, user_offerer, siren_info):
-            logger.warning(
-                "Could not send offerer validation email to offerer",
-                extra={"user_offerer": user_offerer.id},
-            )
+    users_api.validate_pro_user_email(user_to_validate)

--- a/api/tests/routes/backoffice_v3/pro_users_test.py
+++ b/api/tests/routes/backoffice_v3/pro_users_test.py
@@ -4,7 +4,6 @@ from flask import g
 from flask import url_for
 import pytest
 
-from pcapi import settings
 import pcapi.core.history.factories as history_factories
 import pcapi.core.history.models as history_models
 import pcapi.core.offerers.factories as offerers_factories
@@ -37,7 +36,7 @@ class GetProUserTest:
 
     class EmailValidationButtonTest(button_helpers.ButtonHelper):
         needed_permission = perm_models.Permissions.MANAGE_PRO_ENTITY
-        button_label = "Valider l'email"
+        button_label = "Valider l&#39;adresse e-mail"
 
         @property
         def path(self):
@@ -50,7 +49,7 @@ class GetProUserTest:
             assert response.status_code == 200
 
             assert self.button_label in response.data.decode("utf-8")
-            assert f"{settings.PRO_URL}/inscription/validation/{user.validationToken}" in response.data.decode("utf-8")
+            assert f"/backofficev3/pro/user/{user.id}/validate-email" in response.data.decode("utf-8")
 
         def test_no_button_if_validated_email(self, authenticated_client):
             user = offerers_factories.UserOffererFactory(
@@ -305,3 +304,45 @@ class GetProUserOfferersTest:
         with assert_no_duplicated_queries():
             response = authenticated_client.get(url)
         assert response.status_code == 200
+
+
+class ValidateProEmailTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+        endpoint = "backoffice_v3_web.pro_user.validate_pro_user_email"
+        endpoint_kwargs = {"user_id": 1}
+        needed_permission = perm_models.Permissions.MANAGE_PRO_ENTITY
+
+    def test_validate_pro_user_email(self, authenticated_client):
+        authenticated_client.get(url_for("backoffice_v3_web.home"))
+        pro_user = offerers_factories.NotValidatedUserOffererFactory(
+            user__validationToken=False, user__isEmailValidated=False
+        ).user
+        assert not pro_user.isEmailValidated
+
+        data = dict({"csrf_token": g.get("csrf_token", None)})
+
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.pro_user.validate_pro_user_email", user_id=pro_user.id), form=data
+        )
+        assert response.status_code == 303
+        assert pro_user.isEmailValidated
+
+        response_redirect = authenticated_client.get(response.location)
+        assert f"L&#39;e-mail {pro_user.email} est validé !" in response_redirect.data.decode("utf-8")
+
+    def test_already_validated_pro_user_email(self, authenticated_client):
+        authenticated_client.get(url_for("backoffice_v3_web.home"))
+        pro_user = offerers_factories.NotValidatedUserOffererFactory(
+            user__validationToken=False, user__isEmailValidated=True
+        ).user
+
+        data = dict({"csrf_token": g.get("csrf_token", None)})
+
+        response = authenticated_client.post(
+            url_for("backoffice_v3_web.pro_user.validate_pro_user_email", user_id=pro_user.id), form=data
+        )
+        assert response.status_code == 303
+        assert pro_user.isEmailValidated
+
+        response_redirect = authenticated_client.get(response.location)
+        assert f"L&#39;e-mail {pro_user.email} est déjà validé !" in response_redirect.data.decode("utf-8")

--- a/api/tests/routes/pro/validate_user_test.py
+++ b/api/tests/routes/pro/validate_user_test.py
@@ -2,36 +2,20 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.connectors import sirene
 import pcapi.core.offerers.factories as offerers_factories
 
 from tests.conftest import TestClient
 
 
 @pytest.mark.usefixtures("db_session")
-@patch("pcapi.routes.pro.validate.maybe_send_offerer_validation_email")
-def test_validate_user_token(mocked_maybe_send_offerer_validation_email, app):
+@patch("pcapi.core.users.api.validate_pro_user_email")
+def test_validate_user_token(validate_pro_user_email, app):
     user_offerer = offerers_factories.UserOffererFactory(user__validationToken="token")
-
     client = TestClient(app.test_client())
     response = client.patch("/validate/user/token")
-
     assert response.status_code == 204
-    assert user_offerer.user.isValidated
     assert user_offerer.user.isEmailValidated
-
-    mocked_maybe_send_offerer_validation_email.assert_called_once_with(
-        user_offerer.offerer,
-        user_offerer,
-        sirene.SirenInfo(
-            siren=user_offerer.offerer.siren,
-            name="MINISTERE DE LA CULTURE",
-            head_office_siret=f"{user_offerer.offerer.siren}00001",
-            ape_code="90.03A",
-            legal_category_code="1000",
-            address=sirene._Address(street="3 RUE DE VALOIS", postal_code="75001", city="Paris", insee_code="75101"),
-        ),
-    )
+    validate_pro_user_email.assert_called_once_with(user_offerer.user)
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21177

## But de la pull request

Ne plus passer par pro pour valider l'adresse d'un pro.

## Implémentation

- Ajout d'une route bov3 pour valider les emails
- Ajout d'une action history si validation d'email via backoffice

## Informations supplémentaires

- Refacto de la validation de pro dans un utilities pcapi.core.users.api

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
