### PR TITLE
(PC-22055)[PRO] fix: add target parent to track link in adage header

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -43,6 +43,7 @@ const AdageHeader = () => {
         <a
           href={REACT_APP_ADAGE_SUIVI_URL}
           className={styles['adage-header-item']}
+          target="_parent"
         >
           <CalendarCheckIcon className={styles['adage-header-item-icon']} />
           Suivi


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22055

## But de la pull request

Fix le lien de Suivi dans le nouveau header adage pour ouvrir le lien dans adage et non dans l'iframe 

## Screenshot 

![Capture d’écran 2023-05-17 à 14 44 05](https://github.com/pass-culture/pass-culture-main/assets/71768799/81eeadb2-55e5-410f-ae30-594421d440d5)
