### PR TITLE
(BSR)[API] chore: Delete never used USER_PROFILING_FRAUD_CHECK feature flag

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d1eb4e7db641 (pre) (head)
-56bba24a7f57 (post) (head)
+8dbbae44e380 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230327T183509_8dbbae44e380_delete_user_profiling_fraud_check_feature_flag.py
+++ b/api/src/pcapi/alembic/versions/20230327T183509_8dbbae44e380_delete_user_profiling_fraud_check_feature_flag.py
@@ -1,0 +1,33 @@
+"""Delete USER_PROFILING_FRAUD_CHECK feature flag"""
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "8dbbae44e380"
+down_revision = "56bba24a7f57"
+branch_labels = None
+depends_on = None
+
+
+def get_flag():  # type: ignore[no-untyped-def]
+    # Do not import `pcapi.models.feature` at module-level. It breaks
+    # `alembic history` with a SQLAlchemy error that complains about
+    # an unknown table name while initializing the ORM mapper.
+    from pcapi.models import feature
+
+    return feature.Feature(
+        name="USER_PROFILING_FRAUD_CHECK",
+        isActive=False,
+        description="Détection de la fraude basée sur le profil de l''utilisateur",
+    )
+
+
+def upgrade() -> None:
+    from pcapi.models import feature
+
+    feature.remove_feature_from_database(get_flag())
+
+
+def downgrade() -> None:
+    from pcapi.models import feature
+
+    feature.add_feature_to_database(get_flag())

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -91,7 +91,6 @@ class FeatureToggle(enum.Enum):
     SYNCHRONIZE_TITELIVE_PRODUCTS_DESCRIPTION = "Permettre limport journalier des résumés des livres"
     SYNCHRONIZE_TITELIVE_PRODUCTS_THUMBS = "Permettre limport journalier des couvertures de livres"
     UPDATE_BOOKING_USED = "Permettre la validation automatique des contremarques 48h après la fin de lévènement"
-    USER_PROFILING_FRAUD_CHECK = "Détection de la fraude basée sur le profil de l'utilisateur"
     ENABLE_VENUE_STRICT_SEARCH = (
         "Active le fait d'indiquer si un lieu a un moins une offre éligible lors de l'indexation (Algolia)"
     )
@@ -162,7 +161,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.GENERATE_CASHFLOWS_BY_CRON,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
     FeatureToggle.PRO_DISABLE_EVENTS_QRCODE,
-    FeatureToggle.USER_PROFILING_FRAUD_CHECK,
     FeatureToggle.ENABLE_EAC_FINANCIAL_PROTECTION,
     FeatureToggle.ENABLE_ZENDESK_SELL_CREATION,
     FeatureToggle.ENABLE_OFFERER_STATS,


### PR DESCRIPTION
This feature flag was never used. I suppose that it was "replaced" by
ENABLE_USER_PROFILING, which was removed in fe3111376c8350ff51750d1d.