### PR TITLE
(PC-22355)[PRO] fix: confirmed attachment button margin top

### DIFF
--- a/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.module.scss
+++ b/pro/src/screens/SignupJourneyForm/ConfirmedAttachment/ConfirmedAttachment.module.scss
@@ -23,5 +23,4 @@ $confirmed-attachment-gap: rem.torem(32px);
 
 .home-button {
     width: fit-content;
-    margin-top: rem.torem(8px);
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22355

## But de la pull request

- Supprimer le margin top du bouton pour ne garder que le gap de 32px

## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/acb0acb8-1b28-47a0-96c2-86f236ae3fab)
