### PR TITLE
(PC-22481)[API] fix: PRO vs NON_ATTACHED_PRO roles

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -242,7 +242,10 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
 
         updated_roles = self.roles + [role]
 
-        if len(set(updated_roles) & {UserRole.ADMIN, UserRole.BENEFICIARY, UserRole.UNDERAGE_BENEFICIARY}) > 1:
+        if (
+            len(set(updated_roles) & {UserRole.ADMIN, UserRole.BENEFICIARY, UserRole.UNDERAGE_BENEFICIARY}) > 1
+            or len(set(updated_roles) & {UserRole.PRO, UserRole.NON_ATTACHED_PRO}) > 1
+        ):
             msg = "User can't have roles " + " and ".join(r.value for r in updated_roles)
             raise InvalidUserRoleException(msg)
 
@@ -256,8 +259,8 @@ class User(PcObject, Base, Model, NeedsValidationMixin, DeactivableMixin):
         self._add_role(UserRole.BENEFICIARY)
 
     def add_pro_role(self) -> None:
-        self._add_role(UserRole.PRO)
         self.remove_non_attached_pro_role()
+        self._add_role(UserRole.PRO)
 
     def add_non_attached_pro_role(self) -> None:
         self.remove_pro_role()

--- a/api/src/pcapi/scripts/fix_pro_roles.py
+++ b/api/src/pcapi/scripts/fix_pro_roles.py
@@ -1,0 +1,96 @@
+"""
+Fix wrong pro roles in User table.
+
+In some cases, user may have been set back to NON_ATTACHED_PRO when an offerer was moved to pending state, even if the
+user was already PRO because of existing validated attachment to another validated offerer.
+"""
+import argparse
+
+import sqlalchemy as sa
+
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.users import models as users_models
+from pcapi.models import db
+
+
+def fix_users_who_should_be_pro(do_update: bool = False) -> None:
+    """
+    Users who don't have PRO role but have at least one validated attachment to a validated offerer
+    """
+    users = (
+        users_models.User.query.join(offerers_models.UserOfferer)
+        .join(offerers_models.Offerer)
+        .filter(
+            users_models.User.has_pro_role.is_(False),  # type: ignore [attr-defined]
+            offerers_models.UserOfferer.isValidated,
+            offerers_models.Offerer.isValidated,
+        )
+        .options(sa.orm.load_only(users_models.User.id, users_models.User.email, users_models.User.roles))
+    )
+
+    for user in users:
+        print(f"Fix {user.id} {user.email} {user.roles} => PRO")
+        if do_update:
+            user.add_pro_role()
+            db.session.commit()
+
+
+def fix_users_who_should_not_be_pro(do_update: bool = False) -> None:
+    """
+    Users who have PRO roles but do not have any attachment (any status)
+    """
+    users = users_models.User.query.outerjoin(offerers_models.UserOfferer).filter(
+        users_models.User.has_pro_role.is_(True),  # type: ignore [attr-defined]
+        offerers_models.UserOfferer.id.is_(None),
+    )
+
+    for user in users:
+        print(f"Fix {user.id} {user.email} {user.roles} => NON_ATTACHED_PRO (not PRO)")
+        if do_update:
+            user.add_non_attached_pro_role()
+            db.session.commit()
+
+
+def fix_users_who_should_be_non_attached_pro(do_update: bool = False) -> None:
+    """
+    Users who don't have any PRO or NON_ATTACHED_PRO role but have an attachment to an offerer, waiting for validation.
+    """
+    users = (
+        users_models.User.query.join(offerers_models.UserOfferer)
+        .join(offerers_models.Offerer)
+        .filter(
+            users_models.User.has_non_attached_pro_role.is_(False),  # type: ignore [attr-defined]
+            sa.or_(
+                sa.not_(offerers_models.UserOfferer.isValidated),
+                sa.not_(offerers_models.Offerer.isValidated),
+            ),
+        )
+        .options(
+            sa.orm.load_only(users_models.User.roles),
+            sa.orm.joinedload(users_models.User.UserOfferers)
+            .load_only(offerers_models.UserOfferer.validationStatus)
+            .joinedload(offerers_models.UserOfferer.offerer)
+            .load_only(offerers_models.Offerer.validationStatus),
+        )
+    )
+
+    for user in users:
+        if not any(user_offerer.isValidated and user_offerer.offerer.isValidated for user_offerer in user.UserOfferers):
+            print(f"Fix {user.id} {user.email} {user.roles} => NON_ATTACHED_PRO")
+            if do_update:
+                user.add_non_attached_pro_role()
+                db.session.commit()
+
+
+if __name__ == "__main__":
+    from pcapi.flask_app import app
+
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser(description="Fix pro roles in User table")
+    parser.add_argument("--not-dry", action="store_true", help="set to really process (dry-run by default)")
+    args = parser.parse_args()
+
+    fix_users_who_should_be_non_attached_pro(do_update=args.not_dry)
+    fix_users_who_should_not_be_pro(do_update=args.not_dry)
+    fix_users_who_should_be_pro(do_update=args.not_dry)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22481

## But de la pull request

- Corriger les erreurs de transition entre PRO et NON_ATTACHED_PRO
- Script de rattrapage pour corriger les rôles pro ; testé en dry-run sur staging, il y a pas mal d'erreurs accumulées avec le temps

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
