### PR TITLE
(PC-21361)[API] feat: log any successful or failed connexion with email

### DIFF
--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -35,7 +35,7 @@ def check_user_and_credentials(user: models.User | None, password: str, allow_in
     if not (user.checkPassword(password) and (user.isActive or allow_inactive)):
         logger.info(
             "Failed authentication attempt",
-            extra={"user": user.id, "avoid_current_user": True, "success": False},
+            extra={"identifier": user.email, "user": user.id, "avoid_current_user": True, "success": False},
             technical_message_id="users.login",
         )
         raise exceptions.InvalidIdentifier()
@@ -45,11 +45,17 @@ def check_user_and_credentials(user: models.User | None, password: str, allow_in
 
 def get_user_with_credentials(identifier: str, password: str, allow_inactive: bool = False) -> models.User:
     user = find_user_by_email(identifier)
+    if not user:
+        logger.info(
+            "Failed authentication attempt",
+            extra={"identifier": identifier, "user": "not found", "avoid_current_user": True, "success": False},
+            technical_message_id="users.login",
+        )
     check_user_and_credentials(user, password, allow_inactive)
     if user:
         logger.info(
             "Successful authentication attempt",
-            extra={"user": user.id, "avoid_current_user": True, "success": True},
+            extra={"identifier": identifier, "user": user.id, "avoid_current_user": True, "success": True},
             technical_message_id="users.login",
         )
     return typing.cast(models.User, user)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21361

## But de la pull request 

En tant que équipe data ou équipe fraude ou équipe infra
J'aimerais pourvoir identifier quels mails sont ciblés lors des tentatives de signin
Afin de mieux comprendre les attaques sur les routes /signin et prendre des actions pour réduire le nombre de comptes piratés.

doit prendre effet sur tous les endpoints possibles de connexion

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
