### PR TITLE
(PC-21304)[API] feat: Always sort reimbursement points by common_name

### DIFF
--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -9,7 +9,6 @@ from pcapi.core.offerers import api
 from pcapi.core.offerers import repository
 import pcapi.core.offerers.exceptions as offerers_exceptions
 import pcapi.core.offerers.models as offerers_models
-from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.repository import transaction
 from pcapi.routes.apis import private_api
@@ -146,12 +145,11 @@ def get_available_reimbursement_points(
 
     reimbursement_points = repository.find_available_reimbursement_points_for_offerer(offerer_id)
     # TODO(fseguin, 2023-03-01): cleanup when WIP_ENABLE_NEW_ONBOARDING FF is removed
-    is_new_onboarding_enabled = feature.FeatureToggle.WIP_ENABLE_NEW_ONBOARDING.is_active()
     return offerers_serialize.ReimbursementPointListResponseModel(
         __root__=[
             offerers_serialize.ReimbursementPointResponseModel(  # type: ignore [call-arg]
                 venueId=reimbursement_point.id,
-                venueName=reimbursement_point.name if is_new_onboarding_enabled else reimbursement_point.common_name,  # type: ignore [arg-type]
+                venueName=reimbursement_point.common_name,  # type: ignore [arg-type]
                 siret=reimbursement_point.siret,
                 iban=reimbursement_point.iban,  # type: ignore [arg-type]
                 bic=reimbursement_point.bic,

--- a/api/tests/routes/pro/get_available_reimbursement_points_test.py
+++ b/api/tests/routes/pro/get_available_reimbursement_points_test.py
@@ -10,9 +10,8 @@ from pcapi.core.testing import override_features
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-# TODO(fseguin, 2023-03-01): cleanup when WIP_ENABLE_NEW_ONBOARDING FF is removed
 class Returns200Test:
-    @override_features(WIP_ENABLE_NEW_ONBOARDING=False)
+    @pytest.mark.skip("Keep single function WIP_ENABLE_NEW_ONBOARDING FF is removed")
     def test_available_reimbursement_points_sorted_by_common_name(self, client):
         user_offerer = offerers_factories.UserOffererFactory(
             user__email="user.pro@example.com",
@@ -53,6 +52,14 @@ class Returns200Test:
         ]
 
     @override_features(WIP_ENABLE_NEW_ONBOARDING=False)
+    def test_available_reimbursement_points_sorted_by_common_name_legacy(self, client):
+        self.test_available_reimbursement_points_sorted_by_common_name(client)
+
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
+    def test_available_reimbursement_points_sorted_by_common_name_new_onboarding(self, client):
+        self.test_available_reimbursement_points_sorted_by_common_name(client)
+
+    @pytest.mark.skip("Keep single function when WIP_ENABLE_NEW_ONBOARDING FF is removed")
     def test_no_available_reimbursement_point(self, client):
         user_offerer = offerers_factories.UserOffererFactory(
             user__email="user.pro@example.com",
@@ -71,63 +78,10 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json == []
 
-
-class NewOnboardingReturns200Test:
-    @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
-    def test_available_reimbursement_points_sorted_by_name(self, client):
-        user_offerer = offerers_factories.UserOffererFactory(
-            user__email="user.pro@example.com",
-        )
-        offerer = user_offerer.offerer
-        offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
-        first_venue = offerers_factories.VenueFactory(
-            managingOfferer=offerer,
-            name="Raison sociale A",
-            publicName="Nom public F",
-        )
-        finance_factories.BankInformationFactory(venue=first_venue, status=BankInformationStatus.ACCEPTED)
-        second_venue = offerers_factories.VenueFactory(
-            managingOfferer=offerer,
-            name="Raison sociale B",
-            publicName="Nom public D",
-        )
-        finance_factories.BankInformationFactory(venue=second_venue, status=BankInformationStatus.ACCEPTED)
-        offerers_factories.VenueFactory(siret=None, comment="Pas de SIRET", managingOfferer=offerer)
-
-        client = client.with_session_auth("user.pro@example.com")
-
-        with testing.assert_no_duplicated_queries():
-            response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
-
-        assert response.status_code == 200
-        assert response.json == [
-            {
-                "venueId": first_venue.id,
-                "venueName": "Raison sociale A",
-                "iban": first_venue.iban,
-            },
-            {
-                "venueId": second_venue.id,
-                "venueName": "Raison sociale B",
-                "iban": second_venue.iban,
-            },
-        ]
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=False)
+    def test_no_available_reimbursement_point_legacy(self, client):
+        self.test_no_available_reimbursement_point(client)
 
     @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
-    def test_no_available_reimbursement_point(self, client):
-        user_offerer = offerers_factories.UserOffererFactory(
-            user__email="user.pro@example.com",
-        )
-        offerer = user_offerer.offerer
-        offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
-        _venue_without_siret_nor_bank_info = offerers_factories.VenueFactory(
-            siret=None, comment="Pas de SIRET", managingOfferer=offerer
-        )
-        venue_with_pending_bank_info = offerers_factories.VenueFactory(managingOfferer=offerer)
-        finance_factories.BankInformationFactory(venue=venue_with_pending_bank_info, status=BankInformationStatus.DRAFT)
-
-        client = client.with_session_auth("user.pro@example.com")
-        response = client.get(f"/offerers/{offerer.id}/reimbursement-points")
-
-        assert response.status_code == 200
-        assert response.json == []
+    def test_no_available_reimbursement_point_new_onboarding(self, client):
+        self.test_no_available_reimbursement_point(client)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21304

## But de la pull request

Trier les points de remboursement par `common_name` quelque soit l'état du FF `WIP_ENABLE_NEW_ONBOARDING`