### PR TITLE
(PC-21573)[API] save firebase flag when creating user

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1193,7 +1193,7 @@ def validate_pro_user_email(user: users_models.User, author_user: users_models.U
         )
 
 
-def _save_firebase_flags(user: models.User, firebase_value: dict) -> None:
+def save_firebase_flags(user: models.User, firebase_value: dict) -> None:
     if user.pro_flags:
         if user.pro_flags.firebase and user.pro_flags.firebase != firebase_value:
             logger.warning("%s now has different Firebase flags than before", user)
@@ -1207,6 +1207,6 @@ def save_flags(user: models.User, flags: dict) -> None:
     for flag, value in flags.items():
         match flag:
             case "firebase":
-                _save_firebase_flags(user, value)
+                save_firebase_flags(user, value)
             case _:
                 raise ValueError()

--- a/api/src/pcapi/routes/pro/signup.py
+++ b/api/src/pcapi/routes/pro/signup.py
@@ -1,10 +1,8 @@
 from pcapi.core.subscription.phone_validation import exceptions as phone_exceptions
-from pcapi.core.users.api import create_pro_user_V2
-from pcapi.core.users.api import create_pro_user_and_offerer
+from pcapi.core.users import api as users_api
 from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
-from pcapi.routes.serialization.users import ProUserCreationBodyModel
-from pcapi.routes.serialization.users import ProUserCreationBodyV2Model
+from pcapi.routes.serialization import users as users_serialize
 from pcapi.serialization.decorator import spectree_serialize
 
 from . import blueprint
@@ -12,17 +10,17 @@ from . import blueprint
 
 @private_api.route("/users/signup/pro", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
-def signup_pro(body: ProUserCreationBodyModel) -> None:
+def signup_pro(body: users_serialize.ProUserCreationBodyModel) -> None:
     try:
-        create_pro_user_and_offerer(body)
+        users_api.create_pro_user_and_offerer(body)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})
 
 
 @private_api.route("/v2/users/signup/pro", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
-def signup_pro_V2(body: ProUserCreationBodyV2Model) -> None:
+def signup_pro_V2(body: users_serialize.ProUserCreationBodyV2Model) -> None:
     try:
-        create_pro_user_V2(body)
+        users_api.create_pro_user_V2(body)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})

--- a/api/src/pcapi/routes/pro/signup.py
+++ b/api/src/pcapi/routes/pro/signup.py
@@ -12,7 +12,9 @@ from . import blueprint
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def signup_pro(body: users_serialize.ProUserCreationBodyModel) -> None:
     try:
-        users_api.create_pro_user_and_offerer(body)
+        user = users_api.create_pro_user_and_offerer(body)
+        firebase_value = {"BETTER_OFFER_CREATION": False}
+        users_api.save_firebase_flags(user, firebase_value)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})
 
@@ -21,6 +23,8 @@ def signup_pro(body: users_serialize.ProUserCreationBodyModel) -> None:
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def signup_pro_V2(body: users_serialize.ProUserCreationBodyV2Model) -> None:
     try:
-        users_api.create_pro_user_V2(body)
+        user = users_api.create_pro_user_V2(body)
+        firebase_value = {"BETTER_OFFER_CREATION": True}
+        users_api.save_firebase_flags(user, firebase_value)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})

--- a/api/tests/routes/pro/signup_pro_V2_test.py
+++ b/api/tests/routes/pro/signup_pro_V2_test.py
@@ -59,6 +59,13 @@ class Returns204Test:
         user = User.query.filter_by(email="toto_pro@example.com").first()
         assert user.needsToFillCulturalSurvey == False
 
+    def test_firebase_flag(self, client):
+        data = BASE_DATA_PRO.copy()
+        client.post("/v2/users/signup/pro", json=data)
+
+        user = User.query.one()
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -206,6 +206,13 @@ class Returns204Test:
         assert actions_list[1].user == user
         assert actions_list[1].offerer == offerer
 
+    def test_firebase_flag(self, client):
+        data = BASE_DATA_PRO.copy()
+        client.post("/users/signup/pro", json=data)
+
+        user = User.query.one()
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": False}
+
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21573

## But de la pull request

Enregistrer l'info de parcours présenté à l'utilisateur au moment où l'objet User est créé donc lors de l'envoi du formulaire de création de compte.

## Implémentation

- Enregistrement de ce flag lors du traitement des routes signup v1 et v2
