### PR TITLE
(PC-22312)[API] feat: add icon when user has modified email

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -83,12 +83,17 @@
               <p>{{ user.postalCode | empty_string_if_null }}&nbsp;{{ user.city | empty_string_if_null }}</p>
             </div>
           </div>
-          <div class="d-flex flex-column  ms-5">
+          <div class="d-flex flex-column">
             <div class="mb-1">
               <span class="fw-bold">Numéro de pièce d'identité</span>
               <p>{{ user.idPieceNumber | empty_string_if_null }}</p>
               <div class="mb-1">
-                <span class="fw-bold">E-mail :</span> {{ user.email }}
+                <div class="d-flex align-items-center">
+                  <span class="fw-bold me-1">E-mail :</span> {{ user.email }}
+                  {% if user.email_history | length > 0 %}
+                    <i class="bi bi-exclamation-circle-fill text-warning ms-1 fs-4 pc-email-changed-icon"></i>
+                  {% endif %}
+                </div>
                 {% if has_permission("MANAGE_PUBLIC_ACCOUNT") %}
                   <form action="{{ url_for('.resend_validation_email', user_id=user.id) }}"
                         name="{{ url_for('.resend_validation_email', user_id=user.id) | action_to_name }}"

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -453,6 +453,21 @@ class GetPublicAccountTest(GetEndpointHelper):
             assert expected_badge in content
         assert "Suspendu" not in content
 
+    def test_get_public_account_with_modified_email(self, authenticated_client):
+        _, grant_18, _, _, _ = create_bunch_of_accounts()
+        users_factories.EmailUpdateEntryFactory(user=grant_18)
+
+        # when
+        user_id = grant_18.id
+
+        with assert_num_queries(3):
+            response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
+
+        # then
+        assert response.status_code == 200
+        parsed_html = html_parser.get_soup(response.data)
+        assert parsed_html.find("i", class_="pc-email-changed-icon") is not None
+
     @pytest.mark.parametrize(
         "reasonCodes",
         ([fraud_models.FraudReasonCode.DUPLICATE_ID_PIECE_NUMBER], [fraud_models.FraudReasonCode.DUPLICATE_USER]),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22312

## But de la pull request

Ajout d'un warning quand un utilisateur a une adresse mail modifiée

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
