### PR TITLE
(PC-21412)[API] fix: add dashboard link to collective offer templates

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/collective_offer_templates.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offer_templates.py
@@ -96,7 +96,9 @@ def _get_collective_offer_templates(
             base_query = base_query.filter(educational_models.CollectiveOfferTemplate.name.ilike(name_query))
 
     if form.sort.data:
-        base_query = base_query.order_by(getattr(educational_models.CollectiveOfferTemplate, form.sort.data))
+        base_query = base_query.order_by(
+            getattr(getattr(educational_models.CollectiveOfferTemplate, form.sort.data), form.order.data)()
+        )
 
     # +1 to check if there are more results than requested
     return base_query.limit(form.limit.data + 1).all()

--- a/api/src/pcapi/routes/backoffice_v3/forms/collective_offer_template.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/collective_offer_template.py
@@ -42,7 +42,12 @@ class GetCollectiveOfferTemplatesListForm(FlaskForm):
     )
     only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
     sort = wtforms.HiddenField(
-        "sort", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("id", "dateCreated")))
+        "sort",
+        default="dateCreated",
+        validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("id", "dateCreated"))),
+    )
+    order = wtforms.HiddenField(
+        "order", default="asc", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("asc", "desc")))
     )
 
     def is_empty(self) -> bool:

--- a/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
@@ -44,7 +44,8 @@
         {{ stats_card(
         pending_collective_templates_count,
         "offre collective vitrine en attente",
-        "offres collectives vitrine en attente") }}
+        "offres collectives vitrine en attente",
+        url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates", status="PENDING", only_validated_offerers="on", sort="dateCreated", order="desc")) }}
       </div>
     {% endif %}
   </div>

--- a/api/tests/routes/backoffice_v3/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offer_templates_test.py
@@ -89,7 +89,7 @@ class ListCollectiveOfferTemplatesTest:
         # when
         searched_name = collective_offer_templates[1].name
         with assert_num_queries(self.expected_num_queries):
-            response = authenticated_client.get(url_for(self.endpoint, q=searched_name))
+            response = authenticated_client.get(url_for(self.endpoint, q=searched_name, sort="id", order="asc"))
 
         # then
         assert response.status_code == 200

--- a/api/tests/routes/backoffice_v3/home_test.py
+++ b/api/tests/routes/backoffice_v3/home_test.py
@@ -68,5 +68,5 @@ class HomePageTest:
         assert cards_text == [
             "2 offres individuelles en attente CONSULTER",
             "3 offres collectives en attente CONSULTER",
-            "4 offres collectives vitrine en attente À VENIR",
+            "4 offres collectives vitrine en attente CONSULTER",
         ]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21412

## But de la pull request

Activation du lien dashboard pour collective offer templates 

## Implémentation

- trier par `createdDate` desc
- seulement les offres vitrines avec le statut `PENDING` 
- seulement pour les structures validées.

## Informations supplémentaires

- Ajout du params `order` avec valeur par défaut `desc`
- Modification du params `sort` avec valeur par défaut `createdDate`.

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
