### PR TITLE
(PC-22143)[PRO] fix: venue id should be nullable in offer venue

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -119,7 +119,7 @@ def create_collective_offer(
     if body.offerer_id is not None:
         logger.error("offerer_id sent in body", extra={"offerer_id": body.offerer_id})
     try:
-        body.offer_venue.venueId = humanize(body.offer_venue.venueId)  # type: ignore [assignment, arg-type]
+        body.offer_venue.venueId = humanize(body.offer_venue.venueId)  # type: ignore [arg-type]
         offer = educational_api_offer.create_collective_offer(offer_data=body, user=current_user)
     except offerers_exceptions.CannotFindOffererSiren:
         raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -395,7 +395,7 @@ class CollectiveOfferResponseIdModel(BaseModel):
 class CollectiveOfferVenueBodyModel(BaseModel):
     addressType: OfferAddressType
     otherAddress: str
-    venueId: int | str
+    venueId: int | str | None
 
     class Config:
         alias_generator = to_camel

--- a/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
@@ -7,6 +7,6 @@ import type { OfferAddressType } from './OfferAddressType';
 export type CollectiveOfferVenueBodyModel = {
   addressType: OfferAddressType;
   otherAddress: string;
-  venueId: (number | string);
+  venueId?: (number | string) | null;
 };
 

--- a/pro/src/screens/OfferEducational/validationSchema.ts
+++ b/pro/src/screens/OfferEducational/validationSchema.ts
@@ -54,10 +54,13 @@ export const validationSchema = yup.object().shape({
       is: OfferAddressType.OTHER,
       then: schema => schema.required('Veuillez renseigner une adresse'),
     }),
-    venueId: yup.string().when('addressType', {
-      is: OfferAddressType.OFFERER_VENUE,
-      then: schema => schema.required('Veuillez sélectionner un lieu'),
-    }),
+    venueId: yup
+      .string()
+      .nullable()
+      .when('addressType', {
+        is: OfferAddressType.OFFERER_VENUE,
+        then: schema => schema.required('Veuillez sélectionner un lieu'),
+      }),
   }),
   participants: yup.object().test({
     name: 'is-one-true',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22143

## But de la pull request

PR pour fix la duplication d'offre template. Le champs venueId devrait être nullable. En effet ce champs n'est renseigné que si le `Adresse où se déroulera l’évènement :` est `Dans votre lieu`
