### PR TITLE
(PC-22147)[API] feat: bo: track blacklisted domain names

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/fraud.py
+++ b/api/src/pcapi/routes/backoffice_v3/fraud.py
@@ -186,11 +186,13 @@ def blacklist_domain_name() -> utils.BackofficeResponse:
 
 @fraud_blueprint.route("/blacklist-domain-name/remove/<string:domain>", methods=["POST"])
 def remove_blacklisted_domain_name(domain: str) -> utils.BackofficeResponse:
-    row = fraud_models.BlacklistedDomainName.query.filter_by(domain=domain).one_or_none()
+    query = fraud_models.BlacklistedDomainName.query.filter_by(domain=domain)
+
+    row = query.one_or_none()
     if not row:
         raise NotFound()
 
-    row.query.delete(synchronize_session=False)
+    query.delete(synchronize_session=False)
     action = history_api.log_action(
         action_type=history_models.ActionType.REMOVE_BLACKLISTED_DOMAIN_NAME,
         author=current_user,

--- a/api/src/pcapi/routes/backoffice_v3/templates/fraud/blacklist_domain_name_summary.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/fraud/blacklist_domain_name_summary.html
@@ -1,7 +1,7 @@
 {% extends "layouts/connected.html" %}
 {% block page %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Règles de conformité &gt; Noms de domaines > Résumé</h2>
+    <h2 class="fw-light"> Suspension de comptes jeunes &gt; Noms de domaines > Résumé</h2>
     <div class="my-4">
       {% if targeted_non_pro_accounts | length == 0 %}
         Aucune entrée ne correspond aux critères.

--- a/api/src/pcapi/routes/backoffice_v3/templates/fraud/domain_names.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/fraud/domain_names.html
@@ -7,7 +7,7 @@
 {% from "components/presentation/details/tabs.html" import build_details_tabs_content_wrapper %}
 {% extends "layouts/standard.html" %}
 {% block title %}
-  Règles de conformité
+  Suspension de comptes jeunes
 {% endblock title %}
 {% block main_content %}
   <div class="row row-cols-1 g-4 py-3">

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -127,7 +127,7 @@
                 <div class="nav nav-pills flex-column">
                   {% call menu_section("Fraude et conformité") %}
                     {{ menu_section_item("Règles de validation d'offres", "backoffice_v3_web.offer_validation_rules.list_rules") }}
-                    {{ menu_section_item("Règles de conformité", "backoffice_v3_web.fraud.list_blacklisted_domain_names") }}
+                    {{ menu_section_item("Suspension de comptes jeunes", "backoffice_v3_web.fraud.list_blacklisted_domain_names") }}
                   {% endcall %}
                 </div>
                 <hr />

--- a/api/tests/routes/backoffice_v3/fraud_test.py
+++ b/api/tests/routes/backoffice_v3/fraud_test.py
@@ -129,6 +129,8 @@ class RemoveBlacklistedDomainNameTest(PostEndpointHelper):
 
     def test_remove_blacklisted_domain(self, authenticated_client):
         domain = fraud_factories.BlacklistedDomainNameFactory().domain
+        other_domain = fraud_factories.BlacklistedDomainNameFactory().domain
+
         response = self.post_to_endpoint(authenticated_client, domain=domain)
 
         assert response.status_code == 302
@@ -138,6 +140,9 @@ class RemoveBlacklistedDomainNameTest(PostEndpointHelper):
 
         # domain is not blacklisted anymore
         assert fraud_models.BlacklistedDomainName.query.filter_by(domain=domain).first() is None
+
+        # other domain is still blacklisted
+        assert fraud_models.BlacklistedDomainName.query.filter_by(domain=other_domain).first() is not None
 
         # action has been logged
         action_type = history_models.ActionType.REMOVE_BLACKLISTED_DOMAIN_NAME


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22147

## But de la pull request

Un `.query` en trop et c'est le drame (une instruction supprimait toute la table au lieu de ne supprimer qu'une ligne de `blacklisted_domain_name`).

Au passage : renommer le titre de la page.