### PR TITLE
(PC-22483)[API] chore: modify generate_fake_adage_token to match new url

### DIFF
--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -35,12 +35,13 @@ def reindex_all_collective_offers() -> None:
 
 
 @blueprint.cli.command("generate_fake_adage_token")
-def generate_fake_adage_token() -> None:
+@click.option("--readonly", type=bool, is_flag=True, default=False, help="Generate a readonly token.")
+def generate_fake_adage_token(readonly: bool) -> None:
     """
     TO BE USED IN LOCAL ENV
     """
-    token = create_adage_jwt_fake_valid_token()
-    print(f"Adage localhost URL: http://localhost:3002/?token={token}")
+    token = create_adage_jwt_fake_valid_token(readonly)
+    print(f"Adage localhost URL: http://localhost:3001/adage-iframe?token={token}")
 
 
 @blueprint.cli.command("import_deposit_csv")

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -60,16 +60,17 @@ def log_information_for_data_purpose(
     )
 
 
-def create_adage_jwt_fake_valid_token() -> str:
+def create_adage_jwt_fake_valid_token(readonly: bool) -> str:
     with open("tests/routes/adage_iframe/private_keys_for_tests/valid_rsa_private_key", "rb") as reader:
         authenticated_informations = {
             "civilite": "M.",
             "nom": "TEST",
             "prenom": "COMPTE",
             "mail": "compte.test@education.gouv.fr",
-            "uai": "0910620E",
             "exp": datetime.utcnow() + timedelta(days=1),
         }
+        if not readonly:
+            authenticated_informations["uai"] = "0910620E"
 
         return jwt.encode(
             authenticated_informations,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22483

## But de la pull request

Modifier la commande `generate_fake_adage_token` : 

- Modifier l'url pour qu'elle corresponde à l'url de pro (l'iframe est désormais migrée dans ce dossier)
- Ajouter un flag `readonly` à la commande pour générer un token pour un utilisateur qui n'aurait des droits seulement en lecture

**Contexte sur les différents type d'utilisateurs adage  :** 

Sur adage on gère deux types d'utilisateurs désignés dans le code par les roles `readonly` ou `redactor`. Ces roles sont définis par la présence de la propriété `uai` dans le token d'authentification : 

- Si le token contient un uai l'utilisateur à le role de redactor (tout les droits : réservation, demande d'offre réservable, filtre en plus, etc ....)
- Sinon l'utilisateur a le role readonly (droit seulement en lecture : voir la liste des offres, filtres basiques, etc...)