### PR TITLE
(PC-22129)[API] feat: Add choice of subscription step when generating user

### DIFF
--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -31,6 +31,17 @@ class SubscriptionStep(enum.Enum):
     IDENTITY_CHECK = "identity-check"
     HONOR_STATEMENT = "honor-statement"
 
+    @classmethod
+    def is_valid(cls, value: str) -> bool:
+        try:
+            cls(value)
+        except ValueError:
+            return False
+        return True
+
+    def get_title(self) -> str:
+        return self.value.title().replace("-", " ")
+
 
 class SubscriptionStepTitle(enum.Enum):
     PHONE_VALIDATION = "Numéro de téléphone"

--- a/api/src/pcapi/core/users/generator.py
+++ b/api/src/pcapi/core/users/generator.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 from pcapi import settings
+import pcapi.core.subscription.models as subscription_models
 import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
 
@@ -10,15 +11,28 @@ from . import exceptions
 @dataclasses.dataclass
 class GenerateUserData:
     age: int
-    is_email_validated: bool
     is_beneficiary: bool
+    step: subscription_models.SubscriptionStep | None = None
 
 
 def generate_user(user_data: GenerateUserData) -> users_models.User:
     if not settings.ENABLE_TEST_USER_GENERATION:
         raise exceptions.UserGenerationForbiddenException("Test user generation is disabled")
 
-    if user_data.is_beneficiary:
-        return users_factories.BeneficiaryFactory(age=user_data.age)
+    factory = users_factories.BaseUserFactory
+    match user_data.step:
+        case subscription_models.SubscriptionStep.EMAIL_VALIDATION:
+            factory = users_factories.EmailValidatedUserFactory
+        case subscription_models.SubscriptionStep.PHONE_VALIDATION:
+            factory = users_factories.PhoneValidatedUserFactory
+        case subscription_models.SubscriptionStep.PROFILE_COMPLETION:
+            factory = users_factories.ProfileCompletedUserFactory
+        case subscription_models.SubscriptionStep.IDENTITY_CHECK:
+            factory = users_factories.IdentityValidatedUserFactory
+        case subscription_models.SubscriptionStep.HONOR_STATEMENT:
+            factory = users_factories.HonorStatementValidatedUserFactory
 
-    return users_factories.BaseUserFactory(age=user_data.age, isEmailValidated=user_data.is_email_validated)
+    if user_data.is_beneficiary:
+        factory = users_factories.BeneficiaryFactory
+
+    return factory(age=user_data.age)

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
@@ -36,7 +36,9 @@ def generate_user() -> utils.BackofficeResponse:
 
     try:
         user_data = users_generator.GenerateUserData(
-            age=form.age.data, is_email_validated=form.is_email_validated.data, is_beneficiary=form.is_beneficiary.data
+            age=form.age.data,
+            step=form.step.data,
+            is_beneficiary=form.is_beneficiary.data,
         )
         user = users_generator.generate_user(user_data=user_data)
     except users_exceptions.UserGenerationForbiddenException:

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
@@ -1,3 +1,4 @@
+from pcapi.core.subscription.models import SubscriptionStep
 from pcapi.core.users import constants as users_constants
 from pcapi.routes.backoffice_v3.forms import fields
 from pcapi.routes.backoffice_v3.forms import utils
@@ -5,5 +6,10 @@ from pcapi.routes.backoffice_v3.forms import utils
 
 class UserGeneratorForm(utils.PCForm):
     age = fields.PCIntegerField("Age", default=users_constants.ELIGIBILITY_AGE_18)
-    is_email_validated = fields.PCSwitchBooleanField("Email validé", default=True)
+    step = fields.PCSelectField(
+        "Étape de validation",
+        choices=[(step.value, step.get_title()) for step in SubscriptionStep if step != SubscriptionStep.MAINTENANCE],
+        default=SubscriptionStep.EMAIL_VALIDATION.value,
+        coerce=lambda value: SubscriptionStep(value) if SubscriptionStep.is_valid(value) else None,
+    )
     is_beneficiary = fields.PCSwitchBooleanField("Bénéficiaire", default=False)

--- a/api/tests/core/users/test_generator.py
+++ b/api/tests/core/users/test_generator.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pcapi.core.fraud.models as fraud_models
+import pcapi.core.subscription.models as subscription_models
 from pcapi.core.users import constants as users_constants
 import pcapi.core.users.generator as users_generator
 import pcapi.core.users.models as users_models
@@ -9,9 +11,53 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 
 class UserGeneratorTest:
