### PR TITLE
(PC-18868)[API] feat: add default venue banner according to venue category

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -61,6 +61,7 @@ class VenueFactory(BaseFactory):
     contact = factory.RelatedFactory("pcapi.core.offerers.factories.VenueContactFactory", factory_related_name="venue")
     bookingEmail = factory.Sequence("venue{}@example.net".format)
     dmsToken = factory.LazyFunction(api.generate_dms_token)
+    bannerUrl = None
 
     @factory.post_generation
     def pricing_point(  # pylint: disable=no-self-argument

--- a/api/tests/core/search/test_backend_algolia.py
+++ b/api/tests/core/search/test_backend_algolia.py
@@ -343,7 +343,7 @@ def test_unindex_all_offers(app):
 
 def test_index_venues(app):
     backend = get_backend()
-    venue = offerers_factories.VenueFactory.build()
+    venue = offerers_factories.VenueFactory()
     with requests_mock.Mocker() as mock:
         posted = mock.post("https://dummy-app-id.algolia.net/1/indexes/venues/batch", json={})
         backend.index_venues([venue])

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -114,7 +114,16 @@ class Returns200Test:
             "visualDisabilityCompliant": venue.visualDisabilityCompliant,
             "withdrawalDetails": None,
             "bannerUrl": venue.bannerUrl,
-            "bannerMeta": None,
+            "bannerMeta": {
+                "crop_params": {
+                    "height_crop_percent": 1.0,
+                    "width_crop_percent": 1.0,
+                    "x_crop_percent": 0.0,
+                    "y_crop_percent": 0.0,
+                },
+                "image_credit": None,
+                "original_image_url": None,
+            },
             "nonHumanizedId": venue.id,
             "collectiveAccessInformation": None,
             "collectiveDescription": "Description du lieu",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18868

## But de la pull request

déterminer une bannière par défaut pour chaque lieu qui n'en a pas en fonction de sa catégorie

## Implémentation

- déclaration d'une hybrid_property bannerUrl (l'attribut de modèle `bannerUrl` est devenu `_bannerUrl`)

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
