### PR TITLE
(BSR)[API] fix: Fix N+1 SQL queries in "/years/<year>/prebookings" route

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -301,9 +301,7 @@ def get_paginated_collective_bookings_for_educational_year(
         .joinedload(educational_models.CollectiveStock.collectiveOffer, innerjoin=True)
         .load_only(educational_models.CollectiveOffer.name)
         .joinedload(educational_models.CollectiveOffer.venue, innerjoin=True)
-        .load_only(offerers_models.Venue.managingOffererId, offerers_models.Venue.departementCode)
-        .joinedload(offerers_models.Venue.managingOfferer, innerjoin=True)
-        .load_only(offerers_models.Offerer.postalCode)
+        .load_only(offerers_models.Venue.timezone)
     )
     query = query.options(
         sa.orm.joinedload(educational_models.CollectiveBooking.collectiveStock, innerjoin=True)


### PR DESCRIPTION
`Venue.timezone` has been changed from a property to a column, see
2746c08182e09020a1119eb522296700589d44d8.