### PR TITLE
(PC-21975)[API] feat: move to ended bookings when subcategories match  (REVERT)

### DIFF
--- a/api/src/pcapi/core/bookings/commands.py
+++ b/api/src/pcapi/core/bookings/commands.py
@@ -10,14 +10,7 @@ blueprint = Blueprint(__name__, __name__)
 logger = logging.getLogger(__name__)
 
 
-# TODO(@kopax-polyconseil): remove when v240 is in production (PC-22308)
 @blueprint.cli.command("archive_old_activation_code_bookings")
 @cron_decorators.log_cron_with_transaction
 def archive_old_activation_code_bookings() -> None:
-    api.archive_old_bookings()
-
-
-@blueprint.cli.command("archive_old_bookings")
-@cron_decorators.log_cron_with_transaction
-def archive_old_bookings() -> None:
-    api.archive_old_bookings()
+    api.archive_old_activation_code_bookings()

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -1,17 +1,14 @@
 import datetime
 
-import pytest
-
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models as bookings_models
-from pcapi.core.categories import subcategories_v2
 from pcapi.core.offers import factories as offers_factories
 
 from tests.conftest import clean_database
 from tests.test_utils import run_command
 
 
-class ArchiveOldBookingsTest:
+class ArchiveOldDigitalBookingsTest:
     @clean_database
     def test_basics(self, app):
         # given
@@ -28,49 +25,10 @@ class ArchiveOldBookingsTest:
         old_booking_id = old_booking.id
 
         # when
-        run_command(app, "archive_old_bookings")
+        run_command(app, "archive_old_activation_code_bookings")
 
         # then
         old_booking = bookings_models.Booking.query.get(old_booking_id)
         recent_booking = bookings_models.Booking.query.get(recent_booking_id)
         assert old_booking.displayAsEnded
         assert not recent_booking.displayAsEnded
-
-    @clean_database
-    @pytest.mark.parametrize(
-        "subcategoryId",
-        [
-            subcategories_v2.ABO_MUSEE.id,
-            subcategories_v2.CARTE_MUSEE.id,
-            subcategories_v2.ABO_BIBLIOTHEQUE.id,
-            subcategories_v2.ABO_MEDIATHEQUE.id,
-        ],
-    )
-    def test_old_subcategories_bookings_are_archived(self, app, subcategoryId):
-        # given
-        now = datetime.datetime.utcnow()
-        recent = now - datetime.timedelta(days=29, hours=23)
-        old = now - datetime.timedelta(days=30, hours=1)
-        stock_free = offers_factories.StockFactory(
-            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=0
-        )
-        stock_not_free = offers_factories.StockFactory(
-            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=10
-        )
-        recent_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=recent)
-        old_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=old)
-        old_not_free_booking = bookings_factories.BookingFactory(stock=stock_not_free, dateCreated=old)
-        recent_booking_id = recent_booking.id
-        old_booking_id = old_booking.id
-        old_not_free_booking_id = old_not_free_booking.id
-
-        # when
-        run_command(app, "archive_old_bookings")
-
-        # then
-        old_booking = bookings_models.Booking.query.get(old_booking_id)
-        old_not_free_booking = bookings_models.Booking.query.get(old_not_free_booking_id)
-        recent_booking = bookings_models.Booking.query.get(recent_booking_id)
-        assert not recent_booking.displayAsEnded
-        assert not old_not_free_booking.displayAsEnded
-        assert old_booking.displayAsEnded

--- a/pro/src/apiClient/v1/models/SiretInfo.ts
+++ b/pro/src/apiClient/v1/models/SiretInfo.ts
@@ -12,3 +12,4 @@ export type SiretInfo = {
   name: string;
   siret: string;
 };
+


### PR DESCRIPTION
This reverts commit f986c6a4ce50b9d547f99ba46ae99e6f24565871.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21975

## But de la pull request

Supprime l'archivation des offres gratuites de certaines sous catégories

## Implémentation

Revert

## Informations supplémentaires

Des nouvelles demandes métier sont apparues et nous ne voulons pas embarquer cela dans la MES de demain

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
