### PR TITLE
(PC-21834)[PRO] feat: display dms buttons when application is refused

### DIFF
--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -1,8 +1,6 @@
 import cn from 'classnames'
-import { addDays, isBefore } from 'date-fns'
 import React from 'react'
 
-import { DMSApplicationstatus } from 'apiClient/v1'
 import { ButtonLink } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -26,10 +24,8 @@ interface IVenueOfferStepsProps {
   offererId: string
   venueId?: string | null
   hasCreatedOffer?: boolean
-  dmsStatus?: DMSApplicationstatus
-  dmsInProgress?: boolean
   hasAdageId?: boolean
-  adageInscriptionDate?: string | null
+  shouldDisplayEACInformationSection?: boolean
 }
 
 const VenueOfferSteps = ({
@@ -38,29 +34,14 @@ const VenueOfferSteps = ({
   hasMissingReimbursementPoint = true,
   venueId = null,
   hasCreatedOffer = false,
-  dmsStatus,
-  dmsInProgress = false,
   hasAdageId = false,
-  adageInscriptionDate,
+  shouldDisplayEACInformationSection = false,
 }: IVenueOfferStepsProps) => {
   const isVenueCreationAvailable = useActiveFeature('API_SIRENE_AVAILABLE')
   const venueCreationUrl = isVenueCreationAvailable
     ? `/structures/${offererId}/lieux/creation`
     : UNAVAILABLE_ERROR_PAGE
   const { logEvent } = useAnalytics()
-  const isCollectiveDmsTrackingActive = useActiveFeature(
-    'WIP_ENABLE_COLLECTIVE_DMS_TRACKING'
-  )
-  const hasAdageIdForMoreThan30Days =
-    hasAdageId &&
-    !!adageInscriptionDate &&
-    isBefore(new Date(adageInscriptionDate), addDays(new Date(), -30))
-
-  const shouldDisplayEACInformationSection =
-    isCollectiveDmsTrackingActive &&
-    !(dmsStatus === DMSApplicationstatus.REFUSE) &&
-    dmsInProgress &&
-    !hasAdageIdForMoreThan30Days
 
   return (
     <div

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
@@ -2,7 +2,6 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
-import { DMSApplicationstatus } from 'apiClient/v1'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import {
@@ -19,9 +18,7 @@ const mockLogEvent = jest.fn()
 
 const renderVenueOfferSteps = (
   venueId: string | null = null,
-  hasMissingReimbursementPoint = true,
-  dmsStatus: DMSApplicationstatus = DMSApplicationstatus.ACCEPTE,
-  dmsInProgress = false
+  hasMissingReimbursementPoint = true
 ) => {
   const currentUser = {
     id: 'EY',
@@ -39,8 +36,6 @@ const renderVenueOfferSteps = (
       venueId={venueId}
       offererId="AB"
       hasMissingReimbursementPoint={hasMissingReimbursementPoint}
-      dmsStatus={dmsStatus}
-      dmsInProgress={dmsInProgress}
     />,
     { storeOverrides, initialRouterEntries: ['/accueil'] }
   )

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -67,11 +67,21 @@ const Venue = ({
     !!adageInscriptionDate &&
     isBefore(new Date(adageInscriptionDate), addDays(new Date(), -30))
 
+  const hasRefusedApplicationForMoreThan30Days =
+    (dmsInformations?.state == DMSApplicationstatus.REFUSE ||
+      dmsInformations?.state == DMSApplicationstatus.SANS_SUITE) &&
+    dmsInformations.processingDate &&
+    isBefore(
+      new Date(dmsInformations?.processingDate),
+      addDays(new Date(), -30)
+    )
+
   const shouldDisplayEACInformationSection =
     isCollectiveDmsTrackingActive &&
-    !(dmsInformations?.state === DMSApplicationstatus.REFUSE) &&
     Boolean(dmsInformations) &&
-    !hasAdageIdForMoreThan30Days
+    !hasAdageIdForMoreThan30Days &&
+    !hasRefusedApplicationForMoreThan30Days
+
   const initialOpenState =
     shouldDisplayEACInformationSection ||
     (hasNewOfferCreationJourney && !hasCreatedOffer)
@@ -318,10 +328,10 @@ const Venue = ({
                       hasMissingReimbursementPoint={
                         hasMissingReimbursementPoint
                       }
-                      dmsStatus={dmsInformations?.state}
-                      dmsInProgress={dmsInformations !== null}
                       hasAdageId={hasAdageId}
-                      adageInscriptionDate={adageInscriptionDate}
+                      shouldDisplayEACInformationSection={
+                        shouldDisplayEACInformationSection
+                      }
                     />
                   )}
                   {!hasNewOfferCreationJourney &&

--- a/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
+++ b/pro/src/pages/Home/Venues/__specs__/Venue.spec.tsx
@@ -233,12 +233,38 @@ describe('venues', () => {
         '/structures/OFFERER01/lieux/VENUE01?modification#remboursement'
       )
     })
+  })
+  describe('when new offer creation journey is enabled', () => {
+    beforeEach(() => {
+      jest.spyOn(useNewOfferCreationJourney, 'default').mockReturnValue(true)
+    })
 
+    it('should not display dms timeline link if venue has no dms application', async () => {
+      renderVenue(
+        {
+          ...props,
+          hasAdageId: false,
+          dmsInformations: null,
+        },
+        {
+          list: [
+            {
+              isActive: true,
+              nameKey: 'WIP_ENABLE_COLLECTIVE_DMS_TRACKING',
+            },
+          ],
+        }
+      )
+      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+      // Then
+      expect(
+        screen.queryByRole('link', {
+          name: 'Suivre ma demande de référencement ADAGE',
+        })
+      ).not.toBeInTheDocument()
+    })
     it('should display dms timeline link when venue has dms applicaiton and adage id less than 30 days', async () => {
-      // When
-      await jest
-        .spyOn(useNewOfferCreationJourney, 'default')
-        .mockReturnValue(false)
       renderVenue(
         {
           ...props,
@@ -269,6 +295,91 @@ describe('venues', () => {
         'href',
         '/structures/OFFERER01/lieux/VENUE01#venue-collective-data'
       )
+    })
+    it('should not display dms timeline link if venue has adageId for more than 30days', async () => {
+      renderVenue(
+        {
+          ...props,
+          hasAdageId: true,
+          adageInscriptionDate: addDays(new Date(), -32).toISOString(),
+          dmsInformations: {
+            ...defaultCollectiveDmsApplication,
+            state: DMSApplicationstatus.ACCEPTE,
+          },
+        },
+        {
+          list: [
+            {
+              isActive: true,
+              nameKey: 'WIP_ENABLE_COLLECTIVE_DMS_TRACKING',
+            },
+          ],
+        }
+      )
+      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+      // Then
+      expect(
+        screen.queryByRole('link', {
+          name: 'Suivre ma demande de référencement ADAGE',
+        })
+      ).not.toBeInTheDocument()
+    })
+    it('should display dms timeline link if venue has refused application for less than 30days', async () => {
+      renderVenue(
+        {
+          ...props,
+          dmsInformations: {
+            ...defaultCollectiveDmsApplication,
+            state: DMSApplicationstatus.REFUSE,
+            processingDate: addDays(new Date(), -15).toISOString(),
+          },
+        },
+        {
+          list: [
+            {
+              isActive: true,
+              nameKey: 'WIP_ENABLE_COLLECTIVE_DMS_TRACKING',
+            },
+          ],
+        }
+      )
+      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+      // Then
+      expect(
+        screen.getByRole('link', {
+          name: 'Suivre ma demande de référencement ADAGE',
+        })
+      ).toBeInTheDocument()
+    })
+    it('should not display dms timeline link if venue has refused application for more than 30days', async () => {
+      renderVenue(
+        {
+          ...props,
+          dmsInformations: {
+            ...defaultCollectiveDmsApplication,
+            state: DMSApplicationstatus.REFUSE,
+            processingDate: addDays(new Date(), -31).toISOString(),
+          },
+        },
+        {
+          list: [
+            {
+              isActive: true,
+              nameKey: 'WIP_ENABLE_COLLECTIVE_DMS_TRACKING',
+            },
+          ],
+        }
+      )
+      await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+      // Then
+      expect(
+        screen.queryByRole('link', {
+          name: 'Suivre ma demande de référencement ADAGE',
+        })
+      ).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21834

## But de la pull request

Afficher les boutons pour accéder au suivi de la démarche DMS pour les démarches refusé ou sans_suite

## Test 

Utiliser les structure `eac_sans_suite` et `eac_refuse`
