### PR TITLE
(BSR)[API] refactor: cds cleanup and refactor

### DIFF
--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -46,13 +46,6 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             f"for cinemaId={self.cinema_id} & url={self.api_url}"
         )
 
-    def get_show_remaining_places(self, show_id: int) -> int:
-        show = self.get_show(show_id)
-        internet_sale_gauge_active = self.get_internet_sale_gauge_active()
-        if internet_sale_gauge_active:
-            return show.internet_remaining_place
-        return show.remaining_place
-
     def get_shows_remaining_places(self, show_ids: list[int]) -> dict[int, int]:
         data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.SHOWS)
         shows = parse_obj_as(list[cds_serializers.ShowCDS], data)
@@ -108,18 +101,6 @@ class CineDigitalServiceAPI(ExternalBookingsClientAPI):
             for voucher_type in voucher_types
             if voucher_type.code == cds_constants.PASS_CULTURE_VOUCHER_CODE and voucher_type.tariff
         ]
-
-    def get_tariff(self) -> cds_serializers.TariffCDS:
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.TARIFFS)
-        tariffs = parse_obj_as(list[cds_serializers.TariffCDS], data)
-
-        for tariff in tariffs:
-            if tariff.label == cds_constants.PASS_CULTURE_TARIFF_LABEL_CDS:
-                return tariff
-        raise cds_exceptions.CineDigitalServiceAPIException(
-            f"Tariff Pass Culture not found in Cine Digital Service API for cinemaId={self.cinema_id}"
-            f" & url={self.api_url}"
-        )
 
     def get_screen(self, screen_id: int) -> cds_serializers.ScreenCDS:
         data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.SCREENS)

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -444,62 +444,6 @@ class CineDigitalServiceGetPCVoucherTypesTest:
         assert pc_voucher_types[1].tariff.id == 4
 
 
-class CineDigitalServiceGetTariffTest:
-    @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    def test_should_return_tariffs_with_pass_culture_tariff(self, mocked_get_resource):
-        json_tariffs = [
-            {
-                "id": 1,
-                "price": 10,
-                "label": "Pass Culture 5€",
-                "is_active": True,
-            },
-            {
-                "id": 2,
-                "price": 3.5,
-                "label": "Other tariff",
-                "is_active": True,
-            },
-        ]
-        mocked_get_resource.return_value = json_tariffs
-        cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="cinema_id_test",
-            account_id="accountid_test",
-            cinema_api_token="token_test",
-            api_url="apiUrl_test",
-        )
-        tariff = cine_digital_service.get_tariff()
-
-        assert tariff.label == "Pass Culture 5€"
-
-    @patch("pcapi.core.external_bookings.cds.client.get_resource")
-    def test_should_raise_exception_if_tariff_not_found(self, mocked_get_resource):
-        json_tariffs = [
-            {
-                "id": 1,
-                "price": 10,
-                "label": "Another Tariff",
-                "is_active": True,
-            },
-            {
-                "id": 2,
-                "price": 3.5,
-                "label": "Other tariff",
-                "is_active": True,
-            },
-        ]
-        mocked_get_resource.return_value = json_tariffs
-        cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
-        )
-        with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as cds_exception:
-            cine_digital_service.get_tariff()
-        assert (
-            str(cds_exception.value)
-            == "Tariff Pass Culture not found in Cine Digital Service API for cinemaId=test_id & url=test_url"
-        )
-
-
 class CineDigitalServiceGetScreenTest:
     @patch("pcapi.core.external_bookings.cds.client.get_resource")
     def test_should_return_screen_corresponding_to_screen_id(self, mocked_get_resource):

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -5,11 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.connectors.serialization.cine_digital_service_serializers import IdObjectCDS
-from pcapi.connectors.serialization.cine_digital_service_serializers import ShowCDS
-from pcapi.connectors.serialization.cine_digital_service_serializers import ShowTariffCDS
 from pcapi.core.categories import subcategories
-from pcapi.core.external_bookings.models import Movie
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import PriceCategory
 from pcapi.core.offers.models import PriceCategoryLabel
@@ -25,6 +21,8 @@ from pcapi.utils.human_ids import humanize
 
 import tests
 
+from . import fixtures
+
 
 @pytest.mark.usefixtures("db_session")
 class CDSStocksTest:
