### PR TITLE
(PC-21570)[PRO] fix: patch offer arg serialization

### DIFF
--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
@@ -145,7 +145,7 @@ describe('updateIndividualOffer', () => {
 
     const expectedBody: PatchOfferBodyModel = {
       audioDisabilityCompliant: true,
-      bookingEmail: null,
+      bookingEmail: undefined,
       description: undefined,
       durationMinutes: undefined,
       externalTicketOfficeUrl: 'https://example.com',

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -93,9 +93,12 @@ export const serializePatchOffer = ({
       sentValues.accessibility[AccessiblityEnum.VISUAL],
     withdrawalType: sentValues.withdrawalType,
     durationMinutes: serializeDurationMinutes(sentValues.durationMinutes || ''),
-    bookingEmail: sentValues.receiveNotificationEmails
-      ? sentValues.bookingEmail
-      : null,
+    bookingEmail:
+      sentValues.receiveNotificationEmails === undefined
+        ? undefined
+        : sentValues.receiveNotificationEmails === false
+        ? null
+        : sentValues.bookingEmail,
     externalTicketOfficeUrl: sentValues.externalTicketOfficeUrl || undefined,
     url: sentValues.url || undefined,
     shouldSendMail: shouldSendMail,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21570

## But de la pull request

La modification du `bookingEmail` n'est pas autorisé pour les offres Allociné, donc il faut le sérialiser en `undefined` quand il n'apparait pas dans le formulaire, càd quand `sentValues.receiveNotificationEmails` vaut `undefined` plutôt que `false`