### PR TITLE
PC-21896 remove profile subtitle when done

### DIFF
--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -13,6 +13,7 @@ import pytz
 
 from pcapi.core import testing
 import pcapi.core.fraud.ubble.models as ubble_fraud_models
+from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 import pcapi.core.users.factories as users_factories
 
@@ -158,7 +159,11 @@ class BeneficiaryFraudCheckFactory(testing.BaseFactory):
     type = models.FraudCheckType.UBBLE
     thirdPartyId = factory.LazyFunction(lambda: str(uuid.uuid4()))
     status = models.FraudCheckStatus.PENDING
-    eligibilityType = users_models.EligibilityType.AGE18
+    eligibilityType = factory.LazyAttribute(
+        lambda o: users_models.EligibilityType.UNDERAGE
+        if o.user.age in users_constants.ELIGIBILITY_UNDERAGE_RANGE
+        else users_models.EligibilityType.AGE18
+    )
 
     @classmethod
     def _create(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21896

## But de la pull request

Ne plus afficher de sous titre quand on a fini l'étape profil

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
