### PR TITLE
(PC-22232)[API] feat: add button to delete user offerer without sendi…

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -33,6 +33,7 @@ class ActionType(enum.Enum):
     USER_OFFERER_PENDING = "Rattachement mis en attente"
     USER_OFFERER_VALIDATED = "Rattachement validé"
     USER_OFFERER_REJECTED = "Rattachement rejeté"
+    USER_OFFERER_DELETED = "Rattachement supprimé, sans mail envoyé"
     # User account status changes:
     USER_CREATED = "Création du compte"
     USER_SUSPENDED = "Compte suspendu"

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -643,6 +643,27 @@ def reject_offerer_attachment(
     db.session.commit()
 
 
+def delete_offerer_attachment(
+    user_offerer: offerers_models.UserOfferer,
+    author_user: users_models.User,
+    comment: str | None = None,
+) -> None:
+    db.session.add(
+        history_api.log_action(
+            history_models.ActionType.USER_OFFERER_DELETED,
+            author_user,
+            user=user_offerer.user,
+            offerer=user_offerer.offerer,
+            comment=comment,
+            save=False,
+        )
+    )
+
+    db.session.delete(user_offerer)
+    remove_pro_role_and_add_non_attached_pro_role([user_offerer.user])
+    db.session.commit()
+
+
 def validate_offerer(offerer: models.Offerer, author_user: users_models.User) -> None:
     if offerer.isValidated:
         raise exceptions.OffererAlreadyValidatedException()

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get/details/users.html
@@ -91,6 +91,11 @@
                    data-bs-toggle="modal"
                    data-bs-target="#pending-modal-{{ user_offerer.id }}">Mettre en attente</a>
               </li>
+              <li class="dropdown-item p-0">
+                <a class="btn btn-sm d-block w-100 text-start px-3"
+                   data-bs-toggle="modal"
+                   data-bs-target="#delete-modal-{{ user_offerer.id }}">Supprimer</a>
+              </li>
             </ul>
           </div>
         </td>
@@ -110,5 +115,8 @@
   {{ build_lazy_modal(
   url_for("backoffice_v3_web.validation.get_user_offerer_pending_form", user_offerer_id=user_offerer.id),
   "pending-modal-" + user_offerer.id|string) }}
+  {{ build_lazy_modal(
+  url_for("backoffice_v3_web.offerer.get_delete_user_offerer_form", offerer_id=user_offerer.offerer.id, user_offerer_id=user_offerer.id),
+  "delete-modal-" + user_offerer.id|string) }}
 {% endfor %}
 </turbo-frame>


### PR DESCRIPTION
…ng mail

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22232

## But de la pull request

Ajout d'un bouton pour supprimer un rattachement sans envoi de mail.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
