### PR TITLE
(PC-22047)[PRO] fix: browser bottom space

### DIFF
--- a/pro/src/styles/global/_page.scss
+++ b/pro/src/styles/global/_page.scss
@@ -72,7 +72,8 @@ main {
   &.container {
     position: relative;
     max-width: rem.torem(874px);
-    margin: rem.torem(-88px) auto calc(size.$action-bar-sticky-height + rem.torem(16px)) auto;
+    margin: rem.torem(-88px) auto 0 auto;
+    padding-bottom: calc(size.$action-bar-sticky-height + rem.torem(16px));
 
     .page-content {
       background: colors.$white;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22047

## But de la pull request

- Corriger l'espacement en bas des pages de l'application PRO.

## Implémentation

:warning: à tester sur firefox et chrome
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/edb8a799-405e-41ad-a8f1-caea7cde2721)

## Informations supplémentaires

Le margin bottom ne s'appliquait pas sur chrome, le padding à l'air de fonctionner sur chrome et firefox
