### PR TITLE
(PC-21655)[API] feat: Add CGR password column in CGRCinemaDetails

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-49ed95a60b07 (pre) (head)
+4bec5e4e7ee7 (pre) (head)
 515b8245129f (post) (head)

--- a/api/src/pcapi/alembic/versions/20230411T140035_4bec5e4e7ee7_add_password_to_cgr_cinema_details.py
+++ b/api/src/pcapi/alembic/versions/20230411T140035_4bec5e4e7ee7_add_password_to_cgr_cinema_details.py
@@ -1,0 +1,19 @@
+"""add_password_to_cgr_cinema_details"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "4bec5e4e7ee7"
+down_revision = "49ed95a60b07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("cgr_cinema_details", sa.Column("password", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("cgr_cinema_details", "password")

--- a/api/src/pcapi/connectors/cgr/cgr.py
+++ b/api/src/pcapi/connectors/cgr/cgr.py
@@ -33,7 +33,7 @@ def get_seances_pass_culture(
     if allocine_film_id is not 0 CGR API wil return only shows for concerned movie
     """
     user = settings.CGR_API_USER
-    password = settings.CGR_API_PASSWORD
+    password = cinema_details.password or settings.CGR_API_PASSWORD
     # FIXME(fseguin, 2023-01-26): remove default from settings when FA page and pc pro pages are built
     cinema_url = cinema_details.cinemaUrl or settings.CGR_API_URL
     service = get_cgr_service_proxy(cinema_url)

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -126,6 +126,7 @@ class CGRCinemaDetailsFactory(BaseFactory):
     cinemaProviderPivot = factory.SubFactory(CGRCinemaProviderPivotFactory)
     cinemaUrl = factory.Sequence("https://cgr-cinema-{}.example.com/".format)
     numCinema = factory.Sequence(int)
+    password = "a great password"
 
 
 class AllocineProviderFactory(BaseFactory):

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -320,3 +320,6 @@ class CGRCinemaDetails(PcObject, Base, Model):
     cinemaProviderPivot = relationship(CinemaProviderPivot, foreign_keys=[cinemaProviderPivotId])  # type: ignore [misc]
     cinemaUrl: str = Column(Text, nullable=False)
     numCinema: int = Column(Integer, nullable=True)
+    password: str = Column(
+        Text, nullable=True
+    )  # FIXME (yacine-pc) since we already have a row in production, make this column not nullable later


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21655

## But de la pull request
- Ajouter une colonne `password` dans la table `CGRCinemaDetails`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
