### PR TITLE
(PC-22513)[BO] fix: ADMIN role for backoffice users (access to PC Pro)

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/auth.py
+++ b/api/src/pcapi/routes/backoffice_v3/auth.py
@@ -43,6 +43,7 @@ def login() -> utils.BackofficeResponse:
             local_admin = create_local_admin_user(local_admin_email, "Local", "Admin")
 
         local_admin.lastConnectionDate = datetime.datetime.utcnow()
+        local_admin.add_admin_role()
         backoffice_api.upsert_roles(local_admin, list(perm_models.Roles))
         db.session.commit()
 
@@ -92,6 +93,7 @@ def authorize() -> utils.BackofficeResponse:
         )
 
     user.lastConnectionDate = datetime.datetime.utcnow()
+    user.add_admin_role()
     backoffice_api.upsert_roles(user, roles)
     db.session.commit()
 
@@ -134,7 +136,6 @@ def create_local_admin_user(email: str, first_name: str, last_name: str) -> user
         remote_updates=False,
     )
 
-    local_admin.add_admin_role()
     local_admin.firstName = first_name
     local_admin.lastName = last_name
     local_admin.hasSeenProTutorials = True

--- a/api/tests/routes/backoffice_v3/auth_test.py
+++ b/api/tests/routes/backoffice_v3/auth_test.py
@@ -76,6 +76,7 @@ class AuthorizePageTest:
         assert "Successful authentication attempt" in caplog.messages
 
         user = users_models.User.query.get(user.id)
+        assert user.has_admin_role
         user_role_names = {role.name for role in user.backoffice_profile.roles}
         expected_role_names = {role.value for role in expected_roles}
 
@@ -108,6 +109,7 @@ class AuthorizePageTest:
 
         user = users_models.User.query.filter(users_models.User.email == email).first()
         assert user is not None
+        assert user.has_admin_role
         assert response.status_code == 302
         assert response.location == url_for("backoffice_v3_web.home", _external=True)
         assert "Successful authentication attempt" in caplog.messages


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22513

## But de la pull request

Permettre à tous les utilisateurs du backoffice d'accéder en ADMIN à PC Pro, quel que soit l'ordre de création du compte, connexion à PC pro ou backoffice.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
