### PR TITLE
(PC-21918)[API] feat: add page action on venues 

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -5,7 +5,7 @@ import wtforms
 from pcapi.connectors.dms.models import GraphQLApplicationStates
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models.validation_status_mixin import ValidationStatus
-from pcapi.utils.regions import get_all_regions
+from pcapi.routes.backoffice_v3.utils import get_regions_choices
 
 from . import fields
 from . import utils
@@ -14,10 +14,6 @@ from .empty import BatchEmptyForm
 
 
 TAG_NAME_REGEX = r"^[^\s]+$"
-
-
-def _get_regions_choices() -> list[tuple]:
-    return [(key, key) for key in get_all_regions()]
 
 
 def _get_all_tags_query() -> sa.orm.Query:
@@ -81,7 +77,7 @@ class OffererValidationListForm(utils.PCForm):
         csrf = False
 
     q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
-    regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
+    regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags",
         query_factory=_get_validation_tags_query,
@@ -126,7 +122,7 @@ class UserOffererValidationListForm(utils.PCForm):
         csrf = False
 
     q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
-    regions = fields.PCSelectMultipleField("Régions", choices=_get_regions_choices())
+    regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags",
         query_factory=_get_validation_tags_query,

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -91,6 +91,9 @@
                   {% if has_permission("MANAGE_OFFERS_AND_VENUES_TAGS") %}
                     {{ menu_section_item("Tags des offres et lieux", "backoffice_v3_web.tags.list_tags") }}
                   {% endif %}
+                  {% if has_permission("MANAGE_PRO_ENTITY") %}
+                    {{ menu_section_item("Actions sur les lieux", "backoffice_v3_web.venue.list_venues") }}
+                  {% endif %}
                 {% endcall %}
               </div>
               <hr />

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
@@ -1,0 +1,47 @@
+{% from "components/forms.html" import build_filters_form with context %}
+{% import "components/links.html" as links %}
+{% extends "layouts/connected.html" %}
+{% block page %}
+  <div class="pt-3 px-5">
+    <h2 class="fw-light">Actions sur les lieux</h2>
+    {{ build_filters_form(form, dst) }}
+    <div>
+      {% if rows %}
+        <div class="d-flex justify-content-between">
+          <p class="lead num-results">
+            {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
+            résultat{{ "s" if rows | length > 1 else "" }}
+          </p>
+        </div>
+        <table class="table mb-4">
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">Nom</th>
+              <th scope="col">Structure</th>
+              <th scope="col">Lieu permanent</th>
+              <th scope="col">Label</th>
+              <th scope="col">Tags</th>
+              <th scope="col">Date de création</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for venue in rows %}
+              <tr>
+                <td>{{ venue.id }}</td>
+                <td>{{ links.build_venue_name_to_details_link(venue) }}</td>
+                <td>{{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}</td>
+                <td>
+                  {% if venue.isPermanent %}<span class="visually-hidden">Lieu permanent</span><i class="bi bi-check-circle-fill"></i>{% endif %}
+                </td>
+                <td>{{ venue.venueLabel.label }}</td>
+                <td>{{ venue.criteria | format_criteria | safe }}</td>
+                <td>{{ venue.dateCreated | format_date }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    </div>
+  </div>
+{% endblock page %}

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -19,6 +19,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
+from pcapi.utils.regions import get_all_regions
 
 from . import blueprint
 
@@ -156,3 +157,7 @@ def is_feature_active(feature_name: str) -> bool:
 
 def get_setting(setting_name: str) -> typing.Any:
     return getattr(settings, setting_name)
+
+
+def get_regions_choices() -> list[tuple]:
+    return [(key, key) for key in get_all_regions()]

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -15,12 +15,13 @@ from pcapi.core.history import models as history_models
 import pcapi.core.history.factories as history_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
+from pcapi.core.offerers.models import VenueTypeCode
 import pcapi.core.permissions.models as perm_models
 from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
 from pcapi.models import db
-from pcapi.routes.backoffice_v3 import venues
+from pcapi.routes.backoffice_v3 import venues as venues_blueprint
 from pcapi.routes.backoffice_v3.filters import format_dms_status
 
 from .helpers import button as button_helpers
@@ -44,6 +45,118 @@ def venue_fixture(offerer) -> offerers_models.Venue:
         status=finance_models.BankInformationStatus.ACCEPTED,
     )
     return venue
+
+
+@pytest.fixture(scope="function", name="venues")
+def venues_fixture() -> list[offerers_models.Venue]:
+    return [
+        offerers_factories.VenueFactory(
+            venueTypeCode=VenueTypeCode.MOVIE,
+            venueLabelId=offerers_factories.VenueLabelFactory(label="Cinéma d'art et d'essai").id,
+            criteria=[
+                criteria_factories.CriterionFactory(name="Criterion_cinema"),
+                criteria_factories.CriterionFactory(name="Criterion_art"),
+            ],
+            postalCode="82000",
+            isPermanent=True,
+        ),
+        offerers_factories.VenueFactory(
+            venueTypeCode=VenueTypeCode.GAMES,
+            venueLabelId=offerers_factories.VenueLabelFactory(label="Scènes conventionnées").id,
+            criteria=[criteria_factories.CriterionFactory()],
+            postalCode="45000",
+            isPermanent=False,
+        ),
+    ]
+
+
+class ListVenuesTest(GetEndpointHelper):
+    endpoint = "backoffice_v3_web.venue.list_venues"
+    needed_permission = perm_models.Permissions.MANAGE_PRO_ENTITY
+
+    # Use assert_num_queries() instead of assert_no_duplicated_queries() which does not detect one extra query caused
+    # by a field added in the jinja template.
+    # - fetch session (1 query)
+    # - fetch user (1 query)
+    # - fetch venue_label for select (1 query)
+    # - fetch venues with joinedload including extra data (1 query)
+    expected_num_queries = 4
+
+    def test_list_venues_without_filter(self, authenticated_client):
+        # when
+        response = authenticated_client.get(url_for(self.endpoint))
+
+        # then
+        assert response.status_code == 200
+        assert html_parser.count_table_rows(response.data) == 0
+
+    def test_list_venues_by_type(self, authenticated_client, venues):
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, type=VenueTypeCode.MOVIE.name))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert int(rows[0]["ID"]) == venues[0].id
+        assert rows[0]["Nom"] == venues[0].name
+        assert rows[0]["Structure"] == venues[0].managingOfferer.name
+        assert rows[0]["Lieu permanent"] == "Lieu permanent"
+        assert rows[0]["Label"] == venues[0].venueLabel.label
+        assert sorted(rows[0]["Tags"].split()) == sorted("Criterion_cinema Criterion_art".split())
+        assert rows[0]["Date de création"] == venues[0].dateCreated.strftime("%d/%m/%Y")
+
+    def test_list_venues_by_label(self, authenticated_client, venues):
+        # when
+        venue_label_id = venues[0].venueLabelId
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, venue_label=venue_label_id))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert int(rows[0]["ID"]) == venues[0].id
+
+    def test_list_venues_by_tags(self, authenticated_client, venues):
+        # when
+        expected_num_queries = (
+            self.expected_num_queries + 1
+        )  # 1 more request is necessary to prefill form choices with selected tag(s)
+        criteria_id = venues[0].criteria[0].id
+        with assert_num_queries(expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, criteria=criteria_id))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert int(rows[0]["ID"]) == venues[0].id
+
+    def test_list_venues_by_regions(self, authenticated_client, venues):
+        # when
+        venue = offerers_factories.VenueFactory(postalCode="82000")
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, regions="Occitanie"))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 2
+        assert int(rows[0]["ID"]) == venues[0].id
+        assert int(rows[1]["ID"]) == venue.id
+
+    def test_list_venues_by_department(self, authenticated_client, venues):
+        # when
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, department="82"))
+
+        # then
+        assert response.status_code == 200
+        rows = html_parser.extract_table_rows(response.data)
+        assert len(rows) == 1
+        assert int(rows[0]["ID"]) == venues[0].id
 
 
 class GetVenueTest(GetEndpointHelper):
