### PR TITLE
(BSR)[BO] refactor: strip() form strings globally and consider empty strings as None

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/account.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/account.py
@@ -8,12 +8,12 @@ from . import utils
 
 
 class EditAccountForm(utils.PCForm):
-    first_name = fields.PCOptStringField("Prénom", filters=(utils.sanitize_pc_string,))
-    last_name = fields.PCOptStringField("Nom", filters=(utils.sanitize_pc_string,))
+    first_name = fields.PCOptStringField("Prénom")
+    last_name = fields.PCOptStringField("Nom")
     email = fields.PCEmailField("Email")
     birth_date = fields.PCDateField("Date de naissance")
-    phone_number = fields.PCOptStringField("Numéro de téléphone", filters=(utils.sanitize_pc_string,))
-    id_piece_number = fields.PCOptStringField("N° pièce d'identité", filters=(utils.sanitize_pc_string,))
+    phone_number = fields.PCOptStringField("Numéro de téléphone")
+    id_piece_number = fields.PCOptStringField("N° pièce d'identité")
     postal_address_autocomplete = fields.PcPostalAddressAutocomplete(
         "Adresse",
         address="address",
@@ -26,9 +26,9 @@ class EditAccountForm(utils.PCForm):
         has_manual_editing=True,
         limit=10,
     )
-    address = fields.PCOptHiddenField("Adresse", filters=(utils.sanitize_pc_string,))
-    postal_code = fields.PCOptPostalCodeHiddenField("Code postal", filters=(utils.sanitize_pc_string,))
-    city = fields.PCOptHiddenField("Ville", filters=(utils.sanitize_pc_string,))
+    address = fields.PCOptHiddenField("Adresse")
+    postal_code = fields.PCOptPostalCodeHiddenField("Code postal")
+    city = fields.PCOptHiddenField("Ville")
 
 
 class ManualReviewForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
@@ -38,11 +38,6 @@ class GetCollectiveBookingListForm(FlaskForm):
         validators=(wtforms.validators.Optional(),),
     )
 
