### PR TITLE
(BSR)[API] chore: Delete unused `max_user_id` script

### DIFF
--- a/api/src/pcapi/scripts/external_users/max_user_id.py
+++ b/api/src/pcapi/scripts/external_users/max_user_id.py
@@ -1,8 +1,0 @@
-from flask import current_app as app
-
-from pcapi.core.users.models import User
-
-
-with app.app_context():
-    last_user = User.query.order_by(User.id.desc()).first()
-    print(last_user.id)


### PR DESCRIPTION
It was useful when used in a loop for SendinBlue-related scripts. It's
not used anymore.