### PR TITLE
(PC-21795)[PRO] feat: log event when wrong students modal is displayed

### DIFF
--- a/pro/src/core/FirebaseEvents/constants.ts
+++ b/pro/src/core/FirebaseEvents/constants.ts
@@ -54,6 +54,7 @@ export enum Events {
   DELETE_DRAFT_OFFER = 'DeleteDraftOffer',
   CLICKED_NO_VENUE = 'hasClickedNoVenue',
   CLICKED_EAC_DMS_LINK = 'hasClickedEacDmsLink',
+  EAC_WRONG_STUDENTS_MODAL_OPEN = 'hasOpenedEacWrongStudentsModal',
 }
 export enum VenueEvents {
   CLICKED_VENUE_ACCORDION_BUTTON = 'hasClickedVenueAccordionButton',

--- a/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/screens/OfferEducationalStock/OfferEducationalStock.tsx
@@ -11,6 +11,7 @@ import ActionsBarSticky from 'components/ActionsBarSticky'
 import BannerPublicApi from 'components/Banner/BannerPublicApi'
 import FormLayout from 'components/FormLayout'
 import OfferEducationalActions from 'components/OfferEducationalActions'
+import { Events } from 'core/FirebaseEvents/constants'
 import {
   CollectiveOffer,
   CollectiveOfferTemplate,
@@ -22,6 +23,7 @@ import {
   OPENING_DATE_FOR_6E_AND_5E,
 } from 'core/OfferEducational'
 import { isOfferDisabled } from 'core/Offers/utils'
+import useAnalytics from 'hooks/useAnalytics'
 import { Banner, ButtonLink, SubmitButton, TextArea } from 'ui-kit'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -70,6 +72,8 @@ const OfferEducationalStock = <
           isBefore(new Date(), addDays(new Date(beginningDatetime), 2))))
   )
 
+  const { logEvent } = useAnalytics()
+
   const disablePriceAndParticipantInputs =
     isCollectiveOffer(offer) &&
     mode === Mode.READ_ONLY &&
@@ -98,6 +102,10 @@ const OfferEducationalStock = <
         offer.students.includes(StudentLevels.COLL_GE_5E))
     ) {
       setIsWrongStudentsModalVisible(true)
+      logEvent?.(Events.EAC_WRONG_STUDENTS_MODAL_OPEN, {
+        from: location.pathname,
+        hasOnly6eAnd5eStudents: hasOnly6eAnd5eStudents,
+      })
       return
     }
     postForm(values)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21975

## But de la pull request

Ajouter un tracker à l'ouverture de la modal 6e/5e dans la création de stock collective 

## Screenshot 

![Capture d’écran 2023-04-25 à 11 11 18](https://user-images.githubusercontent.com/71768799/234230483-ae818d15-c781-4666-9c6a-69366d193ae3.png)
