### PR TITLE
PC-21378 wording message connexion

### DIFF
--- a/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
+++ b/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
@@ -21,7 +21,7 @@ const ChangePasswordRequestForm = ({
 }: IChangePasswordRequestForm): JSX.Element => (
   <section className={styles['change-password-request-form']}>
     <div className={styles['hero-body']}>
-      <h1>Mot de passe égaré ?</h1>
+      <h1>Mot de passe oublié ?</h1>
       <p>
         Indiquez ci-dessous l’adresse e-mail avec laquelle vous avez créé votre
         compte.

--- a/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
+++ b/pro/src/pages/LostPassword/ChangePasswordRequestForm/ChangePasswordRequestForm.tsx
@@ -34,7 +34,6 @@ const ChangePasswordRequestForm = ({
           onChange={onChange}
           placeholder="email@exemple.com"
           required
-          subLabel="obligatoire"
           type="email"
           value={emailValue}
         />
@@ -44,7 +43,7 @@ const ChangePasswordRequestForm = ({
           disabled={isChangePasswordRequestSubmitDisabled()}
           type="submit"
         >
-          Envoyer
+          Valider
         </button>
       </form>
     </div>

--- a/pro/src/pages/LostPassword/__specs__/LostPassword.spec.tsx
+++ b/pro/src/pages/LostPassword/__specs__/LostPassword.spec.tsx
@@ -41,7 +41,7 @@ describe('src | components | pages | LostPassword', () => {
         screen.getByLabelText(/Adresse e-mail/),
         'coucou@example.com'
       )
-      await userEvent.click(screen.getByText(/Envoyer/))
+      await userEvent.click(screen.getByText(/Valider/))
 
       // he has been redirected to next step
       expect(screen.getByText(/Merci/)).toBeInTheDocument()

--- a/pro/src/pages/SignIn/SigninForm/SigninForm.tsx
+++ b/pro/src/pages/SignIn/SigninForm/SigninForm.tsx
@@ -118,7 +118,7 @@ const SigninForm = (): JSX.Element => {
                 to="/mot-de-passe-perdu"
               >
                 <KeyIcon className="ico-key" />
-                Mot de passe égaré ?
+                Mot de passe oublié ?
               </Link>
               <div className={styles['buttons-field']}>
                 <Link

--- a/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
+++ b/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
@@ -88,7 +88,7 @@ describe('src | components | pages | SignIn', () => {
     expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument()
     expect(screen.getByText('Se connecter')).toBeInTheDocument()
     expect(screen.getByText('Créer un compte')).toBeInTheDocument()
-    expect(screen.getByText('Mot de passe égaré ?')).toBeInTheDocument()
+    expect(screen.getByText('Mot de passe oublié ?')).toBeInTheDocument()
     expect(
       screen.getByRole('link', {
         name: 'Consulter nos recommandations de sécurité',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21378

## But de la pull request

Sur la [page Mot de passe égaré](https://pro.testing.passculture.team/mot-de-passe-perdu) :

Remplacer le wording “égaré” par “oublié”. 

Remplacer le wording “Envoyer” du bouton par “Valider”

Retirer le mot “obligatoire” sur le champActuel

Sur la [page de connexion](https://pro.testing.passculture.team/connexion) remplacer le wording “égaré” par “oublié”

## Implémentation


## Informations supplémentaires
<img width="595" alt="Capture d’écran 2023-04-21 à 11 10 07" src="https://user-images.githubusercontent.com/115089249/233618441-1d8125be-d801-4823-9491-0747b0d86952.png">

<img width="565" alt="Capture d’écran 2023-04-21 à 11 09 45" src="https://user-images.githubusercontent.com/115089249/233618487-072d13bd-8d51-4672-83fe-a0c0861cd753.png">


## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : PC-21378-wording-message-connexion
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : PC-21378 wording message connexion
