### PR TITLE
(PC-22306)[API] feat: add legal category code to get_siret response

### DIFF
--- a/api/src/pcapi/routes/pro/sirene.py
+++ b/api/src/pcapi/routes/pro/sirene.py
@@ -48,4 +48,5 @@ def get_siret_info(siret: str) -> sirene_serializers.SiretInfo:
         active=info.active,
         address=sirene_serializers.Address(**info_address_dict),
         ape_code=info.ape_code,
+        legal_category_code=info.legal_category_code,
     )

--- a/api/src/pcapi/routes/serialization/sirene.py
+++ b/api/src/pcapi/routes/serialization/sirene.py
@@ -25,3 +25,4 @@ class SiretInfo(serialization.BaseModel):
     active: bool
     address: Address
     ape_code: str
+    legal_category_code: str

--- a/api/tests/connectors/sirene_test.py
+++ b/api/tests/connectors/sirene_test.py
@@ -93,6 +93,7 @@ def test_get_siret():
         assert siret_info.address.postal_code == "75002"
         assert siret_info.address.city == "PARIS"
         assert siret_info.ape_code == "47.61Z"
+        assert siret_info.legal_category_code == "5499"
 
 
 @override_settings(SIRENE_BACKEND="pcapi.connectors.sirene.InseeBackend")

--- a/api/tests/routes/pro/sirene_test.py
+++ b/api/tests/routes/pro/sirene_test.py
@@ -59,6 +59,7 @@ class GetSiretTest:
                 "city": "Paris",
             },
             "ape_code": "90.03A",
+            "legal_category_code": "1000",
         }
 
     @pytest.mark.usefixtures("db_session")

--- a/pro/src/apiClient/v1/models/SiretInfo.ts
+++ b/pro/src/apiClient/v1/models/SiretInfo.ts
@@ -8,6 +8,7 @@ export type SiretInfo = {
   active: boolean;
   address: Address;
   ape_code: string;
+  legal_category_code: string;
   name: string;
   siret: string;
 };

--- a/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
+++ b/pro/src/components/VenueForm/Informations/__specs__/Informations.spec.tsx
@@ -105,6 +105,7 @@ describe('components | Informations', () => {
         postalCode: '14400',
       },
       ape_code: '95.07A',
+      legal_category_code: '1000',
     })
     jest
       .spyOn(apiAdresse, 'getDataFromAddress')

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -107,6 +107,7 @@ describe('screens:SignupJourney::Offerer', () => {
       name: 'Test',
       siret: '12345678933333',
       ape_code: '95.01A',
+      legal_category_code: '1000',
     })
   })
 
@@ -328,6 +329,7 @@ describe('screens:SignupJourney::Offerer', () => {
       name: 'Test',
       siret: '12345678933335',
       ape_code: '85.31Z',
+      legal_category_code: '1000',
     })
     renderOffererScreen(contextValue)
 

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
@@ -107,6 +107,7 @@ describe('screens:SignupJourney::OffererForm', () => {
       name: 'Test',
       siret: '12345678933333',
       ape_code: '95.01A',
+      legal_category_code: '1000',
     })
   })
 

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.spec.tsx
@@ -120,6 +120,7 @@ jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
   name: 'lieu',
   siret: '88145723823022',
   ape_code: '95.07A',
+  legal_category_code: '1000',
 })
 
 jest.spyOn(api, 'canOffererCreateEducationalOffer').mockResolvedValue()

--- a/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
+++ b/pro/src/screens/VenueForm/__specs__/VenueFormScreen.tracker.spec.tsx
@@ -123,6 +123,7 @@ jest.spyOn(api, 'getSiretInfo').mockResolvedValue({
   name: 'lieu',
   siret: '88145723823022',
   ape_code: '95.07A',
+  legal_category_code: '1000',
 })
 
 // Mock l'appel à https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${address}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22306

## But de la pull request

- Récupérer la catégorie juridique côté back et l'envoyer sur la route de récupération sur les SIRET

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
