### PR TITLE
(PC-21157) save pc pro navigation flags

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-1b9fe434199c (pre) (head)
-adeb447a5a8a (post) (head)
+66c2977b3cfe (pre) (head)
+580466424daf (post) (head)

--- a/api/src/pcapi/alembic/versions/20230403T131445_66c2977b3cfe_add_pro_user_flags_table.py
+++ b/api/src/pcapi/alembic/versions/20230403T131445_66c2977b3cfe_add_pro_user_flags_table.py
@@ -1,0 +1,26 @@
+"""Add user_pro_flags table"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "66c2977b3cfe"
+down_revision = "1b9fe434199c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_pro_flags",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=True),
+        sa.Column("firebase", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("userId", sa.BigInteger(), nullable=False, unique=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_pro_flags")

--- a/api/src/pcapi/alembic/versions/20230403T131907_841f91f7e665_add_pro_user_flags_userid_fkey_step_1_2.py
+++ b/api/src/pcapi/alembic/versions/20230403T131907_841f91f7e665_add_pro_user_flags_userid_fkey_step_1_2.py
@@ -1,0 +1,36 @@
+"""Add user_pro_flags_userId_fkey (step 1/2)"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "841f91f7e665"
+down_revision = "adeb447a5a8a"
+branch_labels = None
+depends_on = None
+
+
+FOREIGN_KEY_NAME = "user_pro_flags_userId_fkey"
+
+
+def upgrade() -> None:
+    op.execute("""SET SESSION statement_timeout='300s'""")
+    op.execute(
+        f"""
+        ALTER TABLE user_pro_flags DROP CONSTRAINT IF EXISTS "{FOREIGN_KEY_NAME}";
+        ALTER TABLE user_pro_flags 
+        ADD CONSTRAINT "{FOREIGN_KEY_NAME}" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE NOT VALID;
+        """
+    )
+    op.execute(f"""SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}""")
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        ALTER TABLE user_pro_flags 
+        DROP CONSTRAINT IF EXISTS "{FOREIGN_KEY_NAME}";
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20230403T132753_580466424daf_add_pro_user_flags_userid_fkey_step_2_2.py
+++ b/api/src/pcapi/alembic/versions/20230403T132753_580466424daf_add_pro_user_flags_userid_fkey_step_2_2.py
@@ -1,0 +1,26 @@
+"""Add pro_user_flags_userId_fkey (step 2/2)"""
+from alembic import op
+from alembic.runtime.migration import log
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "580466424daf"
+down_revision = "841f91f7e665"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    # The timeout here has the same value (5 minutes) as `helm upgrade`.
+    log.info(">>> HINT: If this migration fails, you'll have to execute it manually from a pgcli console")
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute('ALTER TABLE "user_pro_flags" VALIDATE CONSTRAINT "user_pro_flags_userId_fkey"')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1191,3 +1191,22 @@ def validate_pro_user_email(user: users_models.User, author_user: users_models.U
             "Could not send welcome email when pro user is valid",
             extra={"user": user.id},
         )
+
+
+def _save_firebase_flags(user: models.User, firebase_value: dict) -> None:
+    if user.pro_flags:
+        if user.pro_flags.firebase and user.pro_flags.firebase != firebase_value:
+            logger.warning("%s now has different Firebase flags than before", user)
+        user.pro_flags.firebase = firebase_value
+    else:
+        user.pro_flags = users_models.UserProFlags(user=user, firebase=firebase_value)
+    db.session.commit()
+
+
+def save_flags(user: models.User, flags: dict) -> None:
+    for flag, value in flags.items():
+        match flag:
+            case "firebase":
+                _save_firebase_flags(user, value)
+            case _:
+                raise ValueError()

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -536,3 +536,11 @@ class EmailValidationEntryFactory(UserEmailHistoryFactory):
 
 class EmailAdminValidationEntryFactory(UserEmailHistoryFactory):
     eventType = models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION.value
+
+
+class UserProFlagsFactory(BaseFactory):
+    class Meta:
+        model = models.UserProFlags
+
+    user = factory.SubFactory(ProFactory)
+    firebase = {"BETTER_OFFER_CREATION": True}

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -207,3 +207,10 @@ def signin(body: users_serializers.LoginUserBodyModel) -> users_serializers.Shar
 def signout() -> None:
     discard_session()
     logout_user()
+
+
+@blueprint.pro_private_api.route("/users/pro_flags", methods=["POST"])
+@login_required
+@spectree_serialize(on_success_status=204, on_error_statuses=[400], api=blueprint.pro_private_schema)
+def post_pro_flags(body: users_serializers.ProFlagsQueryModel) -> None:
+    users_api.save_flags(user=current_user, flags=body.dict())

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -204,6 +204,6 @@ def signin(body: users_serializers.LoginUserBodyModel) -> users_serializers.Shar
 @blueprint.pro_private_api.route("/users/signout", methods=["GET"])
 @login_required
 @spectree_serialize(api=blueprint.pro_private_schema, on_success_status=204)
-def signout():  # type: ignore [no-untyped-def]
+def signout() -> None:
     discard_session()
     logout_user()

