### PR TITLE
(PC-21620)[PRO] fix: ui returns margin bottom

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.module.scss
@@ -26,6 +26,10 @@
 
     color: colors.$black;
     margin-bottom: rem.torem(8px);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21620

## But de la pull request

- La marge entre le bloc gris et le texte interieur doit être de 16px
- Corriger la marge en bas du bloc

## Implémentation

### Avant:
![image](https://user-images.githubusercontent.com/106379750/232440208-2461bb84-da20-4242-aec8-1b67559bec8d.png)

### Après:
![image](https://user-images.githubusercontent.com/106379750/232440105-7e8ec0e5-12dc-413c-9d91-64002407c2ca.png)
