### PR TITLE
(PC-21885)[API] fix: enable turbo navigation

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/turbo/modal_form.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/turbo/modal_form.html
@@ -1,4 +1,4 @@
-<turbo-frame id="turbo-{{ div_id }}">
+<turbo-frame id="turbo-{{ div_id }}" data-turbo="false">
 <form action="{{ dst }}"
       name="{{ dst | action_to_name }}"
       method="post"

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -80,8 +80,7 @@
     {% endblock head %}
   </head>
   {#  Navigation with turbolink is disabled because bootstrap is not reloaded and so is not working after navigation  #}
-  <body data-turbo="false"
-        class="data-bs-no-jquery">
+  <body class="data-bs-no-jquery">
     {% block content %}
     {% endblock content %}
   </body>

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -148,7 +148,7 @@
         </div>
       </div>
       <div class="mt-4">
-        <turbo-frame id="total_revenue_frame" src="{{ url_for("backoffice_v3_web.offerer.get_stats", offerer_id=offerer.id) }}">
+        <turbo-frame id="total_revenue_frame" src="{{ url_for("backoffice_v3_web.offerer.get_stats", offerer_id=offerer.id) }}" data-turbo="false">
         <p class="text-center">
           <span class="spinner-grow spinner-grow-sm"
                 role="status">
@@ -159,7 +159,7 @@
         </turbo-frame>
       </div>
       <div class="mt-4">
-        <turbo-frame id="offerer_details_frame" src="{{ url_for("backoffice_v3_web.offerer.get_details", offerer_id=offerer.id, active_tab=request.args.get("active_tab", "history")) }}">
+        <turbo-frame id="offerer_details_frame" src="{{ url_for("backoffice_v3_web.offerer.get_details", offerer_id=offerer.id, active_tab=request.args.get("active_tab", "history")) }}" data-turbo="false">
         <p class="text-center">
           <span class="spinner-grow spinner-grow-sm"
                 role="status">

--- a/api/src/pcapi/routes/backoffice_v3/templates/providers/get/allocine.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/providers/get/allocine.html
@@ -1,7 +1,7 @@
 {% from "components/forms.html" import build_filters_form with context %}
 {% import "components/links.html" as links %}
 {% import "providers/get/common.html" as common %}
-<turbo-frame id="allocine_frame">
+<turbo-frame id="allocine_frame" data-turbo="false">
 {{ common.build_provider_bar("allocine", form, dst) }}
 <table class="table table-hover my-4">
   <thead>

--- a/api/src/pcapi/routes/backoffice_v3/templates/providers/get/boost.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/providers/get/boost.html
@@ -1,6 +1,6 @@
 {% import "components/links.html" as links %}
 {% import "providers/get/common.html" as common %}
-<turbo-frame id="boost_frame">
+<turbo-frame id="boost_frame" data-turbo="false">
 {{ common.build_provider_bar("boost", form, dst, true) }}
 <table class="table table-hover my-4">
   <thead>

--- a/api/src/pcapi/routes/backoffice_v3/templates/providers/get/cgr.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/providers/get/cgr.html
@@ -1,6 +1,6 @@
 {% import "components/links.html" as links %}
 {% import "providers/get/common.html" as common %}
-<turbo-frame id="cgr_frame">
+<turbo-frame id="cgr_frame" data-turbo="false">
 {{ common.build_provider_bar("cgr", form, dst, true) }}
 <table class="table table-hover my-4">
   <thead>

--- a/api/src/pcapi/routes/backoffice_v3/templates/providers/get/cineoffice.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/providers/get/cineoffice.html
@@ -1,6 +1,6 @@
 {% import "components/links.html" as links %}
 {% import "providers/get/common.html" as common %}
-<turbo-frame id="cineoffice_frame">
+<turbo-frame id="cineoffice_frame" data-turbo="false">
 {{ common.build_provider_bar("cineoffice", form, dst, true) }}
 <table class="table table-hover my-4">
   <thead>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21885

## But de la pull request

Active la navigation turbo

## Implémentation

- Suppression du `data-turbo="false"` sur le body
- Les hooks pour notre JS pour supporter la navigation ont été rajoutés en amont via https://passculture.atlassian.net/browse/PC-21883 / https://github.com/pass-culture/pass-culture-main/pull/6222

## Informations supplémentaires

À merger après la MES pour se laisser du temps de test

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
