### PR TITLE
(PC-21952) feat(ci): Increase number of worker for pylint

### DIFF
--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -119,7 +119,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.tests_docker_image }}
-          run: pylint src tests --jobs=2
+          run: pylint src tests --jobs=15
       - name: Slack Notification
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: slackapi/slack-github-action@v1.23.0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21952

## But de la pull request

Accroitre le nombre de jobs pour pylint afin d'accélérer le run

## Implémentation

Compte tenu de l'image utilisée pour les runners  nous pouvons augmenter le nombre de job jusqu'à 15, le job pylint passe  ainsi de 3min à 45 secondes

