### PR TITLE
(PC-21991)[API] fix: error if isbn contains invalid json

### DIFF
--- a/api/src/pcapi/scripts/offer/fill_product_and_offer_ean.py
+++ b/api/src/pcapi/scripts/offer/fill_product_and_offer_ean.py
@@ -40,7 +40,7 @@ def fill_product_ean(start: int, end: int) -> None:
         start_time = time.perf_counter()
         db.session.execute(
             """
-            update product set "jsonData" = jsonb_set("jsonData", '{ean}', ("jsonData"->>'isbn')::jsonb)
+            update product set "jsonData" = jsonb_set("jsonData", '{ean}', "jsonData"->'isbn')
             where "jsonData"->>'isbn' != ''
             and id between :start and :end
             """,
@@ -68,7 +68,7 @@ def fill_offer_ean(start: int, end: int) -> None:
         start_time = time.perf_counter()
         db.session.execute(
             """
-            update offer set "jsonData" = jsonb_set("jsonData", '{ean}', ("jsonData"->>'isbn')::jsonb)
+            update offer set "jsonData" = jsonb_set("jsonData", '{ean}', "jsonData"->'isbn')
             where "jsonData"->>'isbn' != ''
             and id between :start and :end
             """,


### PR DESCRIPTION
Like '978-2-811-61170-5'

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21991

jsonb -> text returns jsonb
jsonb ->> text returns text

I had problems with `::jsonb` cast while it should not be needed

<img width="822" alt="Screenshot 2023-05-26 at 10 58 15" src="https://github.com/pass-culture/pass-culture-main/assets/95358853/2541c045-421a-4bbc-91c3-09ddba535e3b">

<img width="703" alt="Screenshot 2023-05-26 at 11 29 17" src="https://github.com/pass-culture/pass-culture-main/assets/95358853/70a3bf1c-5155-4a99-b560-9790566dd47b">


