### PR TITLE
(PC-21235)[BO] fix: try to save column width in individual offers

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offer/list.html
@@ -59,13 +59,12 @@
               <th scope="col">Nom de l'offre</th>
               <th scope="col">Catégorie</th>
               <th scope="col">Sous-catégorie</th>
-              <th scope="col">Stock initial</th>
               <th scope="col">Stock restant</th>
               <th scope="col">Tag</th>
-              <th scope="col">Pondération</th>
+              <th scope="col">Pond.</th>
               <th scope="col">État</th>
               <th scope="col">Date de création</th>
-              <th scope="col">Dernière date de validation</th>
+              <th scope="col">Dernière validation</th>
               <th scope="col">Dép.</th>
               <th scope="col">Structure</th>
               <th scope="col">Lieu</th>
@@ -116,8 +115,7 @@
                 <td>{{ links.build_offer_name_to_pc_pro_link(offer) }}</td>
                 <td>{{ offer.category.pro_label }}</td>
                 <td>{{ offer.subcategory_v2.pro_label }}</td>
-                <td>{{ get_initial_stock(offer) }}</td>
-                <td>{{ get_remaining_stock(offer) }}</td>
+                <td class="text-nowrap">{{ get_remaining_stock(offer) }} / {{ get_initial_stock(offer) }}</td>
                 <td>{{ offer.criteria | format_criteria | safe }}</td>
                 <td>{{ offer.rankingWeight | empty_string_if_null }}</td>
                 <td>{{ offer.validation | format_offer_validation_status }}</td>

--- a/api/tests/routes/backoffice_v3/offers_test.py
+++ b/api/tests/routes/backoffice_v3/offers_test.py
@@ -107,13 +107,12 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Nom de l'offre"] == offers[0].name
         assert rows[0]["Catégorie"] == offers[0].category.pro_label
         assert rows[0]["Sous-catégorie"] == offers[0].subcategory_v2.pro_label
-        assert rows[0]["Stock initial"] == "Illimité"
-        assert rows[0]["Stock restant"] == "Illimité"
+        assert rows[0]["Stock restant"] == "Illimité / Illimité"
         assert rows[0]["Tag"] == offers[0].criteria[0].name
-        assert rows[0]["Pondération"] == ""
+        assert rows[0]["Pond."] == ""
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today()).strftime("%d/%m/%Y")
-        assert rows[0]["Dernière date de validation"] == ""
+        assert rows[0]["Dernière validation"] == ""
         assert rows[0]["Dép."] == offers[0].venue.departementCode
         assert rows[0]["Structure"] == offers[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == offers[0].venue.name
@@ -160,13 +159,12 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Nom de l'offre"] == offers[1].name
         assert rows[0]["Catégorie"] == offers[1].category.pro_label
         assert rows[0]["Sous-catégorie"] == offers[1].subcategory_v2.pro_label
-        assert rows[0]["Stock initial"] == "20"
-        assert rows[0]["Stock restant"] == "15"
+        assert rows[0]["Stock restant"] == "15 / 20"
         assert rows[0]["Tag"] == ""
-        assert rows[0]["Pondération"] == ""
+        assert rows[0]["Pond."] == ""
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today()).strftime("%d/%m/%Y")
-        assert rows[0]["Dernière date de validation"] == "22/02/2022"
+        assert rows[0]["Dernière validation"] == "22/02/2022"
         assert rows[0]["Dép."] == offers[1].venue.departementCode
         assert rows[0]["Structure"] == offers[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == offers[1].venue.name
@@ -396,7 +394,7 @@ class EditOfferTest(PostEndpointHelper):
         assert response.status_code == 200
         row = html_parser.extract_table_rows(response.data)
         assert len(row) == 1
-        assert row[0]["Pondération"] == str(choosen_ranking_weight)
+        assert row[0]["Pond."] == str(choosen_ranking_weight)
         assert criteria[0].name in row[0]["Tag"]
         assert criteria[1].name in row[0]["Tag"]
         assert criteria[2].name not in row[0]["Tag"]
@@ -416,7 +414,7 @@ class EditOfferTest(PostEndpointHelper):
         assert response.status_code == 200
         row = html_parser.extract_table_rows(response.data)
         assert len(row) == 1
-        assert row[0]["Pondération"] == ""
+        assert row[0]["Pond."] == ""
         assert criteria[2].name in row[0]["Tag"]
         assert criteria[1].name in row[0]["Tag"]
         assert criteria[0].name not in row[0]["Tag"]
@@ -565,7 +563,7 @@ class ValidateOfferTest(PostEndpointHelper):
         row = html_parser.extract_table_rows(response.data)
         assert len(row) == 1
         assert row[0]["État"] == "Validée"
-        assert row[0]["Dernière date de validation"] == (datetime.date.today()).strftime("%d/%m/%Y")
+        assert row[0]["Dernière validation"] == (datetime.date.today()).strftime("%d/%m/%Y")
 
         assert offer_to_validate.isActive is True
         assert offer_to_validate.lastValidationType == OfferValidationType.MANUAL
@@ -607,7 +605,7 @@ class RejectOfferTest(PostEndpointHelper):
         row = html_parser.extract_table_rows(response.data)
         assert len(row) == 1
         assert row[0]["État"] == "Rejetée"
-        assert row[0]["Dernière date de validation"] == (datetime.date.today()).strftime("%d/%m/%Y")
+        assert row[0]["Dernière validation"] == (datetime.date.today()).strftime("%d/%m/%Y")
 
         assert offer_to_reject.isActive is False
         assert offer_to_reject.lastValidationType == OfferValidationType.MANUAL


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21235

## But de la pull request

Gagner un peu de place sur la largeur des colonnes dans la liste des offres individuelles

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
