### PR TITLE
(PC-22148)[API] feat: show beneficiary fraud review on stepper

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-dcfd7657a244 (pre) (head)
+83f944319ccf (pre) (head)
 33e76b6e3a77 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230523T153540_83f944319ccf_add_eligibility_type_to_beneficiary_fraud_review.py
+++ b/api/src/pcapi/alembic/versions/20230523T153540_83f944319ccf_add_eligibility_type_to_beneficiary_fraud_review.py
@@ -1,0 +1,20 @@
+"""add_eligibility_type_to_beneficiary_fraud_review
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "83f944319ccf"
+down_revision = "dcfd7657a244"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("beneficiary_fraud_review", sa.Column("eligibilityType", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("beneficiary_fraud_review", "eligibilityType")

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -18,6 +18,7 @@ from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
 from pcapi.serialization.utils import to_camel
 
+from ..users.models import EligibilityType
 from .common import models as common_models
 from .ubble import models as ubble_fraud_models
 
@@ -598,6 +599,10 @@ class BeneficiaryFraudReview(PcObject, Base, Model):
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
     user: users_models.User = sa.orm.relationship(
         "User", foreign_keys=[userId], backref=sa.orm.backref("beneficiaryFraudReviews")
+    )
+    eligibilityType: EligibilityType = sa.Column(
+        sa.Enum(EligibilityType, create_constraint=False),
+        nullable=True,
     )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -213,6 +213,7 @@ def render_public_account_details(
     return render_template(
         "accounts/get.html",
         user=user,
+        beneficiaryFraudReviews=user.beneficiaryFraudReviews,
         tunnel=tunnel,
         id_check_histories_desc=id_check_histories_desc,
         credit=domains_credit,

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -213,7 +213,6 @@ def render_public_account_details(
     return render_template(
         "accounts/get.html",
         user=user,
-        beneficiaryFraudReviews=user.beneficiaryFraudReviews,
         tunnel=tunnel,
         id_check_histories_desc=id_check_histories_desc,
         credit=domains_credit,
@@ -496,6 +495,27 @@ def _get_steps_tunnel_underage_age18(
     return steps
 
 
+def _convert_bfr_to_bfc_dict(beneficiaryFraudReviews: list[fraud_models.BeneficiaryFraudReview]):
+    bfrs = []
+
+    for beneficiaryFraudReview in beneficiaryFraudReviews:
+        if beneficiaryFraudReview.eligibilityType == EligibilityType.AGE18:
+            bfrs.append(
+                {
+                    "dateCreated": beneficiaryFraudReview.dateReviewed,
+                    "thirdPartyId": beneficiaryFraudReview.author.full_name,
+                    "type": beneficiaryFraudReview.author.full_name,
+                    "applicable_eligibilities": [EligibilityType.AGE18.value],
+                    "status": beneficiaryFraudReview.review.value,
+                    "reason": beneficiaryFraudReview.reason,
+                    "reasonCodes": None,
+                    "technicalDetails": {},
+                }
+            )
+
+    return bfrs
+
+
 def _get_steps_tunnel_age18(
     user: users_models.User, id_check_histories: list, item_status_18: dict
 ) -> list[RegistrationStep]:
@@ -559,6 +579,7 @@ def _get_steps_tunnel_age18(
             if user.received_pass_18
             else SubscriptionItemStatus.VOID.value,
             icon="18",
+            id_check_histories=[],
         ),
     ]
     return steps

--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -277,10 +277,13 @@ def format_criteria(criteria: list[criteria_models.OfferCriterion]) -> str:
 
 
 def format_fraud_check_url(id_check_item: serialization_accounts.IdCheckItemModel) -> str:
-    if id_check_item.type == fraud_models.FraudCheckType.UBBLE.value:
-        return f"https://dashboard.ubble.ai/identifications/{id_check_item.thirdPartyId}"
-    if id_check_item.type == fraud_models.FraudCheckType.DMS.value and id_check_item.technicalDetails:
-        return f"https://www.demarches-simplifiees.fr/procedures/{id_check_item.technicalDetails['procedure_number']}/dossiers/{id_check_item.thirdPartyId}"
+    try:
+        if id_check_item.type == fraud_models.FraudCheckType.UBBLE.value:
+            return f"https://dashboard.ubble.ai/identifications/{id_check_item.thirdPartyId}"
+        if id_check_item.type == fraud_models.FraudCheckType.DMS.value and id_check_item.technicalDetails:
+            return f"https://www.demarches-simplifiees.fr/procedures/{id_check_item.technicalDetails['procedure_number']}/dossiers/{id_check_item.thirdPartyId}"
+    except AttributeError:
+        return ""
     return ""
 
 

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
@@ -3,6 +3,33 @@
 {% for step in tunnel.steps %}
   {% set _ = builded_steps.append(macro.build_step('step-' + step.step_id|string, step.description, step.subscription_item_status, step.icon, step.status)) %}
 {% endfor %}
+<h3>Revue(s) manuelle(s)</h3>
+{% for review in user.beneficiaryFraudReviews %}
+
+<table class="table" style="border-style: solid; border-width:1px;">
+    <tr>
+        <th scope="row">Auteur</th>
+        <td>{{ review.author.full_name }}</td>
+    </tr>
+
+    <tr>
+        <th scope="row">Etat</th>
+        <td>{{ review.review.value }}</td>
+    </tr>
+    <tr>
+        <th scope="row">Date de création</th>
+        <td>{{ review.dateReviewed.strftime('le %d/%m/%Y à %H:%M:%S') }}</td>
+    </tr>
+    <tr>
+        <th scope="row">Explication</th>
+        <td>{{ review.reason | safe }}</td>
+    </tr>
+    <tr>
+        <th scope="row">Éligibilité</th>
+        <td>{{ review.eligibilityType }}</td>
+    </tr>
+</table>
+{% endfor %}
 {% call macro.build_registration_steps(tunnel, builded_steps) %}
   <div class="col-6 form-check form-switch m-3 form-switch-show-all-steps">
     {% set switch_boolean_field_id = random_hash() %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/public_accounts/registration_steps.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/public_accounts/registration_steps.html
@@ -26,7 +26,7 @@
               </td>
               <td>{{ id_check_item.thirdPartyId }}</td>
               <td>
-                {% if id_check_item | format_fraud_check_url %}
+                {% if id_check_item.type and id_check_item | format_fraud_check_url %}
                   <a href="{{ id_check_item | format_fraud_check_url }}"
                      target="_blank">
                     {{ id_check_item.type }}
@@ -46,15 +46,15 @@
                 {% endif %}
               </td>
               <td>
-                {% if id_check_item.status == 'ok' %}
+                {% if id_check_item.status.upper() == 'OK' %}
                   <span class="badge rounded-pill text-bg-success align-middle px-3 py-2">
                     <i class="bi bi-check-circle"></i> {{ id_check_item.status.upper() }}
                   </span>
-                {% elif id_check_item.status == 'ko' %}
+                {% elif id_check_item.status.upper() == 'KO' %}
                   <span class="badge rounded-pill text-bg-danger align-middle px-3 py-2">
                     <i class="bi bi-exclamation-circle"></i> {{ id_check_item.status.upper() }}
                   </span>
-                {% elif id_check_item.status == 'suspicious' %}
+                {% elif id_check_item.status.upper() == 'SUSPICIOUS' %}
                   <span class="badge rounded-pill text-bg-warning align-middle px-3 py-2">
                     <i class="bi bi-shield-shaded"></i> {{ id_check_item.status.upper() }}
                   </span>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22148

## But de la pull request

Ajout des revues manuelle sur le parcours d'inscription

## Implémentation

- Ajout d'une colonne `eligiblity_type` dans la table `beneficiary_fraud_review` 
- Sauvegarde de l'info lors de la fraud review
- Script pour remplir les champs de l'historique des revues manuelles

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
