### PR TITLE
(PC-21206)[API] feat: set offerer active when validated and vice versa

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -31,6 +31,7 @@ class NotValidatedOffererFactory(OffererFactory):
 
 class RejectedOffererFactory(OffererFactory):
     validationStatus = ValidationStatus.REJECTED
+    isActive = False
 
 
 class CollectiveOffererFactory(OffererFactory):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -810,6 +810,7 @@ def _generate_user_offerer_when_existing_offerer(
 def _generate_offerer(data: dict, existing_offerer: offerers_models.Offerer | None = None) -> offerers_models.Offerer:
     if existing_offerer is not None:
         offerer = existing_offerer
+        offerer.isActive = True
     else:
         offerer = offerers_models.Offerer()
     offerer.populate_from_dict(data)

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -484,6 +484,7 @@ class CreateOffererTest:
         assert created_offerer.postalCode == offerer_informations.postalCode
         assert created_offerer.city == offerer_informations.city
         assert created_offerer.validationStatus == ValidationStatus.NEW
+        assert created_offerer.isActive
         assert "Collectivité" in (tag.label for tag in created_offerer.tags)
 
         assert created_user_offerer.userId == user.id
@@ -529,6 +530,7 @@ class CreateOffererTest:
         created_offerer = created_user_offerer.offerer
         assert created_offerer.name == offerer.name
         assert created_offerer.isValidated
+        assert created_offerer.isActive
 
         assert created_user_offerer.userId == user.id
         assert created_user_offerer.validationStatus == ValidationStatus.NEW
@@ -572,10 +574,9 @@ class CreateOffererTest:
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
             name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
         )
-        offerer = offerers_factories.OffererFactory(
+        offerer = offerers_factories.RejectedOffererFactory(
             name="Rejected Offerer",
             siren=offerer_informations.siren,
-            validationStatus=ValidationStatus.REJECTED,
         )
         first_creation_date = offerer.dateCreated
 
@@ -591,6 +592,7 @@ class CreateOffererTest:
         assert created_offerer.postalCode == offerer_informations.postalCode
         assert created_offerer.city == offerer_informations.city
         assert created_offerer.validationStatus == ValidationStatus.NEW
+        assert created_offerer.isActive
         assert created_offerer.dateCreated > first_creation_date
 
         assert created_user_offerer.userId == user.id

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -1507,6 +1507,7 @@ class ValidateOffererTest:
 
         db.session.refresh(user_offerer)
         assert user_offerer.offerer.isValidated
+        assert user_offerer.offerer.isActive
         assert user_offerer.user.has_pro_role
 
         action = history_models.ActionHistory.query.one()
@@ -1516,6 +1517,21 @@ class ValidateOffererTest:
         assert action.userId == user_offerer.user.id
         assert action.offererId == user_offerer.offerer.id
         assert action.venueId is None
+
+    def test_validate_rejected_offerer(self, legit_user, authenticated_client):
+        # given
+        offerer = offerers_factories.RejectedOffererFactory()
+
+        # when
+        url = url_for("backoffice_v3_web.validation.validate_offerer", offerer_id=offerer.id)
+        response = send_request(authenticated_client, offerer.id, url)
+
+        # then
+        assert response.status_code == 303
+
+        db.session.refresh(offerer)
+        assert offerer.isValidated
+        assert offerer.isActive
 
     def test_validate_offerer_returns_404_if_offerer_is_not_found(self, authenticated_client):
         # when
@@ -1585,6 +1601,7 @@ class RejectOffererTest:
         db.session.refresh(user)
         db.session.refresh(offerer)
         assert not offerer.isValidated
+        assert not offerer.isActive
         assert offerer.isRejected
         assert not user.has_pro_role
 
@@ -1669,6 +1686,7 @@ class SetOffererPendingTest:
 
         db.session.refresh(offerer)
         assert not offerer.isValidated
+        assert offerer.isActive
         assert offerer.validationStatus == ValidationStatus.PENDING
         assert set(offerer.tags) == {non_homologation_tag, offerer_tags[0], offerer_tags[2]}
         action = history_models.ActionHistory.query.one()

--- a/api/tests/routes/pro/signup_pro_test.py
+++ b/api/tests/routes/pro/signup_pro_test.py
@@ -166,10 +166,9 @@ class Returns204Test:
 
     def test_when_offerer_was_previously_rejected(self, client):
         # Given
-        offerer = offerers_factories.OffererFactory(
+        offerer = offerers_factories.RejectedOffererFactory(
             name="Rejected Offerer",
             siren=BASE_DATA_PRO["siren"],
-            validationStatus=ValidationStatus.REJECTED,
         )
 
         first_creation_date = offerer.dateCreated
@@ -187,6 +186,7 @@ class Returns204Test:
         offerer = Offerer.query.filter_by(siren="349974931").one()
         assert offerer.name == BASE_DATA_PRO["name"]
         assert offerer.validationStatus == ValidationStatus.NEW
+        assert offerer.isActive
         assert offerer.dateCreated > first_creation_date
         user_offerer = UserOfferer.query.filter_by(user=user, offerer=offerer).one()
         assert user_offerer.validationStatus == ValidationStatus.VALIDATED


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21206

## But de la pull request

Lors du rejet d’une structure, on désactive la structure
Si on valide une structure et que cette structure est désactivée, on active la structure
Si on passe en attente une structure et que cette structure est désactivée, on active la structure

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
