### PR TITLE
(PC-21991)[API] fix: error if isbn contains invalid json

### DIFF
--- a/api/src/pcapi/scripts/offer/fill_product_and_offer_ean.py
+++ b/api/src/pcapi/scripts/offer/fill_product_and_offer_ean.py
@@ -40,7 +40,7 @@ def fill_product_ean(start: int, end: int) -> None:
         start_time = time.perf_counter()
         db.session.execute(
             """
-            update product set "jsonData" = jsonb_set("jsonData", '{ean}', ("jsonData"->>'isbn')::jsonb)
+            update product set "jsonData" = jsonb_set("jsonData", '{ean}', to_jsonb("jsonData"->>'isbn'))
             where "jsonData"->>'isbn' != ''
             and id between :start and :end
             """,
@@ -68,7 +68,7 @@ def fill_offer_ean(start: int, end: int) -> None:
         start_time = time.perf_counter()
         db.session.execute(
             """
-            update offer set "jsonData" = jsonb_set("jsonData", '{ean}', ("jsonData"->>'isbn')::jsonb)
+            update offer set "jsonData" = jsonb_set("jsonData", '{ean}', to_jsonb("jsonData"->>'isbn'))
             where "jsonData"->>'isbn' != ''
             and id between :start and :end
             """,


### PR DESCRIPTION
Casting to jsonb with `::jsonb` does not work if json is invalid like : '978-2-811-61170-5'

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21991

```sql
CREATE OR REPLACE FUNCTION f_is_json(_txt text)
    RETURNS bool
    LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE AS
  $func$
  BEGIN
     RETURN _txt::jsonb IS NOT NULL;
  EXCEPTION
     WHEN SQLSTATE '22P02' THEN  -- invalid_text_representation
        RETURN false;
  END
  $func$;
CREATE FUNCTION
Time: 0.011s
SELECT f_is_json('61451128-9549'), f_is_json('1234567891234');
+-----------+-----------+
| f_is_json | f_is_json |
|-----------+-----------|
| False     | True      |
+-----------+-----------+
```