### PR TITLE
(PC-22262)[BO] feat: edit end date for custom reimbursement rule

### DIFF
--- a/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
+++ b/api/src/pcapi/admin/custom_views/custom_reimbursement_rule_view.py
@@ -201,10 +201,7 @@ def get_error_message(exception: finance_exceptions.ReimbursementRuleValidationE
     if isinstance(exception, finance_exceptions.ConflictingReimbursementRule):
         msg = str(exception)
         msg += " Identifiant(s) technique(s) : "
-        msg += ", ".join(
-            f'<a href="/pc/back-office/customreimbursementrule/?flt1_0={rule_id}" target="_blank">{rule_id}</a>'
-            for rule_id in exception.conflicts
-        )
+        msg += ", ".join(str(rule_id) for rule_id in exception.conflicts)
         msg += "."
         return markupsafe.Markup(msg)  # pylint: disable=markupsafe-uncontrolled-string
     return str(exception)

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1802,11 +1802,11 @@ def _create_reimbursement_rule(
 ) -> models.CustomReimbursementRule:
     subcategories = subcategories or []
     if not (bool(offerer_id) ^ bool(offer_id)):
-        raise ValueError("Must provider offer or offerer (but not both)")
+        raise ValueError("Must provide offer or offerer (but not both)")
     if not (bool(rate) ^ bool(amount)):
-        raise ValueError("Must provider rate or amount (but not both)")
+        raise ValueError("Must provide rate or amount (but not both)")
     if not (bool(rate) or not bool(offerer_id)):
-        raise ValueError("Rate must be specified only with an offerere (not with an offer)")
+        raise ValueError("Rate must be specified only with an offerer (not with an offer)")
     if not (bool(amount) or not bool(offer_id)):
         raise ValueError("Amount must be specified only with an offer (not with an offerer)")
     if not start_date:
@@ -1829,6 +1829,9 @@ def edit_reimbursement_rule(
     rule: models.CustomReimbursementRule,
     end_date: datetime.datetime,
 ) -> models.CustomReimbursementRule:
+    if rule.timespan.lower <= datetime.datetime.utcnow():
+        error = "Il n'est pas possible de modifier la date de fin lorsque la date de début est dépassée."
+        raise exceptions.WrongDateForReimbursementRule(error)
     # To avoid complexity, we do not allow to edit the end date of a
     # rule that already has one.
     if rule.timespan.upper:

--- a/api/src/pcapi/routes/backoffice_v3/forms/custom_reimbursement_rule.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/custom_reimbursement_rule.py
@@ -38,7 +38,7 @@ class GetCustomReimbursementRulesListForm(FlaskForm):
         )
 
 
-class EditCustomReimbursementRule(FlaskForm):
+class CreateCustomReimbursementRuleForm(FlaskForm):
     class Meta:
         locales = ["fr_FR", "fr"]
 
