### PR TITLE
(PC-21608)[API] fix: show dateCreated label as a link

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/user_offerer_validation.html
@@ -72,7 +72,7 @@
               <th scope="col">État</th>
               <th scope="col">
                 <a href="{{ date_created_sort_url }}"
-                   class="text-decoration-none{{ ' text-body' if request.args.get('sort') != 'dateCreated' else '' }}"
+                   class="text-decoration-none"
                    title="Changer pour un tri {{ 'décroissant' if request.args.get('sort') == 'dateCreated' and request.args.get('order') == 'asc' else 'croissant' }}">
                   Date de la demande
                   <i class="bi bi-sort-{{ 'up' if request.args.get('sort') == 'dateCreated' and request.args.get('order') == 'asc' else 'down' }}-alt"></i>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21608

## But de la pull request

Par défaut, le rouge indiquait que le tri était actif sur la colonne date de création, cela faisait un mauvais UX, l'utilisateur ne comprenant pas pourquoi la couleur est actif que sur une page.

Cette PR supprime l'affichage de la séléction du tri, et affiche le text en rouge comme un lien ce qui est le comportement par défaut.

## Implémentation

- Suppression de la class `text-body` ajouté automatiquement sur le `<th>` quand le query params `sort` n'est pas passé

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
