### PR TITLE
(PC-22011)[API] fix: use non-humanized ids in all links from the backoffice to PC Pro

### DIFF
--- a/api/src/pcapi/utils/urls.py
+++ b/api/src/pcapi/utils/urls.py
@@ -38,25 +38,25 @@ def build_pc_pro_offer_link(offer: CollectiveOffer | CollectiveOfferTemplate | O
     if isinstance(offer, CollectiveOfferTemplate):
         return f"{settings.PRO_URL}/offre/T-{humanize(offer.id)}/collectif/edition"
 
-    return f"{settings.PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif"
+    return f"{settings.PRO_URL}/offre/individuelle/{offer.id}/recapitulatif"
 
 
 def build_pc_pro_offerer_link(offerer: offerers_models.Offerer) -> str:
-    return f"{settings.PRO_URL}/accueil?structure={humanize(offerer.id)}"
+    return f"{settings.PRO_URL}/accueil?structure={offerer.id}"
 
 
 def build_pc_pro_venue_link(venue: offerers_models.Venue) -> str:
     if venue.isVirtual:
         return build_pc_pro_offerer_link(venue.managingOfferer)
-    return f"{settings.PRO_URL}/structures/{humanize(venue.managingOffererId)}/lieux/{humanize(venue.id)}"
+    return f"{settings.PRO_URL}/structures/{venue.managingOffererId}/lieux/{venue.id}"
 
 
 def build_pc_pro_venue_bookings_link(venue: offerers_models.Venue) -> str:
-    return f"{settings.PRO_URL}/reservations?offerVenueId={humanize(venue.id)}"
+    return f"{settings.PRO_URL}/reservations?offerVenueId={venue.id}"
 
 
 def build_pc_pro_venue_offers_link(venue: offerers_models.Venue) -> str:
-    return f"{settings.PRO_URL}/offres?lieu={humanize(venue.id)}"
+    return f"{settings.PRO_URL}/offres?lieu={venue.id}"
 
 
 def build_pc_pro_user_email_validation_link(user: users_models.User) -> str:

--- a/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
@@ -12,7 +12,6 @@ from pcapi.core.mails.transactional.sendinblue_template_ids import Transactional
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.settings import PRO_URL
-from pcapi.utils.human_ids import humanize
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -34,7 +33,7 @@ class SendinblueSendFirstVenueOfferEmailTest:
             "IS_EVENT": False,
             "IS_THING": True,
             "IS_DIGITAL": False,
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "WITHDRAWAL_PERIOD": 30,
         }
 
@@ -54,7 +53,7 @@ class SendinblueSendFirstVenueOfferEmailTest:
             "IS_EVENT": False,
             "IS_THING": True,
             "IS_DIGITAL": False,
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "WITHDRAWAL_PERIOD": 10,
         }
 
@@ -75,7 +74,7 @@ class SendinblueSendFirstVenueOfferEmailTest:
         assert mails_testing.outbox[0].sent_data["To"] == "venue@bookingEmail.com"
         assert mails_testing.outbox[0].sent_data["params"] == {
             "OFFER_NAME": offer.name,
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "VENUE_NAME": venue.name,
             "IS_EVENT": False,
             "IS_THING": True,

--- a/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
@@ -10,7 +10,6 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.settings import PRO_URL
-from pcapi.utils.human_ids import humanize
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -29,7 +28,7 @@ class SendinblueSendOfferValidationTest:
         assert new_offer_validation_email.params == {
             "OFFER_NAME": "Ma petite offre",
             "VENUE_NAME": "Mon stade",
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
         }
 
     def test_send_offer_approval_email(
@@ -48,7 +47,7 @@ class SendinblueSendOfferValidationTest:
         assert mails_testing.outbox[0].sent_data["To"] == "jules.verne@example.com"
         assert mails_testing.outbox[0].sent_data["params"] == {
             "OFFER_NAME": offer.name,
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "VENUE_NAME": venue.name,
         }
 
@@ -65,7 +64,7 @@ class SendinblueSendOfferValidationTest:
             "IS_COLLECTIVE_OFFER": False,
             "OFFER_NAME": "Ma petite offre",
             "VENUE_NAME": "Mon stade",
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
         }
 
     def test_get_validation_rejection_correct_collective_attribute(self):
@@ -107,6 +106,6 @@ class SendinblueSendOfferValidationTest:
         assert mails_testing.outbox[0].sent_data["params"] == {
             "IS_COLLECTIVE_OFFER": False,
             "OFFER_NAME": offer.name,
-            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{humanize(offer.id)}/recapitulatif",
+            "PC_PRO_OFFER_LINK": f"{PRO_URL}/offre/individuelle/{offer.id}/recapitulatif",
             "VENUE_NAME": venue.name,
         }

--- a/api/tests/core/mails/transactional/users/reported_offer_by_user_test.py
+++ b/api/tests/core/mails/transactional/users/reported_offer_by_user_test.py
@@ -10,7 +10,6 @@ from pcapi.core.mails.transactional.users.reported_offer_by_user import send_ema
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.models import Reason
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
-from pcapi.utils.human_ids import humanize
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -60,5 +59,5 @@ class ReportedOfferByUserEmailTest:
             "OFFER_ID": offer.id,
             "OFFER_NAME": offer.name,
             "REASON": "Le contenu est inapproprié",
-            "OFFER_URL": "http://localhost:3001/offre/" + f"individuelle/{humanize(offer.id)}/recapitulatif",
+            "OFFER_URL": "http://localhost:3001/offre/" + f"individuelle/{offer.id}/recapitulatif",
         }

--- a/api/tests/utils/urls_test.py
+++ b/api/tests/utils/urls_test.py
@@ -1,7 +1,6 @@
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import override_settings
 from pcapi.utils import urls
-from pcapi.utils.human_ids import humanize
 
 
 class FirebaseLinksTest:
@@ -32,8 +31,7 @@ class FirebaseLinksTest:
 @override_settings(PRO_URL="http://pcpro.com")
 def test_build_pc_pro_offer_link():
     offer = offers_factories.OfferFactory.build(id=123)
-    human_id = humanize(offer.id)
 
     url = urls.build_pc_pro_offer_link(offer)
 
-    assert url == f"http://pcpro.com/offre/individuelle/{human_id}/recapitulatif"
+    assert url == f"http://pcpro.com/offre/individuelle/{offer.id}/recapitulatif"


### PR DESCRIPTION

Issues are experienced with redirection, so let's use numeric ids since all URL paths have now been migrated

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22011

## But de la pull request

Utiliser les id numériques, non humanisés, dans tous les liens depuis FA ou le backoffice vers PC Pro.
Toutes ces URL utilisent désormais l'id numérique, donc utilisons les plutôt que de gérer des soucis de redirection.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
