### PR TITLE
(PC-21501)[PRO] fix: move tooltip in composent using it

### DIFF
--- a/pro/src/app/AppLayout.tsx
+++ b/pro/src/app/AppLayout.tsx
@@ -1,13 +1,11 @@
 import classnames from 'classnames'
 import React from 'react'
-import { Tooltip } from 'react-tooltip'
 
 import DomainNameBanner from 'components/DomainNameBanner'
 import Header from 'components/Header/Header'
 import TutorialDialog from 'components/TutorialDialog'
 
 import { ILayoutConfig } from './AppRouter/routes_map'
-import 'react-tooltip/dist/react-tooltip.css'
 
 export interface AppLayoutProps {
   children?: React.ReactNode
@@ -29,12 +27,6 @@ const AppLayout = ({ children, layoutConfig, className }: AppLayoutProps) => {
   return (
     <>
       {!fullscreen && <Header />}
-      <Tooltip
-        className="type-info flex-center items-center"
-        delayHide={500}
-        anchorSelect=".react-tooltip-anchor"
-      />
-
       <main
         className={classnames(
           {

--- a/pro/src/pages/Offerers/List/Offerers.jsx
+++ b/pro/src/pages/Offerers/List/Offerers.jsx
@@ -4,7 +4,9 @@ import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
 import LoadingInfiniteScroll from 'react-loading-infinite-scroller'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { Tooltip } from 'react-tooltip'
 
+import 'react-tooltip/dist/react-tooltip.css'
 import { api } from 'apiClient/api'
 import PageTitle from 'components/PageTitle/PageTitle'
 import useActiveFeature from 'hooks/useActiveFeature'
@@ -21,7 +23,6 @@ import { mapApiToBrowser } from 'utils/translate'
 import OffererItem from './OffererItem/OffererItem'
 import PendingOffererItem from './OffererItem/PendingOffererItem'
 import createVenueForOffererUrl from './utils/createVenueForOffererUrl'
-
 /* eslint-disable */
 function withRouterAndApiSiren(Component) {
   return props => (
@@ -196,10 +197,15 @@ class Offerers extends PureComponent {
         </ButtonLink>
         <Icon
           data-tooltip-place="bottom"
-          className="react-tooltip-anchor"
           data-tooltip-html="<p>Ajouter les SIREN des structures que vous souhaitez gérer au global avec ce compte (par exemple, un réseau de grande distribution ou de franchisés).</p>"
           data-tooltip-type="info"
+          data-tooltip-id="tooltip-siren"
           svg="picto-tip"
+        />
+        <Tooltip
+          className="type-info flex-center items-center"
+          delayHide={500}
+          id="tooltip-siren"
         />
       </span>
     )

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.jsx
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types'
 import React, { useCallback, useState } from 'react'
 import { Form } from 'react-final-form'
+import { Tooltip } from 'react-tooltip'
 
+import 'react-tooltip/dist/react-tooltip.css'
 import { CheckboxField } from 'ui-kit'
 import NumberField from 'ui-kit/form_rff/fields/NumberField'
 import Icon from 'ui-kit/Icon/Icon'
 import Insert from 'ui-kit/Insert/Insert'
 import { getCanSubmit } from 'utils/react-final-form'
-
 const AllocineProviderForm = ({
   saveVenueProvider,
   providerId,
@@ -63,13 +64,19 @@ const AllocineProviderForm = ({
                     <span className="field-asterisk">*</span>
                   </label>
                   <span
-                    className="apf-tooltip react-tooltip-anchor"
+                    className="apf-tooltip"
                     data-tooltip-place="bottom"
                     data-tooltip-html="<p>Prix de vente/place : Prix auquel la place de cinéma sera vendue.</p>"
+                    data-tooltip-id="tooltip-price"
                     data-type="info"
                   >
                     <Icon svg="picto-info" />
                   </span>
+                  <Tooltip
+                    className="type-info flex-center items-center"
+                    delayHide={500}
+                    id="tooltip-price"
+                  />
                 </div>
                 <NumberField
                   onKeyPress={e =>
@@ -102,13 +109,19 @@ const AllocineProviderForm = ({
                   name="isDuo"
                 />
                 <span
-                  className="apf-tooltip react-tooltip-anchor"
+                  className="apf-tooltip"
                   data-tooltip-place="bottom"
                   data-tooltip-html="<p>En activant cette option, vous permettez au bénéficiaire du pass Culture de venir accompagné. La seconde place sera délivrée au même tarif que la première, quel que soit l’accompagnateur.</p>"
                   data-tooltip-type="info"
+                  data-tooltip-id="tooltip-duo"
                 >
                   <Icon svg="picto-info" />
                 </span>
+                <Tooltip
+                  className="type-info flex-center items-center"
+                  delayHide={500}
+                  id="tooltip-duo"
+                />
               </div>
 
               <Insert className="blue-insert" icon="picto-info-solid-black">

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/CinemaProviderForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/CinemaProviderForm/CinemaProviderForm.tsx
@@ -2,7 +2,9 @@ import './CinemaProviderForm.scss'
 
 import { Form, FormikProvider, useFormik } from 'formik'
 import React, { useState } from 'react'
+import { Tooltip } from 'react-tooltip'
 
+import 'react-tooltip/dist/react-tooltip.css'
 import FormLayout from 'components/FormLayout'
 import { Checkbox, SubmitButton } from 'ui-kit'
 import Icon from 'ui-kit/Icon/Icon'
@@ -63,13 +65,19 @@ export const CinemaProviderForm = ({
                   value={formik.values.isDuo}
                 />
                 <span
-                  className="cpf-tooltip react-tooltip-anchor"
+                  className="cpf-tooltip"
                   data-tooltip-place="bottom"
                   data-tooltip-html="<p>En activant cette option, vous permettez au bénéficiaire du pass Culture de venir accompagné. La seconde place sera délivrée au même tarif que la première, quel que soit l’accompagnateur.</p>"
                   data-tooltip-type="info"
+                  data-tooltip-id="tooltip-duo"
                 >
                   <Icon svg="picto-info" />
                 </span>
+                <Tooltip
+                  className="type-info flex-center items-center"
+                  delayHide={500}
+                  id="tooltip-duo"
+                />
               </FormLayout.Row>
               {isCreatedEntity ? (
                 <div className="cpf-provider-import-button">


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21501

## But de la pull request

- La mise à jour de react-tooltip semble avoir cassé certains tests unitaires. Il semblerait qu'au passage à la v5, il est plus pertinent d'utiliser le composant Tooltip seulement là ou on en a besoin. 

- BSR sur le fichier de test Signin : la variable storeOverride était écrasé dans plusieurs tests

