### PR TITLE
(PC-20893)[PRO] chore: remove adage fontbarlow package

### DIFF
--- a/pro/jest.config.js
+++ b/pro/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
     '\\.(png|svg)': '<rootDir>/src/utils/svgrMock.js',
     '\\.module\\.scss$': 'identity-obj-proxy',
     '\\.(css|less|scss|sass)$': '<rootDir>/src/utils/styleMock.js',
-    '@fontsource/barlow': '<rootDir>/src/utils/styleMock.js',
   },
   modulePaths: ['node_modules', 'src'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts', 'jest-canvas-mock'],

--- a/pro/package.json
+++ b/pro/package.json
@@ -43,7 +43,6 @@
     "@firebase/analytics": "^0.9.5",
     "@firebase/app": "^0.9.7",
     "@firebase/remote-config": "0.4.4",
-    "@fontsource/barlow": "^4.5.9",
     "@reach/dialog": "^0.18.0",
     "@reach/menu-button": "^0.18.0",
     "@reduxjs/toolkit": "^1.9.3",

--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react'
 import { useCallback, useEffect, useState } from 'react'
 
-import '@fontsource/barlow'
-import '@fontsource/barlow/600.css'
-import '@fontsource/barlow/700.css'
-import '@fontsource/barlow/300.css'
 import {
   AdageFrontRoles,
   AuthenticatedResponse,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/SearchBox/SearchBox.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/SearchBox/SearchBox.scss
@@ -19,7 +19,6 @@
     padding-left: rem.torem(46px);
     transition: none;
     font-size: rem.torem(15px);
-    font-family: Barlow;
 
     &::placeholder {
       font-style: italic;
@@ -46,7 +45,6 @@
   padding-left: rem.torem(46px);
   transition: all 0.25s ease-in-out;
   font-size: rem.torem(15px);
-  font-family: Barlow;
 
   &::placeholder {
     font-style: italic;

--- a/pro/src/pages/AdageIframe/index.scss
+++ b/pro/src/pages/AdageIframe/index.scss
@@ -5,7 +5,6 @@ html {
 }
 
 body {
-  font-family: Barlow, sans-serif;
   height: 100%;
   margin: 0;
 }

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -2289,11 +2289,6 @@
   dependencies:
     "@floating-ui/core" "^1.2.4"
 
-"@fontsource/barlow@^4.5.9":
-  version "4.5.9"
-  resolved "https://registry.yarnpkg.com/@fontsource/barlow/-/barlow-4.5.9.tgz#e3b18084e839c1c0a5ac30f7fef6737cd720f6df"
-  integrity sha512-Nzg7bpw6raZtNdHwvLIt6ue/Gas/tpsNyf7zrRvVdV38iOrtOip2aabO3lexEyiYkKjKrlqAjEyAtTrC2XfkRg==
-
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20893

## But de la pull request

Supprimer la dépendance fontsource/barlow que l'on utilise dans adage.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
