### PR TITLE
(PC-19449)[api] fix: invoice style pdf

### DIFF
--- a/api/src/pcapi/templates/invoices/invoice.html
+++ b/api/src/pcapi/templates/invoices/invoice.html
@@ -57,12 +57,12 @@
             margin: 0;
         }
 
-        .custumerInfo {
+        .customerInfo {
             margin: 1cm 0;
         }
 
-        .custumerInfo > p {
-            margin: 0.1cm;
+        .customerInfo > p {
+            margin: 0.1cm 0;
         }
 
         h3 {
@@ -157,6 +157,7 @@
 
         .coloredTitle {
             color: #870087;
+            font-weight: 700;
         }
 
         .coloredSection {
@@ -191,12 +192,12 @@
     </defs>
 </svg>
 <h1>Justificatif de remboursement</h1>
-<div class="custumerInfo">
+<div class="customerInfo">
     <p><b>Structure :</b> {{ reimbursement_point.managingOfferer.name }} - {{ reimbursement_point.managingOfferer.siren }}</p>
     <p><b>Point de remboursement :</b> {{ reimbursement_point_name }} - {{ reimbursement_point_iban }}</p>
 </div>
 <h3 class="coloredTitle">
-    Remboursement des réservations validées entre le {{ period_start.strftime("%d/%m/%y") }} et le {{ period_end.strftime("%d/%m/%y") }}, sauf cas exceptionnels
+    Remboursement des réservations validées entre le {{ period_start.strftime("%d/%m/%y") }} et le {{ period_end.strftime("%d/%m/%y") }}, sauf cas exceptionnels.
 </h3>
 <h3>
     Détail des offres remboursées incluant la contribution offreur,

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -1909,8 +1909,8 @@ class GenerateInvoiceHtmlTest:
         )
         start_period, end_period = api.get_invoice_period(invoice.date)
         expected_invoice_html = expected_invoice_html.replace(
-            "Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels",
-            f'Remboursement des réservations validées entre le {start_period.strftime("%d/%m/%y")} et le {end_period.strftime("%d/%m/%y")}, sauf cas exceptionnels',
+            "Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels.",
+            f'Remboursement des réservations validées entre le {start_period.strftime("%d/%m/%y")} et le {end_period.strftime("%d/%m/%y")}, sauf cas exceptionnels.',
         )
         expected_invoice_html = expected_invoice_html.replace("\n    <p><b>SIRET :</b> 85331845900023</p>", "")
         assert expected_invoice_html == invoice_html

--- a/api/tests/files/invoice/rendered_invoice.html
+++ b/api/tests/files/invoice/rendered_invoice.html
@@ -57,12 +57,12 @@
             margin: 0;
         }
 
-        .custumerInfo {
+        .customerInfo {
             margin: 1cm 0;
         }
 
-        .custumerInfo > p {
-            margin: 0.1cm;
+        .customerInfo > p {
+            margin: 0.1cm 0;
         }
 
         h3 {
@@ -157,6 +157,7 @@
 
         .coloredTitle {
             color: #870087;
+            font-weight: 700;
         }
 
         .coloredSection {
@@ -191,12 +192,12 @@
     </defs>
 </svg>
 <h1>Justificatif de remboursement</h1>
-<div class="custumerInfo">
+<div class="customerInfo">
     <p><b>Structure :</b> Association de coiffeurs - 853318459</p>
     <p><b>Point de remboursement :</b> Coiffeur justificaTIF - FR2710010000000000000000064</p>
 </div>
 <h3 class="coloredTitle">
-    Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels
+    Remboursement des réservations validées entre le 01/01/22 et le 14/01/22, sauf cas exceptionnels.
 </h3>
 <h3>
     Détail des offres remboursées incluant la contribution offreur,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19449

Mettre le template de l'html de l'invoice au style

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin) 
![image](https://github.com/pass-culture/pass-culture-main/assets/56326095/1d286e94-9584-4f58-b623-bd9b1fb55505)

