### PR TITLE
(PC-21526)[BO] fix: button displayed only if user has required permission

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
@@ -61,7 +61,7 @@
               <p>
                 <b>ISBN :</b> {{ isbn }}
               </p>
-              {% if product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0 %}
+              {% if has_permission("FRAUD_ACTIONS") and (product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0) %}
                 <div>
                   {{ build_modal_form("set-gcu-incompatible", url_for('.set_product_gcu_incompatible'), incompatibility_form,
                   "Rendre le livre et les offres associées incompatibles avec les CGU", "Confirmer",

--- a/api/tests/routes/backoffice_v3/multiple_offers_test.py
+++ b/api/tests/routes/backoffice_v3/multiple_offers_test.py
@@ -16,6 +16,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
 
+from .helpers import button as button_helpers
 from .helpers import html_parser
 from .helpers.get import GetEndpointHelper
 from .helpers.post import PostEndpointHelper
@@ -195,6 +196,16 @@ class AddCriteriaToOffersTest(PostEndpointHelper):
         )
 
         assert response.status_code == 303
+
+
+class SetProductGcuIncompatibleButtonTest(button_helpers.ButtonHelper):
+    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    button_label = "Rendre le livre et les offres associées incompatibles avec les CGU"
+
+    @property
+    def path(self):
+        offers_factories.ThingProductFactory(extraData={"isbn": "9781234567890"})
+        return url_for("backoffice_v3_web.multiple_offers.search_multiple_offers", isbn="9781234567890")
 
 
 class SetProductGcuIncompatibleTest(PostEndpointHelper):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21526

## But de la pull request

Petite correction suite à la revue PO : le bouton pour rendre les offres incompatibles ne doit être affiché que si l'utilisateur a la permission sur l'action associée.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
