### PR TITLE
(PC-21935)[PRO] feat: add form stock error message for eventTime

### DIFF
--- a/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/screens/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { addMinutes } from 'date-fns'
 import React from 'react'
 
 import { StudentLevels } from 'apiClient/adage'
@@ -27,7 +28,7 @@ const defaultProps: IOfferEducationalStockProps = {
 const initialValuesNotEmpty = {
   ...DEFAULT_EAC_STOCK_FORM_VALUES,
   eventDate: new Date(),
-  eventTime: new Date(),
+  eventTime: addMinutes(new Date(), 15),
   bookingLimitDatetime: new Date('2023-03-30'),
   numberOfPlaces: 10,
   totalPrice: 100,
@@ -277,6 +278,33 @@ describe('OfferEducationalStock', () => {
         Events.EAC_WRONG_STUDENTS_MODAL_OPEN,
         { from: '/', hasOnly6eAnd5eStudents: false }
       )
+    })
+
+    it('should render for offer with a stock', async () => {
+      const offer = collectiveOfferFactory()
+
+      const testProps: IOfferEducationalStockProps = {
+        ...defaultProps,
+        offer,
+        initialValues: {
+          ...DEFAULT_EAC_STOCK_FORM_VALUES,
+          eventDate: new Date(),
+          eventTime: new Date(),
+          bookingLimitDatetime: new Date('2023-03-30'),
+          numberOfPlaces: 10,
+          totalPrice: 100,
+        },
+      }
+
+      renderWithProviders(<OfferEducationalStock {...testProps} />)
+
+      const submitButton = screen.getByRole('button', {
+        name: 'Étape suivante',
+      })
+
+      await userEvent.click(submitButton)
+
+      screen.getByText("L'heure doit être postérieure à l'heure actuelle")
     })
   })
 })

--- a/pro/src/screens/OfferEducationalStock/validationSchema.ts
+++ b/pro/src/screens/OfferEducationalStock/validationSchema.ts
@@ -1,3 +1,4 @@
+import { isBefore, isSameDay } from 'date-fns'
 import * as yup from 'yup'
 
 import { MAX_DETAILS_LENGTH } from 'core/OfferEducational'
@@ -55,7 +56,20 @@ export const generateValidationSchema = (
             "La date de l’évènement doit être supérieure à aujourd'hui"
           ),
       }),
-    eventTime: yup.string().nullable().required('Champ requis'),
+    eventTime: yup
+      .string()
+      .nullable()
+      .required('Champ requis')
+      .when('eventDate', {
+        is: (eventDate: string) => isSameDay(new Date(eventDate), new Date()),
+        then: schema =>
+          schema.test({
+            name: 'is-before-current-time',
+            test: (eventTime: string) =>
+              isBefore(new Date(), new Date(eventTime)),
+            message: "L'heure doit être postérieure à l'heure actuelle",
+          }),
+      }),
     numberOfPlaces: yup
       .number()
       .nullable()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21935

## But de la pull request

Afficher un message d'erreur sous le champs 'Horaire' du formulaire Date et prix lors d'une création/édition d'offre lorsque la date de l'évènement est au jour d'aujourd'hui et que l'horaire est déjà passé

Exemple avec la date du 3 mai 2023 à 11h00 :

<img width="806" alt="Capture d’écran 2023-05-03 à 10 59 57" src="https://user-images.githubusercontent.com/119043808/235873433-340a4aaa-a35c-4370-bc14-bf559aeac912.png">

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
