### PR TITLE
(PC-21938)[API] modify welcome pro email triggers

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1670,4 +1670,10 @@ def create_from_onboarding_data(
         venue_creation_info = venues_serialize.PostVenueBodyModel(**venue_kwargs)  # type: ignore [arg-type]
         create_venue(venue_creation_info, strict_accessibility_compliance=False)
 
+    if not transactional_mails.send_welcome_to_pro_email(user):
+        logger.warning(
+            "Could not send welcome to pro email",
+            extra={"user": user.id},
+        )
+
     return user_offerer

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -32,6 +32,7 @@ import pcapi.core.users.repository as users_repository
 import pcapi.core.users.utils as users_utils
 from pcapi.domain.password import random_hashed_password
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.repository import repository
@@ -1072,11 +1073,12 @@ def validate_pro_user_email(user: users_models.User, author_user: users_models.U
     else:
         repository.save(user)
 
-    if not transactional_mails.send_welcome_to_pro_email(user):
-        logger.warning(
-            "Could not send welcome email when pro user is valid",
-            extra={"user": user.id},
-        )
+    if not feature.FeatureToggle.WIP_ENABLE_NEW_ONBOARDING.is_active():
+        if not transactional_mails.send_welcome_to_pro_email(user):
+            logger.warning(
+                "Could not send welcome email when pro user is valid",
+                extra={"user": user.id},
+            )
 
 
 def save_firebase_flags(user: models.User, firebase_value: dict) -> None:

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -9,11 +9,13 @@ from pcapi.core.offerers import api
 from pcapi.core.offerers import repository
 import pcapi.core.offerers.exceptions as offerers_exceptions
 import pcapi.core.offerers.models as offerers_models
+from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.repository import transaction
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import offerers_serialize
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.feature import feature_required
 from pcapi.utils.rest import check_user_has_access_to_offerer
 
 from . import blueprint
@@ -174,6 +176,7 @@ def get_offerer_stats_dashboard_url(
 
 
 @private_api.route("/offerers/new", methods=["POST"])
+@feature_required(feature.FeatureToggle.WIP_ENABLE_NEW_ONBOARDING)
 @login_required
 @spectree_serialize(
     on_success_status=201, response_model=offerers_serialize.GetOffererResponseModel, api=blueprint.pro_private_schema

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -2,9 +2,9 @@ from unittest.mock import patch
 
 import pytest
 
-from pcapi.connectors import api_adresse
 from pcapi.connectors import sirene
 import pcapi.core.offerers.models as offerers_models
+from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
 
 
@@ -21,11 +21,11 @@ REQUEST_BODY = {
 
 
 class Returns200Test:
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     def test_nominal(self, client):
         user = users_factories.UserFactory(email="pro@example.com")
 
         client = client.with_session_auth(user.email)
-
         response = client.post("/offerers/new", json=REQUEST_BODY)
 
         assert response.status_code == 201
@@ -54,6 +54,7 @@ class Returns200Test:
 
 
 class Returns400Test:
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.UnknownEntityException())
     def test_siret_unknown(self, _get_siret_mock, client):
         user = users_factories.UserFactory()
@@ -66,6 +67,7 @@ class Returns400Test:
         assert offerers_models.UserOfferer.query.count() == 0
         assert offerers_models.Venue.query.count() == 0
 
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.NonPublicDataException())
     def test_non_diffusible_siret(self, _get_siret_mock, client):
         user = users_factories.UserFactory()
@@ -79,20 +81,20 @@ class Returns400Test:
         assert offerers_models.UserOfferer.query.count() == 0
         assert offerers_models.Venue.query.count() == 0
 
-    @patch("pcapi.connectors.api_adresse.get_address", side_effect=api_adresse.AdresseApiException())
-    def test_api_adresse_ko(self, _get_siret_mock, client):
+
+class Returns403Test:
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=False)
+    def test_siret_unknown(self, client):
         user = users_factories.UserFactory()
 
         client = client.with_session_auth(user.email)
         response = client.post("/offerers/new", json=REQUEST_BODY)
 
-        assert response.status_code == 400
-        assert offerers_models.Offerer.query.count() == 0
-        assert offerers_models.UserOfferer.query.count() == 0
-        assert offerers_models.Venue.query.count() == 0
+        assert response.status_code == 403
 
 
 class Returns500Test:
+    @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     @patch("pcapi.connectors.sirene.get_siret", side_effect=sirene.SireneApiException())
     def test_sirene_api_ko(self, _get_siret_mock, client):
         user = users_factories.UserFactory()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21938

## But de la pull request

- Dans le parcours actuel, le mail de bienvenue est déclenché post création de compte
- Dans le nouveau parcours d’inscription, le mail de bienvenue doit être déclenché post validation et création de l’espace.
