### PR TITLE
(PC-21824)[API] feat: collective offers: add _geoloc field

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -536,6 +536,10 @@ class AlgoliaBackend(base.SearchBackend):
                 "name": venue.name,
                 "publicName": venue.publicName,
             },
+            "_geoloc": {
+                "lat": venue.latitude,
+                "lng": venue.longitude,
+            },
             "isTemplate": False,
         }
 
@@ -573,6 +577,10 @@ class AlgoliaBackend(base.SearchBackend):
                 "id": venue.id,
                 "name": venue.name,
                 "publicName": venue.publicName,
+            },
+            "_geoloc": {
+                "lat": venue.latitude,
+                "lng": venue.longitude,
             },
             "isTemplate": True,
         }

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -317,6 +317,10 @@ def test_serialize_collective_offer():
             "name": "La Moyenne Librairie SA",
             "publicName": "La Moyenne Librairie",
         },
+        "_geoloc": {
+            "lat": collective_offer.venue.latitude,
+            "lng": collective_offer.venue.longitude,
+        },
         "isTemplate": False,
     }
 
@@ -369,6 +373,10 @@ def test_serialize_collective_offer_template():
             "id": collective_offer_template.venue.id,
             "name": "La Moyenne Librairie SA",
             "publicName": "La Moyenne Librairie",
+        },
+        "_geoloc": {
+            "lat": collective_offer_template.venue.latitude,
+            "lng": collective_offer_template.venue.longitude,
         },
         "isTemplate": True,
     }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21824

## But de la pull request

Ajout d'un champ `_geoloc` aux offres collectives et au offres vitrines : ceci devrait permettre de rechercher les offres à l'intérieur d'un certain périmètre