### PR TITLE
(PC-21616)[PRO] refactor: sign up title wording and field order

### DIFF
--- a/pro/src/pages/Signup/SignupContainer/SignupContainer.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupContainer.tsx
@@ -134,7 +134,7 @@ const SignupContainer = (): JSX.Element => {
     <section className={styles['sign-up-form-page']}>
       {visible && <MaybeAppUserDialog onCancel={hideModal} />}
       <div className={styles['content']}>
-        <h1>Créer votre compte professionnel</h1>
+        <h1>Créer votre compte</h1>
         <OperatingProcedures />
 
         <div className={styles['sign-up-tips']}>

--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -64,6 +64,16 @@ const SignupForm = (): JSX.Element => {
     <FormLayout>
       <div className={styles['sign-up-form']}>
         <FormLayout.Row>
+          <TextInput label="Nom" name="lastName" placeholder="Votre nom" />
+        </FormLayout.Row>
+        <FormLayout.Row>
+          <TextInput
+            label="Prénom"
+            name="firstName"
+            placeholder="Votre prénom"
+          />
+        </FormLayout.Row>
+        <FormLayout.Row>
           <EmailSpellCheckInput
             name="email"
             placeholder="email@exemple.com"
@@ -76,16 +86,6 @@ const SignupForm = (): JSX.Element => {
             label="Mot de passe"
             placeholder="Votre mot de passe"
             withErrorPreview={true}
-          />
-        </FormLayout.Row>
-        <FormLayout.Row>
-          <TextInput label="Nom" name="lastName" placeholder="Votre nom" />
-        </FormLayout.Row>
-        <FormLayout.Row>
-          <TextInput
-            label="Prénom"
-            name="firstName"
-            placeholder="Votre prénom"
           />
         </FormLayout.Row>
         <FormLayout.Row>

--- a/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
+++ b/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
@@ -82,7 +82,7 @@ describe('Signup', () => {
       // then it should have a title
       expect(
         screen.getByRole('heading', {
-          name: /Créer votre compte professionnel/,
+          name: /Créer votre compte/,
         })
       ).toBeInTheDocument()
       // and an external link to the help center

--- a/pro/src/pages/Signup/__specs__/Signup.spec.tsx
+++ b/pro/src/pages/Signup/__specs__/Signup.spec.tsx
@@ -41,7 +41,7 @@ describe('src | components | pages | Signup', () => {
 
     // then
     expect(
-      screen.getByRole('heading', { name: /Créer votre compte professionnel/ })
+      screen.getByRole('heading', { name: /Créer votre compte/ })
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21616

## But de la pull request

- Wording titre page : Créer votre compte professionnel → Créer votre compte
- Ordre des champs (faire remonter Nom et prénom avant) : 
        Nom
        Prénom
        Adresse mail
        Mot de passe
        Téléphone

## Implémentation

### Avant
![image](https://user-images.githubusercontent.com/106379750/231795856-87863c0f-77fa-49d3-8ec0-581537f4f7ba.png)

### Après
![image](https://user-images.githubusercontent.com/106379750/231795581-549b18d2-2fa6-4c43-8b5a-a39653661bf2.png)
