### PR TITLE
(PC-21739)[PRO] fix: only distinct price categories are allowed in event reccurency Form

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksEventCreation/RecurrenceForm.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventCreation/RecurrenceForm.tsx
@@ -260,22 +260,24 @@ export const RecurrenceForm = ({
                       </FormLayout.Row>
                     )
                   )}
-
-                  <ButtonLink
-                    variant={ButtonVariant.TERNARY}
-                    Icon={PlusCircleIcon}
-                    onClick={() =>
-                      arrayHelpers.push(INITIAL_QUANTITY_PER_PRICE_CATEGORY)
-                    }
-                    link={{
-                      to: `#quantityPerPriceCategories[${
-                        values.quantityPerPriceCategories.length - 1
-                      }].quantity`,
-                      isExternal: true,
-                    }}
-                  >
-                    Ajouter d’autres places et tarifs
-                  </ButtonLink>
+                  {values.quantityPerPriceCategories.length <
+                    priceCategoryOptions.length && (
+                    <ButtonLink
+                      variant={ButtonVariant.TERNARY}
+                      Icon={PlusCircleIcon}
+                      onClick={() =>
+                        arrayHelpers.push(INITIAL_QUANTITY_PER_PRICE_CATEGORY)
+                      }
+                      link={{
+                        to: `#quantityPerPriceCategories[${
+                          values.quantityPerPriceCategories.length - 1
+                        }].quantity`,
+                        isExternal: true,
+                      }}
+                    >
+                      Ajouter d’autres places et tarifs
+                    </ButtonLink>
+                  )}
                 </>
               )}
             />

--- a/pro/src/screens/OfferIndividual/StocksEventCreation/__specs__/RecurrenceForm.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventCreation/__specs__/RecurrenceForm.spec.tsx
@@ -5,7 +5,10 @@ import React from 'react'
 
 import { Events } from 'core/FirebaseEvents/constants'
 import * as useAnalytics from 'hooks/useAnalytics'
-import { individualOfferFactory } from 'utils/individualApiFactories'
+import {
+  individualOfferFactory,
+  priceCategoryFactory,
+} from 'utils/individualApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import { RecurrenceForm } from '../RecurrenceForm'
@@ -96,20 +99,25 @@ describe('RecurrenceForm', () => {
     ).toBeDisabled()
   })
 
-  it('should add and remove a price category', async () => {
+  it('should show an add button until we have less or an equal number of fields than different price_categories', async () => {
+    defaultProps.offer.priceCategories = [
+      priceCategoryFactory(),
+      priceCategoryFactory(),
+      priceCategoryFactory(),
+    ]
     renderWithProviders(<RecurrenceForm {...defaultProps} />)
 
-    expect(
-      screen.getByRole('button', { name: 'Supprimer les places' })
-    ).toBeDisabled()
-
     await userEvent.click(screen.getByText('Ajouter d’autres places et tarifs'))
-
     const deleteButton = screen.getAllByRole('button', {
       name: 'Supprimer les places',
     })[0]
     expect(deleteButton).toBeEnabled()
+    await userEvent.click(screen.getByText('Ajouter d’autres places et tarifs'))
+    expect(
+      screen.queryByText('Ajouter d’autres places et tarifs')
+    ).not.toBeInTheDocument()
 
+    await userEvent.click(deleteButton)
     await userEvent.click(deleteButton)
 
     expect(

--- a/pro/src/screens/OfferIndividual/StocksEventCreation/form/validationSchema.ts
+++ b/pro/src/screens/OfferIndividual/StocksEventCreation/form/validationSchema.ts
@@ -32,14 +32,43 @@ export const getValidationSchema = (priceCategoriesOptions: SelectOption[]) =>
     beginningTimes: yup
       .array()
       .of(yup.string().nullable().required('Veuillez renseigner un horaire')),
-    quantityPerPriceCategories: yup.array().of(
-      yup.object().shape({
-        quantity: yup.number(),
-        priceCategory: oneOfSelectOption(
-          yup.string().required('Veuillez renseigner un tarif'),
-          priceCategoriesOptions
-        ),
-      })
-    ),
+    quantityPerPriceCategories: yup
+      .array()
+      .of(
+        yup.object().shape({
+          quantity: yup.number(),
+          priceCategory: oneOfSelectOption(
+            yup.string().required('Veuillez renseigner un tarif'),
+            priceCategoriesOptions
+          ),
+        })
+      )
+      .test('isPriceCategoryUnique', function (list) {
+        if (!list) return
+        const price_category_map = list.map(a => a.priceCategory)
+        const duplicateIndex = price_category_map.reduce<yup.ValidationError[]>(
+          (ac, a, i) => {
+            if (
+              price_category_map.indexOf(a) !==
+              price_category_map.lastIndexOf(a)
+            ) {
+              ac.push(
+                new yup.ValidationError(
+                  'Veuillez renseigner des tarifs différents',
+                  null,
+                  `quantityPerPriceCategories[${i}].priceCategory`
+                )
+              )
+            }
+            return ac
+          },
+          []
+        )
+
+        if (duplicateIndex) {
+          return new yup.ValidationError(duplicateIndex)
+        }
+        return true
+      }),
     bookingLimitDateInterval: yup.number(),
   })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21739

Une incompréhension a mené a des stocks créés en plusieurs fois, petit fix et amélioration pour que l'utilisateur comprenne qu'il faut des catégories de prix différentes.
- Ajout d'une erreur sur le champ Tarif (le screen le montre pas mais l'erreur est sur les 2 champs)
- Cacher le bouton "Ajouter d'autres places et tarifs" quand le nombre de tarif séléctionnés est = au nombre de tarif dispo
<img width="839" alt="Screenshot 2023-04-13 at 14 17 25" src="https://user-images.githubusercontent.com/95358853/231755701-3a1289cd-e386-4c15-8b10-3a23859c79fc.png">
