### PR TITLE
(BSR) fix: move beamer to the bottom

### DIFF
--- a/pro/public/index.html
+++ b/pro/public/index.html
@@ -34,7 +34,7 @@
     >
     <% if (process.env.REACT_APP_ENVIRONMENT_NAME==='testing' ) { %>
     <script>
-      var beamer_config = { product_id: 'vjbiYuMS52566' }
+      var beamer_config = { product_id: 'vjbiYuMS52566', display_position: 'right-bottom' }
     </script>
     <script
       type="text/javascript"


### PR DESCRIPTION
Déplacement du bouton beamer. Ce bouton est affiché uniquement en testing et pose des pbs pour tester des choses sur adage ou autre. Celui-ci sera intégré au produit quand on développera vraiment le sujet. 
A cause de la config de beamer, impossible de tester en local, celui-ci s'affiche uniquement sur https://pro.testing.passculture.team/.
Assez peu de risque ceci dit !
Beamer doc : https://www.getbeamer.com/docs/#parameters
