### PR TITLE
(PC-21975)[API] feat: move to ended bookings when subcategories match

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -4,6 +4,7 @@ import typing
 
 import sentry_sdk
 import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
 
 from pcapi.analytics.amplitude import events as amplitude_events
 from pcapi.core import search
@@ -12,6 +13,7 @@ from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.bookings.models import ExternalBooking
 from pcapi.core.bookings.repository import generate_booking_token
+from pcapi.core.categories import subcategories_v2
 from pcapi.core.educational import utils as educational_utils
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
@@ -539,20 +541,45 @@ def get_individual_bookings_from_stock(stock_id: int) -> typing.Generator[Bookin
         yield booking
 
 
-def archive_old_activation_code_bookings() -> None:
-    old_bookings = Booking.query.join(Booking.stock, Stock.offer, Booking.activationCode).filter(
-        offers_models.Offer.isDigital.is_(True),  # type: ignore [attr-defined]
-        offers_models.ActivationCode.id.isnot(None),
-        Booking.dateCreated < datetime.datetime.utcnow() - constants.ARCHIVE_DELAY,
+def archive_old_bookings() -> None:
+    date_condition = Booking.dateCreated < datetime.datetime.utcnow() - constants.ARCHIVE_DELAY
+
+    query_old_booking_ids = (
+        Booking.query.join(Booking.stock, Stock.offer, Booking.activationCode)
+        .filter(date_condition)
+        .filter(
+            offers_models.Offer.isDigital.is_(True),  # type: ignore [attr-defined]
+            offers_models.ActivationCode.id.isnot(None),
+        )
+        .options(sa_orm.load_only(Booking.id))
+        .with_entities(Booking.id)
+        .union(
+            Booking.query.join(Booking.stock, Stock.offer)
+            .filter(date_condition)
+            .filter(
+                offers_models.Offer.subcategoryId.in_(
+                    [
+                        subcategories_v2.ABO_MUSEE.id,
+                        subcategories_v2.CARTE_MUSEE.id,
+                        subcategories_v2.ABO_BIBLIOTHEQUE.id,
+                        subcategories_v2.ABO_MEDIATHEQUE.id,
+                    ]
+                ),
+                offers_models.Stock.price == 0,
+            )
+            .options(sa_orm.load_only(Booking.id))
+            .with_entities(Booking.id)
+        )
     )
-    number_updated = Booking.query.filter(Booking.id.in_(old_bookings.with_entities(Booking.id))).update(
+
+    number_updated = Booking.query.filter(Booking.id.in_(query_old_booking_ids)).update(
         {"displayAsEnded": True},
         synchronize_session=False,
     )
     db.session.commit()
 
     logger.info(
-        "Old activation code bookings archived (displayAsEnded=True)",
+        "Old bookings archived (displayAsEnded=True)",
         extra={
             "archivedBookings": number_updated,
         },

--- a/api/src/pcapi/core/bookings/commands.py
+++ b/api/src/pcapi/core/bookings/commands.py
@@ -10,7 +10,14 @@ blueprint = Blueprint(__name__, __name__)
 logger = logging.getLogger(__name__)
 
 
+# TODO(@kopax-polyconseil): remove when v240 is in production (PC-22308)
 @blueprint.cli.command("archive_old_activation_code_bookings")
 @cron_decorators.log_cron_with_transaction
 def archive_old_activation_code_bookings() -> None:
-    api.archive_old_activation_code_bookings()
+    api.archive_old_bookings()
+
+
+@blueprint.cli.command("archive_old_bookings")
+@cron_decorators.log_cron_with_transaction
+def archive_old_bookings() -> None:
+    api.archive_old_bookings()

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -22,6 +22,7 @@ from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
+from pcapi.core.categories import subcategories_v2
 import pcapi.core.educational.factories as educational_factories
 from pcapi.core.educational.models import CollectiveBooking
 from pcapi.core.educational.models import CollectiveBookingStatus
@@ -1189,7 +1190,7 @@ class GetInvidualBookingsFromStockTest:
         assert not list(api.get_individual_bookings_from_stock(stock.id))
 
 
-class ArchiveOldActivationCodeBookingsTest:
+class ArchiveOldBookingsTest:
     def test_old_activation_code_bookings_are_archived(self, db_session):
         # given
         now = datetime.utcnow()
@@ -1203,10 +1204,45 @@ class ArchiveOldActivationCodeBookingsTest:
         offers_factories.ActivationCodeFactory(booking=old_booking, stock=stock)
 
         # when
-        api.archive_old_activation_code_bookings()
+        api.archive_old_bookings()
 
         # then
         db_session.refresh(recent_booking)
         db_session.refresh(old_booking)
         assert not recent_booking.displayAsEnded
+        assert old_booking.displayAsEnded
+
+    @pytest.mark.parametrize(
+        "subcategoryId",
+        [
+            subcategories_v2.ABO_MUSEE.id,
+            subcategories_v2.CARTE_MUSEE.id,
+            subcategories_v2.ABO_BIBLIOTHEQUE.id,
+            subcategories_v2.ABO_MEDIATHEQUE.id,
+        ],
+    )
+    def test_old_subcategories_bookings_are_archived(self, db_session, subcategoryId):
+        # given
+        now = datetime.utcnow()
+        recent = now - timedelta(days=29, hours=23)
+        old = now - timedelta(days=30, hours=1)
+        stock_free = offers_factories.StockFactory(
+            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=0
+        )
+        stock_not_free = offers_factories.StockFactory(
+            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=10
+        )
+        recent_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=recent)
+        old_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=old)
+        old_not_free_booking = bookings_factories.BookingFactory(stock=stock_not_free, dateCreated=old)
+
+        # when
+        api.archive_old_bookings()
+
+        # then
+        db_session.refresh(recent_booking)
+        db_session.refresh(old_booking)
+        db_session.refresh(old_not_free_booking)
+        assert not recent_booking.displayAsEnded
+        assert not old_not_free_booking.displayAsEnded
         assert old_booking.displayAsEnded


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21975

## But de la pull request

Déplacer les offres automatiquement en réservations terminées après 30J si la sous catégorie est :
  
- Abonnement musée → `ABO_MUSEE`
- Carte musée → `CARTE_MUSEE`
- Abonnement bibliothèque → `ABO_BIBLIOTHEQUE`
- Abonnement médiathèque → `ABO_MEDIATHEQUE`

Et si le prix est `GRATUIT`

## Implémentation

- Modification du script flask `archive_old_activation_code_bookings`
- Renommage de `archive_old_activation_code_bookings` en `archive_old_bookings` 
- Création d'une nouvelle cmd flask le temps de la transition

TODO: ajouter un ticket ops et un ticket backend pour plus tard supprimer l'ancienne cmd.

## Informations supplémentaires

- PR Ajout initial du script `archive_old_activation_code_bookings` :  https://github.com/pass-culture/pass-culture-main/pull/5316
- PR initial ajout du cron pour le script `archive_old_activation_code_bookings` : https://github.com/pass-culture/pass-culture-deployment/pull/199
- Ticket initial demande de `archive_old_activation_code_bookings` : https://passculture.atlassian.net/browse/PC-20441

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
