### PR TITLE
(PC-21778)[API] perf: move venue timezone from property to column

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-dcfd7657a244 (pre) (head)
+69ef0222cdc8 (pre) (head)
 5b80257fdb94 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230531T131439_69ef0222cdc8_add_venue_timezone.py
+++ b/api/src/pcapi/alembic/versions/20230531T131439_69ef0222cdc8_add_venue_timezone.py
@@ -1,0 +1,24 @@
+"""Add `venue.timezone`
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi import settings
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "69ef0222cdc8"
+down_revision = "dcfd7657a244"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("SET SESSION statement_timeout = '300s'")
+    op.add_column("venue", sa.Column("timezone", sa.String(length=50), server_default="Europe/Paris", nullable=False))
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    op.drop_column("venue", "timezone")

--- a/api/src/pcapi/scripts/venue/populate_venue_timezone.py
+++ b/api/src/pcapi/scripts/venue/populate_venue_timezone.py
@@ -1,0 +1,45 @@
+import logging
+import math
+import typing
+
+import sqlalchemy.orm as sqla_orm
+
+import pcapi.core.offerers.models as offerers_models
+from pcapi.models import db
+
+
+CHUNK_SIZE = 500
+
+logger = logging.getLogger(__name__)
+
+
+def populate_venue_timezone(from_venue_id: typing.Optional[int] = None) -> None:
+    venues = _get_venues(from_venue_id)
+
+    for venue in venues:
+        venue.store_timezone()
+        db.session.add(venue)
+
+
+def _get_venues(from_venue_id: typing.Optional[int]) -> typing.Generator[offerers_models.Venue, None, None]:
+    venue_query = offerers_models.Venue.query.options(
+        sqla_orm.joinedload(offerers_models.Venue.managingOfferer)
+    ).order_by(offerers_models.Venue.id)
+    if from_venue_id:
+        venue_query = venue_query.filter(offerers_models.Venue.id >= from_venue_id)
+
+    venue_count = venue_query.count()
+    max_chunk_index = math.ceil(venue_count / CHUNK_SIZE)
+    logger.info("Venue count : %s", venue_count)
+    logger.info("Chunk count : %s", max_chunk_index)
+
+    for chunk_index in range(max_chunk_index):
+        venues = venue_query.offset(chunk_index * CHUNK_SIZE).limit(CHUNK_SIZE)
+        last_venue_id = None
+        for venue in venues:
+            last_venue_id = venue.id
+            yield venue
+        logger.info("Chunk %s/%s", chunk_index + 1, max_chunk_index)
+        logger.info("Current progress %s%%", (chunk_index + 1) / max_chunk_index * 100)
+        logger.info("Last venue id %s", last_venue_id)
+        db.session.commit()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21778

## But de la pull request

Eviter de requêter la table `Offerer` plusieurs lorsque l'on filtre les offres avec des dates

## Implémentation

La propriété hybride `timezone` du modèle `Venue` est surclassée en vraie colonne

## Informations supplémentaires

### Scénario de test

Avec cette différence pour le test de la requête : 

<details>

```diff
diff --git a/api/tests/core/offers/test_repository.py b/api/tests/core/offers/test_repository.py
index 0d0af86874..052b4552ba 100644
--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -185,6 +185,7 @@ class GetCappedOffersForFiltersTest:
         assert offer_in_cayenne.id in offers_id
         assert offer_in_mayotte.id in offers_id
         assert len(offers.offers) == 2
+        assert False
 
     class WhenUserIsAdminTest:
         @pytest.mark.usefixtures("db_session")
```

</details>

Et le test suivant : 

<details>

```sh
pass-culture-main/api ➜ SQLALCHEMY_ECHO=1 pytest -W ignore::DeprecationWarning tests/core/offers/test_repository.py::GetCappedOffersForFiltersTest::should_consider_venue_locale_datetime_when_filtering_by_date
```

</details>

On a un gain de performance de 38.8% sur une table `Venue` contenant 77 lignes, qui est en partie expliqué par le seul `join` sur la table `Offerer` plutôt que trois.

### Avant

#### Requête générée 

<details>

```sql
EXPLAIN ANALYZE SELECT anon_1."offer_jsonData" AS "anon_1_offer_jsonData", anon_1.offer_id AS anon_1_offer_id, anon_1."offer_isActive" AS "anon_1_offer_isActive", anon_1."offer_lastValidationDate" AS "anon_1_offer_lastValidationDate", anon_1."offer_lastValidationType" AS "anon_1_offer_lastValidationType", anon_1.offer_validation AS anon_1_offer_validation, anon_1."offer_audioDisabilityCompliant" AS "anon_1_offer_audioDisabilityCompliant", anon_1."offer_mentalDisabilityCompliant" AS "anon_1_offer_mentalDisabilityCompliant", anon_1."offer_motorDisabilityCompliant" AS "anon_1_offer_motorDisabilityCompliant", anon_1."offer_visualDisabilityCompliant" AS "anon_1_offer_visualDisabilityCompliant", anon_1."offer_ageMin" AS "anon_1_offer_ageMin", anon_1."offer_ageMax" AS "anon_1_offer_ageMax", anon_1."offer_authorId" AS "anon_1_offer_authorId", anon_1."offer_bookingEmail" AS "anon_1_offer_bookingEmail", anon_1.offer_conditions AS anon_1_offer_conditions, anon_1."offer_dateCreated" AS "anon_1_offer_dateCreated", anon_1."offer_dateModifiedAtLastProvider" AS "anon_1_offer_dateModifiedAtLastProvider", anon_1."offer_dateUpdated" AS "anon_1_offer_dateUpdated", anon_1.offer_description AS anon_1_offer_description, anon_1."offer_durationMinutes" AS "anon_1_offer_durationMinutes", anon_1."offer_externalTicketOfficeUrl" AS "anon_1_offer_externalTicketOfficeUrl", anon_1."offer_fieldsUpdated" AS "anon_1_offer_fieldsUpdated", anon_1."offer_idAtProvider" AS "anon_1_offer_idAtProvider", anon_1."offer_isDuo" AS "anon_1_offer_isDuo", anon_1."offer_isNational" AS "anon_1_offer_isNational", anon_1.offer_name AS anon_1_offer_name, anon_1."offer_mediaUrls" AS "anon_1_offer_mediaUrls", anon_1."offer_productId" AS "anon_1_offer_productId", anon_1."offer_rankingWeight" AS "anon_1_offer_rankingWeight", anon_1."offer_subcategoryId" AS "anon_1_offer_subcategoryId", anon_1.offer_url AS anon_1_offer_url, anon_1."offer_venueId" AS "anon_1_offer_venueId", anon_1."offer_withdrawalDelay" AS "anon_1_offer_withdrawalDelay", anon_1."offer_withdrawalDetails" AS "anon_1_offer_withdrawalDetails", anon_1."offer_withdrawalType" AS "anon_1_offer_withdrawalType", anon_1."offer_lastProviderId" AS "anon_1_offer_lastProviderId", product_1."jsonData" AS "product_1_jsonData", product_1.id AS product_1_id, product_1."thumbCount" AS "product_1_thumbCount", product_1."idAtProviders" AS "product_1_idAtProviders", product_1."dateModifiedAtLastProvider" AS "product_1_dateModifiedAtLastProvider", product_1."fieldsUpdated" AS "product_1_fieldsUpdated", product_1."ageMin" AS "product_1_ageMin", product_1."ageMax" AS "product_1_ageMax", product_1.conditions AS product_1_conditions, product_1.description AS product_1_description, product_1."durationMinutes" AS "product_1_durationMinutes", product_1."isGcuCompatible" AS "product_1_isGcuCompatible", product_1."isNational" AS "product_1_isNational", product_1."isSynchronizationCompatible" AS "product_1_isSynchronizationCompatible", product_1."mediaUrls" AS "product_1_mediaUrls", product_1.name AS product_1_name, product_1."owningOffererId" AS "product_1_owningOffererId", product_1."subcategoryId" AS "product_1_subcategoryId", product_1.url AS product_1_url, product_1."lastProviderId" AS "product_1_lastProviderId", offerer_1.id AS offerer_1_id, offerer_1."isActive" AS "offerer_1_isActive", offerer_1.address AS offerer_1_address, offerer_1."postalCode" AS "offerer_1_postalCode", offerer_1.city AS offerer_1_city, offerer_1."thumbCount" AS "offerer_1_thumbCount", offerer_1."idAtProviders" AS "offerer_1_idAtProviders", offerer_1."dateModifiedAtLastProvider" AS "offerer_1_dateModifiedAtLastProvider", offerer_1."fieldsUpdated" AS "offerer_1_fieldsUpdated", offerer_1."validationStatus" AS "offerer_1_validationStatus", offerer_1."dateCreated" AS "offerer_1_dateCreated", offerer_1.name AS offerer_1_name, offerer_1.siren AS offerer_1_siren, offerer_1."dateValidated" AS "offerer_1_dateValidated", offerer_1."lastProviderId" AS "offerer_1_lastProviderId", venue_1."bannerUrl" AS "venue_1_bannerUrl", venue_1.id AS venue_1_id, venue_1."audioDisabilityCompliant" AS "venue_1_audioDisabilityCompliant", venue_1."mentalDisabilityCompliant" AS "venue_1_mentalDisabilityCompliant", venue_1."motorDisabilityCompliant" AS "venue_1_motorDisabilityCompliant", venue_1."visualDisabilityCompliant" AS "venue_1_visualDisabilityCompliant", venue_1."thumbCount" AS "venue_1_thumbCount", venue_1."idAtProviders" AS "venue_1_idAtProviders", venue_1."dateModifiedAtLastProvider" AS "venue_1_dateModifiedAtLastProvider", venue_1."fieldsUpdated" AS "venue_1_fieldsUpdated", venue_1.name AS venue_1_name, venue_1.siret AS venue_1_siret, venue_1."departementCode" AS "venue_1_departementCode", venue_1.latitude AS venue_1_latitude, venue_1.longitude AS venue_1_longitude, venue_1."managingOffererId" AS "venue_1_managingOffererId", venue_1."bookingEmail" AS "venue_1_bookingEmail", venue_1.address AS venue_1_address, venue_1."postalCode" AS "venue_1_postalCode", venue_1.city AS venue_1_city, venue_1."publicName" AS "venue_1_publicName", venue_1."isVirtual" AS "venue_1_isVirtual", venue_1."isPermanent" AS "venue_1_isPermanent", venue_1.comment AS venue_1_comment, venue_1."venueTypeCode" AS "venue_1_venueTypeCode", venue_1."venueLabelId" AS "venue_1_venueLabelId", venue_1."dateCreated" AS "venue_1_dateCreated", venue_1."withdrawalDetails" AS "venue_1_withdrawalDetails", venue_1.description AS venue_1_description, venue_1."bannerMeta" AS "venue_1_bannerMeta", venue_1."adageId" AS "venue_1_adageId", venue_1."adageInscriptionDate" AS "venue_1_adageInscriptionDate", venue_1."dmsToken" AS "venue_1_dmsToken", venue_1."venueEducationalStatusId" AS "venue_1_venueEducationalStatusId", venue_1."collectiveDescription" AS "venue_1_collectiveDescription", venue_1."collectiveStudents" AS "venue_1_collectiveStudents", venue_1."collectiveWebsite" AS "venue_1_collectiveWebsite", venue_1."collectiveInterventionArea" AS "venue_1_collectiveInterventionArea", venue_1."collectiveNetwork" AS "venue_1_collectiveNetwork", venue_1."collectiveAccessInformation" AS "venue_1_collectiveAccessInformation", venue_1."collectivePhone" AS "venue_1_collectivePhone", venue_1."collectiveEmail" AS "venue_1_collectiveEmail", venue_1."collectiveSubCategoryId" AS "venue_1_collectiveSubCategoryId", venue_1."lastProviderId" AS "venue_1_lastProviderId", provider_1.id AS provider_1_id, provider_1."isActive" AS "provider_1_isActive", provider_1.name AS provider_1_name, provider_1."localClass" AS "provider_1_localClass", provider_1."apiUrl" AS "provider_1_apiUrl", provider_1."authToken" AS "provider_1_authToken", provider_1."enabledForPro" AS "provider_1_enabledForPro", provider_1."enableParallelSynchronization" AS "provider_1_enableParallelSynchronization", provider_1."logoUrl" AS "provider_1_logoUrl", provider_1."pricesInCents" AS "provider_1_pricesInCents", mediation_1.id AS mediation_1_id, mediation_1."isActive" AS "mediation_1_isActive", mediation_1."thumbCount" AS "mediation_1_thumbCount", mediation_1."idAtProviders" AS "mediation_1_idAtProviders", mediation_1."dateModifiedAtLastProvider" AS "mediation_1_dateModifiedAtLastProvider", mediation_1."fieldsUpdated" AS "mediation_1_fieldsUpdated", mediation_1."authorId" AS "mediation_1_authorId", mediation_1.credit AS mediation_1_credit, mediation_1."dateCreated" AS "mediation_1_dateCreated", mediation_1."offerId" AS "mediation_1_offerId", mediation_1."lastProviderId" AS "mediation_1_lastProviderId", stock_1.id AS stock_1_id, stock_1."idAtProviders" AS "stock_1_idAtProviders", stock_1."dateModifiedAtLastProvider" AS "stock_1_dateModifiedAtLastProvider", stock_1."fieldsUpdated" AS "stock_1_fieldsUpdated", stock_1."isSoftDeleted" AS "stock_1_isSoftDeleted", stock_1."beginningDatetime" AS "stock_1_beginningDatetime", stock_1."bookingLimitDatetime" AS "stock_1_bookingLimitDatetime", stock_1."dateCreated" AS "stock_1_dateCreated", stock_1."dateModified" AS "stock_1_dateModified", stock_1."dnBookedQuantity" AS "stock_1_dnBookedQuantity", stock_1."educationalPriceDetail" AS "stock_1_educationalPriceDetail", stock_1."numberOfTickets" AS "stock_1_numberOfTickets", stock_1."offerId" AS "stock_1_offerId", stock_1.price AS stock_1_price, stock_1."priceCategoryId" AS "stock_1_priceCategoryId", stock_1.quantity AS stock_1_quantity, stock_1."rawProviderQuantity" AS "stock_1_rawProviderQuantity", stock_1."lastProviderId" AS "stock_1_lastProviderId" 
FROM (
  SELECT offer."jsonData" AS "offer_jsonData", offer.id AS offer_id, offer."isActive" AS "offer_isActive", offer."lastValidationDate" AS "offer_lastValidationDate", offer."lastValidationType" AS "offer_lastValidationType", offer.validation AS offer_validation, offer."audioDisabilityCompliant" AS "offer_audioDisabilityCompliant", offer."mentalDisabilityCompliant" AS "offer_mentalDisabilityCompliant", offer."motorDisabilityCompliant" AS "offer_motorDisabilityCompliant", offer."visualDisabilityCompliant" AS "offer_visualDisabilityCompliant", offer."ageMin" AS "offer_ageMin", offer."ageMax" AS "offer_ageMax", offer."authorId" AS "offer_authorId", offer."bookingEmail" AS "offer_bookingEmail", offer.conditions AS offer_conditions, offer."dateCreated" AS "offer_dateCreated", offer."dateModifiedAtLastProvider" AS "offer_dateModifiedAtLastProvider", offer."dateUpdated" AS "offer_dateUpdated", offer.description AS offer_description, offer."durationMinutes" AS "offer_durationMinutes", offer."externalTicketOfficeUrl" AS "offer_externalTicketOfficeUrl", offer."fieldsUpdated" AS "offer_fieldsUpdated", offer."idAtProvider" AS "offer_idAtProvider", offer."isDuo" AS "offer_isDuo", offer."isNational" AS "offer_isNational", offer.name AS offer_name, offer."mediaUrls" AS "offer_mediaUrls", offer."productId" AS "offer_productId", offer."rankingWeight" AS "offer_rankingWeight", offer."subcategoryId" AS "offer_subcategoryId", offer.url AS offer_url, offer."venueId" AS "offer_venueId", offer."withdrawalDelay" AS "offer_withdrawalDelay", offer."withdrawalDetails" AS "offer_withdrawalDetails", offer."withdrawalType" AS "offer_withdrawalType", offer."lastProviderId" AS "offer_lastProviderId" 
  FROM offer JOIN (SELECT DISTINCT ON (stock."offerId") stock."offerId" AS "offerId" 
  FROM stock JOIN offer ON offer.id = stock."offerId" JOIN venue ON venue.id = offer."venueId" 
  WHERE stock."isSoftDeleted" IS false AND timezone(CASE WHEN (venue."departementCode" IS NULL) THEN CASE (SELECT CASE WHEN (CAST(SUBSTRING(offerer_2."postalCode" FROM 1 FOR 2) AS INTEGER) >= 97) THEN SUBSTRING(offerer_2."postalCode" FROM 1 FOR 3) ELSE SUBSTRING(offerer_2."postalCode" FROM 1 FOR 2) END AS anon_3 
  FROM offerer AS offerer_2 
  WHERE venue."managingOffererId" = offerer_2.id) WHEN '971' THEN 'America/Guadeloupe' WHEN '972' THEN 'America/Martinique' WHEN '973' THEN 'America/Cayenne' WHEN '974' THEN 'Indian/Reunion' WHEN '975' THEN 'America/Miquelon' WHEN '976' THEN 'Indian/Mayotte' WHEN '977' THEN 'America/St_Barthelemy' WHEN '978' THEN 'America/Guadeloupe' WHEN '986' THEN 'Pacific/Wallis' WHEN '987' THEN 'Pacific/Tahiti' WHEN '988' THEN 'Pacific/Noumea' WHEN '989' THEN 'Pacific/Pitcairn' ELSE 'Europe/Paris' END ELSE CASE venue."departementCode" WHEN '971' THEN 'America/Guadeloupe' WHEN '972' THEN 'America/Martinique' WHEN '973' THEN 'America/Cayenne' WHEN '974' THEN 'Indian/Reunion' WHEN '975' THEN 'America/Miquelon' WHEN '976' THEN 'Indian/Mayotte' WHEN '977' THEN 'America/St_Barthelemy' WHEN '978' THEN 'America/Guadeloupe' WHEN '986' THEN 'Pacific/Wallis' WHEN '987' THEN 'Pacific/Tahiti' WHEN '988' THEN 'Pacific/Noumea' WHEN '989' THEN 'Pacific/Pitcairn' ELSE 'Europe/Paris' END END, timezone('UTC', stock."beginningDatetime")) >= '2020-04-21T00:00:00' AND timezone(CASE WHEN (venue."departementCode" IS NULL) THEN CASE (SELECT CASE WHEN (CAST(SUBSTRING(offerer_3."postalCode" FROM 1 FOR 2) AS INTEGER) >= 97) THEN SUBSTRING(offerer_3."postalCode" FROM 1 FOR 3) ELSE SUBSTRING(offerer_3."postalCode" FROM 1 FOR 2) END AS anon_4 
  FROM offerer AS offerer_3 
  WHERE venue."managingOffererId" = offerer_3.id) WHEN '971' THEN 'America/Guadeloupe' WHEN '972' THEN 'America/Martinique' WHEN '973' THEN 'America/Cayenne' WHEN '974' THEN 'Indian/Reunion' WHEN '975' THEN 'America/Miquelon' WHEN '976' THEN 'Indian/Mayotte' WHEN '977' THEN 'America/St_Barthelemy' WHEN '978' THEN 'America/Guadeloupe' WHEN '986' THEN 'Pacific/Wallis' WHEN '987' THEN 'Pacific/Tahiti' WHEN '988' THEN 'Pacific/Noumea' WHEN '989' THEN 'Pacific/Pitcairn' ELSE 'Europe/Paris' END ELSE CASE venue."departementCode" WHEN '971' THEN 'America/Guadeloupe' WHEN '972' THEN 'America/Martinique' WHEN '973' THEN 'America/Cayenne' WHEN '974' THEN 'Indian/Reunion' WHEN '975' THEN 'America/Miquelon' WHEN '976' THEN 'Indian/Mayotte' WHEN '977' THEN 'America/St_Barthelemy' WHEN '978' THEN 'America/Guadeloupe' WHEN '986' THEN 'Pacific/Wallis' WHEN '987' THEN 'Pacific/Tahiti' WHEN '988' THEN 'Pacific/Noumea' WHEN '989' THEN 'Pacific/Pitcairn' ELSE 'Europe/Paris' END END, timezone('UTC', stock."beginningDatetime")) <= '2020-04-21T23:59:59') AS anon_2 ON anon_2."offerId" = offer.id 
  LIMIT 10
) AS anon_1 LEFT OUTER JOIN product AS product_1 ON product_1.id = anon_1."offer_productId" LEFT OUTER JOIN venue AS venue_1 ON venue_1.id = anon_1."offer_venueId" LEFT OUTER JOIN offerer AS offerer_1 ON offerer_1.id = venue_1."managingOffererId" LEFT OUTER JOIN provider AS provider_1 ON provider_1.id = anon_1."offer_lastProviderId" LEFT OUTER JOIN mediation AS mediation_1 ON anon_1.offer_id = mediation_1."offerId" LEFT OUTER JOIN stock AS stock_1 ON anon_1.offer_id = stock_1."offerId"
```

</details>

#### Résultat du `explain analyze`

<details>

```
Hash Left Join  (cost=146.07..190.07 rows=48 width=4888) (actual time=1.946..1.949 rows=0 loops=1)
  Hash Cond: (offer."lastProviderId" = provider_1.id)
  ->  Hash Left Join  (cost=144.89..188.76 rows=48 width=4444) (actual time=1.946..1.949 rows=0 loops=1)
        Hash Cond: (venue_1."managingOffererId" = offerer_1.id)
        ->  Hash Right Join  (cost=141.68..185.40 rows=48 width=4157) (actual time=1.946..1.949 rows=0 loops=1)
              Hash Cond: (stock_1."offerId" = offer.id)
              ->  Seq Scan on stock stock_1  (cost=0.00..38.27 rows=1327 width=302) (never executed)
              ->  Hash  (cost=141.55..141.55 rows=10 width=3855) (actual time=1.941..1.943 rows=0 loops=1)
                    Buckets: 1024  Batches: 1  Memory Usage: 8kB
                    ->  Hash Left Join  (cost=101.42..141.55 rows=10 width=3855) (actual time=1.941..1.943 rows=0 loops=1)
                          Hash Cond: (offer."venueId" = venue_1.id)
                          ->  Hash Right Join  (cost=94.73..134.84 rows=10 width=2332) (actual time=1.941..1.943 rows=0 loops=1)
                                Hash Cond: (product_1.id = offer."productId")
                                ->  Seq Scan on product product_1  (cost=0.00..37.55 rows=655 width=629) (never executed)
                                ->  Hash  (cost=94.61..94.61 rows=10 width=1703) (actual time=1.937..1.938 rows=0 loops=1)
                                      Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                      ->  Hash Right Join  (cost=91.30..94.61 rows=10 width=1703) (actual time=1.937..1.938 rows=0 loops=1)
                                            Hash Cond: (mediation_1."offerId" = offer.id)
                                            ->  Seq Scan on mediation mediation_1  (cost=0.00..2.88 rows=88 width=740) (never executed)
                                            ->  Hash  (cost=91.17..91.17 rows=10 width=963) (actual time=1.931..1.933 rows=0 loops=1)
                                                  Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                                  ->  Limit  (cost=88.77..91.07 rows=10 width=963) (actual time=1.931..1.933 rows=0 loops=1)
                                                        ->  Merge Join  (cost=88.77..122.57 rows=147 width=963) (actual time=1.931..1.932 rows=0 loops=1)
                                                              Merge Cond: (offer.id = stock."offerId")
                                                              ->  Index Scan using offer_pkey on offer  (cost=0.15..29.09 rows=325 width=963) (actual time=0.006..0.006 rows=1 loops=1)
                                                              ->  Unique  (cost=88.63..89.36 rows=147 width=8) (actual time=1.924..1.925 rows=0 loops=1)
                                                                    ->  Sort  (cost=88.63..88.99 rows=147 width=8) (actual time=1.924..1.925 rows=0 loops=1)
                                                                          Sort Key: stock."offerId"
                                                                          Sort Method: quicksort  Memory: 25kB
                                                                          ->  Hash Join  (cost=27.00..83.33 rows=147 width=8) (actual time=1.921..1.922 rows=0 loops=1)
                                                                                Hash Cond: (offer_1."venueId" = venue.id)
                                                                                Join Filter: ((timezone(CASE WHEN (venue."departementCode" IS NULL) THEN CASE (SubPlan 1) WHEN '971'::text THEN 'America/Guadeloupe'::text WHEN '972'::text THEN 'America/Martinique'::text WHEN '973'::text THEN 'America/Cayenne'::text WHEN '974'::text THEN 'Indian/Reunion'::text WHEN '975'::text THEN 'America/Miquelon'::text WHEN '976'::text THEN 'Indian/Mayotte'::text WHEN '977'::text THEN 'America/St_Barthelemy'::text WHEN '978'::text THEN 'America/Guadeloupe'::text WHEN '986'::text THEN 'Pacific/Wallis'::text WHEN '987'::text THEN 'Pacific/Tahiti'::text WHEN '988'::text THEN 'Pacific/Noumea'::text WHEN '989'::text THEN 'Pacific/Pitcairn'::text ELSE 'Europe/Paris'::text END ELSE CASE venue."departementCode" WHEN '971'::text THEN 'America/Guadeloupe'::text WHEN '972'::text THEN 'America/Martinique'::text WHEN '973'::text THEN 'America/Cayenne'::text WHEN '974'::text THEN 'Indian/Reunion'::text WHEN '975'::text THEN 'America/Miquelon'::text WHEN '976'::text THEN 'Indian/Mayotte'::text WHEN '977'::text THEN 'America/St_Barthelemy'::text WHEN '978'::text THEN 'America/Guadeloupe'::text WHEN '986'::text THEN 'Pacific/Wallis'::text WHEN '987'::text THEN 'Pacific/Tahiti'::text WHEN '988'::text THEN 'Pacific/Noumea'::text WHEN '989'::text THEN 'Pacific/Pitcairn'::text ELSE 'Europe/Paris'::text END END, timezone('UTC'::text, stock."beginningDatetime")) >= '2020-04-21 00:00:00'::timestamp without time zone) AND (timezone(CASE WHEN (venue."departementCode" IS NULL) THEN CASE (SubPlan 2) WHEN '971'::text THEN 'America/Guadeloupe'::text WHEN '972'::text THEN 'America/Martinique'::text WHEN '973'::text THEN 'America/Cayenne'::text WHEN '974'::text THEN 'Indian/Reunion'::text WHEN '975'::text THEN 'America/Miquelon'::text WHEN '976'::text THEN 'Indian/Mayotte'::text WHEN '977'::text THEN 'America/St_Barthelemy'::text WHEN '978'::text THEN 'America/Guadeloupe'::text WHEN '986'::text THEN 'Pacific/Wallis'::text WHEN '987'::text THEN 'Pacific/Tahiti'::text WHEN '988'::text THEN 'Pacific/Noumea'::text WHEN '989'::text THEN 'Pacific/Pitcairn'::text ELSE 'Europe/Paris'::text END ELSE CASE venue."departementCode" WHEN '971'::text THEN 'America/Guadeloupe'::text WHEN '972'::text THEN 'America/Martinique'::text WHEN '973'::text THEN 'America/Cayenne'::text WHEN '974'::text THEN 'Indian/Reunion'::text WHEN '975'::text THEN 'America/Miquelon'::text WHEN '976'::text THEN 'Indian/Mayotte'::text WHEN '977'::text THEN 'America/St_Barthelemy'::text WHEN '978'::text THEN 'America/Guadeloupe'::text WHEN '986'::text THEN 'Pacific/Wallis'::text WHEN '987'::text THEN 'Pacific/Tahiti'::text WHEN '988'::text THEN 'Pacific/Noumea'::text WHEN '989'::text THEN 'Pacific/Pitcairn'::text ELSE 'Europe/Paris'::text END END, timezone('UTC'::text, stock."beginningDatetime")) <= '2020-04-21 23:59:59'::timestamp without time zone))
                                                                                Rows Removed by Join Filter: 1327
                                                                                ->  Hash Join  (cost=20.31..62.11 rows=1327 width=24) (actual time=0.078..0.395 rows=1327 loops=1)
                                                                                      Hash Cond: (stock."offerId" = offer_1.id)
                                                                                      ->  Seq Scan on stock  (cost=0.00..38.27 rows=1327 width=16) (actual time=0.002..0.144 rows=1327 loops=1)
                                                                                      ->  Hash  (cost=16.25..16.25 rows=325 width=16) (actual time=0.069..0.069 rows=325 loops=1)
                                                                                            Buckets: 1024  Batches: 1  Memory Usage: 24kB
                                                                                            ->  Seq Scan on offer offer_1  (cost=0.00..16.25 rows=325 width=16) (actual time=0.002..0.038 rows=325 loops=1)
                                                                                ->  Hash  (cost=5.75..5.75 rows=75 width=19) (actual time=0.026..0.026 rows=77 loops=1)
                                                                                      Buckets: 1024  Batches: 1  Memory Usage: 13kB
                                                                                      ->  Seq Scan on venue  (cost=0.00..5.75 rows=75 width=19) (actual time=0.005..0.017 rows=77 loops=1)
                                                                                SubPlan 1
                                                                                  ->  Seq Scan on offerer offerer_2  (cost=0.00..2.69 rows=1 width=32) (actual time=0.001..0.004 rows=1 loops=38)
                                                                                        Filter: (venue."managingOffererId" = id)
                                                                                        Rows Removed by Filter: 55
                                                                                SubPlan 2
                                                                                  ->  Seq Scan on offerer offerer_3  (cost=0.00..2.69 rows=1 width=32) (actual time=0.002..0.004 rows=1 loops=9)
                                                                                        Filter: (venue."managingOffererId" = id)
                                                                                        Rows Removed by Filter: 55
                          ->  Hash  (cost=5.75..5.75 rows=75 width=1523) (never executed)
                                ->  Seq Scan on venue venue_1  (cost=0.00..5.75 rows=75 width=1523) (never executed)
        ->  Hash  (cost=2.54..2.54 rows=54 width=287) (never executed)
              ->  Seq Scan on offerer offerer_1  (cost=0.00..2.54 rows=54 width=287) (never executed)
  ->  Hash  (cost=1.08..1.08 rows=8 width=444) (never executed)
        ->  Seq Scan on provider provider_1  (cost=0.00..1.08 rows=8 width=444) (never executed)
Planning Time: 1.467 ms
Execution Time: 2.141 ms
```

</details>

### Après

#### Requête générée

<details>

```sql
EXPLAIN ANALYZE SELECT anon_1."offer_jsonData" AS "anon_1_offer_jsonData", anon_1.offer_id AS anon_1_offer_id, anon_1."offer_isActive" AS "anon_1_offer_isActive", anon_1."offer_lastValidationDate" AS "anon_1_offer_lastValidationDate", anon_1."offer_lastValidationType" AS "anon_1_offer_lastValidationType", anon_1.offer_validation AS anon_1_offer_validation, anon_1."offer_audioDisabilityCompliant" AS "anon_1_offer_audioDisabilityCompliant", anon_1."offer_mentalDisabilityCompliant" AS "anon_1_offer_mentalDisabilityCompliant", anon_1."offer_motorDisabilityCompliant" AS "anon_1_offer_motorDisabilityCompliant", anon_1."offer_visualDisabilityCompliant" AS "anon_1_offer_visualDisabilityCompliant", anon_1."offer_ageMin" AS "anon_1_offer_ageMin", anon_1."offer_ageMax" AS "anon_1_offer_ageMax", anon_1."offer_authorId" AS "anon_1_offer_authorId", anon_1."offer_bookingEmail" AS "anon_1_offer_bookingEmail", anon_1.offer_conditions AS anon_1_offer_conditions, anon_1."offer_dateCreated" AS "anon_1_offer_dateCreated", anon_1."offer_dateModifiedAtLastProvider" AS "anon_1_offer_dateModifiedAtLastProvider", anon_1."offer_dateUpdated" AS "anon_1_offer_dateUpdated", anon_1.offer_description AS anon_1_offer_description, anon_1."offer_durationMinutes" AS "anon_1_offer_durationMinutes", anon_1."offer_externalTicketOfficeUrl" AS "anon_1_offer_externalTicketOfficeUrl", anon_1."offer_fieldsUpdated" AS "anon_1_offer_fieldsUpdated", anon_1."offer_idAtProvider" AS "anon_1_offer_idAtProvider", anon_1."offer_isDuo" AS "anon_1_offer_isDuo", anon_1."offer_isNational" AS "anon_1_offer_isNational", anon_1.offer_name AS anon_1_offer_name, anon_1."offer_mediaUrls" AS "anon_1_offer_mediaUrls", anon_1."offer_productId" AS "anon_1_offer_productId", anon_1."offer_rankingWeight" AS "anon_1_offer_rankingWeight", anon_1."offer_subcategoryId" AS "anon_1_offer_subcategoryId", anon_1.offer_url AS anon_1_offer_url, anon_1."offer_venueId" AS "anon_1_offer_venueId", anon_1."offer_withdrawalDelay" AS "anon_1_offer_withdrawalDelay", anon_1."offer_withdrawalDetails" AS "anon_1_offer_withdrawalDetails", anon_1."offer_withdrawalType" AS "anon_1_offer_withdrawalType", anon_1."offer_lastProviderId" AS "anon_1_offer_lastProviderId", product_1."jsonData" AS "product_1_jsonData", product_1.id AS product_1_id, product_1."thumbCount" AS "product_1_thumbCount", product_1."idAtProviders" AS "product_1_idAtProviders", product_1."dateModifiedAtLastProvider" AS "product_1_dateModifiedAtLastProvider", product_1."fieldsUpdated" AS "product_1_fieldsUpdated", product_1."ageMin" AS "product_1_ageMin", product_1."ageMax" AS "product_1_ageMax", product_1.conditions AS product_1_conditions, product_1.description AS product_1_description, product_1."durationMinutes" AS "product_1_durationMinutes", product_1."isGcuCompatible" AS "product_1_isGcuCompatible", product_1."isNational" AS "product_1_isNational", product_1."isSynchronizationCompatible" AS "product_1_isSynchronizationCompatible", product_1."mediaUrls" AS "product_1_mediaUrls", product_1.name AS product_1_name, product_1."owningOffererId" AS "product_1_owningOffererId", product_1."subcategoryId" AS "product_1_subcategoryId", product_1.url AS product_1_url, product_1."lastProviderId" AS "product_1_lastProviderId", offerer_1.id AS offerer_1_id, offerer_1."isActive" AS "offerer_1_isActive", offerer_1.address AS offerer_1_address, offerer_1."postalCode" AS "offerer_1_postalCode", offerer_1.city AS offerer_1_city, offerer_1."thumbCount" AS "offerer_1_thumbCount", offerer_1."idAtProviders" AS "offerer_1_idAtProviders", offerer_1."dateModifiedAtLastProvider" AS "offerer_1_dateModifiedAtLastProvider", offerer_1."fieldsUpdated" AS "offerer_1_fieldsUpdated", offerer_1."validationStatus" AS "offerer_1_validationStatus", offerer_1."dateCreated" AS "offerer_1_dateCreated", offerer_1.name AS offerer_1_name, offerer_1.siren AS offerer_1_siren, offerer_1."dateValidated" AS "offerer_1_dateValidated", offerer_1."lastProviderId" AS "offerer_1_lastProviderId", venue_1."bannerUrl" AS "venue_1_bannerUrl", venue_1.id AS venue_1_id, venue_1."audioDisabilityCompliant" AS "venue_1_audioDisabilityCompliant", venue_1."mentalDisabilityCompliant" AS "venue_1_mentalDisabilityCompliant", venue_1."motorDisabilityCompliant" AS "venue_1_motorDisabilityCompliant", venue_1."visualDisabilityCompliant" AS "venue_1_visualDisabilityCompliant", venue_1."thumbCount" AS "venue_1_thumbCount", venue_1."idAtProviders" AS "venue_1_idAtProviders", venue_1."dateModifiedAtLastProvider" AS "venue_1_dateModifiedAtLastProvider", venue_1."fieldsUpdated" AS "venue_1_fieldsUpdated", venue_1.name AS venue_1_name, venue_1.siret AS venue_1_siret, venue_1."departementCode" AS "venue_1_departementCode", venue_1.latitude AS venue_1_latitude, venue_1.longitude AS venue_1_longitude, venue_1."managingOffererId" AS "venue_1_managingOffererId", venue_1."bookingEmail" AS "venue_1_bookingEmail", venue_1.address AS venue_1_address, venue_1."postalCode" AS "venue_1_postalCode", venue_1.city AS venue_1_city, venue_1.timezone AS venue_1_timezone, venue_1."publicName" AS "venue_1_publicName", venue_1."isVirtual" AS "venue_1_isVirtual", venue_1."isPermanent" AS "venue_1_isPermanent", venue_1.comment AS venue_1_comment, venue_1."venueTypeCode" AS "venue_1_venueTypeCode", venue_1."venueLabelId" AS "venue_1_venueLabelId", venue_1."dateCreated" AS "venue_1_dateCreated", venue_1."withdrawalDetails" AS "venue_1_withdrawalDetails", venue_1.description AS venue_1_description, venue_1."bannerMeta" AS "venue_1_bannerMeta", venue_1."adageId" AS "venue_1_adageId", venue_1."adageInscriptionDate" AS "venue_1_adageInscriptionDate", venue_1."dmsToken" AS "venue_1_dmsToken", venue_1."venueEducationalStatusId" AS "venue_1_venueEducationalStatusId", venue_1."collectiveDescription" AS "venue_1_collectiveDescription", venue_1."collectiveStudents" AS "venue_1_collectiveStudents", venue_1."collectiveWebsite" AS "venue_1_collectiveWebsite", venue_1."collectiveInterventionArea" AS "venue_1_collectiveInterventionArea", venue_1."collectiveNetwork" AS "venue_1_collectiveNetwork", venue_1."collectiveAccessInformation" AS "venue_1_collectiveAccessInformation", venue_1."collectivePhone" AS "venue_1_collectivePhone", venue_1."collectiveEmail" AS "venue_1_collectiveEmail", venue_1."collectiveSubCategoryId" AS "venue_1_collectiveSubCategoryId", venue_1."lastProviderId" AS "venue_1_lastProviderId", provider_1.id AS provider_1_id, provider_1."isActive" AS "provider_1_isActive", provider_1.name AS provider_1_name, provider_1."localClass" AS "provider_1_localClass", provider_1."apiUrl" AS "provider_1_apiUrl", provider_1."authToken" AS "provider_1_authToken", provider_1."enabledForPro" AS "provider_1_enabledForPro", provider_1."enableParallelSynchronization" AS "provider_1_enableParallelSynchronization", provider_1."logoUrl" AS "provider_1_logoUrl", provider_1."pricesInCents" AS "provider_1_pricesInCents", mediation_1.id AS mediation_1_id, mediation_1."isActive" AS "mediation_1_isActive", mediation_1."thumbCount" AS "mediation_1_thumbCount", mediation_1."idAtProviders" AS "mediation_1_idAtProviders", mediation_1."dateModifiedAtLastProvider" AS "mediation_1_dateModifiedAtLastProvider", mediation_1."fieldsUpdated" AS "mediation_1_fieldsUpdated", mediation_1."authorId" AS "mediation_1_authorId", mediation_1.credit AS mediation_1_credit, mediation_1."dateCreated" AS "mediation_1_dateCreated", mediation_1."offerId" AS "mediation_1_offerId", mediation_1."lastProviderId" AS "mediation_1_lastProviderId", stock_1.id AS stock_1_id, stock_1."idAtProviders" AS "stock_1_idAtProviders", stock_1."dateModifiedAtLastProvider" AS "stock_1_dateModifiedAtLastProvider", stock_1."fieldsUpdated" AS "stock_1_fieldsUpdated", stock_1."isSoftDeleted" AS "stock_1_isSoftDeleted", stock_1."beginningDatetime" AS "stock_1_beginningDatetime", stock_1."bookingLimitDatetime" AS "stock_1_bookingLimitDatetime", stock_1."dateCreated" AS "stock_1_dateCreated", stock_1."dateModified" AS "stock_1_dateModified", stock_1."dnBookedQuantity" AS "stock_1_dnBookedQuantity", stock_1."educationalPriceDetail" AS "stock_1_educationalPriceDetail", stock_1."numberOfTickets" AS "stock_1_numberOfTickets", stock_1."offerId" AS "stock_1_offerId", stock_1.price AS stock_1_price, stock_1."priceCategoryId" AS "stock_1_priceCategoryId", stock_1.quantity AS stock_1_quantity, stock_1."rawProviderQuantity" AS "stock_1_rawProviderQuantity", stock_1."lastProviderId" AS "stock_1_lastProviderId" 
FROM (
  SELECT offer."jsonData" AS "offer_jsonData", offer.id AS offer_id, offer."isActive" AS "offer_isActive", offer."lastValidationDate" AS "offer_lastValidationDate", offer."lastValidationType" AS "offer_lastValidationType", offer.validation AS offer_validation, offer."audioDisabilityCompliant" AS "offer_audioDisabilityCompliant", offer."mentalDisabilityCompliant" AS "offer_mentalDisabilityCompliant", offer."motorDisabilityCompliant" AS "offer_motorDisabilityCompliant", offer."visualDisabilityCompliant" AS "offer_visualDisabilityCompliant", offer."ageMin" AS "offer_ageMin", offer."ageMax" AS "offer_ageMax", offer."authorId" AS "offer_authorId", offer."bookingEmail" AS "offer_bookingEmail", offer.conditions AS offer_conditions, offer."dateCreated" AS "offer_dateCreated", offer."dateModifiedAtLastProvider" AS "offer_dateModifiedAtLastProvider", offer."dateUpdated" AS "offer_dateUpdated", offer.description AS offer_description, offer."durationMinutes" AS "offer_durationMinutes", offer."externalTicketOfficeUrl" AS "offer_externalTicketOfficeUrl", offer."fieldsUpdated" AS "offer_fieldsUpdated", offer."idAtProvider" AS "offer_idAtProvider", offer."isDuo" AS "offer_isDuo", offer."isNational" AS "offer_isNational", offer.name AS offer_name, offer."mediaUrls" AS "offer_mediaUrls", offer."productId" AS "offer_productId", offer."rankingWeight" AS "offer_rankingWeight", offer."subcategoryId" AS "offer_subcategoryId", offer.url AS offer_url, offer."venueId" AS "offer_venueId", offer."withdrawalDelay" AS "offer_withdrawalDelay", offer."withdrawalDetails" AS "offer_withdrawalDetails", offer."withdrawalType" AS "offer_withdrawalType", offer."lastProviderId" AS "offer_lastProviderId" 
  FROM offer JOIN (
    SELECT DISTINCT ON (stock."offerId") stock."offerId" AS "offerId" 
    FROM stock JOIN offer ON offer.id = stock."offerId" JOIN venue ON venue.id = offer."venueId" 
    WHERE stock."isSoftDeleted" IS false AND timezone(venue.timezone, timezone('UTC', stock."beginningDatetime")) >= '2020-04-21T00:00:00' AND timezone(venue.timezone, timezone('UTC', stock."beginningDatetime")) <= '2020-04-21T23:59:59'
  ) AS anon_2 ON anon_2."offerId" = offer.id 
  LIMIT 10
) AS anon_1
LEFT OUTER JOIN product AS product_1 ON product_1.id = anon_1."offer_productId"
LEFT OUTER JOIN venue AS venue_1 ON venue_1.id = anon_1."offer_venueId"
LEFT OUTER JOIN offerer AS offerer_1 ON offerer_1.id = venue_1."managingOffererId"
LEFT OUTER JOIN provider AS provider_1 ON provider_1.id = anon_1."offer_lastProviderId"
LEFT OUTER JOIN mediation AS mediation_1 ON anon_1.offer_id = mediation_1."offerId"
LEFT OUTER JOIN stock AS stock_1 ON anon_1.offer_id = stock_1."offerId"
```

</details>

#### Résultat du `explain analyze`

<details>

```Hash Left Join  (cost=135.07..179.07 rows=48 width=5006) (actual time=1.143..1.145 rows=0 loops=1)
  Hash Cond: (offer."lastProviderId" = provider_1.id)
  ->  Hash Left Join  (cost=133.89..177.76 rows=48 width=4562) (actual time=1.142..1.144 rows=0 loops=1)
        Hash Cond: (venue_1."managingOffererId" = offerer_1.id)
        ->  Hash Right Join  (cost=130.68..174.40 rows=48 width=4275) (actual time=1.142..1.144 rows=0 loops=1)
              Hash Cond: (stock_1."offerId" = offer.id)
              ->  Seq Scan on stock stock_1  (cost=0.00..38.27 rows=1327 width=302) (never executed)
              ->  Hash  (cost=130.55..130.55 rows=10 width=3973) (actual time=1.136..1.138 rows=0 loops=1)
                    Buckets: 1024  Batches: 1  Memory Usage: 8kB
                    ->  Hash Left Join  (cost=90.42..130.55 rows=10 width=3973) (actual time=1.136..1.138 rows=0 loops=1)
                          Hash Cond: (offer."venueId" = venue_1.id)
                          ->  Hash Right Join  (cost=83.73..123.84 rows=10 width=2332) (actual time=1.136..1.137 rows=0 loops=1)
                                Hash Cond: (product_1.id = offer."productId")
                                ->  Seq Scan on product product_1  (cost=0.00..37.55 rows=655 width=629) (never executed)
                                ->  Hash  (cost=83.61..83.61 rows=10 width=1703) (actual time=1.132..1.134 rows=0 loops=1)
                                      Buckets: 1024  Batches: 1  Memory Usage: 8kB
                                      ->  Hash Right Join  (cost=80.30..83.61 rows=10 width=1703) (actual time=1.132..1.133 rows=0 loops=1)
                                            Hash Cond: (mediation_1."offerId" = offer.id)
                                            ->  Seq Scan on mediation mediation_1  (cost=0.00..2.88 rows=88 width=740) (never executed)
                                            ->  Hash  (cost=80.17..80.17 rows=10 width=963) (actual time=1.129..1.130 rows=0 loops=1)
                                                  ->  Limit  (cost=77.77..80.07 rows=10 width=963) (actual time=1.129..1.130 rows=0 loops=1)
                                                        ->  Merge Join  (cost=77.77..111.57 rows=147 width=963) (actual time=1.128..1.129 rows=0 loops=1)
                                                              Merge Cond: (offer.id = stock."offerId")
                                                              ->  Index Scan using offer_pkey on offer  (cost=0.15..29.09 rows=325 width=963) (actual time=0.006..0.006 rows=1 loops=1)
                                                              ->  Unique  (cost=77.63..78.36 rows=147 width=8) (actual time=1.121..1.122 rows=0 loops=1)
                                                                    ->  Sort  (cost=77.63..77.99 rows=147 width=8) (actual time=1.121..1.122 rows=0 loops=1)
                                                                          Sort Key: stock."offerId"
                                                                          Sort Method: quicksort  Memory: 25kB
                                                                          ->  Hash Join  (cost=27.00..72.33 rows=147 width=8) (actual time=1.118..1.119 rows=0 loops=1)
                                                                                Hash Cond: (offer_1."venueId" = venue.id)
                                                                                Join Filter: ((timezone((venue.timezone)::text, timezone('UTC'::text, stock."beginningDatetime")) >= '2020-04-21 00:00:00'::timestamp without time zone) AND (timezone((venue.timezone)::text, timezone('UTC'::text, stock."beginningDatetime")) <= '2020-04-21 23:59:59'::timestamp without time zone))
                                                                                Rows Removed by Join Filter: 1327
                                                                                ->  Hash Join  (cost=20.31..62.11 rows=1327 width=24) (actual time=0.076..0.383 rows=1327 loops=1)
                                                                                      Hash Cond: (stock."offerId" = offer_1.id)
                                                                                      ->  Seq Scan on stock  (cost=0.00..38.27 rows=1327 width=16) (actual time=0.002..0.138 rows=1327 loops=1)
                                                                                            Filter: ("isSoftDeleted" IS FALSE)
                                                                                      ->  Hash  (cost=16.25..16.25 rows=325 width=16) (actual time=0.069..0.069 rows=325 loops=1)
                                                                                            Buckets: 1024  Batches: 1  Memory Usage: 24kB
                                                                                            ->  Seq Scan on offer offer_1  (cost=0.00..16.25 rows=325 width=16) (actual time=0.001..0.037 rows=325 loops=1)
                                                                                ->  Hash  (cost=5.75..5.75 rows=75 width=126) (actual time=0.033..0.034 rows=77 loops=1)
                                                                                      Buckets: 1024  Batches: 1  Memory Usage: 12kB
                                                                                      ->  Seq Scan on venue  (cost=0.00..5.75 rows=75 width=126) (actual time=0.005..0.023 rows=77 loops=1)
                          ->  Hash  (cost=5.75..5.75 rows=75 width=1641) (never executed)
                                ->  Seq Scan on venue venue_1  (cost=0.00..5.75 rows=75 width=1641) (never executed)
        ->  Hash  (cost=2.54..2.54 rows=54 width=287) (never executed)
              ->  Seq Scan on offerer offerer_1  (cost=0.00..2.54 rows=54 width=287) (never executed)
  ->  Hash  (cost=1.08..1.08 rows=8 width=444) (never executed)
        ->  Seq Scan on provider provider_1  (cost=0.00..1.08 rows=8 width=444) (never executed)
Planning Time: 1.191 ms
Execution Time: 1.310 ms
```

</details>

## Modifications du schéma de la base de données

Ajout de la colonne `timezone`. Le script de remplissage arrive sous peu.
