### PR TITLE
(PC-21757) fix(ci): Tag version should be get if version failed

### DIFF
--- a/.github/workflows/release--deploy.yml
+++ b/.github/workflows/release--deploy.yml
@@ -108,7 +108,7 @@ jobs:
                             "author_icon": "https://github.com/${{github.actor}}.png",
                             "title": "PCAPI Deployment",
                             "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                            "text": "Le déploiement de la version `v${{ needs.version.outputs.APP_VERSION }}` a ${{ fromJSON('["réussi", "échoué"]')[env.WORKFLOW_CONCLUSION == 'failure'] }} sur `${{ github.event.inputs.target_environment }}` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
+                            "text": "Le déploiement de la version `${{ github.ref_name }}` a ${{ fromJSON('["réussi", "échoué"]')[env.WORKFLOW_CONCLUSION == 'failure'] }} sur `${{ github.event.inputs.target_environment }}` ${{ fromJSON('[":muscle:", ":boom:"]')[env.WORKFLOW_CONCLUSION == 'failure'] }}"
                         }
                     ],
                     "unfurl_links": false,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21757
## But de la pull request

Si le job "version" failed aucun output n'est donné au channel Slack, la version du tag n'est alors pas fourni sur le channel voulu

## Implémentation

Utiliser la variable fournie par github directement

