### PR TITLE
(PC-21786)[API] fix: use bookingEmail on booking list of public accou…

### DIFF
--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -260,15 +260,6 @@ class Booking(PcObject, Base, Model):
     def email(self) -> str:
         return self.user.email
 
-    @property
-    def emailAtDateCreated(self) -> str:
-        email = self.user.email
-        for email_history in sorted(self.user.email_history, key=lambda history: history.creationDate):
-            if self.dateCreated < email_history.creationDate:
-                email = email_history.oldEmail
-                break
-        return email
-
     @hybrid_property
     def isExternal(self) -> bool:
         return any(externalBooking.id for externalBooking in self.externalBookings)

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -143,6 +143,9 @@ def render_public_account_details(
             sa.orm.joinedload(users_models.User.userBookings)
             .joinedload(bookings_models.Booking.offerer)
             .load_only(offerers_models.Offerer.name),
+            sa.orm.joinedload(users_models.User.userBookings)
+            .joinedload(bookings_models.Booking.venue)
+            .load_only(offerers_models.Venue.bookingEmail),
             sa.orm.joinedload(users_models.User.beneficiaryFraudChecks),
             sa.orm.joinedload(users_models.User.beneficiaryFraudReviews),
             sa.orm.joinedload(users_models.User.beneficiaryImports)

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/bookings.html
@@ -69,8 +69,8 @@
                 {{ booking.deposit.type | format_deposit_type | safe }}
               </p>
               <p class="mb-1">
-                <span class="fw-bold">E-mail à la réservation :</span>
-                {{ booking.emailAtDateCreated }}
+                <span class="fw-bold">E-mail du pro :</span>
+                {{ booking.venue.bookingEmail | empty_string_if_null }}
               </p>
             </div>
           </td>

--- a/api/tests/core/bookings/test_models.py
+++ b/api/tests/core/bookings/test_models.py
@@ -72,14 +72,6 @@ def test_too_many_bookings_postgresql_exception():
         assert exc.value.errors["global"] == ["La quantité disponible pour cette offre est atteinte."]
 
 
-def test_email_at_booking_date_without_mail_history():
-    user = users_factories.BeneficiaryGrant18Factory(
-        dateCreated=datetime.utcnow() - relativedelta(days=8), email="first@example.com"
-    )
-    booking = factories.BookingFactory(user=user, dateCreated=datetime.utcnow())
-    assert booking.emailAtDateCreated == "first@example.com"
-
-
 @pytest.mark.parametrize(
     "booking_date_created, email_at_booking_created_date",
     [
@@ -117,8 +109,6 @@ def test_email_at_booking_date_with_mail_history(booking_date_created, email_at_
         newDomainEmail="example.app",
         creationDate=datetime.utcnow() - relativedelta(days=2),
     )
-    booking = factories.BookingFactory(user=user, dateCreated=booking_date_created)
-    assert booking.emailAtDateCreated == email_at_booking_created_date
 
 
 class BookingIsConfirmedPropertyTest:

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -524,17 +524,7 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
             assert "Crédit restant" not in html_parser.content_as_text(response.data)
 
     def test_get_beneficiary_bookings(self, authenticated_client):
-        user_initial_email = "first@example.com"
-        user_current_email = "second@example.com"
-        user = users_factories.BeneficiaryGrant18Factory(email=user_current_email)
-        users_factories.EmailValidationEntryFactory(
-            user=user,
-            oldUserEmail=user_initial_email.split("@", maxsplit=1)[0],
-            oldDomainEmail=user_initial_email.split("@", maxsplit=1)[1],
-            newUserEmail=user_current_email.split("@", maxsplit=1)[0],
-            newDomainEmail=user_current_email.split("@", maxsplit=1)[1],
-            creationDate=datetime.date.today() - relativedelta(days=1),
-        )
+        user = users_factories.BeneficiaryGrant18Factory()
         b1 = bookings_factories.CancelledBookingFactory(
             user=user, amount=12.5, dateCreated=datetime.date.today() - relativedelta(days=2)
         )
@@ -569,8 +559,8 @@ class GetPublicAccountTest(accounts_helpers.PageRendersHelper):
         assert f"Utilisée le : {datetime.date.today().strftime('%d/%m/%Y')}" in text
         assert f"Annulée le : {datetime.date.today().strftime('%d/%m/%Y')}" in text
         assert "Motif d'annulation : Annulée par le bénéficiaire" in text
-        assert f"E-mail à la réservation : {user_current_email}" in text  # extra row for bookings[1]
-        assert f"E-mail à la réservation : {user_initial_email}" in text  # extra row for bookings[0]
+        assert f"E-mail du pro : {b1.venue.bookingEmail}" in text  # extra row for bookings[1]
+        assert f"E-mail du pro : {b2.venue.bookingEmail}" in text  # extra row for bookings[0]
 
     def test_get_beneficiary_bookings_empty(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory()


### PR DESCRIPTION
…nts page

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21786

## But de la pull request

Utiliser l'email de réservation du lieu et pas celle du jeune dans la sous ligne d'info du jeune, dans la liste des réservations liées à un compte jeune.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