@@ -39,43 +37,9 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-            Movie(
-                id="51",
-                title="Top Gun",
-                duration=150,
-                description="Film sur les avions",
-                visa="333333",
-                posterpath="fakeUrl/topgun.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1, fixtures.MOVIE_2]
         mock_get_venue_movies.return_value = mocked_movies
-        mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=51),
-                ),
-                "price": 5,
-            }
-        ]
+        mocked_shows = [{"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5}]
         mock_get_shows.return_value = mocked_shows
         # When
         cds_stocks = CDSStocks(venue_provider=venue_provider)
@@ -96,50 +60,11 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1]
         mock_get_venue_movies.return_value = mocked_movies
         mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5,
-            },
-            {
-                "show_information": ShowCDS(
-                    id=2,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=51),
-                ),
-                "price": 5,
-            },
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5},
+            {"show_information": fixtures.MOVIE_2_SHOW_1, "price": 5},
         ]
         mock_get_shows.return_value = mocked_shows
         # When
@@ -178,52 +103,13 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1]
         mock_get_venue_movies.return_value = mocked_movies
 
         # these shows are not matching movies (by mediaid)
         mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=88888),
-                ),
-                "price": 5,
-            },
-            {
-                "show_information": ShowCDS(
-                    id=2,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=88888),
-                ),
-                "price": 5,
-            },
+            {"show_information": fixtures.MOVIE_OTHER_SHOW_1, "price": 5},
+            {"show_information": fixtures.MOVIE_OTHER_SHOW_2, "price": 5},
         ]
         mock_get_shows.return_value = mocked_shows
         # When
@@ -240,7 +126,9 @@ class CDSStocksTest:
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl")
-    def should_create_offers_for_each_movie(self, mock_get_venue_movies, mock_get_shows, mock_get_internet_sale_gauge):
+    def should_create_offers_for_each_movie(
+        self, mock_get_venue_movies, mock_get_shows, mock_get_internet_sale_gauge, requests_mock
+    ):
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
         venue_provider = VenueProviderFactory(provider=cds_provider)
@@ -248,62 +136,15 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-            Movie(
-                id="51",
-                title="Top Gun",
-                duration=150,
-                description="Film sur les avions",
-                visa="333333",
-                posterpath="fakeUrl/topgun.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1, fixtures.MOVIE_2]
         mock_get_venue_movies.return_value = mocked_movies
         mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5,
-                "price_label": "pass Culture",
-            },
-            {
-                "show_information": ShowCDS(
-                    id=2,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=51),
-                ),
-                "price": 5,
-                "price_label": "pass Culture",
-            },
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5, "price_label": "pass Culture"},
+            {"show_information": fixtures.MOVIE_2_SHOW_1, "price": 5, "price_label": "pass Culture"},
         ]
         mock_get_shows.return_value = mocked_shows
+        requests_mock.get("https://example.com/coupez.png", content=bytes())
+        requests_mock.get("https://example.com/topgun.png", content=bytes())
 
         cds_stocks = CDSStocks(venue_provider=venue_provider)
 
@@ -331,64 +172,15 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="http://fakeUrl/coupez.png",
-            ),
-            Movie(
-                id="51",
-                title="Top Gun",
-                duration=150,
-                description="Film sur les avions",
-                visa="333333",
-                posterpath="http://fakeUrl/topgun.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1, fixtures.MOVIE_2]
         mock_get_venue_movies.return_value = mocked_movies
 
-        requests_mock.get("http://fakeUrl/coupez.png", content=bytes())
-        requests_mock.get("http://fakeUrl/topgun.png", content=bytes())
+        requests_mock.get("https://example.com/coupez.png", content=bytes())
+        requests_mock.get("https://example.com/topgun.png", content=bytes())
 
         mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5.0,
-                "price_label": "pass Culture",
-            },
-            {
-                "show_information": ShowCDS(
-                    id=2,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=78,
-                    internet_remaining_place=11,
-                    showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=51),
-                ),
-                "price": 6.5,
-                "price_label": "pass Culture",
-            },
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5.0, "price_label": "pass Culture"},
+            {"show_information": fixtures.MOVIE_2_SHOW_1, "price": 6.5, "price_label": "pass Culture"},
         ]
         mock_get_shows.return_value = mocked_shows
 