@@ -248,7 +361,7 @@ class GetVenueStatsDataTest:
         venue_id = venue_with_accepted_bank_info.id
 
         with assert_num_queries(2):
-            data = venues.get_stats_data(venue_id)
+            data = venues_blueprint.get_stats_data(venue_id)
 
         stats = data.stats
 
@@ -263,7 +376,7 @@ class GetVenueStatsDataTest:
         venue_id = venue.id
 
         with assert_num_queries(2):
-            data = venues.get_stats_data(venue_id)
+            data = venues_blueprint.get_stats_data(venue_id)
 
         stats = data.stats
 
@@ -379,7 +492,7 @@ class GetVenueStatsTest(GetEndpointHelper):
 
 class HasReimbursementPointTest:
     def test_venue_with_reimbursement_point_links(self, venue):
-        assert venues.has_reimbursement_point(venue)
+        assert venues_blueprint.has_reimbursement_point(venue)
 
     def test_venue_with_no_current_reimbursement_point_links(self):
         venue = offerers_factories.VenueFactory()
@@ -405,11 +518,11 @@ class HasReimbursementPointTest:
             timespan=[datetime.utcnow() - timedelta(days=100), datetime.utcnow() - timedelta(days=10)],
         )
 
-        assert not venues.has_reimbursement_point(venue)
+        assert not venues_blueprint.has_reimbursement_point(venue)
 
     def test_venue_with_no_reimbursement_point_links(self):
         venue = offerers_factories.VenueFactory()
-        assert not venues.has_reimbursement_point(venue)
+        assert not venues_blueprint.has_reimbursement_point(venue)
 
 
 class DeleteVenueTest(PostEndpointHelper):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21918

## But de la pull request

Ajout d'une page pour rechercher des lieux qui plus tard servira à ajouter des actions de traitement par lot

## Implémentation

Créer une nouvelle page “Actions sur les lieux” dans le menu “Acteurs culturels”  

- Afficher un tableau des lieux  
- Avec de base aucune ligne sur le tableau  
- Avoir les colonnes suivantes :
  - Venue id  
  - Nom  + un lien qui mène vers le lieu du BO  
  - Structure  + un lien qui mène vers la structure du BO  
  - Label  
  - Tags  
  - Date de création du lieu  
  - une visualisation de permanent/pas permanent, par exemple une colonne "Permanent" avec un tick pour si oui  
- Ajouter les filtres par : 
  - Type de lieu (activité principale)  
  - Par label  
  - Par tag  
  - Par région  
  - Par département  

Cette page est disponible dans les onglet via la permission “Gérer les acteurs culturels”

## Informations supplémentaires

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/95a3cf40-0854-4a8b-a7ea-1fd9ddb63371)



## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
