### PR TITLE
(PC-22430)[BO] Change offers order and limit on home links (antifraud)

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
@@ -35,17 +35,17 @@
         pending_individual_offers_count,
         "offre individuelle en attente",
         "offres individuelles en attente",
-        url_for("backoffice_v3_web.offer.list_offers", status="PENDING", only_validated_offerers="on", sort="dateCreated")) }}
+        url_for("backoffice_v3_web.offer.list_offers", status="PENDING", only_validated_offerers="on", sort="dateCreated", order="desc", limit="1000")) }}
         {{ stats_card(
         pending_collective_offers_count,
         "offre collective en attente",
         "offres collectives en attente",
-        url_for("backoffice_v3_web.collective_offer.list_collective_offers", status="PENDING", only_validated_offerers="on", sort="dateCreated")) }}
+        url_for("backoffice_v3_web.collective_offer.list_collective_offers", status="PENDING", only_validated_offerers="on", sort="dateCreated", order="desc", limit="1000")) }}
         {{ stats_card(
         pending_collective_templates_count,
         "offre collective vitrine en attente",
         "offres collectives vitrine en attente",
-        url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates", status="PENDING", only_validated_offerers="on", sort="dateCreated")) }}
+        url_for("backoffice_v3_web.collective_offer_template.list_collective_offer_templates", status="PENDING", only_validated_offerers="on", sort="dateCreated", order="desc", limit="1000")) }}
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22430

## But de la pull request

Permettre à l'antifraude d'afficher en un clic les 1000 premières offres individuelles, collectives ou collectives vitrine en attente triées par ordre de la plus récente à la plus ancienne.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
