### PR TITLE
(PC-21402)[BO] fix: update venue without SIRET

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/account.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/account.py
@@ -7,23 +7,13 @@ from . import fields
 from . import utils
 
 
-def sanitize_pc_string(value: str | None) -> str | None:
-    """
-    Strips leading whitespaces and avoids empty strings in database.
-    This filter may be set globally for any PCOptStringField but has not been tested on every form yet.
-    """
-    if value:
-        value = value.strip()
-    return value if value else None
-
-
 class EditAccountForm(utils.PCForm):
-    first_name = fields.PCOptStringField("Prénom", filters=(sanitize_pc_string,))
-    last_name = fields.PCOptStringField("Nom", filters=(sanitize_pc_string,))
+    first_name = fields.PCOptStringField("Prénom", filters=(utils.sanitize_pc_string,))
+    last_name = fields.PCOptStringField("Nom", filters=(utils.sanitize_pc_string,))
     email = fields.PCEmailField("Email")
     birth_date = fields.PCDateField("Date de naissance")
-    phone_number = fields.PCOptStringField("Numéro de téléphone", filters=(sanitize_pc_string,))
-    id_piece_number = fields.PCOptStringField("N° pièce d'identité", filters=(sanitize_pc_string,))
+    phone_number = fields.PCOptStringField("Numéro de téléphone", filters=(utils.sanitize_pc_string,))
+    id_piece_number = fields.PCOptStringField("N° pièce d'identité", filters=(utils.sanitize_pc_string,))
     postal_address_autocomplete = fields.PcPostalAddressAutocomplete(
         "Adresse",
         address="address",
@@ -36,9 +26,9 @@ class EditAccountForm(utils.PCForm):
         has_manual_editing=True,
         limit=10,
     )
-    address = fields.PCOptHiddenField("Adresse", filters=(sanitize_pc_string,))
-    postal_code = fields.PCOptPostalCodeHiddenField("Code postal", filters=(sanitize_pc_string,))
-    city = fields.PCOptHiddenField("Ville", filters=(sanitize_pc_string,))
+    address = fields.PCOptHiddenField("Adresse", filters=(utils.sanitize_pc_string,))
+    postal_code = fields.PCOptPostalCodeHiddenField("Code postal", filters=(utils.sanitize_pc_string,))
+    city = fields.PCOptHiddenField("Ville", filters=(utils.sanitize_pc_string,))
 
 
 class ManualReviewForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice_v3/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/utils.py
@@ -25,3 +25,13 @@ def choices_from_enum(
 
 def values_from_enum(enum_cls: typing.Type[enum.Enum]) -> list[tuple]:
     return [(opt.value, opt.value) for opt in enum_cls]
+
+
+def sanitize_pc_string(value: str | None) -> str | None:
+    """
+    Strips leading whitespaces and avoids empty strings in database.
+    This filter may be set globally for any PCOptStringField but has not been tested on every form yet.
+    """
+    if value:
+        value = value.strip()
+    return value if value else None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21402

## But de la pull request

Correction (bis) de la modification d'un lieu sans SIRET

## Implémentation

Le formulaire ne passe jamais `None` mais une chaîne vide, donc ça tentait de remplacer le SIRET à `None` par un SIRET chaîne vide ; lorsque ça existe déjà, ça refuse sur la contrainte d'unicité. Il faut laisser à `None` !

## Informations supplémentaires

Le filtre `sanitize_pc_string` sera étendu à tous les champs, de manière globale, dans un prochain commit ; et pas dans celui-ci destiné à un hotfix !

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
