### PR TITLE
(PC-21269)[PRO] feat: Wording modification lieu

### DIFF
--- a/pro/src/components/OfferIndividualForm/UsefulInformations/Venue/__specs__/Venue.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/Venue/__specs__/Venue.spec.tsx
@@ -294,7 +294,7 @@ describe('OfferIndividual section: venue', () => {
     )
     await userEvent.selectOptions(selectVenue, 'Venue CCBB')
 
-    await userEvent.selectOptions(selectVenue, 'Selectionner un lieu')
+    await userEvent.selectOptions(selectVenue, 'Sélectionner un lieu')
     await userEvent.tab()
     await waitFor(() =>
       expect(

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/Venue/utils.ts
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/Venue/utils.ts
@@ -50,7 +50,7 @@ export const buildVenueOptions = (
     .sort((a, b) => a.label.localeCompare(b.label, 'fr'))
   if (venueOptions.length !== 1) {
     venueOptions = [
-      { value: '', label: 'Selectionner un lieu' },
+      { value: '', label: 'Sélectionner un lieu' },
       ...venueOptions,
     ]
   }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21269

## But de la pull request

Sur la page de création d’offre corriger le texte du place holder
 :cross_mark: “Selectionner un lieu” par 
:check_mark:  “Sélectionner un lieu”
<img width="540" alt="Capture d’écran 2023-04-12 à 11 46 13" src="https://user-images.githubusercontent.com/115089249/231422889-4f6085b4-07b1-4128-b54a-792ca0873a25.png">


## Checklist :

- [ x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-21269-wording-offre-creation`
  - PR : `(PC-21269)[PRO] feat: Wording modification lieu`
  - Commit(s) : `(PC-21269)[PRO] feat: Wording modification lieu`

