### PR TITLE
(PC-21664)[API] feat: Send email when login is suspicious

### DIFF
--- a/api/src/pcapi/core/mails/transactional/__init__.py
+++ b/api/src/pcapi/core/mails/transactional/__init__.py
@@ -65,5 +65,6 @@ from .users.recredit_to_underage_beneficiary import send_recredit_email_to_under
 from .users.reported_offer_by_user import send_email_reported_offer_by_user
 from .users.reset_password import send_email_already_exists_email
 from .users.reset_password import send_reset_password_email_to_user
+from .users.suspicious_login_email import send_suspicious_login_email
 from .users.ubble.subscription_document_error import send_subscription_document_error_email
 from .users.unsuspension import send_unsuspension_email

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -78,6 +78,7 @@ class TransactionalEmail(Enum):
     SUBSCRIPTION_UNREADABLE_DOCUMENT_ERROR = models.Template(
         id_prod=304, id_not_prod=38, tags=["jeunes_document_illisible"]
     )
+    SUSPICIOUS_LOGIN = models.Template(id_prod=964, id_not_prod=129)
     USER_REQUEST_DELETE_ACCOUNT_RECEPTION = models.Template(
         id_prod=511, id_not_prod=54, tags=["reception_demande_suppression_compte_jeune"]
     )

--- a/api/src/pcapi/core/mails/transactional/users/suspicious_login_email.py
+++ b/api/src/pcapi/core/mails/transactional/users/suspicious_login_email.py
@@ -1,0 +1,14 @@
+from pcapi.core import mails
+from pcapi.core.mails import models
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+
+
+def get_suspicious_login_email_data() -> models.TransactionalEmailData:
+    return models.TransactionalEmailData(template=TransactionalEmail.SUSPICIOUS_LOGIN.value)
+
+
+def send_suspicious_login_email(
+    user_email: str,
+) -> bool:
+    data = get_suspicious_login_email_data()
+    return mails.send(recipients=[user_email], data=data)

