### PR TITLE
(PC-21490)[PRO] fix: signup journey breadcrumb position

### DIFF
--- a/pro/src/components/SignupJourneyBreadcrumb/SignupJourneyBreadcrumb.module.scss
+++ b/pro/src/components/SignupJourneyBreadcrumb/SignupJourneyBreadcrumb.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.signup-breadcrumb {
+    width: 100%;
+}

--- a/pro/src/components/SignupJourneyBreadcrumb/SignupJourneyBreadcrumb.tsx
+++ b/pro/src/components/SignupJourneyBreadcrumb/SignupJourneyBreadcrumb.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_OFFERER_FORM_VALUES } from 'screens/SignupJourneyForm/Offerer/c
 
 import { SIGNUP_JOURNEY_STEP_IDS } from './constants'
 import { useActiveStep } from './hooks'
+import styles from './SignupJourneyBreadcrumb.module.scss'
 
 const SignupJourneyBreadcrumb = () => {
   const { activity, offerer } = useSignupJourneyContext()
@@ -52,6 +53,7 @@ const SignupJourneyBreadcrumb = () => {
       activeStep={activeStep}
       steps={signupJourneyBreadcrumbSteps}
       styleType={BreadcrumbStyle.STEPPER}
+      className={styles['signup-breadcrumb']}
     />
   )
 }

--- a/pro/src/components/SignupJourneyFormLayout/SignupJourneyFormLayout.tsx
+++ b/pro/src/components/SignupJourneyFormLayout/SignupJourneyFormLayout.tsx
@@ -14,7 +14,7 @@ const SignupJourneyFormLayout = ({
 }: ISignupOffererFormLayoutProps): JSX.Element => (
   <div className={styles['signup-offerer-layout-wrapper']}>
     <SignupJourneyBreadcrumb />
-    <div className={styles['content']}>{children}</div>
+    {children}
   </div>
 )
 

--- a/pro/src/components/SignupJourneyFormLayout/SignupJourneyFormLayoutContent.module.scss
+++ b/pro/src/components/SignupJourneyFormLayout/SignupJourneyFormLayoutContent.module.scss
@@ -5,7 +5,9 @@ $header-height: rem.torem(30px) + rem.torem(42px);
 
 .signup-offerer-layout-wrapper {
   display: flex;
+  flex-direction: column;
   min-height: calc(100vh - #{size.$action-bar-sticky-height + $header-height});
+  gap: rem.torem(60px);
   align-items: center;
   margin: 0 auto rem.torem(80px);
   padding-top: rem.torem(50px);

--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.module.scss
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.module.scss
@@ -8,6 +8,7 @@ $confirmed-attachment-gap: rem.torem(32px);
     display: flex;
     flex-direction: column;
     gap: $confirmed-attachment-gap;
+    margin: auto;
 }
 
 .title {

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
@@ -1,5 +1,9 @@
 @use "styles/mixins/_rem.scss" as rem;
 
+.offerer-layout {
+  margin: auto;
+}
+
 .siret-banner {
   margin-top: rem.torem(58px);
 }

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -65,7 +65,7 @@ const Offerer = (): JSX.Element => {
   })
 
   return (
-    <FormLayout>
+    <FormLayout className={styles['offerer-layout']}>
       <FormikProvider value={formik}>
         <form onSubmit={formik.handleSubmit} data-testid="signup-offerer-form">
           <OffererForm />

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.module.scss
@@ -29,6 +29,6 @@
 
 }
 
-.validation-screen:nth-child(even) {
+.validation-screen section:nth-child(even) {
   margin-bottom: rem.torem(52px);
 }

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -71,8 +71,8 @@ const Validation = (): JSX.Element => {
   }
 
   return (
-    <>
-      <section className={styles['validation-screen']}>
+    <div className={styles['validation-screen']}>
+      <section>
         <h1 className={styles['title']}>Vérification</h1>
         <h2 className={styles['subtitle']}>
           Informations structure
@@ -151,7 +151,7 @@ const Validation = (): JSX.Element => {
         withRightIcon={false}
         nextStepTitle="Valider et créer mon espace"
       />
-    </>
+    </div>
   )
 }
 

--- a/pro/src/screens/SignupJourneyForm/Welcome/Welcome.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Welcome/Welcome.module.scss
@@ -9,6 +9,7 @@ $welcome-gap: rem.torem(40px);
     flex-direction: column;
     text-align: center;
     gap: $welcome-gap;
+    margin: auto;
 }
 
 .title {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21337

## But de la pull request

- Corriger l'affichage du nouveau parcours d'inscription

## Implémentation

Avant: 
![image](https://user-images.githubusercontent.com/106379750/229766988-d6dc0784-1247-4947-8f10-8e76841833aa.png)

Après:
![image](https://user-images.githubusercontent.com/106379750/229766828-c8ff3989-e299-4eb1-a568-98136b717612.png)

Pour accéder au nouveau parcours d'inscription:

Après la création d'un nouveau compte, juste après la connexion, sinon il faut se rendre à /parcours-inscription
En local ce n'est pas vraiment possible, donc il faut aller sur l'url directement, ou alors il faut supprimer via le backoffice les structures d'un compte en local, le pro par exemple
à la connexion, le parcours s'affichera

Il faut le FF: WIP_ENABLE_NEW_ONBOARDING