### PR TITLE
(PC-22024)[PRO] feat: Wording de modal de validation.

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.jsx
@@ -71,14 +71,16 @@ const StocksProviderForm = ({
           confirmText="Continuer"
           onCancel={handleCloseConfirmDialog}
           onConfirm={handleFormSubmit}
-          title="Certains ouvrages seront exclus de la synchronisation automatique."
+          title="Certaines offres ne seront pas synchronisées"
         >
           <p>
-            Vous pouvez retrouver la liste des catégories de livres qui sont
-            exclus de la synchronisation automatique en suivant le lien
+            Le pass Culture ne permet l’import automatique que des offres dans
+            les catégories support audio et livres à l’heure actuelle. Certains
+            rayons ne seront en outre pas synchronisés. Notre FAQ vous décriera
+            les règles précisément.
             <a
               className="tertiary-link"
-              href="https://aide.passculture.app/hc/fr/articles/4412007214225"
+              href="https://aide.passculture.app/hc/fr/articles/4411999024401--Acteurs-Culturels-Quels-sont-les-livres-%C3%A9ligibles-au-pass-Culture-"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -86,7 +88,6 @@ const StocksProviderForm = ({
                 alt="lien externe, nouvel onglet"
                 svg="ico-external-site-red"
               />
-              FAQ
             </a>
           </p>
         </ConfirmDialog>

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
@@ -116,9 +116,7 @@ describe('src | StocksProviderForm', () => {
 
       // then
       expect(
-        screen.getByText(
-          'Certains ouvrages seront exclus de la synchronisation automatique.'
-        )
+        screen.getByText('Certaines offres ne seront pas synchronisées')
       ).toBeInTheDocument()
 
       const confirmImportButton = screen.getByRole('button', {
@@ -156,9 +154,7 @@ describe('src | StocksProviderForm', () => {
 
       // then
       expect(
-        screen.getByText(
-          'Certains ouvrages seront exclus de la synchronisation automatique.'
-        )
+        screen.getByText('Certaines offres ne seront pas synchronisées')
       ).toBeInTheDocument()
 
       const confirmImportButton = screen.getByRole('button', {
@@ -189,9 +185,7 @@ describe('src | StocksProviderForm', () => {
 
       // then
       expect(
-        screen.getByText(
-          'Certains ouvrages seront exclus de la synchronisation automatique.'
-        )
+        screen.getByText('Certaines offres ne seront pas synchronisées')
       ).toBeInTheDocument()
 
       const confirmImportButton = screen.getByRole('button', {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22024

## But de la pull request

Modifier la modale de validation d'ajout de partenaire technique

## Informations supplémentaires
<img width="927" alt="Capture d’écran 2023-05-02 à 16 31 54" src="https://user-images.githubusercontent.com/115089249/235697960-a48b011d-2539-4e1d-ad3c-b7792e4f5605.png">




Aller sur la page Lieu d’un lieu qui n’a pas de synchronisation (Club Dorothy par exemple)

Cliquer sur Synchroniser des offres

Choisir un provider

Voir la nouvelle modale lors de la synchronisation avec titelive ou avec tout provider nouvellement créé. 

## Checklist :

- [x ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-22024-modale-validation`
  - PR : `(PC-22024)[PRO] feat: Wording de modal de validation.`
  - Commit(s) : `(PC-22024)[PRO] feat: Wording de modal de validation.`