### PR TITLE
(PC-19125)[PRO] fix: on withdrawalType change set withdrawalDelay correct value

### DIFF
--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
@@ -26,13 +26,22 @@ const TicketWithdrawal = ({
     dirty,
   } = useFormikContext<IOfferIndividualFormValues>()
 
+  const getFirstWithdrawalTypeEnumValue = () => {
+    if (withdrawalType === WithdrawalTypeEnum.BY_EMAIL) {
+      return ticketSentDateOptions[0].value
+    }
+
+    if (withdrawalType === WithdrawalTypeEnum.ON_SITE) {
+      return ticketWithdrawalHourOptions[0].value
+    }
+
+    return undefined
+  }
+
   useEffect(
     function onWithdrawalTypeChange() {
       if (dirty) {
-        setFieldValue(
-          'withdrawalDelay',
-          withdrawalType === WithdrawalTypeEnum.NO_TICKET ? undefined : '0'
-        )
+        setFieldValue('withdrawalDelay', getFirstWithdrawalTypeEnumValue())
       }
     },
     [withdrawalType]

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
@@ -27,16 +27,16 @@ const TicketWithdrawal = ({
   } = useFormikContext<IOfferIndividualFormValues>()
 
   const getFirstWithdrawalTypeEnumValue = () => {
-    if (withdrawalType === WithdrawalTypeEnum.BY_EMAIL) {
-      return ticketSentDateOptions[0].value
-    }
+    switch (withdrawalType) {
+      case WithdrawalTypeEnum.BY_EMAIL:
+        return ticketSentDateOptions[0].value
 
-    if (withdrawalType === WithdrawalTypeEnum.ON_SITE) {
-      return ticketWithdrawalHourOptions[0].value
-    }
+      case WithdrawalTypeEnum.ON_SITE:
+        return ticketWithdrawalHourOptions[0].value
 
-    /* istanbul ignore next: already tested in InformationsScreen.edition.spec.tsx */
-    return undefined
+      default:
+        return undefined
+    }
   }
 
   useEffect(

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/TicketWithdrawal.tsx
@@ -35,6 +35,7 @@ const TicketWithdrawal = ({
       return ticketWithdrawalHourOptions[0].value
     }
 
+    /* istanbul ignore next: already tested in InformationsScreen.edition.spec.tsx */
     return undefined
   }
 

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/TicketWithdrawal/__specs__/TicketWithdrawal.spec.tsx
@@ -64,6 +64,10 @@ describe('OfferIndividual section: TicketWithdrawal', () => {
       await screen.findByText('Retrait sur place (guichet, comptoir...)')
     )
     expect(await screen.findByText('Heure de retrait')).toBeInTheDocument()
+
+    await userEvent.click(await screen.findByText('Évènement sans billet'))
+    expect(await screen.queryByText('Date d’envoi')).not.toBeInTheDocument()
+    expect(await screen.queryByText('Heure de retrait')).not.toBeInTheDocument()
   })
 
   it('should display an error when withdrawalType is empty', async () => {

--- a/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
+++ b/pro/src/components/OfferIndividualForm/UsefulInformations/__specs__/UsefulInformations.spec.tsx
@@ -163,7 +163,7 @@ describe('OfferIndividual section: UsefulInformations', () => {
         url: '',
         subcategoryId: 'CONCERT',
         venueId: venueList[0].nonHumanizedId.toString(),
-        withdrawalDelay: '0',
+        withdrawalDelay: (60 * 60 * 24).toString(),
         withdrawalDetails: '',
         withdrawalType: 'by_email',
       }),

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -86,7 +86,10 @@ export const serializePatchOffer = ({
       sentValues.accessibility &&
       sentValues.accessibility[AccessiblityEnum.MOTOR],
     name: sentValues.name,
-    withdrawalDelay: Number(sentValues.withdrawalDelay) || null,
+    withdrawalDelay:
+      sentValues.withdrawalDelay === undefined
+        ? null
+        : Number(sentValues.withdrawalDelay),
     withdrawalDetails: sentValues.withdrawalDetails || undefined,
     visualDisabilityCompliant:
       sentValues.accessibility &&

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -898,7 +898,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
           ]
         }
 
-        expectedBody.withdrawalDelay = null
+        expectedBody.withdrawalDelay = 0
         expectedBody.withdrawalType = WithdrawalTypeEnum.ON_SITE
         expectedBody.shouldSendMail = true
 
@@ -942,6 +942,7 @@ describe('screens:OfferIndividual::Informations:edition', () => {
           )
           await userEvent.click(withdrawalTypeField)
           expectedBody.withdrawalType = WithdrawalTypeEnum.BY_EMAIL
+          expectedBody.withdrawalDelay = 60 * 60 * 24
         }
 
         const submitButton = await screen.findByText(

--- a/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/Informations/__specs__/InformationsScreen.edition.spec.tsx
@@ -814,15 +814,18 @@ describe('screens:OfferIndividual::Informations:edition', () => {
         subcategoryId: 'SCID virtual',
         isEvent: true,
         withdrawalDelay: undefined,
-        withdrawalType: null,
+        withdrawalType: WithdrawalTypeEnum.NO_TICKET,
         stocks: [individualStock],
         isActive: false,
       }
+
       props = {
         venueId: virtualVenueId.toString(),
         offererId: offererId.toString(),
       }
       renderInformationsScreen(props, contextOverride, features)
+      expectedBody.withdrawalDelay = null
+      expectedBody.withdrawalType = WithdrawalTypeEnum.NO_TICKET
 
       const nameField = screen.getByLabelText('Titre de l’offre')
       await userEvent.clear(nameField)
@@ -856,6 +859,10 @@ describe('screens:OfferIndividual::Informations:edition', () => {
       await waitFor(() => {
         expect(api.patchOffer).toHaveBeenCalledTimes(1)
       })
+      expect(api.patchOffer).toHaveBeenCalledWith(
+        offer.nonHumanizedId,
+        expectedBody
+      )
       expect(
         await screen.findByText('There is the summary route content')
       ).toBeInTheDocument()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19125

## But de la pull request

- Corriger l'erreur lors de la mise à jour des modalités de retrait d'une offre

## Implémentation

- Lorsque la valeur de withdrawalType est mise à jour, maj du champ wihdrawalDelay avec la bonne valeur

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
