### PR TITLE
(PC-21784)[PRO] fix: center signup confirmation page vertially

### DIFF
--- a/pro/src/styles/components/pages/SignupConfirmation/_SignupConfirmation.scss
+++ b/pro/src/styles/components/pages/SignupConfirmation/_SignupConfirmation.scss
@@ -5,7 +5,7 @@
 @use "styles/variables/_forms.scss" as forms;
 
 .sign-up-confirmation-page {
-  min-height: rem.torem(600px);
+  height: 100%;
   position: relative;
   left: forms.$sign-form-space-left;
   width: 100%;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21784

## But de la pull request

- Centrer verticalement le message de la page de confirmation d'incription.

## Implémentation

![image](https://user-images.githubusercontent.com/106379750/235871302-b027a27c-af47-404a-8b66-06e5e71e69fd.png)
