### PR TITLE
(PC-21975)[API] fix: move old booking set status to used

### DIFF
--- a/api/src/pcapi/core/bookings/commands.py
+++ b/api/src/pcapi/core/bookings/commands.py
@@ -10,7 +10,14 @@ blueprint = Blueprint(__name__, __name__)
 logger = logging.getLogger(__name__)
 
 
+# TODO(@kopax-polyconseil): remove when v244 is in production (PC-22308)
 @blueprint.cli.command("archive_old_activation_code_bookings")
 @cron_decorators.log_cron_with_transaction
 def archive_old_activation_code_bookings() -> None:
-    api.archive_old_activation_code_bookings()
+    api.archive_old_bookings()
+
+
+@blueprint.cli.command("archive_old_bookings")
+@cron_decorators.log_cron_with_transaction
+def archive_old_bookings() -> None:
+    api.archive_old_bookings()

--- a/api/src/pcapi/core/bookings/constants.py
+++ b/api/src/pcapi/core/bookings/constants.py
@@ -1,5 +1,7 @@
 import datetime
 
+from pcapi.core.categories import subcategories
+
 
 ARCHIVE_DELAY = datetime.timedelta(days=30)
 CONFIRM_BOOKING_AFTER_CREATION_DELAY = datetime.timedelta(hours=48)
@@ -11,6 +13,12 @@ BOOKS_BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=5)
 AUTO_USE_AFTER_EVENT_TIME_DELAY = datetime.timedelta(hours=48)
 REDIS_EXTERNAL_BOOKINGS_NAME = "api:external_bookings:barcodes"
 EXTERNAL_BOOKINGS_MINIMUM_ITEM_AGE_IN_QUEUE = 60
+FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE = [
+    subcategories.ABO_MUSEE,
+    subcategories.CARTE_MUSEE,
+    subcategories.ABO_BIBLIOTHEQUE,
+    subcategories.ABO_MEDIATHEQUE,
+]
 
 
 def _get_hours_from_timedelta(td: datetime.timedelta) -> float:

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -4,6 +4,7 @@ import logging
 from sqlalchemy.orm import joinedload
 
 import pcapi.core.bookings.api as bookings_api
+from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
 import pcapi.core.bookings.exceptions as bookings_exceptions
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
@@ -194,8 +195,10 @@ def is_ended_booking(booking: Booking) -> bool:
         # consider future events as "ongoing" even if they are used
         return False
 
-    if booking.stock.canHaveActivationCodes and booking.activationCode:
-        # consider digital bookings as special: is_used should be true anyway so
+    if (booking.stock.canHaveActivationCodes and booking.activationCode) or (
+        booking.stock.offer.subcategoryId in FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE and booking.stock.price == 0
+    ):
+        # consider digital bookings and free offer from defined subcategories as special: is_used should be true anyway so
         # let's use displayAsEnded
         return booking.displayAsEnded  # type: ignore [return-value]
 

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -1,14 +1,17 @@
 import datetime
 
+import pytest
+
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models as bookings_models
+from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
 from pcapi.core.offers import factories as offers_factories
 
 from tests.conftest import clean_database
 from tests.test_utils import run_command
 
 
-class ArchiveOldDigitalBookingsTest:
+class ArchiveOldBookingsTest:
     @clean_database
     def test_basics(self, app):
         # given
@@ -25,10 +28,44 @@ class ArchiveOldDigitalBookingsTest:
         old_booking_id = old_booking.id
 
         # when
-        run_command(app, "archive_old_activation_code_bookings")
+        run_command(app, "archive_old_bookings")
 
         # then
         old_booking = bookings_models.Booking.query.get(old_booking_id)
         recent_booking = bookings_models.Booking.query.get(recent_booking_id)
         assert old_booking.displayAsEnded
         assert not recent_booking.displayAsEnded
+
+    @clean_database
+    @pytest.mark.parametrize(
+        "subcategory",
+        FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE,
+    )
+    def test_old_subcategories_bookings_are_archived(self, app, subcategory):
+        # given
+        now = datetime.datetime.utcnow()
+        recent = now - datetime.timedelta(days=29, hours=23)
+        old = now - datetime.timedelta(days=30, hours=1)
+        stock_free = offers_factories.StockFactory(
+            offer=offers_factories.OfferFactory(subcategoryId=subcategory.id), price=0
+        )
+        stock_not_free = offers_factories.StockFactory(
+            offer=offers_factories.OfferFactory(subcategoryId=subcategory.id), price=10
+        )
+        recent_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=recent)
+        old_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=old)
+        old_not_free_booking = bookings_factories.BookingFactory(stock=stock_not_free, dateCreated=old)
+        recent_booking_id = recent_booking.id
+        old_booking_id = old_booking.id
+        old_not_free_booking_id = old_not_free_booking.id
+
+        # when
+        run_command(app, "archive_old_bookings")
+
+        # then
+        old_booking = bookings_models.Booking.query.get(old_booking_id)
+        old_not_free_booking = bookings_models.Booking.query.get(old_not_free_booking_id)
+        recent_booking = bookings_models.Booking.query.get(recent_booking_id)
+        assert not recent_booking.displayAsEnded
+        assert not old_not_free_booking.displayAsEnded
+        assert old_booking.displayAsEnded


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21975

## But de la pull request

Force le passage du statut du booking à `USED`

## Implémentation

Modification du script qui maj les anciennes résas

## Informations supplémentaires

D'après le ticket https://passculture.atlassian.net/browse/PC-8359 , l'ajout de la colonne `displayAsUsed` était nécessaire pour afficher en résa en cours des offres consommés directement (deezer) alors que le statut est `USED`

Du coup l'archivage peut consommer et afficher en résa terminé via ce changement.

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
