### PR TITLE
(PC-21517)[PRO] feat: update submit new offerer datas

### DIFF
--- a/pro/src/components/SignupJourneyBreadcrumb/__specs__/SignupJourneyBreadcrumb.spec.tsx
+++ b/pro/src/components/SignupJourneyBreadcrumb/__specs__/SignupJourneyBreadcrumb.spec.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
-import { Target } from 'apiClient/v1'
+import { Target, VenueTypeCode } from 'apiClient/v1'
 import { DEFAULT_ADDRESS_FORM_VALUES } from 'components/Address'
 import {
   ISignupJourneyContext,
@@ -115,7 +115,7 @@ describe('test SignupBreadcrumb', () => {
       ...DEFAULT_ADDRESS_FORM_VALUES,
     }
     contextValue.activity = {
-      venueType: 'Cinéma',
+      venueTypeCode: VenueTypeCode.MUS_E,
       socialUrls: [],
       targetCustomer: Target.INDIVIDUAL,
     }

--- a/pro/src/context/SignupJourneyContext/SignupJourneyContext.tsx
+++ b/pro/src/context/SignupJourneyContext/SignupJourneyContext.tsx
@@ -9,6 +9,7 @@ import { IOffererFormValues } from 'screens/SignupJourneyForm/Offerer/OffererFor
 export interface IOfferer extends IOffererFormValues, IAddress {
   name: string
   publicName?: string
+  createVenueWithoutSiret?: boolean
 }
 
 export interface ISignupJourneyContext {

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames'
 import { FieldArray, useFormikContext } from 'formik'
 import React from 'react'
 
+import { VenueTypeCode } from 'apiClient/v1'
 import { Target } from 'apiClient/v1/models/Target'
 import FormLayout from 'components/FormLayout'
 import { PlusCircleIcon, TrashFilledIcon } from 'icons'
@@ -12,7 +13,7 @@ import styles from './ActivityForm.module.scss'
 import { activityTargetCustomerTypeRadios } from './constants'
 
 export interface IActivityFormValues {
-  venueType: string
+  venueTypeCode: VenueTypeCode | ''
   socialUrls: string[]
   targetCustomer: Target | undefined | null
 }
@@ -38,7 +39,7 @@ const ActivityForm = ({ venueTypes }: IActivityFormProps): JSX.Element => {
             },
             ...venueTypes,
           ]}
-          name="venueType"
+          name="venueTypeCode"
           label="Activité principale"
           className={styles['venue-type-select']}
         />

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -121,7 +121,7 @@ describe('screens:SignupJourney::ActivityForm', () => {
 
   it('should render activity form with initialValues', async () => {
     initialValues = {
-      venueTypeCode: venueTypes[0].value as VenueTypeCode,
+      venueTypeCode: VenueTypeCode.MUS_E,
       socialUrls: ['https://example.com', 'https://exampleTwo.fr'],
       targetCustomer: Target.INDIVIDUAL_AND_EDUCATIONAL,
     }

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -4,7 +4,7 @@ import { Form, Formik } from 'formik'
 import React from 'react'
 
 import { api } from 'apiClient/api'
-import { Target } from 'apiClient/v1'
+import { Target, VenueTypeCode } from 'apiClient/v1'
 import {
   ISignupJourneyContext,
   SignupJourneyContext,
@@ -121,7 +121,7 @@ describe('screens:SignupJourney::ActivityForm', () => {
 
   it('should render activity form with initialValues', async () => {
     initialValues = {
-      venueType: venueTypes[0].value,
+      venueTypeCode: venueTypes[0].value as VenueTypeCode,
       socialUrls: ['https://example.com', 'https://exampleTwo.fr'],
       targetCustomer: Target.INDIVIDUAL_AND_EDUCATIONAL,
     }

--- a/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { Target } from 'apiClient/v1'
+import { Target, VenueTypeCode } from 'apiClient/v1'
 import Notification from 'components/Notification/Notification'
 import {
   ISignupJourneyContext,
@@ -63,7 +63,7 @@ describe('screens:SignupJourney::Activity', () => {
       setOfferer: () => {},
     }
     jest.spyOn(api, 'getVenueTypes').mockResolvedValue([
-      { id: 'venue1', label: 'first venue label' },
+      { id: VenueTypeCode.MUS_E, label: 'first venue label' },
       { id: 'venue2', label: 'second venue label' },
     ])
   })
@@ -117,7 +117,7 @@ describe('screens:SignupJourney::Activity', () => {
 
   it('should display validation screen on click next step button', async () => {
     contextValue.activity = {
-      venueType: 'venue1',
+      venueTypeCode: VenueTypeCode.MUS_E,
       socialUrls: [],
       targetCustomer: Target.INDIVIDUAL_AND_EDUCATIONAL,
     }

--- a/pro/src/screens/SignupJourneyForm/Activity/constants.ts
+++ b/pro/src/screens/SignupJourneyForm/Activity/constants.ts
@@ -1,7 +1,9 @@
 import { Target } from 'apiClient/v1'
 
-export const DEFAULT_ACTIVITY_FORM_VALUES = {
-  venueType: '',
+import { IActivityFormValues } from './ActivityForm'
+
+export const DEFAULT_ACTIVITY_FORM_VALUES: IActivityFormValues = {
+  venueTypeCode: '',
   socialUrls: [''],
   targetCustomer: undefined,
 }

--- a/pro/src/screens/SignupJourneyForm/Activity/validationSchema.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/validationSchema.tsx
@@ -3,7 +3,7 @@ import * as yup from 'yup'
 import { Target } from 'apiClient/v1'
 
 export const validationSchema = yup.object().shape({
-  venueType: yup
+  venueTypeCode: yup
     .string()
     .required('Veuillez sélectionner une activité principale'),
   socialUrls: yup

--- a/pro/src/screens/SignupJourneyForm/Activity/validationSchema.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/validationSchema.tsx
@@ -1,10 +1,14 @@
 import * as yup from 'yup'
 
-import { Target } from 'apiClient/v1'
+import { Target, VenueTypeCode } from 'apiClient/v1'
 
 export const validationSchema = yup.object().shape({
   venueTypeCode: yup
     .string()
+    .oneOf(
+      Object.values(VenueTypeCode),
+      'Veuillez sélectionner une activité principale'
+    )
     .required('Veuillez sélectionner une activité principale'),
   socialUrls: yup
     .array()

--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
@@ -47,12 +47,11 @@ const Offerers = (): JSX.Element => {
     }
   }, [isLoadingVenues])
 
-  if (isLoadingVenues) {
+  if (isLoadingVenues || !offerer) {
     return <Spinner />
   }
 
   const redirectToOnboarding = () => {
-    // @ts-expect-error offerer cannot be null at this step
     const newOfferer: IOfferer = {
       ...offerer,
       createVenueWithoutSiret: true,

--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { api } from 'apiClient/api'
 import { CreateOffererQueryModel } from 'apiClient/v1'
 import ConfirmDialog from 'components/Dialog/ConfirmDialog'
-import { useSignupJourneyContext } from 'context/SignupJourneyContext'
+import { IOfferer, useSignupJourneyContext } from 'context/SignupJourneyContext'
 import { getSirenDataAdapter } from 'core/Offerers/adapters'
 import { humanizeSiren } from 'core/Offerers/utils'
 import { getVenuesOfOffererFromSiretAdapter } from 'core/Venue/adapters/getVenuesOfOffererFromSiretAdapter'
@@ -26,7 +26,7 @@ const Offerers = (): JSX.Element => {
   const [isVenueListOpen, setIsVenueListOpen] = useState<boolean>(false)
   const [showLinkDialog, setShowLinkDialog] = useState<boolean>(false)
 
-  const { offerer } = useSignupJourneyContext()
+  const { offerer, setOfferer } = useSignupJourneyContext()
 
   /* istanbul ignore next: redirect to offerer if there is no siret */
   const {
@@ -49,6 +49,15 @@ const Offerers = (): JSX.Element => {
 
   if (isLoadingVenues) {
     return <Spinner />
+  }
+
+  const redirectToOnboarding = () => {
+    const newOfferer: IOfferer = {
+      ...(offerer as IOfferer),
+      createVenueWithoutSiret: true,
+    }
+    setOfferer(newOfferer)
+    navigate('/parcours-inscription/authentification')
   }
 
   const doLinkAccount = async () => {
@@ -129,7 +138,7 @@ const Offerers = (): JSX.Element => {
       </div>
       <Button
         className={styles['button-add-new-offerer']}
-        onClick={() => navigate('/parcours-inscription/authentification')}
+        onClick={redirectToOnboarding}
         variant={ButtonVariant.SECONDARY}
       >
         Ajouter une nouvelle structure

--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
@@ -52,8 +52,9 @@ const Offerers = (): JSX.Element => {
   }
 
   const redirectToOnboarding = () => {
+    // @ts-expect-error offerer cannot be null at this step
     const newOfferer: IOfferer = {
-      ...(offerer as IOfferer),
+      ...offerer,
       createVenueWithoutSiret: true,
     }
     setOfferer(newOfferer)

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -49,13 +49,17 @@ const Validation = (): JSX.Element => {
 
   const onSubmit = async () => {
     const data: SaveNewOnboardingDataQueryModel = {
-      name: offerer.publicName ?? '',
+      name: offerer.name,
+      publicName: offerer.publicName ?? '',
       siret: offerer.siret.replaceAll(' ', ''),
-      venueType: activity.venueType,
+      venueTypeCode:
+        /* istanbul ignore next: should not have empty or null venueTypeCode at this step */
+        activity.venueTypeCode === '' ? null : activity.venueTypeCode,
       webPresence: activity.socialUrls.join(', '),
       target:
         /* istanbul ignore next: the form validation already handles this */
         activity.targetCustomer ?? Target.EDUCATIONAL,
+      createVenueWithoutSiret: offerer?.createVenueWithoutSiret ?? false,
     }
 
     try {
@@ -124,7 +128,7 @@ const Validation = (): JSX.Element => {
           <div className={styles['data-line']}>
             {
               venueTypes?.find(
-                venueType => venueType.value === activity.venueType
+                venueType => venueType.value === activity.venueTypeCode
               )?.label
             }
           </div>

--- a/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { GetOffererResponseModel, Target } from 'apiClient/v1'
+import { GetOffererResponseModel, Target, VenueTypeCode } from 'apiClient/v1'
 import { IAddress } from 'components/Address'
 import Notification from 'components/Notification/Notification'
 import {
@@ -79,7 +79,7 @@ describe('screens:SignupJourney::Validation', () => {
       setOfferer: () => {},
     }
     jest.spyOn(api, 'getVenueTypes').mockResolvedValue([
-      { id: 'venue1', label: 'first venue label' },
+      { id: VenueTypeCode.MUS_E, label: 'first venue label' },
       { id: 'venue2', label: 'second venue label' },
     ])
   })
@@ -110,7 +110,7 @@ describe('screens:SignupJourney::Validation', () => {
     renderValidationScreen({
       ...contextValue,
       activity: {
-        venueType: 'venue1',
+        venueTypeCode: VenueTypeCode.MUS_E,
         socialUrls: ['url1', 'url2'],
         targetCustomer: Target.EDUCATIONAL,
       },
@@ -137,7 +137,7 @@ describe('screens:SignupJourney::Validation', () => {
     beforeEach(() => {
       contextValue = {
         activity: {
-          venueType: 'venue1',
+          venueTypeCode: VenueTypeCode.MUS_E,
           socialUrls: ['url1', 'url2'],
           targetCustomer: Target.EDUCATIONAL,
         },
@@ -181,11 +181,13 @@ describe('screens:SignupJourney::Validation', () => {
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
       await userEvent.click(screen.getByText('Valider et créer mon espace'))
       expect(api.saveNewOnboardingData).toHaveBeenCalledWith({
-        name: 'nom public',
+        name: 'nom',
+        publicName: 'nom public',
         siret: '123123123',
-        venueType: 'venue1',
+        venueTypeCode: 'Musée',
         webPresence: 'url1, url2',
         target: Target.EDUCATIONAL,
+        createVenueWithoutSiret: false,
       })
 
       expect(screen.getByText('accueil')).toBeInTheDocument()
@@ -196,7 +198,7 @@ describe('screens:SignupJourney::Validation', () => {
     beforeEach(() => {
       contextValue = {
         activity: {
-          venueType: 'venue1',
+          venueTypeCode: VenueTypeCode.MUS_E,
           socialUrls: ['url1', 'url2'],
           targetCustomer: Target.EDUCATIONAL,
         },
@@ -218,11 +220,13 @@ describe('screens:SignupJourney::Validation', () => {
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
       await userEvent.click(screen.getByText('Valider et créer mon espace'))
       expect(api.saveNewOnboardingData).toHaveBeenCalledWith({
-        name: '',
+        name: 'nom',
+        publicName: '',
         siret: '123123123',
-        venueType: 'venue1',
+        venueTypeCode: VenueTypeCode.MUS_E,
         webPresence: 'url1, url2',
         target: Target.EDUCATIONAL,
+        createVenueWithoutSiret: false,
       })
     })
 
@@ -238,7 +242,7 @@ describe('screens:SignupJourney::Validation', () => {
     beforeEach(() => {
       contextValue = {
         activity: {
-          venueType: 'venue1',
+          venueTypeCode: VenueTypeCode.MUS_E,
           socialUrls: ['url1', 'url2'],
           targetCustomer: Target.EDUCATIONAL,
         },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21517

## But de la pull request

Lors du submit de l'étape de validation du nouveau parcours d'onboarding:
- Ajouter createVenueWithoutSiret dans le cas d’une création de lieu sans SIRET
- Utiliser publicName à la place de name
- Utiliser venueTypeCode à la place devenueType

Pour accéder au nouveau parcours d'inscription:

Après la création d'un nouveau compte, juste après la connexion, sinon il faut se rendre à `/parcours-inscription`
En local ce n'est pas vraiment possible, donc il faut aller sur l'url directement, ou alors il faut supprimer via le backoffice les structures d'un compte en local, le pro par exemple
à la connexion, le parcours s'affichera

Il faut le FF: WIP_ENABLE_NEW_ONBOARDING

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
