### PR TITLE
(PC-21573)[API] feat: do not save firebase flags during signup

### DIFF
--- a/api/src/pcapi/routes/pro/signup.py
+++ b/api/src/pcapi/routes/pro/signup.py
@@ -12,9 +12,7 @@ from . import blueprint
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def signup_pro(body: users_serialize.ProUserCreationBodyModel) -> None:
     try:
-        user = users_api.create_pro_user_and_offerer(body)
-        firebase_value = {"BETTER_OFFER_CREATION": False}
-        users_api.save_firebase_flags(user, firebase_value)
+        users_api.create_pro_user_and_offerer(body)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})
 
@@ -23,8 +21,6 @@ def signup_pro(body: users_serialize.ProUserCreationBodyModel) -> None:
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def signup_pro_V2(body: users_serialize.ProUserCreationBodyV2Model) -> None:
     try:
-        user = users_api.create_pro_user_V2(body)
-        firebase_value = {"BETTER_OFFER_CREATION": True}
-        users_api.save_firebase_flags(user, firebase_value)
+        users_api.create_pro_user_V2(body)
     except phone_exceptions.InvalidPhoneNumber:
         raise ApiErrors(errors={"phoneNumber": ["Le numéro de téléphone est invalide"]})

--- a/api/tests/routes/pro/signup_pro_V2_test.py
+++ b/api/tests/routes/pro/signup_pro_V2_test.py
@@ -57,13 +57,6 @@ class Returns204Test:
         user = User.query.filter_by(email="toto_pro@example.com").first()
         assert user.needsToFillCulturalSurvey == False
 
-    def test_firebase_flag(self, client):
-        data = BASE_DATA_PRO.copy()
-        client.post("/v2/users/signup/pro", json=data)
-
-        user = User.query.one()
-        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
-
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -204,13 +204,6 @@ class Returns204Test:
         assert actions_list[1].user == user
         assert actions_list[1].offerer == offerer
 
-    def test_firebase_flag(self, client):
-        data = BASE_DATA_PRO.copy()
-        client.post("/users/signup/pro", json=data)
-
-        user = User.query.one()
-        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": False}
-
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21573

## But de la pull request

Ne pas enregistrer les flags firebase de A/B testing de _création d'offre_ lors de _l'inscription_ de l'utilisateur.
