### PR TITLE
(PC-21619)[PRO] feat: wording and add link to new onboarding offerer page banner

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
@@ -2,6 +2,7 @@
 
 .offerer-layout {
   margin: auto;
+  padding-bottom: rem.torem(24px);
 }
 
 .siret-banner {

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.module.scss
@@ -2,7 +2,6 @@
 
 .offerer-layout {
   margin: auto;
-  margin-bottom: rem.torem(24px);
 }
 
 .siret-banner {

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -76,11 +76,22 @@ const Offerer = (): JSX.Element => {
       <FormikProvider value={formik}>
         <form onSubmit={formik.handleSubmit} data-testid="signup-offerer-form">
           <OffererForm />
-          <Banner type="notification-info" className={styles['siret-banner']}>
-            <strong>Votre structure dépend d’un autre SIRET ?</strong>
+          <Banner
+            type="notification-info"
+            className={styles['siret-banner']}
+            links={[
+              {
+                href: 'https://aide.passculture.app/hc/fr/articles/4633420022300--Acteurs-Culturels-Collectivit%C3%A9-Lieu-rattach%C3%A9-%C3%A0-une-collectivit%C3%A9-S-inscrire-et-param%C3%A9trer-son-compte-pass-Culture-',
+                linkTitle: 'En savoir plus',
+              },
+            ]}
+          >
+            <strong>
+              Vous êtes un équipement d’une collectivité ou d'un établissement
+              public ?
+            </strong>
             <p className={styles['banner-content-info']}>
-              Renseignez le SIRET de la collectivité, de la régie ou de
-              l’établissement public auquel vous êtes rattaché.
+              Renseignez le SIRET de la structure à laquelle vous êtes rattaché.
             </p>
           </Banner>
           <ActionBar

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -111,7 +111,9 @@ describe('screens:SignupJourney::Offerer', () => {
     renderOffererScreen(contextValue)
 
     expect(
-      await screen.findByText('Renseignez le SIRET de votre structure')
+      await screen.findByText(
+        'Renseignez le SIRET de la structure à laquelle vous êtes rattaché.'
+      )
     ).toBeInTheDocument()
     expect(
       await screen.findByRole('button', { name: 'Continuer' })
@@ -121,7 +123,13 @@ describe('screens:SignupJourney::Offerer', () => {
     ).not.toBeInTheDocument()
 
     expect(
-      await screen.getByText('Votre structure dépend d’un autre SIRET ?')
+      await screen.getByText(
+        "Vous êtes un équipement d’une collectivité ou d'un établissement public ?"
+      )
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: 'En savoir plus' })
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21619

## But de la pull request

Bannière “À savoir” 

- “Votre structure dépend d’un autre SIRET ?” → “Vous êtes un équipement d’une collectivité ou d'un établissement public ?”

- “Renseignez le SIRET de la collectivité[…] auquel vous êtes rattaché.” → “Renseignez le SIRET de la structure à laquelle vous êtes rattaché.”

-  ajout d’un lien externe qui redirige vers la FAQ : Label : “En savoir plus”(lien :  )

## Implémentation

### Avant
![image](https://user-images.githubusercontent.com/106379750/231803831-e9c56369-115c-4a75-9c45-f310d8a7ceba.png)

### Après
![image](https://user-images.githubusercontent.com/106379750/231803684-996a693a-f557-44bc-bf32-6bd28f8fb7d4.png)
