### PR TITLE
(PC-21773)[API] refactor: Add env var to enable/disable requests to Zendesk

### DIFF
--- a/api/src/pcapi/core/external/zendesk.py
+++ b/api/src/pcapi/core/external/zendesk.py
@@ -234,7 +234,7 @@ def _put_to_zendesk(zendesk_user_id: int, route: str, data: dict) -> bool:
         testing.zendesk_requests.append({"zendesk_user_id": zendesk_user_id, "data": data})
         return True
 
-    if settings.IS_DEV or not settings.ZENDESK_API_URL:
+    if not settings.ZENDESK_API_URL:
         logger.info("A request to Zendesk API would be sent for user %s with data %s", zendesk_user_id, data)
         return True
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21773

## But de la pull request

Dans le cadre du chantier technique consistant à enlever les références à l'environnement (ici dans le client Zendesk):
- Ajout d'une variable d'environnement pour activer/désactiver l'envoi de requêtes à Zendesk. Il est désactivé par défaut.

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
