### PR TITLE
(PC-21439)[PRO] feat: do not display the 6e/5e options for an offer t…

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -1,7 +1,11 @@
+import isBefore from 'date-fns/isBefore'
 import { useFormikContext } from 'formik'
 import React from 'react'
 
-import { StudentLevels } from 'apiClient/v1'
+import {
+  GetCollectiveOfferCollectiveStockResponseModel,
+  StudentLevels,
+} from 'apiClient/v1'
 import FormLayout from 'components/FormLayout'
 import { IOfferEducationalFormValues } from 'core/OfferEducational'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -12,8 +16,10 @@ import useParicipantUpdates from './useParticipantUpdates'
 
 const FormParticipants = ({
   disableForm,
+  offerStock,
 }: {
   disableForm: boolean
+  offerStock?: GetCollectiveOfferCollectiveStockResponseModel | null
 }): JSX.Element => {
   const { values, setFieldValue } =
     useFormikContext<IOfferEducationalFormValues>()
@@ -25,14 +31,21 @@ const FormParticipants = ({
   useParicipantUpdates(values.participants, handleParticipantsChange)
 
   const isCLG6Active = useActiveFeature('WIP_ADD_CLG_6_5_COLLECTIVE_OFFER')
+  const isBeforeSeptembre1st =
+    offerStock?.beginningDatetime &&
+    isBefore(
+      new Date(offerStock.beginningDatetime),
+      new Date('2023-09-01T00:00:00Z')
+    )
 
-  const filteredParticipantsOptions = isCLG6Active
-    ? participantsOptions
-    : participantsOptions.filter(
-        x =>
-          x.name !== `participants.${StudentLevels.COLL_GE_6E}` &&
-          x.name !== `participants.${StudentLevels.COLL_GE_5E}`
-      )
+  const filteredParticipantsOptions =
+    isCLG6Active && !isBeforeSeptembre1st
+      ? participantsOptions
+      : participantsOptions.filter(
+          x =>
+            x.name !== `participants.${StudentLevels.COLL_GE_6E}` &&
+            x.name !== `participants.${StudentLevels.COLL_GE_5E}`
+        )
 
   return (
     <FormLayout.Section title="Participants">

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -181,7 +181,10 @@ const OfferEducationalForm = ({
             disableForm={mode === Mode.READ_ONLY}
             isTemplate={isTemplate}
           />
-          <FormParticipants disableForm={mode === Mode.READ_ONLY} />
+          <FormParticipants
+            disableForm={mode === Mode.READ_ONLY}
+            offerStock={isCollectiveOffer(offer) ? offer.collectiveStock : null}
+          />
           <FormAccessibility disableForm={mode === Mode.READ_ONLY} />
           <FormContact disableForm={mode === Mode.READ_ONLY} />
           <FormNotifications disableForm={mode === Mode.READ_ONLY} />


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21439

## But de la pull request

Sous FF : WIP_ADD_CLG_6_5_COLLECTIVE_OFFER

Si l'on souhaite modifier une offre ayant un stock déjà créer et que la date de début de l'évènement est avant le 1er septembre 2023 alors on ne veut pas afficher dans les participants les options `Collège - 6e` et `Collège - 5e`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
