### PR TITLE
(PC-22022)[API] fix: add begginingDatetime to collective offers table

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/collective_offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offers.py
@@ -45,6 +45,9 @@ def _get_collective_offers(
             educational_models.CollectiveOffer.dateCreated,
             educational_models.CollectiveOffer.validation,
         ),
+        sa.orm.joinedload(educational_models.CollectiveOffer.collectiveStock).load_only(
+            educational_models.CollectiveStock.beginningDatetime
+        ),
         sa.orm.joinedload(educational_models.CollectiveOffer.venue).load_only(
             offerers_models.Venue.managingOffererId, offerers_models.Venue.name
         )

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
@@ -24,6 +24,7 @@
               <th scope="col">Sous-catégorie</th>
               <th scope="col">État</th>
               <th scope="col">Date de création</th>
+              <th scope="col">Date de l'événement</th>
               <th scope="col">Structure</th>
               <th scope="col">Lieu</th>
             </tr>
@@ -60,7 +61,8 @@
                 <td>{{ collective_offer.category.pro_label }}</td>
                 <td>{{ collective_offer.subcategory.pro_label }}</td>
                 <td>{{ collective_offer.validation | format_offer_validation_status }}</td>
-                <td>{{ collective_offer.dateCreated | format_date("%d/%m/%Y") }}</td>
+                <td>{{ collective_offer.dateCreated | format_date }}</td>
+                <td>{{ collective_offer.collectiveStock.beginningDatetime | format_date }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(collective_offer.venue) }}</td>
               </tr>

--- a/api/tests/routes/backoffice_v3/collective_offers_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offers_test.py
@@ -27,19 +27,22 @@ pytestmark = [
 
 @pytest.fixture(scope="function", name="collective_offers")
 def collective_offers_fixture() -> tuple:
-    collective_offer_1 = educational_factories.CollectiveOfferFactory(
-        subcategoryId=subcategories.ATELIER_PRATIQUE_ART.id,
-    )
-    collective_offer_2 = educational_factories.CollectiveOfferFactory(
-        name="A Very Specific Name",
-        subcategoryId=subcategories.EVENEMENT_CINE.id,
-    )
-    collective_offer_3 = educational_factories.CollectiveOfferFactory(
-        name="A Very Specific Name That Is Longer",
-        dateCreated=datetime.date.today() - datetime.timedelta(days=2),
-        validation=offers_models.OfferValidationStatus.REJECTED,
-        subcategoryId=subcategories.FESTIVAL_CINE.id,
-    )
+    collective_offer_1 = educational_factories.CollectiveStockFactory(
+        beginningDatetime=datetime.date.today(),
+        collectiveOffer__subcategoryId=subcategories.ATELIER_PRATIQUE_ART.id,
+    ).collectiveOffer
+    collective_offer_2 = educational_factories.CollectiveStockFactory(
+        beginningDatetime=datetime.date.today(),
+        collectiveOffer__name="A Very Specific Name",
+        collectiveOffer__subcategoryId=subcategories.EVENEMENT_CINE.id,
+    ).collectiveOffer
+    collective_offer_3 = educational_factories.CollectiveStockFactory(
+        beginningDatetime=datetime.date.today(),
+        collectiveOffer__dateCreated=datetime.date.today() - datetime.timedelta(days=2),
+        collectiveOffer__name="A Very Specific Name That Is Longer",
+        collectiveOffer__subcategoryId=subcategories.FESTIVAL_CINE.id,
+        collectiveOffer__validation=offers_models.OfferValidationStatus.REJECTED,
+    ).collectiveOffer
     return collective_offer_1, collective_offer_2, collective_offer_3
 
 
@@ -79,6 +82,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
         assert rows[0]["Sous-catégorie"] == collective_offers[0].subcategory.pro_label
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
+        assert rows[0]["Date de l'événement"] == datetime.date.today().strftime("%d/%m/%Y")
         assert rows[0]["Structure"] == collective_offers[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offers[0].venue.name
 
@@ -98,6 +102,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
         assert rows[0]["Sous-catégorie"] == collective_offers[1].subcategory.pro_label
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
+        assert rows[0]["Date de l'événement"] == datetime.date.today().strftime("%d/%m/%Y")
         assert rows[0]["Structure"] == collective_offers[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offers[1].venue.name
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22022

## But de la pull request

Ajouter la date de l'événement sur la page Offres collectives

## Implémentation

- Ajout d'une colonne `Date de l'évènement` sur le tableau de la page `/backofficev3/pro/collective_offer`

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
