### PR TITLE
(BSR)[API] feat: Betters logs for `synchronize_venue_providers_task`

### DIFF
--- a/api/src/pcapi/alembic/versions/20230407T095241_515b8245129f_remove_old_search_indexes.py
+++ b/api/src/pcapi/alembic/versions/20230407T095241_515b8245129f_remove_old_search_indexes.py
@@ -42,7 +42,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # We need to commit the transaction, because `DROP INDEX
+    # We need to commit the transaction, because `CREATE INDEX
     # CONCURRENTLY` cannot run inside a transaction.
     op.execute("COMMIT")
     for statement in CREATE_STATEMENTS:

--- a/api/src/pcapi/core/providers/commands.py
+++ b/api/src/pcapi/core/providers/commands.py
@@ -38,7 +38,10 @@ def _synchronize_venue_providers_apis() -> None:
                     extra={"provider": provider.name, "venue_provider": venue_provider_id},
                 )
                 tasks.synchronize_venue_providers_task.delay(
-                    tasks.SynchronizeVenueProvidersRequest(venue_provider_ids=[venue_provider_id])
+                    tasks.SynchronizeVenueProvidersRequest(
+                        provider_id=provider.id,
+                        venue_provider_ids=[venue_provider_id],
+                    )
                 )
         else:
             logger.info(
@@ -46,7 +49,10 @@ def _synchronize_venue_providers_apis() -> None:
                 extra={"provider": provider.name, "venue_count": len(venue_provider_ids)},
             )
             tasks.synchronize_venue_providers_task.delay(
-                tasks.SynchronizeVenueProvidersRequest(venue_provider_ids=venue_provider_ids)
+                tasks.SynchronizeVenueProvidersRequest(
+                    provider_id=provider.id,
+                    venue_provider_ids=venue_provider_ids,
+                )
             )
 
 

--- a/api/src/pcapi/core/providers/tasks.py
+++ b/api/src/pcapi/core/providers/tasks.py
@@ -13,11 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class SynchronizeVenueProvidersRequest(BaseModel):
+    provider_id: int
     venue_provider_ids: list[int]
 
 
 @task(settings.GCP_SYNCHRONIZE_VENUE_PROVIDERS_QUEUE_NAME, "/providers/synchronize_venue_providers", task_request_timeout=30 * 60)  # type: ignore [arg-type]
 def synchronize_venue_providers_task(payload: SynchronizeVenueProvidersRequest) -> None:
+    provider_id = payload.provider_id
     venue_provider_ids = payload.venue_provider_ids
     venue_providers = models.VenueProvider.query.filter(models.VenueProvider.id.in_(venue_provider_ids)).all()
 
@@ -25,7 +27,13 @@ def synchronize_venue_providers_task(payload: SynchronizeVenueProvidersRequest) 
         return
 
     start_timer = time.perf_counter()
-    logger.info("Synchronization job started", extra={"venue_providers": venue_provider_ids})
+    logger.info(
+        "Synchronization job started",
+        extra={
+            "providerid": provider_id,
+            "venue_providers": venue_provider_ids,
+        },
+    )
 
     provider_manager.synchronize_venue_providers(venue_providers)
 
@@ -33,7 +41,17 @@ def synchronize_venue_providers_task(payload: SynchronizeVenueProvidersRequest) 
     if duration >= 0.5 * 60 * 60:  # 50% of time between two ProviderAPIsSync cron jobs
         logger.error(
             "Synchronization of venue providers took a long time",
-            extra={"duration": duration, "venue_providers": venue_provider_ids},
+            extra={
+                "provider": provider_id,
+                "duration": duration,
+                "venue_providers": venue_provider_ids,
+            },
         )
 
-    logger.info("Synchronization with provider finished", extra={"duration": duration})
+    logger.info(
+        "Synchronization with provider finished",
+        extra={
+            "provider": provider_id,
+            "duration": duration,
+        },
+    )


### PR DESCRIPTION
The `synchronize_venue_providers_apis` cron enqueues a lot of tasks
within a short time period, generating a lot of same-looking logs that
differ only by the `venue_provider_ids` argument, which is not helpful
if we are looking for a particular provider.