### PR TITLE
(PC-21511) fix(helm): Deployment for backoffice should have a config map

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
 environments:
   testing:
     values:
-      - chartVersion: 0.20.5
+      - chartVersion: 0.21.5
   staging:
     values:
       - chartVersion: 0.17.5


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21511

### But de la pull request
Le Chart helm n'était pas complètement fonctionnel, il manquait notamment un configmap pour une partie du backoffice afin que le sa soit fonctionnel

### Implémentation
Rajout de la création d'un configmap et bump de la version du helm Chart