--- a/api/src/pcapi/routes/serialization/users.py
+++ b/api/src/pcapi/routes/serialization/users.py
@@ -255,3 +255,7 @@ class ChangePasswordBodyModel(BaseModel):
     oldPassword: str
     newPassword: str
     newConfirmationPassword: str
+
+
+class ProFlagsQueryModel(BaseModel):
+    firebase: dict

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1378,3 +1378,37 @@ class UserEmailValidationTest:
 
         assert user_offerer.user.validationToken is None
         assert user_offerer.user.isEmailValidated is True
+
+
+class SaveFlagsTest:
+    def test_new_firebase_flags(self):
+        user = users_factories.UserFactory()
+
+        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": True}})
+
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
+
+    def test_same_pre_existing_firebase_flags(self, caplog):
+        flags = users_factories.UserProFlagsFactory()
+        user = flags.user
+
+        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": True}})
+
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
+        assert not caplog.messages
+
+    def test_different_pre_existing_firebase_flags(self, caplog):
+        flags = users_factories.UserProFlagsFactory()
+        user = flags.user
+
+        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": False}})
+
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": False}
+        assert caplog.messages == [f"{user} now has different Firebase flags than before"]
+
+    def test_unknown_flags(self):
+        flags = users_factories.UserProFlagsFactory()
+        user = flags.user
+
+        with pytest.raises(ValueError):
+            users_api.save_flags(user, {"uknown": {"toto": 10}})

--- a/api/tests/routes/pro/post_user_pro_flags_test.py
+++ b/api/tests/routes/pro/post_user_pro_flags_test.py
@@ -1,0 +1,49 @@
+import pytest
+
+import pcapi.core.users.factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+ROUTE_PATH = "/users/pro_flags"
+
+
+class Returns204Test:
+    def test_new_flags(self, client):
+        user = users_factories.UserFactory()
+
+        client = client.with_session_auth(user.email)
+        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": True}})
+
+        assert response.status_code == 204
+
+    def test_same_flags(self, client):
+        flags = users_factories.UserProFlagsFactory()
+        user = flags.user
+
+        client = client.with_session_auth(user.email)
+        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": True}})
+
+        assert response.status_code == 204
+
+    def test_different_flags(self, client):
+        flags = users_factories.UserProFlagsFactory()
+        user = flags.user
+
+        client = client.with_session_auth(user.email)
+        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": False}})
+
+        assert response.status_code == 204
+
+
+class Returns400Test:
+    def test_uknown_flags(self, client):
+        flags = users_factories.UserProFlagsFactory()
+        user = flags.user
+
+        client = client.with_session_auth(user.email)
+        response = client.post(ROUTE_PATH, json={"unknwown": {"toto": 10}})
+
+        assert response.status_code == 400
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -142,6 +142,7 @@ export type { PostVenueBodyModel } from './models/PostVenueBodyModel';
 export type { PostVenueProviderBody } from './models/PostVenueProviderBody';
 export type { PriceCategoryBody } from './models/PriceCategoryBody';
 export type { PriceCategoryResponseModel } from './models/PriceCategoryResponseModel';
+export type { ProFlagsQueryModel } from './models/ProFlagsQueryModel';
 export type { ProUserCreationBodyModel } from './models/ProUserCreationBodyModel';
 export type { ProUserCreationBodyV2Model } from './models/ProUserCreationBodyV2Model';
 export type { ProviderResponse } from './models/ProviderResponse';

--- a/pro/src/apiClient/v1/models/ProFlagsQueryModel.ts
+++ b/pro/src/apiClient/v1/models/ProFlagsQueryModel.ts
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ProFlagsQueryModel = {
+  firebase: any;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -64,6 +64,7 @@ import type { PostOfferBodyModel } from '../models/PostOfferBodyModel';
 import type { PostVenueBodyModel } from '../models/PostVenueBodyModel';
 import type { PostVenueProviderBody } from '../models/PostVenueProviderBody';
 import type { PriceCategoryBody } from '../models/PriceCategoryBody';
+import type { ProFlagsQueryModel } from '../models/ProFlagsQueryModel';
 import type { ProUserCreationBodyModel } from '../models/ProUserCreationBodyModel';
 import type { ProUserCreationBodyV2Model } from '../models/ProUserCreationBodyV2Model';
 import type { ReimbursementPointListResponseModel } from '../models/ReimbursementPointListResponseModel';
@@ -1714,6 +1715,28 @@ export class DefaultService {
       body: requestBody,
       mediaType: 'application/json',
       errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+
+  /**
+   * post_pro_flags <POST>
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public postProFlags(
+    requestBody?: ProFlagsQueryModel,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/users/pro_flags',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        400: `Bad Request`,
         403: `Forbidden`,
         422: `Unprocessable Entity`,
       },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21157

## But de la pull request

Enregistrer en DB des infos de type navigation (quel parcours A/B par exemple) si l'info ne remonte pas via un service tiers comme Firebase

## Implémentation

- Ajout d'une table `user_pro_flags`
- Ajout d'une route permettant l'écriture des données

## Informations supplémentaires

N/A

## Modifications du schéma de la base de données

- Ajout de la table `user_pro_flags` dont la colonne `firebase` de type JSONB permet de stocker des données de navigation comme par exemple quel parcours est présenté dans un A/B testing
