### PR TITLE
(PC-21526)[BO] feat: multiple offers operations from ISBN

### DIFF
--- a/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
+++ b/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
@@ -190,7 +190,9 @@ class ManyOffersOperationsView(BaseCustomAdminView):
 
         form = OfferCriteriaForm(request.form)
         if form.validate():
-            is_operation_successful = add_criteria_to_offers(form.data["criteria"], isbn=isbn, visa=visa)
+            is_operation_successful = add_criteria_to_offers(
+                [criterion.id for criterion in form.data["criteria"]], isbn=isbn, visa=visa
+            )
             if is_operation_successful:
                 flash("Les offres du produit ont bien été tagguées", "success")
                 return redirect(url_for(".search"))

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -846,7 +846,7 @@ def get_expense_domains(offer: models.Offer) -> list[users_models.ExpenseDomain]
 
 
 def add_criteria_to_offers(
-    criteria: list[criteria_models.Criterion],
+    criterion_ids: list[int],
     isbn: str | None = None,
     visa: str | None = None,
 ) -> bool:
@@ -880,14 +880,14 @@ def add_criteria_to_offers(
     )
 
     offer_criteria: list[criteria_models.OfferCriterion] = []
-    for criterion in criteria:
-        logger.info("Adding criterion %s to %d offers", criterion, len(offer_ids))
+    for criterion_id in criterion_ids:
+        logger.info("Adding criterion %s to %d offers", criterion_id, len(offer_ids))
         for offer_id in offer_ids:
-            if not (offer_id, criterion.id) in existing_criteria_on_offers:
+            if not (offer_id, criterion_id) in existing_criteria_on_offers:
                 offer_criteria.append(
                     criteria_models.OfferCriterion(
                         offerId=offer_id,
-                        criterionId=criterion.id,
+                        criterionId=criterion_id,
                     )
                 )
 

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -42,6 +42,7 @@ class Permissions(enum.Enum):
 
     READ_OFFERS = "visualiser les offres"
     MANAGE_OFFERS = "gérer les offres"
+    MULTIPLE_OFFERS_ACTIONS = "opérations sur plusieurs offres"
 
     VALIDATE_OFFERER = "gérer la validation des structures et des rattachements"
 

--- a/api/src/pcapi/routes/backoffice_v3/__init__.py
+++ b/api/src/pcapi/routes/backoffice_v3/__init__.py
@@ -26,6 +26,7 @@ def install_routes(app: Flask) -> None:
     from . import tags
     from . import users
     from . import venues
+    from .multiple_offers import blueprint as multiple_offers_blueprint
     from .pivots import blueprint as pivots_blueprint
     from .providers import blueprint as providers_blueprint
 

