### PR TITLE
(PC-21099)[API] feat: Ajouter un filtre numéro de virement sur les réservations

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
@@ -119,6 +119,12 @@ def _get_collective_bookings(
     if form.status.data:
         base_query = base_query.filter(educational_models.CollectiveBooking.status.in_(form.status.data))
 
+    if form.cashflow_batches.data:
+        base_query = (
+            base_query.join(finance_models.Pricing).join(finance_models.CashflowPricing).join(finance_models.Cashflow)
+        )
+        base_query = base_query.filter(finance_models.Cashflow.batchId.in_(form.cashflow_batches.data))
+
     if form.q.data:
         search_query = form.q.data
 
@@ -163,6 +169,7 @@ def list_collective_bookings() -> utils.BackofficeResponse:
 
     autocomplete.prefill_offerers_choices(form.offerer)
     autocomplete.prefill_venues_choices(form.venue)
+    autocomplete.prefill_cashflow_batch_choices(form.cashflow_batches)
 
     return render_template(
         "collective_bookings/list.html",

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_booking.py
@@ -26,6 +26,9 @@ class GetCollectiveBookingListForm(FlaskForm):
     status = fields.PCSelectMultipleField(
         "États", choices=utils.choices_from_enum(CollectiveBookingStatus, formatter=filters.format_booking_status)
     )
+    cashflow_batches = fields.PCAutocompleteSelectMultipleField(
+        "Virements", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_cashflow_batches"
+    )
     from_date = fields.PCDateField("À partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
     event_from_date = fields.PCDateField("Événement du", validators=(wtforms.validators.Optional(),))
@@ -55,5 +58,6 @@ class GetCollectiveBookingListForm(FlaskForm):
                 self.to_date.data,
                 self.event_from_date.data,
                 self.event_to_date.data,
+                self.cashflow_batches.data,
             )
         )

--- a/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/individual_booking.py
@@ -26,6 +26,9 @@ class GetIndividualBookingListForm(FlaskForm):
     status = fields.PCSelectMultipleField(
         "États", choices=utils.choices_from_enum(BookingStatus, formatter=filters.format_booking_status)
     )
+    cashflow_batches = fields.PCAutocompleteSelectMultipleField(
+        "Virements", choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_cashflow_batches"
+    )
     from_date = fields.PCDateField("Créées à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Créées jusqu'au", validators=(wtforms.validators.Optional(),))
     event_from_date = fields.PCDateField("Événement du", validators=(wtforms.validators.Optional(),))
@@ -55,5 +58,6 @@ class GetIndividualBookingListForm(FlaskForm):
                 self.to_date.data,
                 self.event_from_date.data,
                 self.event_to_date.data,
+                self.cashflow_batches.data,
             )
         )

--- a/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
@@ -121,6 +121,12 @@ def _get_individual_bookings(
     if form.status.data:
         base_query = base_query.filter(bookings_models.Booking.status.in_(form.status.data))
 
+    if form.cashflow_batches.data:
+        base_query = (
+            base_query.join(finance_models.Pricing).join(finance_models.CashflowPricing).join(finance_models.Cashflow)
+        )
+        base_query = base_query.filter(finance_models.Cashflow.batchId.in_(form.cashflow_batches.data))
+
     if form.q.data:
         search_query = form.q.data
         or_filters = []
@@ -187,6 +193,7 @@ def list_individual_bookings() -> utils.BackofficeResponse:
 
     autocomplete.prefill_offerers_choices(form.offerer)
     autocomplete.prefill_venues_choices(form.venue)
+    autocomplete.prefill_cashflow_batch_choices(form.cashflow_batches)
 
     return render_template(
         "individual_bookings/list.html",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21099

## But de la pull request

En tant que support pro
J'aimerais filtrer les réservations sur les numéros de virement
Afin d’accompagner au mieux les pro lors de leurs questions sur les remboursements

## Implémentation

- Sur les pages réservations individuelles et réservations collectives, ajouter un filtre “Numéro de virement” 
    - booking.cashflow_batch.label
- Ce filtre regroupe tous les numéros de virement existants (se met à jour avec les nouveaux virements)
- Ce filtre permet de retrouver les réservations dont le numéro de virement est sélectionné dans le filtre


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

<img width="1848" alt="Capture d’écran 2023-03-28 à 16 54 46" src="https://user-images.githubusercontent.com/9610732/228279195-4213e56d-ec0b-4e29-97b9-eedc05bf5711.png">
<img width="1781" alt="Capture d’écran 2023-03-28 à 16 55 03" src="https://user-images.githubusercontent.com/9610732/228279198-9383c1b8-52de-4008-9c92-848202232731.png">
