### PR TITLE
(BSR)[PRO] fix: unit tests on master

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksThing/__specs__/StocksThing.spec.tsx
@@ -29,6 +29,7 @@ import {
 } from 'core/Offers/utils/getOfferIndividualUrl'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
+import { serializeThingBookingLimitDatetime } from '../adapters/serializers'
 import StocksThing, { IStocksThingProps } from '../StocksThing'
 
 jest.mock('screens/OfferIndividual/Informations/utils', () => {
@@ -372,7 +373,7 @@ describe('screens:StocksThing', () => {
             quantity: 5,
             activationCodes: ['ABH', 'JHB', 'IOP', 'KLM', 'MLK'],
             activationCodesExpirationDatetime:
-              date.toISOString().slice(0, -5) + 'Z',
+              serializeThingBookingLimitDatetime(date, '75'),
           },
         ],
       })

--- a/pro/src/screens/OfferIndividual/StocksThing/adapters/serializers.ts
+++ b/pro/src/screens/OfferIndividual/StocksThing/adapters/serializers.ts
@@ -6,7 +6,7 @@ import { getUtcDateTimeFromLocalDepartement } from 'utils/timezone'
 
 import { IStockThingFormValues } from '../'
 
-const serializeThingBookingLimitDatetime = (
+export const serializeThingBookingLimitDatetime = (
   bookingLimitDatetime: Date,
   departementCode: string
 ) => {


### PR DESCRIPTION
Bug intéressant :

### Cause

Le test set une date au 25 du mois avec une heure UTC précise (22h59) et expect que le call backend est fait à la même date+heure toISOString 
Hors en interne le upsert stocks serialize les stocks en mettant l'heure à la fin du jour dans le département en question (23h59 avec l'heure de Paris dans le cas du test) et reconvertit en UTC
Là on est dans un cas où le test case a été construit pour correspondre au code, mais du coup ça ne marche que quand il n'y a qu'une heure de décalage entre UTC et la timezone de Paris.
Le changement d'heure a eu lieu au 26 mars, à partir duquel le temps UTC est décalé de 2h du temps de Paris
Jusqu'au 31 mars tout allait bien vu qu'on set la date au 25 du mois et que le changement d'heure est le 26
Au 1er avril, le 25 avril a 2h de décalage avec UTC et ça casse
Ce test case ayant été codé il y a 4 mois il n'a jamais été en heure d'été donc il n'échoue que maintenant

### Résolution : 

La façon correcte d'écrire le test serait de mocker la date avec Jest, par exemple avec `jest.useFakeTimers().setSystemTime(new Date('2020-02-03'))`
Cependant, il y a une issue dans Jest 27 qui timeout le test quand on utilise cette fonction :
https://github.com/nock/nock/issues/2200
https://github.com/facebook/jest/issues/10221
Il ne m'est pas possible de mettre à jour vers Jest 29 car le package Jest est inclus dans Create React App (dépendance react-scripts) et l'installer à la mano demande bcp de reconfiguration (notamment babel)
=> pour l'instant je fais l'assert avec la fonction utilisée dans l'implem