### PR TITLE
(PC-21920)[PRO] fix: doesn't display tutorial on new onboarding signin redirection

### DIFF
--- a/pro/src/hooks/useRedirectLoggedUser.ts
+++ b/pro/src/hooks/useRedirectLoggedUser.ts
@@ -12,28 +12,30 @@ const useRedirectLoggedUser = () => {
   const { currentUser } = useCurrentUser()
   const newOnboardingActive = useActiveFeature('WIP_ENABLE_NEW_ONBOARDING')
 
+  const redirecTotUrl = () => {
+    const queryParams = new URLSearchParams(location.search)
+    const redirectUrl = queryParams.has('de')
+      ? queryParams.get('de')
+      : `/accueil${location.search}`
+    redirectUrl && navigate(redirectUrl)
+  }
+
   useEffect(() => {
     async function fetchOfferersNames() {
       const listOfferer = await api.listOfferersNames()
       if (listOfferer.offerersNames.length === 0) {
         navigate('/parcours-inscription')
+      } else {
+        redirecTotUrl()
       }
     }
 
     if (currentUser) {
-      let redirectUrl = null
-
       if (newOnboardingActive && !currentUser.isAdmin) {
         fetchOfferersNames()
-      }
-
-      const queryParams = new URLSearchParams(location.search)
-      if (queryParams.has('de')) {
-        redirectUrl = queryParams.get('de')
       } else {
-        redirectUrl = `/accueil${location.search}`
+        redirecTotUrl()
       }
-      redirectUrl && navigate(redirectUrl)
     }
   }, [currentUser])
 }

--- a/pro/src/hooks/useRedirectLoggedUser.ts
+++ b/pro/src/hooks/useRedirectLoggedUser.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 
@@ -8,15 +8,14 @@ import useCurrentUser from './useCurrentUser'
 
 const useRedirectLoggedUser = () => {
   const navigate = useNavigate()
-  const location = useLocation()
   const { currentUser } = useCurrentUser()
   const newOnboardingActive = useActiveFeature('WIP_ENABLE_NEW_ONBOARDING')
 
-  const redirecTotUrl = () => {
-    const queryParams = new URLSearchParams(location.search)
-    const redirectUrl = queryParams.has('de')
-      ? queryParams.get('de')
-      : `/accueil${location.search}`
+  const [searchParams] = useSearchParams()
+  const redirectTotUrl = () => {
+    const redirectUrl = searchParams.has('de')
+      ? searchParams.get('de')
+      : `/accueil?${searchParams}`
     redirectUrl && navigate(redirectUrl)
   }
 
@@ -26,7 +25,7 @@ const useRedirectLoggedUser = () => {
       if (listOfferer.offerersNames.length === 0) {
         navigate('/parcours-inscription')
       } else {
-        redirecTotUrl()
+        redirectTotUrl()
       }
     }
 
@@ -34,7 +33,7 @@ const useRedirectLoggedUser = () => {
       if (newOnboardingActive && !currentUser.isAdmin) {
         fetchOfferersNames()
       } else {
-        redirecTotUrl()
+        redirectTotUrl()
       }
     }
   }, [currentUser])

--- a/pro/src/hooks/useRedirectLoggedUser.ts
+++ b/pro/src/hooks/useRedirectLoggedUser.ts
@@ -12,7 +12,7 @@ const useRedirectLoggedUser = () => {
   const newOnboardingActive = useActiveFeature('WIP_ENABLE_NEW_ONBOARDING')
 
   const [searchParams] = useSearchParams()
-  const redirectTotUrl = () => {
+  const redirectToUrl = () => {
     const redirectUrl = searchParams.has('de')
       ? searchParams.get('de')
       : `/accueil?${searchParams}`
@@ -25,7 +25,7 @@ const useRedirectLoggedUser = () => {
       if (listOfferer.offerersNames.length === 0) {
         navigate('/parcours-inscription')
       } else {
-        redirectTotUrl()
+        redirectToUrl()
       }
     }
 
@@ -33,7 +33,7 @@ const useRedirectLoggedUser = () => {
       if (newOnboardingActive && !currentUser.isAdmin) {
         fetchOfferersNames()
       } else {
-        redirectTotUrl()
+        redirectToUrl()
       }
     }
   }, [currentUser])

--- a/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
+++ b/pro/src/pages/SignIn/__specs__/SignIn.spec.tsx
@@ -29,7 +29,10 @@ jest.mock('apiClient/api', () => ({
 
 const mockLogEvent = jest.fn()
 
-const renderSignIn = (storeOverrides?: any) => {
+const renderSignIn = (
+  storeOverrides?: any,
+  initialRouterEntries = ['/connexion']
+) => {
   const store = {
     user: {},
     app: {},
@@ -59,12 +62,13 @@ const renderSignIn = (storeOverrides?: any) => {
           path="/parcours-inscription"
           element={<span>I'm the onboarding page</span>}
         />
+        <Route path="/offres" element={<span>I'm the offer page</span>} />
       </Routes>
       <Notification />
     </>,
     {
       storeOverrides: store,
-      initialRouterEntries: ['/connexion'],
+      initialRouterEntries: initialRouterEntries,
     }
   )
 }
@@ -391,6 +395,39 @@ describe('src | components | pages | SignIn', () => {
       expect(
         screen.getByText("I'm logged standard user redirect route")
       ).toBeInTheDocument()
+    })
+
+    it('should redirect user to offer page on signin with url parameter', async () => {
+      jest.spyOn(api, 'listOfferersNames').mockResolvedValue({
+        offerersNames: [
+          {
+            id: 'A1',
+            nonHumanizedId: 1,
+            name: 'Mon super cinéma',
+          },
+          {
+            id: 'B1',
+            nonHumanizedId: 1,
+            name: 'Ma super librairie',
+          },
+        ],
+      })
+
+      renderSignIn({ ...featureOverride }, ['/connexion?de=%2Foffres'])
+
+      const email = screen.getByLabelText('Adresse e-mail')
+      await userEvent.type(email, 'MonPetitEmail@exemple.com')
+
+      const password = screen.getByLabelText('Mot de passe')
+      await userEvent.type(password, 'MCSolar85')
+
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'Se connecter',
+        })
+      )
+
+      expect(screen.getByText("I'm the offer page")).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21920

## But de la pull request

- Ne plus afficher le tutoriel (page d'accueil) entre la page de connexion et la redirection vers le nouveau parcours

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
