### PR TITLE
(PC-20006)[API] fix: make profile route more robust to existing obsolete data

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -76,9 +76,9 @@ class SubscriptionStepperResponse(BaseModel):
         allow_population_by_field_name = True
 
 
-class ProfileResponse(BaseModel):
+class ProfileContent(BaseModel):
     activity: profile_options.ACTIVITY_ID_ENUM
-    address: str
+    address: str | None  # Address is nullable for backward compatibility
     city: str
     first_name: str
     last_name: str
@@ -89,6 +89,10 @@ class ProfileResponse(BaseModel):
         alias_generator = to_camel
         allow_population_by_field_name = True
         use_enum_values = True
+
+
+class ProfileResponse(BaseModel):
+    profile: ProfileContent | None = fields.Field(None)
 
 
 class ProfileUpdateRequest(BaseModel):

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -3061,6 +3061,7 @@ def test_public_api(client):
                     "responses": {
                         "200": {"description": "OK"},
                         "403": {"description": "Forbidden"},
+                        "404": {"description": "Not Found"},
                         "422": {
                             "content": {
                                 "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -786,15 +786,35 @@ class GetProfileTest:
         response = client.get("/native/v1/subscription/profile")
 
         content: fraud_models.ProfileCompletionContent = fraud_check.source_data()
+        profile_content = response.json["profile"]
 
         assert response.status_code == 200
-        assert response.json["firstName"] == content.first_name
-        assert response.json["lastName"] == content.last_name
-        assert response.json["address"] == content.address
-        assert response.json["city"] == content.city
-        assert response.json["postalCode"] == content.postal_code
-        assert response.json["activity"] == content.activity
-        assert response.json["schoolType"] == content.school_type
+        assert profile_content["firstName"] == content.first_name
+        assert profile_content["lastName"] == content.last_name
+        assert profile_content["address"] == content.address
+        assert profile_content["city"] == content.city
+        assert profile_content["postalCode"] == content.postal_code
+        assert profile_content["activity"] == content.activity
+        assert profile_content["schoolType"] == content.school_type
+
+    def test_get_profile_with_no_fraud_check(self, client):
+        user = users_factories.BeneficiaryGrant18Factory()
+
+        client.with_token(user.email)
+        response = client.get("/native/v1/subscription/profile")
+
+        assert response.status_code == 404
+
+    def test_get_profile_with_obsolete_profile_info(self, client):
+        user = users_factories.BeneficiaryGrant18Factory()
+        content = fraud_factories.ProfileCompletionContentFactory(activity="Étudiant")
+        fraud_factories.ProfileCompletionFraudCheckFactory(resultContent=content, user=user)
+
+        client.with_token(user.email)
+        response = client.get("/native/v1/subscription/profile")
+
+        assert response.status_code == 200
+        assert response.json["profile"] is None
 
 
 class UpdateProfileTest:
@@ -1139,4 +1159,5 @@ class HonorStatementTest:
 
         assert fraud_check.status == fraud_models.FraudCheckStatus.OK
         assert fraud_check.reason == "statement from /subscription/honor_statement endpoint"
+        assert fraud_check.eligibilityType == eligibility_type
         assert fraud_check.eligibilityType == eligibility_type


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20006

## But de la pull request

Certaines données historiques ne suivent pas les contraintes des enums
Pour éviter des 500, dans ce cas on considère que le profil n'est pas rempli. 
Le but de ce ticket étant de proposer une route qui alimente de l'auto-complétion, on préfère ne rien retourner que des valeurs invalides

## Implémentation

- try:except qui retourne None

## Informations supplémentaires

- Nécessite une update de swagger pour le front
- C'est techniquement un breaking change, compte tenu de la nouvelle clef `profile` La route étant à peine en testing, elle n'est pas encore utilisée dans le front, on peut la modifier

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
