### PR TITLE
(PC-21875)[API] chore: delete unused UserSuspension table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 298d82d25d41 (pre) (head)
-d3b0bc11c80a (post) (head)
+a93013fc9866 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230419T131925_a93013fc9866_delete_usersuspension_table.py
+++ b/api/src/pcapi/alembic/versions/20230419T131925_a93013fc9866_delete_usersuspension_table.py
@@ -1,0 +1,19 @@
+"""Delete UserSuspension table
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "a93013fc9866"
+down_revision = "d3b0bc11c80a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("drop table if exists user_suspension")
+
+
+def downgrade() -> None:
+    pass  # there is no point in restoring the table

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -61,10 +61,6 @@ class ActionHistory(PcObject, Base, Model):
 
     Additional information related to a specific action (e.g. reasonCode which is related to user suspension) may be
     stored in extraData field.
-
-    Currently, this class is a first "draft" implementation to start storing log information required for offerer
-    validation. Later, it should store information about all resources. Data should also be migrated from UserSuspension
-    table when working on user history features.
     """
 
     __tablename__ = "action_history"

--- a/api/src/pcapi/core/users/constants.py
+++ b/api/src/pcapi/core/users/constants.py
@@ -67,16 +67,3 @@ SUSPENSION_REASON_CHOICES = {
 }
 
 assert set(SUSPENSION_REASON_CHOICES) == set(SuspensionReason)
-
-
-class SuspensionEventType(enum.Enum):
-    SUSPENDED = "SUSPENDED"
-    UNSUSPENDED = "UNSUSPENDED"
-
-
-SUSPENSION_EVENT_TYPE_CHOICES = (
-    (SuspensionEventType.SUSPENDED, "Suspendu"),
-    (SuspensionEventType.UNSUSPENDED, "Réactivé"),
-)
-
-assert set(_t[0] for _t in SUSPENSION_EVENT_TYPE_CHOICES) == set(SuspensionEventType)

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -731,32 +731,6 @@ class UserEmailHistory(PcObject, Base, Model):
         return func.concat(cls.newUserEmail, "@", cls.newDomainEmail)
 
 
-class UserSuspension(PcObject, Base, Model):
-    __tablename__ = "user_suspension"
-
-    userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), index=True, nullable=False)
-    user = orm.relationship(  # type: ignore [misc]
-        "User",
-        foreign_keys=[userId],
-        backref=orm.backref(
-            "suspension_history", order_by="UserSuspension.eventDate.asc().nullsfirst()", passive_deletes=True
-        ),
-    )
-
-    eventType: constants.SuspensionEventType = sa.Column(sa.Enum(constants.SuspensionEventType), nullable=False)
-
-    # nullable because of old suspensions without date migrated here; but mandatory for new actions
-    eventDate = sa.Column(sa.DateTime, nullable=True, server_default=sa.func.now())
-
-    # Super-admin or the user himself who initiated the suspension event on user account
-    # nullable because of old suspensions without author migrated here; but mandatory for new actions
-    actorUserId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
-    actorUser = orm.relationship("User", foreign_keys=[actorUserId])  # type: ignore [misc]
-
-    # Reason is filled in only when suspended but could be useful also when unsuspended for support traceability
-    reasonCode = sa.Column(sa.Enum(constants.SuspensionReason), nullable=True)
-
-
 class UserSession(PcObject, Base, Model):
     userId: int = sa.Column(sa.BigInteger, nullable=False)
     uuid: UUID = sa.Column(postgresql.UUID(as_uuid=True), unique=True, nullable=False)

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -86,7 +86,6 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     fraud_models.BeneficiaryFraudReview.query.delete()
     users_models.Token.query.delete()
     offers_models.OfferValidationConfig.query.delete()
-    users_models.UserSuspension.query.delete()
     users_models.User.query.delete()
     users_models.UserSession.query.delete()
     providers_models.Provider.query.delete()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21875

## But de la pull request

Suppression de la table inutilisée UserSuspension

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
