### PR TITLE
(PC-22218) Use birth_date property when fetching newly eligible users

### DIFF
--- a/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
+++ b/api/src/pcapi/admin/custom_views/beneficiary_user_view.py
@@ -129,7 +129,7 @@ def _update_underage_beneficiary_deposit_expiration_date(user: User) -> None:
     assert user.deposit and user.deposit.expirationDate  # helps mypy
 
     current_deposit_expiration_datetime = user.deposit.expirationDate
-    new_deposit_expiration_datetime = compute_underage_deposit_expiration_datetime(user.birth_date)
+    new_deposit_expiration_datetime = compute_underage_deposit_expiration_datetime(user.birth_date)  # type: ignore [arg-type]
 
     if current_deposit_expiration_datetime == new_deposit_expiration_datetime:
         return

--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -311,7 +311,7 @@ def get_user_attributes(user: users_models.User) -> models.UserAttributes:
     is_former_beneficiary = (user.has_beneficiary_role and not has_remaining_credit) or (
         user.has_underage_beneficiary_role and user.eligibility is None
     )
-    user_birth_date = datetime.combine(user.birth_date, datetime.min.time()) if user.birth_date else None
+    user_birth_date = datetime.combine(user.birth_date, datetime.min.time()) if user.birth_date else None  # type: ignore [arg-type]
 
     return models.UserAttributes(
         booking_categories=bookings_attributes.booking_categories,

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -42,11 +42,11 @@ def _get_age_at_first_registration(user: users_models.User, eligibility: users_m
     if not user.birth_date:
         return None
 
-    first_registration_date = get_first_registration_date(user, user.birth_date, eligibility)
+    first_registration_date = get_first_registration_date(user, user.birth_date, eligibility)  # type: ignore [arg-type]
     if not first_registration_date:
         return user.age
 
-    age_at_registration = users_utils.get_age_at_date(user.birth_date, first_registration_date)
+    age_at_registration = users_utils.get_age_at_date(user.birth_date, first_registration_date)  # type: ignore [arg-type]
     if (
         eligibility == users_models.EligibilityType.UNDERAGE
         and age_at_registration not in users_constants.ELIGIBILITY_UNDERAGE_RANGE
@@ -589,7 +589,7 @@ def _is_ubble_allowed_if_subscription_overflow(user: users_models.User) -> bool:
         return False
 
     future_age = users_utils.get_age_at_date(
-        user.birth_date,
+        user.birth_date,  # type: ignore [arg-type]
         datetime.datetime.utcnow() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore [arg-type]
     )
     eligibility_ranges = users_constants.ELIGIBILITY_UNDERAGE_RANGE + [users_constants.ELIGIBILITY_AGE_18]

--- a/api/src/pcapi/core/subscription/ubble/api.py
+++ b/api/src/pcapi/core/subscription/ubble/api.py
@@ -39,7 +39,7 @@ def update_ubble_workflow(fraud_check: fraud_models.BeneficiaryFraudCheck) -> No
     status = content.status
 
     if not settings.IS_PROD and ubble_fraud_api.does_match_ubble_test_email(fraud_check.user.email):
-        content.birth_date = fraud_check.user.birth_date
+        content.birth_date = fraud_check.user.birth_date  # type: ignore [assignment]
 
     fraud_check.resultContent = content
     pcapi_repository.repository.save(fraud_check)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -626,7 +626,7 @@ def _update_underage_beneficiary_deposit_expiration_date(user: users_models.User
         raise ValueError("Trying to update underage beneficiary deposit expiration date but user has no deposit")
 
     current_deposit_expiration_datetime = user.deposit.expirationDate
-    new_deposit_expiration_datetime = finance_api.compute_underage_deposit_expiration_datetime(user.birth_date)
+    new_deposit_expiration_datetime = finance_api.compute_underage_deposit_expiration_datetime(user.birth_date)  # type: ignore [arg-type]
 
     if current_deposit_expiration_datetime == new_deposit_expiration_datetime:
         return

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -347,9 +347,9 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
 
     @property
     def age(self) -> int | None:
-        return users_utils.get_age_from_birth_date(self.birth_date) if self.birth_date else None
+        return users_utils.get_age_from_birth_date(self.birth_date) if self.birth_date else None  # type: ignore [arg-type]
 
-    @property
+    @hybrid_property
     def birth_date(self) -> date | None:
         """
         Returns the birth date validated by an Identity Provider if it exists,
@@ -360,6 +360,16 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         if self.dateOfBirth:
             return self.dateOfBirth.date()
         return None
+
+    @birth_date.expression  # type: ignore [no-redef]
+    def birth_date(cls) -> date | None:  # pylint: disable=no-self-argument
+        return sa.case(
+            [
+                (cls.validatedBirthDate.is_not(None), cls.validatedBirthDate),
+                (cls.dateOfBirth.is_not(None), sa.cast(cls.dateOfBirth, sa.Date)),
+            ],
+            else_=None,
+        )
 
     @property
     def deposit(self) -> "Deposit | None":
@@ -395,7 +405,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
     def eligibility(self) -> EligibilityType | None:
         from pcapi.core.fraud import api as fraud_api
 
-        return fraud_api.decide_eligibility(self, self.birth_date, datetime.utcnow())
+        return fraud_api.decide_eligibility(self, self.birth_date, datetime.utcnow())  # type: ignore [arg-type]
 
     @hybrid_property
     def full_name(self) -> str:
@@ -437,7 +447,7 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
 
     @property
     def latest_birthday(self) -> date | None:
-        return _get_latest_birthday(self.birth_date)
+        return _get_latest_birthday(self.birth_date)  # type: ignore [arg-type]
 
     @property
     def wallet_balance(self):  # type: ignore [no-untyped-def]

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -110,10 +110,12 @@ def get_newly_eligible_age_18_users(since: date) -> list[models.User]:
             models.User.has_beneficiary_role == False,  # not already beneficiary
             models.User.has_admin_role == False,  # not an admin
             offerers_models.UserOfferer.userId.is_(None),  # not a pro
-            models.User.dateOfBirth > today - relativedelta(years=(constants.ELIGIBILITY_AGE_18 + 1)),  # less than 19yo
-            models.User.dateOfBirth <= today - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # more than or 18yo
-            models.User.dateOfBirth
-            > since - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # less than 18yo at since
+            # less than 19yo
+            models.User.birth_date > today - relativedelta(years=(constants.ELIGIBILITY_AGE_18 + 1)),  # type: ignore [operator]
+            # more than or 18yo
+            models.User.birth_date <= today - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # type: ignore [operator]
+            # less than 18yo at since
+            models.User.birth_date > since - relativedelta(years=constants.ELIGIBILITY_AGE_18),  # type: ignore [operator]
             models.User.dateCreated < today,
         )
         .all()

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -262,8 +262,8 @@ def _get_tunnel_type(user: users_models.User) -> TunnelType:
     if user.birth_date is None:
         return TunnelType.NOT_ELIGIBLE
 
-    age_at_creation = users_utils.get_age_at_date(user.birth_date, user.dateCreated)
-    age_now = users_utils.get_age_from_birth_date(user.birth_date)
+    age_at_creation = users_utils.get_age_at_date(user.birth_date, user.dateCreated)  # type: ignore [arg-type]
+    age_now = users_utils.get_age_from_birth_date(user.birth_date)  # type: ignore [arg-type]
 
     if age_now < users_constants.ELIGIBILITY_AGE_18:
         return TunnelType.UNDERAGE
@@ -854,7 +854,7 @@ def get_eligibility_history(user: users_models.User) -> dict[str, accounts.Eligi
     ]
     # Do not show information about eligibility types which are not possible depending on known user age
     if user.birth_date:
-        age_at_creation = users_utils.get_age_at_date(user.birth_date, user.dateCreated)
+        age_at_creation = users_utils.get_age_at_date(user.birth_date, user.dateCreated)  # type: ignore [arg-type]
         if age_at_creation <= users_constants.ELIGIBILITY_AGE_18:
             if age_at_creation == users_constants.ELIGIBILITY_AGE_18:
                 eligibility_types.append(users_models.EligibilityType.AGE18)
@@ -864,7 +864,7 @@ def get_eligibility_history(user: users_models.User) -> dict[str, accounts.Eligi
                     eligibility_types.insert(0, users_models.EligibilityType.UNDERAGE)
             else:
                 eligibility_types.append(users_models.EligibilityType.UNDERAGE)
-                age_now = users_utils.get_age_from_birth_date(user.birth_date)
+                age_now = users_utils.get_age_from_birth_date(user.birth_date)  # type: ignore [arg-type]
                 if age_now >= users_constants.ELIGIBILITY_AGE_18 or users_models.EligibilityType.AGE18 in [
                     fraud_check.eligibilityType for fraud_check in user.beneficiaryFraudChecks
                 ]:

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -170,7 +170,7 @@ class UserProfileResponse(BaseModel):
     @staticmethod
     def _show_eligible_card(user: users_models.User) -> bool:
         return (
-            relativedelta(user.dateCreated, user.birth_date).years < users_constants.ELIGIBILITY_AGE_18
+            relativedelta(user.dateCreated, user.birth_date).years < users_constants.ELIGIBILITY_AGE_18  # type: ignore [arg-type]
             and user.has_beneficiary_role is False
             and user.eligibility == users_models.EligibilityType.AGE18
         )
@@ -197,8 +197,8 @@ class UserProfileResponse(BaseModel):
         user.domains_credit = users_api.get_domains_credit(user)
         user.booked_offers = cls._get_booked_offers(user)
         user.isEligibleForBeneficiaryUpgrade = users_api.is_eligible_for_beneficiary_upgrade(user, user.eligibility)
-        user.eligibility_end_datetime = users_api.get_eligibility_end_datetime(user.birth_date)
-        user.eligibility_start_datetime = users_api.get_eligibility_start_datetime(user.birth_date)
+        user.eligibility_end_datetime = users_api.get_eligibility_end_datetime(user.birth_date)  # type: ignore [arg-type]
+        user.eligibility_start_datetime = users_api.get_eligibility_start_datetime(user.birth_date)  # type: ignore [arg-type]
         user.isBeneficiary = user.is_beneficiary
         user.subscriptionMessage = user_subscription_state.subscription_message
         user.status = user_subscription_state.young_status
@@ -209,7 +209,7 @@ class UserProfileResponse(BaseModel):
         serialized_user.needsToFillCulturalSurvey = (
             serialized_user.needsToFillCulturalSurvey and serialized_user.isBeneficiary and _is_cultural_survey_active()
         )
-        serialized_user.date_of_birth = user.birth_date
+        serialized_user.date_of_birth = user.birth_date  # type: ignore [assignment]
 
         return serialized_user
 

--- a/api/src/pcapi/routes/public/booking_token/v2/serialization.py
+++ b/api/src/pcapi/routes/public/booking_token/v2/serialization.py
@@ -64,7 +64,7 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
 
     extra_data = booking.stock.offer.extraData or {}
 
-    birth_date = isoformat(booking.user.birth_date) if booking.user.birth_date else None
+    birth_date = isoformat(booking.user.birth_date) if booking.user.birth_date else None  # type: ignore [arg-type]
     return GetBookingResponse(
         bookingId=humanize(booking.id),  # type: ignore [arg-type]
         dateOfBirth=birth_date,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22219

## But de la pull request

La fonction permettant de trouver les utilisateurs auxquels envoyer un email pour leur anniversaire de 18 ans se basait sur l'attribut `dateOfBirth` alors que la property `birth_date` doit lui être privilégié pour gérer le désaccord éventuel entre la date de naissance déclarée et celle fournie par l'identity provider.

## Implémentation

Changement des filtres sqlalchemy au profit d'un filtrage python ultérieur, permettant d'utiliser la property.

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
