### PR TITLE
(PC-22037)[PRO] fix: offerer redirection

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -1,5 +1,5 @@
 import { FormikProvider, useFormik } from 'formik'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import FormLayout from 'components/FormLayout'
@@ -57,12 +57,17 @@ const Offerer = (): JSX.Element => {
       longitude: response.payload.values.longitude,
       postalCode: response.payload.values.postalCode,
     })
-    if (siretResponse.payload.venues.length === 0) {
-      navigate('/parcours-inscription/authentification')
-    } else {
+
+    if (siretResponse.payload.venues.length > 0) {
       navigate('/parcours-inscription/structure/rattachement')
     }
   }
+
+  useEffect(() => {
+    if (offerer?.siret && offerer?.siret !== '') {
+      navigate('/parcours-inscription/authentification')
+    }
+  }, [offerer])
 
   const formik = useFormik({
     initialValues,

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -63,6 +63,7 @@ const Offerer = (): JSX.Element => {
     }
   }
 
+  // Need to wait for offerer to be updated in the context to redirect user
   useEffect(() => {
     if (offerer?.siret && offerer?.siret !== '') {
       navigate('/parcours-inscription/authentification')

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -133,7 +133,7 @@ describe('screens:SignupJourney::Offerer', () => {
     ).toBeInTheDocument()
   })
 
-  it('should display authentication signup journey step on submit', async () => {
+  it('should display authentication signup journey if offerer is set', async () => {
     contextValue.offerer = {
       siret: '12345678933333',
       name: 'Test',
@@ -141,10 +141,6 @@ describe('screens:SignupJourney::Offerer', () => {
     }
 
     renderOffererScreen(contextValue)
-    expect(
-      await screen.findByText('Renseignez le SIRET de votre structure')
-    ).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
     expect(screen.getByText('Authentication screen')).toBeInTheDocument()
   })
 
@@ -179,6 +175,26 @@ describe('screens:SignupJourney::Offerer', () => {
     expect(
       await screen.getByText('Renseignez le SIRET de votre structure')
     ).toBeInTheDocument()
+  })
+
+  it('should not render offerers screen on submit if venuesList is empty', async () => {
+    jest.spyOn(api, 'getVenuesOfOffererFromSiret').mockResolvedValueOnce({
+      venues: [],
+    })
+    await renderOffererScreen(contextValue)
+
+    expect(
+      await screen.findByText('Renseignez le SIRET de votre structure')
+    ).toBeInTheDocument()
+    await userEvent.type(
+      screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+      '12345678933333'
+    )
+    await userEvent.click(
+      await screen.getByRole('button', { name: 'Continuer' })
+    )
+
+    await expect(screen.queryByText('Offerers screen')).not.toBeInTheDocument()
   })
 
   it('should redirect to offerers screen if venue exist', async () => {

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -181,7 +181,7 @@ describe('screens:SignupJourney::Offerer', () => {
     jest.spyOn(api, 'getVenuesOfOffererFromSiret').mockResolvedValueOnce({
       venues: [],
     })
-    await renderOffererScreen(contextValue)
+    renderOffererScreen(contextValue)
 
     expect(
       await screen.findByText('Renseignez le SIRET de votre structure')
@@ -190,11 +190,9 @@ describe('screens:SignupJourney::Offerer', () => {
       screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
       '12345678933333'
     )
-    await userEvent.click(
-      await screen.getByRole('button', { name: 'Continuer' })
-    )
+    await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
 
-    await expect(screen.queryByText('Offerers screen')).not.toBeInTheDocument()
+    expect(screen.queryByText('Offerers screen')).not.toBeInTheDocument()
   })
 
   it('should redirect to offerers screen if venue exist', async () => {
@@ -204,7 +202,7 @@ describe('screens:SignupJourney::Offerer', () => {
         { id: '2', name: 'Second Venue' },
       ],
     })
-    await renderOffererScreen(contextValue)
+    renderOffererScreen(contextValue)
 
     await userEvent.type(
       screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
@@ -227,7 +225,7 @@ describe('screens:SignupJourney::Offerer', () => {
         ''
       )
     )
-    await renderOffererScreen(contextValue)
+    renderOffererScreen(contextValue)
 
     await userEvent.type(
       screen.getByLabelText('Numéro de SIRET à 14 chiffres'),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22037

## But de la pull request

- Correctement rediriger l'utilisateur sur l'étape d'authentification après la validation du siret

## Implémentation

- Offerer n'a pas le temps de se mettre à jour dans le contexte avant la redirection
- La redirection se passe lorsque la structure est mise à jour dans le state

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