--- a/api/src/pcapi/core/mails/transactional/users/suspicious_login_email.py
+++ b/api/src/pcapi/core/mails/transactional/users/suspicious_login_email.py
@@ -1,14 +1,32 @@
+from datetime import datetime
+
 from pcapi.core import mails
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.users.models import LoginDeviceHistory
 
 
-def get_suspicious_login_email_data() -> models.TransactionalEmailData:
-    return models.TransactionalEmailData(template=TransactionalEmail.SUSPICIOUS_LOGIN.value)
+def get_suspicious_login_email_data(login_info: LoginDeviceHistory | None) -> models.TransactionalEmailData:
+    if login_info:
+        params = {
+            "LOCATION": login_info.location,
+            "LOGIN_DATE": login_info.dateCreated.strftime("%d/%m/%Y"),
+            "LOGIN_TIME": login_info.dateCreated.strftime("%H:%M"),
+            "OS": login_info.os,
+            "SOURCE": login_info.source,
+        }
+    else:
+        params = {
+            "LOGIN_DATE": datetime.utcnow().strftime("%d/%m/%Y"),
+            "LOGIN_TIME": datetime.utcnow().strftime("%H:%M"),
+        }
+
+    return models.TransactionalEmailData(
+        template=TransactionalEmail.SUSPICIOUS_LOGIN.value,
+        params=params,
+    )
 
 
-def send_suspicious_login_email(
-    user_email: str,
-) -> bool:
-    data = get_suspicious_login_email_data()
+def send_suspicious_login_email(user_email: str, login_info: LoginDeviceHistory | None) -> bool:
+    data = get_suspicious_login_email_data(login_info)
     return mails.send(recipients=[user_email], data=data)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1273,3 +1273,5 @@ def is_suspicious_login(device_info: "account_serialization.TrustedDevice | None
     if not user.trusted_devices:
         return True
 
+    if any(device.deviceId == device_info.device_id for device in user.trusted_devices):
+        return False

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1266,6 +1266,10 @@ def should_save_login_device_as_trusted_device(
     ).scalar()
 
 
-def is_suspicious_login(user: models.User) -> bool:
+def is_suspicious_login(device_info: "account_serialization.TrustedDevice | None", user: models.User) -> bool:
+    if device_info is None or not device_info.device_id:
+        return True
+
     if not user.trusted_devices:
         return True
+

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1225,9 +1225,11 @@ def save_trusted_device(device_info: "account_serialization.TrustedDevice | None
     repository.save(trusted_device)
 
 
-def update_login_device_history(device_info: "account_serialization.TrustedDevice | None", user: models.User) -> None:
+def update_login_device_history(
+    device_info: "account_serialization.TrustedDevice | None", user: models.User
+) -> users_models.LoginDeviceHistory | None:
     if device_info is None:
-        return
+        return None
 
     if not device_info.device_id:
         logger.info(
@@ -1238,7 +1240,7 @@ def update_login_device_history(device_info: "account_serialization.TrustedDevic
                 "source": device_info.source,
             },
         )
-        return
+        return None
 
     login_device = users_models.LoginDeviceHistory(
         deviceId=device_info.device_id,
@@ -1247,6 +1249,8 @@ def update_login_device_history(device_info: "account_serialization.TrustedDevic
         user=user,
     )
     repository.save(login_device)
+
+    return login_device
 
 
 def should_save_login_device_as_trusted_device(

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1201,10 +1201,7 @@ def save_flags(user: models.User, flags: dict) -> None:
                 raise ValueError()
 
 
-def save_trusted_device(device_info: "account_serialization.TrustedDevice | None", user: models.User) -> None:
-    if device_info is None:
-        return
-
+def save_trusted_device(device_info: "account_serialization.TrustedDevice", user: models.User) -> None:
     if not device_info.device_id:
         logger.info(
             "Invalid deviceId was provided for trusted device",
@@ -1226,11 +1223,8 @@ def save_trusted_device(device_info: "account_serialization.TrustedDevice | None
 
 
 def update_login_device_history(
-    device_info: "account_serialization.TrustedDevice | None", user: models.User
+    device_info: "account_serialization.TrustedDevice", user: models.User
 ) -> users_models.LoginDeviceHistory | None:
-    if device_info is None:
-        return None
-
     if not device_info.device_id:
         logger.info(
             "Invalid deviceId was provided for login device",
@@ -1254,9 +1248,9 @@ def update_login_device_history(
 
 
 def should_save_login_device_as_trusted_device(
-    device_info: "account_serialization.TrustedDevice | None", user: models.User
+    device_info: "account_serialization.TrustedDevice", user: models.User
 ) -> bool:
-    if device_info is None or not device_info.device_id:
+    if not device_info.device_id:
         return False
 
     if any(device.deviceId == device_info.device_id for device in user.trusted_devices):

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1275,3 +1275,5 @@ def is_suspicious_login(device_info: "account_serialization.TrustedDevice | None
 
     if any(device.deviceId == device_info.device_id for device in user.trusted_devices):
         return False
+
+    return True

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1264,3 +1264,8 @@ def should_save_login_device_as_trusted_device(
         .filter(users_models.LoginDeviceHistory.deviceId == device_info.device_id)
         .exists()
     ).scalar()
+
+
+def is_suspicious_login(user: models.User) -> bool:
+    if not user.trusted_devices:
+        return True

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -153,7 +153,7 @@ def create_account(body: serializers.AccountRequest) -> None:
             apps_flyer_platform=body.apps_flyer_platform,
         )
 
-        if FeatureToggle.WIP_ENABLE_TRUSTED_DEVICE.is_active():
+        if FeatureToggle.WIP_ENABLE_TRUSTED_DEVICE.is_active() and body.trusted_device is not None:
             api.save_trusted_device(device_info=body.trusted_device, user=created_user)
 
     except exceptions.UserAlreadyExistsException:

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -59,10 +59,10 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
         if users_api.should_save_login_device_as_trusted_device(body.device_info, user):
             users_api.save_trusted_device(body.device_info, user)
 
-        if users_api.is_suspicious_login(body.device_info, user):
-            transactional_mails.send_suspicious_login_email(user.email)
+        login_history = users_api.update_login_device_history(body.device_info, user)
 
-        users_api.update_login_device_history(body.device_info, user)
+        if users_api.is_suspicious_login(body.device_info, user):
+            transactional_mails.send_suspicious_login_email(user.email, login_history)
 
     users_api.update_last_connection_date(user)
     return authentication.SigninResponse(

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -56,10 +56,12 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
         raise ApiErrors({"code": "ACCOUNT_DELETED", "general": ["Le compte a été supprimé"]})
 
     if FeatureToggle.WIP_ENABLE_TRUSTED_DEVICE.is_active():
-        if users_api.should_save_login_device_as_trusted_device(body.device_info, user):
-            users_api.save_trusted_device(body.device_info, user)
+        login_history = None
+        if body.device_info is not None:
+            if users_api.should_save_login_device_as_trusted_device(body.device_info, user):
+                users_api.save_trusted_device(body.device_info, user)
 
-        login_history = users_api.update_login_device_history(body.device_info, user)
+            login_history = users_api.update_login_device_history(body.device_info, user)
 
         if users_api.is_suspicious_login(body.device_info, user):
             transactional_mails.send_suspicious_login_email(user.email, login_history)

--- a/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
+++ b/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+import pcapi.core.mails.testing as mails_testing
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.users.suspicious_login_email import get_suspicious_login_email_data
+from pcapi.core.mails.transactional.users.suspicious_login_email import send_suspicious_login_email
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class SendinblueSuspiciousLoginEmailTest:
+    def test_should_return_sendinblue_template_data(self):
+        suspicious_email_data = get_suspicious_login_email_data()
+
+        assert suspicious_email_data.template == TransactionalEmail.SUSPICIOUS_LOGIN.value
+
+    def test_should_send_suspicious_login_email(self):
+        email = "123@test.com"
+        send_suspicious_login_email(email)
+
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
+        assert mails_testing.outbox[0].sent_data["To"] == email

--- a/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
+++ b/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
@@ -1,23 +1,54 @@
+from datetime import datetime
+
+from freezegun import freeze_time
 import pytest
 
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.mails.transactional.users.suspicious_login_email import get_suspicious_login_email_data
 from pcapi.core.mails.transactional.users.suspicious_login_email import send_suspicious_login_email
+from pcapi.core.users.models import LoginDeviceHistory
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class SendinblueSuspiciousLoginEmailTest:
+    login_info = LoginDeviceHistory(
+        deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
+        source="iPhone 13",
+        os="iOS",
+        location="Paris",
+        dateCreated=datetime(2023, 5, 29, 17, 5, 0),
+    )
+
     def test_should_return_sendinblue_template_data(self):
-        suspicious_email_data = get_suspicious_login_email_data()
+        suspicious_email_data = get_suspicious_login_email_data(self.login_info)
 
         assert suspicious_email_data.template == TransactionalEmail.SUSPICIOUS_LOGIN.value
 
     def test_should_send_suspicious_login_email(self):
         email = "123@test.com"
-        send_suspicious_login_email(email)
+        send_suspicious_login_email(email, self.login_info)
 
         assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
         assert mails_testing.outbox[0].sent_data["To"] == email
+        assert mails_testing.outbox[0].sent_data["params"] == {
+            "LOCATION": "Paris",
+            "SOURCE": "iPhone 13",
+            "OS": "iOS",
+            "LOGIN_DATE": "29/05/2023",
+            "LOGIN_TIME": "17:05",
+        }
+
+    @freeze_time("2023-05-29 17:05:00")
+    def test_should_send_suspicious_login_email_with_date_when_no_login_info(self):
+        email = "123@test.com"
+        send_suspicious_login_email(email, login_info=None)
+
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
+        assert mails_testing.outbox[0].sent_data["To"] == email
+        assert mails_testing.outbox[0].sent_data["params"] == {
+            "LOGIN_DATE": "29/05/2023",
+            "LOGIN_TIME": "17:05",
+        }

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1411,3 +1411,11 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=user)
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=self.device_info, user=user) is False
+
+
+class IsSuspiciousLoginTest:
+    def test_should_be_true_when_user_has_no_trusted_device(self):
+        user = users_factories.UserFactory(email="py@test.com")
+
+        assert user.trusted_devices == []
+        assert users_api.is_suspicious_login(user=user) is True

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1414,7 +1414,7 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
 
 
 class IsSuspiciousLoginTest:
-    def test_should_be_true_when_user_has_no_trusted_device(self):
+    def test_is_suspicious_when_user_has_no_trusted_device(self):
         user = users_factories.UserFactory(email="py@test.com")
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B", os="iOS", source="iPhone 13"
@@ -1423,18 +1423,18 @@ class IsSuspiciousLoginTest:
         assert user.trusted_devices == []
         assert users_api.is_suspicious_login(device_info=device_info, user=user) is True
 
-    def test_should_be_true_when_no_device_info(self):
+    def test_is_suspicious_when_no_device_info(self):
         user = users_factories.UserFactory(email="py@test.com")
 
         assert users_api.is_suspicious_login(device_info=None, user=user) is True
 
-    def test_should_be_true_when_no_device_id(self):
+    def test_is_suspicious_when_no_device_id(self):
         user = users_factories.UserFactory(email="py@test.com")
         device_without_id = account_serialization.TrustedDevice(deviceId="", os="iOS", source="iPhone 13")
 
         assert users_api.is_suspicious_login(device_info=device_without_id, user=user) is True
 
-    def test_should_be_false_when_device_id_matches_at_least_one_trusted_device(self):
+    def test_is_not_suspicious_when_device_is_a_trusted_device(self):
         user = users_factories.UserFactory(email="py@test.com")
         trusted_device = users_factories.TrustedDeviceFactory(user=user)
         users_factories.TrustedDeviceFactory(deviceId="3A44812-5776-235D-8E31-G4361H987A1A", user=user)
@@ -1444,7 +1444,7 @@ class IsSuspiciousLoginTest:
 
         assert users_api.is_suspicious_login(device_info=device_info, user=user) is False
 
-    def test_should_be_true_when_device_id_does_not_any_trusted_device(self):
+    def test_is_suspicious_when_device_is_not_a_trusted_device(self):
         user = users_factories.UserFactory(email="py@test.com")
         users_factories.TrustedDeviceFactory(user=user)
         device_info = account_serialization.TrustedDevice(deviceId="other-device-id", os="iOS", source="iPhone 13")

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1218,15 +1218,15 @@ class SearchPublicAccountTest:
 
 
 class SaveTrustedDeviceTest:
-    def test_should_not_save_trusted_device_when_no_info_provided(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_not_save_trusted_device_when_no_info_provided(self):
+        user = users_factories.UserFactory()
 
         users_api.save_trusted_device(device_info=None, user=user)
 
         assert users_models.TrustedDevice.query.count() == 0
 
-    def test_should_not_save_trusted_device_when_no_device_id_provided(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_not_save_trusted_device_when_no_device_id_provided(self):
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="",
             source="iPhone 13",
@@ -1238,7 +1238,7 @@ class SaveTrustedDeviceTest:
         assert users_models.TrustedDevice.query.count() == 0
 
     def test_can_save_trusted_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
             source="iPhone 13",
@@ -1254,7 +1254,7 @@ class SaveTrustedDeviceTest:
         assert trusted_device.os == "iOS"
 
     def test_can_access_trusted_devices_from_user(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
             source="iPhone 13",
@@ -1267,8 +1267,8 @@ class SaveTrustedDeviceTest:
 
         assert user.trusted_devices == [trusted_device]
 
-    def test_should_log_when_no_device_id(self, caplog):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_log_when_no_device_id(self, caplog):
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="",
             source="iPhone 13",
@@ -1287,15 +1287,15 @@ class SaveTrustedDeviceTest:
 
 
 class UpdateLoginDeviceHistoryTest:
-    def test_should_not_save_login_device_when_no_info_provided(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_not_save_login_device_when_no_info_provided(self):
+        user = users_factories.UserFactory()
 
         users_api.update_login_device_history(device_info=None, user=user)
 
         assert users_models.LoginDeviceHistory.query.count() == 0
 
-    def test_should_not_save_login_device_when_no_device_id_provided(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_not_save_login_device_when_no_device_id_provided(self):
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="",
             source="iPhone 13",
@@ -1307,7 +1307,7 @@ class UpdateLoginDeviceHistoryTest:
         assert users_models.LoginDeviceHistory.query.count() == 0
 
     def test_can_save_login_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
             source="iPhone 13",
@@ -1323,8 +1323,8 @@ class UpdateLoginDeviceHistoryTest:
         assert login_device.os == "iOS"
         assert login_device.location == None
 
-    def test_should_return_login_history(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_return_login_history(self):
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
             source="iPhone 13",
@@ -1338,7 +1338,7 @@ class UpdateLoginDeviceHistoryTest:
         assert login_history == login_device
 
     def test_can_access_login_device_history_from_user(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
             source="iPhone 13",
@@ -1351,8 +1351,8 @@ class UpdateLoginDeviceHistoryTest:
 
         assert user.login_device_history == [login_device]
 
-    def test_should_log_when_no_device_id(self, caplog):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_log_when_no_device_id(self, caplog):
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="",
             source="iPhone 13",
@@ -1375,52 +1375,52 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
         deviceId="2E429592-2446-425F-9A62-D6983F375B3B", os="iOS", source="iPhone 13"
     )
 
-    def test_should_be_false_when_no_device_info(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_false_when_no_device_info(self):
+        user = users_factories.UserFactory()
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=None, user=user) is False
 
-    def test_should_be_false_when_no_device_id(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_false_when_no_device_id(self):
+        user = users_factories.UserFactory()
         device_without_id = account_serialization.TrustedDevice(deviceId="", os="iOS", source="iPhone 13")
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=device_without_id, user=user) is False
 
-    def test_should_be_false_when_no_device_history_for_user(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_false_when_no_device_history_for_user(self):
+        user = users_factories.UserFactory()
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=self.device_info, user=user) is False
 
-    def test_should_be_true_when_user_has_device_history_matching_device_id(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_true_when_user_has_device_history_matching_device_id(self):
+        user = users_factories.UserFactory()
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=user)
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=self.device_info, user=user) is True
 
-    def test_should_be_false_when_user_has_device_history_for_different_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_false_when_user_has_device_history_for_different_device(self):
+        user = users_factories.UserFactory()
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=user)
 
         other_device_info = account_serialization.TrustedDevice(deviceId="other_id", os="iOS", source="iPhone 13")
         assert users_api.should_save_login_device_as_trusted_device(device_info=other_device_info, user=user) is False
 
-    def test_should_be_false_when_device_id_matches_different_user(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_false_when_device_id_matches_different_user(self):
+        user = users_factories.UserFactory()
         second_user = users_factories.UserFactory(email="py2@test.com")
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=second_user)
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=self.device_info, user=user) is False
 
-    def test_should_be_true_when_device_id_matches_multiple_users_including_current_user(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_true_when_device_id_matches_multiple_users_including_current_user(self):
+        user = users_factories.UserFactory()
         second_user = users_factories.UserFactory(email="py2@test.com")
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=second_user)
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=user)
 
         assert users_api.should_save_login_device_as_trusted_device(device_info=self.device_info, user=user) is True
 
-    def test_should_be_false_when_login_device_is_already_trusted_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+    def should_be_false_when_login_device_is_already_trusted_device(self):
+        user = users_factories.UserFactory()
         users_factories.TrustedDeviceFactory(deviceId=self.device_info.device_id, user=user)
         users_factories.LoginDeviceHistoryFactory(deviceId=self.device_info.device_id, user=user)
 

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1218,13 +1218,6 @@ class SearchPublicAccountTest:
 
 
 class SaveTrustedDeviceTest:
-    def should_not_save_trusted_device_when_no_info_provided(self):
-        user = users_factories.UserFactory()
-
-        users_api.save_trusted_device(device_info=None, user=user)
-
-        assert users_models.TrustedDevice.query.count() == 0
-
     def should_not_save_trusted_device_when_no_device_id_provided(self):
         user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
@@ -1287,13 +1280,6 @@ class SaveTrustedDeviceTest:
 
 
 class UpdateLoginDeviceHistoryTest:
-    def should_not_save_login_device_when_no_info_provided(self):
-        user = users_factories.UserFactory()
-
-        users_api.update_login_device_history(device_info=None, user=user)
-
-        assert users_models.LoginDeviceHistory.query.count() == 0
-
     def should_not_save_login_device_when_no_device_id_provided(self):
         user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
@@ -1374,11 +1360,6 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
     device_info = account_serialization.TrustedDevice(
         deviceId="2E429592-2446-425F-9A62-D6983F375B3B", os="iOS", source="iPhone 13"
     )
-
-    def should_be_false_when_no_device_info(self):
-        user = users_factories.UserFactory()
-
-        assert users_api.should_save_login_device_as_trusted_device(device_info=None, user=user) is False
 
     def should_be_false_when_no_device_id(self):
         user = users_factories.UserFactory()

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1415,7 +1415,7 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
 
 class IsSuspiciousLoginTest:
     def test_is_suspicious_when_user_has_no_trusted_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         device_info = account_serialization.TrustedDevice(
             deviceId="2E429592-2446-425F-9A62-D6983F375B3B", os="iOS", source="iPhone 13"
         )
@@ -1424,18 +1424,18 @@ class IsSuspiciousLoginTest:
         assert users_api.is_suspicious_login(device_info=device_info, user=user) is True
 
     def test_is_suspicious_when_no_device_info(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
 
         assert users_api.is_suspicious_login(device_info=None, user=user) is True
 
     def test_is_suspicious_when_no_device_id(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         device_without_id = account_serialization.TrustedDevice(deviceId="", os="iOS", source="iPhone 13")
 
         assert users_api.is_suspicious_login(device_info=device_without_id, user=user) is True
 
     def test_is_not_suspicious_when_device_is_a_trusted_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         trusted_device = users_factories.TrustedDeviceFactory(user=user)
         users_factories.TrustedDeviceFactory(deviceId="3A44812-5776-235D-8E31-G4361H987A1A", user=user)
         device_info = account_serialization.TrustedDevice(
@@ -1445,7 +1445,7 @@ class IsSuspiciousLoginTest:
         assert users_api.is_suspicious_login(device_info=device_info, user=user) is False
 
     def test_is_suspicious_when_device_is_not_a_trusted_device(self):
-        user = users_factories.UserFactory(email="py@test.com")
+        user = users_factories.UserFactory()
         users_factories.TrustedDeviceFactory(user=user)
         device_info = account_serialization.TrustedDevice(deviceId="other-device-id", os="iOS", source="iPhone 13")
 

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1323,6 +1323,20 @@ class UpdateLoginDeviceHistoryTest:
         assert login_device.os == "iOS"
         assert login_device.location == None
 
+    def test_should_return_login_history(self):
+        user = users_factories.UserFactory(email="py@test.com")
+        device_info = account_serialization.TrustedDevice(
+            deviceId="2E429592-2446-425F-9A62-D6983F375B3B",
+            source="iPhone 13",
+            os="iOS",
+        )
+
+        login_history = users_api.update_login_device_history(device_info=device_info, user=user)
+
+        login_device = users_models.LoginDeviceHistory.query.one()
+
+        assert login_history == login_device
+
     def test_can_access_login_device_history_from_user(self):
         user = users_factories.UserFactory(email="py@test.com")
         device_info = account_serialization.TrustedDevice(

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1416,6 +1416,20 @@ class ShouldSaveLoginDeviceAsTrustedDeviceTest:
 class IsSuspiciousLoginTest:
     def test_should_be_true_when_user_has_no_trusted_device(self):
         user = users_factories.UserFactory(email="py@test.com")
+        device_info = account_serialization.TrustedDevice(
+            deviceId="2E429592-2446-425F-9A62-D6983F375B3B", os="iOS", source="iPhone 13"
+        )
 
         assert user.trusted_devices == []
-        assert users_api.is_suspicious_login(user=user) is True
+        assert users_api.is_suspicious_login(device_info=device_info, user=user) is True
+
+    def test_should_be_true_when_no_device_info(self):
+        user = users_factories.UserFactory(email="py@test.com")
+
+        assert users_api.is_suspicious_login(device_info=None, user=user) is True
+
+    def test_should_be_true_when_no_device_id(self):
+        user = users_factories.UserFactory(email="py@test.com")
+        device_without_id = account_serialization.TrustedDevice(deviceId="", os="iOS", source="iPhone 13")
+
+        assert users_api.is_suspicious_login(device_info=device_without_id, user=user) is True

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1436,12 +1436,17 @@ class IsSuspiciousLoginTest:
 
     def test_should_be_false_when_device_id_matches_at_least_one_trusted_device(self):
         user = users_factories.UserFactory(email="py@test.com")
-        trusted_device = users_factories.TrustedDeviceFactory(
-            deviceId="2E429592-2446-425F-9A62-D6983F375B3B", user=user
-        )
+        trusted_device = users_factories.TrustedDeviceFactory(user=user)
         users_factories.TrustedDeviceFactory(deviceId="3A44812-5776-235D-8E31-G4361H987A1A", user=user)
         device_info = account_serialization.TrustedDevice(
             deviceId=trusted_device.deviceId, os="iOS", source="iPhone 13"
         )
 
         assert users_api.is_suspicious_login(device_info=device_info, user=user) is False
+
+    def test_should_be_true_when_device_id_does_not_any_trusted_device(self):
+        user = users_factories.UserFactory(email="py@test.com")
+        users_factories.TrustedDeviceFactory(user=user)
+        device_info = account_serialization.TrustedDevice(deviceId="other-device-id", os="iOS", source="iPhone 13")
+
+        assert users_api.is_suspicious_login(device_info=device_info, user=user) is True

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1433,3 +1433,15 @@ class IsSuspiciousLoginTest:
         device_without_id = account_serialization.TrustedDevice(deviceId="", os="iOS", source="iPhone 13")
 
         assert users_api.is_suspicious_login(device_info=device_without_id, user=user) is True
+
+    def test_should_be_false_when_device_id_matches_at_least_one_trusted_device(self):
+        user = users_factories.UserFactory(email="py@test.com")
+        trusted_device = users_factories.TrustedDeviceFactory(
+            deviceId="2E429592-2446-425F-9A62-D6983F375B3B", user=user
+        )
+        users_factories.TrustedDeviceFactory(deviceId="3A44812-5776-235D-8E31-G4361H987A1A", user=user)
+        device_info = account_serialization.TrustedDevice(
+            deviceId=trusted_device.deviceId, os="iOS", source="iPhone 13"
+        )
+
+        assert users_api.is_suspicious_login(device_info=device_info, user=user) is False

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -481,7 +481,7 @@ class AccountCreationTest:
 
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
-    def test_should_not_save_trusted_device_when_feature_flag_is_disabled(
+    def should_not_save_trusted_device_when_feature_flag_is_disabled(
         self, mocked_check_recaptcha_token_is_valid, client
     ):
         data = {

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -464,6 +464,22 @@ class AccountCreationTest:
         assert trusted_device.os == "iOS"
 
     @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
+    @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
+    def should_not_save_trusted_device_when_no_device_info(self, mocked_check_recaptcha_token_is_valid, client):
+        data = {
+            "email": "John.doe@example.com",
+            "password": "Aazflrifaoi6@",
+            "birthdate": "1960-12-31",
+            "notifications": True,
+            "token": "gnagna",
+            "marketingEmailSubscription": True,
+        }
+
+        client.post("/native/v1/account", json=data)
+
+        assert users_models.TrustedDevice.query.count() == 0
+
+    @patch("pcapi.connectors.api_recaptcha.check_recaptcha_token_is_valid")
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
     def test_should_not_save_trusted_device_when_feature_flag_is_disabled(
         self, mocked_check_recaptcha_token_is_valid, client

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -175,7 +175,7 @@ class TrustedDeviceFeatureTest:
         assert login_device.location == None
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
-    def test_should_not_save_login_device_history_when_feature_flag_is_disabled(self, client):
+    def should_not_save_login_device_history_when_feature_flag_is_disabled(self, client):
         users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
 
         client.post("/native/v1/signin", json=self.data)
@@ -193,7 +193,7 @@ class TrustedDeviceFeatureTest:
         assert user.trusted_devices == [trusted_device]
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
-    def test_should_not_save_login_device_as_trusted_device_on_second_signin_when_feature_flag_is_inactive(
+    def should_not_save_login_device_as_trusted_device_on_second_signin_when_feature_flag_is_inactive(
         self,
         client,
     ):
@@ -206,7 +206,7 @@ class TrustedDeviceFeatureTest:
         assert user.trusted_devices == []
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
-    def test_should_not_save_login_device_as_trusted_device_on_second_signin_when_using_different_devices(self, client):
+    def should_not_save_login_device_as_trusted_device_on_second_signin_when_using_different_devices(self, client):
         first_device = {
             "deviceId": "2E429592-2446-425F-9A62-D6983F375B3B",
             "source": "iPhone 13",
@@ -226,7 +226,7 @@ class TrustedDeviceFeatureTest:
         assert user.trusted_devices == []
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
-    def test_should_send_email_when_login_is_suspicious(self, client):
+    def should_send_email_when_login_is_suspicious(self, client):
         users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
 
         client.post("/native/v1/signin", json=self.data)
@@ -238,7 +238,7 @@ class TrustedDeviceFeatureTest:
         assert mails_testing.outbox[0].sent_data["params"]["SOURCE"] == "iPhone 13"
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
-    def test_should_not_send_email_when_logging_in_from_a_trusted_device(self, client):
+    def should_not_send_email_when_logging_in_from_a_trusted_device(self, client):
         user = users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
         users_factories.TrustedDeviceFactory(user=user)
 
@@ -247,7 +247,7 @@ class TrustedDeviceFeatureTest:
         assert len(mails_testing.outbox) == 0
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
-    def test_should_not_send_email_when_feature_flag_is_inactive(self, client):
+    def should_not_send_email_when_feature_flag_is_inactive(self, client):
         users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
 
         client.post("/native/v1/signin", json=self.data)

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -233,7 +233,7 @@ class TrustedDeviceFeatureTest:
         assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
-    def test_should_not_send_email_when_login_is_not_suspicious(self, client):
+    def test_should_not_send_email_when_logging_in_from_a_trusted_device(self, client):
         user = users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
         users_factories.TrustedDeviceFactory(user=user)
 

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -174,6 +174,14 @@ class TrustedDeviceFeatureTest:
         assert login_device.os == "iOS"
         assert login_device.location == None
 
+    @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
+    def should_not_save_login_device_history_on_signin_when_no_device_info(self, client):
+        users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
+
+        client.post("/native/v1/signin", json={**self.data, "deviceInfo": None})
+
+        assert LoginDeviceHistory.query.count() == 0
+
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
     def should_not_save_login_device_history_when_feature_flag_is_disabled(self, client):
         users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -231,6 +231,9 @@ class TrustedDeviceFeatureTest:
 
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
+        assert mails_testing.outbox[0].sent_data["params"]["LOCATION"] == None
+        assert mails_testing.outbox[0].sent_data["params"]["OS"] == "iOS"
+        assert mails_testing.outbox[0].sent_data["params"]["SOURCE"] == "iPhone 13"
 
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
     def test_should_not_send_email_when_logging_in_from_a_trusted_device(self, client):

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -241,16 +241,6 @@ class TrustedDeviceFeatureTest:
 
         assert len(mails_testing.outbox) == 0
 
-    @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
-    def test_should_only_send_one_email_when_logging_in_twice_with_same_device(self, client):
-        users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)
-
-        client.post("/native/v1/signin", json=self.data)
-        client.post("/native/v1/signin", json=self.data)
-
-        assert len(mails_testing.outbox) == 1
-        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
-
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=False)
     def test_should_not_send_email_when_feature_flag_is_inactive(self, client):
         users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -180,6 +180,8 @@ class TrustedDeviceFeatureTest:
 
         client.post("/native/v1/signin", json=self.data)
 
+        assert LoginDeviceHistory.query.count() == 0
+
     @override_features(WIP_ENABLE_TRUSTED_DEVICE=True)
     def test_save_login_device_as_trusted_device_on_second_signin_with_same_device(self, client):
         user = users_factories.UserFactory(email=self.data["identifier"], password=self.data["password"], isActive=True)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21664

## But de la pull request

Notifier un utilisateur si un appareil qui n'est pas de confiance se connecte pour la première fois sur son compte.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
