### PR TITLE
(BSR)[API] fix: landing cards buttons

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
@@ -10,14 +10,14 @@
           <div class="d-flex flex-row-reverse mt-4">
             <a href="{{ link }}"
                class="btn btn-md btn-outline-primary fw-bold">
-              <span class="d-none d-xl-block">CONSULTER</span> <i class="bi bi-arrow-right"></i>
+              <span class="d-none d-xl-inline-block">CONSULTER</span> <i class="bi bi-arrow-right"></i>
             </a>
           </div>
         {% else %}
           <div class="d-flex flex-row-reverse mt-4">
             <a href="#"
                class="btn btn-md btn-outline-grey fw-bold disabled">
-              <span class="d-none d-xl-block">À VENIR</span> <i class="bi bi-clock"></i>
+              <span class="d-none d-xl-inline-block">À VENIR</span> <i class="bi bi-clock"></i>
             </a>
           </div>
         {% endif %}


### PR DESCRIPTION
Replace `d-block` with `d-inline-block` to preserve inline display of btn icons

## But de la pull request

Restaure l'affichage inline block des boutons consulter/à venir

## Implémentation

![image](https://user-images.githubusercontent.com/77674046/235927492-7f1984cd-4f20-4e3d-b9bb-40734240fc12.png)


## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
