### PR TITLE
(PC-21957)[BO] feat: add SIRET in venue edition (for venue without SIRET)

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/string_field.html
@@ -8,6 +8,7 @@
          {% if field.flags.required %}required{% endif %}
          {% if field.flags.pattern %}pattern="{{ field.flags.pattern }}"{% endif %}
          {% if field.flags.minlength %}minlength="{{ field.flags.minlength }}"{% endif %}
-         {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %} />
+         {% if field.flags.maxlength %}maxlength="{{ field.flags.maxlength }}"{% endif %}
+         {% if field.flags.disabled %}disabled{% endif %} />
   <label for="{{ string_field_id }}">{{ field.label.text }}</label>
 </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21957

## But de la pull request

Permettre d'ajouter un SIRET à un lieu sans SIRET depuis le backoffice.

Seuls les utilisateurs du backoffice ayant la permission  “support pro avancé : déplacer un SIRET” pourront faire cette opération, ainsi que la modification de SIRET ; pour les autres, ce champ est désactivé dans la modale d'édition.

## Informations supplémentaires

Les vérifications faites dans FA ont été reprises.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
