### PR TITLE
(PC-21567)[PRO] feat: handle dropped by dms status

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
@@ -49,3 +49,16 @@
     gap: rem.torem(10px);
   }
 }
+
+.refused-state {
+  display: flex;
+  align-items: center;
+  margin-bottom: rem.torem(16px);
+  gap: rem.torem(10px);
+
+  &-icon {
+    fill: colors.$red-warning;
+    width: rem.torem(16px);
+    height: rem.torem(16px);
+  }
+}

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
 import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
-import { ExternalLinkIcon, PenIcon, ValidCircleIcon } from 'icons'
+import {
+  ExternalLinkIcon,
+  PenIcon,
+  ValidCircleIcon,
+  InfoWrongIcon,
+} from 'icons'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import Timeline, { TimelineStepType } from 'ui-kit/Timeline/Timeline'
@@ -248,6 +253,41 @@ const CollectiveDmsTimeline = ({
       </>
     ),
   }
+  const droppedByDms = (
+    <>
+      <div className={styles['refused-state']}>
+        <InfoWrongIcon className={styles['refused-state-icon']} />
+        <span>Votre demande de référencement a été classée sans suite</span>
+      </div>
+      <div>
+        Nous vous invitons à consulter votre messagerie sur Démarches
+        Simplifiées afin d’en savoir plus.
+        <div className={styles['timeline-step-button']}>
+          <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            link={{
+              to: collectiveDmsApplicationLink,
+              isExternal: true,
+            }}
+            Icon={ExternalLinkIcon}
+          >
+            Consulter ma messagerie sur Démarches Simplifiées
+          </ButtonLink>
+        </div>
+      </div>
+    </>
+  )
+  if (
+    hasAdageId &&
+    collectiveDmsApplication.state !== DMSApplicationstatus.ACCEPTE
+  ) {
+    return (
+      <div className={styles['timeline-added-in-adage']}>
+        <ValidCircleIcon />
+        <span>Ce lieu est référencé sur ADAGE</span>
+      </div>
+    )
+  }
 
   switch (collectiveDmsApplication.state) {
     case DMSApplicationstatus.EN_CONSTRUCTION:
@@ -297,6 +337,7 @@ const CollectiveDmsTimeline = ({
           />
         )
       }
+
       return (
         <div className={styles['timeline-added-in-adage']}>
           <ValidCircleIcon />
@@ -305,6 +346,8 @@ const CollectiveDmsTimeline = ({
       )
     case DMSApplicationstatus.REFUSE:
       return <Timeline steps={[refusedByDms]} />
+    case DMSApplicationstatus.SANS_SUITE:
+      return droppedByDms
     default:
       throw new Error('Invalid dms status')
   }

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { DMSApplicationForEAC, DMSApplicationstatus } from 'apiClient/v1'
 import {
-  ExternalLinkIcon,
+  ExternalSiteIcon,
   PenIcon,
   ValidCircleIcon,
   InfoWrongIcon,
@@ -75,7 +75,7 @@ const CollectiveDmsTimeline = ({
             to: collectiveDmsApplicationLink,
             isExternal: true,
           }}
-          Icon={ExternalLinkIcon}
+          Icon={ExternalSiteIcon}
         >
           Modifier mon dossier sur Démarches Simplifiées
         </ButtonLink>
@@ -104,7 +104,7 @@ const CollectiveDmsTimeline = ({
             to: collectiveDmsApplicationLink,
             isExternal: true,
           }}
-          Icon={ExternalLinkIcon}
+          Icon={ExternalSiteIcon}
         >
           Consulter ma messagerie sur Démarches Simplifiées
         </ButtonLink>
@@ -143,7 +143,7 @@ const CollectiveDmsTimeline = ({
             to: collectiveDmsApplicationLink,
             isExternal: true,
           }}
-          Icon={ExternalLinkIcon}
+          Icon={ExternalSiteIcon}
         >
           Consulter ma messagerie sur Démarches Simplifiées
         </ButtonLink>
@@ -224,35 +224,32 @@ const CollectiveDmsTimeline = ({
     ),
   }
 
-  const refusedByDms = {
-    type: TimelineStepType.REFUSED,
-    content: (
-      <>
-        <div className={styles['timeline-step-title']}>
-          Votre demande de référencement a été refusée
+  const refusedByDms = (
+    <>
+      <div className={styles['refused-state']}>
+        <InfoWrongIcon className={styles['refused-state-icon']} />
+        <span>Votre demande de référencement a été refusée</span>
+      </div>
+      <div>
+        Votre dossier a été refusé le {processingDate} par la commission
+        régionale DAAC et DRAC de la région où est déclaré votre siège social.
+        Nous vous invitons à consulter votre messagerie sur Démarches
+        Simplifiées afin d’en savoir plus sur les raisons de ce refus.
+        <div className={styles['timeline-step-button']}>
+          <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            link={{
+              to: collectiveDmsApplicationLink,
+              isExternal: true,
+            }}
+            Icon={ExternalSiteIcon}
+          >
+            Consulter ma messagerie sur Démarches Simplifiées
+          </ButtonLink>
         </div>
-        <div>
-          <br />
-          Votre dossier a été refusé le {processingDate} par la commission
-          régionale DAAC et DRAC de la région où est déclaré votre siège social.
-          Nous vous invitons à consulter votre messagerie sur Démarches
-          Simplifiées afin d’en savoir plus sur les raisons de ce refus.
-          <div className={styles['timeline-step-button']}>
-            <ButtonLink
-              variant={ButtonVariant.TERNARY}
-              link={{
-                to: collectiveDmsApplicationLink,
-                isExternal: true,
-              }}
-              Icon={ExternalLinkIcon}
-            >
-              Consulter ma messagerie sur Démarches Simplifiées
-            </ButtonLink>
-          </div>
-        </div>
-      </>
-    ),
-  }
+      </div>
+    </>
+  )
   const droppedByDms = (
     <>
       <div className={styles['refused-state']}>
@@ -269,7 +266,7 @@ const CollectiveDmsTimeline = ({
               to: collectiveDmsApplicationLink,
               isExternal: true,
             }}
-            Icon={ExternalLinkIcon}
+            Icon={ExternalSiteIcon}
           >
             Consulter ma messagerie sur Démarches Simplifiées
           </ButtonLink>
@@ -345,9 +342,10 @@ const CollectiveDmsTimeline = ({
         </div>
       )
     case DMSApplicationstatus.REFUSE:
-      return <Timeline steps={[refusedByDms]} />
+      return refusedByDms
     case DMSApplicationstatus.SANS_SUITE:
       return droppedByDms
+    /* istanbul ignore next: we dont want to test this case in unit test */
     default:
       throw new Error('Invalid dms status')
   }

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -84,6 +84,21 @@ describe('CollectiveDmsTimeline', () => {
       hasAdageIdForMoreThan30Days: true,
       expectedLabel: 'Ce lieu est référencé sur ADAGE',
     },
+    {
+      collectiveDmsApplication: {
+        ...defaultCollectiveDmsApplication,
+        state: DMSApplicationstatus.EN_CONSTRUCTION,
+      },
+      hasAdageId: true,
+      expectedLabel: 'Ce lieu est référencé sur ADAGE',
+    },
+    {
+      collectiveDmsApplication: {
+        ...defaultCollectiveDmsApplication,
+        state: DMSApplicationstatus.SANS_SUITE,
+      },
+      expectedLabel: 'Votre demande de référencement a été classée sans suite',
+    },
   ]
   it.each(testCases)(
     'should render %s status',

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -1,6 +1,7 @@
 import { addDays, isBefore } from 'date-fns'
 import React from 'react'
 
+import { DMSApplicationstatus } from 'apiClient/v1'
 import FormLayout from 'components/FormLayout'
 import { IVenue } from 'core/Venue'
 
@@ -29,12 +30,18 @@ const CollectiveVenueInformations = ({
     (!venue?.adageInscriptionDate && canCreateCollectiveOffer) ||
     isCreatingVenue
 
+  const hasRefusedDmsApplication =
+    venue?.collectiveDmsApplication?.state === DMSApplicationstatus.REFUSE ||
+    venue?.collectiveDmsApplication?.state === DMSApplicationstatus.SANS_SUITE
+
   return (
     <FormLayout.Section
       title="A destination des scolaires"
       id="for-schools"
       description={
-        venue?.hasAdageId || canCreateCollectiveOffer
+        venue?.hasAdageId ||
+        canCreateCollectiveOffer ||
+        hasRefusedDmsApplication
           ? ''
           : 'Pour publier des offres à destination des scolaires, votre lieu doit être référencé sur ADAGE, la plateforme dédiée aux enseignants et aux chefs d’établissements.'
       }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21567

## But de la pull request

Afficher un message indiquant que la demande a été classée sans suite le cas échéant. 

BSR : Si le lieu à une démarche en cours (non acceptée) mais possède déjà un adageId, on affiche un message en ce sens et non plus la timeline 

## Screenshot 

Cas classée sans suite 

![Capture d’écran 2023-04-13 à 14 18 06](https://user-images.githubusercontent.com/71768799/231755940-bebe14cc-5f83-458d-a04a-d1f46d2388b3.png)

## Test 

Choisir la structure `eac_sans_suite` puis modifier le lieu `accepted_dms eac_sans_suite`


