### PR TITLE
(PC-21447)[API] feat: allow new providers to be linked to existing offerer

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/providers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/providers/forms.py
@@ -20,13 +20,13 @@ class CreateProviderForm(FlaskForm):
         ),
     )
     city = fields.PCStringField(
-        "Ville",
+        "Ville (si le SIREN n'est pas déjà enregistré)",
         validators=(
             wtforms.validators.InputRequired("Information obligatoire"),
             wtforms.validators.Length(min=1, max=140, message="Doit contenir moins de %(max)d caractères"),
         ),
     )
-    postal_code = fields.PCPostalCodeField("Code postal")
+    postal_code = fields.PCPostalCodeField("Code postal (si le SIREN n'est pas déjà enregistré)")
     logo_url = fields.PCOptStringField(
         "URL du logo",
         validators=(
@@ -39,4 +39,6 @@ class CreateProviderForm(FlaskForm):
 
 
 class EditProviderForm(CreateProviderForm):
+    city = None  # type: ignore [assignment]
+    postal_code = None  # type: ignore [assignment]
     siren = None  # type: ignore [assignment]


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21447

## But de la pull request

Les acteurs de la grande distribution, qui ont déjà un compte sur le pass Culture, vont avoir des `Providers` associés à leur compte : 
- Il faut pouvoir autoriser la liaison d'un `Provider` à un `Offerer` déjà existant
- La modification d'un `Provider` ne doit pas impacter l'`Offerer`