### PR TITLE
(PC-21983)[PRO] feat: add MaybeAppUserDialog to offerer new onboarding

### DIFF
--- a/api/src/pcapi/connectors/sirene.py
+++ b/api/src/pcapi/connectors/sirene.py
@@ -79,6 +79,7 @@ class SiretInfo(pydantic.BaseModel):
     active: bool
     name: str
     address: _Address
+    ape_code: str
 
 
 def get_siren(siren: str, with_address: bool = True) -> SirenInfo:
@@ -160,11 +161,22 @@ class TestingBackend(BaseBackend):
 
     def get_siret(self, siret: str) -> SiretInfo:
         assert len(siret) == 14
+
+        siret_ape = defaultdict(
+            lambda: "90.03A",
+            {
+                "77708411211111": "85.31Z",
+                "77708411211112": "85.32Z",
+                "77708411211113": "91.03Z",
+            },
+        )
+
         return SiretInfo(
             siret=siret,
             active=True,
             name="MINISTERE DE LA CULTURE",
             address=self.address,
+            ape_code=siret_ape[siret]
         )
 
 
@@ -259,6 +271,10 @@ class InseeBackend(BaseBackend):
             city=city,
             insee_code=block["codeCommuneEtablissement"] or "",
         )
+    
+    def _get_ape_code_from_siret_data(self, data: dict) -> str:
+        block = data["uniteLegale"]
+        return block["activitePrincipaleUniteLegale"]
 
     def get_siren(self, siren: str, with_address: bool = True) -> SirenInfo:
         subpath = f"/siren/{siren}"
@@ -290,6 +306,7 @@ class InseeBackend(BaseBackend):
             active=active,
             name=self._get_name_from_siret_data(data),
             address=self._get_address_from_siret_data(data),
+            ape_code=self._get_ape_code_from_siret_data(data),
         )
         self._check_non_public_data(info)
         return info

--- a/api/src/pcapi/routes/pro/sirene.py
+++ b/api/src/pcapi/routes/pro/sirene.py
@@ -47,4 +47,5 @@ def get_siret_info(siret: str) -> sirene_serializers.SiretInfo:
         name=info.name,
         active=info.active,
         address=sirene_serializers.Address(**info_address_dict),
+        ape_code=info.ape_code
     )

--- a/api/src/pcapi/routes/serialization/sirene.py
+++ b/api/src/pcapi/routes/serialization/sirene.py
@@ -24,3 +24,4 @@ class SiretInfo(serialization.BaseModel):
     name: str
     active: bool
     address: Address
+    ape_code: str

--- a/api/tests/connectors/sirene_test.py
+++ b/api/tests/connectors/sirene_test.py
@@ -92,6 +92,7 @@ def test_get_siret():
         assert siret_info.address.street == "1 BD POISSONIERE"
         assert siret_info.address.postal_code == "75002"
         assert siret_info.address.city == "PARIS"
+        assert siret_info.ape_code == '47.61Z'
 
 
 @override_settings(SIRENE_BACKEND="pcapi.connectors.sirene.InseeBackend")

--- a/pro/src/apiClient/v1/models/SiretInfo.ts
+++ b/pro/src/apiClient/v1/models/SiretInfo.ts
@@ -9,5 +9,6 @@ export type SiretInfo = {
   address: Address;
   name: string;
   siret: string;
+  ape_code: string;
 };
 

--- a/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
+++ b/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
@@ -104,6 +104,7 @@ describe('components | Informations', () => {
         city: 'BAYEUX',
         postalCode: '14400',
       },
+      ape_code: '95.07A',
     })
     jest
       .spyOn(apiAdresse, 'getDataFromAddress')

--- a/pro/src/core/Venue/adapters/getSiretInfoAdapter.ts
+++ b/pro/src/core/Venue/adapters/getSiretInfoAdapter.ts
@@ -1,0 +1,59 @@
+import { api } from 'apiClient/api'
+import { GET_DATA_ERROR_MESSAGE } from 'core/shared'
+import { unhumanizeSiret } from 'core/Venue/utils'
+import { validateSiret } from 'core/Venue/validate'
+
+type Params = string
+type IPayload = {
+  values?: {
+    address: string
+    city: string
+    name: string
+    postalCode: string
+    siret: string
+    apeCode: string
+  }
+}
+
+const FAILING_RESPONSE: AdapterFailure<IPayload> = {
+  isOk: false,
+  message: GET_DATA_ERROR_MESSAGE,
+  payload: {},
+}
+
+type GetSiretInfoAdapter = Adapter<Params, IPayload, IPayload>
+
+const getSiretInfoAdapter: GetSiretInfoAdapter = async (humanSiret: string) => {
+  const siret = unhumanizeSiret(humanSiret)
+
+  try {
+    const response = await api.getSiretInfo(siret)
+
+    if (!response.active) {
+      return {
+        isOk: false,
+        message: 'SIRET invalide',
+        payload: {},
+      }
+    }
+
+    return {
+      isOk: true,
+      message: '',
+      payload: {
+        values: {
+          address: response.address.street,
+          city: response.address.city,
+          name: response.name,
+          postalCode: response.address.postalCode,
+          siret: response.siret,
+          apeCode: response.ape_code,
+        },
+      },
+    }
+  } catch (error) {
+    return FAILING_RESPONSE
+  }
+}
+
+export default getSiretInfoAdapter

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -1,5 +1,5 @@
 import { FormikProvider, useFormik } from 'formik'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import FormLayout from 'components/FormLayout'
