### PR TITLE
(PC-22492)[API] fix: Change deposit expiration date for 18yo to UTC

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1876,15 +1876,11 @@ def get_granted_deposit(
         )
 
     if eligibility == users_models.EligibilityType.AGE18:
-        pass_culture_tz = pytz.timezone("Europe/Paris")
-        today_paris = pytz.utc.localize(datetime.datetime.utcnow()).astimezone(pass_culture_tz).date()
-        last_day_paris = today_paris + relativedelta(years=conf.GRANT_18_VALIDITY_IN_YEARS)
-        expiration_paris = pass_culture_tz.localize(datetime.datetime.combine(last_day_paris, datetime.time.max))
-        expiration_utc = expiration_paris.astimezone(pytz.utc).replace(tzinfo=None)
-
+        expiration_date = datetime.datetime.utcnow().date() + relativedelta(years=conf.GRANT_18_VALIDITY_IN_YEARS)
+        expiration_datetime = datetime.datetime.combine(expiration_date, datetime.time.max)
         return models.GrantedDeposit(
             amount=conf.GRANTED_DEPOSIT_AMOUNTS_FOR_18_BY_VERSION[2],
-            expiration_date=expiration_utc,
+            expiration_date=expiration_datetime,
             type=models.DepositType.GRANT_18,
             version=2,
         )

--- a/api/tests/core/external/user_automations_test.py
+++ b/api/tests/core/external/user_automations_test.py
@@ -90,14 +90,14 @@ class UserAutomationsTest:
                 email="beneficiary1+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=1),
             )
-            assert user1.deposit.expirationDate == datetime(2034, 10, 31, 22, 59, 59, 999999)
+            assert user1.deposit.expirationDate == datetime(2034, 10, 31, 23, 59, 59, 999999)
 
         with freeze_time("2032-11-01 15:00:00"):
             user2 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary2+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=2),
             )
-            assert user2.deposit.expirationDate == datetime(2034, 11, 1, 22, 59, 59, 999999)
+            assert user2.deposit.expirationDate == datetime(2034, 11, 1, 23, 59, 59, 999999)
             bookings_factories.UsedBookingFactory(user=user2, quantity=1, amount=10)
 
         with freeze_time("2032-12-01 15:00:00"):
@@ -105,28 +105,28 @@ class UserAutomationsTest:
                 email="beneficiary3+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=3),
             )
-            assert user3.deposit.expirationDate == datetime(2034, 12, 1, 22, 59, 59, 999999)
+            assert user3.deposit.expirationDate == datetime(2034, 12, 1, 23, 59, 59, 999999)
 
         with freeze_time("2033-01-30 15:00:00"):
             user4 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary4+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=4),
             )
-            assert user4.deposit.expirationDate == datetime(2035, 1, 30, 22, 59, 59, 999999)
+            assert user4.deposit.expirationDate == datetime(2035, 1, 30, 23, 59, 59, 999999)
 
         with freeze_time("2033-01-31 15:00:00"):
             user5 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary5+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=5),
             )
-            assert user5.deposit.expirationDate == datetime(2035, 1, 31, 22, 59, 59, 999999)
+            assert user5.deposit.expirationDate == datetime(2035, 1, 31, 23, 59, 59, 999999)
 
         with freeze_time("2033-03-10 15:00:00"):
             user6 = users_factories.BeneficiaryGrant18Factory(
                 email="beneficiary6+test@example.net",
                 dateOfBirth=datetime.combine(datetime.today(), datetime.min.time()) - relativedelta(years=18, months=5),
             )
-            assert user6.deposit.expirationDate == datetime(2035, 3, 10, 22, 59, 59, 999999)
+            assert user6.deposit.expirationDate == datetime(2035, 3, 10, 23, 59, 59, 999999)
 
         with freeze_time("2033-05-01 17:00:00"):
             # user6 becomes ex-beneficiary

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2281,7 +2281,103 @@ class CreateDepositTest:
         assert deposit.amount == Decimal(300)
         assert deposit.user.id == beneficiary.id
         # We use freeze time to ensure this test is not flaky. Otherwise, the expiration date would be dependant on the daylight saving time.
-        assert deposit.expirationDate == datetime.datetime(2024, 9, 5, 21, 59, 59, 999999)
+        assert deposit.expirationDate == datetime.datetime(2024, 9, 5, 23, 59, 59, 999999)
+
+    def test_tahiti_grant_18_expiration_is_2_years_after_at_EOD(self):
+        tahiti_tz = datetime.timezone(datetime.timedelta(hours=-10))
+        tahiti_datetime = datetime.datetime(2023, 5, 29, tzinfo=tahiti_tz)
+        with freezegun.freeze_time(tahiti_datetime.replace(hour=0, minute=0, second=0)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 29, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(tahiti_datetime.replace(hour=23, minute=59, second=59)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 30, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(tahiti_datetime.replace(hour=13, minute=59, second=59)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 29, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(tahiti_datetime.replace(hour=14, minute=0, second=0)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 30, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+
+    def test_wallis_grant_18_expiration_is_2_years_after_at_EOD(self):
+        wallis_tz = datetime.timezone(datetime.timedelta(hours=12))
+        wallis_datetime = datetime.datetime(2023, 5, 29, tzinfo=wallis_tz)
+        with freezegun.freeze_time(wallis_datetime.replace(hour=0, minute=0, second=0)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 28, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(wallis_datetime.replace(hour=23, minute=59, second=59)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 29, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(wallis_datetime.replace(hour=11, minute=59, second=59)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 28, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(wallis_datetime.replace(hour=12, minute=00, second=00)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 29, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+
+    def test_metropole_grant_18_expiration_is_2_years_after_at_EOD(self):
+        metropole_tz = datetime.timezone(datetime.timedelta(hours=1))
+        metropole_datetime = datetime.datetime(2023, 5, 29, tzinfo=metropole_tz)
+        with freezegun.freeze_time(metropole_datetime.replace(hour=0, minute=0, second=0)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 28, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(metropole_datetime.replace(hour=23, minute=59, second=59)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 29, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(metropole_datetime.replace(hour=0, minute=59, second=59)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 28, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
+        with freezegun.freeze_time(metropole_datetime.replace(hour=1, minute=0, second=0)):
+            beneficiary = users_factories.UserFactory()
+            deposit = api.create_deposit(beneficiary, "created by test", users_models.EligibilityType.AGE18)
+        assert deposit.type == models.DepositType.GRANT_18
+        assert deposit.expirationDate == datetime.datetime(2025, 5, 29, 23, 59, 59, 999999, tzinfo=pytz.utc).replace(
+            tzinfo=None
+        )
 
     def test_deposit_created_when_another_type_already_exist_for_user(self):
         with freezegun.freeze_time(datetime.datetime.utcnow() - relativedelta(years=3)):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22492

## But de la pull request

Changer le calcul de la date d'expiration du crédit 18 ans pour qu'il soit à 23h59 UTC quelque soit le fuseau horaire.

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ X La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
