### PR TITLE
(BSR)[API] chore: Remove backward-compatibility indexation commands

### DIFF
--- a/api/src/pcapi/core/search/commands/indexation.py
+++ b/api/src/pcapi/core/search/commands/indexation.py
@@ -129,32 +129,6 @@ def _partially_index(
         page += 1
 
 
-# FIXME (dbaty, 2023-02-17): remove `process_offers_from_database`
-# command when it's been replaced by `partially_index_offers` command
-# in staging rebuild process (after v230, probably).
-@blueprint.cli.command("process_offers_from_database")
-@click.option("--clear", help="Clear search index first", type=bool, default=False)
-@click.option("-ep", "--ending-page", help="Ending page", type=int, default=None)
-@click.option("-l", "--limit", help="Number of offers per page", type=int, default=10_000)
-@click.option("-sp", "--starting-page", help="Starting page (first is 0)", type=int, default=0)
-def process_offers_from_database(
-    clear: bool,
-    ending_page: int | None,
-    limit: int,
-    starting_page: int,
-) -> None:
-    if clear:
-        search.unindex_all_offers()
-    _partially_index(
-        what="offers",
-        getter=offers_repository.get_paginated_active_offer_ids,
-        indexation_callback=search.reindex_offer_ids,
-        starting_page=starting_page + 1,
-        last_page=ending_page,
-        batch_size=limit,
-    )
-
-
 @blueprint.cli.command("partially_index_offers")
 @click.option("--clear", help="Clear search index first", type=bool, default=False)
 @click.option("--batch-size", help="Number of offers per page", type=int, default=10_000)
@@ -234,19 +208,6 @@ def partially_index_collective_offer_templates(
         starting_page=starting_page,
         last_page=last_page,
     )
-
-
-# FIXME (dbaty, 2023-02-17): remove `process_venues_from_database`
-# command when it's been replaced by `partially_index_venues` command
-# in staging rebuild process.
-@blueprint.cli.command("process_venues_from_database")
-@click.option("--clear", help="Clear search index first", type=bool, default=False)
-@click.option("--batch-size", help="Batch size (Algolia)", type=int, default=10_000)
-@click.option("--max-venues", help="Max number of venues (total)", type=int, default=10_000)
-def process_venues_from_database(clear: bool, batch_size: int, max_venues: int) -> None:
-    if clear:
-        search.unindex_all_venues()
-    _reindex_all_eligible_venues(batch_size, max_venues)
 
 
 @blueprint.cli.command("partially_index_venues")

--- a/api/tests/core/search/test_commands_indexation.py
+++ b/api/tests/core/search/test_commands_indexation.py
@@ -26,21 +26,6 @@ def test_partially_index_offers(app):
         bookable_offer1.id,
     }
 
-    # test of legacy command, will be deleted until "---" below
-    # fmt: off
-    run_command(
-        app,
-        "process_offers_from_database",
-        "--ending-page", 2,
-        "--limit", 1,
-    )
-    # fmt: on
-
-    assert set(search_testing.search_store["offers"].keys()) == expected_to_be_reindexed
-
-    search_testing.reset_search_store()
-    # --- delete until here when legacy command is removed
-
     # fmt: off
     run_command(
         app,
@@ -116,20 +101,6 @@ def test_partially_index_venues(app):
         # venues, which are _not_indexable_venue and indexable_venue1.
         # Only the latter is indexed.
     }
-
-    # test of legacy command, will be deleted until "---" below
-    # fmt: off
-    run_command(
-        app,
-        "process_venues_from_database",
-        "--max-venues", 2,
-    )
-    # fmt: on
-
-    assert set(search_testing.search_store["venues"].keys()) == expected_to_be_reindexed
-
-    search_testing.reset_search_store()
-    # --- delete until here when legacy command is removed
 
     # fmt: off
     run_command(


### PR DESCRIPTION
These commands have been replaced by "partially_index_offers" and
"partially_index_venues".