### PR TITLE
(PC-21383) [PRO] feat: Wording modification de mot, Réservations.

### DIFF
--- a/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.jsx
+++ b/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.jsx
@@ -2,26 +2,22 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import './NoBookingsForPreFiltersMessage.scss'
-
-import { ReactComponent as ResetIcon } from 'icons/reset.svg'
-import { Button } from 'ui-kit'
 import Icon from 'ui-kit/Icon/Icon'
 
 const NoBookingsForPreFiltersMessage = ({ resetPreFilters }) => (
   <div className="br-warning no-bookings-for-pre-filters">
     <Icon svg="ico-search-gray" />
-    <strong>Aucune réservation trouvée pour votre recherche</strong>
+    <p>Aucune réservation trouvée pour votre recherche</p>
     <p>
       {'Vous pouvez modifier vos filtres et lancer une nouvelle recherche ou '}
+      <button
+        className="tertiary-button reset-filters-link"
+        onClick={resetPreFilters}
+        type="button"
+      >
+        réinitialiser les filtres
+      </button>
     </p>
-    <Button
-      Icon={ResetIcon}
-      className="reset-filters-reservation-link-icon"
-      onClick={resetPreFilters}
-      variant="quaternary"
-    >
-      Réinitialiser les filtres
-    </Button>
   </div>
 )
 

--- a/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
+++ b/pro/src/pages/Bookings/__specs__/BookingsRecap.spec.tsx
@@ -218,8 +218,8 @@ describe('components | BookingsRecap | Pro user', () => {
     await submitFilters()
 
     // When
-    //const resetButton = screen.queryByRole('link')
-    //await userEvent.click(resetButton)
+    const resetButton = screen.getByText('réinitialiser les filtres')
+    await userEvent.click(resetButton)
 
     // Then
     /*expect(screen.getByLabelText('Lieu')).toHaveValue(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21383

## But de la pull request

Règles de gestion

Sur la page réservation, quand je n’ai aucun résultat de recherche à afficher : 
:cross_mark: le texte actuel est : “Veuillez modifier vos filtres et lancer une nouvelle recherche ou réinitialiser tous les filtres.”
:check_mark: Le remplacer par : “Vous pouvez modifier vos filtres et lancer une nouvelle recherche ou réinitialiser les filtres”

<img width="671" alt="Capture d’écran 2023-04-17 à 15 45 27" src="https://user-images.githubusercontent.com/115089249/232503175-621c783f-32de-4b0e-8539-9e14d7a6e4fb.png">


## Informations supplémentaires

## Checklist :

- [ X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : PC-21383-wording-reservations
  - PR : (PC-21383) [PRO] feat: Wording modification de mot, Réservations.
  - Commit(s) : (PC-21383) [PRO] feat: Wording modification de mot, Réservations.

