### PR TITLE
(PC-22100)[API] fix: save user flags correctly

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1131,13 +1131,14 @@ def validate_pro_user_email(user: users_models.User, author_user: users_models.U
 
 
 def save_firebase_flags(user: models.User, firebase_value: dict) -> None:
-    if user.pro_flags:
+    user_pro_flags = users_models.UserProFlags.query.filter(users_models.UserProFlags.user == user).one_or_none()
+    if user_pro_flags:
         if user.pro_flags.firebase and user.pro_flags.firebase != firebase_value:
             logger.warning("%s now has different Firebase flags than before", user)
         user.pro_flags.firebase = firebase_value
     else:
-        user.pro_flags = users_models.UserProFlags(user=user, firebase=firebase_value)
-    db.session.commit()
+        user_pro_flags = users_models.UserProFlags(user=user, firebase=firebase_value)
+    repository.save(user_pro_flags)
 
 
 def save_flags(user: models.User, flags: dict) -> None:

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -780,4 +780,4 @@ class UserProFlagsFactory(BaseFactory):
         model = models.UserProFlags
 
     user = factory.SubFactory(ProFactory)
-    firebase = {"BETTER_OFFER_CREATION": True}
+    firebase = {"BETTER_OFFER_CREATION": "true"}

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1143,26 +1143,25 @@ class SaveFlagsTest:
     def test_new_firebase_flags(self):
         user = users_factories.UserFactory()
 
-        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": True}})
+        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": "true"}})
 
-        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": "true"}
 
     def test_same_pre_existing_firebase_flags(self, caplog):
         flags = users_factories.UserProFlagsFactory()
         user = flags.user
 
-        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": True}})
-
-        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
+        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": "true"}})
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": "true"}
         assert not caplog.messages
 
     def test_different_pre_existing_firebase_flags(self, caplog):
         flags = users_factories.UserProFlagsFactory()
         user = flags.user
 
-        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": False}})
+        users_api.save_flags(user, {"firebase": {"BETTER_OFFER_CREATION": "false"}})
 
-        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": False}
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": "false"}
         assert caplog.messages == [f"{user} now has different Firebase flags than before"]
 
     def test_unknown_flags(self):

--- a/api/tests/routes/pro/post_user_pro_flags_test.py
+++ b/api/tests/routes/pro/post_user_pro_flags_test.py
@@ -14,7 +14,7 @@ class Returns204Test:
         user = users_factories.UserFactory()
 
         client = client.with_session_auth(user.email)
-        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": True}})
+        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": "true"}})
 
         assert response.status_code == 204
 
@@ -23,7 +23,7 @@ class Returns204Test:
         user = flags.user
 
         client = client.with_session_auth(user.email)
-        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": True}})
+        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": "true"}})
 
         assert response.status_code == 204
 
@@ -32,7 +32,7 @@ class Returns204Test:
         user = flags.user
 
         client = client.with_session_auth(user.email)
-        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": False}})
+        response = client.post(ROUTE_PATH, json={"firebase": {"BETTER_OFFER_CREATION": "false"}})
 
         assert response.status_code == 204
 
@@ -46,4 +46,4 @@ class Returns400Test:
         response = client.post(ROUTE_PATH, json={"unknwown": {"toto": 10}})
 
         assert response.status_code == 400
-        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": True}
+        assert user.pro_flags.firebase == {"BETTER_OFFER_CREATION": "true"}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22100

## But de la pull request

Corriger une erreur d'insertion lors de l'enregistrement des flags, en bout de parcours d'inscription

## Implémentation

- Corriger le commit

## Informations supplémentaires

- Correction des tests et factory: la valeur du flag `BETTER_OFFER_CREATION` est une str au lieu de bool
