### PR TITLE
Pc 22163 eac fix collective offer venue id type

### DIFF
--- a/adage-front/src/apiClient/models/CollectiveOfferOfferVenue.ts
+++ b/adage-front/src/apiClient/models/CollectiveOfferOfferVenue.ts
@@ -12,6 +12,6 @@ export type CollectiveOfferOfferVenue = {
   otherAddress: string;
   postalCode?: string | null;
   publicName?: string | null;
-  venueId: string;
+  venueId?: number | null;
 };
 

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -108,7 +108,7 @@ describe('offer', () => {
         },
       },
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },
@@ -158,7 +158,7 @@ describe('offer', () => {
         },
       },
       offerVenue: {
-        venueId: '',
+        venueId: null,
         otherAddress: 'A la mairie',
         addressType: OfferAddressType.OTHER,
       },

--- a/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/adage-front/src/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -131,7 +131,7 @@ describe('offers', () => {
       contactPhone: '',
       domains: [],
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },
@@ -176,7 +176,7 @@ describe('offers', () => {
       contactPhone: '',
       domains: [],
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },
@@ -221,7 +221,7 @@ describe('offers', () => {
       contactPhone: '',
       domains: [],
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -37,7 +37,6 @@ from pcapi.utils import image_conversion
 from pcapi.utils import rest
 from pcapi.utils.human_ids import dehumanize
 from pcapi.utils.human_ids import dehumanize_or_raise
-from pcapi.utils.human_ids import humanize
 
 
 logger = logging.getLogger(__name__)
@@ -462,7 +461,7 @@ def create_collective_offer_public(
             raise offerers_exceptions.VenueNotFoundException()
 
     offer_venue = {
-        "venueId": humanize(body.offer_venue.venueId) or "",
+        "venueId": body.offer_venue.venueId or "",
         "addressType": body.offer_venue.addressType,
         "otherAddress": body.offer_venue.otherAddress or "",
     }
@@ -572,7 +571,7 @@ def edit_collective_offer_public(
                     raise exceptions.EducationalInstitutionIsNotActive()
             offer.institution = institution
         elif key == "offerVenue":
-            offer.offerVenue["venueId"] = humanize(value["venueId"]) or ""
+            offer.offerVenue["venueId"] = value["venueId"] or None
             offer.offerVenue["addressType"] = value["addressType"].value
             offer.offerVenue["otherAddress"] = value["otherAddress"] or ""
         elif key == "bookingLimitDatetime" and value is None:

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -42,7 +42,7 @@ class CollectiveOfferFactory(BaseFactory):
     offerVenue = {
         "addressType": "other",
         "otherAddress": "1 rue des polissons, Paris 75017",
-        "venueId": "",
+        "venueId": None,
     }
     interventionArea = ["93", "94", "95"]
 
@@ -97,7 +97,7 @@ class CollectiveOfferTemplateFactory(BaseFactory):
     offerVenue = {
         "addressType": "other",
         "otherAddress": "1 rue des polissons, Paris 75017",
-        "venueId": "",
+        "venueId": None,
     }
     interventionArea = ["2A", "2B"]
 

--- a/api/src/pcapi/routes/adage_iframe/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/offers.py
@@ -11,7 +11,6 @@ from pcapi.routes.adage_iframe.security import adage_jwt_required
 from pcapi.routes.adage_iframe.serialization import offers as serializers
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
 from pcapi.serialization.decorator import spectree_serialize
-from pcapi.utils.human_ids import dehumanize_or_raise
 
 
 logger = logging.getLogger(__name__)
@@ -49,7 +48,7 @@ def get_collective_offer(
 
     offer_venue_id = offer.offerVenue.get("venueId", None)
     if offer_venue_id:
-        offer_venue = get_venue_by_id(dehumanize_or_raise(offer_venue_id))
+        offer_venue = get_venue_by_id(offer_venue_id)
     else:
         offer_venue = None
 
@@ -75,7 +74,7 @@ def get_collective_offer_template(
 
     offer_venue_id = offer.offerVenue.get("venueId", None)
     if offer_venue_id:
-        offer_venue = get_venue_by_id(dehumanize_or_raise(offer_venue_id))
+        offer_venue = get_venue_by_id(offer_venue_id)
     else:
         offer_venue = None
 

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -99,7 +99,7 @@ class OfferAddressType(enum.Enum):
 class CollectiveOfferOfferVenue(BaseModel):
     addressType: OfferAddressType
     otherAddress: str
-    venueId: str
+    venueId: int | None
     name: str | None
     publicName: str | None
     address: str | None

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -19,7 +19,6 @@ from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.routes.serialization import educational_redactors
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.human_ids import dehumanize_or_raise
-from pcapi.utils.human_ids import humanize
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.workers.update_all_offers_active_status_job import update_all_collective_offers_active_status_job
 
@@ -119,7 +118,6 @@ def create_collective_offer(
     if body.offerer_id is not None:
         logger.error("offerer_id sent in body", extra={"offerer_id": body.offerer_id})
     try:
-        body.offer_venue.venueId = humanize(body.offer_venue.venueId)  # type: ignore [arg-type]
         offer = educational_api_offer.create_collective_offer(offer_data=body, user=current_user)
     except offerers_exceptions.CannotFindOffererSiren:
         raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
@@ -198,8 +196,6 @@ def edit_collective_offer(
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     new_values = body.dict(exclude_unset=True)
-    if "offerVenue" in new_values and "venueId" in new_values["offerVenue"]:
-        new_values["offerVenue"]["venueId"] = humanize(new_values["offerVenue"]["venueId"])
 
     try:
         offerers_api.can_offerer_create_educational_offer(offerer.id)

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -17,7 +17,6 @@ from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.serialization.utils import to_camel
 from pcapi.utils import email as email_utils
 from pcapi.utils import phone_number
-from pcapi.utils.human_ids import dehumanize
 from pcapi.validation.routes.offers import check_collective_offer_name_length_is_valid
 
 
@@ -318,7 +317,7 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
             educationalInstitution=offer.institution.institutionId if offer.institutionId else None,
             educationalInstitutionId=offer.institution.id if offer.institutionId else None,
             offerVenue={  # type: ignore [arg-type]
-                "venueId": dehumanize(offer.offerVenue.get("venueId")) or None,
+                "venueId": offer.offerVenue.get("venueId"),
                 "addressType": offer.offerVenue["addressType"],
                 "otherAddress": offer.offerVenue["otherAddress"] or None,
             },

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -395,17 +395,11 @@ class CollectiveOfferResponseIdModel(BaseModel):
 class CollectiveOfferVenueBodyModel(BaseModel):
     addressType: OfferAddressType
     otherAddress: str
-    venueId: int | str | None
+    venueId: int | None
 
     class Config:
         alias_generator = to_camel
         extra = "forbid"
-
-    @validator("venueId", pre=True)
-    def validate_venueId(cls, venue_id: str | int) -> int | None:
-        if isinstance(venue_id, str):
-            return None
-        return venue_id
 
 
 def is_intervention_area_valid(

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -7,7 +7,6 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_no_duplicated_queries
-from pcapi.utils.human_ids import humanize
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
 
@@ -91,7 +90,7 @@ class Returns200Test:
             priceDetail="détail du prix",
             students=[StudentLevels.GENERAL2],
             offerVenue={
-                "venueId": humanize(venue.id),
+                "venueId": venue.id,
                 "addressType": "offererVenue",
                 "otherAddress": "",
             },
@@ -140,7 +139,7 @@ class Returns200Test:
                 "otherAddress": "",
                 "postalCode": venue.postalCode,
                 "publicName": venue.publicName,
-                "venueId": humanize(venue.id),
+                "venueId": venue.id,
             },
             "students": ["Lycée - Seconde"],
             "offerId": None,

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -7,7 +7,6 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_no_duplicated_queries
-from pcapi.utils.human_ids import humanize
 
 from tests.routes.adage_iframe.utils_create_test_token import create_adage_valid_token_with_email
 
@@ -125,7 +124,7 @@ class Returns200Test:
             collectiveOffer__educational_domains=[educational_factories.EducationalDomainFactory()],
             collectiveOffer__institution=institution,
             collectiveOffer__offerVenue={
-                "venueId": humanize(venue.id),
+                "venueId": venue.id,
                 "addressType": "offererVenue",
                 "otherAddress": "",
             },
@@ -185,7 +184,7 @@ class Returns200Test:
                 "otherAddress": "",
                 "postalCode": venue.postalCode,
                 "publicName": venue.publicName,
-                "venueId": humanize(venue.id),
+                "venueId": venue.id,
             },
             "students": ["Lycée - Seconde"],
             "offerId": None,

--- a/api/tests/routes/pro/post_collective_offers_test.py
+++ b/api/tests/routes/pro/post_collective_offers_test.py
@@ -69,7 +69,7 @@ class Returns200Test:
         assert offer.contactPhone == "01 99 00 25 68"
         assert offer.offerVenue == {
             "addressType": "school",
-            "venueId": humanize(venue.id),
+            "venueId": venue.id,
             "otherAddress": "17 rue aléatoire",
         }
         assert offer.interventionArea == ["75", "92", "93"]
@@ -136,7 +136,7 @@ class Returns200Test:
         assert offer.contactPhone == "01 99 00 25 68"
         assert offer.offerVenue == {
             "addressType": "school",
-            "venueId": humanize(venue.id),
+            "venueId": venue.id,
             "otherAddress": "17 rue aléatoire",
         }
         assert offer.interventionArea == ["75", "92", "93"]
@@ -282,7 +282,7 @@ class Returns200Test:
         assert offer.contactPhone == "01 99 00 25 68"
         assert offer.offerVenue == {
             "addressType": "school",
-            "venueId": humanize(venue.id),
+            "venueId": venue.id,
             "otherAddress": "17 rue aléatoire",
         }
         assert offer.interventionArea == ["75", "92", "93"]
@@ -396,7 +396,7 @@ class Returns400Test:
             "contactPhone": "01 99 00 25 68",
             "offerVenue": {
                 "addressType": "school",
-                "venueId": humanize(125),
+                "venueId": 125,
                 "otherAddress": "17 rue aléatoire",
             },
             "students": ["Lycée - Seconde", "Lycée - Première"],
@@ -433,7 +433,7 @@ class Returns400Test:
             "contactPhone": "01 99 00 25 68",
             "offerVenue": {
                 "addressType": "school",
-                "venueId": humanize(125),
+                "venueId": 125,
                 "otherAddress": "17 rue aléatoire",
             },
             "students": ["Lycée - Seconde", "Lycée - Première"],
@@ -470,7 +470,7 @@ class Returns400Test:
             "contactPhone": "01 99 00 25 68",
             "offerVenue": {
                 "addressType": "school",
-                "venueId": humanize(125),
+                "venueId": 125,
                 "otherAddress": "17 rue aléatoire",
             },
             "students": ["Lycée - Seconde", "Lycée - Première"],
@@ -508,7 +508,7 @@ class Returns400Test:
             "contactPhone": "01 99 00 25 68",
             "offerVenue": {
                 "addressType": "school",
-                "venueId": humanize(125),
+                "venueId": 125,
                 "otherAddress": "17 rue aléatoire",
             },
             "students": ["Lycée - Seconde", "Lycée - Première"],

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_public_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_public_test.py
@@ -11,7 +11,6 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import override_features
-from pcapi.utils.human_ids import humanize
 
 import tests
 from tests.routes import image_data
@@ -103,7 +102,7 @@ class CollectiveOffersPublicPatchOfferTest:
         assert offer.durationMinutes == 183
         assert offer.students == [educational_models.StudentLevels.COLLEGE4]
         assert offer.offerVenue == {
-            "venueId": "",
+            "venueId": None,
             "addressType": "school",
             "otherAddress": "",
         }
@@ -191,7 +190,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         assert offer.venueId == venue2.id
         assert offer.offerVenue == {
-            "venueId": humanize(venue2.id),
+            "venueId": venue2.id,
             "addressType": "offererVenue",
             "otherAddress": "",
         }

--- a/api/tests/routes/public/collective/endpoints/post_collective_offer_public_test.py
+++ b/api/tests/routes/public/collective/endpoints/post_collective_offer_public_test.py
@@ -10,7 +10,6 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import override_features
-from pcapi.utils.human_ids import humanize
 
 import tests
 from tests.routes import image_data
@@ -91,7 +90,7 @@ class CollectiveOffersPublicPostOfferTest:
         assert offer.institutionId == educational_institution.id
         assert offer.interventionArea == []
         assert offer.offerVenue == {
-            "venueId": humanize(venue.id),
+            "venueId": venue.id,
             "addressType": "offererVenue",
             "otherAddress": "",
         }
@@ -211,7 +210,7 @@ class CollectiveOffersPublicPostOfferTest:
         assert offer.institutionId == educational_institution.id
         assert offer.interventionArea == []
         assert offer.offerVenue == {
-            "venueId": humanize(venue.id),
+            "venueId": venue.id,
             "addressType": "offererVenue",
             "otherAddress": "",
         }

--- a/pro/src/apiClient/adage/models/CollectiveOfferOfferVenue.ts
+++ b/pro/src/apiClient/adage/models/CollectiveOfferOfferVenue.ts
@@ -12,6 +12,6 @@ export type CollectiveOfferOfferVenue = {
   otherAddress: string;
   postalCode?: string | null;
   publicName?: string | null;
-  venueId: string;
+  venueId?: number | null;
 };
 

--- a/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferVenueBodyModel.ts
@@ -7,6 +7,6 @@ import type { OfferAddressType } from './OfferAddressType';
 export type CollectiveOfferVenueBodyModel = {
   addressType: OfferAddressType;
   otherAddress: string;
-  venueId?: (number | string) | null;
+  venueId?: number | null;
 };
 

--- a/pro/src/core/OfferEducational/constants.ts
+++ b/pro/src/core/OfferEducational/constants.ts
@@ -19,7 +19,7 @@ export const DEFAULT_EAC_FORM_VALUES: IOfferEducationalFormValues = {
   eventAddress: {
     addressType: OfferAddressType.OFFERER_VENUE,
     otherAddress: '',
-    venueId: '',
+    venueId: 0,
   },
   interventionArea: [],
   participants: {

--- a/pro/src/core/OfferEducational/types.ts
+++ b/pro/src/core/OfferEducational/types.ts
@@ -37,7 +37,7 @@ export type IOfferEducationalFormValues = {
   eventAddress: {
     addressType: OfferAddressType
     otherAddress: string
-    venueId: number | string | null
+    venueId: number | null
   }
   interventionArea: string[]
   participants: Record<StudentLevels | 'all', boolean>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/__specs__/OfferVenue.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferDetails/OfferVenue/__specs__/OfferVenue.spec.tsx
@@ -13,7 +13,7 @@ const renderOfferVenue = (offerVenue: CollectiveOfferOfferVenue) => {
 describe('OfferVenue', () => {
   const defaultOfferVenue = {
     addressType: OfferAddressType.OFFERER_VENUE,
-    venueId: 'VENUE_ID',
+    venueId: 1,
     name: 'Nom juridique',
     publicName: 'Mon petit cinema',
     otherAddress: '',

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offer.spec.tsx
@@ -84,7 +84,7 @@ describe('offer', () => {
         },
       },
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },
@@ -134,7 +134,7 @@ describe('offer', () => {
         },
       },
       offerVenue: {
-        venueId: '',
+        venueId: null,
         otherAddress: 'A la mairie',
         addressType: OfferAddressType.OTHER,
       },

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/__spec__/Offers.spec.tsx
@@ -115,7 +115,7 @@ describe('offers', () => {
       contactPhone: '',
       domains: [],
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },
@@ -160,7 +160,7 @@ describe('offers', () => {
       contactPhone: '',
       domains: [],
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },
@@ -205,7 +205,7 @@ describe('offers', () => {
       contactPhone: '',
       domains: [],
       offerVenue: {
-        venueId: 'VENUE_ID',
+        venueId: 1,
         otherAddress: '',
         addressType: OfferAddressType.OFFERER_VENUE,
       },

--- a/pro/src/screens/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
+++ b/pro/src/screens/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
@@ -102,7 +102,7 @@ const FormPracticalInformation = ({
     ) {
       if (currentOfferer) {
         const selectedVenue = currentOfferer.managedVenues.find(
-          venue => venue.nonHumanizedId === Number(values.eventAddress.venueId)
+          venue => venue.nonHumanizedId === values.eventAddress.venueId
         )
         return setCurrentVenue(selectedVenue ?? null)
       }

--- a/pro/src/screens/OfferEducational/validationSchema.ts
+++ b/pro/src/screens/OfferEducational/validationSchema.ts
@@ -55,7 +55,7 @@ export const validationSchema = yup.object().shape({
       then: schema => schema.required('Veuillez renseigner une adresse'),
     }),
     venueId: yup
-      .string()
+      .number()
       .nullable()
       .when('addressType', {
         is: OfferAddressType.OFFERER_VENUE,

--- a/pro/src/utils/adageFactories.ts
+++ b/pro/src/utils/adageFactories.ts
@@ -17,7 +17,7 @@ export const defaultCollectiveTemplateOffer: CollectiveOfferTemplateResponseMode
     isSoldOut: false,
     name: 'Mon offre vitrine',
     offerVenue: {
-      venueId: 'VENUE_ID',
+      venueId: 1,
       otherAddress: '',
       addressType: OfferAddressType.OFFERER_VENUE,
     },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22163

## But de la pull request

Stocker le champ `offerVenue["venueId"]` sous forme d'`int` et non plus `string` pour les offres collectives vitrines ou non