### PR TITLE
Pc 21357 remove warning cannot update component

### DIFF
--- a/pro/jest.setup.ts
+++ b/pro/jest.setup.ts
@@ -32,18 +32,12 @@ const acceptableErrors = [
   {
     error:
       'Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.%s',
-    files: [
-      'pages/VenueEdition/VenueEdition.tsx',
-      'screens/SignupJourneyForm/Validation/Validation.tsx',
-    ],
+    files: ['screens/SignupJourneyForm/Validation/Validation.tsx'],
   },
   {
     error:
       'Warning: Cannot update a component (`%s`) while rendering a different component (`%s`). To locate the bad setState() call inside `%s`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render%s',
-    files: [
-      'pages/VenueEdition/VenueEdition.tsx',
-      'screens/SignupJourneyForm/Validation/Validation.tsx',
-    ],
+    files: ['screens/SignupJourneyForm/Validation/Validation.tsx'],
   },
   // This error exists in the following test:
   // src/pages/OfferIndividualWizard/Confirmation/__specs__/Confirmation.spec.tsx

--- a/pro/jest.setup.ts
+++ b/pro/jest.setup.ts
@@ -29,16 +29,6 @@ fetchMock.mockResponse(req => {
 // DO NOT ADD ERRORS TO THIS LIST!
 // We should remove it progressively
 const acceptableErrors = [
-  {
-    error:
-      'Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.%s',
-    files: ['screens/SignupJourneyForm/Validation/Validation.tsx'],
-  },
-  {
-    error:
-      'Warning: Cannot update a component (`%s`) while rendering a different component (`%s`). To locate the bad setState() call inside `%s`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render%s',
-    files: ['screens/SignupJourneyForm/Validation/Validation.tsx'],
-  },
   // This error exists in the following test:
   // src/pages/OfferIndividualWizard/Confirmation/__specs__/Confirmation.spec.tsx
   // It exists because we click on an anchor tag (<a>) and assert that the tracking

--- a/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEdition.spec.tsx
@@ -1,6 +1,7 @@
-import { screen } from '@testing-library/react'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 import { Route, Routes } from 'react-router-dom'
+import * as router from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import {
@@ -64,6 +65,7 @@ jest.mock('react-router-dom', () => ({
     offererId: '1234',
     venueId: '12',
   }),
+  useNavigate: jest.fn(),
 }))
 
 describe('route VenueEdition', () => {
@@ -195,14 +197,15 @@ describe('route VenueEdition', () => {
         ''
       )
     )
+    const mockNavigate = jest.fn()
+    jest.spyOn(router, 'useNavigate').mockReturnValue(mockNavigate)
     // When
     renderVenueEdition(venue.nonHumanizedId, offerer.nonHumanizedId)
 
+    await waitForElementToBeRemoved(screen.getByTestId('spinner'))
     // Then
     expect(api.getVenue).toHaveBeenCalledTimes(1)
-    const homeTitle = await screen.findByRole('heading', {
-      name: 'Home',
-    })
-    expect(homeTitle).toBeInTheDocument()
+
+    expect(mockNavigate).toHaveBeenCalledWith('/accueil')
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21357

## But de la pull request

Supprimer 2 warnings jest whitelistés : 

- Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.%s
- Warning: Cannot update a component (`%s`) while rendering a different component (`%s`). To locate the bad setState() call inside `%s`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render%s




