### PR TITLE
(PC-21907)[PRO] feat: wording de status

### DIFF
--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
@@ -312,7 +312,7 @@ describe('route CollectiveOffers', () => {
       await userEvent.click(
         screen.getByAltText('Afficher ou masquer le filtre par statut')
       )
-      await userEvent.click(screen.getByLabelText('Tous'))
+      await userEvent.click(screen.getByLabelText('Toutes'))
       // When
       await userEvent.click(screen.getByText('Appliquer'))
       // Then

--- a/pro/src/pages/Offers/Offers/OffersStatusFiltersModal/OffersStatusFiltersModal.tsx
+++ b/pro/src/pages/Offers/Offers/OffersStatusFiltersModal/OffersStatusFiltersModal.tsx
@@ -69,7 +69,7 @@ export const OffersStatusFiltersModal = ({
   const filters =
     audience === Audience.INDIVIDUAL
       ? [
-          { label: 'Tous', value: ALL_STATUS },
+          { label: 'Toutes', value: ALL_STATUS },
           ...(audience === Audience.INDIVIDUAL
             ? [{ label: 'Brouillon', value: OfferStatus.DRAFT }]
             : []),
@@ -81,7 +81,7 @@ export const OffersStatusFiltersModal = ({
           { label: 'Refusée', value: OfferStatus.REJECTED },
         ]
       : [
-          { label: 'Tous', value: ALL_STATUS },
+          { label: 'Toutes', value: ALL_STATUS },
           { label: 'Désactivée', value: CollectiveOfferStatus.INACTIVE },
           { label: 'Expirée', value: CollectiveOfferStatus.EXPIRED },
           { label: 'Préréservée', value: CollectiveOfferStatus.PREBOOKED },
@@ -102,7 +102,7 @@ export const OffersStatusFiltersModal = ({
         ]
   return (
     <div className="offers-status-filters" ref={modalRef}>
-      <div className="osf-title">Afficher les statuts</div>
+      <div className="osf-title">Afficher les offres</div>
       <>
         {filters.map(({ label, value }) => (
           <RadioInput

--- a/pro/src/pages/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/pages/Offers/__specs__/Offers.spec.tsx
@@ -710,7 +710,7 @@ describe('route Offers', () => {
       await userEvent.click(
         screen.getByAltText('Afficher ou masquer le filtre par statut')
       )
-      await userEvent.click(screen.getByLabelText('Tous'))
+      await userEvent.click(screen.getByLabelText('Toutes'))
       // When
       await userEvent.click(screen.getByText('Appliquer'))
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/FilterByBookingStatus/FilterByBookingStatus.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/FilterByBookingStatus/FilterByBookingStatus.tsx
@@ -127,7 +127,7 @@ const FilterByBookingStatus = <
       <span className="bs-filter">
         {isToolTipVisible && (
           <div className="bs-filter-tooltip">
-            <div className="bs-filter-label">Afficher les statuts</div>
+            <div className="bs-filter-label">Afficher les offres</div>
             {filteredBookingStatuses.map(bookingStatus => (
               <label key={bookingStatus.value}>
                 <input

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -363,7 +363,7 @@ describe('screen Offers', () => {
           // Then
           expect(screen.getByText('Statut')).toBeInTheDocument()
           expect(
-            screen.queryByText('Afficher les statuts')
+            screen.queryByText('Afficher les offres')
           ).not.toBeInTheDocument()
           expect(screen.queryByLabelText('Tous')).not.toBeInTheDocument()
           expect(screen.queryByLabelText('Publiée')).not.toBeInTheDocument()
@@ -377,7 +377,7 @@ describe('screen Offers', () => {
           expect(screen.queryByLabelText('Refusée')).not.toBeInTheDocument()
         })
 
-        it('should display status filters with "Tous" as default value when clicking on "Statut" filter icon', async () => {
+        it('should display status filters with "Toutes" as default value when clicking on "Statut" filter icon', async () => {
           // Given
           renderOffers(props, store)
           // When
@@ -385,8 +385,8 @@ describe('screen Offers', () => {
             screen.getByAltText('Afficher ou masquer le filtre par statut')
           )
           // Then
-          expect(screen.queryByText('Afficher les statuts')).toBeInTheDocument()
-          expect(screen.getByLabelText('Tous')).toBeChecked()
+          expect(screen.queryByText('Afficher les offres')).toBeInTheDocument()
+          expect(screen.getByLabelText('Toutes')).toBeChecked()
           expect(screen.getByLabelText('Publiée')).not.toBeChecked()
           expect(screen.getByLabelText('Désactivée')).not.toBeChecked()
           expect(screen.getByLabelText('Épuisée')).not.toBeChecked()
@@ -416,7 +416,7 @@ describe('screen Offers', () => {
           )
           // Then
           expect(
-            screen.queryByText('Afficher les statuts')
+            screen.queryByText('Afficher les offres')
           ).not.toBeInTheDocument()
         })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Liste des offres - Modif de wording du filtre statut

## Informations supplémentaires
<img width="575" alt="Capture d’écran 2023-05-02 à 17 31 09" src="https://user-images.githubusercontent.com/115089249/235716388-03acd5a5-38ff-48b8-90a2-3089c87d1ede.png">


<img width="517" alt="Capture d’écran 2023-05-02 à 17 31 42" src="https://user-images.githubusercontent.com/115089249/235715550-3ed36b78-d5b2-4b32-a76b-0307c66144b8.png">

Dans le tooltip qui s’affiche quand on clique sur le bouton statut : 
- remplacer le texte “Afficher les statuts” par “Afficher les offres”
- remplacer “Tous” par “Toutes”
- Faire cette modification à la fois côté individuel et collectif 
(Attention : la colonne s’appelle toujours bien Statut)

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `PC-21907-wording-filtre-statut`
  - PR : `(PC-21907)[PRO] feat: wording de status`
  - Commit(s) : `(PC-21907)[PRO] feat: wording de status`
