### PR TITLE
(PC-22260)[PRO] fix: sticky bar being under components at z-index 0

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.module.scss
@@ -4,6 +4,7 @@
 
 .actions-bar {
   position: fixed;
+  z-index: 1;
   left: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22260

Avant

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/0e53495b-7686-4541-a86a-ca8cfb1e777d)

Après

![image](https://github.com/pass-culture/pass-culture-main/assets/6317823/a5b4cd3c-7474-46d5-9591-c23ee87883ae)
