### PR TITLE
(PC-20492)[API] feat: Send projections from cultural survey to Sendinblue and Batch

### DIFF
--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -31,7 +31,12 @@ from pcapi.models.offer_mixin import OfferStatus
 TRACKED_PRODUCT_IDS = {3084625: "brut_x"}
 
 
-def update_external_user(user: users_models.User, skip_batch: bool = False, skip_sendinblue: bool = False) -> None:
+def update_external_user(
+    user: users_models.User,
+    cultural_survey_answers: dict[str, list[str]] | None = None,
+    skip_batch: bool = False,
+    skip_sendinblue: bool = False,
+) -> None:
     if user.has_pro_role:
         update_external_pro(user.email)
     else:
@@ -39,10 +44,10 @@ def update_external_user(user: users_models.User, skip_batch: bool = False, skip
 
         update_batch = user.has_enabled_push_notifications()
         if not skip_batch and update_batch:
-            update_batch_user(user.id, user_attributes)
+            update_batch_user(user.id, user_attributes, cultural_survey_answers=cultural_survey_answers)
 
         if not skip_sendinblue:
-            update_sendinblue_user(user.email, user_attributes)
+            update_sendinblue_user(user.email, user_attributes, cultural_survey_answers=cultural_survey_answers)
 
 
 def update_external_pro(email: str | None) -> None:

--- a/api/src/pcapi/routes/native/v1/cultural_survey.py
+++ b/api/src/pcapi/routes/native/v1/cultural_survey.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from pcapi.core.cultural_survey import cultural_survey
+from pcapi.core.external.attributes.api import update_external_user
 from pcapi.core.users import models as users_models
 from pcapi.repository import transaction
 from pcapi.routes.native.security import authenticated_and_active_user_required
@@ -47,3 +48,7 @@ def post_cultural_survey_answers(user: users_models.User, body: serializers.Cult
     with transaction():
         user.needsToFillCulturalSurvey = False
         user.culturalSurveyFilledDate = datetime.datetime.utcnow()
+
+    update_external_user(
+        user, cultural_survey_answers={answer.question_id: answer.answer_ids for answer in body.answers}  # type: ignore [misc]
+    )

--- a/api/tests/core/external/batch_test.py
+++ b/api/tests/core/external/batch_test.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import pytest
 
+from pcapi.core.cultural_survey import models as cultural_survey_models
 from pcapi.core.external.batch import format_user_attributes
 
 from . import common_user_attributes
@@ -55,6 +56,8 @@ class FormatUserAttributesTest:
             parameter_name = attribute.split(".")[1]
             assert len(parameter_name) <= MAX_BATCH_PARAMETER_SIZE
 
+        assert "ut.intended_categories" not in formatted_attributes
+
     def test_format_attributes_without_bookings(self):
         attributes = deepcopy(common_user_attributes)
         attributes.booking_categories = []
@@ -64,3 +67,20 @@ class FormatUserAttributesTest:
 
         assert formatted_attributes["date(u.last_booking_date)"] == None
         assert "ut.booking_categories" not in formatted_attributes
+
+    def test_format_attributes_with_cultural_survey_answers(self):
+        cultural_survey_answers = {
+            cultural_survey_models.CulturalSurveyQuestionEnum.SORTIES.value: [
+                cultural_survey_models.CulturalSurveyAnswerEnum.FESTIVAL.value,
+            ],
+            cultural_survey_models.CulturalSurveyQuestionEnum.PROJECTIONS.value: [
+                cultural_survey_models.CulturalSurveyAnswerEnum.PROJECTION_CONCERT.value,
+                cultural_survey_models.CulturalSurveyAnswerEnum.PROJECTION_FESTIVAL.value,
+            ],
+        }
+
+        formatted_attributes = format_user_attributes(
+            common_user_attributes, cultural_survey_answers=cultural_survey_answers
+        )
+
+        assert formatted_attributes["ut.intended_categories"] == ["PROJECTION_CONCERT", "PROJECTION_FESTIVAL"]

--- a/api/tests/core/external/sendinblue_test.py
+++ b/api/tests/core/external/sendinblue_test.py
@@ -8,9 +8,11 @@ import pytest
 from sib_api_v3_sdk.models.request_contact_import import RequestContactImport
 
 from pcapi import settings
+from pcapi.core.cultural_survey import models as cultural_survey_models
 from pcapi.core.external.sendinblue import SendinblueUserUpdateData
 from pcapi.core.external.sendinblue import add_contacts_to_list
 from pcapi.core.external.sendinblue import build_file_body
+from pcapi.core.external.sendinblue import format_cultural_survey_answers
 from pcapi.core.external.sendinblue import format_user_attributes
 from pcapi.core.external.sendinblue import import_contacts_in_sendinblue
 from pcapi.core.external.sendinblue import make_update_request
@@ -155,6 +157,39 @@ class FormatUserAttributesTest:
             "LAST_BOOKED_OFFER_2022": None,
             "HAS_COLLECTIVE_OFFERS": False,
         }
+
+
+class FormatCulturalSurveyAnswersTest:
+    def test_format_cultural_survey_answers(self):
+        cultural_survey_answers = {
+            cultural_survey_models.CulturalSurveyQuestionEnum.SORTIES.value: [
+                cultural_survey_models.CulturalSurveyAnswerEnum.FESTIVAL.value,
+            ],
+            cultural_survey_models.CulturalSurveyQuestionEnum.PROJECTIONS.value: [
+                cultural_survey_models.CulturalSurveyAnswerEnum.PROJECTION_CONCERT.value,
+                cultural_survey_models.CulturalSurveyAnswerEnum.PROJECTION_FESTIVAL.value,
+            ],
+        }
+
+        formatted_attributes = format_cultural_survey_answers(cultural_survey_answers)
+
+        assert formatted_attributes == {
+            "INTENDED_CATEGORIES": "PROJECTION_CONCERT,PROJECTION_FESTIVAL",
+        }
+
+    def test_format_cultural_survey_answers_no_projection(self):
+        answers = {
+            cultural_survey_models.CulturalSurveyQuestionEnum.SORTIES.value: [
+                cultural_survey_models.CulturalSurveyAnswerEnum.FESTIVAL.value,
+            ],
+            cultural_survey_models.CulturalSurveyQuestionEnum.FESTIVALS.value: [
+                cultural_survey_models.CulturalSurveyAnswerEnum.FESTIVAL_MUSIQUE.value,
+            ],
+        }
+
+        formatted_attributes = format_cultural_survey_answers(answers)
+
+        assert formatted_attributes == {"INTENDED_CATEGORIES": ""}
 
 
 class BulkImportUsersDataTest:

--- a/api/tests/routes/native/v1/cultural_survey_test.py
+++ b/api/tests/routes/native/v1/cultural_survey_test.py
@@ -9,6 +9,7 @@ from pcapi.core.cultural_survey.models import CulturalSurveyAnswerEnum
 from pcapi.core.cultural_survey.models import CulturalSurveyQuestionEnum
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
+from pcapi.core.users import testing
 from pcapi.utils.string import u_nbsp
 
 
@@ -286,6 +287,7 @@ class CulturalSurveyQuestionsTest:
                 "questionId": CulturalSurveyQuestionEnum.PROJECTIONS.value,
                 "answerIds": [
                     CulturalSurveyAnswerEnum.PROJECTION_SPECTACLE.value,
+                    CulturalSurveyAnswerEnum.PROJECTION_CINEMA.value,
                 ],
             },
         ]
