### PR TITLE
(PC-22515)[API] feat: use ean backoffice

### DIFF
--- a/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
+++ b/api/src/pcapi/admin/custom_views/many_offers_operations_view.py
@@ -191,7 +191,7 @@ class ManyOffersOperationsView(BaseCustomAdminView):
         form = OfferCriteriaForm(request.form)
         if form.validate():
             is_operation_successful = add_criteria_to_offers(
-                [criterion.id for criterion in form.data["criteria"]], isbn=isbn, visa=visa
+                [criterion.id for criterion in form.data["criteria"]], ean=isbn, visa=visa
             )
             if is_operation_successful:
                 flash("Les offres du produit ont bien été tagguées", "success")

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -853,16 +853,16 @@ def get_expense_domains(offer: models.Offer) -> list[users_models.ExpenseDomain]
 
 def add_criteria_to_offers(
     criterion_ids: list[int],
-    isbn: str | None = None,
+    ean: str | None = None,
     visa: str | None = None,
 ) -> bool:
-    if not isbn and not visa:
+    if not ean and not visa:
         return False
 
     query = models.Product.query
-    if isbn:
-        isbn = isbn.replace("-", "").replace(" ", "")
-        query = query.filter(models.Product.extraData["isbn"].astext == isbn)
+    if ean:
+        ean = ean.replace("-", "").replace(" ", "")
+        query = query.filter(models.Product.extraData["ean"].astext == ean)
     if visa:
         query = query.filter(models.Product.extraData["visa"].astext == visa)
 
