### PR TITLE
(PC-21832)[PRO] fix: stock form validation schema

### DIFF
--- a/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/validationSchema.ts
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/StockFormList/validationSchema.ts
@@ -26,7 +26,7 @@ const getSingleValidationSchema = (
     .date()
     .nullable()
     .required('Veuillez renseigner une date')
-    .when(['readOnlyFields'], (readOnlyFields, schema) => {
+    .when(['readOnlyFields'], ([readOnlyFields], schema) => {
       /* istanbul ignore next: DEBT, TO FIX */
       if (readOnlyFields.includes('beginningDate')) {
         return schema


### PR DESCRIPTION
`Yup.Schema.when` second argument is a callback that takes a list as an argument, not a scalar

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21832