### PR TITLE
(BSR)[API] fix: fetch user with joinedloaded data to avoid N+1 queries

### DIFF
--- a/api/src/pcapi/core/fraud/repository.py
+++ b/api/src/pcapi/core/fraud/repository.py
@@ -1,35 +1,44 @@
 from pcapi.core.users import models as users_models
-from pcapi.models import db
 
 from . import models
 
 
 def get_last_user_profiling_fraud_check(user: users_models.User) -> models.BeneficiaryFraudCheck | None:
     # User profiling is not performed for UNDERAGE credit, no need to filter on eligibilityType here
-    return (
-        models.BeneficiaryFraudCheck.query.filter(
-            models.BeneficiaryFraudCheck.user == user,
-            models.BeneficiaryFraudCheck.type == models.FraudCheckType.USER_PROFILING,
-        )
-        .order_by(models.BeneficiaryFraudCheck.dateCreated.desc())
-        .first()
+    # user.beneficiaryFraudChecks should have been joinedloaded before to reduce the number of db requests
+    sorted_fraud_checks = sorted(
+        [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == models.FraudCheckType.USER_PROFILING
+        ],
+        key=lambda fraud_check: fraud_check.dateCreated,
+        reverse=True,
     )
+
+    if sorted_fraud_checks:
+        return sorted_fraud_checks[0]
+
+    return None
 
 
 def has_failed_phone_validation(user: users_models.User) -> bool:
-    return db.session.query(
-        models.BeneficiaryFraudCheck.query.filter(
-            models.BeneficiaryFraudCheck.userId == user.id,
-            models.BeneficiaryFraudCheck.status == models.FraudCheckStatus.KO,
-            models.BeneficiaryFraudCheck.type == models.FraudCheckType.PHONE_VALIDATION,
-        ).exists()
-    ).scalar()
+    # user.beneficiaryFraudChecks should have been joinedloaded before to reduce the number of db requests
+    return any(
+        fraud_check.status == models.FraudCheckStatus.KO and fraud_check.type == models.FraudCheckType.PHONE_VALIDATION
+        for fraud_check in user.beneficiaryFraudChecks
+    )
 
 
 def has_admin_ko_review(user: users_models.User) -> bool:
-    latest_admin_review = (
-        models.BeneficiaryFraudReview.query.filter_by(userId=user.id)
-        .order_by(models.BeneficiaryFraudReview.dateReviewed.desc())
-        .first()
+    # user.beneficiaryFraudReviews should have been joinedloaded before to reduce the number of db requests
+    sorted_reviews = sorted(
+        user.beneficiaryFraudReviews,
+        key=lambda fraud_review: fraud_review.dateReviewed,
+        reverse=True,
     )
-    return bool(latest_admin_review and latest_admin_review.review == models.FraudReviewStatus.KO)
+
+    if sorted_reviews:
+        return sorted_reviews[0].review == models.FraudReviewStatus.KO
+
+    return False

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -321,14 +321,9 @@ class AccountTest:
         assert response.status_code == 200
         client.with_token(user.email)
         n_queries = 1  # get user
-        n_queries += 1  # has beneficiary_fraud_review
-        n_queries += 1  # get user_profiling fraud_check
-        n_queries += 1  # get profile completion fraud_check
-        n_queries += 1  # count ubble beneficiary_fraud_checks
         n_queries += 1  # get feature allow_id_check_registration
         n_queries += 1  # get feature enable_ubble
         n_queries += 1  # get feature enable_subscription_limitation
-        n_queries += 1  # count ubble beneficiary_fraud_checks
         n_queries += 1  # get bookings
 
         with testing.assert_num_queries(n_queries):


### PR DESCRIPTION
BSR

## But de la pull request

Suite à un sujet travaillé en atelier lors de la journée backend :
Réduire le nombre de requêtes à la base de données lors de l'affichage d'un profil jeune dans le backoffice.

## Implémentation

Utilisation de `joinedload` pour précharger tout ce qui est nécessaire, en une seule requête.
Il reste juste des vérifications de _feature flags_ en plus.

## Informations supplémentaires

Les changements affectent aussi les routes de l'app jeunes.
J'ai pour exemple implémenté cette amélioration dans /banner.
Je laisse à la squad jeunes la suite pour anticiper les `joinedload` dans les autres routes. Mais déjà, le chargement de `user.beneficiaryFraudChecks doit se faire a priori une seule fois plutôt que faire n requêtes en fonction du type. @lixxday 


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