@@ -905,8 +905,8 @@ def add_criteria_to_offers(
     return True
 
 
-def reject_inappropriate_products(isbn: str) -> bool:
-    products = models.Product.query.filter(models.Product.extraData["isbn"].astext == isbn).all()
+def reject_inappropriate_products(ean: str) -> bool:
+    products = models.Product.query.filter(models.Product.extraData["ean"].astext == ean).all()
     if not products:
         return False
 
@@ -933,12 +933,12 @@ def reject_inappropriate_products(isbn: str) -> bool:
     except Exception as exception:  # pylint: disable=broad-except
         logger.exception(
             "Could not mark product and offers as inappropriate: %s",
-            extra={"isbn": isbn, "products": [p.id for p in products], "exc": str(exception)},
+            extra={"isbn": ean, "products": [p.id for p in products], "exc": str(exception)},
         )
         return False
     logger.info(
         "Rejected inappropriate products",
-        extra={"isbn": isbn, "products": [p.id for p in products], "offers": offer_ids},
+        extra={"isbn": ean, "products": [p.id for p in products], "offers": offer_ids},
     )
 
     search.async_index_offer_ids(offer_ids)

--- a/api/src/pcapi/routes/backoffice_v3/forms/offer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offer.py
@@ -22,7 +22,7 @@ class OfferSearchColumn(enum.Enum):
     ALL = "Tout"
     ID = "ID de l'offre"
     NAME = "Nom de l'offre"
-    ISBN = "ISBN"
+    EAN = "EAN"
     VISA = "Visa d'exploitation"
 
 
@@ -88,7 +88,7 @@ class GetOffersListForm(OfferMixinForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("ID de l'offre ou liste d'ID, nom, ISBN, visa d'exploitation")
+    q = fields.PCOptSearchField("ID de l'offre ou liste d'ID, nom, EAN, visa d'exploitation")
     where = fields.PCSelectField(
         "Chercher dans",
         choices=utils.choices_from_enum(OfferSearchColumn),
@@ -115,8 +115,8 @@ class GetOffersListForm(OfferMixinForm):
         if q.data:
             if self.where.data == OfferSearchColumn.ID.name and not re.match(r"^[\d\s,;]+$", q.data):
                 raise wtforms.validators.ValidationError("La recherche ne correspond pas à un ID ou une liste d'ID")
-            if self.where.data == OfferSearchColumn.ISBN.name and not bo_utils.is_isbn_valid(q.data):
-                raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un ISBN")
+            if self.where.data == OfferSearchColumn.EAN.name and not bo_utils.is_ean_valid(q.data):
+                raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un EAN")
             if self.where.data == OfferSearchColumn.VISA.name and not bo_utils.is_visa_valid(q.data):
                 raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un visa")
         return q

--- a/api/src/pcapi/routes/backoffice_v3/multiple_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/multiple_offers/forms.py
@@ -6,24 +6,24 @@ from pcapi.routes.backoffice_v3 import utils as bo_utils
 from ..forms import fields
 
 
-class SearchIsbnForm(FlaskForm):
+class SearchEanForm(FlaskForm):
     class Meta:
         csrf = False
 
-    isbn = fields.PCSearchField("ISBN")
+    ean = fields.PCSearchField("EAN")
 
-    def validate_isbn(self, isbn: fields.PCSearchField) -> fields.PCSearchField:
-        if isbn.data and not bo_utils.is_isbn_valid(isbn.data):
-            raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un ISBN")
-        isbn.data = bo_utils.format_isbn_or_visa(isbn.data)
-        return isbn
-
-
-class HiddenIsbnForm(FlaskForm):
-    isbn = fields.PCHiddenField("ISBN")
+    def validate_ean(self, ean: fields.PCSearchField) -> fields.PCSearchField:
+        if ean.data and not bo_utils.is_ean_valid(ean.data):
+            raise wtforms.validators.ValidationError("La recherche ne correspond pas au format d'un EAN")
+        ean.data = bo_utils.format_ean_or_visa(ean.data)
+        return ean
 
 
-class OfferCriteriaForm(HiddenIsbnForm):
+class HiddenEanForm(FlaskForm):
+    ean = fields.PCHiddenField("EAN")
+
+
+class OfferCriteriaForm(HiddenEanForm):
     criteria = fields.PCTomSelectField(
         "Tags",
         multiple=True,

--- a/api/src/pcapi/routes/backoffice_v3/offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers.py
@@ -117,15 +117,15 @@ def _get_offers(form: offer_forms.GetOffersListForm) -> list[offers_models.Offer
         search_query = form.q.data
         or_filters = []
 
-        if form.where.data == offer_forms.OfferSearchColumn.ISBN.name or (
-            form.where.data == offer_forms.OfferSearchColumn.ALL.name and utils.is_isbn_valid(search_query)
+        if form.where.data == offer_forms.OfferSearchColumn.EAN.name or (
+            form.where.data == offer_forms.OfferSearchColumn.ALL.name and utils.is_ean_valid(search_query)
         ):
-            or_filters.append(offers_models.Offer.extraData["isbn"].astext == utils.format_isbn_or_visa(search_query))
+            or_filters.append(offers_models.Offer.extraData["ean"].astext == utils.format_ean_or_visa(search_query))
 
         if form.where.data == offer_forms.OfferSearchColumn.VISA.name or (
             form.where.data == offer_forms.OfferSearchColumn.ALL.name and utils.is_visa_valid(search_query)
         ):
-            or_filters.append(offers_models.Offer.extraData["visa"].astext == utils.format_isbn_or_visa(search_query))
+            or_filters.append(offers_models.Offer.extraData["visa"].astext == utils.format_ean_or_visa(search_query))
 
         if form.where.data in (offer_forms.OfferSearchColumn.ALL.name, offer_forms.OfferSearchColumn.ID.name):
             if search_query.isnumeric():

--- a/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
@@ -59,7 +59,7 @@
                 {% endif %}
               </p>
               <p>
-                <b>ISBN :</b> {{ isbn }}
+                <b>EAN :</b> {{ ean }}
               </p>
               {% if has_permission("FRAUD_ACTIONS") and (product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0) %}
                 <div>

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -119,17 +119,28 @@ def random_hash() -> str:
     return format(random.getrandbits(128), "x")
 
 
+# Will be deleted by the end of the PR
 def format_isbn_or_visa(isbn: str) -> str:
     return isbn.replace("-", "").replace(" ", "")
 
 
+def format_ean_or_visa(ean: str) -> str:
+    return ean.replace("-", "").replace(" ", "")
+
+
+# Will be deleted by the end of the PR
 def is_isbn_valid(isbn: str) -> bool:
     isbn = format_isbn_or_visa(isbn)
     return isbn.isdigit() and len(isbn) == 13
 
 
+def is_ean_valid(ean: str) -> bool:
+    ean = format_ean_or_visa(ean)
+    return ean.isdigit() and len(ean) == 13
+
+
 def is_visa_valid(visa: str) -> bool:
-    visa = format_isbn_or_visa(visa)
+    visa = format_ean_or_visa(visa)
     return visa.isdigit() and len(visa) <= 10
 
 

--- a/api/src/pcapi/routes/backoffice_v3/utils.py
+++ b/api/src/pcapi/routes/backoffice_v3/utils.py
@@ -119,19 +119,8 @@ def random_hash() -> str:
     return format(random.getrandbits(128), "x")
 
 
-# Will be deleted by the end of the PR
-def format_isbn_or_visa(isbn: str) -> str:
-    return isbn.replace("-", "").replace(" ", "")
-
-
 def format_ean_or_visa(ean: str) -> str:
     return ean.replace("-", "").replace(" ", "")
-
-
-# Will be deleted by the end of the PR
-def is_isbn_valid(isbn: str) -> bool:
-    isbn = format_isbn_or_visa(isbn)
-    return isbn.isdigit() and len(isbn) == 13
 
 
 def is_ean_valid(ean: str) -> bool:

--- a/api/src/pcapi/sandboxes/scripts/creators/data/create_data_thing_products.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/data/create_data_thing_products.py
@@ -70,7 +70,9 @@ def create_data_thing_products() -> dict[str, offers_models.Product]:
                     music_sub_type = music_type.children[music_sub_type_index]
                     extraData["musicSubType"] = str(music_sub_type.code)
                 elif conditionalField == "isbn":
-                    extraData[conditionalField] = "".join(random.choices("123456789-", k=13))
+                    # FIXME (mageoffray, 31-05-2023) : temporary duplication, isbn field should be deleted soon
+                    extraData["isbn"] = "".join(random.choices("123456789-", k=13))
+                    extraData["ean"] = "".join(random.choices("123456789-", k=13))
                 extra_data_index += 1
             thing_product.extraData = extraData
             thing_products_by_name[name] = thing_product

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_products.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_products.py
@@ -74,7 +74,9 @@ def create_industrial_thing_products() -> dict[str, offers_models.Product]:
                     music_sub_type = music_type.children[music_sub_type_index]
                     extraData["musicSubType"] = str(music_sub_type.code)
                 elif conditionalField_name == "isbn":
-                    extraData[conditionalField_name] = "".join(random.choices("123456789-", k=13))
+                    # FIXME (mageoffray, 31-05-2023) : temporary duplication, isbn field should be deleted soon
+                    extraData["isbn"] = "".join(random.choices("123456789-", k=13))
+                    extraData["ean"] = "".join(random.choices("123456789-", k=13))
                 extra_data_index += 1
             thing_product.extraData = extraData
             thing_products_by_name[name] = thing_product

--- a/api/tests/admin/custom_views/many_offers_operations_view_test.py
+++ b/api/tests/admin/custom_views/many_offers_operations_view_test.py
@@ -93,16 +93,18 @@ class ManyOffersOperationsViewTest:
 
     @patch("pcapi.core.search.async_index_offer_ids")
     @patch("wtforms.csrf.session.SessionCSRF.validate_csrf_token")
-    def test_edit_product_offers_criteria_from_isbn(
-        self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app
-    ):
+    def test_edit_product_offers_criteria_from_ean(self, mocked_validate_csrf_token, mocked_async_index_offer_ids, app):
         # Given
         users_factories.AdminFactory(email="admin@example.com")
-        product = offers_factories.ProductFactory(extraData={"isbn": "9783161484100"})
-        offer1 = offers_factories.OfferFactory(product=product, extraData={"isbn": "9783161484100"})
-        offer2 = offers_factories.OfferFactory(product=product, extraData={"isbn": "9783161484100"})
+        product = offers_factories.ProductFactory(extraData={"isbn": "9783161484100", "ean": "9783161484100"})
+        offer1 = offers_factories.OfferFactory(
+            product=product, extraData={"isbn": "9783161484100", "ean": "9783161484100"}
+        )
+        offer2 = offers_factories.OfferFactory(
+            product=product, extraData={"isbn": "9783161484100", "ean": "9783161484100"}
+        )
         inactive_offer = offers_factories.OfferFactory(
-            product=product, extraData={"isbn": "9783161484100"}, isActive=False
+            product=product, extraData={"isbn": "9783161484100", "ean": "9783161484100"}, isActive=False
         )
         unmatched_offer = offers_factories.OfferFactory()
         criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
@@ -227,7 +229,7 @@ class ManyOffersOperationsViewTest:
         offerer = offerers_factories.OffererFactory()
         product_1 = offers_factories.ThingProductFactory(
             description="premier produit inapproprié",
-            extraData={"isbn": "isbn-de-test"},
+            extraData={"isbn": "ean-de-test", "ean": "ean-de-test"},
             isGcuCompatible=not validation_status == OfferValidationStatus.REJECTED,
         )
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
@@ -241,7 +243,7 @@ class ManyOffersOperationsViewTest:
 
         # When
         client = TestClient(app.test_client()).with_session_auth("admin@example.com")
-        response = client.post("/pc/back-office/many_offers_operations/product_gcu_compatibility?isbn=isbn-de-test")
+        response = client.post("/pc/back-office/many_offers_operations/product_gcu_compatibility?isbn=ean-de-test")
 
         # Then
         assert response.status_code == 302

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1156,11 +1156,11 @@ class AddCriterionToOffersTest:
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_add_criteria_from_isbn(self, mocked_async_index_offer_ids):
         # Given
-        isbn = "2-221-00164-8"
-        product1 = factories.ProductFactory(extraData={"isbn": "2221001648"})
+        ean = "2-221-00164-8"
+        product1 = factories.ProductFactory(extraData={"isbn": "2221001648", "ean": "2221001648"})
         offer11 = factories.OfferFactory(product=product1)
         offer12 = factories.OfferFactory(product=product1)
-        product2 = factories.ProductFactory(extraData={"isbn": "2221001648"})
+        product2 = factories.ProductFactory(extraData={"isbn": "2221001648", "ean": "2221001648"})
         offer21 = factories.OfferFactory(product=product2)
         inactive_offer = factories.OfferFactory(product=product1, isActive=False)
         unmatched_offer = factories.OfferFactory()
@@ -1168,7 +1168,7 @@ class AddCriterionToOffersTest:
         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], isbn=isbn)
+        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], ean=ean)
 
         # Then
         assert is_successful is True
@@ -1182,19 +1182,19 @@ class AddCriterionToOffersTest:
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_add_criteria_from_isbn_when_one_has_criteria(self, mocked_async_index_offer_ids):
         # Given
-        isbn = "2221001648"
+        ean = "2221001648"
         criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
-        product1 = factories.ProductFactory(extraData={"isbn": isbn})
+        product1 = factories.ProductFactory(extraData={"isbn": ean, "ean": ean})
         offer11 = factories.OfferFactory(product=product1, criteria=[criterion1])
         offer12 = factories.OfferFactory(product=product1, criteria=[criterion2])
-        product2 = factories.ProductFactory(extraData={"isbn": isbn})
+        product2 = factories.ProductFactory(extraData={"isbn": ean, "ean": ean})
         offer21 = factories.OfferFactory(product=product2)
         inactive_offer = factories.OfferFactory(product=product1, isActive=False)
         unmatched_offer = factories.OfferFactory()
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], isbn=isbn)
+        is_successful = api.add_criteria_to_offers([criterion1.id, criterion2.id], ean=ean)
 
         # Then
         assert is_successful is True
