### PR TITLE
(PC-21605)[PRO] feat: check none accessibility checkbox

### DIFF
--- a/pro/src/core/Venue/adapters/__specs__/useGetVenue.spec.ts
+++ b/pro/src/core/Venue/adapters/__specs__/useGetVenue.spec.ts
@@ -67,6 +67,10 @@ describe('useGetVenue', () => {
       collectiveWebsite: '',
       hasAdageId: false,
       collectiveDmsApplications: [],
+      visualDisabilityCompliant: false,
+      mentalDisabilityCompliant: false,
+      audioDisabilityCompliant: false,
+      motorDisabilityCompliant: false,
     }
 
     jest.spyOn(api, 'getVenue').mockResolvedValue(apiVenue)

--- a/pro/src/core/Venue/adapters/getVenueAdapter/serializers.ts
+++ b/pro/src/core/Venue/adapters/getVenueAdapter/serializers.ts
@@ -13,7 +13,14 @@ export const serializeVenueApi = (venue: GetVenueResponseModel): IVenue => {
     [AccessiblityEnum.MENTAL]: venue.mentalDisabilityCompliant || false,
     [AccessiblityEnum.AUDIO]: venue.audioDisabilityCompliant || false,
     [AccessiblityEnum.MOTOR]: venue.motorDisabilityCompliant || false,
+    [AccessiblityEnum.NONE]: [
+      venue.visualDisabilityCompliant,
+      venue.mentalDisabilityCompliant,
+      venue.audioDisabilityCompliant,
+      venue.motorDisabilityCompliant,
+    ].every(accessibility => accessibility === false),
   }
+
   /* istanbul ignore next: DEBT, TO FIX */
   return {
     demarchesSimplifieesApplicationId:
@@ -26,11 +33,7 @@ export const serializeVenueApi = (venue: GetVenueResponseModel): IVenue => {
     reimbursementPointId: venue.reimbursementPointId || null,
     nonHumanizedId: venue.nonHumanizedId || 0,
     pricingPoint: venue.pricingPoint || null,
-    accessibility: {
-      ...venueAccessibility,
-      [AccessiblityEnum.NONE]:
-        !Object.values(venueAccessibility).includes(true),
-    },
+    accessibility: venueAccessibility,
     address: venue.address || '',
     bannerMeta: venue.bannerMeta
       ? serializeBannerMetaApi(venue.bannerMeta)

--- a/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
@@ -142,6 +142,46 @@ describe('route VenueEdition', () => {
     expect(venuePublicName).toBeInTheDocument()
   })
 
+  it('should check none accessibility', async () => {
+    jest.spyOn(api, 'getVenue').mockResolvedValueOnce({
+      ...venue,
+      visualDisabilityCompliant: false,
+      mentalDisabilityCompliant: false,
+      audioDisabilityCompliant: false,
+      motorDisabilityCompliant: false,
+    })
+
+    renderVenueEdition(venue.nonHumanizedId, offerer.nonHumanizedId)
+
+    await screen.findByRole('heading', {
+      name: 'Cinéma des iles',
+    })
+
+    expect(
+      screen.getByLabelText('Non accessible', { exact: false })
+    ).toBeChecked()
+  })
+
+  it('should not check none accessibility if every accessibility parameters are null', async () => {
+    jest.spyOn(api, 'getVenue').mockResolvedValueOnce({
+      ...venue,
+      visualDisabilityCompliant: null,
+      mentalDisabilityCompliant: null,
+      audioDisabilityCompliant: null,
+      motorDisabilityCompliant: null,
+    })
+
+    renderVenueEdition(venue.nonHumanizedId, offerer.nonHumanizedId)
+
+    await screen.findByRole('heading', {
+      name: 'Cinéma des iles',
+    })
+
+    expect(
+      screen.getByLabelText('Non accessible', { exact: false })
+    ).not.toBeChecked()
+  })
+
   it('should return to home when not able to get venue informations', async () => {
     jest.spyOn(api, 'getVenue').mockRejectedValue(
       new ApiError(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21605

## But de la pull request

- Ne pas cocher la case "Non accessible" par défaut lorsque les autres accessibilités sont null par défaut.

Lors du nouveau parcours d'onboarding, on crée les accessibilités d'une structure avec toutes les valeurs à None, on ne veut donc pas que la checkbox "Non accessible" soit coché alors que l'utilisateur n'a pas encore choisi.

## Implémentation

- Si tous les champs d'accessibilités sont à false, on coche la case "Non accessible"
- Sinon, on ne coche pas de case d'accessibilité, ou seulement celles à true.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
