### PR TITLE
(BSR)[BO] fix: missing label in user history for admin email change

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/serialization/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/serialization/accounts.py
@@ -94,6 +94,8 @@ class EmailChangeAction(AccountAction):
                 return "Validation de changement d'email"
             case users_models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION:
                 return "Validation (admin) de changement d'email"
+            case users_models.EmailHistoryEventTypeEnum.ADMIN_UPDATE_REQUEST:
+                return "Changement d'email par l'admin"
             case _:
                 return "Action de changement d'email inconnue"
 


### PR DESCRIPTION
## But de la pull request

Afficher correctement un changement d'email par l'admin dans l'historique d'un utilisateur, plutôt que "Action de changement d'email inconnue"

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
