### PR TITLE
(PC-21975)[API] fix: displayAsEnded was incorrect

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -124,9 +124,7 @@ def book_offer(
         if is_activation_code_applicable:
             booking.activationCode = offers_repository.get_available_activation_code(stock)
             booking.mark_as_used()
-        if stock.price == 0 and stock.offer.subcategoryId in [
-            c.id for c in constants.FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
-        ]:
+        if stock.price == 0 and stock.offer.subcategoryId in constants.FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE:
             booking.mark_as_used()
 
         stock.dnBookedQuantity += booking.quantity
@@ -559,9 +557,7 @@ def archive_old_bookings() -> None:
             Booking.query.join(Booking.stock, Stock.offer)
             .filter(date_condition)
             .filter(
-                offers_models.Offer.subcategoryId.in_(
-                    [category.id for category in constants.FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE]
-                ),
+                offers_models.Offer.subcategoryId.in_(constants.FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE),
                 offers_models.Stock.price == 0,
             )
             .with_entities(Booking.id)

--- a/api/src/pcapi/core/bookings/constants.py
+++ b/api/src/pcapi/core/bookings/constants.py
@@ -13,11 +13,11 @@ BOOKS_BOOKINGS_EXPIRY_NOTIFICATION_DELAY = datetime.timedelta(days=5)
 AUTO_USE_AFTER_EVENT_TIME_DELAY = datetime.timedelta(hours=48)
 REDIS_EXTERNAL_BOOKINGS_NAME = "api:external_bookings:barcodes"
 EXTERNAL_BOOKINGS_MINIMUM_ITEM_AGE_IN_QUEUE = 60
-FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE = [
-    subcategories.ABO_MUSEE,
-    subcategories.CARTE_MUSEE,
-    subcategories.ABO_BIBLIOTHEQUE,
-    subcategories.ABO_MEDIATHEQUE,
+FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE = [
+    subcategories.ABO_MUSEE.id,
+    subcategories.CARTE_MUSEE.id,
+    subcategories.ABO_BIBLIOTHEQUE.id,
+    subcategories.ABO_MEDIATHEQUE.id,
 ]
 
 

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -196,7 +196,8 @@ def is_ended_booking(booking: Booking) -> bool:
         return False
 
     if (booking.stock.canHaveActivationCodes and booking.activationCode) or (
-        booking.stock.offer.subcategoryId in FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE and booking.stock.price == 0
+        booking.stock.offer.subcategoryId in [subcategory.id for subcategory in FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE]
+        and booking.stock.price == 0
     ):
         # consider digital bookings and free offer from defined subcategories as special: is_used should be true anyway so
         # let's use displayAsEnded

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -4,7 +4,7 @@ import logging
 from sqlalchemy.orm import joinedload
 
 import pcapi.core.bookings.api as bookings_api
-from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
+from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE
 import pcapi.core.bookings.exceptions as bookings_exceptions
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
@@ -196,8 +196,7 @@ def is_ended_booking(booking: Booking) -> bool:
         return False
 
     if (booking.stock.canHaveActivationCodes and booking.activationCode) or (
-        booking.stock.offer.subcategoryId in [subcategory.id for subcategory in FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE]
-        and booking.stock.price == 0
+        booking.stock.offer.subcategoryId in FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE and booking.stock.price == 0
     ):
         # consider digital bookings and free offer from defined subcategories as special: is_used should be true anyway so
         # let's use displayAsEnded

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -19,7 +19,7 @@ from pcapi.core.bookings import exceptions
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models
 from pcapi.core.bookings.api import cancel_unstored_external_bookings
-from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
+from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
@@ -1215,19 +1215,19 @@ class ArchiveOldBookingsTest:
         assert old_booking.displayAsEnded
 
     @pytest.mark.parametrize(
-        "subcategory",
-        FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE,
+        "subcategoryId",
+        FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE,
     )
-    def test_old_subcategories_bookings_are_archived(self, db_session, subcategory):
+    def test_old_subcategories_bookings_are_archived(self, db_session, subcategoryId):
         # given
         now = datetime.utcnow()
         recent = now - timedelta(days=29, hours=23)
         old = now - timedelta(days=30, hours=1)
         stock_free = offers_factories.StockFactory(
-            offer=offers_factories.OfferFactory(subcategoryId=subcategory.id), price=0
+            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=0
         )
         stock_not_free = offers_factories.StockFactory(
-            offer=offers_factories.OfferFactory(subcategoryId=subcategory.id), price=10
+            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=10
         )
         recent_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=recent)
         old_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=old)

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -4,7 +4,7 @@ import pytest
 
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings import models as bookings_models
-from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
+from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE
 from pcapi.core.offers import factories as offers_factories
 
 from tests.conftest import clean_database
@@ -38,19 +38,19 @@ class ArchiveOldBookingsTest:
 
     @clean_database
     @pytest.mark.parametrize(
-        "subcategory",
-        FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE,
+        "subcategoryId",
+        FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE,
     )
-    def test_old_subcategories_bookings_are_archived(self, app, subcategory):
+    def test_old_subcategories_bookings_are_archived(self, app, subcategoryId):
         # given
         now = datetime.datetime.utcnow()
         recent = now - datetime.timedelta(days=29, hours=23)
         old = now - datetime.timedelta(days=30, hours=1)
         stock_free = offers_factories.StockFactory(
-            offer=offers_factories.OfferFactory(subcategoryId=subcategory.id), price=0
+            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=0
         )
         stock_not_free = offers_factories.StockFactory(
-            offer=offers_factories.OfferFactory(subcategoryId=subcategory.id), price=10
+            offer=offers_factories.OfferFactory(subcategoryId=subcategoryId), price=10
         )
         recent_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=recent)
         old_booking = bookings_factories.BookingFactory(stock=stock_free, dateCreated=old)

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from pcapi.core.bookings import factories as booking_factories
-from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE
+from pcapi.core.bookings.constants import FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE
 from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingCancellationReasons
 from pcapi.core.bookings.models import BookingStatus
@@ -113,11 +113,11 @@ class PostBookingTest:
         assert response.json["external_booking"] == "Cette offre n'est plus réservable."
 
     @pytest.mark.parametrize(
-        "subcategory,price",
-        [(category, 0) for category in FREE_OFFER_SUBCATEGORIES_TO_ARCHIVE],
+        "subcategoryId,price",
+        [(subcategoryId, 0) for subcategoryId in FREE_OFFER_SUBCATEGORY_IDS_TO_ARCHIVE],
     )
-    def test_post_free_bookings_from_subcategories_with_archive(self, client, subcategory, price):
-        stock = StockFactory(price=price, offer__subcategoryId=subcategory.id)
+    def test_post_free_bookings_from_subcategories_with_archive(self, client, subcategoryId, price):
+        stock = StockFactory(price=price, offer__subcategoryId=subcategoryId)
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
 
         client = client.with_token(self.identifier)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21975

## But de la pull request

Correction de la condition `displayAsEnded` pour les sous categories qui utilisaient l'enum au lieu de son id

## Implémentation

Ajout d'un test

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
