### PR TITLE
(PC-21578)[API] feat: Do not tag transactional email 96 to Sendinblue…

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -4,9 +4,8 @@ from pcapi.core.mails import models
 
 
 class TransactionalEmail(Enum):
-    ACCEPTED_AS_BENEFICIARY = models.Template(
-        id_prod=96, id_not_prod=25, tags=["jeunes_pass_credite_18"], use_priority_queue=True
-    )
+    # Empty tags when it is set directly in Sendinblue template
+    ACCEPTED_AS_BENEFICIARY = models.Template(id_prod=96, id_not_prod=25, use_priority_queue=True)
     ACCEPTED_AS_EAC_BENEFICIARY = models.Template(
         id_prod=257, id_not_prod=27, tags=["jeunes_pass_credite_eac"], use_priority_queue=True
     )


### PR DESCRIPTION
… - tagged in SiB by marketing

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21578

## But de la pull request

Demande marketing : ne plus envoyer le tag `jeunes_pass_credit_18` avec l'email 96 en prod (25 en testing/staging), afin que le tag `activation` qu'elles ont configuré directement dans Sendinblue soit pris en compte.

## Implémentation

Lorsqu'on ne définit pas de `tags`, ce champ n'est pas envoyé, donc on le supprime simplement de la défintion pour cet email.

Testé en me connectant à Sendinblue via la clé d'API => OK.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
