### PR TITLE
(PC-21816)[API] fix: add reponse_model to email_update/status route

### DIFF
--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -108,9 +108,10 @@ def update_user_email(user: users_models.User, body: serializers.UserProfileEmai
 @spectree_serialize(
     on_success_status=200,
     api=blueprint.api,
+    response_model=serializers.EmailUpdateStatus,
 )
 @authenticated_and_active_user_required
-def get_email_update_status(user: users_models.User) -> serializers.EmailUpdateStatus | None:
+def get_email_update_status(user: users_models.User) -> serializers.EmailUpdateStatus:
     latest_email_update_event = email_repository.get_email_update_latest_event(user)
     if not latest_email_update_event:
         raise api_errors.ResourceNotFoundError

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -545,6 +545,29 @@ def test_public_api(client):
                     "enum": ["underage", "age-18"],
                     "title": "EligibilityType",
                 },
+                "EmailHistoryEventTypeEnum": {
+                    "description": "An enumeration.",
+                    "enum": [
+                        "UPDATE_REQUEST",
+                        "CONFIRMATION",
+                        "CANCELLATION",
+                        "VALIDATION",
+                        "ADMIN_VALIDATION",
+                        "ADMIN_UPDATE_REQUEST",
+                        "ADMIN_UPDATE",
+                    ],
+                    "title": "EmailHistoryEventTypeEnum",
+                },
+                "EmailUpdateStatus": {
+                    "properties": {
+                        "expired": {"title": "Expired", "type": "boolean"},
+                        "newEmail": {"title": "Newemail", "type": "string"},
+                        "status": {"$ref": "#/components/schemas/EmailHistoryEventTypeEnum"},
+                    },
+                    "required": ["newEmail", "expired", "status"],
+                    "title": "EmailUpdateStatus",
+                    "type": "object",
+                },
                 "ExpenseDomain": {
                     "description": "An enumeration.",
                     "enum": ["all", "digital", "physical"],
@@ -2607,7 +2630,12 @@ def test_public_api(client):
                     "operationId": "get_/native/v1/profile/email_update/status",
                     "parameters": [],
                     "responses": {
-                        "200": {"description": "OK"},
+                        "200": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/EmailUpdateStatus"}}
+                            },
+                            "description": "OK",
+                        },
                         "403": {"description": "Forbidden"},
                         "422": {
                             "content": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21816

## But de la pull request

Ajouter le response_model qui va bien au décorateur spectree de la route native/v1/profile/email_update/status

## Implémentation

RAS

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
