### PR TITLE
(PC-21241)[API] feat: add DISABLE_XXX_EXTERNAL_BOOKINGS FFs to disable external bookigns

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -170,12 +170,18 @@ def _book_external_ticket(booking: Booking, stock: Stock, beneficiary: User) -> 
         case "CDSStocks":
             if not FeatureToggle.ENABLE_CDS_IMPLEMENTATION.is_active():
                 raise feature.DisabledFeatureError("ENABLE_CDS_IMPLEMENTATION is inactive")
+            if FeatureToggle.DISABLE_CDS_EXTERNAL_BOOKINGS.is_active():
+                raise feature.DisabledFeatureError("DISABLE_CDS_EXTERNAL_BOOKINGS is active")
         case "BoostStocks":
             if not FeatureToggle.ENABLE_BOOST_API_INTEGRATION.is_active():
                 raise feature.DisabledFeatureError("ENABLE_BOOST_API_INTEGRATION is inactive")
+            if FeatureToggle.DISABLE_BOOST_EXTERNAL_BOOKINGS.is_active():
+                raise feature.DisabledFeatureError("DISABLE_BOOST_EXTERNAL_BOOKINGS is active")
         case "CGRStocks":
             if not FeatureToggle.ENABLE_CGR_INTEGRATION.is_active():
                 raise feature.DisabledFeatureError("ENABLE_CGR_INTEGRATION is inactive")
+            if FeatureToggle.DISABLE_CGR_EXTERNAL_BOOKINGS.is_active():
+                raise feature.DisabledFeatureError("DISABLE_CGR_EXTERNAL_BOOKINGS is active")
         case _:
             raise ValueError(f"Unknown Provider: {venue_provider_name}")
 

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -39,6 +39,9 @@ class FeatureToggle(enum.Enum):
     APP_ENABLE_AUTOCOMPLETE = "Active l'autocomplete sur la barre de recherche relative au rework de la homepage"
     BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS = "Active la validation d'un bénéficiaire via les contrôles de sécurité"
     DISABLE_ENTERPRISE_API = "Désactiver les appels à l'API entreprise"
+    DISABLE_BOOST_EXTERNAL_BOOKINGS = "Désactiver les réservations externes Boost"
+    DISABLE_CDS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CDS"
+    DISABLE_CGR_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CGR"
     DISABLE_USER_NAME_AND_FIRST_NAME_VALIDATION_IN_TESTING_AND_STAGING = "Désactiver la validation des noms et prénoms"
     DISPLAY_DMS_REDIRECTION = "Affiche une redirection vers DMS si ID Check est KO"
     ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING = (
@@ -147,6 +150,9 @@ class Feature(PcObject, Base, Model, DeactivableMixin):
 FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.ALLOW_IDCHECK_REGISTRATION_FOR_EDUCONNECT_ELIGIBLE,
     FeatureToggle.DISABLE_ENTERPRISE_API,
+    FeatureToggle.DISABLE_BOOST_EXTERNAL_BOOKINGS,
+    FeatureToggle.DISABLE_CDS_EXTERNAL_BOOKINGS,
+    FeatureToggle.DISABLE_CGR_EXTERNAL_BOOKINGS,
     FeatureToggle.ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING,
     FeatureToggle.ENABLE_BACKOFFICE_API,
     FeatureToggle.ENABLE_CULTURAL_SURVEY,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21241

## But de la pull request

Ajout de 3 FF:
- DISABLE_BOOST_EXTERNAL_BOOKINGS
- DISABLE_CDS_EXTERNAL_BOOKINGS
- DISABLE_CGR_EXTERNAL_BOOKINGS
afin de désactiver les réservations externes pour pouvoir tester en toute sécurité sur les environnements de pré-prod

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
