### PR TITLE
(PC-22464)[PRO] feat: add postal code and city to validation summary new onboarding

### DIFF
--- a/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/Validation.tsx
@@ -125,7 +125,9 @@ const Validation = (): JSX.Element => {
             {offerer?.publicName || offerer?.name}
           </div>
           <div className={styles['data-line']}>{offerer?.siret}</div>
-          <div className={styles['data-line']}>{offerer?.address}</div>
+          <div className={styles['data-line']}>
+            {offerer?.address}, {offerer?.postalCode} {offerer?.city}
+          </div>
         </Banner>
       </section>
       <section className={styles['validation-screen']}>

--- a/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -145,7 +145,7 @@ describe('screens:SignupJourney::Validation', () => {
     expect(screen.getByText('url2')).toBeInTheDocument()
     expect(screen.getByText('nom public')).toBeInTheDocument()
     expect(screen.getByText('123123123')).toBeInTheDocument()
-    expect(screen.getByText('3 Rue de Valois')).toBeInTheDocument()
+    expect(screen.getByText('3 Rue de Valois, 75001 Paris')).toBeInTheDocument()
     expect(screen.getByText('À des groupes scolaires')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22464

## But de la pull request

- Ajout du code postal et du nom de la ville sur la page de récap du nouveau parcours d'onboarding

## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/4c38f76f-c079-431a-876d-29a5a8cdbd6d)
