### PR TITLE
(PC-22204) fix check db models alignment

### DIFF
--- a/api/tests/alembic/check_db_schema.py
+++ b/api/tests/alembic/check_db_schema.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 
 from pcapi import settings
 from pcapi.alembic.run_migrations import include_object
-from pcapi.models import db
+from pcapi.models import Base
 from pcapi.models import install_models
 
 
@@ -17,7 +17,7 @@ def check_db_schema_alignment():
             connection,
             opts={"include_object": include_object, "compare_server_default": True},
         )
-        diff = compare_metadata(migration_context, db.metadata)
+        diff = compare_metadata(migration_context, Base.metadata)
 
         if len(diff) > 0:
             raise RuntimeError(

--- a/api/tests/alembic/check_db_schema.py
+++ b/api/tests/alembic/check_db_schema.py
@@ -1,6 +1,11 @@
+import os
+import sys
+import warnings
+
 from alembic.autogenerate import compare_metadata
 from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine
+from sqlalchemy import exc as sa_exc
 
 from pcapi import settings
 from pcapi.alembic.run_migrations import include_object
@@ -17,12 +22,15 @@ def check_db_schema_alignment():
             connection,
             opts={"include_object": include_object, "compare_server_default": True},
         )
-        diff = compare_metadata(migration_context, Base.metadata)
+        with warnings.catch_warnings():
+            # cleaner output
+            warnings.simplefilter("ignore", category=sa_exc.SAWarning)
+            warnings.simplefilter("ignore", category=UserWarning)
 
-        if len(diff) > 0:
-            raise RuntimeError(
-                f"The database is not aligned with application model, create a migration or change the model to remove the following diff: {diff}"
-            )
+            diff = compare_metadata(migration_context, Base.metadata)
+    if diff:
+        diff.insert(0, ">>>>> The following diff was found ! <<<<<")
+    sys.exit("\n".join(str(d) for d in diff) or os.EX_OK)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22204

## But de la pull request

Corriger `check_db_schema.py` , qui n'utilisait pas la bonne définition du schéma de DB

## Informations supplémentaires

Il faudra, avant de fusionner, corriger les incohérences et fusionner ces PR:
- [x]  https://github.com/pass-culture/pass-culture-main/pull/6461
- [x]  https://github.com/pass-culture/pass-culture-main/pull/6467
- [x] https://github.com/pass-culture/pass-culture-main/pull/6476
