### PR TITLE
(PC-22305)[API] chore: refresh token can actually answer with 401

### DIFF
--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -70,7 +70,7 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
 
 @blueprint.native_v1.route("/refresh_access_token", methods=["POST"])
 @jwt_required(refresh=True)
-@spectree_serialize(response_model=authentication.RefreshResponse, api=blueprint.api)
+@spectree_serialize(response_model=authentication.RefreshResponse, api=blueprint.api, on_error_statuses=[401])
 def refresh() -> authentication.RefreshResponse:
     email = get_jwt_identity()
     user = find_user_by_email(email)

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -2730,6 +2730,7 @@ def test_public_api(client):
                             },
                             "description": "OK",
                         },
+                        "401": {"description": "Unauthorized"},
                         "403": {"description": "Forbidden"},
                         "422": {
                             "content": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22305

## But de la pull request

Swagger ments !

|Avant|Après|
|:--|:--|
|![image](https://github.com/pass-culture/pass-culture-main/assets/95220086/e725099b-2008-4f8e-83b3-ffb266fcc6ac)|![image](https://github.com/pass-culture/pass-culture-main/assets/95220086/48d599fa-13e9-465d-a2fa-97e92e5893b1)|

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