@@ -300,7 +302,7 @@ class CulturalSurveyQuestionsTest:
             '{"user_id": %s, "submitted_at": "2020-01-01T00:00:00", "answers": '
             '[{"question_id": "SORTIES", "answer_ids": ["FESTIVAL"]}, '
             '{"question_id": "FESTIVALS", "answer_ids": ["FESTIVAL_MUSIQUE"]}, '
-            '{"question_id": "PROJECTIONS", "answer_ids": ["PROJECTION_SPECTACLE"]}]}'
+            '{"question_id": "PROJECTIONS", "answer_ids": ["PROJECTION_SPECTACLE", "PROJECTION_CINEMA"]}]}'
         ) % user.id
 
         # Note: if the path does not exist, GCP creates the necessary folders
@@ -313,3 +315,10 @@ class CulturalSurveyQuestionsTest:
 
         assert not user.needsToFillCulturalSurvey
         assert user.culturalSurveyFilledDate == datetime.datetime.utcnow()
+
+        assert len(testing.sendinblue_requests) == 1
+        assert testing.sendinblue_requests[0]["email"] == user.email
+        assert (
+            testing.sendinblue_requests[0]["attributes"]["INTENDED_CATEGORIES"]
+            == "PROJECTION_SPECTACLE,PROJECTION_CINEMA"
+        )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20492

## But de la pull request

Faire remonter les réponses à la question “avec ton pass Culture, tu aimerais…” sous forme de liste dans un nouvel attribut (il pourrait par exemple s’appeler “INTENDED_CATEGORIES”) dans Sendinblue et Batch

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
