### PR TITLE
(BSR)[API] fix: existing unique constraint on role_permission was missing in the model

### DIFF
--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -103,6 +103,7 @@ class RolePermission(PcObject, Base, Model):
 
     roleId: int = sa.Column(sa.BigInteger, sa.ForeignKey("role.id", ondelete="CASCADE"))
     permissionId: int = sa.Column(sa.BigInteger, sa.ForeignKey("permission.id", ondelete="CASCADE"))
+    __table_args__ = (sa.UniqueConstraint("roleId", "permissionId", name="role_permission_roleId_permissionId_key"),)
 
 
 class Permission(PcObject, Base, Model):


### PR DESCRIPTION
## But de la pull request

Redéfinir la contrainte d'unicité de la table `role_permission`, qui existe dans la base de données mais avait disparu du modèle dans le commit [a0688a75ae6a7b105da916c9824e2016e3b7ec58](https://github.com/pass-culture/pass-culture-main/commit/a0688a75ae6a7b105da916c9824e2016e3b7ec58)

J'ai conservé le nom de l'index existant en base afin de ne pas créer de migration de suppression et recréation.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