@@ -51,7 +51,7 @@ class EditCustomReimbursementRule(FlaskForm):
         validators=[wtforms.validators.InputRequired("Information obligatoire")],
     )
     subcategories = fields.PCSelectMultipleField(
-        "Sous-catégories", choices=map(lambda s: (s.id, s.pro_label), subcategories_v2.ALL_SUBCATEGORIES)
+        "Sous-catégories", choices=[(s.id, s.pro_label) for s in subcategories_v2.ALL_SUBCATEGORIES]
     )
 
     rate = fields.PCDecimalField(
@@ -82,3 +82,12 @@ class EditCustomReimbursementRule(FlaskForm):
             raise wtforms.ValidationError("Ne peut pas commencer avant demain")
 
         return start_date
+
+
+class EditCustomReimbursementRuleForm(FlaskForm):
+    class Meta:
+        locales = ["fr_FR", "fr"]
+
+    end_date = fields.PCDateField(
+        "Date de fin d'application", validators=(wtforms.validators.InputRequired("obligatoire"),)
+    )

--- a/api/src/pcapi/routes/backoffice_v3/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/custom_reimbursement_rules/list.html
@@ -26,7 +26,7 @@
                 data-bs-toggle="modal"
                 data-bs-target="#create-custom-reimbursement-rule"
                 type="button">Créer un tarif dérogatoire</button>
-        {{ build_lazy_modal(url_for("backoffice_v3_web.reimbursement_rules.get_custom_reimbursement_rules_form"), "create-custom-reimbursement-rule") }}
+        {{ build_lazy_modal(url_for("backoffice_v3_web.reimbursement_rules.get_create_custom_reimbursement_rule_form"), "create-custom-reimbursement-rule") }}
       {% endif %}
       {% if rows %}
         <div class="d-flex justify-content-between">
@@ -51,14 +51,23 @@
             {% for reimbursement_rule in rows %}
               <tr>
                 <td>
-                  <div class="dropdown">
-                    <button type="button"
-                            data-bs-toggle="dropdown"
-                            aria-expanded="false"
-                            class="btn p-0">
-                      <i class="bi bi-three-dots-vertical"></i>
-                    </button>
-                  </div>
+                  {% if reimbursement_rule.timespan.lower > now and not reimbursement_rule.timespan.upper %}
+                    <div class="dropdown">
+                      <button type="button"
+                              data-bs-toggle="dropdown"
+                              aria-expanded="false"
+                              class="btn p-0">
+                        <i class="bi bi-three-dots-vertical"></i>
+                      </button>
+                      <ul class="dropdown-menu">
+                        <li class="dropdown-item p-0">
+                          <a class="btn btn-sm d-block w-100 text-start px-3"
+                             data-bs-toggle="modal"
+                             data-bs-target="#edit-custom-reimbursement-rule-{{ reimbursement_rule.id }}">Modifier</a>
+                        </li>
+                      </ul>
+                    </div>
+                  {% endif %}
                 </td>
                 <td>{{ reimbursement_rule.id }}</td>
                 {% if reimbursement_rule.offerer %}
@@ -80,6 +89,13 @@
             {% endfor %}
           </tbody>
         </table>
+        {% for reimbursement_rule in rows %}
+          {% if reimbursement_rule.timespan.lower > now and not reimbursement_rule.timespan.upper %}
+            {{ build_lazy_modal(
+            url_for("backoffice_v3_web.reimbursement_rules.get_edit_custom_reimbursement_rule_form", reimbursement_rule_id=reimbursement_rule.id),
+            "edit-custom-reimbursement-rule-" + reimbursement_rule.id|string) }}
+          {% endif %}
+        {% endfor %}
       {% endif %}
     </div>
   </div>

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_with_custom_reimbursement_rule.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_with_custom_reimbursement_rule.py
@@ -10,13 +10,43 @@ logger = logging.getLogger(__name__)
 
 def create_industrial_offerer_with_custom_reimbursement_rule() -> None:
     logger.info("create_industrial_offerer_with_custom_reimbursement_rule")
-    offerer = offerers_factories.OffererFactory(name="Structure avec un tarif dérogatoire")
+    offerer = offerers_factories.OffererFactory(name="Structure avec des tarifs dérogatoires")
     finance_factories.CustomReimbursementRuleFactory(
         offerer=offerer,
         subcategories=["FESTIVAL_LIVRE", "FESTIVAL_CINE"],
-        timespan=[
+        timespan=[  # start date in the past => not editable
             datetime.datetime.utcnow() - datetime.timedelta(days=365),
             None,
         ],
+    )
+    finance_factories.CustomReimbursementRuleFactory(
+        offerer=offerer,
+        subcategories=["FESTIVAL_MUSIQUE"],
+        timespan=[  # start date in the future, end date not defined => editable
+            datetime.datetime.utcnow() + datetime.timedelta(days=100),
+            None,
+        ],
+        amount=None,
+        rate=0.925,
+    )
+    finance_factories.CustomReimbursementRuleFactory(
+        offerer=offerer,
+        subcategories=["FESTIVAL_SPECTACLE"],
+        timespan=[  # start date in the future, end date not defined => editable
+            datetime.datetime.utcnow() + datetime.timedelta(days=150),
+            None,
+        ],
+        amount=None,
+        rate=0.9125,
+    )
+    finance_factories.CustomReimbursementRuleFactory(
+        offerer=offerer,
+        subcategories=["FESTIVAL_ART_VISUEL"],
+        timespan=[  # start date in the future but end date defined => not editable
+            datetime.datetime.utcnow() + datetime.timedelta(days=200),
+            datetime.datetime.utcnow() + datetime.timedelta(days=250),
+        ],
+        amount=None,
+        rate=0.9,
     )
     logger.info("Created offerer with custom reimbursement rule")

--- a/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
+++ b/api/tests/admin/custom_views/custom_reimbursement_rule_view_test.py
@@ -39,7 +39,7 @@ def test_create_rule(mocked_validate_csrf_token, client, app):
 @mock.patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
 def test_edit_rule(mocked_validate_csrf_token, client, app):
     admin = users_factories.AdminFactory()
-    timespan = (datetime.datetime.today() - datetime.timedelta(days=10), None)
+    timespan = (datetime.datetime.today() + datetime.timedelta(days=10), None)
     rule = finance_factories.CustomReimbursementRuleFactory(timespan=timespan)
 
     client = client.with_session_auth(admin.email)

--- a/api/tests/routes/backoffice_v3/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice_v3/custom_reimbursement_rules_test.py
@@ -12,6 +12,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
+from pcapi.models import db
 from pcapi.utils import date as date_utils
 
 from .helpers import html_parser
@@ -158,8 +159,20 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         assert "Il y a plus de 25 résultats dans la base de données" in html_parser.extract_alert(response.data)
 
 
-class CreateCustomReimbursementRulesTest(PostEndpointHelper):
-    endpoint = "backoffice_v3_web.reimbursement_rules.create_custom_reimbursement_rules"
+class GetCreateCustomReimbursementRuleFormTest(GetEndpointHelper):
+    endpoint = "backoffice_v3_web.reimbursement_rules.get_create_custom_reimbursement_rule_form"
+    needed_permission = perm_models.Permissions.CREATE_REIMBURSEMENT_RULES
+
+    def test_get_create_form_test(self, legit_user, authenticated_client):
+        form_url = url_for(self.endpoint)
+
+        with assert_num_queries(2):  # session + user
+            response = authenticated_client.get(form_url)
+            assert response.status_code == 200
+
+
+class CreateCustomReimbursementRuleTest(PostEndpointHelper):
+    endpoint = "backoffice_v3_web.reimbursement_rules.create_custom_reimbursement_rule"
     needed_permission = perm_models.Permissions.CREATE_REIMBURSEMENT_RULES
     tomorrow = datetime.date.today() + datetime.timedelta(days=1)
     next_year = datetime.date.today() + datetime.timedelta(days=365)
@@ -177,6 +190,11 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Le tarif dérogatoire a été créé"
+        )
+
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offererId == offerer.id
         assert rule.rate == Decimal("0.1234")
@@ -187,7 +205,6 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             self.next_year + datetime.timedelta(days=1), finance_utils.ACCOUNTING_TIMEZONE
         ).astimezone(tz=None).replace(tzinfo=None)
         assert set(rule.subcategories) == {"ABO_CONCERT", "ABO_JEU_VIDEO"}
