### PR TITLE
(PC-21055)[PRO] feat: change wording deactive offer popin

### DIFF
--- a/pro/src/pages/Offers/Offers/ActionsBar/ActionsBar.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ActionsBar.tsx
@@ -211,6 +211,7 @@ const ActionsBar = ({
           nbSelectedOffers={nbSelectedOffers}
           onConfirm={handleDeactivate}
           onCancel={hideConfirmDialog}
+          audience={audience}
         />
       )}
       {isDeleteDialogOpen && (

--- a/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/DeactivationConfirmDialog.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/DeactivationConfirmDialog.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 
 import ConfirmDialog from 'components/Dialog/ConfirmDialog'
 import { Events } from 'core/FirebaseEvents/constants'
-import { NBSP } from 'core/shared'
+import { Audience, NBSP } from 'core/shared'
 import useAnalytics from 'hooks/useAnalytics'
 import { ReactComponent as EyeIcon } from 'icons/ico-eye-hidden.svg'
 
@@ -12,6 +12,7 @@ interface IDeactivationConfirmDialogProps {
   nbSelectedOffers: number
   onCancel: (status: boolean) => void
   onConfirm: () => void
+  audience: Audience
 }
 
 const DeactivationConfirmDialog = ({
@@ -19,9 +20,15 @@ const DeactivationConfirmDialog = ({
   onCancel,
   nbSelectedOffers,
   onConfirm,
+  audience,
 }: IDeactivationConfirmDialogProps): JSX.Element => {
   const { logEvent } = useAnalytics()
   const location = useLocation()
+
+  const wordingVisibilityOffer =
+    audience === Audience.COLLECTIVE
+      ? 'par les enseignants sur adage'
+      : 'sur l’application pass Culture'
 
   return (
     <ConfirmDialog
@@ -54,8 +61,8 @@ const DeactivationConfirmDialog = ({
       }
     >
       {nbSelectedOffers === 1
-        ? 'Dans ce cas, elle ne sera plus visible sur l’application pass Culture.'
-        : 'Dans ce cas, elles ne seront plus visibles sur l’application pass Culture.'}
+        ? `Dans ce cas, elle ne sera plus visible ${wordingVisibilityOffer}.`
+        : `Dans ce cas, elles ne seront plus visibles ${wordingVisibilityOffer}.`}
     </ConfirmDialog>
   )
 }

--- a/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/DeactivationConfirmDialog.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/DeactivationConfirmDialog.tsx
@@ -7,7 +7,7 @@ import { Audience, NBSP } from 'core/shared'
 import useAnalytics from 'hooks/useAnalytics'
 import { ReactComponent as EyeIcon } from 'icons/ico-eye-hidden.svg'
 
-interface IDeactivationConfirmDialogProps {
+export interface IDeactivationConfirmDialogProps {
   areAllOffersSelected: boolean
   nbSelectedOffers: number
   onCancel: (status: boolean) => void

--- a/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/__specs__/DeactivationConfirmDialog.spec.tsx
+++ b/pro/src/pages/Offers/Offers/ActionsBar/ConfirmDialog/DeactivationConfirmDialog/__specs__/DeactivationConfirmDialog.spec.tsx
@@ -1,0 +1,76 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { Audience } from 'core/shared'
+import { renderWithProviders } from 'utils/renderWithProviders'
+
+import DeactivationConfirmDialog, {
+  IDeactivationConfirmDialogProps,
+} from '../DeactivationConfirmDialog'
+
+const renderDeactivationConfirmDialog = ({
+  ...props
+}: IDeactivationConfirmDialogProps) => {
+  renderWithProviders(<DeactivationConfirmDialog {...props} />)
+}
+
+describe('DeactivationConfirmDialog', () => {
+  const onCancelDialogMock = jest.fn()
+  const onConfirmDialogMock = jest.fn()
+  const props = {
+    areAllOffersSelected: false,
+    onCancel: onCancelDialogMock,
+    nbSelectedOffers: 0,
+    onConfirm: onConfirmDialogMock,
+    audience: Audience.COLLECTIVE,
+  }
+
+  it('should called onCancel button onclick', async () => {
+    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 1 })
+
+    const onCancelButton = screen.getByText('Annuler')
+    await userEvent.click(onCancelButton)
+    expect(onCancelDialogMock).toHaveBeenCalled()
+  })
+
+  it('should called onConfirm button onclick', async () => {
+    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 1 })
+
+    const onConfirmButton = screen.getByText('Désactiver')
+    await userEvent.click(onConfirmButton)
+    expect(onConfirmDialogMock).toHaveBeenCalled()
+  })
+
+  it('should render text for one offer', async () => {
+    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 1 })
+
+    expect(
+      screen.getByText(/Vous avez sélectionné 1 offre/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/êtes-vous sûr de vouloir la désactiver ?/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Dans ce cas, elle ne sera plus visible par les enseignants sur adage/
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should render text for multiple offers', async () => {
+    renderDeactivationConfirmDialog({ ...props, nbSelectedOffers: 2 })
+
+    expect(
+      screen.getByText(/Vous avez sélectionné 2 offres/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/êtes-vous sûr de vouloir toutes les désactiver ?/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Dans ce cas, elles ne seront plus visibles par les enseignants sur adage./
+      )
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21022

## But de la pull request

Changer le wording de la popin lorsqu'on souhaite désactiver une offre ou plusieurs offres collectives depuis la page de liste d'offre

Avant : 

<img width="548" alt="Capture d’écran 2023-04-12 à 15 34 45" src="https://user-images.githubusercontent.com/119043808/231474407-1699f8be-48cb-4267-8c28-2a40c95a2a17.png">

<img width="548" alt="Capture d’écran 2023-04-12 à 15 34 57" src="https://user-images.githubusercontent.com/119043808/231474459-3bc53564-d582-4af5-9c41-2a06d64c0577.png">


Après : 

<img width="548" alt="Capture d’écran 2023-04-12 à 15 34 11" src="https://user-images.githubusercontent.com/119043808/231474245-3d563488-34c5-421b-b8c0-7c002a962fcc.png">

<img width="548" alt="Capture d’écran 2023-04-12 à 15 34 22" src="https://user-images.githubusercontent.com/119043808/231474306-0cbae673-93ba-4f31-8864-f1bccaa3e430.png">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
