### PR TITLE
(PC-21006)[PRO] feat: dropdown  filtres page Offre

### DIFF
--- a/pro/src/core/Offers/constants.ts
+++ b/pro/src/core/Offers/constants.ts
@@ -101,8 +101,8 @@ export const ALL_CATEGORIES_OPTION = {
 }
 const CREATION_MODES_OPTIONS = [
   { displayName: 'Tous', id: ALL_CREATION_MODES },
-  { displayName: 'Manuelle', id: 'manual' },
-  { displayName: 'Importée', id: 'imported' },
+  { displayName: 'Manuel', id: 'manual' },
+  { displayName: 'Synchronisé', id: 'imported' },
 ]
 const COLLECTIVE_OFFER_TYPES_OPTIONS = [
   { displayName: 'Tout', id: ALL_CREATION_MODES },

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -785,7 +785,7 @@ describe('route Offers', () => {
       await userEvent.click(searchButton)
       // When
       await userEvent.selectOptions(
-        screen.getByDisplayValue('Manuelle'),
+        screen.getByDisplayValue('Manuel'),
         DEFAULT_CREATION_MODE.id
       )
       await userEvent.click(searchButton)

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -322,7 +322,7 @@ describe('screen Offers', () => {
         )
 
         // Then
-        expect(screen.getByDisplayValue('Importée')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('Synchronisé')).toBeInTheDocument()
       })
 
       it('should allow user to select manual creation mode filter', async () => {
@@ -331,10 +331,10 @@ describe('screen Offers', () => {
         const creationModeSelect = screen.getByLabelText('Mode de création')
 
         // When
-        await userEvent.selectOptions(creationModeSelect, 'Manuelle')
+        await userEvent.selectOptions(creationModeSelect, 'Manuel')
 
         // Then
-        expect(screen.getByDisplayValue('Manuelle')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('Manuel')).toBeInTheDocument()
       })
 
       it('should allow user to select imported creation mode filter', async () => {
@@ -346,7 +346,7 @@ describe('screen Offers', () => {
         await userEvent.selectOptions(creationModeSelect, 'imported')
 
         // Then
-        expect(screen.getByDisplayValue('Importée')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('Synchronisé')).toBeInTheDocument()
       })
 
       it('should display event period filter with no default option', async () => {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21006

## But de la pull request

Masculiniser le dropdown du filtre des types d'offre.

## Implémentation

Modifier le dropdown des filtres de la page Offre

Manuelle → Manuel

Importée → Synchronisé

## Checklist :

- [ x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-21006-dropdown-filtre`
  - PR : `PC-21006-dropdown-filtre`
  - Commit(s) : `PC-21006-dropdown-filtre`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