--- a/api/src/pcapi/routes/backoffice_v3/multiple_offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/multiple_offers/blueprint.py
@@ -1,0 +1,145 @@
+from collections import defaultdict
+import itertools
+import typing
+
+from flask import flash
+from flask import redirect
+from flask import render_template
+from flask import url_for
+import sqlalchemy as sa
+
+from pcapi.core.criteria import models as criteria_models
+from pcapi.core.offers import api as offers_api
+from pcapi.core.offers import models as offers_models
+from pcapi.core.permissions import models as perm_models
+from pcapi.models.offer_mixin import OfferValidationStatus
+
+from . import forms
+from .. import utils
+
+
+multiple_offers_blueprint = utils.child_backoffice_blueprint(
+    "multiple_offers",
+    __name__,
+    url_prefix="/pro/multiple-offers",
+    permission=perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS,
+)
+
+
+def _get_current_criteria_on_active_offers(offers: list[offers_models.Offer]) -> dict[criteria_models.Criterion, int]:
+    current_criteria_on_offers: defaultdict[criteria_models.Criterion, int] = defaultdict(int)
+    for offer in offers:
+        if offer.isActive:
+            for criterion in offer.criteria:
+                current_criteria_on_offers[criterion] += 1
+
+    return dict(current_criteria_on_offers)
+
+
+def _get_products_compatible_status(products: list[offers_models.Product]) -> str:
+    if all(product.isGcuCompatible for product in products):
+        return "compatible_products"
+
+    if all(not product.isGcuCompatible for product in products):
+        return "incompatible_products"
+
+    return "partially_incompatible_products"
+
+
+def _render_search(search_form: forms.SearchIsbnForm, **kwargs: typing.Any) -> str:
+    if kwargs:
+        return render_template(
+            "multiple_offers/search_result.html", form=search_form, dst=url_for(".search_multiple_offers"), **kwargs
+        )
+
+    return render_template("multiple_offers/search.html", form=search_form, dst=url_for(".search_multiple_offers"))
+
+
+@multiple_offers_blueprint.route("/", methods=["GET"])
+def multiple_offers_home() -> utils.BackofficeResponse:
+    form = forms.SearchIsbnForm()
+    return _render_search(form)
+
+
+@multiple_offers_blueprint.route("/search", methods=["GET"])
+def search_multiple_offers() -> utils.BackofficeResponse:
+    form = forms.SearchIsbnForm(formdata=utils.get_query_params())
+
+    if not form.validate():
+        flash(utils.build_form_error_msg(form), "warning")
+        return _render_search(form), 400
+
+    isbn = form.isbn.data
+
+    products = (
+        offers_models.Product.query.filter(offers_models.Product.extraData["isbn"].astext == isbn)
+        .options(
+            sa.orm.joinedload(offers_models.Product.offers)
+            .load_only(offers_models.Offer.isActive, offers_models.Offer.validation)
+            .joinedload(offers_models.Offer.criteria)
+            .load_only(criteria_models.Criterion.name)
+        )
+        .all()
+    )
+
+    if not products:
+        flash("Aucun livre n'a été trouvé avec cet ISBN", "error")
+        return _render_search(form)
+
+    offers = list(itertools.chain.from_iterable(p.offers for p in products))
+
+    active_offers_count = sum(offer.isActive for offer in offers)
+    approved_active_offers_count = sum(
+        offer.validation == OfferValidationStatus.APPROVED and offer.isActive for offer in offers
+    )
+    approved_inactive_offers_count = sum(
+        offer.validation == OfferValidationStatus.APPROVED and not offer.isActive for offer in offers
+    )
+    pending_offers_count = sum(offer.validation == OfferValidationStatus.PENDING for offer in offers)
+    rejected_offers_count = sum(offer.validation == OfferValidationStatus.REJECTED for offer in offers)
+
+    return _render_search(
+        form,
+        name=products[0].name,
+        category=products[0].subcategory.category,
+        offers_count=len(offers),
+        active_offers_count=active_offers_count,
+        approved_active_offers_count=approved_active_offers_count,
+        approved_inactive_offers_count=approved_inactive_offers_count,
+        pending_offers_count=pending_offers_count,
+        rejected_offers_count=rejected_offers_count,
+        isbn=isbn,
+        product_compatibility=_get_products_compatible_status(products),
+        incompatibility_form=forms.HiddenIsbnForm(isbn=isbn),
+        current_criteria_on_offers=_get_current_criteria_on_active_offers(offers),
+        offer_criteria_form=forms.OfferCriteriaForm(isbn=isbn),
+    )
+
+
+@multiple_offers_blueprint.route("/add-criteria", methods=["POST"])
+def add_criteria_to_offers() -> utils.BackofficeResponse:
+    form = forms.OfferCriteriaForm()
+
+    if not form.validate():
+        flash(utils.build_form_error_msg(form), "warning")
+    elif offers_api.add_criteria_to_offers(form.criteria.data, isbn=form.isbn.data):
+        flash("Les offres du produit ont bien été taguées", "success")
+    else:
+        flash("Une erreur s'est produite lors de l'opération", "warning")
+
+    return redirect(url_for(".search_multiple_offers", isbn=form.isbn.data), code=303)
+
+
+@multiple_offers_blueprint.route("/set-product-gcu-incompatible", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+def set_product_gcu_incompatible() -> utils.BackofficeResponse:
+    form = forms.HiddenIsbnForm()
+
+    if not form.validate():
+        flash(utils.build_form_error_msg(form), "warning")
+    elif offers_api.reject_inappropriate_products(form.isbn.data):
+        flash("Le produit a été rendu incompatible aux CGU et les offres ont été désactivées", "success")
+    else:
+        flash("Une erreur s'est produite lors de l'opération", "warning")
+
+    return redirect(url_for(".search_multiple_offers", isbn=form.isbn.data), code=303)

--- a/api/src/pcapi/routes/backoffice_v3/multiple_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/multiple_offers/forms.py
@@ -1,0 +1,37 @@
+from flask_wtf import FlaskForm
+import wtforms
+
+from pcapi.routes.backoffice_v3 import utils as bo_utils
+
+from ..forms import fields
+
+
+class SearchIsbnForm(FlaskForm):
+    class Meta:
+        csrf = False
+
+    isbn = fields.PCSearchField("ISBN")
+
+    def validate_isbn(self, isbn: fields.PCSearchField) -> fields.PCSearchField:
+        if isbn.data and not bo_utils.is_isbn_valid(isbn.data):
+            raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un ISBN")
+        isbn.data = bo_utils.format_isbn_or_visa(isbn.data)
+        return isbn
+
+
+class HiddenIsbnForm(FlaskForm):
+    isbn = fields.PCHiddenField("ISBN")
+
+
+class OfferCriteriaForm(HiddenIsbnForm):
+    criteria = fields.PCTomSelectField(
+        "Tags",
+        multiple=True,
+        choices=[],
+        validate_choice=False,
+        coerce=int,
+        endpoint="backoffice_v3_web.autocomplete_criteria",
+        validators=[
+            wtforms.validators.DataRequired(),
+        ],
+    )

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
@@ -1,3 +1,4 @@
+{% from "components/search/result_form.html" import build_result_page_form %}
 {% macro result_card_switch(row, result_type="public_account") %}
   {% if result_type == "offerer" %}
     {% include "components/search/result_card_offerer.html" %}
@@ -7,26 +8,7 @@
     {% include "components/search/result_card.html" %}
   {% endif %}
 {% endmacro %}
-<form action="{{ dst }}"
-      name="{{ dst | action_to_name }}"
-      method="get">
-  <div class="col-8 row">
-    <div class="col-8">
-      <div class="input-group mb-3">
-        {% for form_field in form %}
-          {% if form_field.type != 'HiddenField' %}{{ form_field }}{% endif %}
-        {% endfor %}
-      </div>
-      {% for form_field in form %}
-        {% if form_field.type == 'HiddenField' %}{{ form_field }}{% endif %}
-      {% endfor %}
-    </div>
-    <div class="col-4">
-      <button type="submit"
-              class="btn btn-primary">Chercher</button>
-    </div>
-  </div>
-</form>
+{{ build_result_page_form(form, macro) }}
 <div>
   <div>
     <p class="lead">{{ rows.total }} résultats</p>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_form.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result_form.html
@@ -1,0 +1,22 @@
+{% macro build_result_page_form(form, dst) %}
+  <form action="{{ dst }}"
+        name="{{ dst | action_to_name }}"
+        method="get">
+    <div class="col-8 row">
+      <div class="col-8">
+        <div class="input-group mb-3">
+          {% for form_field in form %}
+            {% if form_field.type != 'HiddenField' %}{{ form_field }}{% endif %}
+          {% endfor %}
+        </div>
+        {% for form_field in form %}
+          {% if form_field.type == 'HiddenField' %}{{ form_field }}{% endif %}
+        {% endfor %}
+      </div>
+      <div class="col-4">
+        <button type="submit"
+                class="btn btn-primary">Chercher</button>
+      </div>
+    </div>
+  </form>
+{% endmacro %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/base.html
@@ -14,10 +14,6 @@
     <link rel="icon"
           type="image/x-icon"
           href="{{ url_for('static', filename='backofficev3/favicon.ico' ) }}" />
-    <!-- Bootstrap CSS -->
-    <link href="{{ url_for('static', filename='backofficev3/css/compiled/bootstrap/bootstrap.css') }}"
-          rel="stylesheet"
-          type="text/css" />
     <!-- Bootstrap icons -->
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css" />

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -85,6 +85,9 @@
                     {{ menu_section_item("Offres collectives", "backoffice_v3_web.collective_offer.list_collective_offers") }}
                     {{ menu_section_item("Offres collectives vitrines", "backoffice_v3_web.collective_offer_template.list_collective_offer_templates") }}
                   {% endif %}
+                  {% if has_permission("MULTIPLE_OFFERS_ACTIONS") %}
+                    {{ menu_section_item("Opérations sur plusieurs offres", "backoffice_v3_web.multiple_offers.multiple_offers_home") }}
+                  {% endif %}
                   {% if has_permission("MANAGE_OFFERS_AND_VENUES_TAGS") %}
                     {{ menu_section_item("Tags des offres et lieux", "backoffice_v3_web.tags.list_tags") }}
                   {% endif %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search.html
@@ -1,0 +1,9 @@
+{% from "components/search/base.html" import build_base_search with context %}
+{% extends "layouts/connected.html" %}
+{% block page %}
+  <div class="pt-3 px-5">
+    {% call build_base_search() %}
+      Opérations sur plusieurs offres
+    {% endcall %}
+  </div>
+{% endblock page %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
@@ -87,7 +87,7 @@
                   </div>
                 </div>
               {% endif %}
-              <div>
+              <div class="search-results-modal-container">
                 {{ build_modal_form("add-criteria", url_for('.add_criteria_to_offers'), offer_criteria_form,
                 "Tag des offres", "Enregistrer",
                 "⚠️ " + active_offers_count|string + " offres actives associées à cet ISBN seront affectées") }}

--- a/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
@@ -1,0 +1,101 @@
+{% from "components/generic_modal.html" import build_modal_form with context %}
+{% from "components/search/result_form.html" import build_result_page_form %}
+{% macro build_has_tag(count, total_count, criterion) %}
+  {{ count }}/{{ total_count }}
+  {% if count > 1 %}
+    offres actives ont
+  {% else %}
+    offre active a
+  {% endif %}
+  déjà le tag {{ [criterion] | format_criteria | safe }}
+{% endmacro %}
+{% extends "layouts/connected.html" %}
+{% block page %}
+  <div class="pt-3 px-5">
+    <h2 class="fw-light">Opérations sur plusieurs offres</h2>
+    {{ build_result_page_form(form, dst) }}
+    <div class="row mt-4">
+      <div class="col-6">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Informations concernant les produits</h5>
+            <h6 class="card-subtitle my-4 text-muted"></h6>
+            <div class="row pt3">
+              <p>
+                <b>Titre du produit :</b> {{ name }}
+              </p>
+              <p>
+                <b>Catégorie :</b> {{ category.pro_label }}
+              </p>
+              <p>
+                <b>Nombre d'offres associées :</b> {{ offers_count }}
+              </p>
+              <p>
+                <b>Approuvées actives :</b> {{ approved_active_offers_count }}
+              </p>
+              <p>
+                <b>Approuvées inactives :</b> {{ approved_inactive_offers_count }}
+              </p>
+              <p>
+                <b>En attente :</b> {{ pending_offers_count }}
+              </p>
+              <p>
+                <b>Rejetées :</b> {{ rejected_offers_count }}
+              </p>
+              <p>
+                <b>compatible avec les CGU :</b>
+                {% if product_compatibility == 'compatible_products' %}
+                  <span class="mx-2 pb-1 badge rounded-pill text-bg-success">
+                    <i class="bi bi-check-circle"></i> Oui
+                  </span>
+                {% elif product_compatibility == 'incompatible_products' %}
+                  <span class="mx-2 pb-1 badge rounded-pill text-bg-dark">
+                    <i class="bi bi-x-circle"></i> Non
+                  </span>
+                {% else %}
+                  <span class="mx-2 pb-1 badge rounded-pill text-bg-warning">
+                    <i class="bi bi-radioactive"></i> Partiellement
+                  </span>
+                {% endif %}
+              </p>
+              <p>
+                <b>ISBN :</b> {{ isbn }}
+              </p>
+              {% if product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0 %}
+                <div>
+                  {{ build_modal_form("set-gcu-incompatible", url_for('.set_product_gcu_incompatible'), incompatibility_form,
+                  "Rendre le livre et les offres associées incompatibles avec les CGU", "Confirmer",
+                  "⚠️ Êtes-vous sûr de vouloir rendre le produit incompatible et rejeter les offres associées ?") }}
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% if active_offers_count > 0 %}
+        <div class="col-6">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title">Tags déjà présents sur les offres actives</h5>
+              <h6 class="card-subtitle my-4 text-muted"></h6>
+              <div class="row pt3">
+                {% if current_criteria_on_offers.items()|length > 0 %}
+                  <div>
+                    {% for criterion, count in current_criteria_on_offers.items() %}
+                      <p>{{ build_has_tag(count, active_offers_count, criterion) }}</p>
+                    {% endfor %}
+                  </div>
+                </div>
+              {% endif %}
+              <div>
+                {{ build_modal_form("add-criteria", url_for('.add_criteria_to_offers'), offer_criteria_form,
+                "Tag des offres", "Enregistrer",
+                "⚠️ " + active_offers_count|string + " offres actives associées à cet ISBN seront affectées") }}
+              </div>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock page %}

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -46,6 +46,7 @@ from pcapi.sandboxes.scripts.creators.industrial.create_offerer_with_several_ven
 from pcapi.sandboxes.scripts.creators.industrial.create_offerer_with_venue_provider_and_external_bookings import (
     create_industrial_provider_external_bookings,
 )
+from pcapi.sandboxes.scripts.creators.industrial.create_offers_with_isbn import create_offers_with_isbn
 from pcapi.sandboxes.scripts.creators.industrial.create_offers_with_price_categories import (
     create_offers_with_price_categories,
 )
@@ -134,3 +135,5 @@ def save_industrial_sandbox() -> None:
     create_industrial_offerer_with_custom_reimbursement_rule()
 
     create_offerer_providers_for_apis()
+
+    create_offers_with_isbn()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offers_with_isbn.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offers_with_isbn.py
@@ -1,0 +1,47 @@
+import logging
+
+from pcapi.core.categories import subcategories
+from pcapi.core.criteria import factories as criteria_factories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
+from pcapi.models.offer_mixin import OfferValidationStatus
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_offers_with_isbn() -> None:
+    isbn_criteria = criteria_factories.CriterionFactory(name="Livre avec ISBN")
+    odd_criteria = criteria_factories.CriterionFactory(name="Librairie impaire")
+    even_criteria = criteria_factories.CriterionFactory(name="Librairie paire")
+
+    products = [
+        offers_factories.ThingProductFactory(
+            name=f"Livre {i} avec ISBN",
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            extraData={"isbn": f"9780000000{i:03}"},
+        )
+        for i in range(1, 5)
+    ]
+
+    user_offerer = offerers_factories.UserOffererFactory(
+        user__firstName="Super", user__lastName="Libraire", offerer__name="Réseau de librairies"
+    )
+
+    for i in range(1, 11):
+        venue = offerers_factories.VenueFactory(name=f"Librairie {i}", managingOfferer=user_offerer.offerer)
+
+        for j, product in enumerate(products):
+            offer_thing = offers_factories.ThingOfferFactory(
+                name=product.name,
+                venue=venue,
+                product=product,
+                subcategoryId=product.subcategoryId,
+                extraData=product.extraData,
+                isActive=(i % 3 > 0),
+                validation=OfferValidationStatus.PENDING if i % 6 == 0 else OfferValidationStatus.APPROVED,
+                criteria=[isbn_criteria, even_criteria] if i % 2 == 0 else [isbn_criteria, odd_criteria],
+            )
+            offers_factories.ThingStockFactory(offer=offer_thing, quantity=10, price=5 + j)
+
+    logger.info("create_offers_with_isbn")

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -41,6 +41,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_BOOKINGS,
         perm_models.Permissions.MANAGE_OFFERS,
         perm_models.Permissions.READ_OFFERS,
+        perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS,
     ],
     "daf": [
         perm_models.Permissions.READ_REIMBURSEMENT_RULES,
@@ -53,6 +54,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.VALIDATE_OFFERER,
         perm_models.Permissions.MANAGE_OFFERS,
         perm_models.Permissions.READ_OFFERS,
+        perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS,
     ],
     "homologation": [],
     "product-management": [

--- a/api/src/pcapi/static/backofficev3/scss/pc/pc.scss
+++ b/api/src/pcapi/static/backofficev3/scss/pc/pc.scss
@@ -1,3 +1,5 @@
+@import "../bootstrap/bootstrap";
+
 // Utilities
 @import "./variables";
 @import "./_utilities";
@@ -12,6 +14,7 @@
 
 // Templates css
 @import "./templates/_login";
+@import "./templates/multiple_offers/_search_results";
 
 // Addons css
 @import "./addons/_personal_information_registration_steps";

--- a/api/src/pcapi/static/backofficev3/scss/pc/templates/multiple_offers/_search_results.scss
+++ b/api/src/pcapi/static/backofficev3/scss/pc/templates/multiple_offers/_search_results.scss
@@ -1,0 +1,18 @@
+.search-results-modal-container {
+  .modal {
+    @extend .modal-fullscreen;
+  }
+  .modal-dialog-scrollable {
+    .modal-body {
+      overflow-y: initial;
+    }
+    .modal-content {
+      max-height: 28em;
+    }
+    .modal-footer {
+      @extend .position-absolute;
+      @extend .w-100;
+      bottom: 0;
+    }
+  }
+}

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1162,7 +1162,7 @@ class AddCriterionToOffersTest:
         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion1, criterion2], isbn=isbn)
