### PR TITLE
(BSR)[API] fix: skip upgrade migration for prod

### DIFF
--- a/api/src/pcapi/alembic/versions/20230328T125306_a46c49320415_validate_stock_price_category_fkey.py
+++ b/api/src/pcapi/alembic/versions/20230328T125306_a46c49320415_validate_stock_price_category_fkey.py
@@ -14,6 +14,10 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # This upgrade failed in staging, it will fail certainly in production.
+    # We will have to run it manually
+    if settings.IS_PROD:
+        return
     op.execute("COMMIT")
     # The timeout here has the same value (5 minutes) as `helm upgrade`.
     # If this migration fails, you'll have to execute it manually.


### PR DESCRIPTION
This commit will have to be hotfixed for monday

cf : https://passcultureteam.slack.com/archives/CQAMNFVPS/p1680185933873629