### PR TITLE
(PC-21495)[BO] fix: offers were unexpectedly sorted

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/collective_offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offers.py
@@ -102,8 +102,7 @@ def _get_collective_offers(
             )
 
     if form.sort.data:
-        # currently only support ascending date
-        base_query = base_query.order_by(educational_models.CollectiveOffer.dateCreated.asc())
+        base_query = base_query.order_by(getattr(educational_models.CollectiveOffer, form.sort.data))
 
     # +1 to check if there are more results than requested
     return base_query.limit(form.limit.data + 1).all()

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_offer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_offer.py
@@ -37,10 +37,12 @@ class GetCollectiveOffersListForm(FlaskForm):
         validators=(wtforms.validators.Optional(),),
     )
     only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
-    sort = fields.PCHiddenBooleanField("Trier par date")
+    sort = wtforms.HiddenField(
+        "sort", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("id", "dateCreated")))
+    )
 
     def is_empty(self) -> bool:
-        # 'only_validated_offerers' must be combined with other filters
+        # 'only_validated_offerers', 'sort' must be combined with other filters
         return not any(
             (
                 self.q.data,

--- a/api/src/pcapi/routes/backoffice_v3/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/fields.py
@@ -207,16 +207,9 @@ class PCSearchField(PCOptSearchField):
     validators = [validators.InputRequired("Information obligatoire")]
 
 
-class PCBooleanField(wtforms.BooleanField):
-    false_values = (False, "False", "false", "off", "0", "")
-
-
-class PCSwitchBooleanField(PCBooleanField):
+class PCSwitchBooleanField(wtforms.BooleanField):
     widget = partial(widget, template="components/forms/switch_boolean_field.html")
-
-
-class PCHiddenBooleanField(PCBooleanField):
-    widget = wtforms.widgets.HiddenInput()
+    false_values = (False, "False", "false", "off", "0", "")
 
 
 class PcPostalAddressAutocomplete(wtforms.StringField):

--- a/api/src/pcapi/routes/backoffice_v3/forms/offer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offer.py
@@ -60,7 +60,9 @@ class GetOffersListForm(FlaskForm):
         validators=(wtforms.validators.Optional(),),
     )
     only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
-    sort = fields.PCHiddenBooleanField("Trier par date")
+    sort = wtforms.HiddenField(
+        "sort", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("id", "dateCreated")))
+    )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data:
@@ -73,7 +75,7 @@ class GetOffersListForm(FlaskForm):
         return q
 
     def is_empty(self) -> bool:
-        # 'where' and 'only_validated_offerers' must be combined with other filters
+        # 'where', 'only_validated_offerers', 'sort' must be combined with other filters
         return not any(
             (
                 self.q.data,

--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -93,8 +93,14 @@ class OffererValidationListForm(utils.PCForm):
         validators=(wtforms.validators.Optional(),),
     )
 
-    order = wtforms.HiddenField("order", default="desc", validators=(wtforms.validators.Optional(),))
-    sort = wtforms.HiddenField("sort", default="dateCreated", validators=(wtforms.validators.Optional(),))
+    order = wtforms.HiddenField(
+        "order", default="desc", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("asc", "desc")))
+    )
+    sort = wtforms.HiddenField(
+        "sort",
+        default="dateCreated",
+        validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("dateCreated",))),
+    )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
@@ -102,17 +108,6 @@ class OffererValidationListForm(utils.PCForm):
                 "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
             )
         return q
-
-    def validate_order(self, order: wtforms.HiddenField) -> wtforms.HiddenField:
-        order.data = order.data.lower()
-        if order.data not in ("asc", "desc"):
-            raise wtforms.validators.ValidationError("L'ordre ne peut être qu'ascendant ou descendant")
-        return order
-
-    def validate_sort(self, sort: wtforms.HiddenField) -> wtforms.HiddenField:
-        if sort.data not in ("dateCreated"):
-            raise wtforms.validators.ValidationError(f"Le tri par {sort.data} n'est pas autorisé")
-        return sort
 
 
 class UserOffererValidationListForm(utils.PCForm):
