### PR TITLE
(PC-22283)[PRO] fix: Do not synchronize new venue_providers after creation

### DIFF
--- a/api/tests/routes/pro/post_venue_provider_test.py
+++ b/api/tests/routes/pro/post_venue_provider_test.py
@@ -532,3 +532,30 @@ class ConnectProviderToVenueTest:
         venue_provider = venue.venueProviders[0]
         assert venue_provider.provider == provider
         mocked_venue_provider_job.assert_called_once_with(venue_provider.id)
+
+    @pytest.mark.usefixtures("db_session")
+    @patch("pcapi.workers.venue_provider_job.venue_provider_job")
+    def test_should_connect_to_provider_linked_to_an_offerer(
+        self,
+        mocked_venue_provider_job,
+        client,
+    ):
+        user = user_factories.AdminFactory()
+        venue = offerers_factories.VenueFactory()
+        provider = providers_factories.ProviderFactory(
+            name="Technical provider", localClass=None, isActive=True, enabledForPro=True
+        )
+        providers_factories.OffererProviderFactory(offerer=venue.managingOfferer, provider=provider)
+
+        venue_provider_data = {
+            "providerId": provider.id,
+            "venueId": venue.id,
+        }
+
+        response = client.with_session_auth(email=user.email).post("/venueProviders", json=venue_provider_data)
+
+        assert response.status_code == 201
+        assert len(venue.venueProviders) == 1
+        venue_provider = venue.venueProviders[0]
+        assert venue_provider.provider == provider
+        mocked_venue_provider_job.assert_not_called()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22283

We used to queue a synchronisation juste after the VenueProvider creation, for new providers (that are linked to an offerer) we don't want to queue a sync since they will use our APIs.

An error was triggered and the sync couldn't start (no problem, we don't want it to start) [Staging sentry](https://sentry.passculture.team/organizations/sentry/issues/413421/?project=5&referrer=slack)