### PR TITLE
(PC-21412)[API] feat: add collective offer template

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -8,6 +8,7 @@ def install_routes(app: Flask) -> None:
     from . import auth
     from . import autocomplete
     from . import collective_bookings
+    from . import collective_offer_templates
     from . import collective_offers
     from . import custom_reimbursement_rules
     from . import filters

--- a/api/src/pcapi/routes/backoffice_v3/collective_offer_templates.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offer_templates.py
@@ -1,0 +1,258 @@
+import datetime
+
+from flask import flash
+from flask import redirect
+from flask import render_template
+from flask import request
+from flask import url_for
+import sqlalchemy as sa
+
+from pcapi.core import search
+from pcapi.core.categories import subcategories
+from pcapi.core.educational import models as educational_models
+from pcapi.core.mails import transactional as transactional_mails
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.permissions import models as perm_models
+from pcapi.models import db
+from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.models.offer_mixin import OfferValidationType
+from pcapi.utils import date as date_utils
+
+from . import autocomplete
+from . import utils
+from .forms import collective_offer_template as collective_offer_template_forms
+from .forms import empty as empty_forms
+
+
+list_collective_offer_templates_blueprint = utils.child_backoffice_blueprint(
+    "collective_offer_template",
+    __name__,
+    url_prefix="/pro/collective_offer_template",
+    permission=perm_models.Permissions.READ_OFFERS,
+)
+
+
+def _get_collective_offer_templates(
+    form: collective_offer_template_forms.GetCollectiveOfferTemplatesListForm,
+) -> list[educational_models.CollectiveOfferTemplate]:
+    base_query = educational_models.CollectiveOfferTemplate.query.options(
+        sa.orm.load_only(
+            educational_models.CollectiveOfferTemplate.id,
+            educational_models.CollectiveOfferTemplate.name,
+            educational_models.CollectiveOfferTemplate.subcategoryId,
+            educational_models.CollectiveOfferTemplate.dateCreated,
+            educational_models.CollectiveOfferTemplate.validation,
+        ),
+        sa.orm.joinedload(educational_models.CollectiveOfferTemplate.venue).load_only(
+            offerers_models.Venue.managingOffererId, offerers_models.Venue.name
+        )
+        # needed to check if stock is bookable and compute initial/remaining stock:
+        .joinedload(offerers_models.Venue.managingOfferer).load_only(
+            offerers_models.Offerer.name, offerers_models.Offerer.isActive, offerers_models.Offerer.validationStatus
+        ),
+    )
+    if form.from_date.data:
+        from_datetime = date_utils.date_to_localized_datetime(form.from_date.data, datetime.datetime.min.time())
+        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.dateCreated >= from_datetime)
+
+    if form.to_date.data:
+        to_datetime = date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time())
+        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.dateCreated <= to_datetime)
+
+    if form.category.data:
+        base_query = base_query.filter(
+            educational_models.CollectiveOfferTemplate.subcategoryId.in_(
+                subcategory.id
+                for subcategory in subcategories.ALL_SUBCATEGORIES
+                if subcategory.category.id in form.category.data
+            )
+        )
+
+    if form.venue.data:
+        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.venueId.in_(form.venue.data))
+
+    if form.offerer.data:
+        base_query = base_query.join(educational_models.CollectiveOfferTemplate.venue).filter(
+            offerers_models.Venue.managingOffererId.in_(form.offerer.data)
+        )
+
+    if form.status.data:
+        base_query = base_query.filter(educational_models.CollectiveOfferTemplate.validation.in_(form.status.data))
+
+    if form.only_validated_offerers.data:
+        base_query = (
+            base_query.join(educational_models.CollectiveOfferTemplate.venue)
+            .join(offerers_models.Venue.managingOfferer)
+            .filter(offerers_models.Offerer.isValidated)
+        )
+
+    if form.q.data:
+        search_query = form.q.data
+
+        if search_query.isnumeric():
+            base_query = base_query.filter(educational_models.CollectiveOfferTemplate.id == int(search_query))
+        else:
+            name_query = "%{}%".format(search_query)
+            base_query = base_query.filter(educational_models.CollectiveOfferTemplate.name.ilike(name_query))
+
+    if form.sort.data:
+        base_query = base_query.order_by(getattr(educational_models.CollectiveOfferTemplate, form.sort.data))
+
+    # +1 to check if there are more results than requested
+    return base_query.limit(form.limit.data + 1).all()
+
+
+@list_collective_offer_templates_blueprint.route("", methods=["GET"])
+def list_collective_offer_templates() -> utils.BackofficeResponse:
+    form = collective_offer_template_forms.GetCollectiveOfferTemplatesListForm(formdata=utils.get_query_params())
+    if not form.validate():
+        return render_template("collective_offer_template/list.html", rows=[], form=form), 400
+
+    if form.is_empty():
+        return render_template("collective_offer_template/list.html", rows=[], form=form)
+
+    collective_offer_templates = _get_collective_offer_templates(form)
+
+    if len(collective_offer_templates) > form.limit.data:
+        flash(
+            f"Il y a plus de {form.limit.data} résultats dans la base de données, la liste ci-dessous n'en donne donc "
+            "qu'une partie. Veuillez affiner les filtres de recherche.",
+            "info",
+        )
+        collective_offer_templates = collective_offer_templates[: form.limit.data]
+
+    autocomplete.prefill_offerers_choices(form.offerer)
+    autocomplete.prefill_venues_choices(form.venue)
+
+    return render_template(
+        "collective_offer_template/list.html",
+        rows=collective_offer_templates,
+        form=form,
+    )
+
+
+@list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/validate", methods=["GET"])
+@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+def get_validate_collective_offer_template_form(collective_offer_template_id: int) -> utils.BackofficeResponse:
+    collective_offer_template = educational_models.CollectiveOfferTemplate.query.get_or_404(
+        collective_offer_template_id
+    )
+
+    form = empty_forms.EmptyForm()
+
+    return render_template(
+        "components/turbo/modal_form.html",
+        form=form,
+        dst=url_for(
+            "backoffice_v3_web.collective_offer_template.validate_collective_offer_template",
+            collective_offer_template_id=collective_offer_template.id,
+        ),
+        div_id=f"validate-collective-offer-template-modal-{collective_offer_template.id}",
+        title=f"Validation de l'offre vitrine {collective_offer_template.name}",
+        button_text="Valider l'offre vitrine",
+    )
+
+
+@list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/validate", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+def validate_collective_offer_template(collective_offer_template_id: int) -> utils.BackofficeResponse:
+    collective_offer_template = educational_models.CollectiveOfferTemplate.query.get_or_404(
+        collective_offer_template_id
+    )
+
+    new_validation_status = OfferValidationStatus.APPROVED
+    if collective_offer_template.validation != OfferValidationStatus.PENDING:
+        flash("Seules les offres collectives vitrines en attente peuvent être validées", "warning")
+        return redirect(
+            request.referrer or url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates"),
+            303,
+        )
+    collective_offer_template.validation = new_validation_status
+    collective_offer_template.isActive = True
+
+    try:
+        db.session.commit()
+    except Exception:  # pylint: disable=broad-except
+        flash("Une erreur est survenue lors de la validation de l'offre vitrine", "warning")
+        return redirect(request.referrer, 400)
+    search.async_index_collective_offer_template_ids([collective_offer_template.id])
+
+    flash("L'offre a bien été validée", "success")
+    collective_offer_template.lastValidationDate = datetime.datetime.utcnow()
+    collective_offer_template.lastValidationType = OfferValidationType.MANUAL
+    recipients = (
+        [collective_offer_template.venue.bookingEmail]
+        if collective_offer_template.venue.bookingEmail
+        else [recipient.user.email for recipient in collective_offer_template.venue.managingOfferer.UserOfferers]
+    )
+
+    transactional_mails.send_offer_validation_status_update_email(
+        collective_offer_template, new_validation_status, recipients
+    )
+
+    return redirect(
+        request.referrer or url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates"), 303
+    )
+
+
+@list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/reject", methods=["GET"])
+@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+def get_reject_collective_offer_template_form(collective_offer_template_id: int) -> utils.BackofficeResponse:
+    collective_offer_template = educational_models.CollectiveOfferTemplate.query.get_or_404(
+        collective_offer_template_id
+    )
+
+    form = empty_forms.EmptyForm()
+
+    return render_template(
+        "components/turbo/modal_form.html",
+        form=form,
+        dst=url_for(
+            "backoffice_v3_web.collective_offer_template.reject_collective_offer_template",
+            collective_offer_template_id=collective_offer_template.id,
+        ),
+        div_id=f"reject-collective-offer-template-modal-{collective_offer_template.id}",
+        title=f"Rejet de l'offre vitrine {collective_offer_template.name}",
+        button_text="Rejeter l'offre vitrine",
+    )
+
+
+@list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/reject", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+def reject_collective_offer_template(collective_offer_template_id: int) -> utils.BackofficeResponse:
+    collective_offer_template = educational_models.CollectiveOfferTemplate.query.get_or_404(
+        collective_offer_template_id
+    )
+
+    new_validation_status = OfferValidationStatus.REJECTED
+    if collective_offer_template.validation != OfferValidationStatus.PENDING:
+        flash("Seules les offres collectives vitrines en attente peuvent être rejetées", "warning")
+        return redirect(
+            request.referrer or url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates"),
+            303,
+        )
+    collective_offer_template.validation = new_validation_status
+
+    try:
+        db.session.commit()
+    except Exception:  # pylint: disable=broad-except
+        flash("Une erreur est survenue lors de la validation de l'offre vitrine", "warning")
+        return redirect(request.referrer, 400)
+    search.async_index_collective_offer_template_ids([collective_offer_template.id])
+
+    flash("L'offre vitrine a bien été rejetée", "success")
+    collective_offer_template.lastValidationDate = datetime.datetime.utcnow()
+    collective_offer_template.lastValidationType = OfferValidationType.MANUAL
+    recipients = (
+        [collective_offer_template.venue.bookingEmail]
+        if collective_offer_template.venue.bookingEmail
+        else [recipient.user.email for recipient in collective_offer_template.venue.managingOfferer.UserOfferers]
+    )
+
+    transactional_mails.send_offer_validation_status_update_email(
+        collective_offer_template, new_validation_status, recipients
+    )
+
+    return redirect(
+        request.referrer or url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates"), 303
+    )

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_offer_template.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_offer_template.py
@@ -1,0 +1,60 @@
+from flask_wtf import FlaskForm
+import wtforms
+
+from pcapi.core.categories import categories
+from pcapi.models.offer_mixin import OfferValidationStatus
+
+from . import fields
+from . import utils
+from .. import filters
+
+
+class GetCollectiveOfferTemplatesListForm(FlaskForm):
+    class Meta:
+        csrf = False
+
+    q = fields.PCOptSearchField("ID, nom de l'offre")
+    category = fields.PCSelectMultipleField(
+        "Catégories", choices=utils.choices_from_enum(categories.CategoryIdLabelEnum)
+    )
+    offerer = fields.PCTomSelectField(
+        "Structures",
+        multiple=True,
+        choices=[],
+        validate_choice=False,
+        endpoint="backoffice_v3_web.autocomplete_offerers",
+    )
+    venue = fields.PCTomSelectField(
+        "Lieux", multiple=True, choices=[], validate_choice=False, endpoint="backoffice_v3_web.autocomplete_venues"
+    )
+    status = fields.PCSelectMultipleField(
+        "États",
+        choices=utils.choices_from_enum(OfferValidationStatus, formatter=filters.format_offer_validation_status),
+    )
+    from_date = fields.PCDateField("Créées à partir du", validators=(wtforms.validators.Optional(),))
+    to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
+    limit = fields.PCSelectField(
+        "Nombre maximum",
+        choices=((100, "100"), (500, "500"), (1000, "1000"), (3000, "3000")),
+        default="100",
+        coerce=int,
+        validators=(wtforms.validators.Optional(),),
+    )
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
+    sort = wtforms.HiddenField(
+        "sort", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("id", "dateCreated")))
+    )
+
+    def is_empty(self) -> bool:
+        # 'only_validated_offerers', 'sort' must be combined with other filters
+        return not any(
+            (
+                self.q.data,
+                self.category.data,
+                self.venue.data,
+                self.offerer.data,
+                self.status.data,
+                self.from_date.data,
+                self.to_date.data,
+            )
+        )

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
@@ -1,0 +1,77 @@
+{% from "components/forms.html" import build_filters_form with context %}
+{% import "components/links.html" as links %}
+{% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
+{% extends "layouts/connected.html" %}
+{% block page %}
+  <div class="pt-3 px-5">
+    <h2 class="fw-light">Offres collectives vitrines</h2>
+    {{ build_filters_form(form, dst) }}
+    <div>
+      {% if rows %}
+        <div class="d-flex justify-content-between">
+          <p class="lead num-results">
+            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            résultat{{ "s" if rows | length > 1 else "" }}
+          </p>
+        </div>
+        <table class="table mb-4">
+          <thead>
+            <tr>
+              <th scope="col"></th>
+              <th scope="col">ID</th>
+              <th scope="col">Nom de l'offre</th>
+              <th scope="col">Catégorie</th>
+              <th scope="col">Sous-catégorie</th>
+              <th scope="col">État</th>
+              <th scope="col">Date de création</th>
+              <th scope="col">Structure</th>
+              <th scope="col">Lieu</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for collective_offer_template in rows %}
+              <tr>
+                <td>
+                  {% if has_permission("FRAUD_ACTIONS") %}
+                    <div class="dropdown">
+                      <button type="button"
+                              data-bs-toggle="dropdown"
+                              aria-expanded="false"
+                              class="btn p-0">
+                        <i class="bi bi-three-dots-vertical"></i>
+                      </button>
+                      <ul class="dropdown-menu">
+                        <li class="dropdown-item">
+                          <a class="btn btn-sm d-block w-100 text-start px-3"
+                             data-bs-toggle="modal"
+                             data-bs-target="#validate-collective-offer-template-modal-{{ collective_offer_template.id }}">Valider l'offre vitrine</a>
+                        </li>
+                        <li class="dropdown-item">
+                          <a class="btn btn-sm d-block w-100 text-start px-3"
+                             data-bs-toggle="modal"
+                             data-bs-target="#reject-collective-offer-template-modal-{{ collective_offer_template.id }}">Rejeter l'offre vitrine</a>
+                        </li>
+                      </ul>
+                    </div>
+                  {% endif %}
+                </td>
+                <td>{{ collective_offer_template.id }}</td>
+                <td>{{ links.build_offer_name_to_pc_pro_link(collective_offer_template) }}</td>
+                <td>{{ collective_offer_template.subcategory.category.pro_label }}</td>
+                <td>{{ collective_offer_template.subcategory.pro_label }}</td>
+                <td>{{ collective_offer_template.validation | format_offer_validation_status }}</td>
+                <td>{{ collective_offer_template.dateCreated | format_date("%d/%m/%Y") }}</td>
+                <td>{{ links.build_offerer_name_to_details_link(collective_offer_template.venue.managingOfferer) }}</td>
+                <td>{{ links.build_venue_name_to_details_link(collective_offer_template.venue) }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% for collective_offer_template in rows %}
+          {{ build_lazy_modal(url_for('backoffice_v3_web.collective_offer_template.get_validate_collective_offer_template_form', collective_offer_template_id=collective_offer_template.id), "validate-collective-offer-template-modal-" + collective_offer_template.id|string) }}
+          {{ build_lazy_modal(url_for('backoffice_v3_web.collective_offer_template.get_reject_collective_offer_template_form', collective_offer_template_id=collective_offer_template.id), "reject-collective-offer-template-modal-" + collective_offer_template.id|string) }}
+        {% endfor %}
+      {% endif %}
+    </div>
+  </div>
+{% endblock page %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -88,6 +88,7 @@
                   {% if has_permission("READ_OFFERS") %}
                     {{ menu_section_item("Offres individuelles", "backoffice_v3_web.offer.list_offers") }}
                     {{ menu_section_item("Offres collectives", "backoffice_v3_web.collective_offer.list_collective_offers") }}
+                    {{ menu_section_item("Offres collectives vitrines", "backoffice_v3_web.collective_offer_template.list_collective_offer_templates") }}
                   {% endif %}
                   {% if has_permission("MANAGE_OFFERS_AND_VENUES_TAGS") %}
                     {{ menu_section_item("Tags des offres et lieux", "backoffice_v3_web.tags.list_tags") }}

--- a/api/tests/routes/backoffice_v3/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offer_templates_test.py
@@ -1,0 +1,425 @@
+import datetime
+
+from flask import g
+from flask import url_for
+import pytest
+
+from pcapi.core.categories import categories
+from pcapi.core.categories import subcategories
+from pcapi.core.educational import factories as educational_factories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import models as offers_models
+import pcapi.core.permissions.models as perm_models
+from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import assert_num_queries
+from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.models.offer_mixin import OfferValidationType
+
+from .helpers import html_parser
+from .helpers import unauthorized as unauthorized_helpers
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
+
+
+@pytest.fixture(scope="function", name="collective_offer_templates")
+def collective_offer_templates_fixture() -> tuple:
+    collective_offer_template_1 = educational_factories.CollectiveOfferTemplateFactory(
+        subcategoryId=subcategories.ATELIER_PRATIQUE_ART.id,
+    )
+    collective_offer_template_2 = educational_factories.CollectiveOfferTemplateFactory(
+        name="A Very Specific Name",
+        subcategoryId=subcategories.EVENEMENT_CINE.id,
+    )
+    collective_offer_template_3 = educational_factories.CollectiveOfferTemplateFactory(
+        name="A Very Specific Name That Is Longer",
+        dateCreated=datetime.date.today() - datetime.timedelta(days=2),
+        validation=offers_models.OfferValidationStatus.REJECTED,
+        subcategoryId=subcategories.FESTIVAL_CINE.id,
+    )
+    return collective_offer_template_1, collective_offer_template_2, collective_offer_template_3
+
+
+class ListCollectiveOfferTemplatesTest:
+    endpoint = "backoffice_v3_web.collective_offer_template.list_collective_offer_templates"
+
+    # Use assert_num_queries() instead of assert_no_duplicated_queries() which does not detect one extra query caused
+    # by a field added in the jinja template.
+    # - fetch session (1 query)
+    # - fetch user (1 query)
+    # - fetch collective offer templates with joinedload including extra data (1 query)
+    expected_num_queries = 3
+
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelper):
+        endpoint = "backoffice_v3_web.collective_offer_template.list_collective_offer_templates"
+        needed_permission = perm_models.Permissions.READ_OFFERS
+
+    def test_list_collective_offer_templates_without_filter(self, authenticated_client, collective_offer_templates):
+        # when
+        with assert_no_duplicated_queries():
+            response = authenticated_client.get(url_for(self.endpoint))
+
+        # then
+        assert response.status_code == 200
+        assert html_parser.count_table_rows(response.data) == 0
+
+    def test_list_collective_offer_templates_by_id(self, authenticated_client, collective_offer_templates):
+        # when
+        searched_id = str(collective_offer_templates[0].id)
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, q=searched_id))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert rows[0]["ID"] == searched_id
+        assert rows[0]["Nom de l'offre"] == collective_offer_templates[0].name
+        assert rows[0]["Catégorie"] == collective_offer_templates[0].subcategory.category.pro_label
+        assert rows[0]["Sous-catégorie"] == collective_offer_templates[0].subcategory.pro_label
+        assert rows[0]["État"] == "Validée"
+        assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
+        assert rows[0]["Structure"] == collective_offer_templates[0].venue.managingOfferer.name
+        assert rows[0]["Lieu"] == collective_offer_templates[0].venue.name
+
+    def test_list_collective_offer_templates_by_name(self, authenticated_client, collective_offer_templates):
+        # when
+        searched_name = collective_offer_templates[1].name
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, q=searched_name))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 2
+        assert rows[0]["ID"] == str(collective_offer_templates[1].id)
+        assert rows[0]["Nom de l'offre"] == collective_offer_templates[1].name
+        assert rows[0]["Catégorie"] == collective_offer_templates[1].subcategory.category.pro_label
+        assert rows[0]["Sous-catégorie"] == collective_offer_templates[1].subcategory.pro_label
+        assert rows[0]["État"] == "Validée"
+        assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
+        assert rows[0]["Structure"] == collective_offer_templates[1].venue.managingOfferer.name
+        assert rows[0]["Lieu"] == collective_offer_templates[1].venue.name
+
+    def test_list_offers_by_date(self, authenticated_client, collective_offer_templates):
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(
+                url_for(
+                    self.endpoint,
+                    from_date=(datetime.date.today() - datetime.timedelta(days=3)).isoformat(),
+                    to_date=(datetime.date.today() - datetime.timedelta(days=1)).isoformat(),
+                )
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID"]) for row in rows) == {collective_offer_templates[2].id}
+
+    def test_list_collective_offer_templates_by_category(self, authenticated_client, collective_offer_templates):
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, category=[categories.CINEMA.id]))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID"]) for row in rows) == {
+            collective_offer_templates[1].id,
+            collective_offer_templates[2].id,
+        }
+
+    def test_list_collective_offer_templates_by_venue(self, authenticated_client, collective_offer_templates):
+        # when
+        venue_id = collective_offer_templates[1].venueId
+        with assert_num_queries(self.expected_num_queries + 1):  # +1 because of reloading selected venue in the form
+            response = authenticated_client.get(url_for(self.endpoint, venue=[venue_id]))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID"]) for row in rows) == {collective_offer_templates[1].id}
+
+    def test_list_collective_offer_templates_by_offerer(self, authenticated_client, collective_offer_templates):
+        # when
+        offerer_id = collective_offer_templates[1].venue.managingOffererId
+        with assert_num_queries(self.expected_num_queries + 1):  # +1 because of reloading selected offerer in the form
+            response = authenticated_client.get(url_for(self.endpoint, offerer=[offerer_id]))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID"]) for row in rows) == {collective_offer_templates[1].id}
+
+    def test_list_collective_offer_templates_by_status(self, authenticated_client, collective_offer_templates):
+        # when
+        status = collective_offer_templates[2].validation
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, status=[status.value]))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID"]) for row in rows) == {collective_offer_templates[2].id}
+        assert rows[0]["État"] == "Rejetée"
+
+    def test_list_offers_by_all_filters(self, authenticated_client, collective_offer_templates):
+        # when
+        venue_id = collective_offer_templates[2].venueId
+        with assert_num_queries(self.expected_num_queries + 1):  # +1 because of reloading selected venue
+            response = authenticated_client.get(
+                url_for(
+                    self.endpoint,
+                    q="specific name",
+                    category=[categories.CINEMA.id],
+                    venue=[venue_id],
+                )
+            )
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert set(int(row["ID"]) for row in rows) == {collective_offer_templates[2].id}
+
+    def test_list_offers_pending_from_validated_offerers_sorted_by_date(self, authenticated_client):
+        # test results when clicking on pending collective offers link (home page)
+        # given
+        educational_factories.CollectiveOfferTemplateFactory(
+            validation=offers_models.OfferValidationStatus.PENDING,
+            venue__managingOfferer=offerers_factories.NotValidatedOffererFactory(),
+        )
+
+        validated_venue = offerers_factories.VenueFactory()
+        for days_ago in (2, 4, 1, 3):
+            educational_factories.CollectiveOfferTemplateFactory(
+                name=f"Offre {days_ago}",
+                dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=days_ago),
+                validation=offers_models.OfferValidationStatus.PENDING,
+                venue=validated_venue,
+            )
+
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(
+                url_for(
+                    self.endpoint,
+                    status=[offers_models.OfferValidationStatus.PENDING.value],
+                    only_validated_offerers="on",
+                    sort="dateCreated",
+                )
+            )
+            assert response.status_code == 200
+
+        # then: must be sorted, older first
+        rows = html_parser.extract_table_rows(response.data)
+        assert [row["Nom de l'offre"] for row in rows] == ["Offre 4", "Offre 3", "Offre 2", "Offre 1"]
+
+
+class ValidateCollectiveOfferTemplateTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+        method = "post"
+        endpoint = "backoffice_v3_web.collective_offer_template.validate_collective_offer_template"
+        endpoint_kwargs = {"collective_offer_template_id": 1}
+        needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+
+    def test_validate_collective_offer_template(self, legit_user, authenticated_client):
+        collective_offer_template_to_validate = educational_factories.CollectiveOfferTemplateFactory(
+            validation=OfferValidationStatus.PENDING
+        )
+        base_form = {}
+
+        response = self._validate_collective_offer(
+            authenticated_client, collective_offer_template_to_validate, base_form
+        )
+        assert response.status_code == 303
+
+        expected_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates", _external=True
+        )
+        assert response.location == expected_url
+
+        collective_offer_template_list_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates",
+            q=collective_offer_template_to_validate.id,
+            _external=True,
+        )
+        response = authenticated_client.get(collective_offer_template_list_url)
+
+        assert response.status_code == 200
+        row = html_parser.extract_table_rows(response.data)
+        assert len(row) == 1
+        assert row[0]["État"] == "Validée"
+
+        assert collective_offer_template_to_validate.isActive is True
+        assert collective_offer_template_to_validate.lastValidationType == OfferValidationType.MANUAL
+
+    # TODO (vroullier) 2023-03-24 : remove when we allow validation of rejected collective offer templates
+    def test_cant_validate_non_pending_offer(self, legit_user, authenticated_client):
+        collective_offer_to_validate = educational_factories.CollectiveOfferTemplateFactory(
+            validation=OfferValidationStatus.REJECTED
+        )
+        base_form = {}
+
+        response = self._validate_collective_offer(authenticated_client, collective_offer_to_validate, base_form)
+        assert response.status_code == 303
+
+        expected_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates", _external=True
+        )
+        assert response.location == expected_url
+
+        collective_offer_list_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates",
+            q=collective_offer_to_validate.id,
+            _external=True,
+        )
+        response = authenticated_client.get(collective_offer_list_url)
+
+        assert response.status_code == 200
+        assert "Seules les offres collectives vitrines en attente peuvent être validées" in response.data.decode(
+            "utf-8"
+        )
+        row = html_parser.extract_table_rows(response.data)
+        assert len(row) == 1
+        assert row[0]["État"] == "Rejetée"
+
+    def _validate_collective_offer(self, authenticated_client, collective_offer_template, form):
+        edit_url = url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates")
+        authenticated_client.get(edit_url)
+
+        url = url_for(
+            "backoffice_v3_web.collective_offer_template.validate_collective_offer_template",
+            collective_offer_template_id=collective_offer_template.id,
+        )
+        form["csrf_token"] = g.get("csrf_token", "")
+
+        return authenticated_client.post(url, form=form)
+
+
+class ValidateCollectiveOfferTemplateFormTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+        method = "post"
+        endpoint = "backoffice_v3_web.collective_offer_template.get_validate_collective_offer_template_form"
+        endpoint_kwargs = {"collective_offer_template_id": 1}
+        needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+
+    def test_get_validate_form_test(self, legit_user, authenticated_client):
+        collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
+
+        form_url = url_for(
+            "backoffice_v3_web.collective_offer_template.get_validate_collective_offer_template_form",
+            collective_offer_template_id=collective_offer_template.id,
+            _external=True,
+        )
+
+        with assert_num_queries(2):  # session + user
+            response = authenticated_client.get(form_url)
+            assert response.status_code == 200
+
+
+class RejectCollectiveOfferTemplateTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+        method = "post"
+        endpoint = "backoffice_v3_web.collective_offer_template.reject_collective_offer_template"
+        endpoint_kwargs = {"collective_offer_template_id": 1}
+        needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+
+    def test_reject_collective_offer_template(self, legit_user, authenticated_client):
+        collective_offer_template_to_reject = educational_factories.CollectiveOfferTemplateFactory(
+            validation=OfferValidationStatus.PENDING
+        )
+        base_form = {}
+
+        response = self._reject_collective_offer_template(
+            authenticated_client, collective_offer_template_to_reject, base_form
+        )
+        assert response.status_code == 303
+
+        expected_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates", _external=True
+        )
+        assert response.location == expected_url
+
+        collective_offer_template_list_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates",
+            q=collective_offer_template_to_reject.id,
+            _external=True,
+        )
+        response = authenticated_client.get(collective_offer_template_list_url)
+
+        assert response.status_code == 200
+        row = html_parser.extract_table_rows(response.data)
+        assert len(row) == 1
+        assert row[0]["État"] == "Rejetée"
+
+        assert collective_offer_template_to_reject.isActive is False
+        assert collective_offer_template_to_reject.lastValidationType == OfferValidationType.MANUAL
+
+    # TODO (vroullier) 2023-03-24 : remove when we allow validation of validated collective offer templates
+    def test_cant_reject_non_pending_offer_template(self, legit_user, authenticated_client):
+        collective_offer_template_to_reject = educational_factories.CollectiveOfferTemplateFactory(
+            validation=OfferValidationStatus.APPROVED
+        )
+        base_form = {}
+
+        response = self._reject_collective_offer_template(
+            authenticated_client, collective_offer_template_to_reject, base_form
+        )
+        assert response.status_code == 303
+
+        expected_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates", _external=True
+        )
+        assert response.location == expected_url
+
+        collective_offer_template_list_url = url_for(
+            "backoffice_v3_web.collective_offer_template.list_collective_offer_templates",
+            q=collective_offer_template_to_reject.id,
+            _external=True,
+        )
+        response = authenticated_client.get(collective_offer_template_list_url)
+
+        assert response.status_code == 200
+        assert "Seules les offres collectives vitrines en attente peuvent être rejetées" in response.data.decode(
+            "utf-8"
+        )
+        row = html_parser.extract_table_rows(response.data)
+        assert len(row) == 1
+        assert row[0]["État"] == "Validée"
+
+    def _reject_collective_offer_template(self, authenticated_client, collective_offer_template, form):
+        edit_url = url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates")
+        authenticated_client.get(edit_url)
+
+        url = url_for(
+            "backoffice_v3_web.collective_offer_template.reject_collective_offer_template",
+            collective_offer_template_id=collective_offer_template.id,
+        )
+        form["csrf_token"] = g.get("csrf_token", "")
+
+        return authenticated_client.post(url, form=form)
+
+
+class RejectCollectiveOfferTemplateFormTest:
+    class UnauthorizedTest(unauthorized_helpers.UnauthorizedHelperWithCsrf):
+        method = "post"
+        endpoint = "backoffice_v3_web.collective_offer_template.get_reject_collective_offer_template_form"
+        endpoint_kwargs = {"collective_offer_template_id": 1}
+        needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+
+    def test_get_reject_form_test(self, legit_user, authenticated_client):
+        collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
+
+        form_url = url_for(
+            "backoffice_v3_web.collective_offer_template.get_reject_collective_offer_template_form",
+            collective_offer_template_id=collective_offer_template.id,
+            _external=True,
+        )
+
+        with assert_num_queries(2):  # session + user
+            response = authenticated_client.get(form_url)
+            assert response.status_code == 200


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21412

## But de la pull request

Ajout de la page offres collectives vitrines

## Implémentation

- Copier coller de `collective_offers.py`
- Modification du naming `collective_offers` -> `collective_offer_templates`
- Suppression du code adage du type:
    ```py
    if collective_offer_template.institutionId is not None:
        adage_client.notify_institution_association(serialize_collective_offer(collective_offer_template))
    ```
- Catégorie des offres collectives vitrines récupéré depuis la sous catégorie.

## Informations supplémentaires

![image](https://user-images.githubusercontent.com/77674046/233962884-f2bcb2d3-1af1-473d-95ce-abf9352eeb7a.png)


## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
