### PR TITLE
(BSR)[API] feat: Add NOT NULL constraint on `Booking.userId`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d1eb4e7db641 (pre) (head)
-aa37244acc4c (post) (head)
+56bba24a7f57 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230324T183947_558feec91836_add_not_null_constraint_on_booking_userId_step_3_of_4.py
+++ b/api/src/pcapi/alembic/versions/20230324T183947_558feec91836_add_not_null_constraint_on_booking_userId_step_3_of_4.py
@@ -1,0 +1,18 @@
+"""Add NOT NULL constraint on "booking.userId" (step 3 of 4)"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "558feec91836"
+down_revision = "f1e0b83e0b42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("booking", "userId", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("booking", "userId", nullable=True)

--- a/api/src/pcapi/alembic/versions/20230324T183947_56bba24a7f57_add_not_null_constraint_on_booking_userId_step_4_of_4.py
+++ b/api/src/pcapi/alembic/versions/20230324T183947_56bba24a7f57_add_not_null_constraint_on_booking_userId_step_4_of_4.py
@@ -1,0 +1,20 @@
+"""Add NOT NULL constraint on "booking.userId" (step 4 of 4)"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "56bba24a7f57"
+down_revision = "558feec91836"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("booking_userId_not_null_constraint", table_name="booking")
+
+
+def downgrade() -> None:
+    op.execute(
+        """ALTER TABLE "booking" ADD CONSTRAINT "booking_userId_not_null_constraint" CHECK ("userId" IS NOT NULL) NOT VALID"""
+    )

--- a/api/src/pcapi/alembic/versions/20230324T183947_8c17d89b7c9a_add_not_null_constraint_on_booking_userId_step_1_of_4.py
+++ b/api/src/pcapi/alembic/versions/20230324T183947_8c17d89b7c9a_add_not_null_constraint_on_booking_userId_step_1_of_4.py
@@ -1,0 +1,23 @@
+"""Add NOT NULL constraint on "booking.userId" (step 1 of 4)"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "8c17d89b7c9a"
+down_revision = "aa37244acc4c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE "booking" DROP CONSTRAINT IF EXISTS "booking_userId_not_null_constraint";
+        ALTER TABLE "booking" ADD CONSTRAINT "booking_userId_not_null_constraint" CHECK ("userId" IS NOT NULL) NOT VALID;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("booking_userId_not_null_constraint", table_name="booking")

--- a/api/src/pcapi/alembic/versions/20230324T183947_f1e0b83e0b42_add_not_null_constraint_on_booking_userId_step_2_of_4.py
+++ b/api/src/pcapi/alembic/versions/20230324T183947_f1e0b83e0b42_add_not_null_constraint_on_booking_userId_step_2_of_4.py
@@ -1,0 +1,25 @@
+"""Add NOT NULL constraint on "booking.userId" (step 2 of 4)"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f1e0b83e0b42"
+down_revision = "8c17d89b7c9a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    # The timeout here has the same value (5 minutes) as `helm upgrade`.
+    # If this migration fails, you'll have to execute it manually.
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute('ALTER TABLE "booking" VALIDATE CONSTRAINT "booking_userId_not_null_constraint"')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/analytics/amplitude/events/booking_events.py
+++ b/api/src/pcapi/analytics/amplitude/events/booking_events.py
@@ -22,9 +22,6 @@ def _track_booking_event(
     event_name: amplitude_connector.AmplitudeEventType,
     reason: bookings_models.BookingCancellationReasons | None = None,
 ) -> None:
-    # TODO: (lixxday) remove this when userId is not null in Booking
-    if not booking.userId:
-        return
     event_properties = _get_booking_event_properties(booking)
     if reason:
         event_properties["reason"] = reason.value

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -103,7 +103,7 @@ class Booking(PcObject, Base, Model):
 
     token: str = Column(String(6), unique=True, nullable=False)
 
-    userId = Column(BigInteger, ForeignKey("user.id"), index=True, nullable=True)
+    userId: int = Column(BigInteger, ForeignKey("user.id"), index=True, nullable=False)
 
     activationCode = relationship("ActivationCode", uselist=False, back_populates="booking")  # type: ignore [misc]
 

--- a/api/src/pcapi/notifications/push/transactional_notifications.py
+++ b/api/src/pcapi/notifications/push/transactional_notifications.py
@@ -55,7 +55,7 @@ def get_bookings_cancellation_notification_data(booking_ids: list[int]) -> Trans
 def get_today_stock_booking_notification_data(booking: Booking, offer: Offer) -> TransactionalNotificationData | None:
     return TransactionalNotificationData(
         group_id=GroupId.TODAY_STOCK.value,
-        user_ids=[booking.userId],  # type: ignore [list-item]
+        user_ids=[booking.userId],
         message=TransactionalNotificationMessage(
             title="C'est aujourd'hui !",
             body=f"Retrouve les détails de la réservation pour {offer.name} sur l’application pass Culture",
@@ -91,7 +91,7 @@ def get_soon_expiring_bookings_with_offers_notification_data(booking: Booking) -
 
     return TransactionalNotificationData(
         group_id=GroupId.SOON_EXPIRING_BOOKINGS.value,
-        user_ids=[booking.userId],  # type: ignore [list-item]
+        user_ids=[booking.userId],
         message=TransactionalNotificationMessage(title="Tu n'as pas récupéré ta réservation", body=body),
         extra={"deeplink": booking_app_link(booking)},
     )


### PR DESCRIPTION
The column could store NULL values when `Booking` could be linked to
an `EducationalBooking`. Now that this model has been removed, all
instances of `Booking` are individual bookings and the column can be
made NOT NULLable.