### PR TITLE
(Pc 21780)[PRO] eac retours recettes dev suivi dms

### DIFF
--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -19,13 +19,16 @@ const CollectiveDmsTimeline = ({
   hasAdageId,
   hasAdageIdForMoreThan30Days,
   adageInscriptionDate,
+  offererId,
 }: {
   collectiveDmsApplication: DMSApplicationForEAC
   hasAdageId: boolean
   hasAdageIdForMoreThan30Days: boolean
   adageInscriptionDate: string | null
+  offererId: string
 }) => {
   const collectiveDmsApplicationLink = `https://www.demarches-simplifiees.fr/dossiers/${collectiveDmsApplication.application}/messagerie`
+  const collectiveVenueInformationsLink = `/structures/${offererId}/lieux/${collectiveDmsApplication.venueId}/eac`
 
   const buildDate =
     collectiveDmsApplication.buildDate &&
@@ -203,7 +206,7 @@ const CollectiveDmsTimeline = ({
           <ButtonLink
             variant={ButtonVariant.TERNARY}
             link={{
-              to: collectiveDmsApplicationLink,
+              to: collectiveVenueInformationsLink,
               isExternal: true,
             }}
             Icon={PenIcon}

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveDmsTimeline/__specs__/CollectiveDmsTimeline.spec.tsx
@@ -12,11 +12,13 @@ const renderCollectiveDmsTimeline = ({
   hasAdageId = false,
   hasAdageIdForMoreThan30Days = false,
   adageInscriptionDate = null,
+  offererId = 'A1',
 }: {
   collectiveDmsApplication: DMSApplicationForEAC
   hasAdageId?: boolean
   hasAdageIdForMoreThan30Days?: boolean
   adageInscriptionDate?: string | null
+  offererId?: string
 }) => {
   renderWithProviders(
     <CollectiveDmsTimeline
@@ -24,6 +26,7 @@ const renderCollectiveDmsTimeline = ({
       hasAdageId={hasAdageId}
       hasAdageIdForMoreThan30Days={hasAdageIdForMoreThan30Days}
       adageInscriptionDate={adageInscriptionDate}
+      offererId={offererId}
     />
   )
 }

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -53,6 +53,7 @@ const CollectiveVenueInformations = ({
           hasAdageId={venue.hasAdageId}
           hasAdageIdForMoreThan30Days={hasAdageIdForMoreThan30Days}
           adageInscriptionDate={venue.adageInscriptionDate}
+          offererId={venue.managingOffererId}
         />
       )}
       {shouldEACInformationSection && (

--- a/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
+++ b/pro/src/components/VenueForm/CollectiveVenueInformations/CollectiveVenueInformations.tsx
@@ -37,7 +37,11 @@ const CollectiveVenueInformations = ({
 
   return (
     <FormLayout.Section
-      title="A destination des scolaires"
+      title={
+        isCreatingVenue
+          ? 'Mes informations pour les enseignants'
+          : 'A destination des scolaires'
+      }
       id="for-schools"
       description={
         venue?.hasAdageId ||

--- a/pro/src/components/VenueForm/EACInformation/NewEACInformation.tsx
+++ b/pro/src/components/VenueForm/EACInformation/NewEACInformation.tsx
@@ -6,7 +6,7 @@ import { IVenue } from 'core/Venue'
 import { ReactComponent as EditIcon } from 'icons/ico-pen-black.svg'
 import { venueHasCollectiveInformation } from 'pages/Offerers/Offerer/VenueV1/VenueEdition/EACInformation/utils/venueHasCollectiveInformation'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { ButtonLink, Title } from 'ui-kit/index'
+import { Banner, ButtonLink, Title } from 'ui-kit/index'
 
 import styles from './eacInformation.module.scss'
 
@@ -24,15 +24,24 @@ const NewEACInformation = ({ venue, isCreatingVenue }: IEACInformation) => {
 
   return (
     <>
-      <Title as="h4" level={4} className={styles['eac-title-info']}>
-        Mes informations pour les enseignants
-      </Title>
+      {!isCreatingVenue && (
+        <Title as="h4" level={4} className={styles['eac-title-info']}>
+          Mes informations pour les enseignants
+        </Title>
+      )}
       <p className={styles['eac-description-info']}>
         Il s'agit d'un formulaire vous permettant de renseigner vos informations
         EAC. Les informations renseignées seront visibles par les enseignants et
         chefs d'établissement sur Adage (Application dédiée à la
         généralisation....)
       </p>
+      {isCreatingVenue && (
+        <Banner type="notification-info">
+          Une fois votre lieu créé, vous pourrez renseigner des informations
+          pour les enseignants en revenant sur cette page.
+        </Banner>
+      )}
+
       <FormLayout.Row>
         <ButtonLink
           link={{

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.module.scss
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.module.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.dms-container {
+  margin-bottom: rem.torem(16px);
+}
+
 .step-button-width {
   max-width: rem.torem(577px);
 }

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -51,12 +51,13 @@ const VenueOfferSteps = ({
   const isCollectiveDmsTrackingActive = useActiveFeature(
     'WIP_ENABLE_COLLECTIVE_DMS_TRACKING'
   )
-  const hasAdageIdForMoreThan30Days = Boolean(
+  const hasAdageIdForMoreThan30Days =
     hasAdageId &&
-      adageInscriptionDate &&
-      isBefore(new Date(adageInscriptionDate), addDays(new Date(), -30))
-  )
-  const shouldEACInformationSection =
+    !!adageInscriptionDate &&
+    isBefore(new Date(adageInscriptionDate), addDays(new Date(), -30))
+
+  const shouldDisplayEACInformationSection =
+    isCollectiveDmsTrackingActive &&
     !(dmsStatus === DMSApplicationstatus.REFUSE) &&
     dmsInProgress &&
     !hasAdageIdForMoreThan30Days
@@ -170,7 +171,7 @@ const VenueOfferSteps = ({
           </div>
         </div>
       )}
-      {isCollectiveDmsTrackingActive && shouldEACInformationSection && (
+      {shouldDisplayEACInformationSection && (
         <div className="h-card-inner">
           <h4>Démarche en cours : </h4>
 

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -182,7 +182,7 @@ const VenueOfferSteps = ({
                 variant={ButtonVariant.BOX}
                 Icon={CircleArrowIcon}
                 link={{
-                  to: `/structures/${offererId}/lieux/${venueId}#reimbursement`,
+                  to: `/structures/${offererId}/lieux/${venueId}#venue-collective-data`,
                   isExternal: false,
                 }}
               >

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -1,4 +1,5 @@
 import cn from 'classnames'
+import { addDays, isBefore } from 'date-fns'
 import React from 'react'
 
 import { DMSApplicationstatus } from 'apiClient/v1'
@@ -28,6 +29,7 @@ interface IVenueOfferStepsProps {
   dmsStatus?: DMSApplicationstatus
   dmsInProgress?: boolean
   hasAdageId?: boolean
+  adageInscriptionDate?: string | null
 }
 
 const VenueOfferSteps = ({
@@ -39,6 +41,7 @@ const VenueOfferSteps = ({
   dmsStatus,
   dmsInProgress = false,
   hasAdageId = false,
+  adageInscriptionDate,
 }: IVenueOfferStepsProps) => {
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
   const venueCreationUrl = isVenueCreationAvailable
@@ -48,9 +51,15 @@ const VenueOfferSteps = ({
   const isCollectiveDmsTrackingActive = useActiveFeature(
     'WIP_ENABLE_COLLECTIVE_DMS_TRACKING'
   )
-
+  const hasAdageIdForMoreThan30Days = Boolean(
+    hasAdageId &&
+      adageInscriptionDate &&
+      isBefore(new Date(adageInscriptionDate), addDays(new Date(), -30))
+  )
   const shouldEACInformationSection =
-    !(dmsStatus === DMSApplicationstatus.REFUSE) && dmsInProgress
+    !(dmsStatus === DMSApplicationstatus.REFUSE) &&
+    dmsInProgress &&
+    !hasAdageIdForMoreThan30Days
 
   return (
     <div
@@ -143,20 +152,21 @@ const VenueOfferSteps = ({
                 Renseigner des coordonnées bancaires
               </ButtonLink>
             )}
-            {dmsStatus !== DMSApplicationstatus.REFUSE && (
-              <ButtonLink
-                className={styles['step-button-width']}
-                isDisabled={!hasAdageId}
-                variant={ButtonVariant.BOX}
-                Icon={CircleArrowIcon}
-                link={{
-                  to: `/structures/${offererId}/lieux/${venueId}/eac`,
-                  isExternal: false,
-                }}
-              >
-                Renseigner mes informations à destination des enseignants
-              </ButtonLink>
-            )}
+            {dmsStatus !== DMSApplicationstatus.REFUSE &&
+              !hasAdageIdForMoreThan30Days && (
+                <ButtonLink
+                  className={styles['step-button-width']}
+                  isDisabled={!hasAdageId}
+                  variant={ButtonVariant.BOX}
+                  Icon={CircleArrowIcon}
+                  link={{
+                    to: `/structures/${offererId}/lieux/${venueId}/eac`,
+                    isExternal: false,
+                  }}
+                >
+                  Renseigner mes informations à destination des enseignants
+                </ButtonLink>
+              )}
           </div>
         </div>
       )}

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
@@ -108,12 +108,22 @@ describe('VenueOfferSteps', () => {
       )
     ).not.toBeInTheDocument()
   })
-  it('should not display dms timeline button has adage id for more than 30 days', async () => {
+  it('should not display dms timeline if button has adage id for more than 30 days', async () => {
     renderVenueOfferSteps({
       hasVenue: false,
       hasAdageId: true,
       adageInscriptionDate: addDays(new Date(), -31).toISOString(),
       dmsStatus: DMSApplicationstatus.ACCEPTE,
+    })
+    expect(
+      screen.queryByText('Suivre ma demande de référencement ADAGE')
+    ).not.toBeInTheDocument()
+  })
+  it('should not display dms timeline if dms application is refused', async () => {
+    renderVenueOfferSteps({
+      hasVenue: false,
+      hasAdageId: false,
+      dmsStatus: DMSApplicationstatus.REFUSE,
     })
     expect(
       screen.queryByText('Suivre ma demande de référencement ADAGE')

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.spec.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react'
+import { addDays } from 'date-fns'
 import React from 'react'
 
 import { DMSApplicationstatus } from 'apiClient/v1'
@@ -17,6 +18,7 @@ const renderVenueOfferSteps = ({
   dmsStatus = DMSApplicationstatus.EN_CONSTRUCTION,
   dmsInProgress = false,
   hasAdageId = false,
+  adageInscriptionDate = '',
 }) => {
   const currentUser = {
     id: 'EY',
@@ -36,6 +38,7 @@ const renderVenueOfferSteps = ({
       dmsStatus={dmsStatus}
       dmsInProgress={dmsInProgress}
       hasAdageId={hasAdageId}
+      adageInscriptionDate={adageInscriptionDate}
     />,
     { storeOverrides, initialRouterEntries: ['/accueil'] }
   )
@@ -90,6 +93,30 @@ describe('VenueOfferSteps', () => {
       screen.queryByText(
         'Renseigner mes informations à destination des enseignants'
       )
+    ).not.toBeInTheDocument()
+  })
+  it('should not display eac informations section if has adage id for more than 30 days', async () => {
+    renderVenueOfferSteps({
+      hasVenue: false,
+      hasAdageId: true,
+      adageInscriptionDate: addDays(new Date(), -31).toISOString(),
+      dmsStatus: DMSApplicationstatus.ACCEPTE,
+    })
+    expect(
+      screen.queryByText(
+        'Renseigner mes informations à destination des enseignants'
+      )
+    ).not.toBeInTheDocument()
+  })
+  it('should not display dms timeline button has adage id for more than 30 days', async () => {
+    renderVenueOfferSteps({
+      hasVenue: false,
+      hasAdageId: true,
+      adageInscriptionDate: addDays(new Date(), -31).toISOString(),
+      dmsStatus: DMSApplicationstatus.ACCEPTE,
+    })
+    expect(
+      screen.queryByText('Suivre ma demande de référencement ADAGE')
     ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -40,6 +40,7 @@ export interface IVenueProps {
   hasCreatedOffer?: boolean
   dmsInformations?: DMSApplicationForEAC | null
   hasAdageId?: boolean
+  adageInscriptionDate?: string | null
 }
 
 const Venue = ({
@@ -54,6 +55,7 @@ const Venue = ({
   hasCreatedOffer,
   dmsInformations,
   hasAdageId,
+  adageInscriptionDate,
 }: IVenueProps) => {
   const [prevInitialOpenState, setPrevInitialOpenState] =
     useState(initialOpenState)
@@ -303,6 +305,7 @@ const Venue = ({
                       dmsStatus={dmsInformations?.state}
                       dmsInProgress={dmsInformations !== null}
                       hasAdageId={hasAdageId}
+                      adageInscriptionDate={adageInscriptionDate}
                     />
                   )}
                   <div className="venue-stats">

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -345,7 +345,7 @@ const Venue = ({
                               variant={ButtonVariant.BOX}
                               Icon={CircleArrowIcon}
                               link={{
-                                to: `/structures/${offererId}/lieux/${id}#reimbursement`,
+                                to: `/structures/${offererId}/lieux/${id}#venue-collective-data`,
                                 isExternal: false,
                               }}
                             >

--- a/pro/src/pages/Home/Venues/VenueList.tsx
+++ b/pro/src/pages/Home/Venues/VenueList.tsx
@@ -38,6 +38,7 @@ const VenueList = ({
             virtualVenue.collectiveDmsApplications
           )}
           hasAdageId={virtualVenue.hasAdageId}
+          adageInscriptionDate={virtualVenue.adageInscriptionDate}
         />
       )}
 
@@ -58,6 +59,7 @@ const VenueList = ({
             venue.collectiveDmsApplications
           )}
           hasAdageId={venue.hasAdageId}
+          adageInscriptionDate={venue.adageInscriptionDate}
         />
       ))}
     </div>

--- a/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
@@ -267,7 +267,7 @@ describe('venues', () => {
         })
       ).toHaveAttribute(
         'href',
-        '/structures/OFFERER01/lieux/VENUE01#reimbursement'
+        '/structures/OFFERER01/lieux/VENUE01#venue-collective-data'
       )
     })
   })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21780

## But de la pull request

Sur la homepage : 

- Ne pas afficher le bouton 'Suivre ma démarche en cours' et/ou 'Mes informations pour les enseignants' si le lieu à un adageId depuis plus de 30j 
- Si le FF WIP_ENABLE_NEW_OFFER_CREATION_JOURNEY n'est pas activé , afficher quand même le bouton 'Suivre ma démarche en cours'

Dans le suivi dms : 

- Fix le lien pour accèder aux informations pour les enseignants 

Creation de lieu 

- Afficher une bannière pour indiquer que le formulaire pour les informations pour les enseignants ne sera disponible qu'une fois le lieu créé

