### PR TITLE
(PC-21066)[PRO] fix: fix typing in collective dms timeline

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { DMSApplicationForEAC } from 'apiClient/v1'
+import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
 import { ExternalLinkIcon, PenIcon } from 'icons'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -8,48 +8,15 @@ import Timeline, { TimelineStepType } from 'ui-kit/Timeline/Timeline'
 
 import styles from './CollectiveDmsTimeline.module.scss'
 
-// Modify status value with backend status value when it's ready
-export const DMS_STATUS = {
-  DRAFT: 'DRAFT',
-  SUBMITTED: 'SUBMITTED',
-  INSTRUCTION: 'INSTRUCTION',
-  ADD_IN_ADAGE: 'ADD_IN_ADAGE',
-  ADDED_IN_ADAGE: 'ADDED_IN_ADAGE',
-}
-
 const CollectiveDmsTimeline = ({
   collectiveDmsApplication,
+  hasAdageId,
 }: {
   collectiveDmsApplication: DMSApplicationForEAC
+  hasAdageId: boolean
 }) => {
   // const collectiveDmsApplicationLink = link to venue.collectiveDmsApplicationId // FIX ME : collectiveDmsApplicationId is not yet a property of IVenue
-  const collectiveDmsApplicationLink = DMS_STATUS.ADDED_IN_ADAGE
-  const waitingDraftStep = {
-    type: TimelineStepType.WAITING,
-    content: (
-      <>
-        <div className={styles['timeline-step-title']}>
-          Déposez votre demande de référencement
-        </div>
-        <div className={styles['timeline-infobox']}>
-          <div className={styles['timeline-infobox-text']}>
-            Votre dossier est au statut “brouillon”. Vous devez le publier si
-            vous souhaitez qu’il soit traité.
-          </div>
-          <ButtonLink
-            variant={ButtonVariant.TERNARY}
-            link={{
-              to: collectiveDmsApplicationLink,
-              isExternal: true,
-            }}
-            Icon={ExternalLinkIcon}
-          >
-            Modifier mon dossier sur Démarches Simplifiées
-          </ButtonLink>
-        </div>
-      </>
-    ),
-  }
+  const collectiveDmsApplicationLink = 'fake link'
 
   const successSubmittedStep = {
     type: TimelineStepType.SUCCESS,
@@ -234,18 +201,7 @@ const CollectiveDmsTimeline = ({
   }
 
   switch (collectiveDmsApplication.state) {
-    case DMS_STATUS.DRAFT:
-      return (
-        <Timeline
-          steps={[
-            waitingDraftStep,
-            disabledInstructionStep,
-            disabledDoneStep,
-            disabledAcceptedAdageStep,
-          ]}
-        />
-      )
-    case DMS_STATUS.SUBMITTED:
+    case DMSApplicationstatus.EN_CONSTRUCTION:
       return (
         <Timeline
           steps={[
@@ -256,7 +212,7 @@ const CollectiveDmsTimeline = ({
           ]}
         />
       )
-    case DMS_STATUS.INSTRUCTION:
+    case DMSApplicationstatus.EN_INSTRUCTION:
       return (
         <Timeline
           steps={[
@@ -267,8 +223,8 @@ const CollectiveDmsTimeline = ({
           ]}
         />
       )
-    case DMS_STATUS.ADD_IN_ADAGE:
-      return (
+    case DMSApplicationstatus.ACCEPTE:
+      return !hasAdageId ? (
         <Timeline
           steps={[
             successSubmittedStep,
@@ -277,9 +233,7 @@ const CollectiveDmsTimeline = ({
             waitingAdageStep,
           ]}
         />
-      )
-    case DMS_STATUS.ADDED_IN_ADAGE:
-      return (
+      ) : (
         <Timeline
           steps={[
             successSubmittedStep,

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -1,27 +1,30 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
 
-import { DMSApplicationForEAC } from 'apiClient/v1'
+import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
 import { defaultCollectiveDmsApplication } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveDmsTimeline from '..'
-import { DMS_STATUS } from '../CollectiveDmsTimeline'
 
 const renderCollectiveDmsTimeline = ({
   collectiveDmsApplication,
+  hasAdageId = false,
 }: {
   collectiveDmsApplication: DMSApplicationForEAC
+  hasAdageId?: boolean
 }) => {
   renderWithProviders(
     <CollectiveDmsTimeline
       collectiveDmsApplication={collectiveDmsApplication}
+      hasAdageId={hasAdageId}
     />
   )
 }
 
 interface ITestCaseProps {
   collectiveDmsApplication: DMSApplicationForEAC
+  hasAdageId?: boolean
   expectedLabel: string
 }
 
@@ -30,28 +33,21 @@ describe('CollectiveDmsTimeline', () => {
     {
       collectiveDmsApplication: {
         ...defaultCollectiveDmsApplication,
-        state: DMS_STATUS.DRAFT,
-      },
-      expectedLabel: 'Déposez votre demande de référencement',
-    },
-    {
-      collectiveDmsApplication: {
-        ...defaultCollectiveDmsApplication,
-        state: DMS_STATUS.SUBMITTED,
+        state: DMSApplicationstatus.EN_CONSTRUCTION,
       },
       expectedLabel: 'Votre dossier a été déposé',
     },
     {
       collectiveDmsApplication: {
         ...defaultCollectiveDmsApplication,
-        state: DMS_STATUS.INSTRUCTION,
+        state: DMSApplicationstatus.EN_INSTRUCTION,
       },
       expectedLabel: "Votre dossier est en cours d'instruction",
     },
     {
       collectiveDmsApplication: {
         ...defaultCollectiveDmsApplication,
-        state: DMS_STATUS.ADD_IN_ADAGE,
+        state: DMSApplicationstatus.ACCEPTE,
       },
       expectedLabel: 'Votre demande de référencement a été acceptée',
     },
@@ -59,30 +55,18 @@ describe('CollectiveDmsTimeline', () => {
     {
       collectiveDmsApplication: {
         ...defaultCollectiveDmsApplication,
-        state: DMS_STATUS.ADDED_IN_ADAGE,
+        state: DMSApplicationstatus.ACCEPTE,
       },
+      hasAdageId: true,
       expectedLabel:
         'Votre lieu a été ajouté dans ADAGE par le Ministère de l’Education Nationale',
     },
   ]
   it.each(testCases)(
     'should render %s status',
-    ({ collectiveDmsApplication, expectedLabel }) => {
-      renderCollectiveDmsTimeline({ collectiveDmsApplication })
+    ({ collectiveDmsApplication, hasAdageId, expectedLabel }) => {
+      renderCollectiveDmsTimeline({ collectiveDmsApplication, hasAdageId })
       expect(screen.getByText(expectedLabel)).toBeInTheDocument()
     }
   )
-
-  it('should throw error if dms status doesnt exist', () => {
-    expect(() =>
-      render(
-        <CollectiveDmsTimeline
-          collectiveDmsApplication={{
-            ...defaultCollectiveDmsApplication,
-            state: 'NOT_EXISTING_STATUS',
-          }}
-        />
-      )
-    ).toThrowError()
-  })
 })

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -41,6 +41,7 @@ const CollectiveVenueInformations = ({
       {venue?.collectiveDmsApplication && (
         <CollectiveDmsTimeline
           collectiveDmsApplication={venue.collectiveDmsApplication}
+          hasAdageId={venue.hasAdageId}
         />
       )}
       {shouldEACInformationSection && (

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/__specs__/CollectiveVenueInformations.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/__specs__/CollectiveVenueInformations.spec.tsx
@@ -2,13 +2,13 @@ import { screen } from '@testing-library/react'
 import { addDays } from 'date-fns'
 import React from 'react'
 
+import { DMSApplicationstatus } from 'apiClient/v1'
 import {
   defaultCollectiveDmsApplication,
   defaultIVenue,
 } from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
-import { DMS_STATUS } from '../CollectiveDmsTimeline/CollectiveDmsTimeline'
 import CollectiveVenueInformations, {
   ICollectiveVenueInformationsProps,
 } from '../CollectiveVenueInformations'
@@ -26,7 +26,7 @@ describe('CollectiveVenueInformations', () => {
         ...defaultIVenue,
         collectiveDmsApplication: {
           ...defaultCollectiveDmsApplication,
-          state: DMS_STATUS.DRAFT,
+          state: DMSApplicationstatus.EN_CONSTRUCTION,
         },
       },
       isCreatingVenue: false,
@@ -46,7 +46,7 @@ describe('CollectiveVenueInformations', () => {
         adageInscriptionDate: addDays(new Date(), -10).toISOString(),
         collectiveDmsApplication: {
           ...defaultCollectiveDmsApplication,
-          state: 'ADDED_IN_ADAGE',
+          state: DMSApplicationstatus.ACCEPTE,
         },
       },
       isCreatingVenue: false,
@@ -66,7 +66,7 @@ describe('CollectiveVenueInformations', () => {
         adageInscriptionDate: addDays(new Date(), -32).toISOString(),
         collectiveDmsApplication: {
           ...defaultCollectiveDmsApplication,
-          state: DMS_STATUS.ADDED_IN_ADAGE,
+          state: DMSApplicationstatus.ACCEPTE,
         },
       },
       isCreatingVenue: false,

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -1078,9 +1078,7 @@ describe('screen | VenueForm', () => {
       await waitFor(
         () => expect(api.canOffererCreateEducationalOffer).toHaveBeenCalled
       )
-      expect(
-        screen.getByText('Déposez votre demande de référencement')
-      ).toBeInTheDocument()
+      expect(screen.getByText('Votre dossier a été déposé')).toBeInTheDocument()
     })
 
     it('should not display eac section if offerer is not eligble and has not dms application', async () => {

--- a/pro/src/utils/collectiveApiFactories.ts
+++ b/pro/src/utils/collectiveApiFactories.ts
@@ -5,6 +5,7 @@ import {
   CollectiveBookingByIdResponseModel,
   CollectiveBookingResponseModel,
   DMSApplicationForEAC,
+  DMSApplicationstatus,
   EducationalInstitutionResponseModel,
   EducationalRedactorResponseModel,
   GetCollectiveOfferCollectiveStockResponseModel,
@@ -305,7 +306,7 @@ export const defaultCollectiveDmsApplication: DMSApplicationForEAC = {
   depositDate: new Date().toISOString(),
   lastChangeDate: new Date().toISOString(),
   procedure: 456,
-  state: 'DRAFT',
+  state: DMSApplicationstatus.EN_CONSTRUCTION,
   venueId: 1,
 }
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21066

## But de la pull request

Fix le typing du state des démarches dms collectives suite au changement côté back. 
On utilise désormais le type DMSApplicationForEAC
Impact : supression du state 'draft' qui n'est finalement pas pertinent pour le chantier 