### PR TITLE
(PC-22265)[API] feat: pro onboarding send welcome email only in the case of new offerer is created

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1714,11 +1714,13 @@ def create_from_onboarding_data(
         venue = create_venue(venue_creation_info, strict_accessibility_compliance=False)
         create_venue_registration(venue.id, new_onboarding_info.target, new_onboarding_info.webPresence)
 
-    if not transactional_mails.send_welcome_to_pro_email(user):
-        logger.warning(
-            "Could not send welcome to pro email",
-            extra={"user": user.id},
-        )
+    # Send welcome email only in the case of offerer creation
+    if user_offerer.validationStatus == ValidationStatus.VALIDATED:
+        if not transactional_mails.send_welcome_to_pro_email(user):
+            logger.warning(
+                "Could not send welcome to pro email",
+                extra={"user": user.id},
+            )
 
     return user_offerer
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1527,7 +1527,7 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.authorUser == user
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
-        self.assert_only_welcome_email_to_pro_was_sent()
+        assert len(mails_testing.outbox) == 0
         # Venue Registration
         self.assert_venue_registration_attrs(created_venue)
 
@@ -1565,7 +1565,7 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.authorUser == user
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
-        self.assert_only_welcome_email_to_pro_was_sent()
+        assert len(mails_testing.outbox) == 0
         # Venue Registration
         self.assert_venue_registration_attrs(created_venue)
 
@@ -1598,6 +1598,6 @@ class CreateFromOnboardingDataTest:
         assert offerer_action.authorUser == user
         assert offerer_action.user == user
         self.assert_common_action_history_extra_data(offerer_action)
-        self.assert_only_welcome_email_to_pro_was_sent()
+        assert len(mails_testing.outbox) == 0
         # Venue Registration
         assert offerers_models.VenueRegistration.query.count() == 0


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22265

## But de la pull request
PRO Onboarding: Envoyer le mail de bienvenue seulement dans le cas de la création de nouvelle structure (rattachement validé automatiquement).
