### PR TITLE
(PC-21950)[PRO] fix: fix wording in offer type selection

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -179,6 +179,7 @@ const OfferType = (): JSX.Element => {
     onSubmit: getNextPageHref,
   })
   const { values, handleChange } = formik
+
   return (
     <div className={styles['offer-type-container']}>
       <PageTitle title="Nature de l'offre" />
@@ -240,9 +241,12 @@ const OfferType = (): JSX.Element => {
                         COLLECTIVE_OFFER_SUBTYPE.TEMPLATE
                       }
                       label="Une offre vitrine"
-                      description={`Cette offre n’est pas réservable. Elle n’a ni date, ni prix et permet aux enseignants de vous contacter pour co-construire une offre adaptée.${
-                        isDuplicateOfferSelectionActive &&
-                        ' Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.'
+                      description={`Cette offre n’est pas réservable. Elle n’a ni date, ni prix et permet 
+                      aux enseignants de vous contacter pour co-construire une offre adaptée.
+                      ${
+                        isDuplicateOfferSelectionActive
+                          ? ' Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.'
+                          : ''
                       }`}
                       onChange={handleChange}
                       value={COLLECTIVE_OFFER_SUBTYPE.TEMPLATE}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21950

## But de la pull request

Fix le wording pour les offres vitrines. On affichait par erreur la valeur d'un FF dans la description du bouton 

## Screenshot 

![Capture d’écran 2023-04-25 à 09 05 50](https://user-images.githubusercontent.com/71768799/234200063-e3ba0df8-3ea3-4956-b3bc-b46f83b54218.png)

