### PR TITLE
(PC-21790)[API] feat: add CGR pivot CRUD

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/providers/contexts/allocine.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/contexts/allocine.py
@@ -1,7 +1,6 @@
 import typing
 
 import sqlalchemy as sa
-from werkzeug.exceptions import NotFound
 
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
@@ -37,10 +36,11 @@ class AllocineContext(ProviderContext):
         return query.all()
 
     @classmethod
-    def get_form(cls, provider_id: int | None = None) -> forms.EditAllocineForm:
-        if provider_id is None:
-            return forms.EditAllocineForm()
+    def get_form(cls) -> forms.EditAllocineForm:
+        return forms.EditAllocineForm()
 
+    @classmethod
+    def get_edit_form(cls, provider_id: int) -> forms.EditAllocineForm:
         provider = providers_models.AllocinePivot.query.get_or_404(provider_id)
         return forms.EditAllocineForm(
             venue_id=[provider.venueId],
@@ -49,23 +49,25 @@ class AllocineContext(ProviderContext):
         )
 
     @classmethod
-    def create_provider(cls, form: forms.EditAllocineForm) -> None:
+    def create_provider(cls, form: forms.EditAllocineForm) -> bool:
         provider = providers_models.AllocinePivot(
             venueId=form.venue_id.data[0],
             theaterId=form.theater_id.data,
             internalId=form.internal_id.data,
         )
         db.session.add(provider)
+        return True
 
     @classmethod
-    def update_provider(cls, form: forms.EditAllocineForm, provider_id: int) -> None:
+    def update_provider(cls, form: forms.EditAllocineForm, provider_id: int) -> bool:
         provider = providers_models.AllocinePivot.query.get_or_404(provider_id)
         provider.venueId = form.venue_id.data[0]
         provider.theaterId = form.theater_id.data
         provider.internalId = form.internal_id.data
         db.session.add(provider)
+        return True
 
     @classmethod
-    def delete_provider(cls, provider_id: int) -> None:
+    def delete_provider(cls, provider_id: int) -> bool:
         # Delete Allocine provider is not allowed
-        raise NotFound()
+        return False

--- a/api/src/pcapi/routes/backoffice_v3/providers/contexts/base.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/contexts/base.py
@@ -43,17 +43,21 @@ class ProviderContext:
         return query.all()
 
     @classmethod
-    def get_form(cls, provider_id: int | None = None) -> forms.EditProviderForm:
+    def get_form(cls) -> forms.EditProviderForm:
         raise NotImplementedError()
 
     @classmethod
-    def create_provider(cls, form: forms.EditProviderForm) -> None:
+    def get_edit_form(cls, provider_id: int) -> forms.EditProviderForm:
         raise NotImplementedError()
 
     @classmethod
-    def update_provider(cls, form: forms.EditProviderForm, provider_id: int) -> None:
+    def create_provider(cls, form: forms.EditProviderForm) -> bool:
         raise NotImplementedError()
 
     @classmethod
-    def delete_provider(cls, provider_id: int) -> None:
+    def update_provider(cls, form: forms.EditProviderForm, provider_id: int) -> bool:
+        raise NotImplementedError()
+
+    @classmethod
+    def delete_provider(cls, provider_id: int) -> bool:
         raise NotImplementedError()

--- a/api/src/pcapi/routes/backoffice_v3/providers/contexts/boost.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/contexts/boost.py
@@ -13,10 +13,11 @@ class BoostContext(ProviderContext):
         return providers_models.BoostCinemaDetails
 
     @classmethod
-    def get_form(cls, provider_id: int | None = None) -> forms.EditBoostForm:
-        if provider_id is None:
-            return forms.EditBoostForm()
+    def get_form(cls) -> forms.EditBoostForm:
+        return forms.EditBoostForm()
 
+    @classmethod
+    def get_edit_form(cls, provider_id: int) -> forms.EditBoostForm:
         provider = providers_models.BoostCinemaDetails.query.get_or_404(provider_id)
         return forms.EditBoostForm(
             # TODO PC-21791
@@ -27,7 +28,7 @@ class BoostContext(ProviderContext):
         )
 
     @classmethod
