### PR TITLE
(PC-21084) feat(ci): deploy adage front only for production environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,8 @@ jobs:
     if: |
       always() &&
       (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
-      inputs.deploy_adage == true
+      inputs.deploy_adage == true &&
+      ${{ inputs.environment == 'production' }}
     uses: ./.github/workflows/deploy-gcs-front.yml
     with:
       app_name: adage


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21084

## But de la pull request

Le déploiement de adage ne doit plus s'effectuer sur le bucket pour les environments testing et staging

## Implémentation

Modification de la CI pour ne trigger que l'environment production
