### PR TITLE
(PC-21428)[API] feat: Link providers to offerers

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-4bec5e4e7ee7 (pre) (head)
-3f4fef666cb4 (post) (head)
+298d82d25d41 (pre) (head)
+7e3cb87c42ec (post) (head)

--- a/api/src/pcapi/alembic/versions/20230418T121413_298d82d25d41_offerer_provider.py
+++ b/api/src/pcapi/alembic/versions/20230418T121413_298d82d25d41_offerer_provider.py
@@ -1,0 +1,28 @@
+"""offerer_provider : table creation (step 1 of 6)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "298d82d25d41"
+down_revision = "4bec5e4e7ee7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "offerer_provider",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("offererId", sa.BigInteger(), nullable=False),
+        sa.Column("providerId", sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.add_column("provider", sa.Column("logoUrl", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("provider", "logoUrl")
+    op.drop_table("offerer_provider")

--- a/api/src/pcapi/alembic/versions/20230418T121548_ed3641db9970_offerer_provider.py
+++ b/api/src/pcapi/alembic/versions/20230418T121548_ed3641db9970_offerer_provider.py
@@ -1,0 +1,30 @@
+"""offerer_provider : create ix_offerer_provider_offererId (step 2 of 6)
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ed3641db9970"
+down_revision = "3f4fef666cb4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_offerer_provider_offererId"
+        ON offerer_provider ("offererId")
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "ix_offerer_provider_offererId"
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20230418T121721_f67ecae084d5_offerer_provider.py
+++ b/api/src/pcapi/alembic/versions/20230418T121721_f67ecae084d5_offerer_provider.py
@@ -1,0 +1,30 @@
+"""offerer_provider : create ix_offerer_provider_providerId (step 3 of 6)
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f67ecae084d5"
+down_revision = "ed3641db9970"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_offerer_provider_providerId"
+        ON offerer_provider ("providerId")
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        """
+        DROP INDEX CONCURRENTLY IF EXISTS "ix_offerer_provider_providerId"
+        """
+    )

--- a/api/src/pcapi/alembic/versions/20230418T121953_fba49261c75f_offerer_provider.py
+++ b/api/src/pcapi/alembic/versions/20230418T121953_fba49261c75f_offerer_provider.py
@@ -1,0 +1,38 @@
+"""offerer_provider : add offerer_provider constraints (step 4 of 6)
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "fba49261c75f"
+down_revision = "f67ecae084d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE offerer_provider ADD CONSTRAINT "offerer_provider_offererId_fkey" FOREIGN KEY ("offererId") REFERENCES "offerer" ("id") ON DELETE CASCADE NOT VALID
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE offerer_provider ADD CONSTRAINT "offerer_provider_providerId_fkey" FOREIGN KEY ("providerId") REFERENCES "provider" ("id") NOT VALID
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE offerer_provider ADD CONSTRAINT "unique_offerer_provider" UNIQUE ("offererId", "providerId");
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE provider DROP CONSTRAINT IF EXISTS "check_provider_has_localclass_or_apiUrl";
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20230418T122206_e9c5ec411702_offerer_provider.py
+++ b/api/src/pcapi/alembic/versions/20230418T122206_e9c5ec411702_offerer_provider.py
@@ -1,0 +1,24 @@
+"""offerer_provider : validate offerer_provider_providerId_fkey (step 5 of 6)
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e9c5ec411702"
+down_revision = "fba49261c75f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute('ALTER TABLE "offerer_provider" VALIDATE CONSTRAINT "offerer_provider_providerId_fkey"')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20230418T122247_7e3cb87c42ec_offerer_provider.py
+++ b/api/src/pcapi/alembic/versions/20230418T122247_7e3cb87c42ec_offerer_provider.py
@@ -1,0 +1,24 @@
+"""offerer_provider : validate offerer_provider_offererId_fkey (step 6 of 6)
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "7e3cb87c42ec"
+down_revision = "e9c5ec411702"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute('ALTER TABLE "offerer_provider" VALIDATE CONSTRAINT "offerer_provider_offererId_fkey"')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -780,3 +780,11 @@ class OffererTagMapping(PcObject, Base, Model):
     tagId: int = Column(BigInteger, ForeignKey("offerer_tag.id", ondelete="CASCADE"), index=True, nullable=False)
 
     __table_args__ = (UniqueConstraint("offererId", "tagId", name="unique_offerer_tag"),)
+
+
+class OffererProvider(PcObject, Base, Model):
+    __tablename__ = "offerer_provider"
+    offererId: int = Column(BigInteger, ForeignKey("offerer.id", ondelete="CASCADE"), index=True, nullable=False)
+    providerId: int = Column(BigInteger, ForeignKey("provider.id"), index=True, nullable=False)
+
+    __table_args__ = (UniqueConstraint("offererId", "providerId", name="unique_offerer_provider"),)

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -42,10 +42,6 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
 
     localClass = Column(
         String(60),
-        CheckConstraint(
-            '("localClass" IS NOT NULL AND "apiUrl" IS NULL) OR ("localClass" IS NULL AND "apiUrl" IS NOT NULL)',
-            name="check_provider_has_localclass_or_apiUrl",
-        ),
         nullable=True,
         unique=True,
     )
@@ -57,11 +53,12 @@ class Provider(PcObject, Base, Model, DeactivableMixin):
 
     enabledForPro: bool = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 
-    pricesInCents: bool = Column(Boolean, nullable=False, default=False, server_default=expression.false())
-
     enableParallelSynchronization: bool = Column(
         Boolean, nullable=False, default=False, server_default=expression.false()
     )
+
+    logoUrl: str = Column(Text(), nullable=True)
+    pricesInCents: bool = Column(Boolean, nullable=False, default=False, server_default=expression.false())
 
     @property
     def isAllocine(self) -> bool:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21428
L'idée est de pouvoir relier un prestataire technique (Provider) à un offerer, c'est une demande légale. La structure associée au provider est celle qui a validée les CGU d'utilisation de l'api.
Une url de logo est ajoutée aux provider, ce logo sera stocké dans un bucket gcp et affiché sur le portail pro