-    def create_provider(cls, form: forms.EditBoostForm) -> None:
+    def create_provider(cls, form: forms.EditBoostForm) -> bool:
         provider = providers_models.BoostCinemaDetails(
             # TODO PC-21791
             # venueId=form.venue_id.data[0],
@@ -36,9 +37,10 @@ class BoostContext(ProviderContext):
             cinemaUrl=form.cinema_url.data,
         )
         db.session.add(provider)
+        return True
 
     @classmethod
-    def update_provider(cls, form: forms.EditBoostForm, provider_id: int) -> None:
+    def update_provider(cls, form: forms.EditBoostForm, provider_id: int) -> bool:
         provider = providers_models.BoostCinemaDetails.query.get_or_404(provider_id)
         # TODO PC-21791
         provider.venueId = form.venue_id.data[0]
@@ -46,7 +48,8 @@ class BoostContext(ProviderContext):
         provider.password = form.password.data
         provider.cinemaUrl = form.cinema_url.data
         db.session.add(provider)
+        return True
 
     @classmethod
-    def delete_provider(cls, provider_id: int) -> None:
-        pass  # TODO PC-21791
+    def delete_provider(cls, provider_id: int) -> bool:
+        return False  # TODO PC-21791

--- a/api/src/pcapi/routes/backoffice_v3/providers/contexts/cgr.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/contexts/cgr.py
@@ -1,10 +1,19 @@
+import logging
 import typing
 
+from flask import flash
+
+from pcapi.connectors.cgr import cgr
+import pcapi.core.offerers.models as offerers_models
 from pcapi.core.providers import models as providers_models
+import pcapi.core.providers.repository as providers_repository
 from pcapi.models import db
 
 from .. import forms
 from .base import ProviderContext
+
+
+logger = logging.getLogger(__name__)
 
 
 class CGRContext(ProviderContext):
@@ -13,33 +22,102 @@ class CGRContext(ProviderContext):
         return providers_models.CGRCinemaDetails
 
     @classmethod
-    def get_form(cls, provider_id: int | None = None) -> forms.EditCGRForm:
-        if provider_id is None:
-            return forms.EditCGRForm()
-
-        provider = providers_models.CGRCinemaDetails.query.get_or_404(provider_id)
-        return forms.EditCGRForm(
-            venue_id=[provider.venueId],
-            account_id=provider.accountId,
-            api_token=provider.cinemaApiToken,
-        )
+    def get_form(cls) -> forms.EditCGRForm:
+        return forms.EditCGRForm()
 
     @classmethod
-    def create_provider(cls, form: forms.EditCGRForm) -> None:
+    def get_edit_form(cls, provider_id: int) -> forms.EditCGRForm:
+        provider = providers_models.CGRCinemaDetails.query.get_or_404(provider_id)
+
+        form = forms.EditCGRForm(
+            venue_id=[provider.cinemaProviderPivot.venue.id],
+            cinema_id=provider.cinemaProviderPivot.idAtProvider,
+            cinema_url=provider.cinemaUrl,
+            password=provider.password,
+        )
+        form.venue_id.disabled = True
+        return form
+
+    @classmethod
+    def create_provider(cls, form: forms.EditCGRForm) -> bool:
+        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+        if not cgr_provider:
+            flash("Provider CGR n'existe pas.", "error")
+            return False
+
+        venue_id = form.venue_id.data
+        cinema_id = form.cinema_id.data
+        cinema_url = form.cinema_url.data.rstrip("/")
+        cinema_password = form.password.data
+
+        venue = offerers_models.Venue.query.get(venue_id)
+        if not venue:
+            flash(f"Lieu id={venue_id} n'existe pas", "danger")
+            return False
+        pivot = providers_models.CinemaProviderPivot.query.filter_by(venueId=venue.id).one_or_none()
+        if pivot:
+            flash(f"Des identifiants cinéma existent déjà pour ce lieu id={venue.id}", "danger")
+            return False
+
+        cinema_provider_pivot = providers_models.CinemaProviderPivot(
+            venue=venue, provider=cgr_provider, idAtProvider=cinema_id
+        )
         provider = providers_models.CGRCinemaDetails(
-            # TODO PC-21790
-            # venueId=form.venue_id.data[0],
-            cinemaUrl=form.cinema_url.data,
+            cinemaProviderPivot=cinema_provider_pivot, cinemaUrl=cinema_url, password=cinema_password
         )
