### PR TITLE
(PC-21554)[API] feat: add command to partially refund an educational …

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-66c2977b3cfe (pre) (head)
+5e23156047b5 (pre) (head)
 580466424daf (post) (head)

--- a/api/src/pcapi/alembic/versions/20230404T133700_5e23156047b5_create_eac_refund_table.py
+++ b/api/src/pcapi/alembic/versions/20230404T133700_5e23156047b5_create_eac_refund_table.py
@@ -1,0 +1,39 @@
+"""create_eac_refund_table
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "5e23156047b5"
+down_revision = "66c2977b3cfe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "collective_refund",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("dateCreated", sa.DateTime(), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.Column("ticket", sa.String(length=10), nullable=False),
+        sa.Column("ministry", postgresql.ENUM(name="ministry", create_type=False), nullable=False),
+        sa.Column("educationalInstitutionId", sa.BigInteger(), nullable=False),
+        sa.Column("educationalYearId", sa.String(length=30), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["educationalInstitutionId"],
+            ["educational_institution.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["educationalYearId"],
+            ["educational_year.adageId"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("collective_refund")

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -141,10 +141,10 @@ def confirm_collective_booking(educational_booking_id: int) -> educational_model
             educational_institution_id, educational_year_id
         )
         validation.check_institution_fund(
-            educational_institution_id,
-            educational_year_id,
-            decimal.Decimal(collective_booking.collectiveStock.price),
-            deposit,
+            educational_institution_id=educational_institution_id,
+            educational_year_id=educational_year_id,
+            booking_amount=decimal.Decimal(collective_booking.collectiveStock.price),
+            deposit=deposit,
         )
         if FeatureToggle.ENABLE_EAC_FINANCIAL_PROTECTION.is_active():
             validation.check_ministry_fund(

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -1,10 +1,13 @@
 import logging
 
+import click
+
 from pcapi import settings
 from pcapi.core import search
 from pcapi.core.educational.api import booking as educational_api_booking
 from pcapi.core.educational.api.adage import synchronize_adage_ids_on_venues
 from pcapi.core.educational.api.dms import import_dms_applications
+from pcapi.core.educational.api.institution import refund_institution as api_refund_institution
 from pcapi.core.educational.utils import create_adage_jwt_fake_valid_token
 from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 from pcapi.utils.blueprint import Blueprint
@@ -37,6 +40,14 @@ def generate_fake_adage_token() -> None:
 @blueprint.cli.command("synchronize_venues_from_adage_cultural_partners")
 def synchronize_venues_from_adage_cultural_partners() -> None:
     synchronize_adage_ids_on_venues()
+
+
+@blueprint.cli.command("refund_institution")
+@click.option("--ticket", help="ticket jira de la demande", required=True)
+@click.option("--collective_booking", type=int, help="id du booking", required=True)
+@click.option("--amount", type=float, help="Valeur du refund", required=True)
+def refund_institution(ticket: str, collective_booking: int, amount: float) -> None:
+    api_refund_institution(ticket=ticket, collective_booking_id=collective_booking, amount=amount)
 
 
 @blueprint.cli.command("eac_notify_pro_one_day")

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -285,3 +285,14 @@ class CollectiveDmsApplicationFactory(BaseFactory):
     depositDate = datetime.datetime.utcnow() - datetime.timedelta(days=10)
     expirationDate = datetime.datetime.utcnow() + datetime.timedelta(days=365)
     buildDate = factory.SelfAttribute("lastChangeDate")
+
+
+class CollectiveRefundFactory(BaseFactory):
+    class Meta:
+        model = models.CollectiveRefund
+
+    educationalInstitution = factory.SubFactory(EducationalInstitutionFactory)
+    educationalYear = factory.SubFactory(EducationalYearFactory)
+    amount = 150.00
+    ministry = models.Ministry.EDUCATION_NATIONALE.name
+    ticket = "PC-20001"

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1126,6 +1126,25 @@ class CollectiveDmsApplication(PcObject, Base, Model):
     userDeletionDate = sa.Column(sa.DateTime, nullable=True)
 
 
+class CollectiveRefund(PcObject, Base, Model):
+    __tablename__ = "collective_refund"
+    dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    amount: float = sa.Column(
+        sa.Numeric(10, 2), sa.CheckConstraint("amount >= 0", name="check_amount_is_not_negative"), nullable=False
+    )
+    ticket: str = sa.Column(sa.String(10), nullable=False)
+    ministry = sa.Column(sa.Enum(Ministry), nullable=False)
+
+    educationalInstitutionId: int = sa.Column(
+        sa.BigInteger, sa.ForeignKey("educational_institution.id"), nullable=False
+    )
+    educationalInstitution: sa_orm.Mapped["EducationalInstitution"] = relationship(
+        EducationalInstitution, foreign_keys=[educationalInstitutionId], backref="collectiveRefunds"
+    )
+    educationalYearId: str = sa.Column(sa.String(30), sa.ForeignKey("educational_year.adageId"), nullable=False)
+    educationalYear: sa_orm.Mapped["EducationalYear"] = relationship(EducationalYear, foreign_keys=[educationalYearId])
+
+
 CollectiveBooking.trig_update_cancellationDate_on_isCancelled_ddl = f"""
     CREATE OR REPLACE FUNCTION save_collective_booking_cancellation_date()
     RETURNS TRIGGER AS $$

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -127,6 +127,18 @@ def get_confirmed_collective_bookings_amount_for_ministry(
     return query.first().amount or Decimal(0)
 
 
+def get_refunds_amount_for_ministry(
+    ministry: educational_models.Ministry | None,
+    educational_year_id: str,
+) -> Decimal:
+    query = db.session.query(sa.func.sum(educational_models.CollectiveRefund.amount).label("amount"))
+    query = query.filter(
+        educational_models.CollectiveRefund.ministry == ministry,
+        educational_models.CollectiveRefund.educationalYearId == educational_year_id,
+    )
+    return query.first().amount or Decimal(0)
+
+
 def get_confirmed_collective_bookings_amount(
     educational_institution_id: int,
     educational_year_id: str,
@@ -139,6 +151,18 @@ def get_confirmed_collective_bookings_amount(
         ~educational_models.CollectiveBooking.status.in_(
             [educational_models.CollectiveBookingStatus.CANCELLED, educational_models.CollectiveBookingStatus.PENDING]
         ),
+    )
+    return query.first().amount or Decimal(0)
+
+
+def get_refunds_amount(
+    educational_institution_id: int,
+    educational_year_id: str,
+) -> Decimal:
+    query = db.session.query(sa.func.sum(educational_models.CollectiveRefund.amount).label("amount"))
+    query = query.filter(
+        educational_models.CollectiveRefund.educationalInstitutionId == educational_institution_id,
+        educational_models.CollectiveRefund.educationalYearId == educational_year_id,
     )
     return query.first().amount or Decimal(0)
 

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -57,7 +57,8 @@ def check_institution_fund(
     deposit: models.EducationalDeposit,
 ) -> None:
     spent_amount = repository.get_confirmed_collective_bookings_amount(educational_institution_id, educational_year_id)
-    total_amount = booking_amount + spent_amount
+    refund_amount = repository.get_refunds_amount(educational_institution_id, educational_year_id)
+    total_amount = booking_amount + spent_amount - refund_amount
     deposit.check_has_enough_fund(total_amount)
 
 
@@ -72,7 +73,10 @@ def check_ministry_fund(
     spent_amount = repository.get_confirmed_collective_bookings_amount_for_ministry(
         educational_year_id=educational_year_id, ministry=ministry
     )
-    total_spent_amount = spent_amount + booking_amount
+    refund_amount = repository.get_refunds_amount_for_ministry(
+        educational_year_id=educational_year_id, ministry=ministry
+    )
+    total_spent_amount = spent_amount + booking_amount - refund_amount
     yearly_available_amount = repository.get_ministry_budget_for_year(
         educational_year_id=educational_year_id, ministry=ministry
     )

--- a/api/tests/core/educational/api/test_refund_institution.py
+++ b/api/tests/core/educational/api/test_refund_institution.py
@@ -1,0 +1,21 @@
+from pcapi.core.educational import factories as educational_factories
+from pcapi.core.educational import models as educational_models
+from pcapi.core.educational.api.institution import refund_institution
+
+
+def test_refund_institution_ok(db_session):
+    booking = educational_factories.ReimbursedCollectiveBookingFactory()
+    deposit = educational_factories.EducationalDepositFactory(
+        educationalInstitution=booking.educationalInstitution,
+        educationalYear=booking.educationalYear,
+    )
+
+    refund_institution(amount=23.24, ticket="pouet", collective_booking_id=booking.id)
+
+    refund = educational_models.CollectiveRefund.query.one_or_none()
+    assert refund is not None
+    assert refund.educationalYear == booking.educationalYear
+    assert refund.educationalInstitution == booking.educationalInstitution
+    assert refund.ministry == deposit.ministry
+    assert float(refund.amount) == 23.24
+    assert refund.ticket == "pouet"

--- a/api/tests/core/educational/test_validation.py
+++ b/api/tests/core/educational/test_validation.py
@@ -4,6 +4,7 @@ import pytest
 
 from pcapi.core.educational import exceptions
 from pcapi.core.educational.factories import CancelledCollectiveBookingFactory
+from pcapi.core.educational.factories import CollectiveRefundFactory
 from pcapi.core.educational.factories import ConfirmedCollectiveBookingFactory
 from pcapi.core.educational.factories import EducationalInstitutionFactory
 from pcapi.core.educational.factories import EducationalYearFactory
@@ -47,6 +48,28 @@ class EducationalValidationTest:
             collectiveStock__price=Decimal(400.00),
             educationalInstitution=educational_institution,
             educationalYear=educational_year,
+        )
+
+        check_institution_fund(
+            educational_institution.id, educational_year.adageId, Decimal(200.00), educational_deposit
+        )
+
+    def test_institution_fund_is_ok_with_refund(self, db_session):
+        educational_institution = EducationalInstitutionFactory()
+        educational_year = EducationalYearFactory(adageId="1")
+        educational_deposit = EducationalDeposit(
+            educationalInstitution=educational_institution,
+            educationalYear=educational_year,
+            amount=Decimal(500.00),
+        )
+        UsedCollectiveBookingFactory(
+            collectiveStock__price=Decimal(400.00),
+            educationalInstitution=educational_institution,
+            educationalYear=educational_year,
+        )
+        CollectiveRefundFactory(
+            educationalYear=educational_year,
+            educationalInstitution=educational_institution,
         )
 
         check_institution_fund(


### PR DESCRIPTION
…institution

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21554

## But de la pull request

Permettre de rembourser partiellement les etablissements scolaire dans le cas ou une prestation n'a pas (ou en partie pas) été effectuée. Ce script ne se substitue pas au travail de la comptabilité et ne doit être utilisé qu'apres le feu vert de ces derniers.

## Implémentation

création d'une table pour des refund (géré comme des anti-reservations au niveau du cancul des budgets)

## Modifications du schéma de la base de données

- Ajout d'une table collective_refund avec une ligne par remboursement.
- la colonne ticket désigne un ticket JIRA, les autres collonnes sont relativement évidentes.