+        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], isbn=isbn)
 
         # Then
         assert is_successful is True
@@ -1188,7 +1188,7 @@ class AddCriterionToOffersTest:
         unmatched_offer = factories.OfferFactory()
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion1, criterion2], isbn=isbn)
+        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], isbn=isbn)
 
         # Then
         assert is_successful is True
@@ -1214,7 +1214,7 @@ class AddCriterionToOffersTest:
         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion1, criterion2], visa=visa)
+        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], visa=visa)
 
         # Then
         assert is_successful is True
@@ -1233,7 +1233,7 @@ class AddCriterionToOffersTest:
         criterion = criteria_factories.CriterionFactory(name="Pretty good books")
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion], isbn=isbn)
+        is_successful = api.add_criteria_to_offers([criterion.id], isbn=isbn)
 
         # Then
         assert is_successful is False

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -64,6 +64,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_BOOKINGS,
         perm_models.Permissions.MANAGE_OFFERS,
         perm_models.Permissions.READ_OFFERS,
+        perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS,
     ],
     "daf": [
         perm_models.Permissions.READ_REIMBURSEMENT_RULES,
@@ -76,6 +77,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.VALIDATE_OFFERER,
         perm_models.Permissions.MANAGE_OFFERS,
         perm_models.Permissions.READ_OFFERS,
+        perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS,
     ],
     "homologation": [],
     "product-management": [perm_models.Permissions.FEATURE_FLIPPING],

