### PR TITLE
(BSR)[API] fix: Fix possible race condition in `get_from_cache()` Redis helper

### DIFF
--- a/api/src/pcapi/utils/cache.py
+++ b/api/src/pcapi/utils/cache.py
@@ -48,15 +48,13 @@ def get_from_cache(
     :param force_update: If True force the update of the field cache.
     """
     redis_client = current_app.redis_client  # type: ignore [attr-defined]
-    miss = False
     if key_args:
         key = key_template % key_args
     else:
         key = key_template
 
     data = redis_client.get(key)
-    if not data and not redis_client.exists(key):
-        miss = True
+    miss = data is None
 
     if miss or force_update:
         data = retriever()


### PR DESCRIPTION
The previous version of the code did this:

    1. Try to get a key.
    2. If empty or `None`, declare that it's a miss only if the key
       does not exist.
    3. If it's a miss, recalculate the value and cache it.

If another thread sets the key between step 1 and 2, the code thinks
that it's not a miss because, at step 2, the key now exists.

We can fix that by changing the condition upon which we declare a
miss: Redis GET command either returns the value (which is always a
string, possibly empty) or `None` when the key does not exist (or when
it has expired). Thus, by properly checking the value ("is it `None`
or not?"), we don't need to explicitly use the `EXISTS` command. This
avoids the risk of a race condition.