### PR TITLE
(BSR)[API] fix: do not start boussole from py process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ docs-build/
 
 # Backoffice scss to css tmp assets
 /api/src/pcapi/static/backofficev3/css/compiled/
-/api/src/pcapi/static/backofficev3/scss/boussole.pid

--- a/api/src/pcapi/routes/backoffice_v3/docs/CSS.md
+++ b/api/src/pcapi/routes/backoffice_v3/docs/CSS.md
@@ -2,7 +2,13 @@
 
 This documentation describe CSS class names code convention.
 
-We use scss as a preprocessing language for css, read their [documentation](https://sass-lang.com/documentation/). 
+We use scss as a preprocessing language for css, read their [documentation](https://sass-lang.com/documentation/).
+
+To watch for scss changes:
+
+```bash
+boussole watch --config src/pcapi/static/backofficev3/scss/boussole.yml --backend yaml
+```
 
 There is 4 categories of css rules:
 

--- a/api/src/pcapi/routes/backoffice_v3/scss.py
+++ b/api/src/pcapi/routes/backoffice_v3/scss.py
@@ -1,10 +1,6 @@
 import glob
 import os
 from pathlib import Path
-import signal
-from subprocess import DEVNULL
-from subprocess import Popen
-from subprocess import STDOUT
 
 import sass
 
@@ -15,7 +11,6 @@ def preprocess_scss(watch: bool) -> None:
     source = Path("src/pcapi/static/backofficev3/scss")
     destination = Path("src/pcapi/static/backofficev3/css/compiled")
     configuration = Path("src/pcapi/static/backofficev3/scss/boussole.yml")
-    pid_file_path = Path("src/pcapi/static/backofficev3/scss/boussole.pid")
 
     Path(destination).mkdir(parents=True, exist_ok=True)
 
@@ -31,29 +26,10 @@ def preprocess_scss(watch: bool) -> None:
                         source_map_embed=True,
                         source_map_root=destination,
                     )
-
-                # kill previous boussole process if python previously crashed
-                try:
-                    if os.path.isfile(pid_file_path):
-                        with open(pid_file_path, "r", encoding="utf8") as pid_file:
-                            pid = int(pid_file.read())
-                            pid_file.close()
-                            os.kill(pid, signal.SIGTERM)
-                except Exception:  # pylint: disable=broad-except
-                    pass
-
-                proc = Popen(  # pylint: disable=consider-using-with
-                    ["boussole", "watch", "--config", configuration, "--backend", "yaml"],
-                    stdout=DEVNULL,
-                    stderr=STDOUT,
+                    print("💅 Scss compiler has compiled css 💅", flush=True)
+                print(
+                    f"💅 watch for scss change with: boussole watch --config {configuration} --backend yaml", flush=True
                 )
-
-                # save new process pid in case of python crash
-                with open(pid_file_path, "w", encoding="utf8") as pid_file:
-                    pid_file.write(str(proc.pid))
-                    pid_file.close()
-
-                print("💅 Scss compiler attached and watching, enjoy styling 💅", flush=True)
         else:
             sass.compile(
                 dirname=(source, destination),


### PR DESCRIPTION
## But de la pull request

Lorsque boussole est lancé via python, cela créé une erreur récurrente:

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/shutil.py", line 713, in rmtree
ImportError: sys.meta_path is None, Python is likely shutting down
```

Bug reporté ici : https://github.com/sveetch/boussole/issues/46

## Implémentation

- Suppression du process boussole lancé depuis python
- Ajout d'un code snippet pour lancer boussole dans la documentation css.

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
