### PR TITLE
(PC-21612)[PRO] refactor: wording and remove siren informations

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/Offerers.tsx
@@ -7,7 +7,6 @@ import { CreateOffererQueryModel } from 'apiClient/v1'
 import ConfirmDialog from 'components/Dialog/ConfirmDialog'
 import { IOfferer, useSignupJourneyContext } from 'context/SignupJourneyContext'
 import { getSirenDataAdapter } from 'core/Offerers/adapters'
-import { humanizeSiren } from 'core/Offerers/utils'
 import { getVenuesOfOffererFromSiretAdapter } from 'core/Venue/adapters/getVenuesOfOffererFromSiretAdapter'
 import { useAdapter } from 'hooks'
 import useNotification from 'hooks/useNotification'
@@ -37,7 +36,6 @@ const Offerers = (): JSX.Element => {
     getVenuesOfOffererFromSiretAdapter(offerer?.siret.replaceAll(' ', '') ?? '')
   )
 
-  const formatedSiret = humanizeSiren(venuesOfOfferer?.offererSiren)
   const displayToggleVenueList =
     venuesOfOfferer && venuesOfOfferer?.venues.length > 5
 
@@ -87,12 +85,9 @@ const Offerers = (): JSX.Element => {
           Nous avons trouvé un espace déjà inscrit sur le pass Culture et
           incluant ce SIRET.
         </div>
-        <div className={styles['title-4']}>
-          Rejoignez-le si votre structure se trouve dans la liste.
-        </div>
         <div className={styles['venues-layout']}>
           <div className={styles['offerer-name-accent']}>
-            {venuesOfOfferer?.offererName} - {formatedSiret}
+            {venuesOfOfferer?.offererName}
           </div>
           <ul className={styles['venue-list']}>
             {venuesOfOfferer?.venues.map((venue, index) => (
@@ -134,7 +129,7 @@ const Offerers = (): JSX.Element => {
         </Button>
       </div>
       <div className={cn(styles['wrong-offerer-title'], styles['title-4'])}>
-        Votre structure ne se trouve pas dans cette liste ?
+        Vous souhaitez ajouter une nouvelle structure à cette liste ?
       </div>
       <Button
         className={styles['button-add-new-offerer']}
@@ -159,9 +154,6 @@ const Offerers = (): JSX.Element => {
           cancelText="Annuler"
           extraClassNames={styles['dialog-content']}
         >
-          <div className={styles['dialog-subtitle']}>
-            {venuesOfOfferer?.offererName} - {venuesOfOfferer?.offererSiren}
-          </div>
           <div className={styles['dialog-info']}>
             Votre demande sera prise en compte et analysée par nos équipes.
           </div>

--- a/pro/src/screens/SignupJourneyForm/Offerers/__specs__/Offerers.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerers/__specs__/Offerers.spec.tsx
@@ -125,15 +125,7 @@ describe('screens:SignupJourney::Offerers', () => {
       )
     ).toBeInTheDocument()
 
-    expect(
-      await screen.getByText(
-        'Rejoignez-le si votre structure se trouve dans la liste.'
-      )
-    ).toBeInTheDocument()
-
-    expect(
-      await screen.getByText('Offerer Name - 123 456 789')
-    ).toBeInTheDocument()
+    expect(await screen.getByText('Offerer Name')).toBeInTheDocument()
 
     expect(screen.getAllByRole('listitem')).toHaveLength(4)
     expect(screen.queryByText('venue 5')).not.toBeVisible()
@@ -163,7 +155,7 @@ describe('screens:SignupJourney::Offerers', () => {
 
     expect(
       await screen.getByText(
-        'Votre structure ne se trouve pas dans cette liste ?'
+        'Vous souhaitez ajouter une nouvelle structure à cette liste ?'
       )
     ).toBeInTheDocument()
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21612

## But de la pull request

- Wording
- Supprimer le siren affiché à l'utilisateur sur la page et sur la popin de rattachement

## Implémentation

### Avant
#### Page
![Capture d’écran du 2023-04-17 15-43-08](https://user-images.githubusercontent.com/106379750/232502754-a318563b-8e7c-40c8-aa38-9c9a99b91915.png)

#### Pop In
![Capture d’écran du 2023-04-17 15-42-59](https://user-images.githubusercontent.com/106379750/232502768-9726f079-d243-4bca-bbbd-9e1b4e01f00e.png)

### Après
#### Page
![Capture d’écran du 2023-04-17 15-35-39](https://user-images.githubusercontent.com/106379750/232502835-d253d749-965f-4575-a553-b059fbe84a1e.png)

#### Pop In
![Capture d’écran du 2023-04-17 15-35-48](https://user-images.githubusercontent.com/106379750/232502821-fd0a5b43-8f71-45fa-984d-8f3bc503e642.png)


Pour tester:
- Avoir le FF: WIP_ENABLE_NEW_ONBOARDING
- En local, dans le fichier src/screens/SignupJourneyForm/Offerer/Offerer.tsx, dans le submit, ne garder que la ligne       `navigate('/parcours-inscription/structure/rattachement')` (l63)
- Se rendre à /parcours-inscription, et effectuer le parcours classique jusqu'à la page en question

