### PR TITLE
(PC-21467)[BO] fix: ignore empty strings in query parameters, which ignored default values

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_bookings.py
@@ -149,7 +149,7 @@ def _get_collective_bookings(
 
 @collective_bookings_blueprint.route("", methods=["GET"])
 def list_collective_bookings() -> utils.BackofficeResponse:
-    form = collective_booking_forms.GetCollectiveBookingListForm(request.args)
+    form = collective_booking_forms.GetCollectiveBookingListForm(formdata=utils.get_query_params())
     if not form.validate():
         return render_template("collective_bookings/list.html", isEAC=True, rows=[], form=form), 400
 

--- a/api/src/pcapi/routes/backoffice_v3/collective_offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offers.py
@@ -111,7 +111,7 @@ def _get_collective_offers(
 
 @list_collective_offers_blueprint.route("", methods=["GET"])
 def list_collective_offers() -> utils.BackofficeResponse:
-    form = collective_offer_forms.GetCollectiveOffersListForm(request.args)
+    form = collective_offer_forms.GetCollectiveOffersListForm(formdata=utils.get_query_params())
     if not form.validate():
         return render_template("collective_offer/list.html", rows=[], form=form), 400
 

--- a/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
@@ -174,7 +174,7 @@ def _get_individual_bookings(
 
 @individual_bookings_blueprint.route("", methods=["GET"])
 def list_individual_bookings() -> utils.BackofficeResponse:
-    form = individual_booking_forms.GetIndividualBookingListForm(request.args)
+    form = individual_booking_forms.GetIndividualBookingListForm(formdata=utils.get_query_params())
     if not form.validate():
         return render_template("individual_bookings/list.html", rows=[], form=form), 400
 

--- a/api/src/pcapi/routes/backoffice_v3/offerers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers.py
@@ -349,7 +349,7 @@ class OffererToBeValidatedRow:
 def list_offerers_to_validate() -> utils.BackofficeResponse:
     stats = offerers_api.count_offerers_by_validation_status()
 
-    form = offerer_forms.OffererValidationListForm(request.args)
+    form = offerer_forms.OffererValidationListForm(formdata=utils.get_query_params())
     if not form.validate():
         return render_template("offerer/validation.html", rows=[], form=form, stats=stats), 400
 
@@ -535,7 +535,7 @@ def _get_serialized_user_offerer_last_comment(
 
 @validation_blueprint.route("/user-offerer", methods=["GET"])
 def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
-    form = offerer_forms.UserOffererValidationListForm(request.args)
+    form = offerer_forms.UserOffererValidationListForm(formdata=utils.get_query_params())
     if not form.validate():
         return render_template("offerer/user_offerer_validation.html", rows=[], form=form), 400
 

--- a/api/src/pcapi/routes/backoffice_v3/offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers.py
@@ -180,7 +180,7 @@ def _get_remaining_stock(offer: offers_models.Offer) -> int | str:
 
 @list_offers_blueprint.route("", methods=["GET"])
 def list_offers() -> utils.BackofficeResponse:
-    form = offer_forms.GetOffersListForm(request.args)
+    form = offer_forms.GetOffersListForm(formdata=utils.get_query_params())
     if not form.validate():
         return render_template("offer/list.html", rows=[], form=form), 400
 

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -10,6 +10,7 @@ from flask import url_for
 from flask_login import current_user
 from flask_wtf import FlaskForm
 import werkzeug
+from werkzeug.datastructures import ImmutableMultiDict
 from werkzeug.exceptions import Forbidden
 from werkzeug.wrappers import Response as WerkzeugResponse
 
@@ -137,3 +138,12 @@ def build_form_error_msg(form: FlaskForm) -> str:
             error_msg += f" {field.label.text}: {', '.join(error for error in field.errors)};"
 
     return error_msg
+
+
+def get_query_params() -> ImmutableMultiDict[str, str]:
+    """
+    Ignore empty query parameters so that they are considered as missing, not set to an empty string.
+    This enables to fallback to the default value in wtforms field.
+    request.args is an ImmutableMultiDict
+    """
+    return ImmutableMultiDict(item for item in request.args.items(multi=True) if item[1])

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -898,6 +898,7 @@ class ListOfferersToValidateTest:
             "row_key,sort,order",
             [
                 ("Date de la demande", None, None),
+                ("Date de la demande", "", ""),
                 ("Date de la demande", "dateCreated", "asc"),
                 ("Date de la demande", "dateCreated", "desc"),
             ],
@@ -1037,6 +1038,8 @@ class ListOfferersToValidateTest:
                 (20, {"per_page": 10, "page": 1}, 2, 1, 10),
                 (27, {"page": 1}, 1, 1, 27),
                 (10, {"per_page": 25, "page": 1}, 1, 1, 10),
+                (1, {"per_page": None, "page": 1}, 1, 1, 1),
+                (1, {"per_page": "", "page": 1}, 1, 1, 1),  # ensure that it does not crash (fallbacks to default)
             ),
         )
         def test_list_pagination(
@@ -1774,6 +1777,8 @@ class ListUserOffererToValidateTest:
             (20, {"per_page": 10, "page": 1}, 2, 1, 10),
             (27, {"page": 1}, 1, 1, 27),
             (10, {"per_page": 25, "page": 1}, 1, 1, 10),
+            (1, {"per_page": None, "page": 1}, 1, 1, 1),
+            (1, {"per_page": "", "page": 1}, 1, 1, 1),  # ensure that it does not crash (fallbacks to default)
         ),
     )
     def test_list_pagination(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21467

## But de la pull request

Ignorer les paramètres de filtrage vides dans les paramètres d'URL, utilisés pour le filtrage et la pagination des listes.
La chaîne vide était conservée comme une valeur, qui ne permettait pas de garder la valeur par défaut (affectée uniquement si le paramètre est absent), d'où certaines erreurs 500 si on modifiait l'URL `&per_page=100` par `&per_page=` vide par exemple.

En fait on traite les _query params_ en les passant à un `FlaskForm` pour être considérés comme les données d'un `POST`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
