### PR TITLE
(PC-21453)[PRO] feat: display new label and banner in participants se…

### DIFF
--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/FormParticipants.tsx
@@ -5,7 +5,7 @@ import { StudentLevels } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout'
 import { IOfferEducationalFormValues } from 'core/OfferEducational'
 import useActiveFeature from 'hooks/useActiveFeature'
-import { CheckboxGroup, InfoBox } from 'ui-kit'
+import { Banner, CheckboxGroup, InfoBox } from 'ui-kit'
 
 import { participantsOptions } from './participantsOptions'
 import useParicipantUpdates from './useParticipantUpdates'
@@ -30,20 +30,29 @@ const FormParticipants = ({
     ? participantsOptions
     : participantsOptions.filter(
         x =>
-          x.label !== StudentLevels.COLL_GE_6E &&
-          x.label !== StudentLevels.COLL_GE_5E
+          x.name !== `participants.${StudentLevels.COLL_GE_6E}` &&
+          x.name !== `participants.${StudentLevels.COLL_GE_5E}`
       )
 
   return (
     <FormLayout.Section title="Participants">
+      {isCLG6Active && (
+        <Banner type="attention">
+          À partir du 1er septembre 2023, le pass Culture est étendu aux classes
+          de 6e et 5e. Grâce au déploiement du dispositif, vous pouvez désormais
+          créer des offres pour ces classes pour l’année scolaire 2023-2024.
+        </Banner>
+      )}
       <FormLayout.Row
         sideComponent={
-          <InfoBox
-            type="info"
-            text={`Le pass Culture à destination du public scolaire s’adresse aux élèves de la ${
-              isCLG6Active ? 'sixième' : 'quatrième'
-            } à la terminale des établissements publics et privés sous contrat.`}
-          />
+          !isCLG6Active ? (
+            <InfoBox
+              type="info"
+              text={`Le pass Culture à destination du public scolaire s’adresse aux élèves de la ${
+                isCLG6Active ? 'sixième' : 'quatrième'
+              } à la terminale des établissements publics et privés sous contrat.`}
+            />
+          ) : null
         }
       >
         <CheckboxGroup

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/__specs__/FormParticipants.spec.tsx
@@ -190,10 +190,14 @@ describe('FormParticipants', () => {
       renderFormParticipants(participants, storeOverride)
 
       expect(
-        screen.getByLabelText(StudentLevels.COLL_GE_6E)
+        screen.getByLabelText(
+          `${StudentLevels.COLL_GE_6E} : à partir de septembre 2023`
+        )
       ).toBeInTheDocument()
       expect(
-        screen.getByLabelText(StudentLevels.COLL_GE_5E)
+        screen.getByLabelText(
+          `${StudentLevels.COLL_GE_5E} : à partir de septembre 2023`
+        )
       ).toBeInTheDocument()
     })
   })

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/participantsOptions.ts
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormParticipants/participantsOptions.ts
@@ -2,10 +2,20 @@ import { StudentLevels } from 'apiClient/v1'
 
 export const ALL_STUDENTS_LABEL = 'Tout sélectionner'
 
+const getStudentLevelLabel = (studentLevel: StudentLevels) => {
+  switch (studentLevel) {
+    case StudentLevels.COLL_GE_6E:
+    case StudentLevels.COLL_GE_5E:
+      return `${studentLevel} : à partir de septembre 2023`
+    default:
+      return studentLevel
+  }
+}
+
 export const participantsOptions = [
   { label: ALL_STUDENTS_LABEL, name: 'participants.all' },
   ...Object.values(StudentLevels).map(studentLevel => ({
-    label: studentLevel,
+    label: getStudentLevelLabel(studentLevel),
     name: `participants.${studentLevel}`,
   })),
 ]


### PR DESCRIPTION
…ction

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21453

## But de la pull request

- Supprimer le bloc d'information si le FF `WIP_ADD_CLG_6_5_COLLECTIVE_OFFER` est actif 
- Afficher une bannière d'info si le FF `WIP_ADD_CLG_6_5_COLLECTIVE_OFFER` est actif
- Préciser à partir de quand les options 6e et 5e seront affichées

## Screenshot 

![Capture d’écran 2023-03-30 à 14 47 25](https://user-images.githubusercontent.com/71768799/228844343-ce936d76-68a4-4f23-aedc-b2bedebe1e31.png)
