### PR TITLE
(PC-21380)[API] feat: update: cancel bookings inside suspend_account

### DIFF
--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -336,13 +336,6 @@ def find_offers_booked_by_beneficiaries(users: list[User]) -> list[Offer]:
     )
 
 
-def find_cancellable_bookings_by_offerer(offerer_id: int) -> list[Booking]:
-    return Booking.query.filter(
-        Booking.offererId == offerer_id,
-        Booking.status == BookingStatus.CONFIRMED,
-    ).all()
-
-
 def get_bookings_from_deposit(deposit_id: int) -> list[Booking]:
     return (
         Booking.query.filter(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21380

## But de la pull request

Lorsqu'un compte pro est suspendu, s'assurer qu'en aucun cas les réservations de ses structures seront annulées.