### PR TITLE
(PC-21395)[API] feat: Add authentication methods in /stepper route response

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -67,6 +67,7 @@ class SubscriptionStepDetailsResponse(BaseModel):
 
 class SubscriptionStepperResponse(BaseModel):
     subscription_steps_to_display: list[SubscriptionStepDetailsResponse]
+    allowed_identity_check_methods: list[subscription_models.IdentityCheckMethod]
     title: str
     subtitle: str | None
     error_message: str | None

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -43,6 +43,9 @@ def next_subscription_step(
     return serializers.NextSubscriptionStepResponse(
         next_subscription_step=user_subscription_state.next_step,
         stepper_includes_phone_validation=subscription_api.is_phone_validation_in_stepper(user),
+        # FIXME: (thconte, 03/04/2023) deprecated. Remove this field when:
+        # [ ] it is not used anymore in the frontend
+        # [ ] a forced updated happened
         allowed_identity_check_methods=subscription_api.get_allowed_identity_check_methods(user),
         maintenance_page_type=subscription_api.get_maintenance_page_type(user),
         has_identity_check_pending=fraud_api.has_user_pending_identity_check(user),
@@ -72,6 +75,7 @@ def get_subscription_stepper(user: users_models.User) -> serializers.Subscriptio
             )
             for step in subscription_steps_to_display
         ],
+        allowed_identity_check_methods=subscription_api.get_allowed_identity_check_methods(user),
         title=stepper_header.title,
         subtitle=stepper_header.subtitle,
         error_message=(

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -1574,6 +1574,10 @@ def test_public_api(client):
                 },
                 "SubscriptionStepperResponse": {
                     "properties": {
+                        "allowedIdentityCheckMethods": {
+                            "items": {"$ref": "#/components/schemas/IdentityCheckMethod"},
+                            "type": "array",
+                        },
                         "errorMessage": {"nullable": True, "title": "Errormessage", "type": "string"},
                         "subscriptionStepsToDisplay": {
                             "items": {"$ref": "#/components/schemas/SubscriptionStepDetailsResponse"},
@@ -1583,7 +1587,7 @@ def test_public_api(client):
                         "subtitle": {"nullable": True, "title": "Subtitle", "type": "string"},
                         "title": {"title": "Title", "type": "string"},
                     },
-                    "required": ["subscriptionStepsToDisplay", "title"],
+                    "required": ["subscriptionStepsToDisplay", "allowedIdentityCheckMethods", "title"],
                     "title": "SubscriptionStepperResponse",
                     "type": "object",
                 },

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -774,6 +774,20 @@ class StepperTest:
             self.get_step("honor_statement_step", SubscriptionStepCompletionState.DISABLED.value),
         ]
 
+    def should_contain_identity_check_methods(self, client):
+        user = users_factories.EligibleUnderageFactory()
+
+        fraud_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=fraud_models.FraudCheckType.USER_PROFILING,
+            status=fraud_models.FraudCheckStatus.PENDING,
+            eligibilityType=users_models.EligibilityType.UNDERAGE,
+        )
+
+        client.with_token(user.email)
+        response = client.get("/native/v1/subscription/stepper")
+        assert "educonnect" in response.json["allowedIdentityCheckMethods"]
+
 
 class GetProfileTest:
     def test_get_profile(self, client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21395

## But de la pull request

Remonter des méthodes d'authentification disponibles dans la route appelée par le stepper /subscription/stepper. De la même manière que c'était déjà fait pour la route /subscription/next_step.

## Implémentation

- Ajout du champ allowed_identity_check_methods à l'objet SubscriptionStepperResponse
- Le champ allowed_identity_check_methods dans l'objet NextSubscriptionStepResponse de la route /subscription/next_step est maintenant déprécié.

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
