### PR TITLE
(PC-21394)[API] feat: use address from form during new onboarding

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -12,7 +12,6 @@ import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 
 from pcapi import settings
-from pcapi.connectors import api_adresse
 from pcapi.connectors import sirene
 from pcapi.connectors.dms.models import GraphQLApplicationStates
 import pcapi.connectors.thumb_storage as storage
@@ -1563,69 +1562,22 @@ def get_metabase_stats_iframe_url(
     return f"{settings.METABASE_SITE_URL}/embed/dashboard/{token}#bordered=false&titled=false"
 
 
-@dataclasses.dataclass
-class AdditionalInfo:
-    address: str
-    city: str
-    name: str
-    latitude: float
-    longitude: float
-    postalCode: str
-    siren: str
-
-
-def _get_additional_info_from_onboarding_data(siret: str) -> AdditionalInfo | None:
-    siret_info = sirene.get_siret(siret)
-
-    try:
-        address_info = api_adresse.get_address(
-            address=siret_info.address.street,
-            city=siret_info.address.city,
-            insee_code=siret_info.address.insee_code,
-        )
-    except api_adresse.AdresseException as exc:
-        logger.warning(
-            "Error on Adresse API when retrieving address",
-            extra={
-                "exc": exc,
-                "queried_address": siret_info.address.street,
-                "insee_code": siret_info.address.insee_code,
-            },
-        )
-        return None
-
-    return AdditionalInfo(
-        address=siret_info.address.street,
-        city=siret_info.address.city,
-        name=siret_info.name,
-        latitude=address_info.latitude,
-        longitude=address_info.longitude,
-        postalCode=siret_info.address.postal_code,
-        siren=siret[:9],
-    )
-
-
 def create_from_onboarding_data(
     user: users_models.User,
     onboarding_data: offerers_serialize.SaveNewOnboardingDataQueryModel,
 ) -> models.UserOfferer:
-    # Get additional info from external APIs (Sirene and Adresse)
-    additional_info = _get_additional_info_from_onboarding_data(onboarding_data.siret)
-    if not additional_info:
-        raise ApiErrors(
-            {
-                "additional_info": "Les informations relatives à l'adresse de cette structure n'ont pas pu être récupérées"
-            }
-        )
+    # Get name (raison sociale) from Sirene API
+    siret_info = sirene.get_siret(onboarding_data.siret)
+    name = siret_info.name
 
     # Create Offerer or attach user to existing Offerer
     offerer_creation_info = offerers_serialize.CreateOffererQueryModel(
-        address=additional_info.address,
-        city=additional_info.city,
-        latitude=additional_info.latitude,
-        longitude=additional_info.longitude,
-        name=additional_info.name,
-        postalCode=additional_info.postalCode,
+        address=onboarding_data.address,
+        city=onboarding_data.city,
+        latitude=onboarding_data.latitude,
+        longitude=onboarding_data.longitude,
+        name=name,
+        postalCode=onboarding_data.postalCode,
         siren=onboarding_data.siret[:9],
     )
     new_onboarding_info = NewOnboardingInfo(
@@ -1638,15 +1590,15 @@ def create_from_onboarding_data(
     # Create Venue with siret if it's not in DB yet, or Venue without siret if requested
     if not offerers_repository.find_venue_by_siret(onboarding_data.siret) or onboarding_data.createVenueWithoutSiret:
         common_kwargs = dict(
-            address=additional_info.address,
+            address=onboarding_data.address,
             bookingEmail=user.email,
-            city=additional_info.city,
-            latitude=additional_info.latitude,
-            longitude=additional_info.longitude,
+            city=onboarding_data.city,
+            latitude=onboarding_data.latitude,
+            longitude=onboarding_data.longitude,
             managingOffererId=user_offerer.offererId,
-            name=additional_info.name,
+            name=name,
             publicName=onboarding_data.publicName,
-            postalCode=additional_info.postalCode,
+            postalCode=onboarding_data.postalCode,
             venueLabelId=None,
             venueTypeCode=onboarding_data.venueTypeCode,
             withdrawalDetails=None,

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -218,8 +218,12 @@ class CreateOffererQueryModel(BaseModel):
 
 
 class SaveNewOnboardingDataQueryModel(BaseModel):
-    # FIXME(fseguin, 2023-03-27): make these attributes not optional when UI is implemented
+    address: str
+    city: str
     createVenueWithoutSiret: bool = False
+    latitude: float
+    longitude: float
+    postalCode: str
     publicName: str | None
     siret: str
     target: Target

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -10,7 +10,6 @@ import jwt
 import pytest
 import sqlalchemy as sa
 
-from pcapi.connectors import api_adresse
 from pcapi.connectors import sirene
 from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import models as finance_models
@@ -1345,43 +1344,6 @@ class UpdateOffererTagTest:
         assert offerer_tag.description == "Why so serious ?"
 
 
-class GetAdditionalInfoFromOnboardingDataTest:
-    def test_simple(self):
-        siret = "12345678901234"
-        info = offerers_api._get_additional_info_from_onboarding_data(siret)
-
-        assert info == offerers_api.AdditionalInfo(
-            address="3 RUE DE VALOIS",
-            city="Paris",
-            name="MINISTERE DE LA CULTURE",
-            latitude=2.308289,
-            longitude=48.87171,
-            postalCode="75001",
-            siren="123456789",
-        )
-
-    @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.SireneApiException)
-    def test_no_siret_info(self, _mocked_get_siret):
-        siret = "12345678901234"
-
-        with pytest.raises(sirene.SireneApiException):
-            offerers_api._get_additional_info_from_onboarding_data(siret)
-
-    @patch("pcapi.connectors.api_adresse.get_address", side_effect=api_adresse.NoResultException)
-    def test_no_address_info(self, _mocked_get_address):
-        siret = "12345678901234"
-        info = offerers_api._get_additional_info_from_onboarding_data(siret)
-
-        assert info is None
-
-    @patch("pcapi.connectors.api_adresse.get_address", side_effect=api_adresse.AdresseApiException)
-    def test_api_adresse_error(self, _mocked_get_address):
-        siret = "12345678901234"
-        info = offerers_api._get_additional_info_from_onboarding_data(siret)
-
-        assert info is None
-
-
 class CreateFromOnboardingDataTest:
     def assert_common_venue_attrs(self, venue: offerers_models.Venue) -> None:
         assert venue.address == "3 RUE DE VALOIS"
@@ -1415,7 +1377,12 @@ class CreateFromOnboardingDataTest:
         self, create_venue_without_siret: bool
     ) -> offerers_serialize.SaveNewOnboardingDataQueryModel:
         return offerers_serialize.SaveNewOnboardingDataQueryModel(
+            address="3 RUE DE VALOIS",
+            city="Paris",
             createVenueWithoutSiret=create_venue_without_siret,
+            latitude=2.30829,
+            longitude=48.87171,
+            postalCode="75001",
             publicName="Nom public de mon lieu",
             siret="85331845900031",
             target=offerers_models.Target.INDIVIDUAL,

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -11,7 +11,12 @@ import pcapi.core.users.factories as users_factories
 pytestmark = pytest.mark.usefixtures("db_session")
 
 REQUEST_BODY = {
+    "address": "3 RUE DE VALOIS",
+    "city": "Paris",
     "createVenueWithoutSiret": False,
+    "latitude": 2.30829,
+    "longitude": 48.87171,
+    "postalCode": "75001",
     "publicName": "Pass Culture",
     "siret": "85331845900031",
     "target": "INDIVIDUAL",

--- a/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
+++ b/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
@@ -5,7 +5,12 @@
 import type { Target } from './Target';
 
 export type SaveNewOnboardingDataQueryModel = {
+  address: string;
+  city: string;
   createVenueWithoutSiret?: boolean;
+  latitude: number;
+  longitude: number;
+  postalCode: string;
   publicName?: string | null;
   siret: string;
   target: Target;

--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -65,6 +65,11 @@ const Validation = (): JSX.Element => {
         /* istanbul ignore next: the form validation already handles this */
         activity.targetCustomer ?? Target.EDUCATIONAL,
       createVenueWithoutSiret: offerer?.createVenueWithoutSiret ?? false,
+      address: offerer.address,
+      longitude: offerer.longitude ?? 0,
+      latitude: offerer.latitude ?? 0,
+      city: offerer.city,
+      postalCode: offerer.postalCode,
     }
 
     try {

--- a/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -30,8 +30,8 @@ jest.mock('react-router-dom', () => ({
 const addressInformations: IAddress = {
   address: '3 Rue de Valois',
   city: 'Paris',
-  latitude: 0,
-  longitude: 0,
+  latitude: 1.23,
+  longitude: 2.9887,
   postalCode: '75001',
 }
 
@@ -210,6 +210,11 @@ describe('screens:SignupJourney::Validation', () => {
         webPresence: 'url1, url2',
         target: Target.EDUCATIONAL,
         createVenueWithoutSiret: false,
+        address: '3 Rue de Valois',
+        city: 'Paris',
+        latitude: 1.23,
+        longitude: 2.9887,
+        postalCode: '75001',
       })
 
       expect(mockNavigate).toHaveBeenCalledWith('/accueil')
@@ -228,6 +233,8 @@ describe('screens:SignupJourney::Validation', () => {
           name: 'nom',
           siret: '123123123',
           ...addressInformations,
+          longitude: null,
+          latitude: null,
         },
         setActivity: () => {},
         setOfferer: () => {},
@@ -248,6 +255,11 @@ describe('screens:SignupJourney::Validation', () => {
         webPresence: 'url1, url2',
         target: Target.EDUCATIONAL,
         createVenueWithoutSiret: false,
+        address: '3 Rue de Valois',
+        city: 'Paris',
+        latitude: 0,
+        longitude: 0,
+        postalCode: '75001',
       })
     })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21394

## But de la pull request

Utiliser l'adresse envoyée par le front lors du nouvel onboarding, au lieu d'appeler l'API Adresse sans input usager.

## Implémentation

- Adaptation du modèle Pydantic et de la route `/offerers/new`
