### PR TITLE
(BSR)[API] fix: set root log level to INFO in alembic.ini

### DIFF
--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -46,7 +46,7 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = INFO
 handlers = console
 qualname =
 

--- a/api/src/pcapi/tasks/amplitude_tasks.py
+++ b/api/src/pcapi/tasks/amplitude_tasks.py
@@ -24,7 +24,7 @@ def track_event(
     event_properties = payload.event_properties
 
     backend().track_event(
-        user_id=str(user_id),
+        user_id=user_id,
         event_name=event_name,
         event_properties=event_properties,
     )

--- a/api/tests/routes/saml/educonnect_test.py
+++ b/api/tests/routes/saml/educonnect_test.py
@@ -527,7 +527,7 @@ class EduconnectTest:
 
         client.post("/saml/acs", form={"SAMLResponse": "encrypted_data"})
 
-        assert amplitude_testing.requests[0]["user_id"] == str(user.id)
+        assert amplitude_testing.requests[0]["user_id"] == user.id
         assert amplitude_testing.requests[0]["event_name"] == AmplitudeEventType.EDUCONNECT_ERROR.value
 
         assert (


### PR DESCRIPTION
The alembic config overrode what is defined in pcapi/core/logging.py, which silences many incoherent logs.

## But de la pull request

Utiliser le niveau de log `INFO` pour le logger `root`, qui est redéfini via `alembic.ini`, et produit une configuration inattendue pendant les tests.

## Implémentation

- Modification de `alembic.ini`

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_
