### PR TITLE
(PC-21511) fix(helm): Deployment for backoffice should have a service account

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.19.5
+      - chartVersion: 0.20.5
   staging:
     values:
       - chartVersion: 0.17.5


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21511

## But de la pull request

Le Chart helm n'était pas complètement fonctionnel, il manquait notamment un SA pour une partie du backoffice afin que le replica soit up

## Implémentation

Rajout de la création d'un SA et bump de la version du helm Chart

