### PR TITLE
(PC-21953) fix(ci): Pytest should have always a report

### DIFF
--- a/.github/workflows/tests-api.yml
+++ b/.github/workflows/tests-api.yml
@@ -334,7 +334,7 @@ jobs:
         with:
           image: ${{ env.tests_docker_image }}
           shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v /github/workspace/tests/:/tests -u 0
+          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests -u 0
           run: |
             echo "Changing owner and group fort directory test"
             chown -R pcapi:pcapi /tests
@@ -343,14 +343,14 @@ jobs:
         with:
           image: ${{ env.tests_docker_image }}
           shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v /github/workspace/tests/:/tests
+          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests
           run: |
             pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml'
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '/github/workspace/tests/junit.xml'
+          report_paths: '${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml'
           check_name: "Pytest Report"
           fail_on_failure: true
       - name: Slack Notification


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21953

## But de la pull request

Actuellement les Pytests Report ne donnent plus le résultat des pytests effectuées, ici on les réactive.

## Implémentation

Depuis le passage au self-hosted le chemin d'accès au junit a changé

