### PR TITLE
(PC-20158)[PRO] fix: remove version from pro/adage deployment

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -63,16 +63,6 @@ jobs:
         cd api
         echo "${{ inputs.tag }}" > version.txt
         git add version.txt
-    - name: Add version to pro
-      run: |
-        cd pro
-        yarn version --new-version "${{ inputs.tag }}"
-        git add package.json
-    - name: Add version to adage
-      run: |
-        cd adage-front
-        yarn version --new-version "${{ inputs.tag }}"
-        git add package.json
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20158

yarn version --new-version only allow semantic version syntax MAJOR.MINOR.PATCH not a commit sha1