### PR TITLE
(PC-21828)[PRO] fix: remove empty space in top of adage iframe

### DIFF
--- a/pro/src/pages/AdageIframe/app/AppLayout.scss
+++ b/pro/src/pages/AdageIframe/app/AppLayout.scss
@@ -4,7 +4,7 @@ main.app-layout {
   display: flex;
   flex-direction: column;
   grid-column-start: col-main;
-  grid-row-start: row-main;
+  grid-row-start: row-nav;
 }
 
 .app-layout-header {
@@ -15,7 +15,7 @@ main.app-layout {
 
   .app-logo {
     width: rem.torem(120px);
-    fill : #7b1e82;
+    fill: #7b1e82;
   }
 
   &-right {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21828

## But de la pull request

Supprimer l'espace blanc en trop en haut de l'iframe adage 

## Screenshot 

Avant 

<img width="1342" alt="Capture d’écran 2023-04-18 à 14 11 57" src="https://user-images.githubusercontent.com/71768799/232774417-7bad3066-7602-4854-9164-174a0550bcb6.png">

Après 

<img width="952" alt="Capture d’écran 2023-04-18 à 14 16 21" src="https://user-images.githubusercontent.com/71768799/232774450-10e5d3eb-8c44-4cf3-965b-655bb3658625.png">
