### PR TITLE
(PC-21296)[PRO] feat: disable limite date lower than creation date

### DIFF
--- a/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/FormStock.tsx
@@ -20,11 +20,13 @@ export interface IFormStockProps {
   mode: Mode
   disablePriceAndParticipantInputs: boolean
   preventPriceIncrease: boolean
+  offerDateCreated: string
 }
 
 const FormStock = ({
   mode,
   disablePriceAndParticipantInputs,
+  offerDateCreated,
 }: IFormStockProps): JSX.Element => {
   const { values, setFieldValue } =
     useFormikContext<OfferEducationalStockFormValues>()
@@ -70,6 +72,7 @@ const FormStock = ({
       <DatePicker
         disabled={mode === Mode.READ_ONLY}
         label={BOOKING_LIMIT_DATETIME_LABEL}
+        minDateTime={new Date(offerDateCreated)}
         maxDateTime={values.eventDate ? values.eventDate : undefined}
         name="bookingLimitDatetime"
         smallLabel

--- a/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/FormStock/__specs__/FormStock.spec.tsx
@@ -51,6 +51,7 @@ describe('TimePicker', () => {
       mode: Mode.CREATION,
       disablePriceAndParticipantInputs: false,
       preventPriceIncrease: false,
+      offerDateCreated: '2023-04-06T13:48:36.304896Z',
     }
     initialValues = {
       eventDate: '',
@@ -81,6 +82,7 @@ describe('TimePicker', () => {
         mode: Mode.EDITION,
         disablePriceAndParticipantInputs: false,
         preventPriceIncrease: false,
+        offerDateCreated: '2023-04-06T13:48:36.304896Z',
       },
     })
 
@@ -102,6 +104,7 @@ describe('TimePicker', () => {
         mode: Mode.READ_ONLY,
         disablePriceAndParticipantInputs: true,
         preventPriceIncrease: true,
+        offerDateCreated: '2023-04-06T13:48:36.304896Z',
       },
     })
 
@@ -120,6 +123,7 @@ describe('TimePicker', () => {
         mode: Mode.READ_ONLY,
         disablePriceAndParticipantInputs: false,
         preventPriceIncrease: true,
+        offerDateCreated: '2023-04-06T13:48:36.304896Z',
       },
     })
 

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -182,6 +182,7 @@ const OfferEducationalStock = <
                       disablePriceAndParticipantInputs
                     }
                     preventPriceIncrease={preventPriceIncrease}
+                    offerDateCreated={offer.dateCreated}
                   />
                 </>
               )}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21296

## But de la pull request

Il faut que la date limite de réservation ne puisse pas avoir de date inférieur à la date de création de l'offre

La date de création pour ce screen `06/04/2023` : 

<img width="243" alt="Capture d’écran 2023-04-12 à 15 07 41" src="https://user-images.githubusercontent.com/119043808/231467240-f63d621e-05dc-4527-bdff-cf9057ef6d1b.png">

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
