### PR TITLE
(PC-22019)[API] feat: add batch validate/reject on collective and collective offer template

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
@@ -3,7 +3,7 @@
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% extends "layouts/connected.html" %}
 {% block page %}
-  <div class="pt-3 px-5">
+  <div class="pt-3 px-5 table-container-collective-offer-validation">
     <h2 class="fw-light">Offres collectives</h2>
     {{ build_filters_form(form, dst) }}
     <div>
@@ -13,10 +13,33 @@
             {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
+          <div class="btn-group btn-group-sm"
+               data-toggle="pc-batch-confirm-btn-group"
+               data-toggle-id="table-container-collective-offer-validation-btn-group"
+               data-pc-table-multi-select-id="table-container-collective-offer-validation"
+               data-input-ids-name="object_ids">
+            <button disabled
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-use-confirmation-modal="true"
+                    data-modal-selector="#batch-validate-modal">Valider</button>
+            <button disabled
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-use-confirmation-modal="true"
+                    data-modal-selector="#batch-reject-modal">Rejeter</button>
+          </div>
+          <div></div>
         </div>
-        <table class="table mb-4">
+        <table class="table mb-4"
+               data-table-multi-select-id="table-container-collective-offer-validation">
           <thead>
             <tr>
+              <th scope="col">
+                <input class="form-check-input"
+                       type="checkbox"
+                       name="pc-table-multi-select-check-all" />
+              </th>
               <th scope="col"></th>
               <th scope="col">ID</th>
               <th scope="col">Nom de l'offre</th>
@@ -44,6 +67,12 @@
           <tbody>
             {% for collective_offer in rows %}
               <tr>
+                <td>
+                  <input type="checkbox"
+                         class="form-check-input"
+                         name="pc-table-multi-select-check-{{ collective_offer.id }}"
+                         data-id="{{ collective_offer.id }}" />
+                </td>
                 <td>
                   {% if has_permission("FRAUD_ACTIONS") %}
                     <div class="dropdown">
@@ -86,6 +115,8 @@
           {{ build_lazy_modal(url_for('backoffice_v3_web.collective_offer.get_validate_collective_offer_form', collective_offer_id=collective_offer.id), "validate-collective-offer-modal-" + collective_offer.id|string) }}
           {{ build_lazy_modal(url_for('backoffice_v3_web.collective_offer.get_reject_collective_offer_form', collective_offer_id=collective_offer.id), "reject-collective-offer-modal-" + collective_offer.id|string) }}
         {% endfor %}
+        {{ build_lazy_modal(url_for("backoffice_v3_web.collective_offer.get_batch_reject_collective_offers_form"), "batch-reject-modal", "true") }}
+        {{ build_lazy_modal(url_for("backoffice_v3_web.collective_offer.get_batch_validate_collective_offers_form"), "batch-validate-modal", "true") }}
       {% endif %}
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
@@ -3,7 +3,7 @@
 {% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% extends "layouts/connected.html" %}
 {% block page %}
-  <div class="pt-3 px-5">
+  <div class="pt-3 px-5 table-container-collective-offer-template-validation">
     <h2 class="fw-light">Offres collectives vitrines</h2>
     {{ build_filters_form(form, dst) }}
     <div>
@@ -13,10 +13,33 @@
             {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
+          <div class="btn-group btn-group-sm"
+               data-toggle="pc-batch-confirm-btn-group"
+               data-toggle-id="table-container-collective-offer-template-validation-btn-group"
+               data-pc-table-multi-select-id="table-container-collective-offer-template-validation"
+               data-input-ids-name="object_ids">
+            <button disabled
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-use-confirmation-modal="true"
+                    data-modal-selector="#batch-validate-modal">Valider</button>
+            <button disabled
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-use-confirmation-modal="true"
+                    data-modal-selector="#batch-reject-modal">Rejeter</button>
+          </div>
+          <div></div>
         </div>
-        <table class="table mb-4">
+        <table class="table mb-4"
+               data-table-multi-select-id="table-container-collective-offer-template-validation">
           <thead>
             <tr>
+              <th scope="col">
+                <input class="form-check-input"
+                       type="checkbox"
+                       name="pc-table-multi-select-check-all" />
+              </th>
               <th scope="col"></th>
               <th scope="col">ID</th>
               <th scope="col">Nom de l'offre</th>
@@ -43,6 +66,12 @@
           <tbody>
             {% for collective_offer_template in rows %}
               <tr>
+                <td>
+                  <input type="checkbox"
+                         class="form-check-input"
+                         name="pc-table-multi-select-check-{{ collective_offer_template.id }}"
+                         data-id="{{ collective_offer_template.id }}" />
+                </td>
                 <td>
                   {% if has_permission("FRAUD_ACTIONS") %}
                     <div class="dropdown">
@@ -86,6 +115,8 @@
           {{ build_lazy_modal(url_for('backoffice_v3_web.collective_offer_template.get_validate_collective_offer_template_form', collective_offer_template_id=collective_offer_template.id), "validate-collective-offer-template-modal-" + collective_offer_template.id|string) }}
           {{ build_lazy_modal(url_for('backoffice_v3_web.collective_offer_template.get_reject_collective_offer_template_form', collective_offer_template_id=collective_offer_template.id), "reject-collective-offer-template-modal-" + collective_offer_template.id|string) }}
         {% endfor %}
+        {{ build_lazy_modal(url_for("backoffice_v3_web.collective_offer_template.get_batch_reject_collective_offer_templates_form"), "batch-reject-modal", "true") }}
+        {{ build_lazy_modal(url_for("backoffice_v3_web.collective_offer_template.get_batch_validate_collective_offer_templates_form"), "batch-validate-modal", "true") }}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22019

## But de la pull request

Ajout de la validation et rejet en masse pour les offres collectives et les offres collectives vitrine

## Implémentation

- Refacto du code existant pour permettre le traitement par lot
- Ajout d'un endpoint de validation et de rejet de traitement par lot pour les offres collectives
- Ajout d'un endpoint de validation et de rejet de traitement par lot pour les offres collectives vitrine
- Ajout d'un endpoint form modal pour la validation et rejet  de traitement par lot pour les offres
- Ajout d'un endpoint form modal pour la validation et rejet  de traitement par lot pour les offres collectives

## Informations supplémentaires

- On vérifie avant que les offres n'ont pas déjà le status sinon on annule
- Si une offre rencontre un problème pendant la validation, on remonte les ids avec traitement réussi et échoué à l'operateur pour l'avertir

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
