### PR TITLE
(PC-22076)[API] feat: Save device as trusted device on second login with same device

### DIFF
--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -764,6 +764,27 @@ class UserEmailHistoryFactory(BaseFactory):
     newDomainEmail = factory.LazyAttribute(lambda o: o.user.email.split("@")[1] + ".update")
 
 
+class TrustedDeviceFactory(BaseFactory):
+    class Meta:
+        model = models.TrustedDevice
+
+    user = factory.SubFactory(UserFactory)
+    deviceId = "2E429592-2446-425F-9A62-D6983F375B3B"
+    os = "iOS"
+    source = "iPhone 13"
+
+
+class LoginDeviceHistoryFactory(BaseFactory):
+    class Meta:
+        model = models.LoginDeviceHistory
+
+    user = factory.SubFactory(UserFactory)
+    deviceId = "2E429592-2446-425F-9A62-D6983F375B3B"
+    os = "iOS"
+    source = "iPhone 13"
+    location = "Paris"
+
+
 class EmailUpdateEntryFactory(UserEmailHistoryFactory):
     eventType = models.EmailHistoryEventTypeEnum.UPDATE_REQUEST.value
 

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -55,6 +55,9 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
         raise ApiErrors({"code": "ACCOUNT_DELETED", "general": ["Le compte a été supprimé"]})
 
     if FeatureToggle.WIP_ENABLE_TRUSTED_DEVICE.is_active():
+        if users_api.should_save_login_device_as_trusted_device(body.device_info, user):
+            users_api.save_trusted_device(body.device_info, user)
+
         users_api.update_login_device_history(body.device_info, user)
 
     users_api.update_last_connection_date(user)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22076

## But de la pull request

Cette PR a pour but de considérer un appareil comme appareil de confiance à la deuxième connexion sur cet appareil par un même utilisateur.
Cela permet d'avoir des users qui ont un appareil de confiance de manière automatique et rapide.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
