### PR TITLE
(PC-22068)[API] feat: use new provider model for offerer_venues and GET /offer

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -130,8 +130,9 @@ def _check_venue_id_is_tied_to_api_key(venue_id: int | None) -> None:
         return
 
     is_venue_tied_to_api_key = db.session.query(
-        offerers_models.Venue.query.filter(
-            offerers_models.Venue.managingOffererId == current_api_key.offererId, offerers_models.Venue.id == venue_id
+        providers_models.VenueProvider.query.filter(
+            providers_models.VenueProvider.provider == current_api_key.provider,
+            providers_models.VenueProvider.venueId == venue_id,
         ).exists()
     ).scalar()
     if not is_venue_tied_to_api_key:
@@ -141,7 +142,8 @@ def _check_venue_id_is_tied_to_api_key(venue_id: int | None) -> None:
 def _retrieve_offer_ids(is_event: bool, filtered_venue_id: int | None) -> list[int]:
     offer_ids_query = (
         offers_models.Offer.query.join(offerers_models.Venue)
-        .filter(offerers_models.Venue.managingOffererId == current_api_key.offererId)
+        .join(providers_models.VenueProvider)
+        .filter(providers_models.VenueProvider.provider == current_api_key.provider)
         .filter(offers_models.Offer.isEvent == is_event)
         .with_entities(offers_models.Offer.id)
         .order_by(offers_models.Offer.id)

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -763,7 +763,7 @@ class PaginationQueryParams(serialization.ConfiguredBaseModel):
 
 
 class GetOffersQueryParams(PaginationQueryParams):
-    venue_id: int | None = pydantic.Field(None, description="Venue id to filter offers on. Optional.")
+    venue_id: int = pydantic.Field(..., description="Venue id to filter offers on. Optional.")
 
 
 class GetDatesQueryParams(PaginationQueryParams):

--- a/api/tests/routes/public/individual_offers/v1/endpoints_test.py
+++ b/api/tests/routes/public/individual_offers/v1/endpoints_test.py
@@ -1971,12 +1971,12 @@ class GetProductsTest:
     ENDPOINT_URL = "http://localhost/public/offers/v1/products"
 
     def test_get_first_page(self, client):
-        api_key = offerers_factories.ApiKeyFactory()
-        offers = offers_factories.ThingOfferFactory.create_batch(12, venue__managingOfferer=api_key.offerer)
+        venue, _ = create_offerer_provider_linked_to_venue()
+        offers = offers_factories.ThingOfferFactory.create_batch(12, venue=venue)
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/public/offers/v1/products?limit=5"
+                f"/public/offers/v1/products?venueId={venue.id}&limit=5"
             )
 
         assert response.status_code == 200
@@ -1987,22 +1987,22 @@ class GetProductsTest:
             "lastPage": 3,
             "limitPerPage": 5,
             "pagesLinks": {
-                "current": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                "first": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                "last": f"{self.ENDPOINT_URL}?page=3&limit=5",
-                "next": f"{self.ENDPOINT_URL}?page=2&limit=5",
+                "current": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                "first": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                "last": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=3&limit=5",
+                "next": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=2&limit=5",
                 "previous": None,
             },
         }
         assert [product["id"] for product in response.json["products"]] == [offer.id for offer in offers[0:5]]
 
     def test_get_last_page(self, client):
-        api_key = offerers_factories.ApiKeyFactory()
-        offers = offers_factories.ThingOfferFactory.create_batch(12, venue__managingOfferer=api_key.offerer)
+        venue, _ = create_offerer_provider_linked_to_venue()
+        offers = offers_factories.ThingOfferFactory.create_batch(12, venue=venue)
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/public/offers/v1/products?limit=5&page=3"
+                f"/public/offers/v1/products?venueId={venue.id}&limit=5&page=3"
             )
 
         assert response.status_code == 200
@@ -2013,34 +2013,33 @@ class GetProductsTest:
             "lastPage": 3,
             "limitPerPage": 5,
             "pagesLinks": {
-                "current": f"{self.ENDPOINT_URL}?page=3&limit=5",
-                "first": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                "last": f"{self.ENDPOINT_URL}?page=3&limit=5",
+                "current": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=3&limit=5",
+                "first": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                "last": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=3&limit=5",
                 "next": None,
-                "previous": f"{self.ENDPOINT_URL}?page=2&limit=5",
+                "previous": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=2&limit=5",
             },
         }
         assert [product["id"] for product in response.json["products"]] == [offer.id for offer in offers[10:12]]
 
     def test_404_when_the_page_is_too_high(self, client):
