### PR TITLE
(PC-21708)[API] feat: Redis external bookings

### DIFF
--- a/api/src/pcapi/core/bookings/constants.py
+++ b/api/src/pcapi/core/bookings/constants.py
@@ -9,6 +9,8 @@ BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=10)
 BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=7)
 BOOKS_BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=5)
 AUTO_USE_AFTER_EVENT_TIME_DELAY = datetime.timedelta(hours=48)
+REDIS_EXTERNAL_BOOKINGS_NAME = "api:external_bookings:barcodes"
+EXTERNAL_BOOKINGS_MINIMUM_ITEM_AGE_IN_QUEUE = 60
 
 
 def _get_hours_from_timedelta(td: datetime.timedelta) -> float:

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -98,6 +98,12 @@ def synchronize_cgr_stocks() -> None:
     synchronize_venue_providers(venue_providers)
 
 
+@blueprint.cli.command("cancel_unstored_external_bookings")
+@log_cron_with_transaction
+def cancel_unstored_external_bookings() -> None:
+    bookings_api.cancel_unstored_external_bookings()
+
+
 # TODO: (lixxday 24/02/2023) remove this command when PR https://github.com/pass-culture/pass-culture-deployment/pull/200 is deployed
 @blueprint.cli.command("import_beneficiaries_from_dms_v4")
 @log_cron_with_transaction

--- a/api/src/pcapi/utils/queue.py
+++ b/api/src/pcapi/utils/queue.py
@@ -1,0 +1,32 @@
+import json
+import logging
+
+from flask import current_app
+import redis.exceptions
+
+
+logger = logging.getLogger(__name__)
+
+
+def add_to_queue(queue_name: str, item: dict, at_head: bool = False) -> None:
+    if not item:
+        return
+    dict_json = json.dumps(item)
+    redis_client = current_app.redis_client  # type: ignore[attr-defined]
+    try:
+        if at_head:
+            redis_client.lpush(queue_name, dict_json)
+        else:
+            redis_client.rpush(queue_name, dict_json)
+    except redis.exceptions.RedisError:
+        logger.exception("Could not add item to redis queue", extra={"queue": queue_name, "item": item})
+
+
+def pop_from_queue(queue_name: str) -> dict | None:
+    redis_client = current_app.redis_client  # type: ignore[attr-defined]
+    try:
+        item = redis_client.lpop(queue_name)
+    except redis.exceptions.RedisError:
+        logger.exception("Could not pop element from queue", extra={"queue": queue_name})
+        return None
+    return json.loads(item) if item else None

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -18,6 +18,7 @@ from pcapi.core.bookings import api
 from pcapi.core.bookings import exceptions
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models
+from pcapi.core.bookings.api import cancel_unstored_external_bookings
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
@@ -44,6 +45,7 @@ from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models import feature
 import pcapi.notifications.push.testing as push_testing
+from pcapi.utils import queue
 
 from tests.conftest import clean_database
 
@@ -1246,3 +1248,38 @@ class ArchiveOldBookingsTest:
         assert not recent_booking.displayAsEnded
         assert not old_not_free_booking.displayAsEnded
         assert old_booking.displayAsEnded
+
+
+@pytest.mark.usefixtures("db_session")
+class PopBarcodesFromQueueAndCancelWastedExternalBookingTest:
+    def test_should_not_pop_and_not_try_to_cancel_external_booking_if_minimum_age_not_reached(self, app):
+        queue.add_to_queue(
+            "api:external_bookings:barcodes",
+            {"barcode": "AAA-123456789", "venue_id": 12, "timestamp": datetime.utcnow().timestamp()},
+        )
+
+        cancel_unstored_external_bookings()
+
+        assert app.redis_client.llen("api:external_bookings:barcodes") == 1
+
+    @patch("pcapi.core.bookings.api.external_bookings_api.cancel_booking")
+    def test_should_pop_and_cancel_only_external_booking_reached_minimum_age(self, mocked_cancel_external_booking, app):
+        queue.add_to_queue(
+            "api:external_bookings:barcodes",
+            {"barcode": "BBB-123456789", "venue_id": 13, "timestamp": datetime.utcnow().timestamp() - 90},
+        )
+        queue.add_to_queue(
+            "api:external_bookings:barcodes",
+            {"barcode": "CCC-123456789", "venue_id": 14, "timestamp": datetime.utcnow().timestamp() - 65},
+        )
+        queue.add_to_queue(
+            "api:external_bookings:barcodes",
+            {"barcode": "AAA-123456789", "venue_id": 12, "timestamp": datetime.utcnow().timestamp()},
+        )
+        ExternalBookingFactory(barcode="BBB-123456789")
+
+        cancel_unstored_external_bookings()
+
+        mocked_cancel_external_booking.assert_called_once_with(14, ["CCC-123456789"])
+
+        assert app.redis_client.llen("api:external_bookings:barcodes") == 1

--- a/api/tests/utils/queue_test.py
+++ b/api/tests/utils/queue_test.py
@@ -1,0 +1,30 @@
+from pcapi.utils import queue
+
+
+class AddToQueueTest:
+    def test_should_add_item_to_queue(self, app):
+        first_item = {"one": 1, "two": "2"}
+        second_item = {"one": 3, "two": "4"}
+        third_item = {"one": 5, "two": "6"}
+        queue.add_to_queue("test:numbers", first_item)
+        queue.add_to_queue("test:numbers", second_item)
+        queue.add_to_queue("test:numbers", third_item, at_head=True)
+
+        numbers = app.redis_client.lrange("test:numbers", 0, -1)
+        assert len(numbers) == 3
+        assert numbers == ['{"one": 5, "two": "6"}', '{"one": 1, "two": "2"}', '{"one": 3, "two": "4"}']
+
+
+class PopFromQueueTest:
+    def test_should_pop_items_from_queue(self):
+        queue.add_to_queue("test:numbers", {"one": 1, "two": "2"})
+        queue.add_to_queue("test:numbers", {"one": 3, "two": "4"})
+
+        first_item = queue.pop_from_queue("test:numbers")
+        assert first_item == {"one": 1, "two": "2"}
+
+        second_item = queue.pop_from_queue("test:numbers")
+        assert second_item == {"one": 3, "two": "4"}
+
+        third_item = queue.pop_from_queue("test:numbers")
+        assert not third_item


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21708

## But de la pull request
Annuler la réservation en cours en cas d'erreur avant l'enregistrement de la réservation pass Culture Afin d'éviter de bloquer des places sur la billetterie de ciné sans avoir la réservation sur le pass Culture et ne pas rembourser l’AC

## Implémentation
- Créer une file Redis.
- Stocker les codes barres récupérés un appel de réservation dans la file Redis.
- Ajouter une commande qui vérifie si les code barres dans la file ont bien été sauvegarder en DB sans soucis, le cas contraire annuler la réservation auprès du cinéma.


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
