### PR TITLE
(PC-21772)[PRO] fix: display eac information section when offerer can…

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -27,7 +27,8 @@ const CollectiveVenueInformations = ({
   )
   const shouldEACInformationSection =
     hasAdageIdForMoreThan30Days ||
-    (!venue?.adageInscriptionDate && canCreateCollectiveOffer) ||
+    ((!venue?.adageInscriptionDate || !venue?.collectiveDmsApplication) &&
+      canCreateCollectiveOffer) ||
     isCreatingVenue
 
   const hasRefusedDmsApplication =


### PR DESCRIPTION
… create eac offer but venue has no dms application

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21772

## But de la pull request

Afficher la section 'Mes informations pour les enseignants' pour les lieux (sans adageId et sans applicationDms) mais faisant partie d'une structure pouvant créer des offres collectives 

## Screenshot 

![Capture d’écran 2023-04-14 à 11 08 52](https://user-images.githubusercontent.com/71768799/232000180-af3576b8-8489-4a6f-af80-aaa3e55a6f26.png)

## Test 

Structure : eac_2_lieu [BON EAC]
Lieu : real_venue 1 eac_2_lieu [BON EAC]
