### PR TITLE
(PC-21893)[PRO] feat: log event when clicking dms timeline link

### DIFF
--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -53,6 +53,7 @@ export enum Events {
   TUTO_PAGE_VIEW = 'tutoPageView',
   DELETE_DRAFT_OFFER = 'DeleteDraftOffer',
   CLICKED_NO_VENUE = 'hasClickedNoVenue',
+  CLICKED_EAC_DMS_TIMELINE = 'hasClickedEacDmsTimeline',
   CLICKED_EAC_DMS_LINK = 'hasClickedEacDmsLink',
 }
 export enum VenueEvents {

--- a/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/VenueOfferSteps.tsx
@@ -167,6 +167,11 @@ const VenueOfferSteps = ({
                   to: `/structures/${offererId}/lieux/${venueId}#venue-collective-data`,
                   isExternal: false,
                 }}
+                onClick={() => {
+                  logEvent?.(Events.CLICKED_EAC_DMS_TIMELINE, {
+                    from: location.pathname,
+                  })
+                }}
               >
                 Suivre ma demande de référencement ADAGE
               </ButtonLink>

--- a/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
+++ b/pro/src/pages/Home/VenueOfferSteps/__specs__/VenueOfferSteps.tracker.spec.tsx
@@ -18,7 +18,8 @@ const mockLogEvent = jest.fn()
 
 const renderVenueOfferSteps = (
   venueId: string | null = null,
-  hasMissingReimbursementPoint = true
+  hasMissingReimbursementPoint = true,
+  shouldDisplayEacSection = false
 ) => {
   const currentUser = {
     id: 'EY',
@@ -36,6 +37,7 @@ const renderVenueOfferSteps = (
       venueId={venueId}
       offererId="AB"
       hasMissingReimbursementPoint={hasMissingReimbursementPoint}
+      shouldDisplayEACInformationSection={shouldDisplayEacSection}
     />,
     { storeOverrides, initialRouterEntries: ['/accueil'] }
   )
@@ -109,6 +111,19 @@ describe('VenueOfferSteps', () => {
 
     expect(mockLogEvent).toHaveBeenCalledTimes(1)
     expect(mockLogEvent).toHaveBeenCalledWith(Events.CLICKED_NO_VENUE, {
+      from: location.pathname,
+    })
+  })
+
+  it('should track click on dms timeline link', async () => {
+    renderVenueOfferSteps('V1', true, true)
+
+    await userEvent.click(
+      screen.getByText('Suivre ma demande de référencement ADAGE')
+    )
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogEvent).toHaveBeenCalledWith(Events.CLICKED_EAC_DMS_TIMELINE, {
       from: location.pathname,
     })
   })

--- a/pro/src/pages/Home/Venues/Venue.tsx
+++ b/pro/src/pages/Home/Venues/Venue.tsx
@@ -358,6 +358,11 @@ const Venue = ({
                                   to: `/structures/${offererId}/lieux/${id}#venue-collective-data`,
                                   isExternal: false,
                                 }}
+                                onClick={() => {
+                                  logEvent?.(Events.CLICKED_EAC_DMS_TIMELINE, {
+                                    from: location.pathname,
+                                  })
+                                }}
                               >
                                 Suivre ma demande de référencement ADAGE
                               </ButtonLink>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21893

## But de la pull request

Ajouter un tracker pour tracker le clic sur le bouton d'accès au suivi du référencement DMS depuis la home 
