### PR TITLE
(BSR)[API] fix: Do not ignore quantity update on stock whose price is set to zero

### DIFF
--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -342,7 +342,7 @@ class SynchronizeStocksTest:
                 stocks_provider_reference="stock_ref3",
                 venue_reference="venue_ref3",
             ),
-            providers_models.StockDetail(  # existing, now free, will be ignored
+            providers_models.StockDetail(  # existing, now free, update qty, keep price
                 offers_provider_reference="offer_ref4",
                 available_quantity=15,
                 price=0,
@@ -354,7 +354,7 @@ class SynchronizeStocksTest:
 
         stocks_by_provider_reference = {
             "stock_ref1": {"id": 1, "booking_quantity": 3, "price": 18.0, "quantity": 2},
-            "stock_ref4": {"id": 2, "booking_quantity": 3, "price": 18.0, "quantity": 2},
+            "stock_ref4": {"id": 4, "booking_quantity": 3, "price": 18.0, "quantity": 2},
         }
         offers_by_provider_reference = {"offer_ref1": 123, "offer_ref2": 134, "offer_ref4": 123}
         products_by_provider_reference = {
@@ -379,6 +379,13 @@ class SynchronizeStocksTest:
                 "id": 1,
                 "quantity": 15 + 3,
                 "price": 15.78,
+                "rawProviderQuantity": 15,
+                "lastProviderId": 1,
+            },
+            {
+                "id": 4,
+                "quantity": 15 + 3,
+                "price": 18.0,
                 "rawProviderQuantity": 15,
                 "lastProviderId": 1,
             },


### PR DESCRIPTION
We sometimes get a price of zero for books that should not be free
(according to our product table). This happens when the library sets a
wrong price in their own software.

Before, we used to ignore the changes (both the new price and the new
quantity). Now we ignore the new price (and keep the previous price)
but we do update the quantity.