### PR TITLE
(PC-22266)[BO] fix: include collective offer templates in venue offers counters

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -235,11 +235,25 @@ def get_stats_data(venue_id: int) -> serialization.VenueStats:
     stats = serialization.VenueOffersStats(
         active=offerers_serialization.BaseOffersStats(
             individual=offers_stats.individual_offers.get("active", 0) if offers_stats.individual_offers else 0,
-            collective=offers_stats.collective_offers.get("active", 0) if offers_stats.collective_offers else 0,
+            collective=sum(
+                [
+                    offers_stats.collective_offers.get("active", 0) if offers_stats.collective_offers else 0,
+                    offers_stats.collective_offer_templates.get("active", 0)
+                    if offers_stats.collective_offer_templates
+                    else 0,
+                ]
+            ),
         ),
         inactive=offerers_serialization.BaseOffersStats(
             individual=offers_stats.individual_offers.get("inactive", 0) if offers_stats.individual_offers else 0,
-            collective=offers_stats.collective_offers.get("inactive", 0) if offers_stats.collective_offers else 0,
+            collective=sum(
+                [
+                    offers_stats.collective_offers.get("inactive", 0) if offers_stats.collective_offers else 0,
+                    offers_stats.collective_offer_templates.get("inactive", 0)
+                    if offers_stats.collective_offer_templates
+                    else 0,
+                ]
+            ),
         ),
         lastSync=serialization.LastOfferSyncStats(
             date=offers_stats.lastSyncDate,

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -330,6 +330,39 @@ def offerer_inactive_collective_offers_fixture(offerer, venue_with_accepted_bank
     return approved_offers + [rejected_offer]
 
 
+@pytest.fixture(name="offerer_active_collective_offer_templates")
+def offerer_active_collective_offer_templates_fixture(offerer, venue_with_accepted_bank_info):
+    approved_offers = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+
+    rejected_offer = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.REJECTED.value,
+    )
+
+    return [approved_offers, rejected_offer]
+
+
+@pytest.fixture(name="offerer_inactive_collective_offer_templates")
+def offerer_inactive_collective_offer_templates_fixture(offerer, venue_with_accepted_bank_info):
+    approved_offers = educational_factories.CollectiveOfferTemplateFactory.create_batch(
+        2,
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.APPROVED.value,
+    )
+
+    rejected_offer = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.REJECTED.value,
+    )
+
+    return approved_offers + [rejected_offer]
+
+
 @pytest.fixture(name="offerer_stocks")
 def offerer_stocks_fixture(offerer_active_individual_offers):
     stocks = [offers_factories.StockFactory(offer=offer) for offer in offerer_active_individual_offers]

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -469,6 +469,8 @@ class GetVenueStatsTest(GetEndpointHelper):
         offerer_inactive_individual_offers,
         offerer_active_collective_offers,
         offerer_inactive_collective_offers,
+        offerer_active_collective_offer_templates,
+        offerer_inactive_collective_offer_templates,
     ):
         # when
         venue_id = venue_with_accepted_bank_info.id
@@ -478,7 +480,7 @@ class GetVenueStatsTest(GetEndpointHelper):
         # then
         assert response.status_code == 200
         cards_text = html_parser.extract_cards_text(response.data)
-        assert "6 offres actives (2 IND / 4 EAC) 8 offres inactives (3 IND / 5 EAC)" in cards_text
+        assert "7 offres actives (2 IND / 5 EAC) 10 offres inactives (3 IND / 7 EAC)" in cards_text
 
     def test_venue_offers_stats_0_if_no_offer(self, authenticated_client, venue_with_accepted_bank_info):
         # when


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22266

## But de la pull request

Prendre en compte les offres collectives vitrine dans les compteurs EAC de la page lieu du backoffice.

## Informations supplémentaires


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
