### PR TITLE
(PC-21226)[API] store venue registration info

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-0e0fe7986d01 (pre) (head)
-ddd2e5df3da7 (post) (head)
+b1ee65265887 (pre) (head)
+4ed5060d7fd7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230504T081500_b1ee65265887_add_venue_registration_table.py
+++ b/api/src/pcapi/alembic/versions/20230504T081500_b1ee65265887_add_venue_registration_table.py
@@ -1,0 +1,30 @@
+"""Add venue_registration table"""
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi.core.offerers.models import Target
+import pcapi.utils.db as db_utils
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "b1ee65265887"
+down_revision = "0e0fe7986d01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "venue_registration",
+        sa.Column("id", sa.BigInteger, sa.Identity(), primary_key=True),
+        sa.Column("venueId", sa.BigInteger(), nullable=False),
+        sa.Column("target", db_utils.MagicEnum(Target), nullable=False),
+        sa.Column("webPresence", sa.Text(), nullable=True),
+    )
+    # new table is empty, unique constraint is created instantly
+    op.create_index(op.f("ix_venue_registration_venueId"), "venue_registration", ["venueId"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_table("venue_registration")

--- a/api/src/pcapi/alembic/versions/20230504T085612_e6452b3c197d_add_venue_registration_venueid_fk.py
+++ b/api/src/pcapi/alembic/versions/20230504T085612_e6452b3c197d_add_venue_registration_venueid_fk.py
@@ -1,0 +1,27 @@
+"""Add venue_registration venueId FK step 1/2"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e6452b3c197d"
+down_revision = "ddd2e5df3da7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # This will commit instantyly as soon as it gets a SHARE ROW lock on both tables
+    op.create_foreign_key(
+        constraint_name="venue_registration_venueId_fkey",
+        source_table="venue_registration",
+        referent_table="venue",
+        local_cols=["venueId"],
+        remote_cols=["id"],
+        postgresql_not_valid=True,
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(constraint_name="venue_registration_venueId_fkey", table_name="venue_registration")

--- a/api/src/pcapi/alembic/versions/20230504T105244_4ed5060d7fd7_add_venue_registration_venueid_fk_2_2.py
+++ b/api/src/pcapi/alembic/versions/20230504T105244_4ed5060d7fd7_add_venue_registration_venueid_fk_2_2.py
@@ -1,0 +1,24 @@
+"""Add venue_registration venueId FK 2/2
+"""
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4ed5060d7fd7"
+down_revision = "e6452b3c197d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.execute('ALTER TABLE "venue_registration" VALIDATE CONSTRAINT "venue_registration_venueId_fkey"')
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1657,6 +1657,11 @@ def get_metabase_stats_iframe_url(
     return f"{settings.METABASE_SITE_URL}/embed/dashboard/{token}#bordered=false&titled=false"
 
 
+def create_venue_registration(venue_id: int, target: offerers_models.Target, web_presence: str | None) -> None:
+    venue_registration = offerers_models.VenueRegistration(venueId=venue_id, target=target, webPresence=web_presence)
+    repository.save(venue_registration)
+
+
 def create_from_onboarding_data(
     user: users_models.User,
     onboarding_data: offerers_serialize.SaveNewOnboardingDataQueryModel,
@@ -1716,7 +1721,8 @@ def create_from_onboarding_data(
             )
         venue_kwargs = common_kwargs | comment_and_siret
         venue_creation_info = venues_serialize.PostVenueBodyModel(**venue_kwargs)  # type: ignore [arg-type]
-        create_venue(venue_creation_info, strict_accessibility_compliance=False)
+        venue = create_venue(venue_creation_info, strict_accessibility_compliance=False)
+        create_venue_registration(venue.id, new_onboarding_info.target, new_onboarding_info.webPresence)
 
     if not transactional_mails.send_welcome_to_pro_email(user):
         logger.warning(

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -427,7 +427,7 @@ def auto_tag_new_offerer(
 
 @dataclasses.dataclass
 class NewOnboardingInfo:
-    target: models.Target | None
+    target: models.Target
     venueTypeCode: str
     webPresence: str | None
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1403,7 +1403,10 @@ class CreateFromOnboardingDataTest:
     def assert_common_action_history_extra_data(self, action: history_models.ActionHistory) -> None:
         assert action.extraData["target"] == offerers_models.Target.INDIVIDUAL.name
         assert action.extraData["venue_type_code"] == offerers_models.VenueTypeCode.MOVIE.name
-        assert action.extraData["web_presence"] == "www.example.com, instagram.com/example, @example@mastodon.example"
+        assert (
+            action.extraData["web_presence"]
+            == "https://www.example.com, https://instagram.com/example, https://mastodon.social/@example"
+        )
 
     def assert_only_welcome_email_to_pro_was_sent(self) -> None:
         assert len(mails_testing.outbox) == 1
@@ -1425,7 +1428,7 @@ class CreateFromOnboardingDataTest:
             siret="85331845900031",
             target=offerers_models.Target.INDIVIDUAL,
             venueTypeCode=offerers_models.VenueTypeCode.MOVIE.name,
-            webPresence="www.example.com, instagram.com/example, @example@mastodon.example",
+            webPresence="https://www.example.com, https://instagram.com/example, https://mastodon.social/@example",
         )
 
     @override_features(WIP_ENABLE_NEW_ONBOARDING=True)

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1408,6 +1408,14 @@ class CreateFromOnboardingDataTest:
             == "https://www.example.com, https://instagram.com/example, https://mastodon.social/@example"
         )
 
+    def assert_venue_registration_attrs(self, venue: Venue) -> None:
+        assert offerers_models.VenueRegistration.query.all() == [venue.registration]
+        assert venue.registration.target == offerers_models.Target.INDIVIDUAL
+        assert (
+            venue.registration.webPresence
+            == "https://www.example.com, https://instagram.com/example, https://mastodon.social/@example"
+        )
+
     def assert_only_welcome_email_to_pro_was_sent(self) -> None:
         assert len(mails_testing.outbox) == 1
         assert (
@@ -1472,6 +1480,8 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
         self.assert_only_welcome_email_to_pro_was_sent()
+        # Venue Registration
+        self.assert_venue_registration_attrs(created_venue)
 
     @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     def test_existing_siren_new_siret(self):
@@ -1507,6 +1517,8 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
         self.assert_only_welcome_email_to_pro_was_sent()
+        # Venue Registration
+        self.assert_venue_registration_attrs(created_venue)
 
     @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     def test_existing_siren_new_venue_without_siret(self):
@@ -1543,6 +1555,8 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
         self.assert_only_welcome_email_to_pro_was_sent()
+        # Venue Registration
+        self.assert_venue_registration_attrs(created_venue)
 
     @override_features(WIP_ENABLE_NEW_ONBOARDING=True)
     def test_existing_siren_existing_siret(self):
@@ -1574,3 +1588,5 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
         self.assert_only_welcome_email_to_pro_was_sent()
+        # Venue Registration
+        assert offerers_models.VenueRegistration.query.count() == 0

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -21,7 +21,7 @@ REQUEST_BODY = {
     "siret": "85331845900031",
     "target": "INDIVIDUAL",
     "venueTypeCode": "MOVIE",
-    "webPresence": "www.example.com, instagram.com/example, @example@mastodon.example",
+    "webPresence": "https://www.example.com, https://instagram.com/example, https://mastodon.social/@example",
 }
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21226

## But de la pull request

Enregistrer les nouvelles données (`target`, `webPresence`) sur le premier lieu créé pendant l'onboarding pro.

## Implémentation

- Ajout d'une table `venue_registration`
- Modification de `create_from_onboarding_data()`

## Informations supplémentaires

- Utilisation d'une colonne `Identity` au lieu d'une `Serial` pour la clé primaire de `venue_registration` cf https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_serial

## Modifications du schéma de la base de données

- Ajout de la table `venue_registration` qui permet de stocker les urls fournies par un AC lors de l'onboarding, et le public visé (grand public, EAC, ou les 2)