-        # TODO PC-21790
+
+        num_cinema = cls.check_if_api_call_is_ok(provider)
+        if num_cinema:
+            provider.numCinema = num_cinema
+
+        db.session.add(cinema_provider_pivot)
         db.session.add(provider)
+        return True
 
     @classmethod
-    def update_provider(cls, form: forms.EditCGRForm, provider_id: int) -> None:
+    def update_provider(cls, form: forms.EditCGRForm, provider_id: int) -> bool:
         provider = providers_models.CGRCinemaDetails.query.get_or_404(provider_id)
-        # TODO PC-21790
+
+        if provider.cinemaProviderPivot is None:
+            flash("Le provider n'a pas de pivot", "danger")  #  Demander le message le mieux adapté
+            return False
+        provider.cinemaProviderPivot.idAtProvider = form.cinema_id.data
+        provider.cinemaUrl = form.cinema_url.data.rstrip("/")
+        provider.password = form.password.data
+        num_cinema = cls.check_if_api_call_is_ok(provider)
+
+        if num_cinema:
+            provider.numCinema = num_cinema
+
         db.session.add(provider)
+        return True
 
     @classmethod
-    def delete_provider(cls, provider_id: int) -> None:
-        pass  # TODO PC-21790
+    def delete_provider(cls, provider_id: int) -> bool:
+        provider = providers_models.CGRCinemaDetails.query.get_or_404(provider_id)
+        cinema_provider_pivot = provider.cinemaProviderPivot
+        assert cinema_provider_pivot  # helps mypy
+        venue_provider = providers_models.VenueProvider.query.filter_by(
+            venueId=cinema_provider_pivot.venueId, providerId=cinema_provider_pivot.providerId
+        ).one_or_none()
+
+        if venue_provider:
+            flash("Ce lieu est toujours synchronisé avec CDS, Vous ne pouvez pas supprimer ce pivot CGR", "danger")
+            return False
+        db.session.delete(provider)
+        db.session.delete(cinema_provider_pivot)
+        return True
+
+    @classmethod
+    def check_if_api_call_is_ok(cls, provider: providers_models.CGRCinemaDetails) -> int | None:
+        try:
+            response = cgr.get_seances_pass_culture(provider)
+            flash("Connexion à l'API CGR OK.")
+            return response.ObjetRetour.NumCine
+        # it could be an unexpected XML parsing error
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception("Error while checking CGR API information", extra={"exc": exc})
+        flash(
+            "Connexion à l'API CGR KO.", "danger"
+        )  # ajout à valider : permet d'alerter l'utilisateur de problème de connexion CGR
+        return None

--- a/api/src/pcapi/routes/backoffice_v3/providers/contexts/cineoffice.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/contexts/cineoffice.py
@@ -13,10 +13,11 @@ class CineofficeContext(ProviderContext):
         return providers_models.CDSCinemaDetails
 
     @classmethod
-    def get_form(cls, provider_id: int | None = None) -> forms.EditCineOfficeForm:
-        if provider_id is None:
-            return forms.EditCineOfficeForm()
+    def get_form(cls) -> forms.EditCineOfficeForm:
+        return forms.EditCineOfficeForm()
 
+    @classmethod
+    def get_edit_form(cls, provider_id: int) -> forms.EditCineOfficeForm:
         provider = providers_models.CDSCinemaDetails.query.get_or_404(provider_id)
         return forms.EditCineOfficeForm(
             # TODO PC-21792
@@ -26,7 +27,7 @@ class CineofficeContext(ProviderContext):
         )
 
     @classmethod
-    def create_provider(cls, form: forms.EditCineOfficeForm) -> None:
+    def create_provider(cls, form: forms.EditCineOfficeForm) -> bool:
         provider = providers_models.CDSCinemaDetails(
             # TODO PC-21792
             # venueId=form.venue_id.data[0],
@@ -34,13 +35,15 @@ class CineofficeContext(ProviderContext):
             cinemaApiToken=form.api_token.data,
         )
         db.session.add(provider)
+        return True
 
     @classmethod
