### PR TITLE
(PC-22790) Ajout de FinanceEvent

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-4a9bc6a57da0 (pre) (head)
-95c24b48212e (post) (head)
+405f222670b2 (pre) (head)
+097c6d306952 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230515T175443_ccacb677c93a_add_finance_event_table.py
+++ b/api/src/pcapi/alembic/versions/20230515T175443_ccacb677c93a_add_finance_event_table.py
@@ -1,0 +1,45 @@
+"""Add finance_event table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+import pcapi.utils
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "ccacb677c93a"
+down_revision = "4a9bc6a57da0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    import pcapi.core.finance.models as finance_models
+
+    op.create_table(
+        "finance_event",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("creationDate", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("valueDate", sa.DateTime(), nullable=False),
+        sa.Column("pricingOrderingDate", sa.DateTime(), nullable=True),
+        sa.Column("status", pcapi.utils.db.MagicEnum(finance_models.FinanceEventStatus), nullable=False),
+        sa.Column("motive", pcapi.utils.db.MagicEnum(finance_models.FinanceEventMotive), nullable=False),
+        sa.Column("bookingId", sa.BigInteger(), nullable=True),
+        sa.Column("collectiveBookingId", sa.BigInteger(), nullable=True),
+        sa.Column("venueId", sa.BigInteger(), nullable=True),
+        sa.Column("pricingPointId", sa.BigInteger(), nullable=True),
+        sa.CheckConstraint('num_nonnulls("bookingId", "collectiveBookingId") = 1'),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_finance_event_bookingId"), "finance_event", ["bookingId"], unique=False)
+    op.create_index(
+        op.f("ix_finance_event_collectiveBookingId"), "finance_event", ["collectiveBookingId"], unique=False
+    )
+    op.create_index(op.f("ix_finance_event_pricingPointId"), "finance_event", ["pricingPointId"], unique=False)
+    op.create_index(op.f("ix_finance_event_status"), "finance_event", ["status"], unique=False)
+    op.create_index(op.f("ix_finance_event_venueId"), "finance_event", ["venueId"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_table("finance_event")

--- a/api/src/pcapi/alembic/versions/20230614T154659_405f222670b2_add_pricing_finance_event_id.py
+++ b/api/src/pcapi/alembic/versions/20230614T154659_405f222670b2_add_pricing_finance_event_id.py
@@ -1,0 +1,19 @@
+"""Add `pricing.eventId` column"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "405f222670b2"
+down_revision = "c00fce7569d7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pricing", sa.Column("eventId", sa.BigInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pricing", "eventId")

--- a/api/src/pcapi/alembic/versions/20230614T181345_c00fce7569d7_remove_booking_constraint_on_pricing.py
+++ b/api/src/pcapi/alembic/versions/20230614T181345_c00fce7569d7_remove_booking_constraint_on_pricing.py
@@ -1,0 +1,21 @@
+"""Remove `booking_xor_collective_booking_check` check constraint on `pricing` table"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "c00fce7569d7"
+down_revision = "ccacb677c93a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE pricing DROP CONSTRAINT IF EXISTS booking_xor_collective_booking_check")
+
+
+def downgrade() -> None:
+    # Do not restore the constraint. It would take too long (or,
+    # actually, we would need to make it NOT VALID first and then
+    # VALIDATE it later) and we will want to remove it, eventually.
+    pass

--- a/api/src/pcapi/alembic/versions/20230705T083544_9801fe92e7af_add_fk_on_pricing_event_id.py
+++ b/api/src/pcapi/alembic/versions/20230705T083544_9801fe92e7af_add_fk_on_pricing_event_id.py
@@ -1,0 +1,22 @@
+"""Add foreign key on `pricing.eventId`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9801fe92e7af"
+down_revision = "95c24b48212e"
+branch_labels = None
+depends_on = None
+
+
+fk_name = "pricing_eventId_fkey"
+
+
+def upgrade() -> None:
+    op.create_foreign_key(fk_name, "pricing", "finance_event", ["eventId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(fk_name, "pricing", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20230705T084328_c1bd21cac4e9_add_fk_on_finance_event_booking_id.py
+++ b/api/src/pcapi/alembic/versions/20230705T084328_c1bd21cac4e9_add_fk_on_finance_event_booking_id.py
@@ -1,0 +1,22 @@
+"""Add foreign key on `finance_event.bookingId`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "c1bd21cac4e9"
+down_revision = "9801fe92e7af"
+branch_labels = None
+depends_on = None
+
+
+fk_name = "finance_event_bookingId_fkey"
+
+
+def upgrade() -> None:
+    op.create_foreign_key(fk_name, "finance_event", "booking", ["bookingId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(fk_name, "finance_event", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20230705T084518_1b0734e11842_add_fk_on_finance_event_collective_booking_id.py
+++ b/api/src/pcapi/alembic/versions/20230705T084518_1b0734e11842_add_fk_on_finance_event_collective_booking_id.py
@@ -1,0 +1,22 @@
+"""Add foreign key on `finance_event.collectiveBookingId`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "1b0734e11842"
+down_revision = "c1bd21cac4e9"
+branch_labels = None
+depends_on = None
+
+
+fk_name = "finance_event_collectiveBookingId_fkey"
+
+
+def upgrade() -> None:
+    op.create_foreign_key(fk_name, "finance_event", "collective_booking", ["collectiveBookingId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(fk_name, "finance_event", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20230705T084850_9e189b7f3fb1_add_fk_on_finance_event_venue_id.py
+++ b/api/src/pcapi/alembic/versions/20230705T084850_9e189b7f3fb1_add_fk_on_finance_event_venue_id.py
@@ -1,0 +1,22 @@
+"""Add foreign key on `finance_event.venueId`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9e189b7f3fb1"
+down_revision = "1b0734e11842"
+branch_labels = None
+depends_on = None
+
+
+fk_name = "finance_event_venueId_fkey"
+
+
+def upgrade() -> None:
+    op.create_foreign_key(fk_name, "finance_event", "venue", ["venueId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(fk_name, "finance_event", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20230705T084951_eb8f028d2a9c_add_fk_on_finance_event_pricing_point_id.py
+++ b/api/src/pcapi/alembic/versions/20230705T084951_eb8f028d2a9c_add_fk_on_finance_event_pricing_point_id.py
@@ -1,0 +1,22 @@
+"""Add foreign key on `finance_event.pricingPointId`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "eb8f028d2a9c"
+down_revision = "9e189b7f3fb1"
+branch_labels = None
+depends_on = None
+
+
+fk_name = "finance_event_pricingPointId_fkey"
+
+
+def upgrade() -> None:
+    op.create_foreign_key(fk_name, "finance_event", "venue", ["pricingPointId"], ["id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint(fk_name, "finance_event", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20230706T123053_097c6d306952_add_index_on_pricing_event_id.py
+++ b/api/src/pcapi/alembic/versions/20230706T123053_097c6d306952_add_index_on_pricing_event_id.py
@@ -1,0 +1,31 @@
+"""Add index on `pricing.eventId`
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "097c6d306952"
+down_revision = "eb8f028d2a9c"
+branch_labels = None
+depends_on = None
+
+
+table = "pricing"
+column = "eventId"
+index = "ix_pricing_eventId"
+
+
+def upgrade() -> None:
+    # We need to commit the transaction, because `create index
+    # concurrently` cannot run inside a transaction.
+    op.execute("commit")
+    op.execute("set session statement_timeout = '300s'")
+    op.execute(f'create index concurrently if not exists "{index}" ON {table} ("{column}")')
+
+
+def downgrade() -> None:
+    # We need to commit the transaction, because `drop index
+    # concurrently` cannot run inside a transaction.
+    op.execute("commit")
+    op.execute(f'drop index concurrently if exists "{index}"')

--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -29,6 +29,14 @@ def price_bookings() -> None:
     finance_api.price_bookings()
 
 
+@blueprint.cli.command("price_finance_events")
+@cron_decorators.log_cron_with_transaction
+@cron_decorators.cron_require_feature(FeatureToggle.PRICE_FINANCE_EVENTS)
+def price_finance_events() -> None:
+    """Price finance events that have recently been created."""
+    finance_api.price_events()
+
+
 @blueprint.cli.command("generate_cashflows_and_payment_files")
 @click.option("--override-feature-flag", help="Override feature flag", is_flag=True, default=False)
 @cron_decorators.log_cron_with_transaction

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -87,6 +87,7 @@ class FeatureToggle(enum.Enum):
         "Inclure les anciens modèles de données pour le téléchargement des remboursements "
     )
     PRICE_BOOKINGS = "Active la valorisation des réservations"
+    PRICE_FINANCE_EVENTS = "Active la valorisation des événements de finance"
     PRO_DISABLE_EVENTS_QRCODE = "Active la possibilité de différencier le type d’envoi des billets sur une offre et le retrait du QR code sur la réservation"
     SYNCHRONIZE_ALLOCINE = "Permettre la synchronisation journalière avec Allociné"
     SYNCHRONIZE_TITELIVE_PRODUCTS = "Permettre limport journalier du référentiel des livres"
@@ -176,6 +177,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.ENABLE_ZENDESK_SELL_CREATION,
     FeatureToggle.ENABLE_EMS_INTEGRATION,
     FeatureToggle.ENABLE_CGR_INTEGRATION,
+    FeatureToggle.PRICE_FINANCE_EVENTS,
     FeatureToggle.WIP_ADD_CLG_6_5_COLLECTIVE_OFFER,
     FeatureToggle.WIP_ENABLE_LIKE_IN_ADAGE,
     FeatureToggle.WIP_ENABLE_NEW_ONBOARDING,

--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -41,6 +41,7 @@ def clean_all_database(*args, **kwargs):  # type: ignore [no-untyped-def]
     finance_models.Pricing.query.delete()
     finance_models.InvoiceLine.query.delete()
     finance_models.Invoice.query.delete()
+    finance_models.FinanceEvent.query.delete()
     finance_models.CustomReimbursementRule.query.delete()
     educational_models.CollectiveOfferDomain.query.delete()
     educational_models.CollectiveOfferTemplateDomain.query.delete()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -6,6 +6,7 @@ from itertools import cycle
 
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
+import pcapi.core.finance.factories as finance_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
@@ -336,7 +337,7 @@ def create_booking_base_list(
             )
     if used_booking:
         for _i in range(5):
-            educational_factories.CollectiveBookingFactory(
+            booking = educational_factories.CollectiveBookingFactory(
                 collectiveStock__collectiveOffer__name=f"USED offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
@@ -351,6 +352,7 @@ def create_booking_base_list(
                 confirmationLimitDate=datetime.utcnow() - timedelta(days=3),
                 dateCreated=datetime.utcnow() - timedelta(days=30),
             )
+            finance_factories.UsedBookingFinanceEventFactory(collectiveBooking=booking)
     if reimbursed_booking:
         for _i in range(5):
             educational_factories.CollectiveBookingFactory(

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 def create_industrial_invoices() -> None:
     logger.info("create_industrial_invoices")
 
-    finance_api.price_bookings()
+    finance_api.price_events()
 
     finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
     cashflows_created = finance_models.Cashflow.query.count()
@@ -93,11 +93,15 @@ def create_specific_invoice() -> None:
             user__deposit__source="create_specific_invoice() in industrial sandbox",
         )
         bookings.append(booking)
+    for booking in bookings:
+        finance_factories.UsedBookingFinanceEventFactory(booking=booking)
     for booking in bookings[:3]:
-        finance_api.price_booking(booking)
+        event = finance_models.FinanceEvent.query.filter_by(booking=booking).one()
+        finance_api.price_event(event)
     finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
     for booking in bookings[3:]:
-        finance_api.price_booking(booking)
+        event = finance_models.FinanceEvent.query.filter_by(booking=booking).one()
+        finance_api.price_event(event)
     finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
     cashflows = finance_models.Cashflow.query.filter_by(reimbursementPoint=venue).all()
     cashflow_ids = [c.id for c in cashflows]

--- a/api/tests/core/finance/test_integration.py
+++ b/api/tests/core/finance/test_integration.py
@@ -1,27 +1,45 @@
 import datetime
 
+import freezegun
 import pytest
 
 import pcapi.core.bookings.api as bookings_api
 import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.bookings.models as bookings_models
 from pcapi.core.finance import api
 from pcapi.core.finance import factories
 from pcapi.core.finance import models
 import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
 from pcapi.models import db
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-def test_integration(css_font_http_request_mock):
+def test_integration_full_workflow(css_font_http_request_mock):
+    # A booking is manually marked as used. Check the whole workflow
+    # until the invoice is generated.
+    initial_dt = datetime.datetime.utcnow()
     venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
     factories.BankInformationFactory(venue=venue)
     booking = bookings_factories.BookingFactory(stock__offer__venue=venue)
 
-    bookings_api.mark_as_used(booking)
-    pricing = api.price_booking(booking)
-    assert pricing.status == models.PricingStatus.VALIDATED
+    with freezegun.freeze_time(initial_dt) as frozen_time:
+        bookings_api.mark_as_used(booking)
+        assert booking.status == bookings_models.BookingStatus.USED
+        event = models.FinanceEvent.query.one()
+        assert event.booking == booking
+        assert event.status == models.FinanceEventStatus.READY
+
+        # `price_events()` ignores recently created events (< 1 minute).
+        frozen_time.move_to(initial_dt + datetime.timedelta(minutes=1))
+        api.price_events()
+        assert event.status == models.FinanceEventStatus.PRICED
+        pricing = models.Pricing.query.one()
+        assert pricing.event == event
+        assert pricing.booking == booking
+        assert pricing.status == models.PricingStatus.VALIDATED
 
     cutoff = datetime.datetime.utcnow()
     api.generate_cashflows_and_payment_files(cutoff)
@@ -36,3 +54,68 @@ def test_integration(css_font_http_request_mock):
     assert cashflow.status == models.CashflowStatus.ACCEPTED
     db.session.refresh(pricing)
     assert pricing.status == models.PricingStatus.INVOICED
+    assert booking.status == bookings_models.BookingStatus.REIMBURSED
+    assert booking.reimbursementDate is not None
+
+
+def test_integration_partial_auto_mark_as_used():
+    # A booking is manually marked as used. Check only until the
+    # generation of the pricing.
+    now = datetime.datetime.utcnow()
+    venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
+    factories.BankInformationFactory(venue=venue)
+    booking = bookings_factories.BookingFactory(
+        stock=offers_factories.EventStockFactory(
+            beginningDatetime=now,
+            offer__venue=venue,
+        ),
+    )
+
+    with freezegun.freeze_time(now) as frozen_time:
+        # `auto_mark_as_used_after_event()` ignores recently used
+        # bookings (< 48 hours).
+        now += datetime.timedelta(hours=48, seconds=1)
+        frozen_time.move_to(now)
+        bookings_api.auto_mark_as_used_after_event()
+        assert booking.status == bookings_models.BookingStatus.USED
+        event = models.FinanceEvent.query.one()
+        assert event.booking == booking
+        assert event.status == models.FinanceEventStatus.READY
+
+        # `price_events()` ignores recently created events (< 1 minute).
+        now += datetime.timedelta(minutes=1, seconds=1)
+        frozen_time.move_to(now)
+        api.price_events()
+        assert event.status == models.FinanceEventStatus.PRICED
+        pricing = models.Pricing.query.one()
+        assert pricing.event == event
+        assert pricing.booking == booking
+        assert pricing.status == models.PricingStatus.VALIDATED
+
+
+def test_integration_partial_used_then_cancelled():
+    # A booking is manually marked as used, then cancelled.
+    initial_dt = datetime.datetime.utcnow()
+    venue = offerers_factories.VenueFactory(pricing_point="self", reimbursement_point="self")
+    factories.BankInformationFactory(venue=venue)
+    booking = bookings_factories.BookingFactory(stock__offer__venue=venue)
+
+    with freezegun.freeze_time(initial_dt) as frozen_time:
+        # Mark as used and price.
+        now = initial_dt
+        bookings_api.mark_as_used(booking)
+        assert booking.status == bookings_models.BookingStatus.USED
+        # `price_events()` ignores recently created events (< 1 minute).
+        now += datetime.timedelta(minutes=1)
+        frozen_time.move_to(now)
+        api.price_events()
+        assert models.Pricing.query.count() == 1
+
+        # Now cancel the booking. We should not get a new pricing.
+        bookings_api.mark_as_cancelled(booking)
+
+        # `price_events()` ignores recently created events (< 1 minute).
+        now += datetime.timedelta(minutes=1)
+        frozen_time.move_to(now)
+        api.price_events()
+        assert models.Pricing.query.count() == 1  # still only one pricing

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1733,6 +1733,17 @@ class LinkVenueToPricingPointTest:
         assert new_link.pricingPoint == pricing_point
         assert new_link.timespan.upper is None
 
+    def test_populate_finance_event_pricing_point_id(self):
+        venue = offerers_factories.VenueWithoutSiretFactory()
+        booking = bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
+        pricing_point = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+        event = finance_factories.UsedBookingFinanceEventFactory(booking=booking)
+        assert event.pricingPointId is None
+
+        offerers_api.link_venue_to_pricing_point(venue, pricing_point.id)
+        assert event.pricingPoint == pricing_point
+        assert event.status == finance_models.FinanceEventStatus.READY
+
     def test_behaviour_if_pre_existing_link(self):
         venue = offerers_factories.VenueWithoutSiretFactory()
         pricing_point_1 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -540,12 +540,17 @@ class DeleteStockTest:
 
     def test_delete_stock_cancel_bookings_and_send_emails(self):
         offerer_email = "offerer@example.com"
-        stock = factories.EventStockFactory(offer__bookingEmail=offerer_email)
+        stock = factories.EventStockFactory(
+            offer__bookingEmail=offerer_email,
+            offer__venue__pricing_point="self",
+        )
         booking1 = bookings_factories.BookingFactory(stock=stock)
         booking2 = bookings_factories.CancelledBookingFactory(stock=stock)
         booking3 = bookings_factories.UsedBookingFactory(stock=stock)
-        booking4 = bookings_factories.UsedBookingFactory(stock=stock)
+        event4 = finance_factories.UsedBookingFinanceEventFactory(booking__stock=stock)
+        booking4 = event4.booking
         finance_factories.PricingFactory(
+            event=event4,
             booking=booking4,
             status=finance_models.PricingStatus.PROCESSED,
         )


### PR DESCRIPTION
J'ai essayé de résumer l'idée dans le message de commit et d'indiquer par des commentaires de pull request les endroits qui sont des copies (ou presque) de l'actuel code (et qui donc présente probablement peu d'intérêt à être relu dans les détails).

À part ça, faut un peu se lancer dedans.  :) Suggestion :

- lire les modifications dans `core.bookings.api`, qui amènent aux nouvelles fonctions `core.finance.api.add_event()` et `cancel_latest_event()` ;
- jeter un oeil aux modèles.

Reste à faire : 

- écrire des tests pour les nouvelles fonctions ;
- modifier les migrations pour créer les clés étrangères dans des migrations séparées (cf. commentaire `FIXME (before merge)`) ;
- compléter les tests d'intégration ;
- adapter la sandbox, probablement.

---

This commit introduces the notion of "finance event", which inserts
itself between a booking (and, in the future, anything that can be
priced) and a pricing. A finance event is thus created:

- when a booking is marked as used;
- when a used booking is cancelled or un-unused (back to "confirmed");
- when a booking has been reimbursed and then cancelled.

Once a finance event is created, it's ready to be priced by a new
`price_finance_events` cronjob. The rest of the finance workflow
(creation of cashflow from pricings, etc.), models and their statuses
do not change.

A `PRICE_FINANCE_EVENTS` feature flag is created to control the switch
from `price_bookings` cronjob to `price_finance_events`:

1. PRICE_BOOKINGS is enabled: `price_bookings` runs,
   `price_finance_events` does not run.

2. Populate the `finance_event` table, so that all pricings have a
   corresponding event.

3. Disable `PRICE_BOOKINGS`. From now on, no pricings will be directly
   created.

4. Finish populating the `finance_event` table (same as step 2, for
   pricings that have been created between step 2 and step 3).

5. Enable `PRICE_FINANCE_EVENTS`.