+    def has_fraud_check_validated(self, user, fraud_check_type) -> bool:
+        return any(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_check_type and fraud_check.status == fraud_models.FraudCheckStatus.OK
+        )
+
+    def assert_user_passed_email_validation(self, user: users_models.User):
+        assert user.isEmailValidated is True
+        assert user.is_beneficiary is False
+
+    def assert_user_passed_phone_validation(self, user: users_models.User):
+        self.assert_user_passed_email_validation(user)
+        if user.age >= users_constants.ELIGIBILITY_AGE_18:
+            assert user.phoneValidationStatus == users_models.PhoneValidationStatusType.VALIDATED
+            assert user.phoneNumber
+            assert self.has_fraud_check_validated(user, fraud_models.FraudCheckType.PHONE_VALIDATION)
+        elif user.age in users_constants.ELIGIBILITY_UNDERAGE_RANGE:
+            assert user.phoneNumber is None
+            assert user.phoneValidationStatus is None
+
+    def assert_user_passed_profile_completion(self, user: users_models.User):
+        self.assert_user_passed_phone_validation(user)
+        assert user.address
+        assert user.city
+        assert user.firstName
+        assert user.lastName
+        assert user.postalCode
+        assert self.has_fraud_check_validated(user, fraud_models.FraudCheckType.PROFILE_COMPLETION)
+
+    def assert_user_passed_identity_check(self, user: users_models.User):
+        self.assert_user_passed_profile_completion(user)
+        assert user.validatedBirthDate
+        assert user.idPieceNumber
+        assert self.has_fraud_check_validated(
+            user, fraud_models.FraudCheckType.UBBLE
+        ) or self.has_fraud_check_validated(user, fraud_models.FraudCheckType.EDUCONNECT)
+
+    def assert_user_passed_honor_statement(self, user: users_models.User):
+        self.assert_user_passed_identity_check(user)
+        assert self.has_fraud_check_validated(user, fraud_models.FraudCheckType.HONOR_STATEMENT)
+
     def test_generate_default_user(self):
         user_data = users_generator.GenerateUserData(
-            age=users_constants.ELIGIBILITY_AGE_18, is_email_validated=True, is_beneficiary=False
+            age=users_constants.ELIGIBILITY_AGE_18,
+            step=subscription_models.SubscriptionStep.EMAIL_VALIDATION,
+            is_beneficiary=False,
         )
         user = users_generator.generate_user(user_data)
 
@@ -21,7 +67,8 @@ class UserGeneratorTest:
 
     def test_generate_beneficiary_user(self):
         user_data = users_generator.GenerateUserData(
-            age=users_constants.ELIGIBILITY_AGE_18, is_email_validated=True, is_beneficiary=True
+            age=users_constants.ELIGIBILITY_AGE_18,
+            is_beneficiary=True,
         )
         user = users_generator.generate_user(user_data)
 
@@ -37,10 +84,41 @@ class UserGeneratorTest:
             users_constants.ELIGIBILITY_UNDERAGE_RANGE[0],
             users_constants.ELIGIBILITY_UNDERAGE_RANGE[1],
             users_constants.ELIGIBILITY_UNDERAGE_RANGE[2],
+            users_constants.ELIGIBILITY_AGE_18,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "step, tests",
+        [
+            (subscription_models.SubscriptionStep.EMAIL_VALIDATION, assert_user_passed_email_validation),
+            (subscription_models.SubscriptionStep.PHONE_VALIDATION, assert_user_passed_phone_validation),
+            (subscription_models.SubscriptionStep.PROFILE_COMPLETION, assert_user_passed_profile_completion),
+            (subscription_models.SubscriptionStep.IDENTITY_CHECK, assert_user_passed_identity_check),
+            (subscription_models.SubscriptionStep.HONOR_STATEMENT, assert_user_passed_honor_statement),
+        ],
+    )
+    def test_generate_user_at_step(self, age, step, tests):
+        user_data = users_generator.GenerateUserData(
+            age=age,
+            step=step,
+            is_beneficiary=False,
+        )
+        user = users_generator.generate_user(user_data)
+        tests(self, user)
+
+    @pytest.mark.parametrize(
+        "age",
+        [
+            users_constants.ELIGIBILITY_UNDERAGE_RANGE[0],
+            users_constants.ELIGIBILITY_UNDERAGE_RANGE[1],
+            users_constants.ELIGIBILITY_UNDERAGE_RANGE[2],
         ],
     )
     def test_generate_underage_beneficiary_user(self, age):
-        user_data = users_generator.GenerateUserData(age=age, is_email_validated=True, is_beneficiary=True)
+        user_data = users_generator.GenerateUserData(
+            age=age,
+            is_beneficiary=True,
+        )
         user = users_generator.generate_user(user_data)
 
         assert user.isEmailValidated is True

--- a/api/tests/routes/backoffice_v3/user_generation_test.py
+++ b/api/tests/routes/backoffice_v3/user_generation_test.py
@@ -33,6 +33,6 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
 
     @override_settings(ENABLE_TEST_USER_GENERATION=False)
     def test_returns_not_found_if_generation_disabled(self, authenticated_client):
-        form = {"age": "18", "is_beneficiary": "0", "is_email_validated": "1"}
+        form = {"age": "18", "is_beneficiary": "0", "step": "email-validation"}
         response = self.post_to_endpoint(authenticated_client, form=form)
         assert response.status_code == 404

--- a/api/tests/routes/native/v1/banner_test.py
+++ b/api/tests/routes/native/v1/banner_test.py
@@ -196,7 +196,9 @@ class BannerTest:
         assert user.age == 18
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_without_subscription_check):
+        with assert_num_queries(
+            self.expected_num_queries_without_subscription_check + 1
+        ):  # FF ENABLE_PHONE_VALIDATION checked
             response = client.get("/native/v1/banner")
             assert response.status_code == 200
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22129

## But de la pull request

Permettre de choisir l'étape de souscription à laquelle un utilisateur est généré dans le backoffice.

## Implémentation

Ajout de factories pour les utilisateurs
Ajout d'un champ dans le formulaire du générateur

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
