### PR TITLE
(PC-21320)[API] feat: set venue accessibility to None in onboarding

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -201,9 +201,11 @@ def upsert_venue_contact(venue: models.Venue, contact_data: serialize_base.Venue
     return venue
 
 
-def create_venue(venue_data: venues_serialize.PostVenueBodyModel) -> models.Venue:
+def create_venue(
+    venue_data: venues_serialize.PostVenueBodyModel, strict_accessibility_compliance: bool = True
+) -> models.Venue:
     data = venue_data.dict(by_alias=True)
-    validation.check_venue_creation(data)
+    validation.check_venue_creation(data, strict_accessibility_compliance)
     venue = models.Venue()
     data["dmsToken"] = generate_dms_token()
     venue.populate_from_dict(data, skipped_keys=("contact",))
@@ -1732,10 +1734,10 @@ def create_from_onboarding_data(
             withdrawalDetails=None,
             description=None,
             contact=None,
-            audioDisabilityCompliant=False,
-            mentalDisabilityCompliant=False,
-            motorDisabilityCompliant=False,
-            visualDisabilityCompliant=False,
+            audioDisabilityCompliant=None,
+            mentalDisabilityCompliant=None,
+            motorDisabilityCompliant=None,
+            visualDisabilityCompliant=None,
         )
         if onboarding_data.createVenueWithoutSiret:
             comment_and_siret = dict(
@@ -1749,6 +1751,6 @@ def create_from_onboarding_data(
             )
         venue_kwargs = common_kwargs | comment_and_siret
         venue_creation_info = venues_serialize.PostVenueBodyModel(**venue_kwargs)  # type: ignore [arg-type]
-        create_venue(venue_creation_info)
+        create_venue(venue_creation_info, strict_accessibility_compliance=False)
 
     return user_offerer

--- a/api/src/pcapi/core/offerers/validation.py
+++ b/api/src/pcapi/core/offerers/validation.py
@@ -29,7 +29,7 @@ def validate_coordinates(raw_latitude: float | str, raw_longitude: float | str) 
         raise api_errors
 
 
-def check_venue_creation(data: dict[str, typing.Any]) -> None:
+def check_venue_creation(data: dict[str, typing.Any], strict_accessibility_compliance: bool) -> None:
     offerer_id = dehumanize(data.get("managingOffererId"))
     if not offerer_id:
         raise ApiErrors(errors={"managingOffererId": ["Vous devez choisir une structure pour votre lieu."]})
@@ -37,7 +37,7 @@ def check_venue_creation(data: dict[str, typing.Any]) -> None:
     if not offerer:
         raise ApiErrors(errors={"managingOffererId": ["La structure que vous avez choisie n'existe pas."]})
 
-    if None in [
+    if strict_accessibility_compliance and None in [
         data.get("audioDisabilityCompliant"),
         data.get("mentalDisabilityCompliant"),
         data.get("motorDisabilityCompliant"),

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1395,10 +1395,10 @@ class CreateFromOnboardingDataTest:
         assert venue.postalCode == "75001"
         assert venue.publicName == "Nom public de mon lieu"
         assert venue.venueTypeCode == offerers_models.VenueTypeCode.MOVIE
-        assert venue.audioDisabilityCompliant is False
-        assert venue.mentalDisabilityCompliant is False
-        assert venue.motorDisabilityCompliant is False
-        assert venue.visualDisabilityCompliant is False
+        assert venue.audioDisabilityCompliant is None
+        assert venue.mentalDisabilityCompliant is None
+        assert venue.motorDisabilityCompliant is None
+        assert venue.visualDisabilityCompliant is None
 
     def assert_common_action_history_extra_data(self, action: history_models.ActionHistory) -> None:
         assert action.extraData["target"] == offerers_models.Target.INDIVIDUAL.name

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -39,10 +39,10 @@ class Returns200Test:
         assert created_venue.address == "3 RUE DE VALOIS"
         assert created_venue.bookingEmail == ""
         assert created_venue.city == "Paris"
-        assert created_venue.audioDisabilityCompliant is False
-        assert created_venue.mentalDisabilityCompliant is False
-        assert created_venue.motorDisabilityCompliant is False
-        assert created_venue.visualDisabilityCompliant is False
+        assert created_venue.audioDisabilityCompliant is None
+        assert created_venue.mentalDisabilityCompliant is None
+        assert created_venue.motorDisabilityCompliant is None
+        assert created_venue.visualDisabilityCompliant is None
         assert created_venue.comment is None
         assert created_venue.departementCode == "75"
         assert created_venue.name == "MINISTERE DE LA CULTURE"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21320

## But de la pull request

Définir les 4 attributs d'accessibilité à None pendant l'onboarding, afin qu'ils soient remplis plus tard par l'AC.

## Implémentation

- Ajout d'un argument `strict_accessibility_compliance` à `create_venue()`, dont la valeur par défaut est `True`, et qui permet d'ignorer la validation des attributs d'accessibilité.