### PR TITLE
(PC-21338)[BO] fix: update venue without SIRET

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -27,7 +27,7 @@ class EditVenueForm(EditVirtualVenueForm):
         "Nom d'usage",
         validators=(wtforms.validators.Length(max=255, message="doit contenir moins de %(max)d caractères"),),
     )
-    siret = fields.PCStringField("siret")
+    siret = fields.PCOptStringField("siret")
     postal_address_autocomplete = fields.PcPostalAddressAutocomplete(
         "Adresse",
         address="address",
@@ -71,7 +71,12 @@ class EditVenueForm(EditVirtualVenueForm):
         self._fields.move_to_end("is_permanent")
 
     def validate_siret(self, siret: fields.PCStringField) -> fields.PCStringField:
-        if not siret.data or len(siret.data) != 14:
+        siret.data = siret.data.strip()
+        if not siret.data:
+            siret.data = None
+            return siret
+
+        if len(siret.data) != 14:
             raise validators.ValidationError("Un siret doit comporter 14 chiffres")
 
         try:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21338

## But de la pull request

Permettre la modification d'un lieu sans SIRET dans le backoffice.

## Informations supplémentaires

On conserve toutefois l'interdiction d'ajouter un SIRET à un lieu sans SIRET ou de le supprimer d'un lieu avec SIRET.
Ces deux cas causeraient de toute façon une exception, puisqu'on n'a pas de champ pour modifier le commentaire (une contrainte vérifie SIRET ou commentaire).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