-        assert "Tarif dérogatoire créé" in html_parser.extract_alert(authenticated_client.get(response.location).data)
 
     def test_create_with_invalid_offerer(self, authenticated_client):
         response = self.post_to_endpoint(
@@ -199,10 +216,12 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
-        assert finance_models.CustomReimbursementRule.query.count() == 0
-        assert "Tarif dérogatoire non créé" in html_parser.extract_alert(
-            authenticated_client.get(response.location).data
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Must provide offer or offerer (but not both)"
         )
+
+        assert finance_models.CustomReimbursementRule.query.count() == 0
 
     def test_create_with_no_end_date(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -216,12 +235,16 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Le tarif dérogatoire a été créé"
+        )
+
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.timespan.lower == date_utils.get_day_start(
             self.tomorrow, finance_utils.ACCOUNTING_TIMEZONE
         ).astimezone(tz=None).replace(tzinfo=None)
-        assert rule.timespan.upper == None
-        assert "Tarif dérogatoire créé" in html_parser.extract_alert(authenticated_client.get(response.location).data)
+        assert rule.timespan.upper is None
 
     def test_create_with_start_date_too_early(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -234,10 +257,11 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
-        assert finance_models.CustomReimbursementRule.query.count() == 0
         assert "Ne peut pas commencer avant demain" in html_parser.extract_alert(
             authenticated_client.get(response.location).data
         )
+
+        assert finance_models.CustomReimbursementRule.query.count() == 0
 
     def test_create_with_end_date_before_start_date(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -251,10 +275,11 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
-        assert finance_models.CustomReimbursementRule.query.count() == 0
         assert "Ne peut pas être postérieure à la date de fin" in html_parser.extract_alert(
             authenticated_client.get(response.location).data
         )
+
+        assert finance_models.CustomReimbursementRule.query.count() == 0
 
     def test_create_with_invalid_rate(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -281,9 +306,13 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Le tarif dérogatoire a été créé"
+        )
+
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.rate == Decimal(1)
-        assert "Tarif dérogatoire créé" in html_parser.extract_alert(authenticated_client.get(response.location).data)
 
     def test_create_with_rate_0(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -297,9 +326,12 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
-        rule = finance_models.CustomReimbursementRule.query.one()
-        assert rule.rate == Decimal(0)
-        assert "Tarif dérogatoire créé" in html_parser.extract_alert(authenticated_client.get(response.location).data)
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Must provide rate or amount (but not both)"
+        )
+
+        assert finance_models.CustomReimbursementRule.query.count() == 0
 
     def test_create_with_negative_rate(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -312,10 +344,11 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
-        assert finance_models.CustomReimbursementRule.query.count() == 0
         assert "Doit contenir un nombre positif" in html_parser.extract_alert(
             authenticated_client.get(response.location).data
         )
+
+        assert finance_models.CustomReimbursementRule.query.count() == 0
 
     def test_create_with_greater_rate(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -328,10 +361,11 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
-        assert finance_models.CustomReimbursementRule.query.count() == 0
         assert "Doit contenir un nombre inférieur ou égal à 100" in html_parser.extract_alert(
             authenticated_client.get(response.location).data
         )
+
+        assert finance_models.CustomReimbursementRule.query.count() == 0
 
     def test_create_with_no_subcategory(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -345,10 +379,14 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
             },
         )
         assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Le tarif dérogatoire a été créé"
+        )
+
         rule = finance_models.CustomReimbursementRule.query.one()
         assert rule.offererId == offerer.id
         assert rule.subcategories == []
-        assert "Tarif dérogatoire créé" in html_parser.extract_alert(authenticated_client.get(response.location).data)
 
     def test_create_with_invalid_subcategory(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -364,3 +402,84 @@ class CreateCustomReimbursementRulesTest(PostEndpointHelper):
         )
         assert response.status_code == 303
         assert finance_models.CustomReimbursementRule.query.count() == 0
+
+
+class GetEditCustomReimbursementRuleFormTest(GetEndpointHelper):
+    endpoint = "backoffice_v3_web.reimbursement_rules.get_edit_custom_reimbursement_rule_form"
+    endpoint_kwargs = {"reimbursement_rule_id": 1}
+    needed_permission = perm_models.Permissions.CREATE_REIMBURSEMENT_RULES
+
+    def test_get_edit_form_test(self, legit_user, authenticated_client):
+        custom_reimbursement_rule = finance_factories.CustomReimbursementRuleFactory()
+        form_url = url_for(self.endpoint, reimbursement_rule_id=custom_reimbursement_rule.id)
+        db.session.expire(custom_reimbursement_rule)
+
+        with assert_num_queries(3):  # session + user + rule
+            response = authenticated_client.get(form_url)
+            assert response.status_code == 200
+
+
+class EditCustomReimbursementRuleTest(PostEndpointHelper):
+    endpoint = "backoffice_v3_web.reimbursement_rules.edit_custom_reimbursement_rule"
+    endpoint_kwargs = {"reimbursement_rule_id": 1}
+    needed_permission = perm_models.Permissions.CREATE_REIMBURSEMENT_RULES
+
+    def test_update_custom_reimbursement_rule(self, authenticated_client):
+        original_timespan = (datetime.datetime.today() + datetime.timedelta(days=1), None)
+        rule = finance_factories.CustomReimbursementRuleFactory(timespan=original_timespan)
+        new_end_date = datetime.date.today() + datetime.timedelta(days=5)
+
+        response = self.post_to_endpoint(
+            authenticated_client, reimbursement_rule_id=rule.id, form={"end_date": new_end_date}
+        )
+
+        assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Le tarif dérogatoire a été mis à jour"
+        )
+
+        db.session.refresh(rule)
+        assert rule.timespan.lower == original_timespan[0]
+        assert rule.timespan.upper == date_utils.get_day_start(
+            new_end_date + datetime.timedelta(days=1), finance_utils.ACCOUNTING_TIMEZONE
+        ).astimezone(tz=None).replace(tzinfo=None)
+
+    def test_update_when_end_date_already_defined(self, authenticated_client):
+        original_timespan = (
+            datetime.datetime.today() + datetime.timedelta(days=5),
+            datetime.datetime.today() + datetime.timedelta(days=10),
+        )
+        rule = finance_factories.CustomReimbursementRuleFactory(timespan=original_timespan)
+        new_end_date = datetime.date.today() + datetime.timedelta(days=15)
+
+        response = self.post_to_endpoint(
+            authenticated_client, reimbursement_rule_id=rule.id, form={"end_date": new_end_date}
+        )
+
+        assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "Il n'est pas possible de modifier la date de fin lorsque celle-ci est déjà définie."
+        )
+
+        db.session.refresh(rule)
+        assert rule.timespan.lower, rule.timespan.upper == original_timespan
+
+    def test_update_with_end_date_before_start_date(self, authenticated_client):
+        original_timespan = (datetime.datetime.today() + datetime.timedelta(days=10), None)
+        rule = finance_factories.CustomReimbursementRuleFactory(timespan=original_timespan)
+        new_end_date = datetime.date.today() + datetime.timedelta(days=5)
+
+        response = self.post_to_endpoint(
+            authenticated_client, reimbursement_rule_id=rule.id, form={"end_date": new_end_date}
+        )
+
+        assert response.status_code == 303
+        assert (
+            html_parser.extract_alert(authenticated_client.get(response.location).data)
+            == "La date de fin d'application doit être postérieure à la date de début."
+        )
+
+        db.session.refresh(rule)
+        assert rule.timespan.lower, rule.timespan.upper == original_timespan


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22262

## But de la pull request

Permettre de définir la date de fin d'un tarif dérogatoire, uniquement dans le cas où la date de début n'est pas encore atteinte ET il n'y a pas de date de fin.
Les vérifications et fonctions appelées sont les mêmes que dans Flask-Admin.

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/82219a9c-e8f8-4015-a000-e717eb43a1a1)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [x] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
