### PR TITLE
(PC-22192)[API] feat: collective: return 400 if stock price too high

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_stock_serialize.py
@@ -39,6 +39,8 @@ def validate_price(price: float | None) -> float:
         raise ValueError("Le prix ne peut pas être nul.")
     if price < 0:
         raise ValueError("Le prix ne peut pas être négatif.")
+    if price > 100_000:
+        raise ValueError("Le prix est trop élevé.")
     return price
 
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22192

## But de la pull request

Éviter de renvoyer laisser passer une erreur 500 dans les rares cas où un utilisateur chercher à créer, par erreur, un stock collectif avec un prix très élevé. On souhaite éviter de se retrouver avec une erreur remontée par la base de données, à cause d'une trop grande valeur (qui dépasse le maximum autorisé par `numeric(10,2)`).

Il s'agit avant tout d'une question d'UX : faire une vérification rapide et renvoyer un message d'erreur clair pour les rares cas où un stock a un prix trop élevé.
