### PR TITLE
(PC-21319)[API] feat: set venue.bookingEmail to user.email in onboarding

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1717,7 +1717,7 @@ def create_from_onboarding_data(
     if not offerers_repository.find_venue_by_siret(onboarding_data.siret) or onboarding_data.createVenueWithoutSiret:
         common_kwargs = dict(
             address=additional_info.address,
-            bookingEmail="",
+            bookingEmail=user.email,
             city=additional_info.city,
             latitude=additional_info.latitude,
             longitude=additional_info.longitude,

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1385,7 +1385,7 @@ class GetAdditionalInfoFromOnboardingDataTest:
 class CreateFromOnboardingDataTest:
     def assert_common_venue_attrs(self, venue: offerers_models.Venue) -> None:
         assert venue.address == "3 RUE DE VALOIS"
-        assert venue.bookingEmail == ""
+        assert venue.bookingEmail == "pro@example.com"
         assert venue.city == "Paris"
         assert not venue.current_reimbursement_point_id
         assert venue.dmsToken
@@ -1418,7 +1418,7 @@ class CreateFromOnboardingDataTest:
         )
 
     def test_new_siren_new_siret(self):
-        user = users_factories.UserFactory()
+        user = users_factories.UserFactory(email="pro@example.com")
         user.add_non_attached_pro_role()
 
         onboarding_data = self.get_onboarding_data(create_venue_without_siret=False)
@@ -1460,7 +1460,7 @@ class CreateFromOnboardingDataTest:
     def test_existing_siren_new_siret(self):
         offerer = offerers_factories.OffererFactory(siren="853318459")
         offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
-        user = users_factories.UserFactory()
+        user = users_factories.UserFactory(email="pro@example.com")
         user.add_non_attached_pro_role()
 
         onboarding_data = self.get_onboarding_data(create_venue_without_siret=False)
@@ -1493,7 +1493,7 @@ class CreateFromOnboardingDataTest:
     def test_existing_siren_new_venue_without_siret(self):
         offerer = offerers_factories.OffererFactory(siren="853318459")
         offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
-        user = users_factories.UserFactory()
+        user = users_factories.UserFactory(email="pro@example.com")
         user.add_non_attached_pro_role()
 
         onboarding_data = self.get_onboarding_data(create_venue_without_siret=True)

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -22,7 +22,7 @@ REQUEST_BODY = {
 
 class Returns200Test:
     def test_nominal(self, client):
-        user = users_factories.UserFactory()
+        user = users_factories.UserFactory(email="pro@example.com")
 
         client = client.with_session_auth(user.email)
 
@@ -37,7 +37,7 @@ class Returns200Test:
         assert created_offerer.postalCode == "75001"
         created_venue = offerers_models.Venue.query.filter(offerers_models.Venue.isVirtual.is_(False)).one()
         assert created_venue.address == "3 RUE DE VALOIS"
-        assert created_venue.bookingEmail == ""
+        assert created_venue.bookingEmail == "pro@example.com"
         assert created_venue.city == "Paris"
         assert created_venue.audioDisabilityCompliant is False
         assert created_venue.mentalDisabilityCompliant is False


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21319

## But de la pull request

Définir le bookingEmail d'un lieu créé pendant l'onboarding comme étant l'email de l'utilisateur 