### PR TITLE
(BSR)[API] test lint migrations with squawk

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -43,29 +43,30 @@ jobs:
   #       api/src/pcapi/alembic/versions/**
   #       api/src/pcapi/alembic/run_migrations.py
 
-  # build-api:
-  #   name: "Build API (backend) Docker image"
-  #   needs: [check-api, check-pro]
-  #   if: |
-  #     needs.check-api.outputs.folder_changed == 'true' ||
-  #     needs.check-pro.outputs.folder_changed == 'true' ||
-  #     github.ref == 'refs/heads/master' ||
-  #     startsWith(github.ref,'refs/heads/maint/v')
-  #   uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
-  #   with:
-  #     ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-  #     tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-  #     # Needed to run end-to-end tests, i.e. when either "pro" or
-  #     # "api" source code changes, which is the condition under which
-  #     # this step is run. In other words: always.
-  #     pcapi: true
-  #     # Extra when tests are run on master before deployment on testing.
-  #     console: ${{ github.ref == 'refs/heads/master' }}
-  #     # Needed to run backend tests.
-  #     tests: ${{ needs.check-api.outputs.folder_changed == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/maint/v') }}
-  #   secrets:
-  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  build-api:
+    name: "Build API (backend) Docker image"
+    # needs: [check-api, check-pro]
+    # if: |
+    #   needs.check-api.outputs.folder_changed == 'true' ||
+    #   needs.check-pro.outputs.folder_changed == 'true' ||
+    #   github.ref == 'refs/heads/master' ||
+    #   startsWith(github.ref,'refs/heads/maint/v')
+    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+    with:
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      # Needed to run end-to-end tests, i.e. when either "pro" or
+      # "api" source code changes, which is the condition under which
+      # this step is run. In other words: always.
+      pcapi: true
+      # Extra when tests are run on master before deployment on testing.
+      console: ${{ github.ref == 'refs/heads/master' }}
+      # Needed to run backend tests.
+      tests: true
+      # tests: ${{ needs.check-api.outputs.folder_changed == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/maint/v') }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   # run-mypy-cop:
   #   name: "MyPy cop"
@@ -106,6 +107,7 @@ jobs:
   test-api:
     name: "Test api"
     # needs: [check-api, build-api]
+    needs: [build-api]
     # if: |
     #   needs.check-api.outputs.folder_changed == 'true' ||
     #   github.ref == 'refs/heads/master' ||

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -17,258 +17,258 @@ concurrency:
   cancel-in-progress: ${{ github.ref == 'refs/heads/master' && false || true }}
 
 jobs:
