### PR TITLE
(PC-22307)[API] feat: add more venue data to Algolia offers index

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -456,9 +456,12 @@ class AlgoliaBackend(base.SearchBackend):
                 "name": offerer.name,
             },
             "venue": {
+                "address": venue.address,
+                "city": venue.city,
                 "departmentCode": venue.departementCode,
                 "id": venue.id,
                 "name": venue.name,
+                "postalCode": venue.postalCode,
                 "publicName": venue.publicName,
             },
             "_geoloc": position(venue),

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -92,9 +92,12 @@ def test_serialize_offer():
             "name": "Les Librairies Associées",
         },
         "venue": {
+            "address": offer.venue.address,
+            "city": offer.venue.city,
             "departmentCode": "86",
             "id": offer.venueId,
             "name": "La Moyenne Librairie SA",
+            "postalCode": offer.venue.postalCode,
             "publicName": "La Moyenne Librairie",
         },
         "_geoloc": {"lat": 48.87004, "lng": 2.3785},


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22307

## But de la pull request

Ajouter 3 infos concernant le lieu dans l'index des offres:
- l'adresse
- le code postal
- la ville

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
