### PR TITLE
(PC-22154)[PRO] fix: add overflow-wrap for collective booking name

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/BookingOfferCell.module.scss
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/BookingOfferCell.module.scss
@@ -5,6 +5,8 @@
 .booking-offer-name {
   @include fonts.button;
 
+  overflow-wrap: break-word;
+
   &:hover,
   &:focus {
     text-decoration: underline;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22154

## But de la pull request

Ajout un overflow-wrap pour couper les mots trop long dans le nom des offres affichés dans la liste des résas collectives

## Screenshot 

**Avant :** 

![Capture d’écran 2023-05-24 à 17 25 27](https://github.com/pass-culture/pass-culture-main/assets/71768799/d1bba5a7-a4d0-4588-9cb0-b3ce3312b0b7)

**Après :** 

![Capture d’écran 2023-05-24 à 17 24 21](https://github.com/pass-culture/pass-culture-main/assets/71768799/1d0acd3b-c859-46ca-a771-9bfc95ee60b5)