@@ -143,8 +138,14 @@ class UserOffererValidationListForm(utils.PCForm):
         default="100",
         validators=(wtforms.validators.Optional(),),
     )
-    order = wtforms.HiddenField("order", default="desc", validators=(wtforms.validators.Optional(),))
-    sort = wtforms.HiddenField("sort", default="id", validators=(wtforms.validators.Optional(),))
+    order = wtforms.HiddenField(
+        "order", default="desc", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("asc", "desc")))
+    )
+    sort = wtforms.HiddenField(
+        "sort",
+        default="id",
+        validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("id", "dateCreated"))),
+    )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
         if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
@@ -152,17 +153,6 @@ class UserOffererValidationListForm(utils.PCForm):
                 "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
             )
         return q
-
-    def validate_order(self, order: wtforms.HiddenField) -> wtforms.HiddenField:
-        order.data = order.data.lower()
-        if order.data not in ("asc", "desc"):
-            raise wtforms.validators.ValidationError("L'ordre ne peut être qu'ascendant ou descendant")
-        return order
-
-    def validate_sort(self, sort: wtforms.HiddenField) -> wtforms.HiddenField:
-        if sort.data not in ("id", "dateCreated"):
-            raise wtforms.validators.ValidationError(f"Le tri par {sort.data} n'est pas autorisé")
-        return sort
 
 
 class CommentForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice_v3/offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers.py
@@ -155,8 +155,7 @@ def _get_offers(form: offer_forms.GetOffersListForm) -> list[offers_models.Offer
         query = base_query
 
     if form.sort.data:
-        # currently only support ascending date
-        query = query.order_by(offers_models.Offer.dateCreated.asc())
+        query = query.order_by(getattr(offers_models.Offer, form.sort.data))
 
     # +1 to check if there are more results than requested
     return query.limit(form.limit.data + 1).all()

--- a/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
@@ -35,12 +35,12 @@
         pending_individual_offers_count,
         "offre individuelle en attente",
         "offres individuelles en attente",
-        url_for("backoffice_v3_web.offer.list_offers", status="PENDING", only_validated_offerers="on", sort="on")) }}
+        url_for("backoffice_v3_web.offer.list_offers", status="PENDING", only_validated_offerers="on", sort="dateCreated")) }}
         {{ stats_card(
         pending_collective_offers_count,
         "offre collective en attente",
         "offres collectives en attente",
-        url_for("backoffice_v3_web.collective_offer.list_collective_offers", status="PENDING", only_validated_offerers="on", sort="on")) }}
+        url_for("backoffice_v3_web.collective_offer.list_collective_offers", status="PENDING", only_validated_offerers="on", sort="dateCreated")) }}
         {{ stats_card(
         pending_collective_templates_count,
         "offre collective vitrine en attente",

--- a/api/tests/routes/backoffice_v3/collective_offers_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offers_test.py
@@ -206,7 +206,7 @@ class ListCollectiveOffersTest:
                     self.endpoint,
                     status=[offers_models.OfferValidationStatus.PENDING.value],
                     only_validated_offerers="on",
-                    sort="on",
+                    sort="dateCreated",
                 )
             )
             assert response.status_code == 200

--- a/api/tests/routes/backoffice_v3/offers_test.py
+++ b/api/tests/routes/backoffice_v3/offers_test.py
@@ -354,7 +354,7 @@ class ListOffersTest:
                     self.endpoint,
                     status=[offers_models.OfferValidationStatus.PENDING.value],
                     only_validated_offerers="on",
-                    sort="on",
+                    sort="dateCreated",
                 )
             )
             assert response.status_code == 200


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21495

## But de la pull request

Éviter que le tri ne se retrouve actif sur la recherche des offres quand il n'est pas attendu (il est demandé uniquement lors du clic sur les compteurs d'offres à valider). Sinon la recherche se retrouve beaucoup plus longue, potentiellement jusqu'au timeout.

## Implémentation

Il y avait un `sort=y` inattendu.
Changement du champ `sort` pour s'aligner avec le tri des validations de structures, fait par @kopax hier.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
