### PR TITLE
(PC-21611)[API] fix: improve UX adage status on venue

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -428,13 +428,17 @@ class Venue(PcObject, Base, Model, HasThumbMixin, ProvidableMixin, Accessibility
 
         return self.bankInformation.applicationId
 
-    @hybrid_property
-    def dms_adage_status(self) -> str | None:
+    @property
+    def last_collective_dms_application(self) -> educational_models.CollectiveDmsApplication | None:
         if self.collectiveDmsApplications:
             return sorted(
-                self.collectiveDmsApplications, key=lambda application: application.lastChangeDate, reverse=True
-            )[0].state
+                self.collectiveDmsApplications, key=lambda application: application.lastChangeDate, reverse=True  # type: ignore [return-value, arg-type]
+            )[0]
         return None
+
+    @hybrid_property
+    def dms_adage_status(self) -> str | None:
+        return self.last_collective_dms_application.state if self.last_collective_dms_application else None
 
     @dms_adage_status.expression  # type: ignore [no-redef]
     def dms_adage_status(cls) -> str | None:  # pylint: disable=no-self-argument

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -143,7 +143,7 @@
             </div>
             <div class="col-4">
               <p class="mb-1">
-                <span class="fw-bold">Référencement Adage :
+                <span class="fw-bold">Peut créer une offre EAC :
                   {% if venue.adageId %}
                     <span class="mx-2 pb-1 badge rounded-pill text-bg-success">
                       <i class="bi bi-check-circle"></i> Oui
@@ -155,16 +155,32 @@
                   {% endif %}
                 </span>
               </p>
-              {% if venue.dms_adage_status %}
+              {% if not venue.dms_adage_status %}
                 <p class="mb-1">
-                  <span class="fw-bold">Statut du dossier DMS Adage :</span>
-                  {{ venue.dms_adage_status | format_dms_status }}
+                  <span class="fw-bold">Pas de dossier DMS Adage</span>
                 </p>
               {% endif %}
               {% if venue.adageId %}
                 <p class="mb-1">
                   <span class="fw-bold">ID Adage :</span>
                   {{ venue.adageId }}
+                </p>
+              {% endif %}
+              {% if venue.dms_adage_status %}
+                {% if venue.dms_adage_status == 'accepte' %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Date de validation DMS Adage :</span>
+                    {{ venue.last_collective_dms_application.lastChangeDate | format_date }}
+                  </p>
+                {% elif venue.dms_adage_status != 'accepte' %}
+                  <p class="mb-1">
+                    <span class="fw-bold">Date de dépôt DMS Adage :</span>
+                    {{ venue.last_collective_dms_application.depositDate | format_date }}
+                  </p>
+                {% endif %}
+                <p class="mb-1">
+                  <span class="fw-bold">Statut du dossier DMS Adage :</span>
+                  {{ venue.dms_adage_status | format_dms_status }}
                 </p>
               {% endif %}
               <p class="mb-1">

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -53,6 +53,7 @@ def get_venue(venue_id: int) -> offerers_models.Venue:
             sa.orm.joinedload(offerers_models.Venue.criteria).load_only(criteria_models.Criterion.name),
             sa.orm.joinedload(offerers_models.Venue.collectiveDmsApplications).load_only(
                 educational_models.CollectiveDmsApplication.state,
+                educational_models.CollectiveDmsApplication.depositDate,
                 educational_models.CollectiveDmsApplication.lastChangeDate,
             ),
         )

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -378,6 +378,8 @@ class VenueDmsAdageStatusTest:
         )
 
         assert venue.dms_adage_status == latest.state
+        last_collective_dms_application = venue.last_collective_dms_application
 
         # hybrid property: also check SQL expression
         assert db.session.query(models.Venue.dms_adage_status).filter_by(id=venue.id).scalar() == latest.state
+        assert last_collective_dms_application is latest


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21611

## But de la pull request

Amélioration de l'UX des dossier DMS adage sur le détail d'un lieu.

## Implémentation

- Sur un lieu, si le lieu a un dossier dms Adage, ajouter sous ID Adage:
  - La “date de dépot dms Adage” si le statut du dossier dms adage n’est pas validé
  - la “date de validation dms Adage” si le statut du dossier dms adage est validé
- Sur un lieu, si le lieu a un dossier dms Adage, ajouter sous “date de dépot DMS Adage”le statut du dossier DMS Adage, avec la liste des statuts disponibles:
  - En construction
  - En instruction
  - Accepté
  - Refusé
  - Sans suite
- Sur un lieu s’il n’y a pas de dossier DMS Adage qui remonte ajouter “Pas de dossier DMS Adage”
- En profiter pour renommer “Référencement Adage” par “Peut créer une offre EAC”

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