-  check-api:
-    name: "Check api folder changes"
-    uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
-    with:
-      folder: api/**
+  # check-api:
+  #   name: "Check api folder changes"
+  #   uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
+  #   with:
+  #     folder: api/**
 
-  check-pro:
-    name: "Check pro folder changes"
-    uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
-    with:
-      folder: pro/**
+  # check-pro:
+  #   name: "Check pro folder changes"
+  #   uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
+  #   with:
+  #     folder: pro/**
 
-  check-maintenance-site:
-    name: "Check maintenance-site folder changes"
-    uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
-    with:
-      folder: maintenance-site/**
+  # check-maintenance-site:
+  #   name: "Check maintenance-site folder changes"
+  #   uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
+  #   with:
+  #     folder: maintenance-site/**
 
-  check-db-migrations:
-    name: "Check db migration folder changes"
-    uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
-    with:
-      folder: |-
-        api/src/pcapi/alembic/versions/**
-        api/src/pcapi/alembic/run_migrations.py
+  # check-db-migrations:
+  #   name: "Check db migration folder changes"
+  #   uses: ./.github/workflows/dev_on_workflow_check_folder_changes.yml
+  #   with:
+  #     folder: |-
+  #       api/src/pcapi/alembic/versions/**
+  #       api/src/pcapi/alembic/run_migrations.py
 
-  build-api:
-    name: "Build API (backend) Docker image"
-    needs: [check-api, check-pro]
-    if: |
-      needs.check-api.outputs.folder_changed == 'true' ||
-      needs.check-pro.outputs.folder_changed == 'true' ||
-      github.ref == 'refs/heads/master' ||
-      startsWith(github.ref,'refs/heads/maint/v')
-    uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
-    with:
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      # Needed to run end-to-end tests, i.e. when either "pro" or
-      # "api" source code changes, which is the condition under which
-      # this step is run. In other words: always.
-      pcapi: true
-      # Extra when tests are run on master before deployment on testing.
-      console: ${{ github.ref == 'refs/heads/master' }}
-      # Needed to run backend tests.
-      tests: ${{ needs.check-api.outputs.folder_changed == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/maint/v') }}
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # build-api:
+  #   name: "Build API (backend) Docker image"
+  #   needs: [check-api, check-pro]
+  #   if: |
+  #     needs.check-api.outputs.folder_changed == 'true' ||
+  #     needs.check-pro.outputs.folder_changed == 'true' ||
+  #     github.ref == 'refs/heads/master' ||
+  #     startsWith(github.ref,'refs/heads/maint/v')
+  #   uses: ./.github/workflows/dev_on_workflow_build_and_push_docker_images.yml
+  #   with:
+  #     ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     tag: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     # Needed to run end-to-end tests, i.e. when either "pro" or
+  #     # "api" source code changes, which is the condition under which
+  #     # this step is run. In other words: always.
+  #     pcapi: true
+  #     # Extra when tests are run on master before deployment on testing.
+  #     console: ${{ github.ref == 'refs/heads/master' }}
+  #     # Needed to run backend tests.
+  #     tests: ${{ needs.check-api.outputs.folder_changed == 'true' || github.ref == 'refs/heads/master' || startsWith(github.ref,'refs/heads/maint/v') }}
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  run-mypy-cop:
-    name: "MyPy cop"
-    needs: check-api
-    if: github.ref != 'refs/heads/master' && needs.check-api.outputs.folder_changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
+  # run-mypy-cop:
+  #   name: "MyPy cop"
+  #   needs: check-api
+  #   if: github.ref != 'refs/heads/master' && needs.check-api.outputs.folder_changed == 'true'
+  #   uses: ./.github/workflows/dev_on_workflow_mypy_cop.yml
 
-  update-api-client-template:
-    name: "Update api client template"
-    needs: build-api
-    uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
-    if: github.base_ref == 'master'
-    concurrency:
-      group: update-api-client-template-${{ github.ref }}
-      cancel-in-progress: true
-    with:
-      PCAPI_DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      TRIGGER_ONLY_ON_API_CHANGE: true
-      TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
-    secrets:
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  # update-api-client-template:
+  #   name: "Update api client template"
+  #   needs: build-api
+  #   uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
+  #   if: github.base_ref == 'master'
+  #   concurrency:
+  #     group: update-api-client-template-${{ github.ref }}
+  #     cancel-in-progress: true
+  #   with:
+  #     PCAPI_DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     TRIGGER_ONLY_ON_API_CHANGE: true
+  #     TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
+  #     CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+  #   secrets:
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  prepare-cache-master:
-    name: "Reset cache on master on dependency update"
-    uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
-    if: github.ref == 'refs/heads/master'
-    with:
-      PCAPI_DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      TRIGGER_ONLY_ON_API_CHANGE: false
-      TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
-    secrets:
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  # prepare-cache-master:
+  #   name: "Reset cache on master on dependency update"
+  #   uses: ./.github/workflows/dev_on_workflow_update_api_client_template.yml
+  #   if: github.ref == 'refs/heads/master'
+  #   with:
+  #     PCAPI_DOCKER_TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     TRIGGER_ONLY_ON_API_CHANGE: false
+  #     TRIGGER_ONLY_ON_DEPENDENCY_CHANGE: true
+  #     CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+  #   secrets:
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
   test-api:
     name: "Test api"
-    needs: [check-api, build-api]
-    if: |
-      needs.check-api.outputs.folder_changed == 'true' ||
-      github.ref == 'refs/heads/master' ||
-      startsWith(github.ref,'refs/heads/maint/v')
+    # needs: [check-api, build-api]
+    # if: |
+    #   needs.check-api.outputs.folder_changed == 'true' ||
+    #   github.ref == 'refs/heads/master' ||
+    #   startsWith(github.ref,'refs/heads/maint/v')
     uses: ./.github/workflows/dev_on_workflow_tests_api.yml
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  test-pro:
-    name: "Tests pro"
-    needs: check-pro
-    if: |
-      needs.check-pro.outputs.folder_changed == 'true' ||
-      github.ref == 'refs/heads/master' ||
-      startsWith(github.ref,'refs/heads/maint/v')
-    uses: ./.github/workflows/dev_on_workflow_tests_pro.yml
-    with:
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # test-pro:
+  #   name: "Tests pro"
+  #   needs: check-pro
+  #   if: |
+  #     needs.check-pro.outputs.folder_changed == 'true' ||
+  #     github.ref == 'refs/heads/master' ||
+  #     startsWith(github.ref,'refs/heads/maint/v')
+  #   uses: ./.github/workflows/dev_on_workflow_tests_pro.yml
+  #   with:
+  #     CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  dependabot-auto-merge:
-    name: "Dependabot"
-    needs: test-pro
-    if: |
-      github.event_name == 'pull_request' &&
-      github.actor == 'dependabot[bot]'
-    uses: ./.github/workflows/dev_on_workflow_dependabot_auto_merge.yml
+  # dependabot-auto-merge:
+  #   name: "Dependabot"
+  #   needs: test-pro
+  #   if: |
+  #     github.event_name == 'pull_request' &&
+  #     github.actor == 'dependabot[bot]'
+  #   uses: ./.github/workflows/dev_on_workflow_dependabot_auto_merge.yml
 
-  test-pro-e2e:
-    name: "Tests pro E2E"
-    needs: [check-api, check-pro, build-api]
-    if: |
-      needs.check-api.outputs.folder_changed == 'true' ||
-      needs.check-pro.outputs.folder_changed == 'true' ||
-      github.ref == 'refs/heads/master' ||
-      startsWith(github.ref,'refs/heads/maint/v')
-    uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-    with:
-      TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+  # test-pro-e2e:
+  #   name: "Tests pro E2E"
+  #   needs: [check-api, check-pro, build-api]
+  #   if: |
+  #     needs.check-api.outputs.folder_changed == 'true' ||
+  #     needs.check-pro.outputs.folder_changed == 'true' ||
+  #     github.ref == 'refs/heads/master' ||
+  #     startsWith(github.ref,'refs/heads/maint/v')
+  #   uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #   with:
+  #     TAG: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
 
-  deploy-storybook:
-    name: "Deploy Storybook"
-    needs: check-pro
-    if: ${{ github.ref == 'refs/heads/master' && needs.check-pro.outputs.folder_changed == 'true' }}
-    uses: ./.github/workflows/dev_on_workflow_deploy_storybook.yml
+  # deploy-storybook:
+  #   name: "Deploy Storybook"
+  #   needs: check-pro
+  #   if: ${{ github.ref == 'refs/heads/master' && needs.check-pro.outputs.folder_changed == 'true' }}
+  #   uses: ./.github/workflows/dev_on_workflow_deploy_storybook.yml
 
-  deploy-validation-env:
-    name: "[PRO] Deploy PR version for validation"
-    needs: check-pro
-    uses: ./.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml
-    if: |
-      always() &&
-      github.base_ref == 'master' &&
-      needs.check-pro.outputs.folder_changed == 'true'
-    secrets:
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-    with:
-      ENV: "testing"
-      CHANNEL: ""
-      REF: "${{ github.ref }}"
-      CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
+  # deploy-validation-env:
+  #   name: "[PRO] Deploy PR version for validation"
+  #   needs: check-pro
+  #   uses: ./.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml
+  #   if: |
+  #     always() &&
+  #     github.base_ref == 'master' &&
+  #     needs.check-pro.outputs.folder_changed == 'true'
+  #   secrets:
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #   with:
+  #     ENV: "testing"
+  #     CHANNEL: ""
+  #     REF: "${{ github.ref }}"
+  #     CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
 
-  deploy-to-testing:
-    name: "Deploy to testing"
-    needs: [test-api, test-pro]
-    if: |
-      always() &&
-      github.ref == 'refs/heads/master' &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-api.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-pro.result)
-    uses: ./.github/workflows/dev_on_workflow_deploy.yml
-    with:
-      environment: testing
-      app_version: ${{ github.sha }}
-      teleport_version: 11.1.1
-      teleport_proxy: teleport.ehp.passculture.team:443
-      teleport_kubernetes_cluster: passculture-metier-ehp
-      deploy_api: ${{ needs.test-api.result == 'success' }}
-      deploy_pro: ${{ needs.test-pro.result == 'success' }}
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # deploy-to-testing:
+  #   name: "Deploy to testing"
+  #   needs: [test-api, test-pro]
+  #   if: |
+  #     always() &&
+  #     github.ref == 'refs/heads/master' &&
+  #     contains(fromJSON('["success", "skipped"]'), needs.test-api.result) &&
+  #     contains(fromJSON('["success", "skipped"]'), needs.test-pro.result)
+  #   uses: ./.github/workflows/dev_on_workflow_deploy.yml
+  #   with:
+  #     environment: testing
+  #     app_version: ${{ github.sha }}
+  #     teleport_version: 11.1.1
+  #     teleport_proxy: teleport.ehp.passculture.team:443
+  #     teleport_kubernetes_cluster: passculture-metier-ehp
+  #     deploy_api: ${{ needs.test-api.result == 'success' }}
+  #     deploy_pro: ${{ needs.test-pro.result == 'success' }}
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  deploy-maintenance-site:
-    name: "Deploy maintenance site"
-    needs: check-maintenance-site
-    if: |
-      always() &&
-      github.ref == 'refs/heads/master' &&
-      needs.check-maintenance-site.outputs.folder_changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_deploy_maintenance_site.yml
-    secrets:
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  # deploy-maintenance-site:
+  #   name: "Deploy maintenance site"
+  #   needs: check-maintenance-site
+  #   if: |
+  #     always() &&
+  #     github.ref == 'refs/heads/master' &&
+  #     needs.check-maintenance-site.outputs.folder_changed == 'true'
+  #   uses: ./.github/workflows/dev_on_workflow_deploy_maintenance_site.yml
+  #   secrets:
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  ping-data-team-on-slack:
-    name: "Ping data team on slack"
-    needs: check-db-migrations
-    if: |
-      always() &&
-      github.ref == 'refs/heads/master' &&
-      needs.check-db-migrations.outputs.folder_changed == 'true'
-    uses: ./.github/workflows/dev_on_workflow_ping_data_team.yml
-    secrets:
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  # ping-data-team-on-slack:
+  #   name: "Ping data team on slack"
+  #   needs: check-db-migrations
+  #   if: |
+  #     always() &&
+  #     github.ref == 'refs/heads/master' &&
+  #     needs.check-db-migrations.outputs.folder_changed == 'true'
+  #   uses: ./.github/workflows/dev_on_workflow_ping_data_team.yml
+  #   secrets:
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
 
-  update-jira-issue:
-    name: "Update Jira issue"
-    if: ${{ always() && github.ref == 'refs/heads/master' }}
-    concurrency: update-jira-issue-${{ github.workflow }}-${{ github.ref }}
-    uses: ./.github/workflows/dev_on_workflow_update_jira_issues.yml
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # update-jira-issue:
+  #   name: "Update Jira issue"
+  #   if: ${{ always() && github.ref == 'refs/heads/master' }}
+  #   concurrency: update-jira-issue-${{ github.workflow }}-${{ github.ref }}
+  #   uses: ./.github/workflows/dev_on_workflow_update_jira_issues.yml
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  slack-notify:
-    name: "Slack notification"
-    runs-on: ubuntu-latest
-    if: ${{ failure() && github.ref == 'refs/heads/master' }}
-    needs: deploy-to-testing
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v3
-      - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
-        with:
-          secrets: |-
-            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
-      - name: "Post to a Slack channel"
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          # channel #alertes-deploiement
-          channel-id: "CQAMNFVPS"
-          payload: |
-            {
-              "attachments": [
-                {
-                  "mrkdwn_in": ["text"],
-                  "color": "#A30002",
-                  "author_name": "${{github.actor}}",
-                  "author_link": "https://github.com/${{github.actor}}",
-                  "author_icon": "https://github.com/${{github.actor}}.png",
-                  "title": "PCAPI Deployment",
-                  "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                  "text": "Le déploiement de la version `master` a échoué sur `testing` :boom:"
-                }
-              ],
-              "unfurl_links": false,
-              "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+  # slack-notify:
+  #   name: "Slack notification"
+  #   runs-on: ubuntu-latest
+  #   if: ${{ failure() && github.ref == 'refs/heads/master' }}
+  #   needs: deploy-to-testing
+  #   steps:
+  #     - uses: technote-space/workflow-conclusion-action@v3
+  #     - name: "Authentification to Google"
+  #       uses: "google-github-actions/auth@v2"
+  #       with:
+  #         workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     - name: "Get Secret"
+  #       id: "secrets"
+  #       uses: "google-github-actions/get-secretmanager-secrets@v2"
+  #       with:
+  #         secrets: |-
+  #           SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+  #     - name: "Post to a Slack channel"
+  #       uses: slackapi/slack-github-action@v1.25.0
+  #       with:
+  #         # channel #alertes-deploiement
+  #         channel-id: "CQAMNFVPS"
+  #         payload: |
+  #           {
+  #             "attachments": [
+  #               {
+  #                 "mrkdwn_in": ["text"],
+  #                 "color": "#A30002",
+  #                 "author_name": "${{github.actor}}",
+  #                 "author_link": "https://github.com/${{github.actor}}",
+  #                 "author_icon": "https://github.com/${{github.actor}}.png",
+  #                 "title": "PCAPI Deployment",
+  #                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+  #                 "text": "Le déploiement de la version `master` a échoué sur `testing` :boom:"
+  #               }
+  #             ],
+  #             "unfurl_links": false,
+  #             "unfurl_media": false
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
 env:
-  tests_docker_image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:3d43e81572de683ae5464939c45cc3febed8181b
+  tests_docker_image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
 defaults:
   run:

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -287,6 +287,7 @@ jobs:
               status_code=1
             exit $status_code
       - name: "Lint migration downgrades"
+        if: always()
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ env.tests_docker_image }}

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -9,158 +9,158 @@ on:
         required: true
 
 env:
-  tests_docker_image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  tests_docker_image: europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry/pcapi-tests:3d43e81572de683ae5464939c45cc3febed8181b
 
 defaults:
   run:
     working-directory: api
 
 jobs:
-  quality-checks:
-    name: "Quality checks"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: "Authentification to Google"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
-            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
-      - name: "OpenID Connect Authentication"
-        id: "openid-auth"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
-      - run: docker pull ${{ env.tests_docker_image }}
-      - name: "Show installed Python packages"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          run: pip freeze
-      - name: "Check imports are well organized with isort"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          run: isort . --check-only
-      - name: "Check code is well formatted with black"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          run: black . --check
-      - name: "Run mypy"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          run: mypy src
-      - name: "Slack Notification"
-        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          # channel #dev
-          channel-id: "CPZ7U1CNP"
-          payload: |
-            {
-            "attachments": [
-              {
-                "mrkdwn_in": ["text"],
-                "color": "#A30002",
-                "author_name": "${{github.actor}}",
-                "author_link": "https://github.com/${{github.actor}}",
-                "author_icon": "https://github.com/${{github.actor}}.png",
-                "title": "Api tests",
-                "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests quality-checks échouent sur `master` :boom:"
-              }
-            ],
-            "unfurl_links": false,
-            "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+  # quality-checks:
+  #   name: "Quality checks"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: "Authentification to Google"
+  #       uses: 'google-github-actions/auth@v2'
+  #       with:
+  #         workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     - name: "Get Secret"
+  #       id: 'secrets'
+  #       uses: 'google-github-actions/get-secretmanager-secrets@v2'
+  #       with:
+  #         secrets: |-
+  #           ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
+  #           ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+  #           SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+  #     - name: "OpenID Connect Authentication"
+  #       id: "openid-auth"
+  #       uses: "google-github-actions/auth@v2"
+  #       with:
+  #         create_credentials_file: false
+  #         token_format: "access_token"
+  #         workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+  #     - uses: docker/login-action@v3
+  #       with:
+  #         registry: "europe-west1-docker.pkg.dev"
+  #         username: oauth2accesstoken
+  #         password: ${{ steps.openid-auth.outputs.access_token }}
+  #     - run: docker pull ${{ env.tests_docker_image }}
+  #     - name: "Show installed Python packages"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         run: pip freeze
+  #     - name: "Check imports are well organized with isort"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         run: isort . --check-only
+  #     - name: "Check code is well formatted with black"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         run: black . --check
+  #     - name: "Run mypy"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         run: mypy src
+  #     - name: "Slack Notification"
+  #       if: ${{ failure() && github.ref == 'refs/heads/master'  }}
+  #       uses: slackapi/slack-github-action@v1.25.0
+  #       with:
+  #         # channel #dev
+  #         channel-id: "CPZ7U1CNP"
+  #         payload: |
+  #           {
+  #           "attachments": [
+  #             {
+  #               "mrkdwn_in": ["text"],
+  #               "color": "#A30002",
+  #               "author_name": "${{github.actor}}",
+  #               "author_link": "https://github.com/${{github.actor}}",
+  #               "author_icon": "https://github.com/${{github.actor}}.png",
+  #               "title": "Api tests",
+  #               "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+  #               "text": "Les tests quality-checks échouent sur `master` :boom:"
+  #             }
+  #           ],
+  #           "unfurl_links": false,
+  #           "unfurl_media": false
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
 
-  pylint-check:
-    name: "Pylint"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Authentification to Google
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
-            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
-      - id: "openid-auth"
-        name: "OpenID Connect Authentication"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
-      - run: docker pull ${{ env.tests_docker_image }}
-      - name: "Show installed Python packages"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          run: pip freeze
-      - name: "Run pylint"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          run: pylint src tests --jobs=15
-      - name: "Slack Notification"
-        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          # channel #dev
-          channel-id: "CPZ7U1CNP"
-          payload: |
-            {
-            "attachments": [
-              {
-                "mrkdwn_in": ["text"],
-                "color": "#A30002",
-                "author_name": "${{github.actor}}",
-                "author_link": "https://github.com/${{github.actor}}",
-                "author_icon": "https://github.com/${{github.actor}}.png",
-                "title": "Api tests",
-                "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests pylint-checks échouent sur `master` :boom:"
-              }
-            ],
-            "unfurl_links": false,
-            "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+  # pylint-check:
+  #   name: "Pylint"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Authentification to Google
+  #       uses: 'google-github-actions/auth@v2'
+  #       with:
+  #         workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     - name: "Get Secret"
+  #       id: 'secrets'
+  #       uses: 'google-github-actions/get-secretmanager-secrets@v2'
+  #       with:
+  #         secrets: |-
+  #           ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
+  #           ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+  #           SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+  #     - id: "openid-auth"
+  #       name: "OpenID Connect Authentication"
+  #       uses: "google-github-actions/auth@v2"
+  #       with:
+  #         create_credentials_file: false
+  #         token_format: "access_token"
+  #         workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+  #     - uses: docker/login-action@v3
+  #       with:
+  #         registry: "europe-west1-docker.pkg.dev"
+  #         username: oauth2accesstoken
+  #         password: ${{ steps.openid-auth.outputs.access_token }}
+  #     - run: docker pull ${{ env.tests_docker_image }}
+  #     - name: "Show installed Python packages"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         run: pip freeze
+  #     - name: "Run pylint"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         run: pylint src tests --jobs=15
+  #     - name: "Slack Notification"
+  #       if: ${{ failure() && github.ref == 'refs/heads/master'  }}
+  #       uses: slackapi/slack-github-action@v1.25.0
+  #       with:
+  #         # channel #dev
+  #         channel-id: "CPZ7U1CNP"
+  #         payload: |
+  #           {
+  #           "attachments": [
+  #             {
+  #               "mrkdwn_in": ["text"],
+  #               "color": "#A30002",
+  #               "author_name": "${{github.actor}}",
+  #               "author_link": "https://github.com/${{github.actor}}",
+  #               "author_icon": "https://github.com/${{github.actor}}.png",
+  #               "title": "Api tests",
+  #               "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+  #               "text": "Les tests pylint-checks échouent sur `master` :boom:"
+  #             }
+  #           ],
+  #           "unfurl_links": false,
+  #           "unfurl_media": false
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
 
   tests-database:
     name: "Tests database schema"
@@ -234,40 +234,40 @@ jobs:
           echo "pre=$pre" >> $GITHUB_OUTPUT
           echo "post=$post" >> $GITHUB_OUTPUT
       - run: docker pull ${{ env.tests_docker_image }}
-      - name: "Check for alembic multiple heads"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          shell: bash
-          run: |
-            LINE_COUNT=$(wc -l <<< "$(alembic heads)")
-            echo "Found "$LINE_COUNT" head(s)"
-            if [ ${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
-      - name: "Check database and model are aligned"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST
-          run: |
-            set -e
-            flask install_postgres_extensions
-            alembic upgrade pre@head
-            alembic upgrade post@head
-            flask install_data
-            alembic check
-      - name: "Check that downgrade scripts are correctly written"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST
-          run: |
-            set -e
-            alembic downgrade post@f460dc2c9f93
-            alembic downgrade pre@f460dc2c9f93
-            alembic upgrade pre@head
-            alembic upgrade post@head
+      # - name: "Check for alembic multiple heads"
+      #   uses: addnab/docker-run-action@v3
+      #   with:
+      #     image: ${{ env.tests_docker_image }}
+      #     shell: bash
+      #     run: |
+      #       LINE_COUNT=$(wc -l <<< "$(alembic heads)")
+      #       echo "Found "$LINE_COUNT" head(s)"
+      #       if [ ${LINE_COUNT} -ne 2 ]; then echo "There must be two heads";exit 1;fi
+      # - name: "Check database and model are aligned"
+      #   uses: addnab/docker-run-action@v3
+      #   with:
+      #     image: ${{ env.tests_docker_image }}
+      #     shell: bash
+      #     options: -e RUN_ENV -e DATABASE_URL_TEST
+      #     run: |
+      #       set -e
+      #       flask install_postgres_extensions
+      #       alembic upgrade pre@head
+      #       alembic upgrade post@head
+      #       flask install_data
+      #       alembic check
+      # - name: "Check that downgrade scripts are correctly written"
+      #   uses: addnab/docker-run-action@v3
+      #   with:
+      #     image: ${{ env.tests_docker_image }}
+      #     shell: bash
+      #     options: -e RUN_ENV -e DATABASE_URL_TEST
+      #     run: |
+      #       set -e
+      #       alembic downgrade post@f460dc2c9f93
+      #       alembic downgrade pre@f460dc2c9f93
+      #       alembic upgrade pre@head
+      #       alembic upgrade post@head
       - name: "Lint migration upgrades"
         uses: addnab/docker-run-action@v3
         with:
@@ -305,160 +305,160 @@ jobs:
               squawk --config .squawk.toml ||
               status_code=1
             exit $status_code
-      - name: "Slack Notification"
-        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          # channel #dev
-          channel-id: "CPZ7U1CNP"
-          payload: |
-            {
-            "attachments": [
-              {
-                "mrkdwn_in": ["text"],
-                "color": "#A30002",
-                "author_name": "${{github.actor}}",
-                "author_link": "https://github.com/${{github.actor}}",
-                "author_icon": "https://github.com/${{github.actor}}.png",
-                "title": "Api tests",
-                "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                "text": "Les tests database échouent sur `master` :boom:"
-              }
-            ],
-            "unfurl_links": false,
-            "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+  #     - name: "Slack Notification"
+  #       if: ${{ failure() && github.ref == 'refs/heads/master'  }}
+  #       uses: slackapi/slack-github-action@v1.25.0
+  #       with:
+  #         # channel #dev
+  #         channel-id: "CPZ7U1CNP"
+  #         payload: |
+  #           {
+  #           "attachments": [
+  #             {
+  #               "mrkdwn_in": ["text"],
+  #               "color": "#A30002",
+  #               "author_name": "${{github.actor}}",
+  #               "author_link": "https://github.com/${{github.actor}}",
+  #               "author_icon": "https://github.com/${{github.actor}}.png",
+  #               "title": "Api tests",
+  #               "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+  #               "text": "Les tests database échouent sur `master` :boom:"
+  #             }
+  #           ],
+  #           "unfurl_links": false,
+  #           "unfurl_media": false
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
 
-  pytest:
-    name: "Pytest"
-    env:
-      RUN_ENV: tests
-      DATABASE_URL_TEST: postgresql://pytest:pytest@postgres:5432/pass_culture
-      REDIS_URL: redis://redis:6379
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        pytest_args:
-          [
-            "tests/core/bookings tests/core/offers tests/core/finance",
-            "tests/core --ignore=tests/core/bookings --ignore=tests/core/offers --ignore=tests/core/finance",
-            "tests/routes -m 'not backoffice'",
-            "tests --ignore=tests/core --ignore=tests/routes",
-            "tests/routes/backoffice -m 'backoffice'",
-          ]
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      postgres:
-        image: cimg/postgres:15.5-postgis
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          POSTGRES_USER: pytest
-          POSTGRES_PASSWORD: pytest
-          POSTGRES_DB: pass_culture
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: "Authentification to Google"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
-            SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
-      - name: "OpenID Connect Authentication"
-        id: "openid-auth"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - uses: docker/login-action@v3
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: oauth2accesstoken
-          password: ${{ steps.openid-auth.outputs.access_token }}
-      - run: docker pull ${{ env.tests_docker_image }}
-      - name: "Setup database"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST
-          run: |
-            set -e
-            flask install_postgres_extensions
-            alembic upgrade pre@head
-            alembic upgrade post@head
-            flask install_data
-      - name: "Mount a Volume with pcapi rights"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests -u 0
-          run: |
-            echo "Changing owner and group fort directory test"
-            chown -R pcapi:pcapi /tests
-      - name: "Run tests"
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ env.tests_docker_image }}
-          shell: bash
-          options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests
-          run: |
-            pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml'
-      - name: "Publish Test Report"
-        uses: mikepenz/action-junit-report@v4
-        if: always() # always run even if the previous step fails
-        with:
-          report_paths: "${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml"
-          check_name: "Pytest Report"
-          fail_on_failure: true
-      - name: "Slack Notification"
-        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          # channel #dev
-          channel-id: "CPZ7U1CNP"
-          payload: |
-            {
-              "attachments": [
-                {
-                  "mrkdwn_in": ["text"],
-                  "color": "#A30002",
-                  "author_name": "${{github.actor}}",
-                  "author_link": "https://github.com/${{github.actor}}",
-                  "author_icon": "https://github.com/${{github.actor}}.png",
-                  "title": "Api tests",
-                  "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
-                  "text": "Les tests pytest échouent sur `master` :boom:"
-                }
-              ],
-              "unfurl_links": false,
-              "unfurl_media": false
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
+  # pytest:
+  #   name: "Pytest"
+  #   env:
+  #     RUN_ENV: tests
+  #     DATABASE_URL_TEST: postgresql://pytest:pytest@postgres:5432/pass_culture
+  #     REDIS_URL: redis://redis:6379
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       pytest_args:
+  #         [
+  #           "tests/core/bookings tests/core/offers tests/core/finance",
+  #           "tests/core --ignore=tests/core/bookings --ignore=tests/core/offers --ignore=tests/core/finance",
+  #           "tests/routes -m 'not backoffice'",
+  #           "tests --ignore=tests/core --ignore=tests/routes",
+  #           "tests/routes/backoffice -m 'backoffice'",
+  #         ]
+  #   services:
+  #     redis:
+  #       image: redis:7-alpine
+  #       ports:
+  #         - 6379:6379
+  #       options: >-
+  #         --health-cmd "redis-cli ping"
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #     postgres:
+  #       image: cimg/postgres:15.5-postgis
+  #       ports:
+  #         - 5432:5432
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #       env:
+  #         POSTGRES_USER: pytest
+  #         POSTGRES_PASSWORD: pytest
+  #         POSTGRES_DB: pass_culture
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: "Authentification to Google"
+  #       uses: 'google-github-actions/auth@v2'
+  #       with:
+  #         workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  #     - name: "Get Secret"
+  #       id: 'secrets'
+  #       uses: 'google-github-actions/get-secretmanager-secrets@v2'
+  #       with:
+  #         secrets: |-
+  #           ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
+  #           ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+  #           SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+  #     - name: "OpenID Connect Authentication"
+  #       id: "openid-auth"
+  #       uses: "google-github-actions/auth@v2"
+  #       with:
+  #         create_credentials_file: false
+  #         token_format: "access_token"
+  #         workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+  #         service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+  #     - uses: docker/login-action@v3
+  #       with:
+  #         registry: "europe-west1-docker.pkg.dev"
+  #         username: oauth2accesstoken
+  #         password: ${{ steps.openid-auth.outputs.access_token }}
+  #     - run: docker pull ${{ env.tests_docker_image }}
+  #     - name: "Setup database"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         shell: bash
+  #         options: -e RUN_ENV -e DATABASE_URL_TEST
+  #         run: |
+  #           set -e
+  #           flask install_postgres_extensions
+  #           alembic upgrade pre@head
+  #           alembic upgrade post@head
+  #           flask install_data
+  #     - name: "Mount a Volume with pcapi rights"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         shell: bash
+  #         options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests -u 0
+  #         run: |
+  #           echo "Changing owner and group fort directory test"
+  #           chown -R pcapi:pcapi /tests
+  #     - name: "Run tests"
+  #       uses: addnab/docker-run-action@v3
+  #       with:
+  #         image: ${{ env.tests_docker_image }}
+  #         shell: bash
+  #         options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests
+  #         run: |
+  #           pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml'
+  #     - name: "Publish Test Report"
+  #       uses: mikepenz/action-junit-report@v4
+  #       if: always() # always run even if the previous step fails
+  #       with:
+  #         report_paths: '${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml'
+  #         check_name: "Pytest Report"
+  #         fail_on_failure: true
+  #     - name: "Slack Notification"
+  #       if: ${{ failure() && github.ref == 'refs/heads/master'  }}
+  #       uses: slackapi/slack-github-action@v1.25.0
+  #       with:
+  #         # channel #dev
+  #         channel-id: "CPZ7U1CNP"
+  #         payload: |
+  #           {
+  #             "attachments": [
+  #               {
+  #                 "mrkdwn_in": ["text"],
+  #                 "color": "#A30002",
+  #                 "author_name": "${{github.actor}}",
+  #                 "author_link": "https://github.com/${{github.actor}}",
+  #                 "author_icon": "https://github.com/${{github.actor}}.png",
+  #                 "title": "Api tests",
+  #                 "title_link": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}",
+  #                 "text": "Les tests pytest échouent sur `master` :boom:"
+  #               }
+  #             ],
+  #             "unfurl_links": false,
+  #             "unfurl_media": false
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -22,13 +22,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
@@ -100,13 +100,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Authentification to Google
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
@@ -195,13 +195,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
@@ -220,6 +220,19 @@ jobs:
           registry: "europe-west1-docker.pkg.dev"
           username: oauth2accesstoken
           password: ${{ steps.openid-auth.outputs.access_token }}
+      - uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ github.base_ref }}
+          sparse-checkout: |
+            api/alembic_version_conflict_detection.txt
+          sparse-checkout-cone-mode: false
+      - name: "Get base alembic pre and post heads"
+        id: "base_heads"
+        run: |
+          pre=$(head --lines 1 alembic_version_conflict_detection.txt | cut --fields 1 --delimiter " ")
+          post=$(tail --lines 1 alembic_version_conflict_detection.txt | cut --fields 1 --delimiter " ")
+          echo "pre=$pre" >> $GITHUB_OUTPUT
+          echo "post=$post" >> $GITHUB_OUTPUT
       - run: docker pull ${{ env.tests_docker_image }}
       - name: "Check for alembic multiple heads"
         uses: addnab/docker-run-action@v3
@@ -255,6 +268,42 @@ jobs:
             alembic downgrade pre@f460dc2c9f93
             alembic upgrade pre@head
             alembic upgrade post@head
+      - name: "Lint migration upgrades"
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.tests_docker_image }}
+          shell: bash
+          options: -e RUN_ENV -e DATABASE_URL_TEST
+          run: |
+            set -uo pipefail
+            status_code=0
+            alembic upgrade ${{ steps.base_heads.outputs.pre }}:pre@head --sql |
+              sed '/squawk:ignore-next-statement/,/;$/d' |
+              squawk --config .squawk.toml ||
+              status_code=1
+            alembic upgrade ${{ steps.base_heads.outputs.post }}:post@head --sql |
+              sed '/squawk:ignore-next-statement/,/;$/d' |
+              squawk --config .squawk.toml ||
+              status_code=1
+            exit $status_code
+      - name: "Lint migration downgrades"
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ env.tests_docker_image }}
+          shell: bash
+          options: -e RUN_ENV -e DATABASE_URL_TEST
+          run: |
+            set -uo pipefail
+            status_code=0
+            alembic downgrade pre@head:${{ steps.base_heads.outputs.pre }} --sql |
+              sed '/squawk:ignore-next-statement/,/;$/d' |
+              squawk --config .squawk.toml ||
+              status_code=1
+            alembic downgrade post@head:${{ steps.base_heads.outputs.post }} --sql |
+              sed '/squawk:ignore-next-statement/,/;$/d' |
+              squawk --config .squawk.toml ||
+              status_code=1
+            exit $status_code
       - name: "Slack Notification"
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: slackapi/slack-github-action@v1.25.0
@@ -325,13 +374,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
       - name: "Get Secret"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
             ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
@@ -384,7 +433,7 @@ jobs:
         uses: mikepenz/action-junit-report@v4
         if: always() # always run even if the previous step fails
         with:
-          report_paths: '${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml'
+          report_paths: "${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml"
           check_name: "Pytest Report"
           fail_on_failure: true
       - name: "Slack Notification"

--- a/api/.squawk.toml
+++ b/api/.squawk.toml
@@ -1,0 +1,11 @@
+pg_version = "15.5"
+excluded_rules = [
+  # backward compatibility is not needed because we are the only ones using our database
+  "adding-required-field",
+  "ban-drop-column",
+  "ban-drop-not-null",
+  "renaming-table",
+  "renaming-column",
+  # every timestamp is stored as UTC, which is i18n best practice
+  "prefer-timestamptz"
+]

--- a/api/.squawk.toml
+++ b/api/.squawk.toml
@@ -2,7 +2,6 @@ pg_version = "15.5"
 excluded_rules = [
   # backward compatibility is not needed because we are the only ones using our database
   "adding-required-field",
-  "ban-drop-column",
   "ban-drop-not-null",
   "renaming-table",
   "renaming-column",

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -151,7 +151,7 @@ FROM api-flask AS pcapi-tests
 USER root
 
 RUN apt-get update && \
-    apt-get install -y git --no-install-recommends && \
+    apt-get install -y git npm --no-install-recommends && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*
 
@@ -159,3 +159,6 @@ COPY --chown=pcapi:pcapi tests/ tests
 COPY --chown=pcapi:pcapi pyproject.toml .
 
 USER pcapi
+
+RUN npm config set prefix "$HOME/.local/"
+RUN npm install --global squawk-cli

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-23e2d3b322ab (pre) (head)
+3c9e910de34d (pre) (head)
 6be778edb2f4 (post) (head)

--- a/api/src/pcapi/alembic/CONTRIBUTING.md
+++ b/api/src/pcapi/alembic/CONTRIBUTING.md
@@ -106,6 +106,19 @@ op.add_column('venue_provider', sa.Column('syncWorkerId', sa.VARCHAR(24), nullab
 
 Pour un meilleur typage des colonnes de type "ARRAY", utiliser `sqlalchemy.dialects.postgresql.ARRAY` plutôt que `sqlalchemy.typing`.
 
+### Lint
+
+[squawk](https://github.com/sbdchd/squawk/) est utilisé afin d'attraper les migrations qui prennent un verrou sur la base
+de donnée, empêchant les lectures/écritures et donc créant du downtime applicatif.
+
+Pour désactiver le lint sur une seule expression SQL, le commentaire `-- squawk:ignore-next-statement` doit être placé juste avant :
+
+```python
+def upgrade() -> None:
+    op.execute("-- squawk:ignore-next-statement")
+    op.execute(sql_statement_that_would_upset_squawk)
+```
+
 # Squasher les migrations
 
 ## Objectif

--- a/api/src/pcapi/alembic/run_migrations.py
+++ b/api/src/pcapi/alembic/run_migrations.py
@@ -81,6 +81,7 @@ def run_migrations() -> None:
                     include_schemas=True,
                     transaction_per_migration=True,
                     compare_server_default=True,
+                    literal_binds=context.is_offline_mode(),
                 )
                 with context.begin_transaction():
                     context.run_migrations()

--- a/api/src/pcapi/alembic/versions/20240207T141914_3c9e910de34d_example.py
+++ b/api/src/pcapi/alembic/versions/20240207T141914_3c9e910de34d_example.py
@@ -1,0 +1,27 @@
+""" example de migration qui ne passe pas le lint avec une expression ignorée
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "3c9e910de34d"
+down_revision = "23e2d3b322ab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("-- squawk:ignore-next-statement")
+    op.execute("commit")  # the rule transaction-nesting should not activate
+    op.add_column("stock", sa.Column("venueId", sa.BigInteger(), nullable=False))
+    op.create_index(op.f("ix_stock_venueId"), "stock", ["venueId"], unique=False)
+    op.create_foreign_key(None, "stock", "venue", ["venueId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("constraint_name", "stock", type_="foreignkey")
+    op.drop_index(op.f("ix_stock_venueId"), table_name="stock")
+    op.drop_column("stock", "venueId")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -198,6 +198,9 @@ class Stock(PcObject, Base, Model, ProvidableMixin, SoftDeletableMixin):
         ),
     )
 
+    venue: sa_orm.Mapped["Venue"] = sa.orm.relationship("Venue", backref="stocks")
+    venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=True, nullable=False)
+
     @property
     def isBookable(self) -> bool:
         return self._bookable and self.offer.isReleased


### PR DESCRIPTION
## But de la pull request

Cette PR est pour tester le lint des migrations : #10602

La règle `ban-drop-column` a été ré-autorisée pour tester la configurabilité via le fichier `.squawk.toml` et pour tester le lint des downgrades.

Une simple migration qui ne suit pas les bonnes pratiques a été ajoutée pour tester squawk.
