### PR TITLE
(PC-21946)[API] feat: write isbn in ean

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -180,8 +180,7 @@ class OfferAlreadyExists(OfferCreationBaseException):
 
 
 class EanFormatException(OfferCreationBaseException):
-    def __init__(self, error_message: str) -> None:
-        super().__init__("ean", error_message)
+    pass
 
 
 class ThumbnailStorageError(ApiErrors):

--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -322,6 +322,7 @@ def get_extra_data_from_infos(infos: dict) -> offers_models.OfferExtraData:
     extra_data = offers_models.OfferExtraData()
     extra_data["author"] = infos["auteurs"]
     extra_data["isbn"] = infos["ean13"]
+    extra_data["ean"] = infos["ean13"]
     if infos["indice_dewey"] != "":
         extra_data["dewey"] = infos["indice_dewey"]
     extra_data["titelive_regroup"] = infos["code_regroupement"]

--- a/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/endpoints.py
@@ -300,7 +300,10 @@ def _create_offer_from_product(
             {"accessibility": ["The accessibility is required when the location type is digital"]}
         )
 
-    offers_validation.check_isbn_or_ean_does_not_exist(product.extraData, venue)
+    if product.extraData:
+        offers_validation.check_isbn_or_ean_does_not_exist(
+            product.extraData.get("ean"), product.extraData.get("isbn"), venue
+        )
 
     offer = offers_api.build_new_offer_from_product(venue, product, id_at_provider, provider_id)
     if accessibility:

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -750,7 +750,12 @@ class CreateOfferTest:
         assert offer.name == "FONDATION T.1"
         assert offer.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert offer.description == "Les prévisions du psychohistorien Hari Seldon sont formelles."
-        assert offer.extraData == {"isbn": "9782207300893", "author": "Isaac Asimov", "bookFormat": "Soft cover"}
+        assert offer.extraData == {
+            "isbn": "9782207300893",
+            "author": "Isaac Asimov",
+            "bookFormat": "Soft cover",
+            "ean": "9782207300893",
+        }
         assert offer.audioDisabilityCompliant
         assert offer.mentalDisabilityCompliant
         assert offer.motorDisabilityCompliant

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -436,12 +436,12 @@ class CheckOfferExtraDataTest:
                 subcategories.JEU_EN_LIGNE.id, {"ean": "invalid ean"}, offerers_factories.VenueFactory()
             )
 
-        assert error.value.errors["ean"] == ["L'EAN doit être composé de 8 ou 13 chiffres"]
+        assert error.value.errors["ean"] == ["L'EAN doit être composé de 13 chiffres"]
 
     def test_valid_ean_extra_data(self):
         assert (
             validation.check_offer_extra_data(
-                subcategories.JEU_EN_LIGNE.id, {"ean": "12345678"}, offerers_factories.VenueFactory()
+                subcategories.JEU_EN_LIGNE.id, {"ean": "1234567891234"}, offerers_factories.VenueFactory()
             )
             is None
         )

--- a/api/tests/local_providers/titelive_things_test.py
+++ b/api/tests/local_providers/titelive_things_test.py
@@ -90,6 +90,7 @@ class TiteliveThingsTest:
         assert product.extraData.get("bookFormat") == offers_models.BookFormat.BEAUX_LIVRES.value
         assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert product.extraData.get("isbn") == "9782895026310"
+        assert product.extraData.get("ean") == "9782895026310"
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -118,6 +118,33 @@ class Returns200Test:
         assert offer.audioDisabilityCompliant == True
         assert offer.mentalDisabilityCompliant == False
 
+    def test_create_offer_with_isbn(self, client):
+        venue = offerers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+
+        data = {
+            "venueId": venue.id,
+            "name": "Les lièvres pas malins",
+            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "extraData": {
+                "isbn": "1234567890112",
+            },
+            "audioDisabilityCompliant": True,
+            "mentalDisabilityCompliant": False,
+            "motorDisabilityCompliant": False,
+            "visualDisabilityCompliant": False,
+        }
+        response = client.with_session_auth("user@example.com").post("/offers", json=data)
+
+        assert response.status_code == 201
+        offer_id = dehumanize(response.json["id"])
+        offer = Offer.query.get(offer_id)
+        assert offer.subcategoryId == subcategories.LIVRE_PAPIER.id
+        assert offer.venue == venue
+        assert offer.extraData["isbn"] == "1234567890112"
+        assert offer.extraData["ean"] == "1234567890112"
+
     def test_withdrawable_event_offer_can_have_no_ticket_to_withdraw(self, client):
         # Given
         venue = offerers_factories.VenueFactory()

