### PR TITLE
(PC-20384)[PRO] refactor: phone number input

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/__specs__/CollectiveDataEdition.spec.tsx
@@ -160,7 +160,7 @@ describe('CollectiveDataEdition', () => {
       )
       const studentsField = screen.getByLabelText(/Public cible/)
       const websiteField = screen.getByLabelText(/URL de votre site web/)
-      const phoneField = screen.getByLabelText(/Téléphone/)
+      const phoneField = screen.getByLabelText(/Numéro de téléphone/)
       const emailField = screen.getByLabelText(/E-mail/)
       const domainsField = screen.getByLabelText(
         /Domaine artistique et culturel/
@@ -206,7 +206,7 @@ describe('CollectiveDataEdition', () => {
 
       await waitForLoader()
 
-      const phoneField = screen.getByLabelText(/Téléphone/)
+      const phoneField = screen.getByLabelText(/Numéro de téléphone/)
       await userEvent.type(phoneField, '0612345678')
       await userEvent.click(screen.getByText('Retour page lieu'))
 
@@ -227,7 +227,7 @@ describe('CollectiveDataEdition', () => {
       await waitForLoader()
 
       const websiteField = screen.getByLabelText(/URL de votre site web/)
-      const phoneField = screen.getByLabelText(/Téléphone/)
+      const phoneField = screen.getByLabelText(/Numéro de téléphone/)
       const emailField = screen.getByLabelText(/E-mail/)
       const title = screen.getByText('Présentation pour les enseignants')
 
@@ -256,7 +256,7 @@ describe('CollectiveDataEdition', () => {
       await waitForLoader()
 
       const websiteField = screen.getByLabelText(/URL de votre site web/)
-      const phoneField = screen.getByLabelText(/Téléphone/)
+      const phoneField = screen.getByLabelText(/Numéro de téléphone/)
       const emailField = screen.getByLabelText(/E-mail/)
       const title = screen.getByText('Présentation pour les enseignants')
 
@@ -287,7 +287,7 @@ describe('CollectiveDataEdition', () => {
       await waitForLoader()
 
       const websiteField = screen.getByLabelText(/URL de votre site web/)
-      const phoneField = screen.getByLabelText(/Téléphone/)
+      const phoneField = screen.getByLabelText(/Numéro de téléphone/)
       const emailField = screen.getByLabelText(/E-mail/)
       const title = screen.getByText('Présentation pour les enseignants')
 

--- a/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
+++ b/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
@@ -154,11 +154,7 @@ describe('Signup', () => {
         })
       ).toBeInTheDocument()
       // and a telephone field
-      expect(
-        screen.getByRole('textbox', {
-          name: /Téléphone/,
-        })
-      ).toBeInTheDocument()
+      expect(screen.getByLabelText('Numéro de téléphone')).toBeInTheDocument()
       // and a SIREN field
       expect(
         screen.getByRole('textbox', {
@@ -190,9 +186,7 @@ describe('Signup', () => {
             'test@example.com'
           )
           await userEvent.type(
-            screen.getByRole('textbox', {
-              name: /Téléphone/,
-            }),
+            screen.getByLabelText('Numéro de téléphone'),
             '1234'
           )
           // We simulate onBlur to have email field touched
@@ -287,10 +281,7 @@ describe('Signup', () => {
           'Prénom'
         )
         await userEvent.type(
-          screen.getByRole('textbox', {
-            name: /Téléphone/,
-          }),
-
+          screen.getByLabelText('Numéro de téléphone'),
           '+33722332233'
         )
         expect(submitButton).toBeEnabled()
@@ -362,9 +353,7 @@ describe('Signup', () => {
         await userEvent.type(screen.getByLabelText('Prénom'), 'Prénom')
 
         await userEvent.type(
-          screen.getByLabelText(
-            'Téléphone (utilisé uniquement par l’équipe du pass Culture)'
-          ),
+          screen.getByLabelText('Numéro de téléphone'),
           '0722332200'
         )
         await userEvent.type(
@@ -383,9 +372,7 @@ describe('Signup', () => {
           )
         ).toBeInTheDocument()
 
-        const phoneInput = screen.getByLabelText(
-          'Téléphone (utilisé uniquement par l’équipe du pass Culture)'
-        )
+        const phoneInput = screen.getByLabelText('Numéro de téléphone')
         await userEvent.clear(phoneInput)
         await userEvent.type(phoneInput, '0622332233')
         await userEvent.tab()
@@ -463,10 +450,7 @@ describe('Signup', () => {
           'Prénom'
         )
         await userEvent.type(
-          screen.getByRole('textbox', {
-            name: /Téléphone/,
-          }),
-
+          screen.getByLabelText('Numéro de téléphone'),
           '+33722332233'
         )
         expect(submitButton).toBeEnabled()

--- a/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.tsx
@@ -31,10 +31,10 @@ const CountryCodeSelect = ({
       />
       <select
         className={styles['select-input']}
+        id="countryCode"
         disabled={disabled}
         value={value}
         onChange={onChange}
-        aria-label="Sélectionner un indicatif téléphonique"
       >
         {options.map(option => (
           <option key={option.value} value={option.value} label={option.label}>

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -5,6 +5,7 @@
 @use "styles/variables/_forms.scss" as forms;
 @use "styles/mixins/_forms.scss" as formsM;
 @use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_a11y.scss" as a11y;
 
 $input-phone-number-padding-left: calc(
   countryCodeSelect.$input-width + rem.torem(8px) + countryCodeSelect.$focus-border-width
@@ -16,6 +17,7 @@ $input-phone-number-padding-left: calc(
 
   &-input {
     padding-left: calc($input-phone-number-padding-left + rem.torem(1px));
+    
     &:focus {
       padding-left: $input-phone-number-padding-left;
     }
@@ -52,8 +54,8 @@ $input-phone-number-padding-left: calc(
   }
 }
 
-.label-hidden {
-  display: none;
+.label-visually-hidden {
+  @include a11y.visually-hidden;
 }
 
 .country-code-select {

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -1,25 +1,63 @@
+@use "styles/variables/_colors.scss" as colors;
 @use "./CodeCountrySelect/CountryCodeSelect.module.scss" as
   countryCodeSelect;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_forms.scss" as forms;
+@use "styles/mixins/_forms.scss" as formsM;
+@use "styles/mixins/_fonts.scss" as fonts;
 
 $input-phone-number-padding-left: calc(
   countryCodeSelect.$input-width + rem.torem(8px) + countryCodeSelect.$focus-border-width
 );
 
-.phone-number-input-wrapper {
-  position: relative;
+.phone-number {
+  width: 100%;
+  margin-bottom: rem.torem(8px);
+
+  &-input {
+    padding-left: calc($input-phone-number-padding-left + rem.torem(1px));
+    &:focus {
+      padding-left: $input-phone-number-padding-left;
+    }
+
+    &-wrapper {
+      position: relative;
+      margin-bottom: rem.torem(8px);
+    }
+
+    &-legend {
+      margin-bottom: rem.torem(forms.$label-space-before-input);
+      display: flex;
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    &-optional {
+      @include fonts.small-caption;
+    
+      color: colors.$grey-dark;
+    }
+
+    &-footer {
+      @include formsM.field-layout-footer;
+    }
+  
+    &-error {
+      flex: 1;
+  
+      svg {
+        flex: 0 0 15px;
+      }
+    }
+  }
+}
+
+.label-hidden {
+  display: none;
 }
 
 .country-code-select {
   position: absolute;
   top: 0;
   left: -1px;
-}
-
-.phone-number-input {
-  padding-left: calc($input-phone-number-padding-left + rem.torem(1px));
-}
-
-.phone-number-input:focus {
-  padding-left: $input-phone-number-padding-left;
 }

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
@@ -28,12 +28,13 @@ const PhoneNumberInput = ({
   )
   const [phoneInputValue, setPhoneInputValue] = useState<string>('')
 
-  const validatePhoneNumber = (
-    phoneNumberInputValue: string
-  ): string | undefined => {
+  const validateAndSetPhoneNumber = (
+    phoneNumberInputValue: string,
+    currentCountryCode: CountryCode
+  ): string => {
     const phoneNumber = parsePhoneNumberFromString(
       phoneNumberInputValue,
-      countryCode
+      currentCountryCode
     )
 
     // save formatted phone number i.e +33639980101 even if user types 0639980101 or 639980101
@@ -57,18 +58,19 @@ const PhoneNumberInput = ({
     }
 
     helpers.setError(undefined)
-    return phoneNumber?.nationalNumber
+    return phoneNumber.nationalNumber
   }
 
   const onPhoneNumberChange = (event: ChangeEvent<HTMLInputElement>) => {
     const phoneNumberInputValue = event.target.value
-    validatePhoneNumber(phoneNumberInputValue)
+    validateAndSetPhoneNumber(phoneNumberInputValue, countryCode)
   }
 
   const onPhoneCodeChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    setCountryCode(e.target.value as CountryCode)
+    const changedCountryCode = e.target.value as CountryCode
+    setCountryCode(changedCountryCode)
     if (phoneInputValue) {
-      validatePhoneNumber(phoneInputValue)
+      validateAndSetPhoneNumber(phoneInputValue, changedCountryCode)
     }
   }
 
@@ -77,7 +79,10 @@ const PhoneNumberInput = ({
       helpers.setTouched(true, false)
     }
 
-    const phoneNumberInputValue = validatePhoneNumber(event.target.value) ?? ''
+    const phoneNumberInputValue = validateAndSetPhoneNumber(
+      event.target.value,
+      countryCode
+    )
     setPhoneInputValue(phoneNumberInputValue)
   }
 
@@ -102,7 +107,7 @@ const PhoneNumberInput = ({
           </span>
         )}
       </legend>
-      <label htmlFor="countryCode" className={styles['label-hidden']}>
+      <label htmlFor="countryCode" className={styles['label-visually-hidden']}>
         Indicatif téléphonique
       </label>
       <CodeCountrySelect
@@ -113,7 +118,7 @@ const PhoneNumberInput = ({
         onChange={onPhoneCodeChange}
       />
 
-      <label htmlFor={name} className={styles['label-hidden']}>
+      <label htmlFor={name} className={styles['label-visually-hidden']}>
         Numéro de téléphone
       </label>
       <BaseInput

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
@@ -3,7 +3,7 @@ import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import type { CountryCode } from 'libphonenumber-js'
 import React, { ChangeEvent, FocusEvent, useEffect, useState } from 'react'
 
-import { BaseInput, FieldLayout } from '../shared'
+import { BaseInput, FieldError } from '../shared'
 import { FieldLayoutBaseProps } from '../shared/FieldLayout/FieldLayout'
 
 import CodeCountrySelect from './CodeCountrySelect/CountryCodeSelect'
@@ -26,7 +26,7 @@ const PhoneNumberInput = ({
   const [countryCode, setCountryCode] = useState<CountryCode>(
     PHONE_CODE_COUNTRY_CODE_OPTIONS[0].value
   )
-  const [phoneInutValue, setPhoneInputValue] = useState<string>('')
+  const [phoneInputValue, setPhoneInputValue] = useState<string>('')
 
   const validatePhoneNumber = (
     phoneNumberInputValue: string
@@ -37,10 +37,14 @@ const PhoneNumberInput = ({
     )
 
     // save formatted phone number i.e +33639980101 even if user types 0639980101 or 639980101
-    helpers.setValue(phoneNumber?.number, false)
+    if (phoneNumber) {
+      helpers.setValue(phoneNumber?.number, false)
+    }
+
     setPhoneInputValue(phoneNumberInputValue)
 
     if (isOptional && phoneNumberInputValue === '') {
+      helpers.setValue('')
       helpers.setError(undefined)
       return phoneNumberInputValue
     }
@@ -63,8 +67,8 @@ const PhoneNumberInput = ({
 
   const onPhoneCodeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     setCountryCode(e.target.value as CountryCode)
-    if (phoneInutValue) {
-      validatePhoneNumber(phoneInutValue)
+    if (phoneInputValue) {
+      validatePhoneNumber(phoneInputValue)
     }
   }
 
@@ -89,35 +93,48 @@ const PhoneNumberInput = ({
   }, [field.value])
 
   return (
-    <FieldLayout
-      label={label}
-      name={name}
-      isOptional={isOptional}
-      showError={meta.touched && !!meta.error}
-      error={meta.error}
-    >
-      <div className={styles['phone-number-input-wrapper']}>
-        <CodeCountrySelect
-          disabled={Boolean(disabled)}
-          options={PHONE_CODE_COUNTRY_CODE_OPTIONS}
-          className={styles['country-code-select']}
-          value={countryCode}
-          onChange={onPhoneCodeChange}
-        />
+    <fieldset className={styles['phone-number-input-wrapper']}>
+      <legend className={styles['phone-number-input-legend']}>
+        {label}
+        {isOptional && (
+          <span className={styles['phone-number-input-optional']}>
+            Optionnel
+          </span>
+        )}
+      </legend>
+      <label htmlFor="countryCode" className={styles['label-hidden']}>
+        Indicatif téléphonique
+      </label>
+      <CodeCountrySelect
+        disabled={Boolean(disabled)}
+        options={PHONE_CODE_COUNTRY_CODE_OPTIONS}
+        className={styles['country-code-select']}
+        value={countryCode}
+        onChange={onPhoneCodeChange}
+      />
 
-        <BaseInput
-          disabled={disabled}
-          hasError={meta.touched && !!meta.error}
-          placeholder={PLACEHOLDER_MAP[countryCode]}
-          type="text"
-          name={name}
-          value={phoneInutValue}
-          onChange={onPhoneNumberChange}
-          className={styles['phone-number-input']}
-          onBlur={onPhoneNumberBlur}
-        />
+      <label htmlFor={name} className={styles['label-hidden']}>
+        Numéro de téléphone
+      </label>
+      <BaseInput
+        disabled={disabled}
+        hasError={meta.touched && !!meta.error}
+        placeholder={PLACEHOLDER_MAP[countryCode]}
+        type="text"
+        name={name}
+        value={phoneInputValue}
+        onChange={onPhoneNumberChange}
+        className={styles['phone-number-input']}
+        onBlur={onPhoneNumberBlur}
+      />
+      <div className={styles['phone-number-input-footer']}>
+        {meta.error && (
+          <div className={styles['phone-number-input-error']}>
+            <FieldError name={name}>{meta.error}</FieldError>
+          </div>
+        )}
       </div>
-    </FieldLayout>
+    </fieldset>
   )
 }
 

--- a/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
@@ -41,9 +41,7 @@ describe('PhoneNumberInput', () => {
 
     it('should change placeholder when user change country code', async () => {
       renderPhoneNumberInput()
-      const countryCodeSelect = screen.getByLabelText(
-        'Sélectionner un indicatif téléphonique'
-      )
+      const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
 
       await userEvent.selectOptions(countryCodeSelect, '+590')
 
@@ -65,7 +63,7 @@ describe('PhoneNumberInput', () => {
 
     it('should show an error if user touched input and did not enter any phone number', async () => {
       renderPhoneNumberInput()
-      const input = screen.getByLabelText('Téléphone')
+      const input = screen.getByText('Numéro de téléphone')
 
       await userEvent.click(input)
       await userEvent.tab()
@@ -77,12 +75,10 @@ describe('PhoneNumberInput', () => {
 
     it('should call phone validation with country code', async () => {
       renderPhoneNumberInput()
-      const countryCodeSelect = screen.getByLabelText(
-        'Sélectionner un indicatif téléphonique'
-      )
+      const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
       await userEvent.selectOptions(countryCodeSelect, '+590')
 
-      const input = screen.getByLabelText('Téléphone')
+      const input = screen.getByLabelText('Numéro de téléphone')
 
       await userEvent.type(input, '123')
       await userEvent.tab()
@@ -91,20 +87,6 @@ describe('PhoneNumberInput', () => {
       expect(
         screen.queryByText('Veuillez entrer un numéro de téléphone valide')
       ).toBeInTheDocument()
-    })
-  })
-
-  describe('label', () => {
-    it('default label', () => {
-      renderPhoneNumberInput()
-
-      expect(screen.getByLabelText('Téléphone')).toBeInTheDocument()
-    })
-
-    it('it should have a custom label when set', async () => {
-      renderPhoneNumberInput('Custom Label')
-      expect(screen.getByLabelText('Custom Label')).toBeInTheDocument()
-      expect(screen.queryByLabelText('Téléphone')).not.toBeInTheDocument()
     })
   })
 })

--- a/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
@@ -23,70 +23,68 @@ const renderPhoneNumberInput = (label = 'Téléphone') => {
 }
 
 describe('PhoneNumberInput', () => {
-  describe('placeholder', () => {
-    it('default placeholder', () => {
-      renderPhoneNumberInput()
+  it('should show default placeholder', () => {
+    renderPhoneNumberInput()
 
-      const defaultCountryCodeOption = PHONE_CODE_COUNTRY_CODE_OPTIONS[0]
-      const defaultPlaceholder = PLACEHOLDER_MAP[defaultCountryCodeOption.value]
+    const defaultCountryCodeOption = PHONE_CODE_COUNTRY_CODE_OPTIONS[0]
+    const defaultPlaceholder = PLACEHOLDER_MAP[defaultCountryCodeOption.value]
 
-      expect(
-        screen.getByText(defaultCountryCodeOption.label)
-      ).toBeInTheDocument()
-      expect(defaultPlaceholder).toBeDefined()
-      expect(
-        screen.getByPlaceholderText(defaultPlaceholder as string)
-      ).toBeInTheDocument()
-    })
-
-    it('should change placeholder when user change country code', async () => {
-      renderPhoneNumberInput()
-      const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
-
-      await userEvent.selectOptions(countryCodeSelect, '+590')
-
-      const guadeloupePlaceholder = PLACEHOLDER_MAP['GP']
-      expect(guadeloupePlaceholder).toBeDefined()
-      expect(
-        screen.getByPlaceholderText(guadeloupePlaceholder as string)
-      ).toBeInTheDocument()
-    })
+    expect(screen.getByText(defaultCountryCodeOption.label)).toBeInTheDocument()
+    expect(defaultPlaceholder).toBeDefined()
+    expect(
+      screen.getByPlaceholderText(defaultPlaceholder as string)
+    ).toBeInTheDocument()
   })
 
-  describe('validation', () => {
-    it('should not show an error if input has not been touched', () => {
-      renderPhoneNumberInput()
-      expect(
-        screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-      ).not.toBeInTheDocument()
-    })
+  it('should change placeholder when user change country code', async () => {
+    renderPhoneNumberInput()
+    const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
 
-    it('should show an error if user touched input and did not enter any phone number', async () => {
-      renderPhoneNumberInput()
-      const input = screen.getByText('Numéro de téléphone')
+    await userEvent.selectOptions(countryCodeSelect, '+590')
 
-      await userEvent.click(input)
-      await userEvent.tab()
+    const guadeloupePlaceholder = PLACEHOLDER_MAP['GP']
+    expect(guadeloupePlaceholder).toBeDefined()
+    expect(
+      screen.getByPlaceholderText(guadeloupePlaceholder as string)
+    ).toBeInTheDocument()
+  })
 
-      expect(
-        screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-      ).toBeInTheDocument()
-    })
+  it('should not show an error if input has not been touched', () => {
+    renderPhoneNumberInput()
+    expect(
+      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+    ).not.toBeInTheDocument()
+  })
 
-    it('should call phone validation with country code', async () => {
-      renderPhoneNumberInput()
-      const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
-      await userEvent.selectOptions(countryCodeSelect, '+590')
+  it('should show an error if user touched input and did not enter any phone number', async () => {
+    renderPhoneNumberInput()
+    const input = screen.getByText('Numéro de téléphone')
 
-      const input = screen.getByLabelText('Numéro de téléphone')
+    await userEvent.click(input)
+    await userEvent.tab()
 
-      await userEvent.type(input, '123')
-      await userEvent.tab()
+    expect(
+      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+    ).toBeInTheDocument()
+  })
 
-      expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'GP')
-      expect(
-        screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-      ).toBeInTheDocument()
-    })
+  it('should call phone validation with country code', async () => {
+    renderPhoneNumberInput()
+    const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
+    await userEvent.selectOptions(countryCodeSelect, '+590')
+
+    const input = screen.getByLabelText('Numéro de téléphone')
+
+    await userEvent.type(input, '123')
+    await userEvent.tab()
+
+    expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'GP')
+    expect(
+      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+    ).toBeInTheDocument()
+
+    await userEvent.selectOptions(countryCodeSelect, '+33')
+
+    expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'FR')
   })
 })

--- a/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
@@ -48,43 +48,56 @@ describe('PhoneNumberInput', () => {
       screen.getByPlaceholderText(guadeloupePlaceholder as string)
     ).toBeInTheDocument()
   })
+})
 
-  it('should not show an error if input has not been touched', () => {
-    renderPhoneNumberInput()
-    expect(
-      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-    ).not.toBeInTheDocument()
-  })
+it('should change placeholder when user change country code', async () => {
+  renderPhoneNumberInput()
+  const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
 
-  it('should show an error if user touched input and did not enter any phone number', async () => {
-    renderPhoneNumberInput()
-    const input = screen.getByText('Numéro de téléphone')
+  await userEvent.selectOptions(countryCodeSelect, '+590')
 
-    await userEvent.click(input)
-    await userEvent.tab()
+  const guadeloupePlaceholder = PLACEHOLDER_MAP['GP']
+  expect(guadeloupePlaceholder).toBeDefined()
+  expect(
+    screen.getByPlaceholderText(guadeloupePlaceholder as string)
+  ).toBeInTheDocument()
+})
 
-    expect(
-      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-    ).toBeInTheDocument()
-  })
+it('should not show an error if input has not been touched', () => {
+  renderPhoneNumberInput()
+  expect(
+    screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+  ).not.toBeInTheDocument()
+})
 
-  it('should call phone validation with country code', async () => {
-    renderPhoneNumberInput()
-    const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
-    await userEvent.selectOptions(countryCodeSelect, '+590')
+it('should show an error if user touched input and did not enter any phone number', async () => {
+  renderPhoneNumberInput()
+  const input = screen.getByText('Numéro de téléphone')
 
-    const input = screen.getByLabelText('Numéro de téléphone')
+  await userEvent.click(input)
+  await userEvent.tab()
 
-    await userEvent.type(input, '123')
-    await userEvent.tab()
+  expect(
+    screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+  ).toBeInTheDocument()
+})
 
-    expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'GP')
-    expect(
-      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-    ).toBeInTheDocument()
+it('should call phone validation with country code', async () => {
+  renderPhoneNumberInput()
+  const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
+  await userEvent.selectOptions(countryCodeSelect, '+590')
 
-    await userEvent.selectOptions(countryCodeSelect, '+33')
+  const input = screen.getByLabelText('Numéro de téléphone')
 
-    expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'FR')
-  })
+  await userEvent.type(input, '123')
+  await userEvent.tab()
+
+  expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'GP')
+  expect(
+    screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+  ).toBeInTheDocument()
+
+  await userEvent.selectOptions(countryCodeSelect, '+33')
+
+  expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'FR')
 })

--- a/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/__specs__/PhoneNumberInput.spec.tsx
@@ -48,56 +48,43 @@ describe('PhoneNumberInput', () => {
       screen.getByPlaceholderText(guadeloupePlaceholder as string)
     ).toBeInTheDocument()
   })
-})
 
-it('should change placeholder when user change country code', async () => {
-  renderPhoneNumberInput()
-  const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
+  it('should not show an error if input has not been touched', () => {
+    renderPhoneNumberInput()
+    expect(
+      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+    ).not.toBeInTheDocument()
+  })
 
-  await userEvent.selectOptions(countryCodeSelect, '+590')
+  it('should show an error if user touched input and did not enter any phone number', async () => {
+    renderPhoneNumberInput()
+    const input = screen.getByText('Numéro de téléphone')
 
-  const guadeloupePlaceholder = PLACEHOLDER_MAP['GP']
-  expect(guadeloupePlaceholder).toBeDefined()
-  expect(
-    screen.getByPlaceholderText(guadeloupePlaceholder as string)
-  ).toBeInTheDocument()
-})
+    await userEvent.click(input)
+    await userEvent.tab()
 
-it('should not show an error if input has not been touched', () => {
-  renderPhoneNumberInput()
-  expect(
-    screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-  ).not.toBeInTheDocument()
-})
+    expect(
+      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+    ).toBeInTheDocument()
+  })
 
-it('should show an error if user touched input and did not enter any phone number', async () => {
-  renderPhoneNumberInput()
-  const input = screen.getByText('Numéro de téléphone')
+  it('should call phone validation with country code', async () => {
+    renderPhoneNumberInput()
+    const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
+    await userEvent.selectOptions(countryCodeSelect, '+590')
 
-  await userEvent.click(input)
-  await userEvent.tab()
+    const input = screen.getByLabelText('Numéro de téléphone')
 
-  expect(
-    screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-  ).toBeInTheDocument()
-})
+    await userEvent.type(input, '123')
+    await userEvent.tab()
 
-it('should call phone validation with country code', async () => {
-  renderPhoneNumberInput()
-  const countryCodeSelect = screen.getByLabelText('Indicatif téléphonique')
-  await userEvent.selectOptions(countryCodeSelect, '+590')
+    expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'GP')
+    expect(
+      screen.queryByText('Veuillez entrer un numéro de téléphone valide')
+    ).toBeInTheDocument()
 
-  const input = screen.getByLabelText('Numéro de téléphone')
+    await userEvent.selectOptions(countryCodeSelect, '+33')
 
-  await userEvent.type(input, '123')
-  await userEvent.tab()
-
-  expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'GP')
-  expect(
-    screen.queryByText('Veuillez entrer un numéro de téléphone valide')
-  ).toBeInTheDocument()
-
-  await userEvent.selectOptions(countryCodeSelect, '+33')
-
-  expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'FR')
+    expect(parsePhoneNumberFromString).toHaveBeenLastCalledWith('123', 'FR')
+  })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20384

## But de la pull request

    - Regrouper champ indicatif téléphonique et téléphone dans un <fieldset>
    - Mettre une <legend> (Téléphone (utilisé uniquement par l’équipe du pass Culture))
    - Mettre 2 <label> cachés visuellement pour chacun des champs: Indicatif téléphonique et Numéro de téléphone
    - Bien prendre en compte le premier caractère

## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/a335b727-53e1-41bc-bb51-41cdfe34b196)
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/4eb09eaa-9bbf-4367-813c-4794cb7f7776)

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
