### PR TITLE
(PC-21187)[API] fix: do not treat book stock api as an inactive provider

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -11,6 +11,7 @@ from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import models as offerers_models
+from pcapi.core.providers import constants as providers_constants
 from pcapi.core.providers import models as providers_models
 from pcapi.core.users import models as users_models
 from pcapi.domain.pro_offers import offers_recap
@@ -740,6 +741,7 @@ def exclude_offers_from_inactive_venue_provider(query: flask_sqlalchemy.BaseQuer
             sa.or_(
                 models.Offer.lastProviderId.is_(None),
                 providers_models.VenueProvider.isActive == True,
+                providers_models.Provider.localClass == providers_constants.PASS_CULTURE_STOCKS_FAKE_CLASS_NAME,
             )
         )
     )

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -13,6 +13,7 @@ import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers import factories
 from pcapi.core.offers import models
 from pcapi.core.offers import repository
+import pcapi.core.providers.constants as providers_constants
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.domain.pro_offers.offers_recap import OffersRecap
@@ -1410,6 +1411,9 @@ class GetFilteredCollectiveOffersTest:
 @pytest.mark.usefixtures("db_session")
 class ExcludeOffersFromInactiveVenueProviderTest:
     def test_exclude_offers_from_inactive_venue_provider(self):
+        stock_api_provider = providers_factories.ProviderFactory(
+            localClass=providers_constants.PASS_CULTURE_STOCKS_FAKE_CLASS_NAME
+        )
         active_venue_provider = providers_factories.VenueProviderFactory(isActive=True)
         inactive_venue_provider = providers_factories.VenueProviderFactory(isActive=False)
         offer_from_active_venue_provider = factories.OfferFactory(
@@ -1424,11 +1428,13 @@ class ExcludeOffersFromInactiveVenueProviderTest:
         offer_from_deleted_venue_provider = factories.OfferFactory(
             lastProvider=inactive_venue_provider.provider,
         )
+        offer_from_stock_api = factories.OfferFactory(lastProvider=stock_api_provider)
 
         result_query = repository.exclude_offers_from_inactive_venue_provider(models.Offer.query)
         selected_offers = result_query.all()
 
         assert offer_from_active_venue_provider in selected_offers
         assert offer_not_from_provider in selected_offers
+        assert offer_from_stock_api in selected_offers
         assert offer_from_inactive_venue_provider not in selected_offers
         assert offer_from_deleted_venue_provider not in selected_offers


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21187

## But de la pull request

Permettre à l'édition massive des offres de désactiver les offres créées par l'API Stock

## Implémentation

Un `Provider` est considéré comme désactivé si le `VenueProvider` est inactif ou supprimé, or le `Provider` associé à l'API Stock n'a pas de `VenueProvider` donc il est considéré à tort comme inactif.