### PR TITLE
Fix/docker scripts

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -58,9 +58,9 @@ COPY --from=builder /home/pcapi/.local /home/pcapi/.local
 
 WORKDIR /usr/src/app
 
-COPY --from=sources /tmp/src .
+COPY --from=sources --chown=pcapi:pcapi /tmp/src .
 
-RUN chown -R pcapi:pcapi .
+RUN chown pcapi:pcapi /usr/src/app
 
 USER pcapi
 

--- a/pc
+++ b/pc
@@ -166,9 +166,9 @@ elif [[ "$CMD" == "dump-db" ]]; then
 
 # Force docker-compose to build the docker images
 elif [[ "$CMD" == "rebuild-backend" ]]; then
-  RUN='docker-compose build --no-cache;
+  RUN='docker-compose -f "$ROOT_PATH/docker-compose-app.yml" build --no-cache;
     sudo rm -rf $ROOT_PATH/api/static/object_store_data;
-    docker-compose down --volumes'
+    docker-compose -f "$ROOT_PATH/docker-compose-app.yml" down --volumes'
 
 # Execute request from specified file
 elif [[ "$CMD" == "psql-file" ]]; then


### PR DESCRIPTION
## Informations supplémentaires

- Le script pc start-backend restait bloqué longtemps sur `CHOWN -R pcapi:pcapi .` faire le chown au moment du copy est plus rapide
- J'ai eu un problème de droit de fichiers sur l'image docker, pour débugguer j'ai tenté de lancer pc rebuild-backend, et ça marchait pas, quand j'ai lu le script qui était lancé, on ne donnait pas le chemin du fichier à la docker compose

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