-        offerers_factories.ApiKeyFactory()
+        venue, _ = create_offerer_provider_linked_to_venue()
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/public/offers/v1/products?limit=5&page=2"
+                f"/public/offers/v1/products?venueId={venue.id}&limit=5&page=2"
             )
-
         assert response.status_code == 404
         assert response.json == {
             "page": "The page you requested does not exist. The maximum page for the " "specified limit is 1"
         }
 
     def test_200_for_first_page_if_no_items(self, client):
-        offerers_factories.ApiKeyFactory()
+        venue, _ = create_offerer_provider_linked_to_venue()
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/public/offers/v1/products?limit=5"
+                f"/public/offers/v1/products?venueId={venue.id}&limit=5"
             )
 
         assert response.status_code == 200
@@ -2052,9 +2051,9 @@ class GetProductsTest:
                 "limitPerPage": 5,
                 "lastPage": 1,
                 "pagesLinks": {
-                    "current": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                    "first": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                    "last": f"{self.ENDPOINT_URL}?page=1&limit=5",
+                    "current": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                    "first": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                    "last": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
                     "next": None,
                     "previous": None,
                 },
@@ -2063,21 +2062,22 @@ class GetProductsTest:
         }
 
     def test_400_when_limit_is_too_high(self, client):
-        offerers_factories.ApiKeyFactory()
+        venue, _ = create_offerer_provider_linked_to_venue()
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/public/offers/v1/products?limit=51"
+                f"/public/offers/v1/products?venueId={venue.id}&limit=51"
             )
 
         assert response.status_code == 400
         assert response.json == {"limit": ["ensure this value is less than or equal to 50"]}
 
     def test_get_filtered_venue_offer(self, client):
-        api_key = offerers_factories.ApiKeyFactory()
-        venue = offerers_factories.VenueFactory(managingOfferer=api_key.offerer)
+        venue, _ = create_offerer_provider_linked_to_venue()
         offer = offers_factories.ThingOfferFactory(venue=venue)
-        offers_factories.ThingOfferFactory(venue__managingOfferer=api_key.offerer)  # offer attached to other venue
+        offers_factories.ThingOfferFactory(
+            venue__managingOfferer=venue.managingOfferer
+        )  # offer attached to other venue
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
@@ -2117,13 +2117,13 @@ class GetEventsTest:
     ENDPOINT_URL = "http://localhost/public/offers/v1/events"
 
     def test_get_first_page(self, client):
-        api_key = offerers_factories.ApiKeyFactory()
-        offers = offers_factories.EventOfferFactory.create_batch(12, venue__managingOfferer=api_key.offerer)
-        offers_factories.ThingOfferFactory.create_batch(3, venue__managingOfferer=api_key.offerer)  # not returned
+        venue, _ = create_offerer_provider_linked_to_venue()
+        offers = offers_factories.EventOfferFactory.create_batch(12, venue=venue)
+        offers_factories.ThingOfferFactory.create_batch(3, venue=venue)  # not returned
 
         with testing.assert_no_duplicated_queries():
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
-                "/public/offers/v1/events?limit=5"
+                f"/public/offers/v1/events?limit=5&venueId={venue.id}"
             )
 
         assert response.status_code == 200
@@ -2134,10 +2134,10 @@ class GetEventsTest:
             "lastPage": 3,
             "limitPerPage": 5,
             "pagesLinks": {
-                "current": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                "first": f"{self.ENDPOINT_URL}?page=1&limit=5",
-                "last": f"{self.ENDPOINT_URL}?page=3&limit=5",
-                "next": f"{self.ENDPOINT_URL}?page=2&limit=5",
+                "current": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                "first": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=1&limit=5",
+                "last": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=3&limit=5",
+                "next": f"{self.ENDPOINT_URL}?venueId={venue.id}&page=2&limit=5",
                 "previous": None,
             },
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22068

Fix pour les routes de création qui créent une offre + un stock
Utilisation des nouveaux providers pour les routes GET /events et GET /products et la route /offerer_venues