-    def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data:
-            q.data = q.data.strip()
-        return q
-
     def is_empty(self) -> bool:
         return not any(
             (

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_offer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_offer.py
@@ -39,11 +39,6 @@ class GetCollectiveOffersListForm(FlaskForm):
     only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
     sort = fields.PCHiddenBooleanField("Trier par date")
 
-    def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data:
-            q.data = q.data.strip()
-        return q
-
     def is_empty(self) -> bool:
         # 'only_validated_offerers' must be combined with other filters
         return not any(

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -15,6 +15,17 @@ def widget(field: wtforms.Field, template: str, *args: typing.Any, **kwargs: typ
     return render_template(template, field=field)
 
 
+def sanitize_pc_string(value: str | None) -> str | None:
+    """
+    Strips leading whitespaces and avoids empty strings in database.
+    """
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    return value
+
+
 class PostalCodeValidator:
     def __init__(self, message: str) -> None:
         self.message = message
@@ -30,6 +41,9 @@ class PCOptStringField(wtforms.StringField):
         validators.Optional(""),
         validators.Length(max=64, message="doit contenir au maximum %(max)d caractères"),
     ]
+
+    def __init__(self, label: str | None = None, **kwargs: typing.Any):
+        super().__init__(label, filters=(sanitize_pc_string,), **kwargs)
 
 
 class PCStringField(PCOptStringField):
@@ -184,6 +198,9 @@ class PCQuerySelectMultipleField(wtforms_sqlalchemy.fields.QuerySelectMultipleFi
 class PCOptSearchField(wtforms.StringField):
     widget = partial(widget, template="components/forms/search_field.html")
     validators = [validators.Optional()]
+
+    def __init__(self, label: str | None = None, **kwargs: typing.Any):
+        super().__init__(label, filters=(sanitize_pc_string,), **kwargs)
 
 
 class PCSearchField(PCOptSearchField):

--- a/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
@@ -38,11 +38,6 @@ class GetIndividualBookingListForm(FlaskForm):
         validators=(wtforms.validators.Optional(),),
     )
 
-    def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data:
-            q.data = q.data.strip()
-        return q
-
     def is_empty(self) -> bool:
         return not any(
             (

--- a/api/src/pcapi/routes/backoffice_v3/forms/offer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offer.py
@@ -64,13 +64,12 @@ class GetOffersListForm(FlaskForm):
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data:
-            q.data = q.data.strip()
-        if self.where.data == OfferSearchColumn.ID.name and not re.match(r"^[\d\s,;]+$", q.data):
-            raise wtforms.validators.ValidationError("La recherche ne correspond pas à un ID ou une liste d'ID")
-        if self.where.data == OfferSearchColumn.ISBN.name and not bo_utils.is_isbn_valid(q.data):
-            raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un ISBN")
-        if self.where.data == OfferSearchColumn.VISA.name and not bo_utils.is_visa_valid(q.data):
-            raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un visa")
+            if self.where.data == OfferSearchColumn.ID.name and not re.match(r"^[\d\s,;]+$", q.data):
+                raise wtforms.validators.ValidationError("La recherche ne correspond pas à un ID ou une liste d'ID")
+            if self.where.data == OfferSearchColumn.ISBN.name and not bo_utils.is_isbn_valid(q.data):
+                raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un ISBN")
+            if self.where.data == OfferSearchColumn.VISA.name and not bo_utils.is_visa_valid(q.data):
+                raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un visa")
         return q
 
     def is_empty(self) -> bool:

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -91,12 +91,10 @@ class OffererValidationListForm(utils.PCForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data:
-            q.data = q.data.strip()
-            if q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
-                raise wtforms.validators.ValidationError(
-                    "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
-                )
+        if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
+            raise wtforms.validators.ValidationError(
+                "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
+            )
         return q
 
 
@@ -130,12 +128,10 @@ class UserOffererValidationListForm(utils.PCForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data:
-            q.data = q.data.strip()
-            if q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
-                raise wtforms.validators.ValidationError(
-                    "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
-                )
+        if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
+            raise wtforms.validators.ValidationError(
+                "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
+            )
         return q
 
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/tags.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/tags.py
@@ -23,11 +23,6 @@ class EditTagForm(FlaskForm):
     start_date = fields.PCDateField("Date de début", validators=(wtforms.validators.Optional(),))
     end_date = fields.PCDateField("Date de fin", validators=(wtforms.validators.Optional(),))
 
-    def filter_name(self, name: str | None) -> str | None:
-        if not name:
-            return None
-        return name.strip()
-
     def validate_start_date(self, start_date: fields.PCDateField) -> fields.PCDateField:
         end_date = self._fields["end_date"]
 

--- a/api/src/pcapi/routes/backoffice_v3/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/utils.py
@@ -25,13 +25,3 @@ def choices_from_enum(
 
 def values_from_enum(enum_cls: typing.Type[enum.Enum]) -> list[tuple]:
     return [(opt.value, opt.value) for opt in enum_cls]
-
-
-def sanitize_pc_string(value: str | None) -> str | None:
-    """
-    Strips leading whitespaces and avoids empty strings in database.
-    This filter may be set globally for any PCOptStringField but has not been tested on every form yet.
-    """
-    if value:
-        value = value.strip()
-    return value if value else None

--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -27,7 +27,7 @@ class EditVenueForm(EditVirtualVenueForm):
         "Nom d'usage",
         validators=(wtforms.validators.Length(max=255, message="doit contenir moins de %(max)d caractères"),),
     )
-    siret = fields.PCOptStringField("siret", filters=(utils.sanitize_pc_string,))
+    siret = fields.PCOptStringField("siret")
     postal_address_autocomplete = fields.PcPostalAddressAutocomplete(
         "Adresse",
         address="address",


### PR DESCRIPTION
BSR

## But de la pull request

Filtrer tous les champs de type chaîne de caractère des formulaires du backoffice afin d'éliminer les espaces en début et fin, et considérer les chaînes vides comme `None` (plus clair et pour être certains de ne jamais changer une colonne vide par une chaîne vide lors des éditions ; en bdd c'est `None` quand c'est vide).

Pas de régression dans les tests :)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
