### PR TITLE
(PC-21352)[API] feat: set top offres replica on Algolia offers index

### DIFF
--- a/api/src/pcapi/algolia_settings_offers.json
+++ b/api/src/pcapi/algolia_settings_offers.json
@@ -30,7 +30,9 @@
     "queryLanguages": [
         "fr"
     ],
-    "replicas": [],
+    "replicas": [
+        "virtual(PRODUCTION Top offres)"
+    ],
     "attributesForFaceting": [
         "offer.bookMacroSection",
         "filterOnly(offer.category)",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21352

## But de la pull request

rétablir le replica _PRODUCTION Top offres_  dans la config de l’index des offres

(maintenant que le clef d'API est autorisée à faire des opérations sur l'index _PRODUCTION Top offres_, ça passe. testé en lanceant manuellement la commande sur le pod console de la prod)

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
