### PR TITLE
(PC-21769)[API] feat: Do not tag transactional emails 257 and 78 to Sendinblue - tagged in SiB by marketing

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -6,13 +6,9 @@ from pcapi.core.mails import models
 class TransactionalEmail(Enum):
     # Empty tags when it is set directly in Sendinblue template
     ACCEPTED_AS_BENEFICIARY = models.Template(id_prod=96, id_not_prod=25, use_priority_queue=True)
-    ACCEPTED_AS_EAC_BENEFICIARY = models.Template(
-        id_prod=257, id_not_prod=27, tags=["jeunes_pass_credite_eac"], use_priority_queue=True
-    )
+    ACCEPTED_AS_EAC_BENEFICIARY = models.Template(id_prod=257, id_not_prod=27, use_priority_queue=True)
     ACCOUNT_UNSUSPENDED = models.Template(id_prod=644, id_not_prod=87, tags=["reactivation_compte_utilisateur"])
-    BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER = models.Template(
-        id_prod=78, id_not_prod=32, tags=["anniversaire_18_ans"], send_to_ehp=False
-    )
+    BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER = models.Template(id_prod=78, id_not_prod=32, send_to_ehp=False)
     BOOKING_CANCELLATION_BY_BENEFICIARY = models.Template(
         id_prod=223, id_not_prod=33, tags=["jeunes_offre_annulee_jeune"]
     )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21769

## But de la pull request

De la même manière que dans le ticket PC-21578, l'équipe marketing souhaite utiliser le tag défini dans Sendinblue, plutôt que celui défini dans le backend, pour les emails 257 et 78 (prod).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
