### PR TITLE
(PC-21131)[API] feat: rename reimbursement point label in bov3

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -173,7 +173,7 @@
                 {{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Présence de CB :</span>
+                <span class="fw-bold">Relié à un point de remboursement :</span>
                 {{ has_reimbursement_point | format_bool }}
               </p>
               {% if venue.contact and venue.contact.website %}

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -116,7 +116,7 @@ class GetVenueTest:
 
         # then
         assert response.status_code == 200
-        assert "Présence de CB : Oui" in html_parser.content_as_text(response.data)
+        assert "Relié à un point de remboursement : Oui" in html_parser.content_as_text(response.data)
 
     def test_get_venue_with_accepted_reimbursement_point(
         self, authenticated_client, venue_with_accepted_reimbursement_point
@@ -128,7 +128,7 @@ class GetVenueTest:
 
         # then
         assert response.status_code == 200
-        assert "Présence de CB : Oui" in html_parser.content_as_text(response.data)
+        assert "Relié à un point de remboursement : Oui" in html_parser.content_as_text(response.data)
 
     def test_get_venue_with_expired_reimbursement_point(
         self, authenticated_client, venue_with_expired_reimbursement_point
@@ -140,7 +140,7 @@ class GetVenueTest:
 
         # then
         assert response.status_code == 200
-        assert "Présence de CB : Non" in html_parser.content_as_text(response.data)
+        assert "Relié à un point de remboursement : Non" in html_parser.content_as_text(response.data)
 
     def test_get_venue_dms_stats(self, authenticated_client, venue_with_draft_bank_info):
         with mock.patch("pcapi.connectors.dms.api.DMSGraphQLClient.get_bank_info_status") as bank_info_mock:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21131

## But de la pull request

Renommer le champ “Présence CB” sur un lieu par “Relié à un point de remboursement”

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
