### PR TITLE
(PC-22199)[PRO] fix: add early return if firebase init failed

### DIFF
--- a/pro/src/hooks/useAnalytics.ts
+++ b/pro/src/hooks/useAnalytics.ts
@@ -38,6 +38,9 @@ export const useConfigureFirebase = (currentUserId: string | undefined) => {
   useEffect(() => {
     if (!app && isFirebaseSupported) {
       const initializeApp = firebase.initializeApp(firebaseConfig)
+      if (!initializeApp) {
+        return
+      }
       setApp(initializeApp)
       isFirebaseSupported &&
         initializeAnalytics(initializeApp, {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22199


## But de la pull request

Ajouter un early return si l'initialisation de firebase fail dans le hook useAnalytics. 

Tentative de correction pour certains utilisateurs qui voient le message suivant apparaitre en prod sur certaines pages 

![image](https://github.com/pass-culture/pass-culture-main/assets/71768799/978a552a-7b34-41ae-8280-bbbdd3008383)


Le message complet : 


> FirebaseError: Analytics: initializeAnalytics() cannot be called again with different options than those it was initially called with. It can be called again with the same options to return the existing instance, or getAnalytics() can be used to get a reference to the already-intialized instance.
