### PR TITLE
(PC-21346)[PRO] ci: run e2e tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests-pro.yml
+++ b/.github/workflows/tests-pro.yml
@@ -154,3 +154,34 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  tests-pro-e2e-tests:
+    name: "E2E tests"
+    runs-on: [self-hosted, linux, x64]
+    needs: read-node-version
+    steps:
+      - uses: actions/checkout@v3
+      - if: ${{ env.use_cache == false }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ needs.read-node-version.outputs.node_version }}
+      - name: Run API server
+        working-directory: api
+        run: ../pc start-backend &
+      # Doc : https://github.com/cypress-io/github-action
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        with:
+          build: yarn build:development
+          start: yarn serve
+          config: baseUrl=http://localhost:3001
+          browser: chrome
+          wait-on: "http://localhost:3001,http://localhost/health/api,http://localhost/health/database"
+          wait-on-timeout: 600
+          working-directory: pro
+      - name: Archive E2E results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-artifacts
+          path: pro/cypress/screenshots

--- a/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/serializers.spec.tsx
@@ -199,6 +199,7 @@ describe('screen | VenueForm | serializers', () => {
       expect(result.contact?.website).toBeNull()
       expect(result.contact?.phoneNumber).toBeNull()
     })
+
     it("User should be able to delete a venue's contact info", async () => {
       const result: EditVenueBodyModel = serializeEditVenueBodyModel(
         {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21346

Exemple de run qui échoue, il y a un report et les screenshots sont sauvegardés : https://github.com/pass-culture/pass-culture-main/actions/runs/4617537799?pr=5990
![image](https://user-images.githubusercontent.com/6317823/230081861-63fe4c62-fc0a-4d65-8826-3e931e45987c.png)

Exemple de run en succès : cf check CI ci dessous