### PR TITLE
(PC-22024)[PRO] feat: wording sur la liste des offres 

### DIFF
--- a/pro/src/components/NoData/NoData.tsx
+++ b/pro/src/components/NoData/NoData.tsx
@@ -12,8 +12,8 @@ interface INoOffers {
 
 const wordingMapping = {
   offers: {
-    [Audience.INDIVIDUAL]: 'Vous n’avez pas encore créé d’offre.',
-    [Audience.COLLECTIVE]: 'Vous n’avez pas encore créé d’offre.',
+    [Audience.INDIVIDUAL]: 'Vous n’avez pas encore créé d’offre',
+    [Audience.COLLECTIVE]: 'Vous n’avez pas encore créé d’offre',
   },
   bookings: {
     [Audience.INDIVIDUAL]: 'Vous n’avez aucune réservation pour le moment',

--- a/pro/src/screens/Offers/__specs__/Offers.spec.tsx
+++ b/pro/src/screens/Offers/__specs__/Offers.spec.tsx
@@ -425,7 +425,7 @@ describe('screen Offers', () => {
           renderOffers({ ...props, offers: [] }, store)
           // Then
           const noOffersText = screen.getByText(
-            'Vous n’avez pas encore créé d’offre.'
+            'Vous n’avez pas encore créé d’offre'
           )
           expect(noOffersText).toBeInTheDocument()
         })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22287

## But de la pull request

Sur la liste des offres quand aucune offre n’est créé, supprimer le point à la fin de la phrase “Vous n’avez pas encore créé d’offre”

<img width="1013" alt="Capture d’écran 2023-05-30 à 11 18 09" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/e685dc7e-30e0-4ead-9428-40faf04b072e">


## Informations supplémentaires

Si tu te connectes en admin tu peux choisir différents lieux, je pense qu’il y en a au moins 1 qui a pas d’offres !
Ah non ça ne s’affiche pas ce message si on met un filtre

Dans ce fichier là : https://github.com/pass-culture/pass-culture-main/blob/bef6a54526871e7e5b42069faefa9a3e3890da33/pro/src/screens/Offers/Offers.tsx#L299

Tu peux remplacer {userHasNoOffers ? ( par {!userHasNoOffers ? (
[Offers.tsx](https://github.com/pass-culture/pass-culture-main/blob/bef6a54526871e7e5b42069faefa9a3e3890da33/pro/src/screens/Offers/Offers.tsx)
      {userHasNoOffers ? (
<https://github.com/[pass-culture/pass-culture-main](https://github.com/pass-culture/pass-culture-main)|pass-culture/pass-culture-main>pass-culture/pass-culture-main | Ajouté(e) par [GitHub](https://passcultureteam.slack.com/services/B01UG7E73UM)

Ca te permettra de tester facilement, il faudra juste pas oublier de remettre comme c’était ensuite !


## Checklist :

- [ x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : PC-22287-wording-offers
  - PR : (PC-22024)[PRO] feat: wording sur la liste des offres
  - Commit(s) : (PC-22287)[PRO] wording sur la liste des offres
