### PR TITLE
(PC-20837)[BO] fix: always same height four counters cards

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
@@ -1,9 +1,11 @@
 {% macro stats_card(value, text_one, text_many, link) %}
-  <div class="col-3 p-2">
-    <div class="card shadow">
-      <div class="card-body">
+  <div class="col">
+    <div class="card shadow h-100">
+      <div class="card-body py-0 pt-3">
         <div class="fs-2">{{ value }}</div>
         <div class="text-muted">{{ text_many if value > 1 else text_one }}</div>
+      </div>
+      <div class="card-footer bg-white border-0 py-0 pb-3">
         {% if link %}
           <div class="d-flex flex-row-reverse mt-4">
             <a href="{{ link }}"
@@ -28,7 +30,7 @@
   <div class="py-4 px-5">
     <h1 class="text-muted mt-5">Bonjour {{ current_user.firstName | empty_string_if_null }} !</h1>
     {% if has_permission("FRAUD_ACTIONS") %}
-      <div class="row px-1 py-4">
+      <div class="row row-cols-4 g-3 py-4">
         {{ stats_card(
         pending_individual_offers_count,
         "offre individuelle en attente",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20837

## But de la pull request

Corriger la mise en forme CSS des compteurs pour s'assurer que les _cards_ aient toujours la même hauteur.

![image](https://user-images.githubusercontent.com/23212130/228206033-70d2ae25-494f-4eb2-ba35-489a095833cc.png)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