@@ -1234,12 +1234,12 @@ class AddCriterionToOffersTest:
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_add_criteria_when_no_offers_is_found(self, mocked_async_index_offer_ids):
         # Given
-        isbn = "2-221-00164-8"
-        factories.OfferFactory(extraData={"isbn": "2221001647"})
+        ean = "2-221-00164-8"
+        factories.OfferFactory(extraData={"isbn": "2221001647", "ean": "2221001647"})
         criterion = criteria_factories.CriterionFactory(name="Pretty good books")
 
         # When
-        is_successful = api.add_criteria_to_offers([criterion.id], isbn=isbn)
+        is_successful = api.add_criteria_to_offers([criterion.id], ean=ean)
 
         # Then
         assert is_successful is False
@@ -1251,17 +1251,17 @@ class DeactivateInappropriateProductTest:
     def test_should_deactivate_product_with_inappropriate_content(self, mocked_async_index_offer_ids):
         # Given
         product1 = factories.ThingProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"isbn": "isbn-de-test"}
+            subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"isbn": "ean-de-test", "ean": "ean-de-test"}
         )
         product2 = factories.ThingProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"isbn": "isbn-de-test"}
+            subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"isbn": "ean-de-test", "ean": "ean-de-test"}
         )
         factories.OfferFactory(product=product1)
         factories.OfferFactory(product=product1)
         factories.OfferFactory(product=product2)
 
         # When
