### PR TITLE
(PC-21511) fix(helm): Helm chart should be on pass-culture-helm-registry

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
 releases:
   - name: {{ .Environment.Name }}
     namespace: {{ .Environment.Name }}
-    chart: passCulture/pass-culture-artifact-registry/pcapi-chart
+    chart: passCulture/pass-culture-helm-registry/pcapi
     version: {{ .Values.chartVersion }}
     values:
       - {{ requiredEnv "PCAPI_VALUES_FILE" }}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21511

## But de la pull request

Une nouvelle registry a été créé depuis le 30/03 et doit être maintenant utilisé par le helmfile

## Implémentation

Les versions 0.17.4 à 0.19.5 sont actuellement bien présentes sur cette registry

