### PR TITLE
(PC-22067)[API] feat: bo: email update: mark as pending and validated

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1041,6 +1041,7 @@ def _filter_user_accounts(
                             {
                                 models.EmailHistoryEventTypeEnum.VALIDATION,
                                 models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION,
+                                models.EmailHistoryEventTypeEnum.ADMIN_UPDATE,
                             }
                         ),
                     ),

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -88,6 +88,22 @@ def request_email_update_from_admin(user: models.User, email: str) -> None:
     api.request_email_confirmation(user)
 
 
+def full_email_update_by_admin(user: models.User, email: str) -> None:
+    """
+    Runs the whole email update process at once, without sending any
+    confirmation email: log update history, update user's email and
+    mark it as validated.
+    """
+    check_email_address_does_not_exist(email)
+
+    admin_update_event = models.UserEmailHistory.build_admin_update(user=user, new_email=email)
+
+    user.email = email
+    user.isEmailValidated = True
+
+    repository.save(user, admin_update_event)
+
+
 def get_no_active_token_key(user: models.User) -> str:
     return f"update_email_active_tokens_{user.id}"
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -687,6 +687,7 @@ class EmailHistoryEventTypeEnum(enum.Enum):
     VALIDATION = "VALIDATION"
     ADMIN_VALIDATION = "ADMIN_VALIDATION"
     ADMIN_UPDATE_REQUEST = "ADMIN_UPDATE_REQUEST"
+    ADMIN_UPDATE = "ADMIN_UPDATE"
 
 
 class UserEmailHistory(PcObject, Base, Model):
@@ -734,6 +735,10 @@ class UserEmailHistory(PcObject, Base, Model):
         if by_admin:
             return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.ADMIN_VALIDATION)
         return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.VALIDATION)
+
+    @classmethod
+    def build_admin_update(cls, user: User, new_email: str) -> "UserEmailHistory":
+        return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.ADMIN_UPDATE)
 
     @hybrid_property
     def oldEmail(self) -> str:

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -691,7 +691,7 @@ def update_public_account(user_id: int) -> utils.BackofficeResponse:
     if form.email.data and form.email.data != email_utils.sanitize_email(user.email):
         snapshot.set("email", old=user.email, new=form.email.data)
         try:
-            email_update.request_email_update_from_admin(user, form.email.data)
+            email_update.full_email_update_by_admin(user, form.email.data)
         except users_exceptions.EmailExistsError:
             form.email.errors.append("L'email est déjà associé à un autre utilisateur")
             snapshot.log_update(save=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22067

## But de la pull request

Lors de la modification de l'email d'un compte jeune et grand public sur le backoffice :

1. ajouter la validation du changement en même temps dans l'historique des changements d'email (et pas seulement la première étape, changement en attente de validation) ;
2. ne plus envoyer d'email de confirmation (qui n'était pas utile et ne sera plus du tout pertinent avec 1.)

Ceci permettra d'avoir un ensemble plus cohérent. L'utilisateur du backoffice pouvait avoir l'impression que le changement d'email était bien validé et que tout était ok alors que l'historique des changements d'email disait le contraire : celle-ci n'est pas validée.

Ce qui pose quelques problèmes :

1. l'historique des modifications d'email risque de sembler étrange puisqu'on peut très bien avoir plusieurs modifications en attente sans aucune validation associée ;
2. lorsque l'on recherche un utilisateur via son ancienne adresse email, rien ne remonte tant que l'utilisateur n'a pas cliqué sur le lien de confirmation ([la recherche ne regarde que dans les lignes de validation](https://github.com/pass-culture/pass-culture-main/pull/6120)). Ce qui risque d'étonner des utilisateurs, à juste titre.