### PR TITLE
PC-22024 modale validation avec lien  et wording bouton

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/DeleteVenueProviderButton/DeleteVenueProviderButton.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/DeleteVenueProviderButton/DeleteVenueProviderButton.tsx
@@ -46,7 +46,7 @@ const DeleteVenueProviderButton = ({
         variant={ButtonVariant.TERNARY}
       >
         <TrashFilledIcon
-          title="Supprimer la synchronisation"
+          title="Continuer"
           className={style['provider-action-icon']}
         />
         Supprimer

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.jsx
@@ -68,7 +68,7 @@ const StocksProviderForm = ({
       {isConfirmDialogOpened && (
         <ConfirmDialog
           cancelText="Annuler"
-          confirmText="Supprimer la synchronisation"
+          confirmText="Continuer"
           onCancel={handleCloseConfirmDialog}
           onConfirm={handleFormSubmit}
           title="Certaines offres ne seront pas synchronisées"
@@ -85,7 +85,7 @@ const StocksProviderForm = ({
               isExternal: true,
               to: 'https://aide.passculture.app/hc/fr/articles/4411999024401--Acteurs-Culturels-Quels-sont-les-livres-%C3%A9ligibles-au-pass-Culture-',
             }}
-            variant="ternary"
+            variant="quaternary"
           >
             Notre FAQ vous décrira les règles précisément.
           </ButtonLink>

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.module.scss
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.module.scss
@@ -1,3 +1,4 @@
+@use "styles/variables/_colors.scss" as colors;
 @use "styles/mixins/_rem.scss" as rem;
 
 .stocks-provider-form {
@@ -5,6 +6,6 @@
 }
 
 .aide-stock-button {
-    margin-top: 2rem;
-    font-size: 12px;
+    margin-top: rem.torem(32px);
+    color: colors.$black; 
 }

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
@@ -120,7 +120,7 @@ describe('src | StocksProviderForm', () => {
       ).toBeInTheDocument()
 
       const confirmImportButton = screen.getByRole('button', {
-        name: 'Supprimer la synchronisation',
+        name: 'Continuer',
       })
       await userEvent.click(confirmImportButton)
 
@@ -158,7 +158,7 @@ describe('src | StocksProviderForm', () => {
       ).toBeInTheDocument()
 
       const confirmImportButton = screen.getByRole('button', {
-        name: 'Supprimer la synchronisation',
+        name: 'Continuer',
       })
       await userEvent.click(confirmImportButton)
 
@@ -189,7 +189,7 @@ describe('src | StocksProviderForm', () => {
       ).toBeInTheDocument()
 
       const confirmImportButton = screen.getByRole('button', {
-        name: 'Supprimer la synchronisation',
+        name: 'Continuer',
       })
       await userEvent.click(confirmImportButton)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22024

## But de la pull request

Manon Desbordes:  le bouton est devenu Supprimer la synchronisation. Remettre Continuer à la place.

Le lien est un bouton quaternary :

quaternary est à 12px et rouge

ternary est à 14px et noir

[15 h 24] Mais le design est à 12px et noir

## Informations supplémentaires

2 texte est en noir de rouge
<img width="968" alt="Capture d’écran 2023-05-17 à 16 27 39" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/7c106114-6b8b-4409-b195-1dddcc86a192">


## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : PC-22024-modale-validation-lien
  - PR : PC-22024 modale validation avec lien  et wording bouton
  - Commit(s) : PC-22024 modale validation bouton
