### PR TITLE
(PC-BSR)[PRO] fix: homepage select

### DIFF
--- a/pro/src/pages/Home/Offerers/OffererDetails.jsx
+++ b/pro/src/pages/Home/Offerers/OffererDetails.jsx
@@ -110,7 +110,7 @@ const OffererDetails = ({
             label=""
             name="offererId"
             options={offererOptions}
-            selectedValue={selectedOfferer.id}
+            selectedValue={selectedOfferer.nonHumanizedId.toString()}
           />
           <div className="od-separator vertical" />
           {!newOfferCreation && (


### PR DESCRIPTION
You couldn't select another offerer from the homepage because it tried to set the option with a humanized Id