### PR TITLE
(PC-22146)[PRO] fix: use deshumanized id if query offerer is empty

### DIFF
--- a/pro/src/screens/OfferType/OfferType.tsx
+++ b/pro/src/screens/OfferType/OfferType.tsx
@@ -91,7 +91,8 @@ const OfferType = (): JSX.Element => {
       setIsLoadingEligibility(true)
       const offererNames = await api.listOfferersNames()
 
-      const offererId = queryOffererId ?? offererNames.offerersNames[0].id
+      const offererId =
+        queryOffererId ?? offererNames.offerersNames[0].nonHumanizedId
       if (offererNames.offerersNames.length > 1 && !queryOffererId) {
         setIsEligible(true)
         setIsLoadingEligibility(false)
@@ -364,7 +365,8 @@ const OfferType = (): JSX.Element => {
                 </FormLayout.Section>
               )}
 
-            {(isLoadingEligibility || isLoadingValidation) && <Spinner />}
+            {values.offerType === OFFER_TYPES.EDUCATIONAL &&
+              (isLoadingEligibility || isLoadingValidation) && <Spinner />}
             {values.offerType === OFFER_TYPES.EDUCATIONAL && !isValidated && (
               <Banner>
                 Votre structure est en cours de validation par les équipes pass

--- a/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/screens/OfferType/__specs__/OfferType.spec.tsx
@@ -392,6 +392,10 @@ describe('screens:OfferIndividual::OfferType', () => {
 
     renderOfferTypes(store, '123')
 
+    await userEvent.click(
+      screen.getByRole('radio', { name: 'À un groupe scolaire' })
+    )
+
     expect(await screen.findByText('Chargement en cours')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22146

## But de la pull request

FIx la création d'offre quand on passe par le bouton dans la liste des offres (compte non admin) 
Il manquait l'utilisation d'un id non humanisé sur un structure

BSR : fix l'affichage du spinner pour les offres non collectives
