### PR TITLE
(BSR)[API] fix: update deposit expiration date when changing birth date

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -16,6 +16,7 @@ from pcapi.connectors import sirene
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.bookings.repository as bookings_repository
 from pcapi.core.external.attributes import api as external_attributes_api
+from pcapi.core.finance import models as finance_models
 import pcapi.core.finance.api as finance_api
 import pcapi.core.fraud.api as fraud_api
 import pcapi.core.fraud.common.models as common_fraud_models
@@ -596,7 +597,9 @@ def update_user_info(
     if validated_birth_date is not UNCHANGED:
         if validated_birth_date != user.validatedBirthDate:
             snapshot.set("validatedBirthDate", old=user.validatedBirthDate, new=validated_birth_date)
-        user.validatedBirthDate = validated_birth_date
+            user.validatedBirthDate = validated_birth_date
+            if _has_underage_deposit(user):
+                _update_underage_beneficiary_deposit_expiration_date(user)
     if id_piece_number is not UNCHANGED:
         if id_piece_number != user.idPieceNumber:
             snapshot.set("idPieceNumber", old=user.idPieceNumber, new=id_piece_number)
@@ -610,6 +613,45 @@ def update_user_info(
     external_attributes_api.update_external_user(user)
 
     return snapshot
+
+
+def _has_underage_deposit(user: users_models.User) -> bool:
+    return user.deposit is not None and user.deposit.type == finance_models.DepositType.GRANT_15_17
+
+
+def _update_underage_beneficiary_deposit_expiration_date(user: users_models.User) -> None:
+    if user.birth_date is None:
+        raise ValueError("User has no birth_date")
+    if not (user.deposit and user.deposit.expirationDate):
+        raise ValueError("Trying to update underage beneficiary deposit expiration date but user has no deposit")
+
+    current_deposit_expiration_datetime = user.deposit.expirationDate
+    new_deposit_expiration_datetime = finance_api.compute_underage_deposit_expiration_datetime(user.birth_date)
+
+    if current_deposit_expiration_datetime == new_deposit_expiration_datetime:
+        return
+
+    logger.info(
+        "Updating deposit expiration date for underage beneficiary %s",
+        user.id,
+        extra={
+            "user": user.id,
+            "deposit": user.deposit.id,
+            "current_expiration_date": current_deposit_expiration_datetime,
+            "new_expiration_date": new_deposit_expiration_datetime,
+        },
+    )
+
+    if new_deposit_expiration_datetime > datetime.datetime.utcnow():
+        user.deposit.expirationDate = new_deposit_expiration_datetime
+    else:
+        if current_deposit_expiration_datetime < datetime.datetime.utcnow():
+            # no need to update the deposit expirationDate because it is already passed
+            return
+        # Else, reduce to now and not to the theoretical new date in case there are bookings made between these dates
+        user.deposit.expirationDate = datetime.datetime.utcnow()
+
+    repository.save(user.deposit)
 
 
 def add_comment_to_user(user: models.User, author_user: models.User, comment: str) -> None:

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -692,6 +692,14 @@ class UpdateUserInfoTest:
             "lastName": {"new_info": "Bonisseur de la Bath", "old_info": "Flantier"},
         }
 
+    def test_update_user_info_also_updates_underage_deposit_expiration_date(self):
+        # Given a user with an underage deposit
+        with freeze_time("2020-05-01"):
+            user = users_factories.BeneficiaryFactory(age=17)
+            users_api.update_user_info(user, author=user, validated_birth_date=datetime.date(2003, 1, 1))
+
+        assert user.deposits[0].expirationDate == datetime.datetime(2021, 1, 1)
+
 
 @pytest.mark.usefixtures("db_session")
 class DomainsCreditTest:


### PR DESCRIPTION

## But de la pull request

Ajouter un comportement de flask admin dans le BO:
A la modification de la date de naissance, mettre à jour la date d'expiration du deposit si besoin. 

## Implémentation

- cf: https://github.com/pass-culture/pass-culture-main/blob/ed210309a261de9e657f8c1bb92d7132153eabcc/api/src/pcapi/admin/custom_views/beneficiary_user_view.py#L318
- Ajouter cette logique dans `update_user_information`

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
