### PR TITLE
(PC-21991)[API] script: to fill product.ean and offer.ean

### DIFF
--- a/api/src/pcapi/scripts/install.py
+++ b/api/src/pcapi/scripts/install.py
@@ -20,6 +20,7 @@ def install_commands(app: flask.Flask) -> None:
         "pcapi.scripts.clean_database",
         "pcapi.scripts.external_users.commands",
         "pcapi.scripts.full_index_offers",
+        "pcapi.scripts.offer.fill_product_and_offer_ean",
         "pcapi.scripts.full_index_collective_offers",
         "pcapi.scripts.install_data",
         "pcapi.scripts.offerer.commands",

--- a/api/src/pcapi/scripts/offer/fill_product_and_offer_ean.py
+++ b/api/src/pcapi/scripts/offer/fill_product_and_offer_ean.py
@@ -1,0 +1,84 @@
+# This script is temporary and will only be executed once.
+import datetime
+import logging
+import statistics
+import time
+
+import click
+import pytz
+
+from pcapi.models import db
+from pcapi.utils.blueprint import Blueprint
+
+
+BATCH_SIZE = 10_000
+REPORT_EVERY = 100_000
+
+logger = logging.getLogger(__name__)
+blueprint = Blueprint(__name__, __name__)
+
+
+def _get_eta(end: int, current: int, elapsed_per_batch: list[int]) -> str:
+    left_to_do = end - current
+    seconds_eta = left_to_do / BATCH_SIZE * statistics.mean(elapsed_per_batch)
+    eta = datetime.datetime.utcnow() + datetime.timedelta(seconds=seconds_eta)
+    eta = eta.astimezone(pytz.timezone("Europe/Paris"))
+    str_eta = eta.strftime("%d/%m/%Y %H:%M:%S")
+    return str_eta
+
+
+@blueprint.cli.command("fill_product_ean")
+@click.argument("start", type=int, required=True)
+@click.argument("end", type=int, required=True)
+def fill_product_ean(start: int, end: int) -> None:
+    if start > end:
+        raise ValueError('"start" must be less than "end"')
+
+    elapsed_per_batch = []
+    to_report = 0
+    for i in range(start, end, BATCH_SIZE):
+        start_time = time.perf_counter()
+        db.session.execute(
+            """
+            update product set "jsonData" = jsonb_set("jsonData", '{ean}', ("jsonData"->>'isbn')::jsonb)
+            where "jsonData"->>'isbn' != ''
+            and id between :start and :end
+            """,
+            params={"start": i, "end": i + BATCH_SIZE},
+        )
+        db.session.commit()
+        elapsed_per_batch.append(int(time.perf_counter() - start_time))
+        eta = _get_eta(end, start, elapsed_per_batch)
+        to_report += BATCH_SIZE
+        if to_report >= REPORT_EVERY:
+            to_report = 0
+            print(f"BATCH : id from {i} | eta = {eta}")
+
+
+@blueprint.cli.command("fill_offer_ean")
+@click.argument("start", type=int, required=True)
+@click.argument("end", type=int, required=True)
+def fill_offer_ean(start: int, end: int) -> None:
+    if start > end:
+        raise ValueError('"start" must be less than "end"')
+
+    elapsed_per_batch = []
+    to_report = 0
+    for i in range(start, end, BATCH_SIZE):
+        start_time = time.perf_counter()
+        db.session.execute(
+            """
+            update offer set "jsonData" = jsonb_set("jsonData", '{ean}', ("jsonData"->>'isbn')::jsonb)
+            where "jsonData"->>'isbn' != ''
+            and id between :start and :end
+            """,
+            params={"start": i, "end": i + BATCH_SIZE},
+        )
+        db.session.commit()
+        elapsed_per_batch.append(int(time.perf_counter() - start_time))
+        eta = _get_eta(end, start, elapsed_per_batch)
+
+        to_report += BATCH_SIZE
+        if to_report >= REPORT_EVERY:
+            to_report = 0
+            print(f"BATCH : id from {i} | eta = {eta}")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21991

[x] Write isbn in isbn and ean when creating a product or an offer
[] Duplicate isbn in ean (We are here !)
[] Delete isbn keys and values from all products / offers

Script to copy every isbn in ean. This information is stored in a json field inside Offer or Product table. 
--- Old performance ---
ETA : 
For 100 000 with batches of 1000 : 
db.session.bulk_update_mappings -> 155s
db.session.add(product) V1 -> 86s
db.session.add(product) V2 -> 87s

For 100 000 with batches of 10000 : 
db.session.bulk_update_mappings -> 146s
db.session.add(product) V1 -> 78.3s
db.session.add(product) V2 -> 78.9s

There is around 3 733 340 products and more than 79 448 037 offers. 
The script should take ~0.8h for products and ~17h for offers choosing 80s for 100 000 objects. 

I think i will use the db.session.add V2. 
I plan to have a single script to handle Product or Offer (with a param) and to be able to start from a specific id if it stops during execution.
--- Old performance ----

Thanks to some advices we were able to be more efficient . This version took 14s for 100 000 objects. 
It should take less than 10 min for products and 3h for offers
