### PR TITLE
(PC-21262)[PRO] fix: various bugs with pagination in recurrence

### DIFF
--- a/pro/src/ui-kit/Pagination/Pagination.tsx
+++ b/pro/src/ui-kit/Pagination/Pagination.tsx
@@ -33,7 +33,7 @@ export const Pagination = ({
       </span>
 
       <button
-        disabled={currentPage === pageCount}
+        disabled={currentPage >= pageCount}
         onClick={onNextPageClick}
         type="button"
         className={styles['button']}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21262

## But de la pull request

_Divers bug fixs liés à la pagination
-> quand la page max était dépassé on pouvait l'augenter à volonté
-> le select sur une checkbox selectionné toutes les lignes à la même position
-> idem pour la suppression
-> après suppression on pouvait se retrouver sur une page vide à la pagination dépassée (page 3/2 par exemple)
-> après suppression, lorsqu'il ne restait plus qu'une page on pouvait se retrouver sur une page vide en étant softlock (il n'y avait plus de bouton de pagination)  