-        api.reject_inappropriate_products("isbn-de-test")
+        api.reject_inappropriate_products("ean-de-test")
 
         # Then
         products = models.Product.query.all()

--- a/api/tests/routes/backoffice_v3/multiple_offers_test.py
+++ b/api/tests/routes/backoffice_v3/multiple_offers_test.py
@@ -49,20 +49,20 @@ class SearchMultipleOffersTest(GetEndpointHelper):
 
     def test_search_product_with_offers(self, authenticated_client):
         offers_factories.ThingOfferFactory(
-            product__name="Product with ISBN",
-            product__extraData={"isbn": "9783161484100"},
+            product__name="Product with EAN",
+            product__extraData={"isbn": "9783161484100", "ean": "9783161484100"},
             product__subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
 
         with assert_num_queries(self.expected_num_queries):
-            response = authenticated_client.get(url_for(self.endpoint, isbn="978-3-16-148410-0"))
+            response = authenticated_client.get(url_for(self.endpoint, ean="978-3-16-148410-0"))
             assert response.status_code == 200
 
         cards = html_parser.extract_cards_text(response.data)
         assert len(cards) == 2  # left and right cards when active offers exist
         left_card = cards[0]
 
-        assert "Titre du produit : Product with ISBN " in left_card
+        assert "Titre du produit : Product with EAN " in left_card
         assert "Catégorie : Livre " in left_card
         assert "Nombre d'offres associées : 1 " in left_card
         assert "Approuvées actives : 1 " in left_card
@@ -70,17 +70,17 @@ class SearchMultipleOffersTest(GetEndpointHelper):
         assert "En attente : 0 " in left_card
         assert "Rejetées : 0 " in left_card
         assert "compatible avec les CGU : Oui" in left_card
-        assert "ISBN : 9783161484100 " in left_card
+        assert "EAN : 9783161484100 " in left_card
 
     def test_search_product_without_offer(self, authenticated_client):
         offers_factories.ThingProductFactory(
             name="Product without offer",
-            extraData={"isbn": "9783161484100"},
+            extraData={"isbn": "9783161484100", "ean": "9783161484100"},
             subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
 
         with assert_num_queries(self.expected_num_queries):
-            response = authenticated_client.get(url_for(self.endpoint, isbn="978 3161484100"))
+            response = authenticated_client.get(url_for(self.endpoint, ean="978 3161484100"))
             assert response.status_code == 200
 
         cards = html_parser.extract_cards_text(response.data)
@@ -95,7 +95,7 @@ class SearchMultipleOffersTest(GetEndpointHelper):
         assert "En attente : 0 " in left_card
         assert "Rejetées : 0 " in left_card
         assert "compatible avec les CGU : Oui" in left_card
-        assert "ISBN : 9783161484100 " in left_card
+        assert "EAN : 9783161484100 " in left_card
 
     @pytest.mark.parametrize(
         "first_compatibility,second_compatibility,expected_cgu_display",
@@ -109,18 +109,18 @@ class SearchMultipleOffersTest(GetEndpointHelper):
         self, authenticated_client, first_compatibility, second_compatibility, expected_cgu_display
     ):
         offers_factories.ThingProductFactory(
-            extraData={"isbn": "9781234567890"},
+            extraData={"isbn": "9781234567890", "ean": "9781234567890"},
             subcategoryId=subcategories.LIVRE_PAPIER.id,
             isGcuCompatible=first_compatibility,
         )
         offers_factories.ThingProductFactory(
-            extraData={"isbn": "9781234567890"},
+            extraData={"isbn": "9781234567890", "ean": "9781234567890"},
             subcategoryId=subcategories.LIVRE_PAPIER.id,
             isGcuCompatible=second_compatibility,
         )
 
         with assert_num_queries(self.expected_num_queries):
-            response = authenticated_client.get(url_for(self.endpoint, isbn="9781234567890"))
+            response = authenticated_client.get(url_for(self.endpoint, ean="9781234567890"))
             assert response.status_code == 200
 
         left_card = html_parser.extract_cards_text(response.data)[0]
@@ -130,14 +130,14 @@ class SearchMultipleOffersTest(GetEndpointHelper):
     def test_get_current_criteria_on_active_offers(self, authenticated_client):
         criterion1 = criteria_models.Criterion(name="One criterion")
         criterion2 = criteria_models.Criterion(name="Another criterion")
-        product = offers_factories.ThingProductFactory(extraData={"isbn": "9783161484100"})
+        product = offers_factories.ThingProductFactory(extraData={"isbn": "9783161484100", "ean": "9783161484100"})
         offers_factories.ThingOfferFactory(product=product, criteria=[criterion1], isActive=True)
         offers_factories.ThingOfferFactory(product=product, criteria=[criterion1, criterion2], isActive=True)
         offers_factories.ThingOfferFactory(product=product, criteria=[], isActive=True)
         offers_factories.ThingOfferFactory(product=product, criteria=[criterion1, criterion2], isActive=False)
 
         with assert_num_queries(self.expected_num_queries):
-            response = authenticated_client.get(url_for(self.endpoint, isbn="978-3-16-148410-0"))
+            response = authenticated_client.get(url_for(self.endpoint, ean="978-3-16-148410-0"))
             assert response.status_code == 200
 
         (_, right_card) = html_parser.extract_cards_text(response.data)
@@ -146,40 +146,42 @@ class SearchMultipleOffersTest(GetEndpointHelper):
         assert "1/3 offre active a déjà le tag Another criterion " in right_card
         assert "Tag des offres ⚠️ 3 offres actives associées à cet ISBN seront affectées" in right_card
 
-    def test_search_product_from_isbn_with_invalid_isbn(self, authenticated_client):
+    def test_search_product_from_ean_with_invalid_ean(self, authenticated_client):
         with assert_num_queries(2):
-            response = authenticated_client.get(url_for(self.endpoint, isbn="978-3-16-14840-0"))
+            response = authenticated_client.get(url_for(self.endpoint, ean="978-3-16-14840-0"))
             assert response.status_code == 400
 
-        assert "La recherche ne correspond pas au format d'un ISBN" in html_parser.extract_alert(response.data)
+        assert "La recherche ne correspond pas au format d'un EAN" in html_parser.extract_alert(response.data)
 
 
 class AddCriteriaToOffersTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.multiple_offers.add_criteria_to_offers"
-    endpoint_kwargs = {"isbn": "9781234567890"}
+    endpoint_kwargs = {"ean": "9781234567890"}
     needed_permission = perm_models.Permissions.MULTIPLE_OFFERS_ACTIONS
 
     @patch("pcapi.core.search.async_index_offer_ids")
-    def test_edit_product_offers_criteria_from_isbn(self, mocked_async_index_offer_ids, authenticated_client):
+    def test_edit_product_offers_criteria_from_ean(self, mocked_async_index_offer_ids, authenticated_client):
         criterion1 = criteria_factories.CriterionFactory(name="Pretty good books")
         criterion2 = criteria_factories.CriterionFactory(name="Other pretty good books")
-        product = offers_factories.ProductFactory(extraData={"isbn": "9783161484100"})
+        product = offers_factories.ProductFactory(extraData={"isbn": "9783161484100", "ean": "9783161484100"})
         offer1 = offers_factories.OfferFactory(
-            product=product, extraData={"isbn": "9783161484100"}, criteria=[criterion1]
+            product=product, extraData={"isbn": "9783161484100", "ean": "9783161484100"}, criteria=[criterion1]
         )
-        offer2 = offers_factories.OfferFactory(product=product, extraData={"isbn": "9783161484100"})
+        offer2 = offers_factories.OfferFactory(
+            product=product, extraData={"isbn": "9783161484100", "ean": "9783161484100"}
+        )
         inactive_offer = offers_factories.OfferFactory(
-            product=product, extraData={"isbn": "9783161484100"}, isActive=False
+            product=product, extraData={"isbn": "9783161484100", "ean": "9783161484100"}, isActive=False
         )
         unmatched_offer = offers_factories.OfferFactory()
 
         response = self.post_to_endpoint(
-            authenticated_client, form={"isbn": "9783161484100", "criteria": [criterion1.id, criterion2.id]}
+            authenticated_client, form={"ean": "9783161484100", "criteria": [criterion1.id, criterion2.id]}
         )
 
         assert response.status_code == 303
         assert response.location == url_for(
-            "backoffice_v3_web.multiple_offers.search_multiple_offers", isbn="9783161484100", _external=True
+            "backoffice_v3_web.multiple_offers.search_multiple_offers", ean="9783161484100", _external=True
         )
         assert set(offer1.criteria) == {criterion1, criterion2}
         assert set(offer2.criteria) == {criterion1, criterion2}
@@ -187,12 +189,12 @@ class AddCriteriaToOffersTest(PostEndpointHelper):
         assert not unmatched_offer.criteria
         mocked_async_index_offer_ids.assert_called_once_with([offer1.id, offer2.id])
 
-    def test_edit_product_offers_criteria_from_isbn_without_offers(self, authenticated_client):
-        offers_factories.ProductFactory(extraData={"isbn": "9783161484100"})
+    def test_edit_product_offers_criteria_from_ean_without_offers(self, authenticated_client):
+        offers_factories.ProductFactory(extraData={"isbn": "9783161484100", "ean": "9783161484100"})
         criterion = criteria_factories.CriterionFactory(name="Pretty good books")
 
         response = self.post_to_endpoint(
-            authenticated_client, form={"isbn": "9783161484100", "criteria": [criterion.id]}
+            authenticated_client, form={"ean": "9783161484100", "criteria": [criterion.id]}
         )
 
         assert response.status_code == 303
@@ -204,13 +206,13 @@ class SetProductGcuIncompatibleButtonTest(button_helpers.ButtonHelper):
 
     @property
     def path(self):
-        offers_factories.ThingProductFactory(extraData={"isbn": "9781234567890"})
-        return url_for("backoffice_v3_web.multiple_offers.search_multiple_offers", isbn="9781234567890")
+        offers_factories.ThingProductFactory(extraData={"isbn": "9781234567890", "ean": "9781234567890"})
+        return url_for("backoffice_v3_web.multiple_offers.search_multiple_offers", ean="9781234567890")
 
 
 class SetProductGcuIncompatibleTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.multiple_offers.set_product_gcu_incompatible"
-    endpoint_kwargs = {"isbn": "9781234567890"}
+    endpoint_kwargs = {"ean": "9781234567890"}
     needed_permission = perm_models.Permissions.FRAUD_ACTIONS
 
     @pytest.mark.parametrize(
@@ -228,7 +230,7 @@ class SetProductGcuIncompatibleTest(PostEndpointHelper):
     ):
         product_1 = offers_factories.ThingProductFactory(
             description="premier produit inapproprié",
-            extraData={"isbn": "9781234567890"},
+            extraData={"isbn": "9781234567890", "ean": "9781234567890"},
             isGcuCompatible=not validation_status == OfferValidationStatus.REJECTED,
         )
         venue = offerers_factories.VenueFactory()
@@ -240,11 +242,11 @@ class SetProductGcuIncompatibleTest(PostEndpointHelper):
             for offer in Offer.query.filter(Offer.validation == OfferValidationStatus.REJECTED)
         }
 
-        response = self.post_to_endpoint(authenticated_client, form={"isbn": "9781234567890"})
+        response = self.post_to_endpoint(authenticated_client, form={"ean": "9781234567890"})
 
         assert response.status_code == 303
         assert response.location == url_for(
-            "backoffice_v3_web.multiple_offers.search_multiple_offers", isbn="9781234567890", _external=True
+            "backoffice_v3_web.multiple_offers.search_multiple_offers", ean="9781234567890", _external=True
         )
 
         product = offers_models.Product.query.one()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22515

Utilisation des EAN à la place des ISBN pour :

Filtre pour la liste des offres individuelles
Actions groupées pour rejeté ou tagger des offres par isbn
Lorsqu'on supprimera la clé isbn de "jsonData" je repasserais sur les tests pour enlever les "isbn": "..."