-    def update_provider(cls, form: forms.EditCineOfficeForm, provider_id: int) -> None:
+    def update_provider(cls, form: forms.EditCineOfficeForm, provider_id: int) -> bool:
         provider = providers_models.CDSCinemaDetails.query.get_or_404(provider_id)
         # TODO PC-21792
         db.session.add(provider)
+        return True
 
     @classmethod
-    def delete_provider(cls, provider_id: int) -> None:
-        pass  # TODO PC-21792
+    def delete_provider(cls, provider_id: int) -> bool:
+        return False  # TODO PC-21792

--- a/api/src/pcapi/routes/backoffice_v3/providers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/forms.py
@@ -1,5 +1,8 @@
+from flask import flash
 from flask_wtf import FlaskForm
 import wtforms
+
+import pcapi.core.providers.repository as providers_repository
 
 from ..forms import fields
 
@@ -44,14 +47,30 @@ class EditBoostForm(EditProviderForm):
 
 # TODO PC-21790
 class EditCGRForm(EditProviderForm):
-    cinema_id = fields.PCStringField("URL du cinéma (CGR)")
+    cinema_id = fields.PCStringField("Identifiant Cinéma (CGR)")
     cinema_url = fields.PCStringField(
-        "Identifiant Cinéma (CGR)",
+        "URL du cinéma (CGR)",
         validators=(
             wtforms.validators.InputRequired("Information obligatoire"),
             wtforms.validators.URL("Doit avoir la forme d'une URL"),
         ),
     )
+    password = fields.PCStringField("Mot de passe (CGR)")
+
+    def validate(self, extra_validators=None) -> bool:  # type: ignore [no-untyped-def]
+        # do not use this custom validation on DeleteForm
+        if not isinstance(self, EditCGRForm):
+            return super().validate(extra_validators)
+
+        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+        pivot = providers_repository.get_pivot_for_id_at_provider(
+            id_at_provider=self.cinema_id.data, provider_id=cgr_provider.id
+        )
+        if pivot and pivot.venueId != self.venue_id.data:
+            flash("Cet identifiant cinéma existe déjà pour un autre lieu", "danger")
+            return False
+
+        return super().validate(extra_validators)
 
 
 # TODO PC-21792

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/tom_select_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/tom_select_field.html
@@ -1,6 +1,7 @@
 <div class="form-floating {{ field.name }}-container">
   {% set tom_select_field_id = random_hash() %}
   <select {% if field.multiple %}multiple{% endif %}
+          {% if field.disabled %}disabled{% endif %}
           data-tomselect-autocomplete-url="{{ field.tomselect_autocomplete_url }}"
           data-tomselect-options="{{ field.tomselect_options }}"
           data-tomselect-items="{{ field.tomselect_items }}"

--- a/api/src/pcapi/routes/backoffice_v3/templates/providers/get/cgr.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/providers/get/cgr.html
@@ -1,7 +1,7 @@
 {% import "components/links.html" as links %}
 {% import "providers/get/common.html" as common %}
 <turbo-frame id="cgr_frame">
-{{ common.build_provider_bar("cgr", form, dst, true) }}
+{{ common.build_provider_bar("cgr", form, dst) }}
 <table class="table table-hover my-4">
   <thead>
     <tr>
@@ -10,16 +10,18 @@
       <th scope="col">Lieu</th>
       <th scope="col">Identifiant cinéma (CGR)</th>
       <th scope="col">URL du cinéma (CGR)</th>
+      <th scope="col">Mot de passe (CGR)</th>
     </tr>
   </thead>
   <tbody>
     {% for provider in rows %}
       <tr>
