### PR TITLE
(PC-21221)[API] fix: Change cancellation delay when offer is modified

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -439,8 +439,11 @@ def update_cancellation_limit_dates(
 def _compute_edition_cancellation_limit_date(
     event_beginning: datetime.datetime, edition_date: datetime.datetime
 ) -> datetime.datetime:
-    after_edition_cancellation_date = edition_date + constants.CONFIRM_BOOKING_AFTER_CREATION_DELAY
-    return min(event_beginning, after_edition_cancellation_date)
+    after_edition_cancellation_date = min(
+        edition_date + constants.CONFIRM_BOOKING_AFTER_CREATION_DELAY,
+        event_beginning - constants.CONFIRM_EDITED_BOOKING_BEFORE_EVENT_DELAY,
+    )
+    return after_edition_cancellation_date
 
 
 def recompute_dnBookedQuantity(stock_ids: list[int]) -> None:

--- a/api/src/pcapi/core/bookings/constants.py
+++ b/api/src/pcapi/core/bookings/constants.py
@@ -3,6 +3,7 @@ import datetime
 
 ARCHIVE_DELAY = datetime.timedelta(days=30)
 CONFIRM_BOOKING_AFTER_CREATION_DELAY = datetime.timedelta(hours=48)
+CONFIRM_EDITED_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(minutes=5)
 CONFIRM_BOOKING_BEFORE_EVENT_DELAY = datetime.timedelta(hours=48)
 BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=30)
 BOOKS_BOOKINGS_AUTO_EXPIRY_DELAY = datetime.timedelta(days=10)

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1013,7 +1013,8 @@ class UpdateCancellationLimitDatesTest:
         )
         # Then
         assert updated_bookings == [recent_booking, old_booking]
-        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == tomorrow
+        five_min_prior_event = tomorrow - timedelta(minutes=5)
+        assert recent_booking.cancellationLimitDate == old_booking.cancellationLimitDate == five_min_prior_event
 
     def should_update_bookings_cancellation_limit_dates_for_event_beginning_in_three_days(self):
         #  Given


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21221

## But de la pull request

Changement du délai pour l'annulation d'une réservation quand l'heure de l'offre a été modifiée.

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