@@ -473,56 +265,15 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="http://fakeUrl/coupez.png",
-            )
-        ]
+        mocked_movies = [fixtures.MOVIE_1]
         mock_get_venue_movies.return_value = mocked_movies
         mocked_same_film_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5.0,
-                "price_label": "Diffusion 2D",
-            },
-            {
-                "show_information": ShowCDS(
-                    id=2,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=78,
-                    internet_remaining_place=11,
-                    showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 6.5,
-                "price_label": "Diffusion 3D",
-            },
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5.0, "price_label": "Diffusion 2D"},
+            {"show_information": fixtures.MOVIE_1_SHOW_2, "price": 6.5, "price_label": "Diffusion 3D"},
         ]
         mock_get_shows.return_value = mocked_same_film_shows
 
-        requests_mock.get("http://fakeUrl/coupez.png", content=bytes())
+        requests_mock.get("https://example.com/coupez.png", content=bytes())
 
         cds_stocks = CDSStocks(venue_provider=venue_provider)
 
@@ -597,39 +348,14 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="http://fakeUrl/coupez.png",
-            )
-        ]
+        mocked_movies = [fixtures.MOVIE_1]
         mock_get_venue_movies.return_value = mocked_movies
         mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 6.9,
-                "price_label": "pass Culture",
-            },
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 6.9, "price_label": "pass Culture"},
         ]
         mock_get_shows.return_value = mocked_shows
 
-        requests_mock.get("http://fakeUrl/coupez.png", content=bytes())
+        requests_mock.get("https://example.com/coupez.png", content=bytes())
 
         # When
         CDSStocks(venue_provider=venue_provider).updateObjects()
@@ -658,61 +384,12 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-            Movie(
-                id="51",
-                title="Top Gun",
-                duration=150,
-                description="Film sur les avions",
-                visa="333333",
-                posterpath="fakeUrl/topgun.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1, fixtures.MOVIE_2]
         mock_get_venue_movies.return_value = mocked_movies
 
         mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5,
-                "price_label": "pass Culture",
-            },
-            {
-                "show_information": ShowCDS(
-                    id=2,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=78,
-                    internet_remaining_place=11,
-                    showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=51),
-                ),
-                "price": 6,
-                "price_label": "pass Culture",
-            },
+            {"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5, "price_label": "pass Culture"},
+            {"show_information": fixtures.MOVIE_2_SHOW_1, "price": 6, "price_label": "pass Culture"},
         ]
         mock_get_shows.return_value = mocked_shows
 
@@ -759,37 +436,10 @@ class CDSStocksTest:
             venue=venue_provider.venue, idAtProvider=venue_provider.venueIdAtOfferProvider
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1]
         mock_get_venue_movies.return_value = mocked_movies
 
