### PR TITLE
(BSR)[API] fix: offer factory datetime precision

### DIFF
--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -142,7 +142,9 @@ class StockFactory(BaseFactory):
 
     beginningDatetime = factory.Maybe(
         "offer.isEvent",
-        factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=30)),
+        factory.LazyFunction(
+            lambda: datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+        ),
         None,
     )
     bookingLimitDatetime = factory.Maybe(
@@ -158,7 +160,9 @@ class ThingStockFactory(StockFactory):
 
 class EventStockFactory(StockFactory):
     offer = factory.SubFactory(EventOfferFactory)
-    beginningDatetime = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=30))
+    beginningDatetime = factory.LazyFunction(
+        lambda: datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+    )
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
     priceCategory = factory.SubFactory(
         PriceCategoryFactory,


### PR DESCRIPTION
## But de la pull request

Les `*StockFactory` sont utilisés dans nos sandbox mais génèrent des dates trop précises avec des secondes et millisecondes. 

Cette précision n'est pas atteignable en utilisant le front, ce qui amène à une mauvaise reconnaissance des champs qui ont changés comme

```python
    # src/pcapi/core/offers/api.py:610
    if beginning_datetime not in (UNCHANGED, stock.beginningDatetime):
        modifications["beginningDatetime"] = beginning_datetime
```