@@ -9,9 +9,12 @@ import { useSignupJourneyContext } from 'context/SignupJourneyContext'
 import { Events } from 'core/FirebaseEvents/constants'
 import { FORM_ERROR_MESSAGE } from 'core/shared'
 import getSiretData from 'core/Venue/adapters/getSiretDataAdapter'
+import getSiretInfoAdapter from 'core/Venue/adapters/getSiretInfoAdapter'
 import { getVenuesOfOffererFromSiretAdapter } from 'core/Venue/adapters/getVenuesOfOffererFromSiretAdapter'
 import useAnalytics from 'hooks/useAnalytics'
 import useNotification from 'hooks/useNotification'
+import { MAYBE_APP_USER_APE_CODE } from 'pages/Signup/SignupContainer/constants'
+import MaybeAppUserDialog from 'pages/Signup/SignupContainer/MaybeAppUserDialog'
 import { Banner } from 'ui-kit'
 
 import { ActionBar } from '../ActionBar'
@@ -26,6 +29,7 @@ const Offerer = (): JSX.Element => {
   const notify = useNotification()
   const navigate = useNavigate()
   const { offerer, setOfferer } = useSignupJourneyContext()
+  const [showIsAppUserDialog, setShowIsAppUserDialog] = useState<boolean>(false)
 
   const initialValues: IOffererFormValues = offerer
     ? { siret: offerer.siret }
@@ -91,38 +95,66 @@ const Offerer = (): JSX.Element => {
     enableReinitialize: true,
   })
 
