### PR TITLE
(PC-14748)[API] refactor: Parse registration_datetime with pydantic validator in DMSContent

### DIFF
--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -132,6 +132,7 @@ class DmsApplicationResponse(pydantic.BaseModel):
     profile: Profile = pydantic.Field(alias="usager")
     state: GraphQLApplicationStates
 
+    _format_draft_date = pydantic.validator("draft_date", allow_reuse=True)(parse_dms_datetime)
     _format_processed_datetime = pydantic.validator("processed_datetime", allow_reuse=True)(parse_dms_datetime)
     _format_filing_date = pydantic.validator("filing_date", allow_reuse=True)(parse_dms_datetime)
     _format_latest_modification_datetime = pydantic.validator("latest_modification_datetime", allow_reuse=True)(

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -9,7 +9,6 @@ import uuid
 from dateutil.relativedelta import relativedelta
 from factory.declarations import LazyAttribute
 import factory.fuzzy
-import pytz
 
 from pcapi.core import testing
 import pcapi.core.fraud.ubble.models as ubble_fraud_models
@@ -85,9 +84,7 @@ class DMSContentFactory(factory.Factory):
     phone = factory.Sequence("+33612{:06}".format)
     postal_code = "75008"
     procedure_number = factory.Faker("pyint")
-    registration_datetime = LazyAttribute(
-        lambda _: datetime.utcnow().replace(tzinfo=pytz.utc).strftime("%Y-%m-%dT%H:%M:%S%z")
-    )
+    registration_datetime = LazyAttribute(lambda _: datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S%z"))
 
 
 class UbbleContentFactory(factory.Factory):

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -10,7 +10,6 @@ import pydantic.errors
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-from pcapi.connectors.dms import models as dms_models
 from pcapi.core.users import models as users_models
 from pcapi.models import Base
 from pcapi.models import Model
@@ -262,7 +261,7 @@ class DMSContent(common_models.IdentityCheckContent):
         return self.postal_code
 
     def get_registration_datetime(self) -> datetime.datetime | None:
-        return dms_models.parse_dms_datetime(self.registration_datetime) if self.registration_datetime else None
+        return self.registration_datetime
 
 
 class HonorStatementContent(pydantic.BaseModel):

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -363,9 +363,7 @@ class HandleDmsApplicationTest:
         result_content = fraud_check.source_data()
         assert result_content.application_number == 1
         assert result_content.birth_date == AGE18_ELIGIBLE_BIRTH_DATE
-        assert result_content.registration_datetime == datetime.datetime(
-            2020, 5, 13, 9, 9, 46, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))
-        )
+        assert result_content.registration_datetime == datetime.datetime(2020, 5, 13, 7, 9, 46)
         assert result_content.first_name == ""
         assert result_content.field_errors == [
             fraud_models.DmsFieldErrorDetails(key=fraud_models.DmsFieldErrorKeyEnum.first_name, value=""),

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -316,9 +316,7 @@ class DmsWebhookApplicationTest:
         assert content.postal_code == "06000"
         assert content.procedure_number == 45678
         assert content.state == "accepte"
-        assert content.registration_datetime == datetime.datetime(
-            2022, 3, 17, 12, 19, 37, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600))
-        )
+        assert content.registration_datetime == datetime.datetime(2022, 3, 17, 11, 19, 37)
 
         db.session.refresh(user)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-14748

## But de la pull request

Changer la parsing de `registration_datetime` dans `DMSContent` pour le faire faire par le validateur pydantic sur le `draft_date` de DMSApplicationResponse.

## Implémentation

- Ajout d'un formateur dans la classe DMSApplicationResponse pour l'attribute draft_date.

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
