### PR TITLE
(PC-21787)[API] fix: restore tom select class on select multiple field

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/select_multiple_field.html
@@ -1,8 +1,8 @@
 <div class="form-floating {{ field.name }}-container">
   {% set select_field_id = random_hash() %}
   <select multiple
-          class="form-select pc-select-field"
-          id="{{ select_multiple_field_id }}"
+          class="form-select pc-select-field pc-tom-select-field"
+          id="{{ select_field_id }}"
           name="{{ field.name }}"
           size="2">
     {% for value, label, selected in field.iter_choices() %}
@@ -12,5 +12,5 @@
     {% endfor %}
   </select>
   <label class="pc-select-label"
-         for="{{ select_multiple_field_id }}">{{ field.label.text }}</label>
+         for="{{ select_field_id }}">{{ field.label.text }}</label>
 </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21787

## But de la pull request

Restore la class tom select pour que l'input `select_multiple_field.html` soit aussi initialisé avec tom select

## Implémentation

On s'y perds encore, p-e il faudrait le renommer en `tom_select_field_static` ?

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