--- a/api/tests/routes/public/individual_offers/v1/endpoints_test.py
+++ b/api/tests/routes/public/individual_offers/v1/endpoints_test.py
@@ -205,7 +205,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -225,7 +225,7 @@ class PostProductTest:
         assert created_offer.motorDisabilityCompliant is True
         assert created_offer.visualDisabilityCompliant is True
         assert not created_offer.isDuo
-        assert created_offer.extraData == {"ean": "12345678", "musicType": "820", "musicSubType": "829"}
+        assert created_offer.extraData == {"ean": "1234567891234", "musicType": "820", "musicSubType": "829"}
         assert created_offer.bookingEmail is None
         assert created_offer.description is None
         assert created_offer.status == offer_mixin.OfferStatus.SOLD_OUT
@@ -235,7 +235,7 @@ class PostProductTest:
             "categoryRelatedFields": {
                 "author": None,
                 "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                "ean": "12345678",
+                "ean": "1234567891234",
                 "musicType": "ROCK-LO_FI",
                 "performer": None,
             },
@@ -271,7 +271,7 @@ class PostProductTest:
                 "categoryRelatedFields": {
                     "author": "Maurice",
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "JAZZ-FUSION",
                     "performer": "Pink Pâtisserie",
                     "stageDirector": "Alfred",  # field not applicable
@@ -312,7 +312,7 @@ class PostProductTest:
         assert created_offer.isDuo is False
         assert created_offer.extraData == {
             "author": "Maurice",
-            "ean": "12345678",
+            "ean": "1234567891234",
             "musicType": "501",
             "musicSubType": "511",
             "performer": "Pink Pâtisserie",
@@ -341,7 +341,7 @@ class PostProductTest:
             "bookingEmail": "spam@example.com",
             "categoryRelatedFields": {
                 "author": "Maurice",
-                "ean": "12345678",
+                "ean": "1234567891234",
                 "category": "SUPPORT_PHYSIQUE_MUSIQUE",
                 "musicType": "JAZZ-FUSION",
                 "performer": "Pink Pâtisserie",
@@ -382,7 +382,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -416,7 +416,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -442,7 +442,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -468,7 +468,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -494,7 +494,7 @@ class PostProductTest:
                 "enableDoubleBookings": True,
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -535,7 +535,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                     "performer": "Ichika Nito",
                     "isbn": "1234567891123",  # this field is not applicable and not added to extraData
@@ -552,7 +552,7 @@ class PostProductTest:
         created_offer = offers_models.Offer.query.one()
 
         assert created_offer.extraData == {
-            "ean": "12345678",
+            "ean": "1234567891234",
             "musicType": "820",
             "musicSubType": "829",
             "performer": "Ichika Nito",
@@ -561,7 +561,7 @@ class PostProductTest:
         assert response.json["categoryRelatedFields"] == {
             "author": None,
             "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-            "ean": "12345678",
+            "ean": "1234567891234",
             "musicType": "ROCK-LO_FI",
             "performer": "Ichika Nito",
         }
@@ -575,7 +575,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "CHANSON_VARIETE-OTHER",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -617,7 +617,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -641,7 +641,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -667,7 +667,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -696,7 +696,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -723,7 +723,7 @@ class PostProductTest:
             json={
                 "categoryRelatedFields": {
                     "category": "SUPPORT_PHYSIQUE_MUSIQUE",
-                    "ean": "12345678",
+                    "ean": "1234567891234",
                     "musicType": "ROCK-LO_FI",
                 },
                 "accessibility": ACCESSIBILITY_FIELDS,
@@ -1682,7 +1682,7 @@ class GetProductByEanTest:
 
     def test_400_when_wrong_ean_format(self, client):
         venue, _ = create_offerer_provider_linked_to_venue()
-        product_offer = offers_factories.ThingOfferFactory(venue=venue, extraData={"ean": "12345678"})
+        product_offer = offers_factories.ThingOfferFactory(venue=venue, extraData={"ean": "123456789"})
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(
             f"/public/offers/v1/products/ean/{product_offer.extraData['ean']}"
@@ -2496,7 +2496,7 @@ class PatchProductByEanTest:
         product_offer = offers_factories.ThingOfferFactory(
             venue=venue,
             lastProvider=individual_offers_api_provider,
-            extraData={"ean": "12345678"},
+            extraData={"ean": "123456789"},
         )
 
         response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).get(


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21946

This is the first (out of four) step to delete isbn.
Everytime we write an isbn we also write an ean.
Few changes : 
- Isbn is now validated like ean (13 digits)
- It will not be possible to create a Book with the same ean as a CD (this is a good thing)