-        mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5,
-                "price_label": "pass Culture",
-            },
-        ]
+        mocked_shows = [{"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5, "price_label": "pass Culture"}]
         mock_get_shows.return_value = mocked_shows
 
         cds_stocks = CDSStocks(venue_provider=venue_provider)
@@ -812,7 +462,7 @@ class CDSStocksQuantityTest:
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl")
     def should_update_cds_stock_with_correct_stock_quantity(
-        self, mock_get_venue_movies, mock_get_shows, mock_get_internet_sale_gauge
+        self, mock_get_venue_movies, mock_get_shows, mock_get_internet_sale_gauge, requests_mock
     ):
         # Given
         cds_provider = Provider.query.filter(Provider.localClass == "CDSStocks").one()
@@ -822,38 +472,11 @@ class CDSStocksQuantityTest:
         )
         CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
 
-        mocked_movies = [
-            Movie(
-                id="123",
-                title="Coupez !",
-                duration=120,
-                description="Ca tourne mal",
-                visa="123456",
-                posterpath="fakeUrl/coupez.png",
-            ),
-        ]
+        mocked_movies = [fixtures.MOVIE_1]
         mock_get_venue_movies.return_value = mocked_movies
-        mocked_shows = [
-            {
-                "show_information": ShowCDS(
-                    id=1,
-                    is_cancelled=False,
-                    is_deleted=False,
-                    is_disabled_seatmap=False,
-                    is_empty_seatmap=False,
-                    remaining_place=77,
-                    internet_remaining_place=10,
-                    showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                ),
-                "price": 5,
-                "price_label": "pass Culture",
-            }
-        ]
+        mocked_shows = [{"show_information": fixtures.MOVIE_1_SHOW_1, "price": 5, "price_label": "pass Culture"}]
         mock_get_shows.return_value = mocked_shows
-
+        requests_mock.get("https://example.com/coupez.png", content=bytes())
         # When
         cds_stocks_provider = CDSStocks(venue_provider=cds_venue_provider)
         cds_stocks_provider.updateObjects()

--- a/api/tests/local_providers/cinema_providers/cds/fixtures.py
+++ b/api/tests/local_providers/cinema_providers/cds/fixtures.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+
+from pcapi.connectors.serialization.cine_digital_service_serializers import IdObjectCDS
+from pcapi.connectors.serialization.cine_digital_service_serializers import ShowCDS
+from pcapi.connectors.serialization.cine_digital_service_serializers import ShowTariffCDS
+from pcapi.core.external_bookings.models import Movie
+
+
+MOVIE_1 = Movie(
+    id="123",
+    title="Coupez !",
+    duration=120,
+    description="Ca tourne mal",
+    visa="123456",
+    posterpath="https://example.com/coupez.png",
+)
+
+MOVIE_2 = Movie(
+    id="51",
+    title="Top Gun",
+    duration=150,
+    description="Film sur les avions",
+    visa="333333",
+    posterpath="https://example.com/topgun.png",
+)
+
+MOVIE_1_SHOW_1 = ShowCDS(
+    id=1,
+    is_cancelled=False,
+    is_deleted=False,
+    is_disabled_seatmap=False,
+    is_empty_seatmap=False,
+    remaining_place=77,
+    internet_remaining_place=10,
+    showtime=datetime(2022, 6, 20, 11, 00, 00),
+    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
+    screen=IdObjectCDS(id=1),
+    media=IdObjectCDS(id=123),
+)
+
+MOVIE_2_SHOW_1 = ShowCDS(
+    id=2,
+    is_cancelled=False,
+    is_deleted=False,
+    is_disabled_seatmap=False,
+    is_empty_seatmap=False,
+    remaining_place=78,
+    internet_remaining_place=10,
+    showtime=datetime(2022, 7, 1, 12, 00, 00),
+    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
+    screen=IdObjectCDS(id=1),
+    media=IdObjectCDS(id=51),
+)
+
+MOVIE_1_SHOW_2 = ShowCDS(
+    id=3,
+    is_cancelled=False,
+    is_deleted=False,
+    is_disabled_seatmap=False,
+    is_empty_seatmap=False,
+    remaining_place=78,
+    internet_remaining_place=11,
+    showtime=datetime(2022, 7, 1, 12, 00, 00),
+    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
+    screen=IdObjectCDS(id=1),
+    media=IdObjectCDS(id=123),
+)
+
+MOVIE_OTHER_SHOW_1 = ShowCDS(
+    id=1,
+    is_cancelled=False,
+    is_deleted=False,
+    is_disabled_seatmap=False,
+    is_empty_seatmap=False,
+    remaining_place=77,
+    internet_remaining_place=10,
+    showtime=datetime(2022, 6, 20, 11, 00, 00),
+    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
+    screen=IdObjectCDS(id=1),
+    media=IdObjectCDS(id=88888),
+)
+
+MOVIE_OTHER_SHOW_2 = ShowCDS(
+    id=2,
+    is_cancelled=False,
+    is_deleted=False,
+    is_disabled_seatmap=False,
+    is_empty_seatmap=False,
+    remaining_place=77,
+    internet_remaining_place=10,
+    showtime=datetime(2022, 7, 1, 12, 00, 00),
+    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
+    screen=IdObjectCDS(id=1),
+    media=IdObjectCDS(id=88888),
+)


### PR DESCRIPTION
## But de la pull request

- Nettoyer du code mort
- Simplifier les tests en utilisant des mixtures

## Informations supplémentaires

On pourra par la suite définir des réponses en JSON via requests_mock au lieu d'objets déjà sérializés, comme ce qui a été fait pour Boost et CGR.
