### PR TITLE
(PC-21486)[PRO] feat: Changement wording  bouton- Edition d'une offre

### DIFF
--- a/pro/src/screens/OfferIndividual/DialogStockDeleteConfirm/DialogStockEventDeleteConfirm.tsx
+++ b/pro/src/screens/OfferIndividual/DialogStockDeleteConfirm/DialogStockEventDeleteConfirm.tsx
@@ -19,7 +19,7 @@ const DialogStockEventDeleteConfirm = ({
       onCancel={onCancel}
       onConfirm={onConfirm}
       title="Voulez-vous supprimer cette occurrence ?"
-      confirmText="Supprimer"
+      confirmText="Confirmer la suppression"
       cancelText="Annuler"
       icon={Trash}
     >

--- a/pro/src/screens/OfferIndividual/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/screens/OfferIndividual/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -331,7 +331,9 @@ describe('screens:StocksEventEdition', () => {
     expect(
       await screen.findByText('Voulez-vous supprimer cette occurrence ?')
     ).toBeInTheDocument()
-    await userEvent.click(screen.getByText('Supprimer', { selector: 'button' }))
+    await userEvent.click(
+      screen.getByText('Confirmer la suppression', { selector: 'button' })
+    )
 
     expect(
       await screen.findByText('Le stock a été supprimé.')
@@ -415,7 +417,9 @@ describe('screens:StocksEventEdition', () => {
     expect(
       screen.getByText('Voulez-vous supprimer cette occurrence ?')
     ).toBeInTheDocument()
-    await userEvent.click(screen.getByText('Supprimer', { selector: 'button' }))
+    await userEvent.click(
+      screen.getByText('Confirmer la suppression', { selector: 'button' })
+    )
 
     expect(
       await screen.findByText('Le stock a été supprimé.')
@@ -480,7 +484,9 @@ describe('screens:StocksEventEdition', () => {
     expect(
       screen.getByText('Voulez-vous supprimer cette occurrence ?')
     ).toBeInTheDocument()
-    await userEvent.click(screen.getByText('Supprimer', { selector: 'button' }))
+    await userEvent.click(
+      screen.getByText('Confirmer la suppression', { selector: 'button' })
+    )
 
     expect(
       await screen.findByText('Le stock a été supprimé.')
@@ -547,7 +553,9 @@ describe('screens:StocksEventEdition', () => {
     await userEvent.dblClick(await screen.findByText('Supprimer le stock'))
 
     await userEvent.click(
-      await screen.findByText('Supprimer', { selector: 'button' })
+      await screen.findByText('Confirmer la suppression', {
+        selector: 'button',
+      })
     )
     expect(
       screen.getByText(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21486

## But de la pull request

Quand on supprime un stock sur une offre qui a déjà des réservations on affiche une pop in. 
Attendu : 
changer le wording du bouton d’action principale. Remplacer “Supprimer” par “Confirmer la suppression”

## Informations supplémentaires

http://localhost:3001/offre/individuelle/150/stocks, j'ai trouvé une offre qui marche,  donc je suis débloquée, mais j'ai jamais pu en créer une avec la réservation.

<img width="896" alt="Capture d’écran 2023-05-02 à 13 21 05" src="https://user-images.githubusercontent.com/115089249/235655684-273af7c8-9795-4b98-a181-f8f2d924204b.png">

## Checklist :

- [x ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-21486-wording-bouton-suppression`
  - PR : `(PC-21486)[PRO] feat: Changement wording  bouton- Edition d'une offre`
  - Commit(s) : `(PC-21486)[PRO] feat: Changement wording  bouton- Edition d'une offre`