### PR TITLE
(PC-22434)[API] fix: Change wording for banner on 17-18 transition

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/banner.py
+++ b/api/src/pcapi/routes/native/v1/serialization/banner.py
@@ -31,7 +31,7 @@ class BannerText(enum.Enum):
     ACTIVATION_BANNER = "à dépenser sur l'application"
     RETRY_IDENTITY_CHECK_BANNER = "Réessaie dès maintenant"
     TRANSITION_17_18_BANNER_ID_CHECK_DONE = "Confirme tes informations"
-    TRANSITION_17_18_BANNER_ID_CHECK_TODO = "Confirme ton identité"
+    TRANSITION_17_18_BANNER_ID_CHECK_TODO = "Vérifie ton identité"
 
 
 @dataclasses.dataclass

--- a/api/tests/routes/native/v1/banner_test.py
+++ b/api/tests/routes/native/v1/banner_test.py
@@ -183,7 +183,7 @@ class BannerTest:
         assert response.json == {
             "banner": {
                 "name": "transition_17_18_banner",
-                "text": "Confirme ton identité",
+                "text": "Vérifie ton identité",
                 "title": f"Débloque tes 300{u_nbsp}€",
             },
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22434

## But de la pull request
Changer le wording de la bannière de transition 17-18 pour les utilisateurs n'étant pas passés par DMS ou Ubble de "Confirme ton identité" à "Vérifie ton identité".

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
