### PR TITLE
(PC-21611)[API] fix: improve UX adage status on venue

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -155,12 +155,6 @@
                   {% endif %}
                 </span>
               </p>
-              {% if venue.dms_adage_status %}
-                <p class="mb-1">
-                  <span class="fw-bold">Statut du dossier DMS Adage :</span>
-                  {{ venue.dms_adage_status | format_dms_status }}
-                </p>
-              {% endif %}
               <p class="mb-1">
                 {% if venue.adageId %}
                   <span class="fw-bold">ID Adage :</span>
@@ -169,25 +163,25 @@
                   <span class="fw-bold">Pas de dossier DMS Adage</span>
                 {% endif %}
               </p>
-              {% if venue.dms_adage_status %}
+{#              {% if dms_stats.status %}#}
                 <p class="mb-1">
-                  {% if venue.dms_adage_status != "accepte" %}
-                    <span class="fw-bold">Date de dépôt DMS Adage :</span>
-                    {{ venue.dms_adage_date }}
-                    {% eif venue.dms_adage_status == "accepte" %}
+{#                  {% if dms_stats.status != "accepte" %}#}
+                    <span class="fw-bold">Date de dépôt DMS Adage :{{ dms_stats |tojson }}</span>
+                    {{ dms_stats.subscriptionDate | format_date }}
+{#                  {% elif dms_stats.status == "accepte" %}#}
                     <span class="fw-bold">Date de validation DMS Adage :</span>
-                    {{ venue.dms_adage_date }}
-                  {% endif %}
+                    {{ dms_stats.lastChangeDate | format_date }}
+{#                  {% endif %}#}
                 </p>
-              {% endif %}
-              {% if venue.dms_adage_status %}
+{#              {% endif %}#}
+{#              {% if dms_stats.status %}#}
                 <p class="mb-1">
-                  {% if venue.dms_adage_status != "accepte" %}
+{#                  {% if dms_stats.status != "accepte" %}#}
                     <span class="fw-bold">Statut du dossier DMS Adage :</span>
-                    {{ venue.dms_adage_status | format_dms_status }}
-                  {% endif %}
+                    {{ dms_stats.status | format_dms_status }}
+{#                  {% endif %}#}
                 </p>
-              {% endif %}
+{#              {% endif %}#}
               <p class="mb-1">
                 <span class="fw-bold">{{ "Activité principale" if is_feature_active("WIP_ENABLE_NEW_ONBOARDING") else "Type de lieu" }} :</span>
                 {{ venue.venueTypeCode.value }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -143,7 +143,7 @@
             </div>
             <div class="col-4">
               <p class="mb-1">
-                <span class="fw-bold">Référencement Adage :
+                <span class="fw-bold">Peut créer une offre EAC :
                   {% if venue.adageId %}
                     <span class="mx-2 pb-1 badge rounded-pill text-bg-success">
                       <i class="bi bi-check-circle"></i> Oui
@@ -161,10 +161,31 @@
                   {{ venue.dms_adage_status | format_dms_status }}
                 </p>
               {% endif %}
-              {% if venue.adageId %}
-                <p class="mb-1">
+              <p class="mb-1">
+                {% if venue.adageId %}
                   <span class="fw-bold">ID Adage :</span>
                   {{ venue.adageId }}
+                {% else %}
+                  <span class="fw-bold">Pas de dossier DMS Adage</span>
+                {% endif %}
+              </p>
+              {% if venue.dms_adage_status %}
+                <p class="mb-1">
+                  {% if venue.dms_adage_status != "accepte" %}
+                    <span class="fw-bold">Date de dépôt DMS Adage :</span>
+                    {{ venue.dms_adage_date }}
+                    {% eif venue.dms_adage_status == "accepte" %}
+                    <span class="fw-bold">Date de validation DMS Adage :</span>
+                    {{ venue.dms_adage_date }}
+                  {% endif %}
+                </p>
+              {% endif %}
+              {% if venue.dms_adage_status %}
+                <p class="mb-1">
+                  {% if venue.dms_adage_status != "accepte" %}
+                    <span class="fw-bold">Statut du dossier DMS Adage :</span>
+                    {{ venue.dms_adage_status | format_dms_status }}
+                  {% endif %}
                 </p>
               {% endif %}
               <p class="mb-1">


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21611

## But de la pull request

Amélioration de l'UX des dossier DMS adage sur le détail d'un lieu.

## Implémentation

- Sur un lieu, si le lieu a un dossier dms Adage, ajouter sous ID Adage:
  - La “date de dépot dms Adage” si le statut du dossier dms adage n’est pas validé
  - la “date de validation dms Adage” si le statut du dossier dms adage est validé
- Sur un lieu, si le lieu a un dossier dms Adage, ajouter sous “date de dépot DMS Adage”le statut du dossier DMS Adage, avec la liste des statuts disponibles:
  - En construction
  - En instruction
  - Accepté
  - Refusé
  - Sans suite
- Sur un lieu s’il n’y a pas de dossier DMS Adage qui remonte ajouter “Pas de dossier DMS Adage”
- En profiter pour renommer “Référencement Adage” par “Peut créer une offre EAC”

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
