### PR TITLE
(PC-19125)[PRO] fix: issue send withdrawalDelay as null instead of undefined

### DIFF
--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/serializers.spec.ts
@@ -103,7 +103,7 @@ describe('test updateIndividualOffer::serializers', () => {
         name: 'test name',
         url: 'http://my.url',
         visualDisabilityCompliant: true,
-        withdrawalDelay: undefined,
+        withdrawalDelay: null,
         withdrawalDetails: 'test withdrawalDetails',
         withdrawalType: undefined,
         durationMinutes: 120,

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
@@ -157,7 +157,7 @@ describe('updateIndividualOffer', () => {
       name: undefined,
       url: undefined,
       visualDisabilityCompliant: true,
-      withdrawalDelay: undefined,
+      withdrawalDelay: null,
       withdrawalDetails: undefined,
       withdrawalType: undefined,
       shouldSendMail: false,

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -86,7 +86,7 @@ export const serializePatchOffer = ({
       sentValues.accessibility &&
       sentValues.accessibility[AccessiblityEnum.MOTOR],
     name: sentValues.name,
-    withdrawalDelay: Number(sentValues.withdrawalDelay) || undefined,
+    withdrawalDelay: Number(sentValues.withdrawalDelay) || null,
     withdrawalDetails: sentValues.withdrawalDetails || undefined,
     visualDisabilityCompliant:
       sentValues.accessibility &&

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -410,7 +410,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
       url: 'http://offer.example.com',
       visualDisabilityCompliant: true,
       withdrawalDetails: 'Offer withdrawalDetails',
-      withdrawalDelay: undefined,
+      withdrawalDelay: null,
       withdrawalType: undefined,
       shouldSendMail: false,
     })
@@ -565,7 +565,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
         url: 'http://offer.example.com',
         visualDisabilityCompliant: true,
         withdrawalDetails: 'Offer withdrawalDetails',
-        withdrawalDelay: undefined,
+        withdrawalDelay: null,
         withdrawalType: undefined,
         shouldSendMail: false,
       }
@@ -898,7 +898,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
           ]
         }
 
-        expectedBody.withdrawalDelay = undefined
+        expectedBody.withdrawalDelay = null
         expectedBody.withdrawalType = WithdrawalTypeEnum.ON_SITE
         expectedBody.shouldSendMail = true
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19125

## But de la pull request

- Problème d'envoi de formulaire lors de la mise à jour des modalités de retrait à la sélection du choix "Événement sans billet".

## Implémentation

- Envoi null au lieu de undefined pour withdrawalDelay si c'est un événement sans billet.

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
