### PR TITLE
(PC-21743)[API] fix: missing eligibilityType in suspicious phone validation fraud checks

### DIFF
--- a/api/src/pcapi/core/subscription/phone_validation/api.py
+++ b/api/src/pcapi/core/subscription/phone_validation/api.py
@@ -90,6 +90,7 @@ def _ensure_phone_number_unicity(
         reasonCodes=[fraud_models.FraudReasonCode.PHONE_UNVALIDATED_BY_PEER],
         reason=f"Phone number {phone_number} was unvalidated by user {user_validating_phone.id}",
         status=fraud_models.FraudCheckStatus.SUSPICIOUS,
+        eligibilityType=user_with_same_validated_number.eligibility,
         thirdPartyId=f"PC-{user_with_same_validated_number.id}",
     )
 
@@ -99,6 +100,7 @@ def _ensure_phone_number_unicity(
         reasonCodes=[fraud_models.FraudReasonCode.PHONE_UNVALIDATION_FOR_PEER],
         reason=f"The phone number validation had the following side effect: phone number {phone_number} was unvalidated for user {user_with_same_validated_number.id}",
         status=fraud_models.FraudCheckStatus.SUSPICIOUS,
+        eligibilityType=user_validating_phone.eligibility,
         thirdPartyId=f"PC-{user_validating_phone.id}",
     )
 

--- a/api/tests/core/fraud/test_api.py
+++ b/api/tests/core/fraud/test_api.py
@@ -79,13 +79,14 @@ class CommonTest:
             assert fraud_api.is_subscription_name_valid(name) is True
 
     def test_create_profile_completion_fraud_check(self, caplog):
-        user = users_factories.UserFactory()
+        user = users_factories.EligibleGrant18Factory()
         content = fraud_factories.ProfileCompletionContentFactory(origin="Origine orignale")
         fraud_api.create_profile_completion_fraud_check(user, user.eligibility, content)
         profile_completion_fraud_check = user.beneficiaryFraudChecks[0]
 
         assert profile_completion_fraud_check.type == fraud_models.FraudCheckType.PROFILE_COMPLETION
         assert profile_completion_fraud_check.status == fraud_models.FraudCheckStatus.OK
+        assert profile_completion_fraud_check.eligibilityType == users_models.EligibilityType.AGE18
 
         # try to create duplicate
         fraud_api.create_profile_completion_fraud_check(user, user.eligibility, content)

--- a/api/tests/core/subscription/phone_validation/test_api.py
+++ b/api/tests/core/subscription/phone_validation/test_api.py
@@ -15,7 +15,7 @@ from pcapi.core.users import models as users_models
 @pytest.mark.usefixtures("db_session")
 class EnsurePhoneNumberUnicityTest:
     def test_send_phone_code_error_if_validated_by_beneficiary(self):
-        users_factories.UserFactory(
+        users_factories.EligibleGrant18Factory(
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             phoneNumber="+33607080900",
             roles=[users_models.UserRole.BENEFICIARY],
@@ -28,12 +28,12 @@ class EnsurePhoneNumberUnicityTest:
         assert users_models.Token.query.count() == 0
 
     def test_send_phone_code_success_if_validated_by_not_beneficiary(self):
-        already_validated_user = users_factories.UserFactory(
+        already_validated_user = users_factories.EligibleUnderageFactory(
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
             phoneNumber="+33607080900",
             roles=[],
         )
-        in_validation_user = users_factories.UserFactory()
+        in_validation_user = users_factories.EligibleGrant18Factory()
 
         # 1. send_phone_validation_code is authorized and does not change owner
         phone_validation_api.send_phone_validation_code(in_validation_user, "+33607080900")
@@ -55,6 +55,7 @@ class EnsurePhoneNumberUnicityTest:
             unvalidated_by_peer_check.reason
             == f"Phone number +33607080900 was unvalidated by user {in_validation_user.id}"
         )
+        assert unvalidated_by_peer_check.eligibilityType == users_models.EligibilityType.UNDERAGE
 
         unvalidated_for_peer_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
             userId=in_validation_user.id,
@@ -67,6 +68,7 @@ class EnsurePhoneNumberUnicityTest:
             unvalidated_for_peer_check.reason
             == f"The phone number validation had the following side effect: phone number +33607080900 was unvalidated for user {already_validated_user.id}"
         )
+        assert unvalidated_for_peer_check.eligibilityType == users_models.EligibilityType.AGE18
 
         success_check = fraud_models.BeneficiaryFraudCheck.query.filter_by(
             userId=in_validation_user.id,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21743

## But de la pull request

Dans les blocs du parcours d’inscription, si un numéro de téléphone est suspicieux car associé aussi à un autre compte, les fraud checks créés le sont sans référence à l'éligibilité, donc ils ne sont pas dans le parcours Pass 18 ou Pass 15-17.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
