### PR TITLE
(PC-22482)[PRO] fix: fix CollectiveOfferSummaryEdition unit test flakyness

### DIFF
--- a/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/screens/CollectiveOfferSummaryEdition/__specs__/CollectiveOfferSummaryEdition.spec.tsx
@@ -4,11 +4,7 @@ import fetchMock from 'jest-fetch-mock'
 import React from 'react'
 
 import { api } from 'apiClient/api'
-import {
-  ApiError,
-  CollectiveOfferResponseIdModel,
-  GetVenueResponseModel,
-} from 'apiClient/v1'
+import { ApiError, CollectiveOfferResponseIdModel } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
 import { ApiResult } from 'apiClient/v1/core/ApiResult'
 import {
@@ -28,7 +24,10 @@ import {
   categoriesFactory,
   subCategoriesFactory,
 } from 'screens/OfferEducational/__tests-utils__'
-import { collectiveOfferTemplateFactory } from 'utils/collectiveApiFactories'
+import {
+  collectiveOfferTemplateFactory,
+  defaultVenueResponseModel,
+} from 'utils/collectiveApiFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 
 import CollectiveOfferSummaryEdition from '../CollectiveOfferSummaryEdition'
@@ -89,7 +88,7 @@ describe('CollectiveOfferSummary', () => {
       setLogEvent: null,
     }))
 
-    jest.spyOn(api, 'getVenue').mockResolvedValue({} as GetVenueResponseModel)
+    jest.spyOn(api, 'getVenue').mockResolvedValue(defaultVenueResponseModel)
 
     jest.spyOn(api, 'getCollectiveOfferTemplate').mockResolvedValue(offer)
 

--- a/pro/src/utils/collectiveApiFactories.ts
+++ b/pro/src/utils/collectiveApiFactories.ts
@@ -12,11 +12,13 @@ import {
   GetCollectiveOfferManagingOffererResponseModel,
   GetCollectiveOfferVenueResponseModel,
   GetCollectiveVenueResponseModel,
+  GetVenueResponseModel,
   OfferAddressType,
   OfferStatus,
   StudentLevels,
   SubcategoryIdEnum,
   SubcategoryResponseModel,
+  VenueTypeCode,
 } from 'apiClient/v1'
 import { BOOKING_STATUS } from 'core/Bookings'
 import { CollectiveOffer, CollectiveOfferTemplate } from 'core/OfferEducational'
@@ -399,4 +401,33 @@ export const defaultIVenue: IVenue = {
   adageInscriptionDate: null,
   hasAdageId: false,
   collectiveDmsApplication: null,
+}
+
+export const defaultVenueResponseModel: GetVenueResponseModel = {
+  dateCreated: new Date().toISOString(),
+  dmsToken: 'fakeDmsToken',
+  fieldsUpdated: [],
+  hasAdageId: true,
+  id: '1',
+  collectiveDmsApplications: [],
+  isVirtual: false,
+  collectiveDomains: [],
+  managingOfferer: {
+    city: 'Paris',
+    dateCreated: new Date().toISOString(),
+    fieldsUpdated: [],
+    id: '1',
+    isValidated: true,
+    lastProviderId: '',
+    name: 'Ma super structure',
+    nonHumanizedId: 1,
+    postalCode: '75000',
+    siren: '',
+  },
+  managingOffererId: '1',
+  mentalDisabilityCompliant: null,
+  motorDisabilityCompliant: null,
+  name: 'Lieu de test',
+  nonHumanizedId: 1,
+  venueTypeCode: VenueTypeCode.CENTRE_CULTUREL,
 }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22482

## But de la pull request

Tentative de fix de la flakyness des tests unitaires `CollectiveOfferSummaryEdition.spec.tsx`. Il semblerait que le fait de ne pas mocker correctement le lieu retourné par `getVenue` cause des problèmes lors des tests 