### PR TITLE
(PC-22088)[PRO] refactor: activity page replace trashIcon with listIconButton

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.module.scss
@@ -12,12 +12,12 @@
 }
 
 .form-row-actions {
-  margin-top: rem.torem(8px);
+  margin-top: rem.torem(4px);
 }
 
 .first-row {
   margin-top: calc(
-    #{forms.$label-space-before-input} + #{forms.$input-space-before-error} + #{fonts.$caption-line-height} + #{forms.$input-border-width-focus * 2}
+    #{forms.$label-space-before-input} + #{forms.$input-space-before-error} + #{fonts.$caption-line-height}
   );
 }
 

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -3,9 +3,10 @@ import { FieldArray, useFormikContext } from 'formik'
 import React from 'react'
 
 import FormLayout from 'components/FormLayout'
-import { PlusCircleIcon, TrashFilledIcon } from 'icons'
+import { PlusCircleIcon, TrashFilledIcon, TrashIcon } from 'icons'
 import { Button, CheckboxGroup, Select, TextInput } from 'ui-kit'
 import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+import ListIconButton from 'ui-kit/ListIconButton'
 
 import styles from './ActivityForm.module.scss'
 import { activityTargetCustomerCheckboxGroup } from './constants'
@@ -70,17 +71,15 @@ const ActivityForm = ({ venueTypes }: IActivityFormProps): JSX.Element => {
                     [styles['first-row']]: index === 0,
                   })}
                 >
-                  <Button
-                    variant={ButtonVariant.TERNARY}
-                    Icon={TrashFilledIcon}
-                    iconPosition={IconPositionEnum.CENTER}
-                    disabled={values.socialUrls.length <= 1}
-                    onClick={() => arrayHelpers.remove(index)}
-                    className={styles['delete-button']}
+                  <ListIconButton
                     hasTooltip
+                    Icon={TrashFilledIcon}
+                    onClick={() => arrayHelpers.remove(index)}
+                    disabled={values.socialUrls.length <= 1}
+                    className={styles['delete-button']}
                   >
                     Supprimer l'url
-                  </Button>
+                  </ListIconButton>
                 </div>
               </FormLayout.Row>
             ))}

--- a/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/screens/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -3,9 +3,9 @@ import { FieldArray, useFormikContext } from 'formik'
 import React from 'react'
 
 import FormLayout from 'components/FormLayout'
-import { PlusCircleIcon, TrashFilledIcon, TrashIcon } from 'icons'
+import { PlusCircleIcon, TrashFilledIcon } from 'icons'
 import { Button, CheckboxGroup, Select, TextInput } from 'ui-kit'
-import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+import { ButtonVariant } from 'ui-kit/Button/types'
 import ListIconButton from 'ui-kit/ListIconButton'
 
 import styles from './ActivityForm.module.scss'

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
@@ -29,7 +29,7 @@
   }
 
   &:hover:not(:disabled) {
-    background-color: hsl(261, 100%, 95%);
+    background-color: #ede3ff;
     outline: 0;
 
     .button-icon {

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
@@ -28,8 +28,8 @@
     background-color: transparent;
   }
 
-  &:hover {
-    background-color: #ede3ff;
+  &:hover:not(:disabled) {
+    background-color: hsl(261, 100%, 95%);
     outline: 0;
 
     .button-icon {
@@ -46,6 +46,14 @@
 
     &:active {
       fill: colors.$tertiary;
+    }
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+
+    .button-icon {
+      fill: colors.$grey-semi-dark;
     }
   }
 }


### PR DESCRIPTION
…n and replace trash icon with listIconButton in activity page

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22088

## But de la pull request

- Utiliser le bouton listIconButton dans la page activité du nouveau parcours

## Implémentation

![image](https://user-images.githubusercontent.com/106379750/236205572-2eaf9e65-d322-4695-9f6f-091cd0360110.png)
![image](https://user-images.githubusercontent.com/106379750/236205474-98a6d662-6698-4d3b-a655-0bc827c38243.png)