--- a/api/tests/routes/backoffice_v3/multiple_offers_test.py
+++ b/api/tests/routes/backoffice_v3/multiple_offers_test.py
@@ -1,0 +1,253 @@
+import datetime
+from unittest.mock import patch
+
+from flask import url_for
+import pytest
+
+from pcapi.core.categories import subcategories
+import pcapi.core.criteria.factories as criteria_factories
+import pcapi.core.criteria.models as criteria_models
+import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
+import pcapi.core.offers.models as offers_models
+from pcapi.core.offers.models import Offer
+import pcapi.core.permissions.models as perm_models
+from pcapi.core.testing import assert_num_queries
+from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.models.offer_mixin import OfferValidationType
+
+from .helpers import html_parser
+from .helpers.get import GetEndpointHelper
+from .helpers.post import PostEndpointHelper
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice_v3,
+]
+
+
+class MultipleOffersHomeTest(GetEndpointHelper):
+    endpoint = "backoffice_v3_web.multiple_offers.multiple_offers_home"
+    needed_permission = perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS
+
+    def test_get_search_form(self, authenticated_client):
+        with assert_num_queries(2):
+            response = authenticated_client.get(url_for(self.endpoint))
+            assert response.status_code == 200
+
+
+class SearchMultipleOffersTest(GetEndpointHelper):
+    endpoint = "backoffice_v3_web.multiple_offers.search_multiple_offers"
+    needed_permission = perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS
+
+    # - fetch session (1 query)
+    # - fetch user (1 query)
+    # - fetch product and offers with joinedload including extra data (1 query)
+    expected_num_queries = 3
+
+    def test_search_product_with_offers(self, authenticated_client):
+        offers_factories.ThingOfferFactory(
+            product__name="Product with ISBN",
+            product__extraData={"isbn": "9783161484100"},
+            product__subcategoryId=subcategories.LIVRE_PAPIER.id,
+        )
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, isbn="978-3-16-148410-0"))
+            assert response.status_code == 200
+
+        cards = html_parser.extract_cards_text(response.data)
+        assert len(cards) == 2  # left and right cards when active offers exist
+        left_card = cards[0]
+
+        assert "Titre du produit : Product with ISBN " in left_card
+        assert "Catégorie : Livre " in left_card
+        assert "Nombre d'offres associées : 1 " in left_card
+        assert "Approuvées actives : 1 " in left_card
+        assert "Approuvées inactives : 0 " in left_card
+        assert "En attente : 0 " in left_card
+        assert "Rejetées : 0 " in left_card
+        assert "compatible avec les CGU : Oui" in left_card
+        assert "ISBN : 9783161484100 " in left_card
+
+    def test_search_product_without_offer(self, authenticated_client):
+        offers_factories.ThingProductFactory(
+            name="Product without offer",
+            extraData={"isbn": "9783161484100"},
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+        )
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, isbn="978 3161484100"))
+            assert response.status_code == 200
+
+        cards = html_parser.extract_cards_text(response.data)
+        assert len(cards) == 1  # no offer => no card about tags
+        left_card = cards[0]
+
+        assert "Titre du produit : Product without offer " in left_card
+        assert "Catégorie : Livre " in left_card
+        assert "Nombre d'offres associées : 0 " in left_card
+        assert "Approuvées actives : 0 " in left_card
+        assert "Approuvées inactives : 0 " in left_card
+        assert "En attente : 0 " in left_card
+        assert "Rejetées : 0 " in left_card
+        assert "compatible avec les CGU : Oui" in left_card
+        assert "ISBN : 9783161484100 " in left_card
+
+    @pytest.mark.parametrize(
+        "first_compatibility,second_compatibility,expected_cgu_display",
+        [
+            (True, True, "Oui"),
+            (False, False, "Non"),
+            (True, False, "Partiellement"),
+        ],
+    )
+    def test_product_compatibility(
+        self, authenticated_client, first_compatibility, second_compatibility, expected_cgu_display
+    ):
+        offers_factories.ThingProductFactory(
+            extraData={"isbn": "9781234567890"},
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            isGcuCompatible=first_compatibility,
+        )
+        offers_factories.ThingProductFactory(
+            extraData={"isbn": "9781234567890"},
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            isGcuCompatible=second_compatibility,
+        )
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, isbn="9781234567890"))
+            assert response.status_code == 200
+
+        left_card = html_parser.extract_cards_text(response.data)[0]
+
+        assert f"compatible avec les CGU : {expected_cgu_display}" in left_card
+
+    def test_get_current_criteria_on_active_offers(self, authenticated_client):
+        criterion1 = criteria_models.Criterion(name="One criterion")
+        criterion2 = criteria_models.Criterion(name="Another criterion")
+        product = offers_factories.ThingProductFactory(extraData={"isbn": "9783161484100"})
+        offers_factories.ThingOfferFactory(product=product, criteria=[criterion1], isActive=True)
+        offers_factories.ThingOfferFactory(product=product, criteria=[criterion1, criterion2], isActive=True)
+        offers_factories.ThingOfferFactory(product=product, criteria=[], isActive=True)
+        offers_factories.ThingOfferFactory(product=product, criteria=[criterion1, criterion2], isActive=False)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, isbn="978-3-16-148410-0"))
+            assert response.status_code == 200
+
+        (_, right_card) = html_parser.extract_cards_text(response.data)
+
+        assert "2/3 offres actives ont déjà le tag One criterion " in right_card
+        assert "1/3 offre active a déjà le tag Another criterion " in right_card
+        assert "Tag des offres ⚠️ 3 offres actives associées à cet ISBN seront affectées" in right_card
+
+    def test_search_product_from_isbn_with_invalid_isbn(self, authenticated_client):
+        with assert_num_queries(2):
+            response = authenticated_client.get(url_for(self.endpoint, isbn="978-3-16-14840-0"))
+            assert response.status_code == 400
+
+        assert "La recherche ne correspond pas au format d'un ISBN" in html_parser.extract_alert(response.data)
+
+
+class AddCriteriaToOffersTest(PostEndpointHelper):
+    endpoint = "backoffice_v3_web.multiple_offers.add_criteria_to_offers"
+    endpoint_kwargs = {"isbn": "9781234567890"}
+    needed_permission = perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS
+
+    @patch("pcapi.core.search.async_index_offer_ids")
+    def test_edit_product_offers_criteria_from_isbn(self, mocked_async_index_offer_ids, authenticated_client):
+        criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
+        criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
+        product = offers_factories.ProductFactory(extraData={"isbn": "9783161484100"})
+        offer1 = offers_factories.OfferFactory(
+            product=product, extraData={"isbn": "9783161484100"}, criteria=[criterion1]
+        )
+        offer2 = offers_factories.OfferFactory(product=product, extraData={"isbn": "9783161484100"})
+        inactive_offer = offers_factories.OfferFactory(
+            product=product, extraData={"isbn": "9783161484100"}, isActive=False
+        )
+        unmatched_offer = offers_factories.OfferFactory()
+
+        response = self.post_to_endpoint(
+            authenticated_client, form={"isbn": "9783161484100", "criteria": [criterion1.id, criterion2.id]}
+        )
+
+        assert response.status_code == 303
+        assert response.location == url_for(
+            "backoffice_v3_web.multiple_offers.search_multiple_offers", isbn="9783161484100", _external=True
+        )
+        assert set(offer1.criteria) == {criterion1, criterion2}
+        assert set(offer2.criteria) == {criterion1, criterion2}
+        assert not inactive_offer.criteria
+        assert not unmatched_offer.criteria
+        mocked_async_index_offer_ids.assert_called_once_with([offer1.id, offer2.id])
+
+    def test_edit_product_offers_criteria_from_isbn_without_offers(self, authenticated_client):
+        offers_factories.ProductFactory(extraData={"isbn": "9783161484100"})
+        criterion = criteria_factories.CriterionFactory(name="Pretty good books")
+
+        response = self.post_to_endpoint(
+            authenticated_client, form={"isbn": "9783161484100", "criteria": [criterion.id]}
+        )
+
+        assert response.status_code == 303
+
+
+class SetProductGcuIncompatibleTest(PostEndpointHelper):
+    endpoint = "backoffice_v3_web.multiple_offers.set_product_gcu_incompatible"
+    endpoint_kwargs = {"isbn": "9781234567890"}
+    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+
+    @pytest.mark.parametrize(
+        "validation_status",
+        [
+            OfferValidationStatus.DRAFT,
+            OfferValidationStatus.PENDING,
+            OfferValidationStatus.REJECTED,
+            OfferValidationStatus.APPROVED,
+        ],
+    )
+    @patch("pcapi.core.search.async_index_offer_ids")
+    def test_edit_product_gcu_compatibility(
+        self, mocked_async_index_offer_ids, authenticated_client, validation_status
+    ):
+        product_1 = offers_factories.ThingProductFactory(
+            description="premier produit inapproprié",
+            extraData={"isbn": "9781234567890"},
+            isGcuCompatible=not validation_status == OfferValidationStatus.REJECTED,
+        )
+        venue = offerers_factories.VenueFactory()
+        offers_factories.OfferFactory(product=product_1, venue=venue, validation=validation_status)
+        offers_factories.OfferFactory(product=product_1, venue=venue)
+
+        initially_rejected = {
+            offer.id: {"type": offer.lastValidationType, "date": offer.lastValidationDate}
+            for offer in Offer.query.filter(Offer.validation == OfferValidationStatus.REJECTED)
+        }
+
+        response = self.post_to_endpoint(authenticated_client, form={"isbn": "9781234567890"})
+
+        assert response.status_code == 303
+        assert response.location == url_for(
+            "backoffice_v3_web.multiple_offers.search_multiple_offers", isbn="9781234567890", _external=True
+        )
+
+        product = offers_models.Product.query.one()
+        offers = Offer.query.order_by("id").all()
+
+        assert not product.isGcuCompatible
+        for offer in offers:
+            assert offer.validation == offers_models.OfferValidationStatus.REJECTED
+            if offer.id in initially_rejected:
+                assert offer.lastValidationType == initially_rejected[offer.id]["type"]
+                assert offer.lastValidationDate == initially_rejected[offer.id]["date"]
+            else:
+                assert offer.lastValidationType == OfferValidationType.CGU_INCOMPATIBLE_PRODUCT
+                assert datetime.datetime.utcnow() - offer.lastValidationDate < datetime.timedelta(seconds=5)
+        mocked_async_index_offer_ids.assert_called_once_with(
+            [offer.id for offer in offers if offer.id not in initially_rejected]
+        )


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21526

## But de la pull request

Ajout d'une page permettant la recherche de produits/offres par ISBN afin de permettre les opérations sur ces offres : 
- ajouter des tags sur toutes les offres
- rendre le produit incompatible avec les CGU et désactiver les offres.

Il s'agit de la reprise d'une page de FA, dont on reprend du code et des tests.

## Informations supplémentaires

Ajout dans la sandbox de produits avec des offres et des tags pour faciliter les tests dans l'interface, sur les ISBN : 9780000000001 à 9780000000004.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