+  const siretMeta = formik.getFieldMeta('siret')
+  const checkSiretApeCode = async () => {
+    const response = await getSiretInfoAdapter(siretMeta.value)
+    if (
+      response.isOk &&
+      response.payload.values?.apeCode &&
+      MAYBE_APP_USER_APE_CODE.includes(response.payload.values.apeCode)
+    ) {
+      setShowIsAppUserDialog(true)
+    }
+  }
+  useEffect(() => {
+    if (!siretMeta.error && siretMeta.touched) {
+      if (siretMeta.value !== '') {
+        checkSiretApeCode()
+      }
+    }
+  }, [siretMeta.touched, siretMeta.error, siretMeta.value])
+
   return (
-    <FormLayout className={styles['offerer-layout']}>
-      <FormikProvider value={formik}>
-        <form onSubmit={formik.handleSubmit} data-testid="signup-offerer-form">
-          <OffererForm />
-          <Banner
-            type="notification-info"
-            className={styles['siret-banner']}
-            links={[
-              {
-                href: 'https://aide.passculture.app/hc/fr/articles/4633420022300--Acteurs-Culturels-Collectivit%C3%A9-Lieu-rattach%C3%A9-%C3%A0-une-collectivit%C3%A9-S-inscrire-et-param%C3%A9trer-son-compte-pass-Culture-',
-                linkTitle: 'En savoir plus',
-              },
-            ]}
+    <>
+      {showIsAppUserDialog && (
+        <MaybeAppUserDialog onCancel={() => setShowIsAppUserDialog(false)} />
+      )}
+      <FormLayout className={styles['offerer-layout']}>
+        <FormikProvider value={formik}>
+          <form
+            onSubmit={formik.handleSubmit}
+            data-testid="signup-offerer-form"
           >
-            <strong>
-              Vous êtes un équipement d’une collectivité ou d'un établissement
-              public ?
-            </strong>
-            <p className={styles['banner-content-info']}>
-              Renseignez le SIRET de la structure à laquelle vous êtes rattaché.
-            </p>
-          </Banner>
-          <ActionBar
-            onClickNext={handleNextStep()}
-            isDisabled={formik.isSubmitting}
-            nextStepTitle="Continuer"
-            logEvent={logEvent}
-          />
-        </form>
-      </FormikProvider>
-    </FormLayout>
+            <OffererForm />
+            <Banner
+              type="notification-info"
+              className={styles['siret-banner']}
+              links={[
+                {
+                  href: 'https://aide.passculture.app/hc/fr/articles/4633420022300--Acteurs-Culturels-Collectivit%C3%A9-Lieu-rattach%C3%A9-%C3%A0-une-collectivit%C3%A9-S-inscrire-et-param%C3%A9trer-son-compte-pass-Culture-',
+                  linkTitle: 'En savoir plus',
+                },
+              ]}
+            >
+              <strong>
+                Vous êtes un équipement d’une collectivité ou d'un établissement
+                public ?
+              </strong>
+              <p className={styles['banner-content-info']}>
+                Renseignez le SIRET de la structure à laquelle vous êtes
+                rattaché.
+              </p>
+            </Banner>
+            <ActionBar
+              onClickNext={handleNextStep()}
+              isDisabled={formik.isSubmitting}
+              nextStepTitle="Continuer"
+              logEvent={logEvent}
+            />
+          </form>
+        </FormikProvider>
+      </FormLayout>
+    </>
   )
 }
 

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
-import { ApiError } from 'apiClient/v1'
+import { ApiError, SiretInfo } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import { DEFAULT_ADDRESS_FORM_VALUES } from 'components/Address'
@@ -99,6 +99,7 @@ describe('screens:SignupJourney::Offerer', () => {
       },
       name: 'Test',
       siret: '12345678933333',
+      ape_code: '95.01A',
     })
 
     jest.spyOn(api, 'getVenuesOfOffererFromSiret').mockResolvedValue({
@@ -247,6 +248,123 @@ describe('screens:SignupJourney::Offerer', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
     await waitFor(() => {
       expect(screen.getByText('Une erreur est survenue')).toBeInTheDocument()
+    })
+  })
+
+  it('should not display MaybeAppUserDialog component on siret input blur', async () => {
+    renderOffererScreen(contextValue)
+
+    await userEvent.click(
+      screen.getByLabelText('Numéro de SIRET à 14 chiffres')
+    )
+    await userEvent.tab()
+    expect(api.getSiretInfo).not.toHaveBeenCalled()
+
+    await userEvent.type(
+      screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+      '12345678933333'
+    )
+    await userEvent.tab()
+    expect(api.getSiretInfo).toHaveBeenCalled()
+    expect(
+      screen.queryByText('Il semblerait que tu ne sois pas')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not display MaybeAppUserDialog component if siret is incorrect', async () => {
+    jest.spyOn(api, 'getSiretInfo').mockRejectedValueOnce(
+      new ApiError(
+        {} as ApiRequestOptions,
+        {
+          status: 500,
+          body: [{ error: ['ERROR'] }],
+        } as ApiResult,
+        ''
+      )
+    )
+    renderOffererScreen(contextValue)
+
+    await userEvent.type(
+      screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+      '12345678933333'
+    )
+    await userEvent.tab()
+    expect(api.getSiretInfo).toHaveBeenCalled()
+    expect(
+      screen.queryByText('Il semblerait que tu ne sois pas')
+    ).not.toBeInTheDocument()
+  })
+
+  describe('MaybeAppUserDialog displayed behavior', () => {
+    const siretInfo: SiretInfo = {
+      active: true,
+      address: {
+        city: 'Paris',
+        postalCode: '75008',
+        street: 'rue du test',
+      },
+      name: 'Test',
+      siret: '12345678933333',
+      ape_code: '85.31Z',
+    }
+
+    beforeEach(() => {
+      jest.spyOn(api, 'getSiretInfo').mockResolvedValueOnce(siretInfo)
+    })
+
+    it('should display MaybeAppUserDialog and hide on cancel button', async () => {
+      renderOffererScreen(contextValue)
+
+      await userEvent.type(
+        screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+        '12345678933333'
+      )
+      await userEvent.tab()
+      expect(api.getSiretInfo).toHaveBeenCalled()
+      expect(
+        screen.getByText('Il semblerait que tu ne sois pas')
+      ).toBeInTheDocument()
+
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'Continuer vers le pass Culture Pro',
+        })
+      )
+
+      expect(
+        screen.queryByText('Il semblerait que tu ne sois pas')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should display MaybeAppUserDialog component and redirect user to public app', async () => {
+      renderOffererScreen(contextValue)
+
+      await userEvent.type(
+        screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+        '12345678933333'
+      )
+      await userEvent.tab()
+
+      await userEvent.click(
+        screen.getByRole('link', {
+          name: 'S’inscrire sur l’application pass Culture',
+        })
+      )
+    })
+
+    it('should not open dialog if siret offerer is not active', async () => {
+      siretInfo.active = false
+      renderOffererScreen(contextValue)
+      await userEvent.type(
+        screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+        '12345678933333'
+      )
+      await userEvent.tab()
+
+      expect(api.getSiretInfo).toHaveBeenCalled()
+      expect(
+        screen.queryByText('Il semblerait que tu ne sois pas')
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
@@ -106,6 +106,7 @@ describe('screens:SignupJourney::OffererForm', () => {
       },
       name: 'Test',
       siret: '12345678933333',
+      ape_code: '95.01A',
     })
   })
 

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -119,6 +119,7 @@ jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
   },
   name: 'lieu',
   siret: '88145723823022',
+  ape_code: '95.07A',
 })
 
 jest.spyOn(api, 'canOffererCreateEducationalOffer').mockResolvedValue()

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
@@ -122,6 +122,7 @@ jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
   },
   name: 'lieu',
   siret: '88145723823022',
+  ape_code: '95.07A',
 })
 
 // Mock l'appel à https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${address}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21983

## But de la pull request

Si je rentre un SIRET qui récupère un code NAF correspondant à : 
- Enseignement secondaire général (8531Z)
- ou Enseignement secondaire technique ou professionnel (8532Z)
→ alors la pop in s’affiche au blur

## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/4c03f2e2-766d-48ef-849f-1a9265049f64)

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
