### PR TITLE
(PC-20353)[API] feat: Add fraud reason code to users notifications when Ubble ID check fails

### DIFF
--- a/api/src/pcapi/core/external/batch.py
+++ b/api/src/pcapi/core/external/batch.py
@@ -85,7 +85,10 @@ def track_identity_check_started_event(user_id: int, fraud_check_type: fraud_mod
     batch_tasks.track_event_task.delay(payload)
 
 
-def bulk_track_ubble_ko_events(user_ids: list[int]) -> None:
-    event_name = push_notifications.BatchEvent.HAS_UBBLE_KO_STATUS.value
-    payload = batch_tasks.TrackBatchBulkEventRequest(event_name=event_name, event_payload={}, user_ids=user_ids)  # type: ignore [arg-type]
-    batch_tasks.bulk_track_events_task.delay(payload)
+def bulk_track_ubble_ko_events(users_per_code: dict[fraud_models.FraudReasonCode, list[int]]) -> None:
+    event_name = push_notifications.BatchEvent.HAS_UBBLE_KO_STATUS
+    for reason_code, user_ids in users_per_code.items():
+        payload = batch_tasks.TrackBatchBulkEventRequest(
+            event_name=event_name, event_payload={"error_code": reason_code.value}, user_ids=user_ids
+        )
+        batch_tasks.bulk_track_events_task.delay(payload)

--- a/api/src/pcapi/core/mails/transactional/users/ubble/reminder_emails.py
+++ b/api/src/pcapi/core/mails/transactional/users/ubble/reminder_emails.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import logging
 
@@ -37,7 +38,7 @@ def send_reminder_emails() -> None:
         ],
     )
 
-    users_to_notify = []
+    users_to_notify_per_code = collections.defaultdict(list)
 
     for user, fraud_check_reason_codes in users_with_quick_actions + users_with_long_actions:
         relevant_reason_code = ubble_subscription.get_most_relevant_ubble_error(fraud_check_reason_codes)
@@ -53,10 +54,10 @@ def send_reminder_emails() -> None:
             logger.error("Could not find reminder email template for reason code %s", relevant_reason_code)
             continue
 
-        users_to_notify.append(user.id)
+        users_to_notify_per_code[relevant_reason_code].append(user.id)
         mails.send(recipients=[user.email], data=email_data)
 
-    bulk_track_ubble_ko_events(users_to_notify)
+    bulk_track_ubble_ko_events(users_to_notify_per_code)
 
 
 def _get_reminder_email_data(code: fraud_models.FraudReasonCode) -> mails_models.TransactionalEmailData | None:

--- a/api/tests/core/mails/transactional/users/ubble_ko_reminder_test.py
+++ b/api/tests/core/mails/transactional/users/ubble_ko_reminder_test.py
@@ -243,12 +243,25 @@ class SendUbbleKoReminderEmailTest:
         user2 = build_user_with_ko_retryable_ubble_fraud_check(
             reasonCodes=[fraud_models.FraudReasonCode.ID_CHECK_EXPIRED], ubble_date_created=twenty_one_days_ago
         )
+        user3 = build_user_with_ko_retryable_ubble_fraud_check(
+            reasonCodes=[fraud_models.FraudReasonCode.ID_CHECK_NOT_SUPPORTED], ubble_date_created=twenty_one_days_ago
+        )
+
+        request1 = {
+            "can_be_asynchronously_retried": True,
+            "event_name": "has_ubble_ko_status",
+            "event_payload": {"error_code": "id_check_not_supported"},
+            "user_ids": [user1.id, user3.id],
+        }
+        request2 = {
+            "can_be_asynchronously_retried": True,
+            "event_name": "has_ubble_ko_status",
+            "event_payload": {"error_code": "id_check_expired"},
+            "user_ids": [user2.id],
+        }
 
         send_reminder_emails()
 
-        assert len(push_testing.requests) == 1
-
-        assert push_testing.requests[0]["can_be_asynchronously_retried"] is True
-        assert push_testing.requests[0]["event_name"] == "has_ubble_ko_status"
-        assert push_testing.requests[0]["event_payload"] == {}
-        assert set(push_testing.requests[0]["user_ids"]) == {user1.id, user2.id}
+        assert len(push_testing.requests) == 2
+        assert request1 in push_testing.requests
+        assert request2 in push_testing.requests


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20353

## But de la pull request

- Add fraud failure reason to batch notifications

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
