### PR TITLE
(PC-22023)[BO] feat: an icon to open all offers for a venue from offers lists

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
@@ -27,6 +27,7 @@
               <th scope="col">Date de l'événement</th>
               <th scope="col">Structure</th>
               <th scope="col">Lieu</th>
+              <th scope="col">{# icon #}</th>
             </tr>
           </thead>
           <tbody>
@@ -65,6 +66,7 @@
                 <td>{{ collective_offer.collectiveStock.beginningDatetime | format_date }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(collective_offer.venue) }}</td>
+                <td>{{ links.build_venue_offers_icon_link(".list_collective_offers", "Offres collectives", collective_offer.venue) }}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
@@ -26,6 +26,7 @@
               <th scope="col">Date de création</th>
               <th scope="col">Structure</th>
               <th scope="col">Lieu</th>
+              <th scope="col">{# icon #}</th>
             </tr>
           </thead>
           <tbody>
@@ -63,6 +64,9 @@
                 <td>{{ collective_offer_template.dateCreated | format_date("%d/%m/%Y") }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(collective_offer_template.venue.managingOfferer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(collective_offer_template.venue) }}</td>
+                <td>
+                  {{ links.build_venue_offers_icon_link(".list_collective_offer_templates", "Offres collectives vitrines", collective_offer_template.venue) }}
+                </td>
               </tr>
             {% endfor %}
           </tbody>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/links.html
@@ -28,6 +28,12 @@
      class="link-primary"
      target="_top">{{ offer[text_attr] }}</a>
 {% endmacro %}
+{% macro build_venue_offers_icon_link(endpoint, hint, venue, text_attr="name") %}
+  <a href="{{ url_for(endpoint, venue=venue.id) }}"
+     class="link-primary"
+     target="_blank"
+     title="{{ hint }} associées au lieu"><i class="bi bi-box-arrow-up-right"></i></a>
+{% endmacro %}
 {# ----- PC Pro links ----- #}
 {% macro build_offerer_name_to_pc_pro_link(offerer) %}
   <a href="{{ offerer | pc_pro_offerer_link }}"

--- a/api/src/pcapi/routes/backoffice_v3/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offer/list.html
@@ -69,6 +69,7 @@
               <th scope="col">Dép.</th>
               <th scope="col">Structure</th>
               <th scope="col">Lieu</th>
+              <th scope="col">{# icon #}</th>
             </tr>
           </thead>
           <tbody>
@@ -125,6 +126,7 @@
                 <td>{{ offer.venue.departementCode | empty_string_if_null }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}</td>
                 <td>{{ links.build_venue_name_to_details_link(offer.venue) }}</td>
+                <td>{{ links.build_venue_offers_icon_link(".list_offers", "Offres individuelles", offer.venue) }}</td>
               </tr>
             {% endfor %}
           </tbody>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22023

## But de la pull request

Sur les tableaux des offres individuelles, collectives et collectives vitrine, ajouter une nouvelle colonne avec une icône permettant d'ouvrir un nouvel onglet sur cette même page Offre avec le filtre fait sur le lieu de l’offre uniquement

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/94e4e290-b9bb-4207-a001-34df27133673)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
