### PR TITLE
(PC-18868)[API] fix: fix default banner urls

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -40,6 +40,7 @@ import sqlalchemy.sql.functions as sqla_func
 from sqlalchemy.sql.sqltypes import LargeBinary
 from werkzeug.utils import cached_property
 
+from pcapi import settings
 from pcapi.connectors import sirene
 from pcapi.core.educational import models as educational_models
 import pcapi.core.finance.models as finance_models
@@ -147,7 +148,7 @@ class VenueTypeCode(enum.Enum):
         return value
 
 
-VENUE_DEFAULTS_DIR = "venue_default_images"
+VENUE_DEFAULTS_DIR = "assets/venue_default_images"
 VENUE_TYPE_DEFAULT_BANNERS: dict[VenueTypeCode, tuple[str, ...]] = {
     VenueTypeCode.ADMINISTRATIVE: (),
     VenueTypeCode.ARTISTIC_COURSE: (
@@ -382,7 +383,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
             default_banner = elligible_banners[self.id % 2]
         except IndexError:
             return None
-        return os.path.join(VENUE_DEFAULTS_DIR, default_banner)
+        return os.path.join(settings.OBJECT_STORAGE_URL, VENUE_DEFAULTS_DIR, default_banner)
 
     @hybrid_property
     def bannerUrl(self) -> str | None:

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -1,10 +1,10 @@
 import datetime
-import pathlib
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from pcapi import settings
 from pcapi.connectors import sirene
 from pcapi.core.educational import factories as educational_factories
 import pcapi.core.finance.factories as finance_factories
@@ -152,7 +152,9 @@ class VenueBannerUrlTest:
     def test_can_get_category_default_banner_url_when_exists(self, venue_type_code):
         venue = factories.VenueFactory(venueTypeCode=venue_type_code)
 
-        assert pathlib.Path(venue.bannerUrl).name in models.VENUE_TYPE_DEFAULT_BANNERS[venue_type_code]
+        banner_base_url, banner_name = venue.bannerUrl.rsplit("/", 1)
+        assert banner_name in models.VENUE_TYPE_DEFAULT_BANNERS[venue_type_code]
+        assert banner_base_url == f"{settings.OBJECT_STORAGE_URL}/assets/venue_default_images"
 
     @pytest.mark.parametrize(
         "venue_type_code",

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -16,7 +16,7 @@ from tests.conftest import TestClient
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    def when_user_has_rights_on_managing_offerer(self, client):
+    def when_user_has_rights_on_managing_offerer(self, client, db_session):
         now = datetime.datetime.utcnow()
         user_offerer = offerers_factories.UserOffererFactory(user__email="user.pro@test.com")
         venue = offerers_factories.CollectiveVenueFactory(
@@ -156,7 +156,7 @@ class Returns200Test:
             "adageInscriptionDate": format_into_utc_date(venue.adageInscriptionDate),
         }
         auth_request = client.with_session_auth(email=user_offerer.user.email)
-        db.session.commit()  # clear SQLA cached objects
+        db_session.commit()  # clear SQLA cached objects
 
         with testing.assert_no_duplicated_queries():
             response = auth_request.get("/venues/%s" % venue_id)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-18868

## But de la pull request

correction de la construction des URLs de bannière par défaut pour les lieux

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
