### PR TITLE
(PC-21663)[API] fix: Dont save ip address in location column

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -8,7 +8,6 @@ import typing
 
 from dateutil.relativedelta import relativedelta
 from flask_jwt_extended import create_access_token
-from flask_limiter.util import get_remote_address
 from flask_sqlalchemy import BaseQuery
 import sqlalchemy as sa
 
@@ -1245,7 +1244,6 @@ def update_login_device_history(device_info: "account_serialization.TrustedDevic
         deviceId=device_info.device_id,
         os=device_info.os,
         source=device_info.source,
-        location=get_remote_address(),  # TODO(PC-21660): Save location instead of ip address
         user=user,
     )
     repository.save(login_device)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1321,7 +1321,7 @@ class UpdateLoginDeviceHistoryTest:
         assert login_device.deviceId == device_info.device_id
         assert login_device.source == "iPhone 13"
         assert login_device.os == "iOS"
-        assert login_device.location == "127.0.0.1"
+        assert login_device.location == None
 
     def test_can_access_login_device_history_from_user(self):
         user = users_factories.UserFactory(email="py@test.com")

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -168,7 +168,7 @@ def test_save_login_device_history_on_signin(client):
     assert login_device.deviceId == data["deviceInfo"]["deviceId"]
     assert login_device.source == "iPhone 13"
     assert login_device.os == "iOS"
-    assert login_device.location == "127.0.0.1"
+    assert login_device.location == None
 
 
 @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21663

## But de la pull request

Ne pas stocker l'adresse IP au lieu de la localisation pour éviter les cohérences

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
