### PR TITLE
(PC-22556)[PRO] fix: hide element for readonly user

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.module.scss
@@ -54,7 +54,7 @@
 .adage-header-separator {
   width: rem.torem(1px);
   height: rem.torem(42px);
-  background-color: #CBCDD2;
+  background-color: colors.$grey-medium;
   margin-right: rem.torem(32px);
 }
 

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -4,7 +4,8 @@ import type { HitsProvided } from 'react-instantsearch-core'
 import { connectHits } from 'react-instantsearch-dom'
 import { NavLink } from 'react-router-dom'
 
-import { AdageHeaderLink } from 'apiClient/adage'
+import { AdageFrontRoles } from 'apiClient/adage'
+import { AdageHeaderLink } from 'apiClient/adage/models/AdageHeaderLink'
 import { apiAdage } from 'apiClient/api'
 import useNotification from 'hooks/useNotification'
 import { CalendarCheckIcon, InstitutionIcon, SearchIcon } from 'icons'
@@ -12,6 +13,7 @@ import Icon from 'ui-kit/Icon/Icon'
 import { ResultType } from 'utils/types'
 
 import { getEducationalInstitutionWithBudgetAdapter } from '../../adapters/getEducationalInstitutionWithBudgetAdapter'
+import useAdageUser from '../../hooks/useAdageUser'
 
 import styles from './AdageHeader.module.scss'
 
@@ -19,6 +21,7 @@ export const AdageHeaderComponent = ({ hits }: HitsProvided<ResultType>) => {
   const params = new URLSearchParams(location.search)
   const adageAuthToken = params.get('token')
   const notify = useNotification()
+  const adageUser = useAdageUser()
 
   const [isLoading, setIsLoading] = useState(true)
   const [institutionBudget, setInstitutionBudget] = useState(0)
@@ -36,8 +39,10 @@ export const AdageHeaderComponent = ({ hits }: HitsProvided<ResultType>) => {
   }
 
   useEffect(() => {
-    getEducationalInstitutionBudget()
-  }, [])
+    if (adageUser.role !== AdageFrontRoles.READONLY) {
+      getEducationalInstitutionBudget()
+    }
+  }, [adageUser.role])
 
   const logAdageLinkClick = (headerLinkName: AdageHeaderLink) => {
     apiAdage.logHeaderLinkClick({ header_link_name: headerLinkName })
@@ -61,21 +66,23 @@ export const AdageHeaderComponent = ({ hits }: HitsProvided<ResultType>) => {
           <SearchIcon className={styles['adage-header-item-icon']} />
           Rechercher
         </NavLink>
-        <NavLink
-          to={`/adage-iframe/mon-etablissement?token=${adageAuthToken}`}
-          className={({ isActive }) => {
-            return cn(styles['adage-header-item'], {
-              [styles['adage-header-item-active']]: isActive,
-            })
-          }}
-          onClick={() =>
-            logAdageLinkClick(AdageHeaderLink.MY_INSTITUTION_OFFERS)
-          }
-        >
-          <InstitutionIcon className={styles['adage-header-item-icon']} />
-          Pour mon établissement
-          <div className={styles['adage-header-nb-hits']}>{hits.length}</div>
-        </NavLink>
+        {adageUser.role !== AdageFrontRoles.READONLY && (
+          <NavLink
+            to={`/adage-iframe/mon-etablissement?token=${adageAuthToken}`}
+            className={({ isActive }) => {
+              return cn(styles['adage-header-item'], {
+                [styles['adage-header-item-active']]: isActive,
+              })
+            }}
+            onClick={() =>
+              logAdageLinkClick(AdageHeaderLink.MY_INSTITUTION_OFFERS)
+            }
+          >
+            <InstitutionIcon className={styles['adage-header-item-icon']} />
+            Pour mon établissement
+            <div className={styles['adage-header-nb-hits']}>{hits.length}</div>
+          </NavLink>
+        )}
         <a
           href={`${document.referrer}adage/passculture/index`}
           className={styles['adage-header-item']}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22556

## But de la pull request

Pour générer un lien adage en readonly : 

pc bash 
flask generate_fake_adage_token --readonly

Si l'utilisateur est connecté avec un rôle READONLY il ne verra pas le budget ainsi que le lien du header 'Pour mon établissement'

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