-        <th scope="row">{# common.build_provider_row_menu("cgr", provider, true, true) #}</th>
+        <th scope="row">{{ common.build_provider_row_menu("cgr", provider, true) }}</th>
         <td class="fw-bolder">{{ provider.cinemaProviderPivot.venue.id }}</td>
         <td>{{ links.build_venue_name_to_details_link(provider.cinemaProviderPivot.venue, text_attr="name") }}</td>
         <td>{{ provider.cinemaProviderPivot.idAtProvider }}</td>
         <td>{{ provider.cinemaUrl }}</td>
+        <td>{{ provider.password }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/api/tests/routes/backoffice_v3/providers_test.py
+++ b/api/tests/routes/backoffice_v3/providers_test.py
@@ -5,8 +5,12 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
+import pcapi.core.providers.repository as providers_repository
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+
+from tests.connectors.cgr import soap_definitions
+from tests.local_providers.cinema_providers.cgr import fixtures
 
 from .helpers import html_parser
 from .helpers.get import GetEndpointHelper
@@ -126,9 +130,51 @@ class ListProvidersTest(GetEndpointHelper):
         assert cgr_rows[0]["Identifiant cinéma (CGR)"] == cgr_provider.cinemaProviderPivot.idAtProvider
         assert cgr_rows[0]["URL du cinéma (CGR)"] == cgr_provider.cinemaUrl
 
-    @pytest.mark.skip(reason="TODO PC-21790")
+    @pytest.mark.parametrize(
+        "query_string,expected_venues",
+        [
+            ("10", {"Cinéma Edison"}),  # id
+            ("91", set()),
+            ("cinéma", {"Cinéma Edison", "Cinéma Lumière"}),  # beginning, accent
+            ("lumiere", {"Cinéma Lumière", "Chez les Frères Lumière"}),  # end, no accent
+            ("idProvider1010", {"Cinéma Edison"}),  # full idAtProvider
+            ("idProvider101", set()),  # part idAtProvider
+            ("http://cgr-cinema-", set()),  # not searchable
+        ],
+    )
     def test_filter_providers_cgr(self, authenticated_client, query_string, expected_venues):
-        pass  # TODO PC-21790
+        # given
+        cgr_provider = providers_repository.get_provider_by_local_class("CGRStocks")
+        providers_factories.CGRCinemaDetailsFactory(
+            cinemaProviderPivot=providers_factories.CinemaProviderPivotFactory(
+                venue=offerers_factories.VenueFactory(id=10, name="Cinéma Edison"),
+                provider=cgr_provider,
+                idAtProvider="idProvider1010",
+            ),
+        )
+        providers_factories.CGRCinemaDetailsFactory(
+            cinemaProviderPivot=providers_factories.CinemaProviderPivotFactory(
+                venue=offerers_factories.VenueFactory(id=11, name="Cinéma Lumière"),
+                provider=cgr_provider,
+                idAtProvider="idProvider1111",
+            ),
+        )
+        providers_factories.CGRCinemaDetailsFactory(
+            cinemaProviderPivot=providers_factories.CinemaProviderPivotFactory(
+                venue=offerers_factories.VenueFactory(id=12, name="Chez les Frères Lumière"),
+                provider=cgr_provider,
+                idAtProvider="idProvider1212",
+            ),
+        )
+
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, name="cgr", q=query_string))
+            assert response.status_code == 200
+
+        # then
+        cgr_rows = html_parser.extract_table_rows(response.data)
+        assert {row["Lieu"] for row in cgr_rows} == expected_venues
 
     def test_list_providers_cineoffice(self, authenticated_client):
         # given
@@ -203,9 +249,26 @@ class CreateProviderTest(PostEndpointHelper):
     def test_create_provider_boost(self, authenticated_client):
         pass  # TODO PC-21791
 
-    @pytest.mark.skip(reason="TODO PC-21790")
-    def test_create_provider_cgr(self, authenticated_client):
-        pass  # TODO PC-21790
+    def test_create_provider_cgr(self, requests_mock, authenticated_client):
+        requests_mock.get("http://example.com/another_web_service", text=soap_definitions.WEB_SERVICE_DEFINITION)
+        requests_mock.post(
+            "http://example.com/another_web_service", text=fixtures.cgr_response_template([fixtures.FILM_138473])
+        )
+        venue_id = offerers_factories.VenueFactory().id
+        form = {
+            "venue_id": venue_id,
+            "cinema_id": "idProvider1111",
+            "cinema_url": "http://example.com/another_web_service",
+            "password": "azerty!123",
+        }
+
+        self.post_to_endpoint(authenticated_client, name="cgr", form=form)
+
+        created = providers_models.CGRCinemaDetails.query.one()
+        assert created.cinemaProviderPivot.venueId == venue_id
+        assert created.cinemaProviderPivot.idAtProvider == form["cinema_id"]
+        assert created.cinemaUrl == form["cinema_url"]
+        assert created.password == form["password"]
 
     @pytest.mark.skip(reason="TODO PC-21792")
     def test_create_provider_cineoffice(self, authenticated_client):
