### PR TITLE
(PC-22128)[PRO] fix: serializer updateIndividualOffer

### DIFF
--- a/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/__specs__/updateIndividualOffer.spec.ts
@@ -157,7 +157,7 @@ describe('updateIndividualOffer', () => {
       name: undefined,
       url: undefined,
       visualDisabilityCompliant: true,
-      withdrawalDelay: null,
+      withdrawalDelay: undefined,
       withdrawalDetails: undefined,
       withdrawalType: undefined,
       shouldSendMail: false,

--- a/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
+++ b/pro/src/core/Offers/adapters/updateIndividualOffer/serializers.ts
@@ -88,7 +88,9 @@ export const serializePatchOffer = ({
     name: sentValues.name,
     withdrawalDelay:
       sentValues.withdrawalDelay === undefined
-        ? null
+        ? sentValues.withdrawalDetails
+          ? null
+          : undefined
         : Number(sentValues.withdrawalDelay),
     withdrawalDetails: sentValues.withdrawalDetails || undefined,
     visualDisabilityCompliant:


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22128

## But de la pull request

- Erreur lors de l'envoi des données d'une offre invidivuel.

## Implémentation

- Si withdrawalType est null ou undefined, withdrawalDelay = undefined, sinon null si withdrawalDelay est undefined
