### PR TITLE
(PC-21228)[API] feat: Add FF and use it to choose booking reminder template

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary.py
@@ -4,6 +4,7 @@ from pcapi.core.bookings.models import Booking
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.bookings import common as bookings_common
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.models.feature import FeatureToggle
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -33,8 +34,14 @@ def get_booking_event_reminder_to_beneficiary_email_data(
     formatted_event_beginning_date = get_date_formatted_for_email(event_beginning_date_in_tz)
     formatted_event_beginning_time = get_time_formatted_for_email(event_beginning_date_in_tz)
 
+    emailTemplate = (
+        TransactionalEmail.BOOKING_EVENT_REMINDER_TO_BENEFICIARY_WITH_METADATA
+        if FeatureToggle.WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY.is_active()
+        else TransactionalEmail.BOOKING_EVENT_REMINDER_TO_BENEFICIARY
+    )
+
     return models.TransactionalEmailData(
-        template=TransactionalEmail.BOOKING_EVENT_REMINDER_TO_BENEFICIARY.value,
+        template=emailTemplate.value,
         params={
             "BOOKING_LINK": booking_app_link(booking),
             "EVENT_DATETIME_ISO": event_beginning_date_in_tz.isoformat(),

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -26,6 +26,9 @@ class TransactionalEmail(Enum):
     BOOKING_EVENT_REMINDER_TO_BENEFICIARY = models.Template(
         id_prod=665, id_not_prod=82, tags=["jeunes_rappel_evenement_j-1"]
     )
+    BOOKING_EVENT_REMINDER_TO_BENEFICIARY_WITH_METADATA = models.Template(
+        id_prod=941, id_not_prod=124, tags=["jeunes_rappel_evenement_j-1"]
+    )
     BOOKING_POSTPONED_BY_PRO_TO_BENEFICIARY = models.Template(
         id_prod=224, id_not_prod=36, tags=["jeunes_offre_reportee_pro"]
     )

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -115,6 +115,7 @@ class FeatureToggle(enum.Enum):
     WIP_RECURRENCE = "Active l'ajout de dates récurrentes pour événements sur les offres individuelles"
     WIP_ENABLE_NEW_ONBOARDING = "Active le nouvel onboarding sans SIREN"
     WIP_ENABLE_COLLECTIVE_DMS_TRACKING = "Active le suivi du référencement DMS pour les acteurs EAC"
+    WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY = "Changer le template d'email de confirmation de réservation"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -176,6 +177,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_RECURRENCE,
     FeatureToggle.WIP_ENABLE_NEW_ONBOARDING,
     FeatureToggle.WIP_ENABLE_COLLECTIVE_DMS_TRACKING,
+    FeatureToggle.WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY,
 )
 
 if settings.IS_PROD or settings.IS_STAGING:

--- a/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_event_reminder_to_beneficiary_test.py
@@ -14,6 +14,7 @@ from pcapi.core.mails.transactional.bookings.booking_event_reminder_to_beneficia
 )
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 import pcapi.core.offers.factories as offers_factories
+from pcapi.core.testing import override_features
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -29,6 +30,17 @@ class SendEventReminderEmailToBeneficiaryTest:
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["template"] == dataclasses.asdict(
             TransactionalEmail.BOOKING_EVENT_REMINDER_TO_BENEFICIARY.value
+        )
+
+    @override_features(WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY=True)
+    def should_use_template_with_metadata_when_FF_is_enabled(self):
+        booking = BookingFactory(stock=offers_factories.EventStockFactory())
+
+        send_individual_booking_event_reminder_email_to_beneficiary(booking)
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0].sent_data["template"] == dataclasses.asdict(
+            TransactionalEmail.BOOKING_EVENT_REMINDER_TO_BENEFICIARY_WITH_METADATA.value
         )
 
     def should_not_try_to_send_email_when_there_is_no_data(self):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21228

## But de la pull request

Pour tester que le template qui contient les métadonnées fonctionne correctement en prod, on le conditionne d'un FF pour pouvoir le désactiver en cas de problème.

## Implémentation

- Ajout d'un feature flag désactivé par défaut : ENABLE_MARKETING_MAIL_METADATA_DISPLAY
- Utilisation de ce FF dans les rappels de résa J-1, pour utiliser ou non ce nouveau template

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
