### PR TITLE
(PC-21543)[API] feat: cache CGR WSDL

### DIFF
--- a/api/src/pcapi/connectors/cgr/cgr.py
+++ b/api/src/pcapi/connectors/cgr/cgr.py
@@ -3,6 +3,7 @@ import logging
 
 from pydantic import parse_obj_as
 from zeep import Client
+from zeep.cache import InMemoryCache
 from zeep.proxy import ServiceProxy
 
 from pcapi import settings
@@ -16,7 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_cgr_service_proxy(cinema_url: str) -> ServiceProxy:
-    transport = requests.CustomZeepTransport(timeout=10, operation_timeout=10)
+    # https://docs.python-zeep.org/en/master/transport.html#caching
+    cache = InMemoryCache()
+    transport = requests.CustomZeepTransport(cache=cache, timeout=10, operation_timeout=10)
     client = Client(wsdl=f"{cinema_url}?wsdl", transport=transport)
     service = client.create_service(binding_name="{urn:GestionCinemaWS}GestionCinemaWSSOAPBinding", address=cinema_url)
     return service

--- a/api/tests/connectors/cgr/api_cgr_test.py
+++ b/api/tests/connectors/cgr/api_cgr_test.py
@@ -20,6 +20,18 @@ class CGRGetServiceProxyTest:
         assert service._binding_options["address"] == "http://example.com/web_service"
         assert service._operations["GetSeancesPassCulture"]
 
+    def test_cache_wsdl_files(self, requests_mock):
+        # Use a different service url than before
+        adapter = requests_mock.get(
+            "http://example.com/another_web_service?wsdl", text=soap_definitions.WEB_SERVICE_DEFINITION
+        )
+
+        get_cgr_service_proxy(cinema_url="http://example.com/another_web_service")
+        get_cgr_service_proxy(cinema_url="http://example.com/another_web_service")
+        get_cgr_service_proxy(cinema_url="http://example.com/another_web_service")
+
+        assert adapter.call_count == 1
+
 
 def _get_seances_pass_culture_xml_response_template(body_response: str) -> str:
     return f"""


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21543

## But de la pull request

Eviter un appel récupérant le WSDL de CGR à chaque appel à une méthode de leur webservice.

## Implémentation

- https://docs.python-zeep.org/en/master/transport.html#caching

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
