### PR TITLE
(PC-21908)[PRO] feat: Wording des réservations, tags et statuts.

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/BookingStatusCell.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/BookingStatusCell.tsx
@@ -44,7 +44,7 @@ const BookingStatusCell = ({
           aria-describedby={tooltipId}
         >
           <Icon svg={bookingDisplayInfo?.svgIconFilename} />
-          <span>{bookingDisplayInfo?.status}</span>
+          <span>{bookingDisplayInfo?.status.toLowerCase()}</span>
         </div>
       </Tooltip>
     )
@@ -55,7 +55,7 @@ const BookingStatusCell = ({
   )
   const offerName = bookingRecapInfo.original.stock.offerName
 
-  const statusName = bookingDisplayInfo?.status
+  const statusName = bookingDisplayInfo?.status.toLowerCase()
   const amount = computeBookingAmount(bookingRecapInfo.original.bookingAmount)
   const icon = bookingDisplayInfo?.svgIconFilename
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingStatusCell.spec.jsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/CellsFormatter/__specs__/BookingStatusCell.spec.jsx
@@ -42,7 +42,7 @@ describe('bookings | bookingsStatusCell', () => {
     renderBookingStatusCell(props)
 
     // Then
-    const title = screen.getByText('validé', { selector: 'span' })
+    const title = screen.getByText('validée', { selector: 'span' })
     expect(title).toBeInTheDocument()
   })
 

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/FilterByBookingStatus/FilterByBookingStatus.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/FilterByBookingStatus/FilterByBookingStatus.tsx
@@ -127,7 +127,7 @@ const FilterByBookingStatus = <
       <span className="bs-filter">
         {isToolTipVisible && (
           <div className="bs-filter-tooltip">
-            <div className="bs-filter-label">Afficher les offres</div>
+            <div className="bs-filter-label">Afficher les réservations</div>
             {filteredBookingStatuses.map(bookingStatus => (
               <label key={bookingStatus.value}>
                 <input

--- a/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/__specs__/FilterByBookingStatus.spec.tsx
+++ b/pro/src/screens/Bookings/BookingsRecapTable/components/Filters/__specs__/FilterByBookingStatus.spec.tsx
@@ -123,8 +123,8 @@ describe('components | FilterByBookingStatus', () => {
       expect(checkbox).toHaveLength(2)
       expect(checkbox[0]).toHaveAttribute('checked')
       expect(checkbox[1]).toHaveAttribute('checked')
-      expect(screen.getByText('réservé')).toBeInTheDocument()
-      expect(screen.getByText('validé')).toBeInTheDocument()
+      expect(screen.getByText('Réservée')).toBeInTheDocument()
+      expect(screen.getByText('Validée')).toBeInTheDocument()
     })
 
     it('should add value to filters when unchecking on a checkbox', async () => {

--- a/pro/src/screens/Bookings/BookingsRecapTable/utils/bookingStatusConverter.ts
+++ b/pro/src/screens/Bookings/BookingsRecapTable/utils/bookingStatusConverter.ts
@@ -6,7 +6,7 @@ import styles from './BookingStatus.module.scss'
 const BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   {
     id: BOOKING_STATUS.VALIDATED,
-    status: 'validé',
+    status: 'Validée',
     label: 'Réservation validée',
     historyClassName: 'bs-history-validated',
     statusClassName: styles['booking-status-validated'],
@@ -25,7 +25,7 @@ const BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   },
   {
     id: BOOKING_STATUS.BOOKED,
-    status: 'réservé',
+    status: 'Réservée',
     label: 'Réservé',
     historyClassName: 'bs-history-booked',
     statusClassName: styles['booking-status-booked'],
@@ -43,7 +43,7 @@ const BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   },
   {
     id: BOOKING_STATUS.REIMBURSED,
-    status: 'remboursé',
+    status: 'Remboursée',
     label: 'Remboursée',
     historyClassName: 'bs-history-reimbursed',
     statusClassName: styles['booking-status-reimbursed'],
@@ -52,7 +52,7 @@ const BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   },
   {
     id: BOOKING_STATUS.CONFIRMED,
-    status: 'confirmé',
+    status: 'Confirmée',
     label: 'Réservation confirmée',
     historyClassName: 'bs-history-confirmed',
     statusClassName: styles['booking-status-confirmed'],
@@ -64,14 +64,14 @@ const BOOKING_STATUS_DISPLAY_INFORMATIONS = [
 const COLLECTIVE_BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   {
     id: BOOKING_STATUS.VALIDATED,
-    status: 'terminée',
+    status: 'Terminée',
     label: 'Votre évènement a eu lieu',
     statusClassName: styles['booking-status-validated'],
     svgIconFilename: 'ico-status-double-validated',
   },
   {
     id: BOOKING_STATUS.CANCELLED,
-    status: 'annulée',
+    status: 'Annulée',
     label: 'Réservation annulée',
     statusClassName: styles['booking-status-cancelled'],
     icon: 'ico-status-cancelled',
@@ -79,28 +79,28 @@ const COLLECTIVE_BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   },
   {
     id: BOOKING_STATUS.BOOKED,
-    status: 'réservée',
+    status: 'Réservée',
     label: 'Le chef d’établissement scolaire a réservé.',
     statusClassName: styles['booking-status-booked'],
     svgIconFilename: 'ico-status-booked',
   },
   {
     id: BOOKING_STATUS.PENDING,
-    status: 'préréservée',
+    status: 'Préréservée',
     label: 'L’enseignant a préréservé.',
     statusClassName: styles['booking-status-pending'],
     svgIconFilename: 'ico-status-pending-tag',
   },
   {
     id: BOOKING_STATUS.REIMBURSED,
-    status: 'remboursée',
+    status: 'Remboursée',
     label: 'La réservation a été remboursée',
     statusClassName: styles['booking-status-reimbursed'],
     svgIconFilename: 'ico-status-reimbursed',
   },
   {
     id: BOOKING_STATUS.CONFIRMED,
-    status: 'confirmée',
+    status: 'Confirmée',
     label: 'L’établissement scolaire ne peut plus annuler la réservation',
     statusClassName: styles['booking-status-confirmed'],
     svgIconFilename: 'ico-status-validated-white',


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21908

## But de la pull request

Wording des réservations, tags et statut.

Résultats (individuelles et collectives):

<img width="409" alt="Capture d’écran 2023-05-31 à 20 46 40" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/1621576e-3bee-40c4-8b3c-64dd56b3fdb6">

<img width="888" alt="Capture d’écran 2023-05-31 à 20 42 58" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/92d51199-aa94-4ecd-bc0e-eeb512ee0118">


## Informations supplémentaires

Dans le tooltip du filtre Statut : 

- Remplacer le wording “Afficher les statuts” par “Afficher les réservations”

- Mettre une Majuscule à chaque début de mot (Annulée, Confirmée…)
- Faire cette modif à la fois côté individuel et collectif

- côté individuel uniquement, mettre les éléments de la liste au féminin (annulée, confirmée…)

Dans la liste des réservations : 
- côté individuel uniquement mettre tous les tags des statuts au féminin (annulée, confirmée…)

## Checklist :

- [x ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : PC-21908-wording-liste
  - PR : (PC-21908) Wording des réservations, tags et statuts.
  - Commit(s) : Wording des réservations, tags et statuts.