### PR TITLE
(PC-22110)[PRO] feat: display budget in adage header menu

### DIFF
--- a/pro/src/pages/AdageIframe/app/adapters/getEducationalInstitutionWithBudgetAdapter.ts
+++ b/pro/src/pages/AdageIframe/app/adapters/getEducationalInstitutionWithBudgetAdapter.ts
@@ -1,0 +1,29 @@
+import { EducationalInstitutionWithBudgetResponseModel } from 'apiClient/adage'
+import { apiAdage } from 'apiClient/api'
+
+type getEducationalInstitutionWithBudgetAdapter = Adapter<
+  void,
+  EducationalInstitutionWithBudgetResponseModel,
+  null
+>
+
+const FAILING_RESPONSE: AdapterFailure<null> = {
+  isOk: false,
+  message: 'Nous avons rencontré un problème lors du chargemement des données',
+  payload: null,
+}
+
+export const getEducationalInstitutionWithBudgetAdapter: getEducationalInstitutionWithBudgetAdapter =
+  async () => {
+    try {
+      const result = await apiAdage.getEducationalInstitutionWithBudget()
+
+      return {
+        isOk: true,
+        message: null,
+        payload: result,
+      }
+    } catch (e) {
+      return FAILING_RESPONSE
+    }
+  }

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.module.scss
@@ -21,6 +21,23 @@
     height: rem.torem(85px);
     align-items: center;
     gap: rem.torem(48px);
+
+
+    &-budget {
+      display: flex;
+      margin-left: auto;
+      margin-right: rem.torem(6px);
+
+      &-item {
+        @include fonts.caption;
+
+        position: relative;
+        display: flex;
+        align-items: center;
+        color: colors.$grey-dark;
+      }
+    }
+
   }
 
   &-nb-hits {
@@ -32,6 +49,27 @@
     border-radius: rem.torem(22px);
     margin-left: rem.torem(4px);
   }
+}
+
+.adage-header-separator {
+  width: rem.torem(1px);
+  height: rem.torem(42px);
+  background-color: #CBCDD2;
+  margin-right: rem.torem(32px);
+}
+
+.adage-header-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.adage-header-budget {
+  @include fonts.title4;
+  
+  display: block;
+  background-image: linear-gradient(to bottom, #eb0055, #320096);
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .adage-header-item {

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -1,7 +1,11 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import type { Hit } from 'react-instantsearch-core'
 
+import { EducationalInstitutionWithBudgetResponseModel } from 'apiClient/adage'
+import { apiAdage } from 'apiClient/api'
+import * as useNotification from 'hooks/useNotification'
+import { getEducationalInstitutionWithBudgetAdapter } from 'pages/AdageIframe/app/adapters/getEducationalInstitutionWithBudgetAdapter'
 import { defaultAlgoliaHits } from 'utils/adageFactories'
 import { renderWithProviders } from 'utils/renderWithProviders'
 import { ResultType } from 'utils/types'
@@ -13,6 +17,15 @@ const renderAdageHeader = (hits: Hit<ResultType>[] = []) => {
 }
 
 describe('AdageHeader', () => {
+  const notifyError = jest.fn()
+
+  beforeEach(() => {
+    jest.spyOn(useNotification, 'default').mockImplementation(() => ({
+      ...jest.requireActual('hooks/useNotification'),
+      error: notifyError,
+    }))
+  })
+
   it('should render adage header', () => {
     renderAdageHeader()
 
@@ -27,5 +40,39 @@ describe('AdageHeader', () => {
     renderAdageHeader([defaultAlgoliaHits, defaultAlgoliaHits])
 
     expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('should display the institution budget', async () => {
+    jest
+      .spyOn(apiAdage, 'getEducationalInstitutionWithBudget')
+      .mockResolvedValueOnce({
+        budget: 10000,
+      } as EducationalInstitutionWithBudgetResponseModel)
+
+    renderAdageHeader()
+
+    await waitFor(
+      async () => await getEducationalInstitutionWithBudgetAdapter()
+    )
+
+    expect(screen.getByText('Budget restant')).toBeInTheDocument()
+    expect(screen.getByText('10,000€')).toBeInTheDocument()
+  })
+
+  it('should return an error when the institution budget could not be retrieved', async () => {
+    jest
+      .spyOn(apiAdage, 'getEducationalInstitutionWithBudget')
+      .mockRejectedValueOnce('')
+
+    renderAdageHeader()
+
+    const response = await getEducationalInstitutionWithBudgetAdapter()
+
+    expect(response.isOk).toBeFalsy()
+
+    expect(notifyError).toHaveBeenNthCalledWith(
+      1,
+      'Nous avons rencontré un problème lors du chargemement des données'
+    )
   })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22110

## But de la pull request

SOUS FF : 
WIP_ENABLE_NEW_ADAGE_HEADER

Ajouter le budget restant dans le nouveau menu d'adage

<img width="1512" alt="Capture d’écran 2023-05-26 à 11 25 39" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/7e0ebcb0-d414-4126-bbba-f254c483740c">

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
