### PR TITLE
(BSR)[API] fix: Fix non-thread safe usage of boto3 client in outscale connector

### DIFF
--- a/api/tests/connectors/beneficiaries/outscale_test.py
+++ b/api/tests/connectors/beneficiaries/outscale_test.py
@@ -28,8 +28,8 @@ class UploadFileTest:
         record = caplog.records[0]
         assert expected_log_message in record.message
 
-    @patch("pcapi.connectors.beneficiaries.outscale.boto3.client")
-    def test_upload_file_succesfully(self, mock_s3_client, caplog) -> None:
+    @patch("botocore.session.Session.create_client")
+    def test_upload_file_succesfully(self, mocked_storage_client, caplog) -> None:
         # Given
         file_name = "carte_identite_front.png"
         file_path = f"{IMAGES_DIR}/{file_name}"
@@ -41,7 +41,7 @@ class UploadFileTest:
             outscale.upload_file(user_id, file_path, file_name)
 
         # Then
-        assert mock_s3_client.return_value.upload_file.call_count == 1
+        assert mocked_storage_client.return_value.upload_file.call_count == 1
         assert len(caplog.records) >= 1
         record = caplog.records[0]
         assert expected_log_message in record.message


### PR DESCRIPTION
`boto3.client()` is not thread-safe. We sometimes get the following
error:

    KeyError: 'default_config_resolver'
      File "pcapi/tasks/ubble_tasks.py", line 23, in store_id_pictures_task
        ubble_subscription_api.archive_ubble_user_id_pictures(payload.identification_id)
      [...]
      File "pcapi/connectors/beneficiaries/outscale.py", line 13, in upload_file
        client = boto3.client(
      File "__init__.py", line 92, in client
        return _get_default_session().client(*args, **kwargs)
      [...]
      File "botocore/session.py", line 1009, in get_component
        del self._deferred[name]

To work around that, we now use a dedicated session. And we keep one
for each thread to lessen the overhead of the session initialization.

References:
 - discussion of the issue and possible workarounds: https://github.com/boto/boto3/issues/1592
 - similar fix in Sentry client code: https://github.com/getsentry/sentry/commit/f58ca5eef79a8fc1091703d72611e8e3e63b34a0

---

L'erreur sur Sentry : https://sentry.passculture.team/organizations/sentry/issues/408606/?project=5&query=default_config_resolver&statsPeriod=90d