### PR TITLE
(PC-21068)[PRO] feat: add case if venue has adageId for more than 30 …

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
@@ -41,4 +41,11 @@
       font-weight: 500;
     }
   }
+
+  &-added-in-adage {
+    display: flex;
+    align-items: center;
+    margin-bottom: rem.torem(32px);
+    gap: rem.torem(10px);
+  }
 }

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
-import { ExternalLinkIcon, PenIcon } from 'icons'
+import { ExternalLinkIcon, PenIcon, ValidCircleIcon } from 'icons'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Timeline, { TimelineStepType } from 'ui-kit/Timeline/Timeline'
@@ -11,9 +11,11 @@ import styles from './CollectiveDmsTimeline.module.scss'
 const CollectiveDmsTimeline = ({
   collectiveDmsApplication,
   hasAdageId,
+  hasAdageIdForMoreThan30Days,
 }: {
   collectiveDmsApplication: DMSApplicationForEAC
   hasAdageId: boolean
+  hasAdageIdForMoreThan30Days: boolean
 }) => {
   // const collectiveDmsApplicationLink = link to venue.collectiveDmsApplicationId // FIX ME : collectiveDmsApplicationId is not yet a property of IVenue
   const collectiveDmsApplicationLink = 'fake link'
@@ -254,24 +256,35 @@ const CollectiveDmsTimeline = ({
         />
       )
     case DMSApplicationstatus.ACCEPTE:
-      return !hasAdageId ? (
-        <Timeline
-          steps={[
-            successSubmittedStep,
-            successInstructionStep,
-            successDoneReferencement,
-            waitingAdageStep,
-          ]}
-        />
-      ) : (
-        <Timeline
-          steps={[
-            successSubmittedStep,
-            successInstructionStep,
-            successDoneReferencement,
-            successAdageStep,
-          ]}
-        />
+      if (!hasAdageId) {
+        return (
+          <Timeline
+            steps={[
+              successSubmittedStep,
+              successInstructionStep,
+              successDoneReferencement,
+              waitingAdageStep,
+            ]}
+          />
+        )
+      }
+      if (!hasAdageIdForMoreThan30Days) {
+        return (
+          <Timeline
+            steps={[
+              successSubmittedStep,
+              successInstructionStep,
+              successDoneReferencement,
+              successAdageStep,
+            ]}
+          />
+        )
+      }
+      return (
+        <div className={styles['timeline-added-in-adage']}>
+          <ValidCircleIcon />
+          <span>Ce lieu est référencé sur ADAGE</span>
+        </div>
       )
     case DMSApplicationstatus.REFUSE:
       return <Timeline steps={[refusedByDms]} />

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -10,14 +10,17 @@ import CollectiveDmsTimeline from '..'
 const renderCollectiveDmsTimeline = ({
   collectiveDmsApplication,
   hasAdageId = false,
+  hasAdageIdForMoreThan30Days = false,
 }: {
   collectiveDmsApplication: DMSApplicationForEAC
   hasAdageId?: boolean
+  hasAdageIdForMoreThan30Days?: boolean
 }) => {
   renderWithProviders(
     <CollectiveDmsTimeline
       collectiveDmsApplication={collectiveDmsApplication}
       hasAdageId={hasAdageId}
+      hasAdageIdForMoreThan30Days={hasAdageIdForMoreThan30Days}
     />
   )
 }
@@ -25,6 +28,7 @@ const renderCollectiveDmsTimeline = ({
 interface ITestCaseProps {
   collectiveDmsApplication: DMSApplicationForEAC
   hasAdageId?: boolean
+  hasAdageIdForMoreThan30Days?: boolean
   expectedLabel: string
 }
 
@@ -68,11 +72,29 @@ describe('CollectiveDmsTimeline', () => {
       },
       expectedLabel: 'Votre demande de référencement a été refusée',
     },
+    {
+      collectiveDmsApplication: {
+        ...defaultCollectiveDmsApplication,
+        state: DMSApplicationstatus.ACCEPTE,
+      },
+      hasAdageId: true,
+      hasAdageIdForMoreThan30Days: true,
+      expectedLabel: 'Ce lieu est référencé sur ADAGE',
+    },
   ]
   it.each(testCases)(
     'should render %s status',
-    ({ collectiveDmsApplication, hasAdageId, expectedLabel }) => {
-      renderCollectiveDmsTimeline({ collectiveDmsApplication, hasAdageId })
+    ({
+      collectiveDmsApplication,
+      hasAdageId,
+      hasAdageIdForMoreThan30Days,
+      expectedLabel,
+    }) => {
+      renderCollectiveDmsTimeline({
+        collectiveDmsApplication,
+        hasAdageId,
+        hasAdageIdForMoreThan30Days,
+      })
       expect(screen.getByText(expectedLabel)).toBeInTheDocument()
     }
   )

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -19,13 +19,13 @@ const CollectiveVenueInformations = ({
   isCreatingVenue,
   canCreateCollectiveOffer,
 }: ICollectiveVenueInformationsProps) => {
+  const hasAdageIdForMoreThan30Days = Boolean(
+    venue?.hasAdageId &&
+      venue?.adageInscriptionDate &&
+      isBefore(new Date(venue?.adageInscriptionDate), addDays(new Date(), -30))
+  )
   const shouldEACInformationSection =
-    (venue?.hasAdageId &&
-      venue.adageInscriptionDate &&
-      isBefore(
-        new Date(venue.adageInscriptionDate),
-        addDays(new Date(), -30)
-      )) ||
+    hasAdageIdForMoreThan30Days ||
     (!venue?.adageInscriptionDate && canCreateCollectiveOffer) ||
     isCreatingVenue
 
@@ -43,6 +43,7 @@ const CollectiveVenueInformations = ({
         <CollectiveDmsTimeline
           collectiveDmsApplication={venue.collectiveDmsApplication}
           hasAdageId={venue.hasAdageId}
+          hasAdageIdForMoreThan30Days={hasAdageIdForMoreThan30Days}
         />
       )}
       {shouldEACInformationSection && (


### PR DESCRIPTION
…days

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21068

## But de la pull request

Ajouter le cas dans le suivi DMS pour un lieu avec un adageID depuis plus de 30 jours. 
Pour tester ce cas en local : 
-  Sélectionner la structure eac_complete_30+d (relancer la sandbox, il se peut que le cas nécessaire ne soit pas dans votre jeu de données si vous n'avez pas relancer la sandbox récemment) 
- Vérifier que l'affichage correspond à la maquette (cf: screen ci-dessous) 
- Pour un lieu ajouté il y a moins de 30 jours : eac_complete_30-d

## Screenshot 

![Capture d’écran 2023-04-06 à 11 13 47](https://user-images.githubusercontent.com/71768799/230333768-8b189bef-9209-4264-8a80-a8d8c4633c80.png)

