### PR TITLE
(BSR)[PRO] fix: dehumanize /collective/offers call

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -75,7 +75,9 @@ const OfferType = (): JSX.Element => {
       const apiFilters = {
         ...DEFAULT_SEARCH_FILTERS,
         collectiveOfferType: COLLECTIVE_OFFER_SUBTYPE.TEMPLATE.toLowerCase(),
-        offererId: queryOffererId ?? 'all',
+        offererId: queryOffererId
+          ? dehumanizeId(queryOffererId)?.toString() || 'all'
+          : 'all',
         venueId: queryVenueId ?? 'all',
       }
       const { isOk, message, payload } =


### PR DESCRIPTION
Après avoir déshumanisé la route "/collective/offers" il restait un appel sur le hub de création d'offre