@@ -239,9 +302,24 @@ class GetUpdateProviderFormTest(GetEndpointHelper):
     def test_get_update_provider_form_boost(self, authenticated_client):
         pass  # TODO PC-21791
 
-    @pytest.mark.skip(reason="TODO PC-21790")
     def test_get_update_provider_form_cgr(self, authenticated_client):
-        pass  # TODO PC-21790
+        # given
+        # - fetch cgr cinema details (1 query)
+        # - fetch session (1 query)
+        # - fetch user (1 query)
+        # - fetch provider (1 query)
+        # - fetch venue for form validate (1 query)
+        # - fetch venue to fill autocomplete (1 query)
+        expected_num_queries = 6
+
+        cgr_provider = providers_factories.CGRCinemaDetailsFactory(cinemaUrl="http://example.com/another_web_service")
+
+        db.session.expire(cgr_provider)
+
+        # when
+        with assert_num_queries(expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, name="cgr", provider_id=cgr_provider.id))
+            assert response.status_code == 200
 
     @pytest.mark.skip(reason="TODO PC-21792")
     def test_get_update_provider_form_cineoffice(self, authenticated_client):
@@ -271,10 +349,47 @@ class UpdateProviderTest(PostEndpointHelper):
     def test_update_provider_boost(self, authenticated_client):
         pass  # TODO PC-21791
 
-    @pytest.mark.skip(reason="TODO PC-21790")
-    def test_update_provider_cgr(self, authenticated_client):
-        pass  # TODO PC-21790
+    def test_update_provider_cgr(self, authenticated_client, requests_mock):
+        requests_mock.get("http://example.com/another_web_service", text=soap_definitions.WEB_SERVICE_DEFINITION)
+        requests_mock.post(
+            "http://example.com/another_web_service", text=fixtures.cgr_response_template([fixtures.FILM_138473])
+        )
+        cgr_provider = providers_factories.CGRCinemaDetailsFactory()
+
+        form = {
+            "cinema_id": "idProvider1000",
+            "cinema_url": "http://example.com/another_web_service",
+            "password": "Azerty!123",
+        }
+
+        self.post_to_endpoint(authenticated_client, name="cgr", provider_id=cgr_provider.id, form=form)
+
+        updated = providers_models.CGRCinemaDetails.query.one()
+        assert updated.cinemaProviderPivot.idAtProvider == form["cinema_id"]
+        assert updated.cinemaUrl == form["cinema_url"]
+        assert updated.password == form["password"]
 
     @pytest.mark.skip(reason="TODO PC-21792")
     def test_update_provider_cineoffice(self, authenticated_client):
+        pass  # TODO PC-21792
+
+
+class DeleteProviderTest(PostEndpointHelper):
+    endpoint = "backoffice_v3_web.providers.delete_provider"
+    endpoint_kwargs = {"name": "cgr", "provider_id": 1}
+    needed_permission = perm_models.Permissions.MANAGE_PROVIDERS
+
+    @pytest.mark.skip(reason="TODO PC-21791")
+    def test_delete_provider_boost(self, authenticated_client):
+        pass  # TODO PC-21791
+
+    def test_delete_provider_cgr(self, authenticated_client):
+        cgr_provider = providers_factories.CGRCinemaDetailsFactory()
+
+        self.post_to_endpoint(authenticated_client, name="cgr", provider_id=cgr_provider.id)
+
+        assert not providers_models.CGRCinemaDetails.query.get(cgr_provider.id)
+
+    @pytest.mark.skip(reason="TODO PC-21792")
+    def test_delete_provider_cineoffice(self, authenticated_client):
         pass  # TODO PC-21792


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21790

## But de la pull request

Ajout d'un CRUD pour les pivot CGR

## Implémentation

Identique à celle de la page flask admin (ie: https://backend.testing.passculture.team/pc/back-office/cgr/)

## Informations supplémentaires

- À discuter : Ajout de flash message pour l'utilisateur si l'API CGR est KO. (p-e pas souhaitable ?)

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
