### PR TITLE
(PC-19698) multi select on bookings

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/individual_bookings/list.html
@@ -2,6 +2,7 @@
 {% from "components/bookings/extra_row.html" import build_booking_extra_row with context %}
 {% import "components/forms.html" as forms with context %}
 {% import "components/links.html" as links %}
+{% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 {% extends "layouts/connected.html" %}
 {% set validate_booking_aria_described_by_id = random_hash() %}
 {% set cancel_booking_aria_described_by_id = random_hash() %}
@@ -14,9 +15,33 @@
         <div class="d-flex justify-content-between">
           <p class="lead num-results">{{ rows|length }} résultat{{ "s" if rows|length > 1 else "" }}</p>
         </div>
-        <table class="table mb-4">
+        {% if has_permission("MANAGE_BOOKINGS") %}
+          <div class="btn-group btn-group-sm"
+               data-toggle="pc-batch-confirm-btn-group"
+               data-toggle-id="table-container-individual-booking-btn-group"
+               data-pc-table-multi-select-id="table-individual-bookings-multiselect"
+               data-input-ids-name="object_ids">
+            <button disabled
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-use-confirmation-modal="true"
+                    data-modal-selector="#batch-validate-booking-modal">Valider</button>
+            <button disabled
+                    type="button"
+                    class="btn btn-outline-primary"
+                    data-use-confirmation-modal="true"
+                    data-modal-selector="#batch-cancel-booking-modal">Annuler</button>
+          </div>
+        {% endif %}
+        <table class="table mb-4"
+               data-table-multi-select-id="table-individual-bookings-multiselect">
           <thead>
             <tr>
+              <th scope="col">
+                <input type="checkbox"
+                       class="form-check-input"
+                       name="pc-table-multi-select-check-all" />
+              </th>
               <th scope="col"></th>
               <th scope="col">ID résa</th>
               <th scope="col">Contremarque</th>
@@ -37,7 +62,13 @@
             {% for booking in rows %}
               {% set offer = booking.stock.offer %}
               <tr>
-                <th scope="row">
+                <td>
+                  <input type="checkbox"
+                         class="form-check-input"
+                         name="pc-table-multi-select-check-{{ booking.id }}"
+                         data-id="{{ booking.id }}" />
+                </td>
+                <td>
                   <div class="d-flex">
                     {{ build_booking_toggle_extra_row_button(booking) }}
                     <div class="mx-2 dropdown">
@@ -106,13 +137,19 @@
                                        id="{{ cancel_booking_aria_described_by_id }}">
                                     <h5 class="modal-title">Annuler la réservation {{ booking.token }}</h5>
                                   </div>
-                                  <div class="modal-body row">{{ forms.build_form_fields_group(cancel_booking_form) }}</div>
+                                  <div class="modal-body row">
+                                    {{ forms.build_form_fields_group(cancel_booking_form) }}
+                                  </div>
                                   <div class="modal-footer">
                                     <button type="button"
                                             class="btn btn-outline-primary"
-                                            data-bs-dismiss="modal">Annuler</button>
+                                            data-bs-dismiss="modal">
+                                      Annuler
+                                    </button>
                                     <button type="submit"
-                                            class="btn btn-primary">Confirmer</button>
+                                            class="btn btn-primary">
+                                      Confirmer
+                                    </button>
                                   </div>
                                 </form>
                               </div>
@@ -122,25 +159,53 @@
                       {% endif %}
                     </div>
                   </div>
-                </th>
-                <td>{{ booking.id }}</td>
-                <td>{{ booking.token }}</td>
-                <td>{{ links.build_public_user_name_to_details_link(booking.user) }}</td>
-                <td>{{ links.build_offer_name_to_pc_pro_link(offer) }}</td>
-                <td>{{ links.build_offer_name_to_details_link(offer, text_attr="id") }}</td>
-                <td>{{ (offer.isDuo and booking.quantity == 2) | format_bool }}</td>
-                <td>{{ booking.stock.quantity }}</td>
-                <td>{{ booking.total_amount | format_amount }}</td>
-                <td>{{ booking.status | format_booking_status(with_badge=True) | safe }}</td>
-                <td>{{ booking.dateCreated | format_date_time }}</td>
-                <td>{{ booking.stock.beginningDatetime | format_date_time }}</td>
-                <td>{{ links.build_offerer_name_to_details_link(booking.offerer) }}</td>
-                <td>{{ links.build_venue_name_to_details_link(booking.venue) }}</td>
+                </td>
+                <td>
+                  {{ booking.id }}
+                </td>
+                <td>
+                  {{ booking.token }}
+                </td>
+                <td>
+                  {{ links.build_public_user_name_to_details_link(booking.user) }}
+                </td>
+                <td>
+                  {{ links.build_offer_name_to_pc_pro_link(offer) }}
+                </td>
+                <td>
+                  {{ links.build_offer_name_to_details_link(offer, text_attr="id") }}
+                </td>
+                <td>
+                  {{ (offer.isDuo and booking.quantity == 2) | format_bool }}
+                </td>
+                <td>
+                  {{ booking.stock.quantity }}
+                </td>
+                <td>
+                  {{ booking.total_amount | format_amount }}
+                </td>
+                <td>
+                  {{ booking.status | format_booking_status(with_badge=True) | safe }}
+                </td>
+                <td>
+                  {{ booking.dateCreated | format_date_time }}
+                </td>
+                <td>
+                  {{ booking.stock.beginningDatetime | format_date_time }}
+                </td>
+                <td>
+                  {{ links.build_offerer_name_to_details_link(booking.offerer) }}
+                </td>
+                <td>
+                  {{ links.build_venue_name_to_details_link(booking.venue) }}
+                </td>
               </tr>
               {{ build_booking_extra_row(booking, booking.stock, offer) }}
             {% endfor %}
           </tbody>
         </table>
+        {{ build_lazy_modal(url_for("backoffice_v3_web.individual_bookings.get_batch_validate_individual_bookings_form"), "batch-validate-booking-modal", "true") }}
+        {{ build_lazy_modal(url_for("backoffice_v3_web.individual_bookings.get_batch_cancel_individual_bookings_form"), "batch-cancel-booking-modal", "true") }}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19698

## But de la pull request

En tant que support pro
J'aimerais valider/annuler en masse des réservations d’offres
Afin de gagner du temps 

## Implémentation

Ajout de boutons “Valider” et “Annuler” en haut de l'écran. Par défaut ces boutons sont grisés et inactifs. Dès sélection d’au moins 2 réservations, ils deviennent actifs. 

Au clic sur “Valider”, l’ensemble des réservations sélectionnées passent au statut “VALIDATED”

Au clic sur “Annuler”, l’ensemble des réservations sélectionnées passent au statut “CANCELED”

Reporter les contrôles bloquants (ceux de Flask admin) lorsqu’on sélectionne une ou plusieurs réservations dont le statut n’est pas éligible au changement souhaité :

On ne peut pas valider une réservation individuelle si le stock est épuisé (ou inférieur à 2 s’il s’agit d’une offre duo)

On ne peut pas valider une réservation individuelle si le jeune a un crédit insuffisant

On ne peut pas annuler une réservation individuelle si la réservation est valorisée dans le script de virement (le 1er ou le 16 du mois)

L’accès au bouton pour valider ou annuler en masse dépend de la permission “gérer les réservations”

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
<img width="1660" alt="Capture d’écran 2023-05-22 à 14 51 56" src="https://github.com/pass-culture/pass-culture-main/assets/9610732/49741111-4ee4-4723-a0af-91c4c74831e3">
<img width="1677" alt="Capture d’écran 2023-05-22 à 14 51 46" src="https://github.com/pass-culture/pass-culture-main/assets/9610732/8df15008-df97-43e5-bc19-16d1d8302228">

