### PR TITLE
(PC-20950)[API] feat: add env name to warning feature flipping message

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/admin.py
+++ b/api/src/pcapi/routes/backoffice_v3/admin.py
@@ -4,6 +4,7 @@ from flask import render_template
 from flask import url_for
 from flask_login import current_user
 
+from pcapi import settings
 from pcapi.core.permissions import api as perm_api
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import feature as feature_models
@@ -68,7 +69,9 @@ def update_role(role_id: int) -> utils.BackofficeResponse:
 def list_feature_flags() -> utils.BackofficeResponse:
     feature_flags = feature_models.Feature.query.order_by(feature_models.Feature.name).all()
     form = empty_forms.EmptyForm()
-    return render_template("admin/feature_flipping.html", rows=feature_flags, toggle_feature_flag_form=form)
+    return render_template(
+        "admin/feature_flipping.html", rows=feature_flags, toggle_feature_flag_form=form, env=settings.ENV
+    )
 
 
 @blueprint.backoffice_v3_web.route("/admin/feature-flipping/<int:feature_flag_id>/enable", methods=["POST"])

--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/feature_flipping.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/feature_flipping.html
@@ -39,7 +39,7 @@
                         </div>
                         <div class="modal-body row">
                           <p>
-                            Vous allez {{ "désactiver" if feature_flag.isActive else "activer" }} le feature flag {{ feature_flag.name }}. Veuillez confirmer ce choix.
+                            Vous allez {{ "désactiver" if feature_flag.isActive else "activer" }} le feature flag {{ feature_flag.name }} dans l'environnement <strong>{{ env | upper }}</strong>. Veuillez confirmer ce choix.
                           </p>
                           {{ build_form_fields_group(toggle_feature_flag_form) }}
                         </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20950

## But de la pull request

Ajout de l'environnement au message de confirmation d'activation/désactivation du FF.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
