### PR TITLE
(PC-21499)[PRO] feat: Wording corrections de Réinitialisation du MDP

### DIFF
--- a/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
@@ -19,8 +19,7 @@ const ChangePasswordForm = ({ onSubmit }: IChangePasswordForm): JSX.Element => {
   return (
     <section className={styles['change-password-form']}>
       <div className={styles['hero-body']}>
-        <h1>Créer un nouveau mot de passe</h1>
-        <p>Saisissez le nouveau mot de passe</p>
+        <h1>Définir un nouveau mot de passe</h1>
         <FormikProvider value={formik}>
           <Form onSubmit={formik.handleSubmit}>
             <FormLayout>
@@ -28,11 +27,11 @@ const ChangePasswordForm = ({ onSubmit }: IChangePasswordForm): JSX.Element => {
                 <PasswordInput
                   label="Nouveau mot de passe"
                   name="newPasswordValue"
-                  placeholder="Mon nouveau mot de passe"
+                  placeholder="Votre mot de passe"
                 />
               </FormLayout.Row>
               <SubmitButton isLoading={formik.isSubmitting}>
-                Envoyer
+                Valider
               </SubmitButton>
             </FormLayout>
           </Form>

--- a/pro/src/pages/ResetPassword/__specs__/ResetPassword.spec.tsx
+++ b/pro/src/pages/ResetPassword/__specs__/ResetPassword.spec.tsx
@@ -40,7 +40,7 @@ describe('ResetPassword', () => {
         screen.getByLabelText(/Nouveau mot de passe/),
         'MyN3wP4$$w0rd'
       )
-      await userEvent.click(screen.getByText(/Envoyer/))
+      await userEvent.click(screen.getByText(/Valider/))
 
       // he has been redirected to final step
       expect(
@@ -63,7 +63,7 @@ describe('ResetPassword', () => {
         screen.getByLabelText(/Nouveau mot de passe/),
         'MyN3wP4$$w0rd'
       )
-      await userEvent.click(screen.getByText(/Envoyer/))
+      await userEvent.click(screen.getByText(/Valider/))
 
       // he has been redirected to final step
       expect(screen.getByText('Ce lien a expiré !')).toBeInTheDocument()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21499

## But de la pull request

Sur la page de réinitialisation du mot de passe, changer les wording suivants : 

- Remplacer “Créer un nouveau mot de passe” par “Définir un nouveau mot de passe”
- 
- SUPPRIMER la phrase “Saisissez le nouveau mot de passe”
- 
- Remplacer “Mon mot de passe” par “Votre mot de passe”
- 
- Remplacer “Envoyer” par “Valider”


## Informations supplémentaires
<img width="677" alt="Capture d’écran 2023-04-11 à 19 01 14" src="https://user-images.githubusercontent.com/115089249/231385054-02ad719a-ffd2-4e42-b472-e23d0c719e5c.png">


- [ x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-21499-wording-message-password`
  - PR : `(PC-21499) Description rapide de l' US`
  - Commit(s) : `(PC-21499)[PRO] Wording message corrections de mdp.

