### PR TITLE
(PC-21135)[BO] fix: offerer name is mandatory

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -39,7 +39,10 @@ class EditOffererForm(FlaskForm):
     )
     name = fields.PCStringField(
         "Nom de la structure",
-        validators=(wtforms.validators.Length(max=140, message="doit contenir moins de %(max)d caractères"),),
+        validators=(
+            wtforms.validators.InputRequired("Le nom est obligatoire"),
+            wtforms.validators.Length(max=140, message="doit contenir moins de %(max)d caractères"),
+        ),
     )
     postal_address_autocomplete = fields.PcPostalAddressAutocomplete(
         "Adresse",

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -49,7 +49,7 @@ offerer_blueprint = utils.child_backoffice_blueprint(
 
 def render_offerer_details(
     offerer: offerers_models.Offerer, edit_offerer_form: offerer_forms.EditOffererForm | None = None
-) -> utils.BackofficeResponse:
+) -> str:
     basic_info = offerers_api.get_offerer_basic_info(offerer.id)
 
     if not basic_info:
@@ -222,7 +222,7 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
             """
         ).format()
         flash(msg, "warning")
-        return render_offerer_details(offerer=offerer, edit_offerer_form=form)
+        return render_offerer_details(offerer=offerer, edit_offerer_form=form), 400
 
     modified_info = offerers_api.update_offerer(
         offerer,

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -297,6 +297,24 @@ class UpdateOffererTest:
         for item in ("Adresse", "Code postal", "Ville"):
             assert item not in history_rows[0]["Commentaire"]
 
+    def test_update_offerer_empty_name(self, legit_user, authenticated_client):
+        offerer = offerers_factories.OffererFactory(name="Original")
+
+        base_form = {
+            "name": "",
+            "city": offerer.city,
+            "postal_code": offerer.postalCode,
+            "address": offerer.address,
+            "tags": [],
+        }
+
+        response = self.update_offerer(authenticated_client, offerer, base_form)
+        assert response.status_code == 400
+        assert "Les données envoyées comportent des erreurs" in html_parser.extract_alert(response.data)
+
+        assert offerer.name == "Original"
+        assert len(offerer.action_history) == 0
+
     def update_offerer(self, authenticated_client, offerer_to_edit, form):
         # generate csrf token
         edit_url = url_for("backoffice_v3_web.offerer.get", offerer_id=offerer_to_edit.id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21135

## But de la pull request

Refuser le nom d'une structure vide, dans la modification des infos d'une structure.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
