### PR TITLE
(PC-21494)[API] fix: do not update date of birth on activation if already validated

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -251,7 +251,7 @@ def update_user_information_from_external_source(
 ) -> models.User:
     first_name = data.get_first_name()
     last_name = data.get_last_name()
-    birth_date = data.get_birth_date()
+    birth_date = user.validatedBirthDate or data.get_birth_date()
 
     if not first_name or not last_name or not birth_date:
         raise exceptions.IncompleteDataException()

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -972,6 +972,19 @@ class BeneficiaryInformationUpdateTest:
 
         assert user.firstName == "Julie"
 
+    def should_not_update_date_of_birth_if_already_validated(self):
+        # Given
+        user = users_factories.UserFactory(
+            dateOfBirth=datetime.date(2000, 1, 1),
+            validatedBirthDate=datetime.date(2000, 1, 1),
+        )
+
+        # When
+        users_api.update_user_information_from_external_source(user, fraud_factories.DMSContentFactory())
+
+        # Then
+        assert user.birth_date == datetime.date(2000, 1, 1)
+
 
 class UpdateUserLastConnectionDateTest:
     @freeze_time("2021-9-20 11:11:11")


### PR DESCRIPTION
Current version overrides the birth date when the support team changes a wrong date in an application

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21494

## But de la pull request

Débloquer les utilisateurs qui ont une date validée erronée (erreur DMS par exemple)
Si le support change la date de naisance, on veut qu'elle reste, pas qu'elle soit écrasée par celle du dossier

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
