### PR TITLE
(PC-22148)[BO] Display fraud reviews in subscription steps

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-cf9c67b851f6 (pre) (head)
+54974ef1d55a (pre) (head)
 ad2884071862 (post) (head)

--- a/api/src/pcapi/admin/custom_views/support_view/view.py
+++ b/api/src/pcapi/admin/custom_views/support_view/view.py
@@ -226,7 +226,7 @@ class BeneficiaryView(base_configuration.BaseAdminView):
                 reviewer=flask_login.current_user,
                 reason=form.data["reason"],
                 review=fraud_models.FraudReviewStatus(form.data["review"]),
-                eligibility=eligibility,
+                reviewed_eligibility=eligibility,
             )
 
         except (DisabledFeatureError, fraud_api.FraudCheckError, fraud_api.EligibilityError) as err:

--- a/api/src/pcapi/alembic/versions/20230602T090227_54974ef1d55a_add_eligibility_type_to_fraud_reviews.py
+++ b/api/src/pcapi/alembic/versions/20230602T090227_54974ef1d55a_add_eligibility_type_to_fraud_reviews.py
@@ -1,0 +1,20 @@
+"""Add eligibility column to BeneficiaryFraudReview table
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "54974ef1d55a"
+down_revision = "cf9c67b851f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("beneficiary_fraud_review", sa.Column("eligibilityType", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("beneficiary_fraud_review", "eligibilityType")

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -593,6 +593,9 @@ class BeneficiaryFraudReview(PcObject, Base, Model):
     authorId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
     author: users_models.User = sa.orm.relationship("User", foreign_keys=[authorId], backref="adminFraudReviews")
     dateReviewed: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
+    eligibilityType: users_models.EligibilityType | None = sa.Column(
+        sa.Enum(users_models.EligibilityType, create_constraint=False), nullable=True
+    )
     reason = sa.Column(sa.Text)
     review = sa.Column(sa.Enum(FraudReviewStatus, create_constraint=False))
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)

--- a/api/src/pcapi/routes/backoffice_v3/filters.py
+++ b/api/src/pcapi/routes/backoffice_v3/filters.py
@@ -289,6 +289,14 @@ def format_fraud_check_url(id_check_item: serialization_accounts.IdCheckItemMode
     return ""
 
 
+def format_fraud_action_dict_url(fraud_action_dict: dict) -> str:
+    if fraud_action_dict["type"] == fraud_models.FraudCheckType.UBBLE.value:
+        return f"https://dashboard.ubble.ai/identifications/{fraud_action_dict['techId']}"
+    if fraud_action_dict["type"] == fraud_models.FraudCheckType.DMS.value and fraud_action_dict["technicalDetails"]:
+        return f"https://www.demarches-simplifiees.fr/procedures/{fraud_action_dict['technicalDetails']['procedure_number']}/dossiers/{fraud_action_dict['techId']}"
+    return ""
+
+
 def format_adage_referred(venues: list[offerers_models.Venue]) -> str:
     return f"{len([venue for venue in venues if venue.adageId])}/{len(venues)}"
 
@@ -450,6 +458,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_dms_status"] = format_dms_status
     app.jinja_env.filters["format_graphql_application_status"] = format_graphql_application_status
     app.jinja_env.filters["format_fraud_check_url"] = format_fraud_check_url
+    app.jinja_env.filters["format_fraud_action_dict_url"] = format_fraud_action_dict_url
     app.jinja_env.filters["format_role"] = format_role
     app.jinja_env.filters["format_state"] = format_state
     app.jinja_env.filters["format_reason_label"] = format_reason_label

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/details/personal_information_registration.html
@@ -17,10 +17,10 @@
   </div>
   {% for step in tunnel.steps %}
     {% call macro.build_step_content(step) %}
-      {{ macro.build_idcheck_histories(step.id_check_histories) }}
+      {{ macro.build_idcheck_histories(step.fraud_actions_history) }}
     {% endcall %}
   {% endfor %}
   <div class="row all-id-check-history-container d-none">
-    <div class="col-md-12 well text-center">{{ macro.build_idcheck_histories(id_check_histories_desc) }}</div>
+    <div class="col-md-12 well text-center">{{ macro.build_idcheck_histories(fraud_actions_desc) }}</div>
   </div>
 {% endcall %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/forms/field_list_field.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/forms/field_list_field.html
@@ -1,8 +1,7 @@
 {% set field_id = random_hash() %}
 <div class="d-flex d-flex-column justify-content-between"
      data-field-list-container="{{ field.name }}-{{ field_id }}">
-  <ul
-      data-entries-count="{{ field|length }}"
+  <ul data-entries-count="{{ field|length }}"
       data-max-entries="{{ field.max_entries }}"
       data-min-entries="{{ field.min_entries }}"
       data-field-name="{{ field.name }}"
@@ -10,13 +9,15 @@
     {% for subfield in field %}
       <li>
         {{ subfield }}
-        <button class="btn btn-primary field-list-rm-btn" type="button">
+        <button class="btn btn-primary field-list-rm-btn"
+                type="button">
           <i class="bi bi-trash3 pe-none"></i>
         </button>
       </li>
     {% endfor %}
   </ul>
-  <button class="btn btn-primary field-list-add-btn align-self-start" type="button">
+  <button class="btn btn-primary field-list-add-btn align-self-start"
+          type="button">
     <i class="bi bi-plus-circle pe-none"></i>
   </button>
 </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/public_accounts/registration_steps.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/public_accounts/registration_steps.html
@@ -1,4 +1,4 @@
-{% macro build_idcheck_histories(id_check_histories) %}
+{% macro build_idcheck_histories(fraud_actions) %}
   <div class="table-responsive">
     <table class="table table-hover table-bordered">
       <thead>
@@ -14,91 +14,97 @@
         </tr>
       </thead>
       <tbody>
-        {% if id_check_histories|length == 0 %}
+        {% if fraud_actions|length == 0 %}
           <tr>
             <td colspan="8">Aucune données</td>
           </tr>
         {% else %}
-          {% for id_check_item in id_check_histories if id_check_histories|length > 0 %}
+          {% for fraud_action in fraud_actions %}
             <tr>
               <td>
-                <time datetime="{{ id_check_item.dateCreated }}">{{ id_check_item.dateCreated | format_date_time }}</time>
+                <time datetime="{{ fraud_action['creationDate'] }}">{{ fraud_action['creationDate'] | format_date_time }}</time>
               </td>
-              <td>{{ id_check_item.thirdPartyId }}</td>
+              <td>{{ fraud_action['techId'] }}</td>
               <td>
-                {% if id_check_item | format_fraud_check_url %}
-                  <a href="{{ id_check_item | format_fraud_check_url }}"
+                {% if fraud_action | format_fraud_action_dict_url %}
+                  <a href="{{ fraud_action | format_fraud_action_dict_url }}"
                      target="_blank">
-                    {{ id_check_item.type }}
+                    {{ fraud_action['type'] }}
                     <i class="bi bi-folder"></i>
                   </a>
                 {% else %}
-                  {{ id_check_item.type }}
+                  {{ fraud_action['type'] }}
                 {% endif %}
               </td>
               <td>
-                {% if id_check_item.applicable_eligibilities|length == 0 %}
+                {% if fraud_action['applicableEligibilities']|length == 0 %}
                   <span class="badge rounded-pill bg-secondary px-3 py-2">NA</span>
                 {% else %}
-                  {% for applicable_eligibility in id_check_item.applicable_eligibilities if id_check_item.applicable_eligibilities|length > 0 %}
+                  {% for applicable_eligibility in fraud_action['applicableEligibilities'] %}
                     <span class="badge rounded-pill bg-primary px-3 py-2">{{ applicable_eligibility | i18n_public_account }}</span>
                   {% endfor %}
                 {% endif %}
               </td>
               <td>
-                {% if id_check_item.status == 'ok' %}
+                {% if fraud_action['status'].lower() == 'ok' %}
                   <span class="badge rounded-pill text-bg-success align-middle px-3 py-2">
-                    <i class="bi bi-check-circle"></i> {{ id_check_item.status.upper() }}
+                    <i class="bi bi-check-circle"></i> {{ fraud_action['status'].upper() }}
                   </span>
-                {% elif id_check_item.status == 'ko' %}
+                {% elif fraud_action['status'].lower() == 'ko' %}
                   <span class="badge rounded-pill text-bg-danger align-middle px-3 py-2">
-                    <i class="bi bi-exclamation-circle"></i> {{ id_check_item.status.upper() }}
+                    <i class="bi bi-exclamation-circle"></i> {{ fraud_action['status'].upper() }}
                   </span>
-                {% elif id_check_item.status == 'suspicious' %}
+                {% elif fraud_action['status'].lower() == 'suspicious' %}
                   <span class="badge rounded-pill text-bg-warning align-middle px-3 py-2">
-                    <i class="bi bi-shield-shaded"></i> {{ id_check_item.status.upper() }}
+                    <i class="bi bi-shield-shaded"></i> {{ fraud_action['status'].upper() }}
                   </span>
-                {% elif id_check_item.status %}
+                {% elif fraud_action['status'].lower() == 'redirected_to_dms' %}
                   <span class="badge rounded-pill text-bg-warning align-middle px-3 py-2">
-                    <i class="bi bi-exclamation-circle"></i> {{ id_check_item.status.upper() }}
+                    <i class="bi bi-person-circle"></i> {{ fraud_action['status'].upper() }}
+                  </span>
+                {% elif fraud_action['status'] %}
+                  <span class="badge rounded-pill text-bg-warning align-middle px-3 py-2">
+                    <i class="bi bi-exclamation-circle"></i> {{ fraud_action['status'].upper() }}
                   </span>
                 {% endif %}
               </td>
-              <td>{{ id_check_item.reason | empty_string_if_null | pc_backoffice_public_account_link_in_comment | safe }}</td>
-              <td>{{ id_check_item.reasonCodes | format_string_list }}</td>
+              <td>{{ fraud_action['reason'] | empty_string_if_null | pc_backoffice_public_account_link_in_comment | safe }}</td>
+              <td>{{ fraud_action['errorCode'] | format_string_list }}</td>
               <td>
-                {% set idcheck_history_random_id = random_hash() %}
-                <button class="btn btn-light"
-                        type="button"
-                        data-bs-toggle="modal"
-                        data-bs-target=".technical-details-{{ idcheck_history_random_id }}">
-                  <i class="bi bi-zoom-in"></i>
-                </button>
-                <div class="modal modal-lg fade text-start technical-details-{{ idcheck_history_random_id }}"
-                     tabindex="-1"
-                     aria-labelledby="view-technical-details"
-                     aria-hidden="true">
-                  <div class="modal-dialog modal-dialog-centered">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <h5 class="modal-title">Détails techniques</h5>
-                      </div>
-                      <div class="modal-body">
-                        <div class="form-floating my-3">
-                          <pre>
-                             <code><br />{{ id_check_item.technicalDetails  | tojson(indent=4) | safe | empty_string_if_null }}</code>
-                          </pre>
+                {% if fraud_action['technicalDetails'] %}
+                  {% set idcheck_history_random_id = random_hash() %}
+                  <button class="btn btn-light"
+                          type="button"
+                          data-bs-toggle="modal"
+                          data-bs-target=".technical-details-{{ idcheck_history_random_id }}">
+                    <i class="bi bi-zoom-in"></i>
+                  </button>
+                  <div class="modal modal-lg fade text-start technical-details-{{ idcheck_history_random_id }}"
+                       tabindex="-1"
+                       aria-labelledby="view-technical-details"
+                       aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <h5 class="modal-title">Détails techniques</h5>
                         </div>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button"
-                                class="btn btn-outline-primary"
-                                data-bs-dismiss="modal">Fermer</button>
-                      </div>
-                    </form>
+                        <div class="modal-body">
+                          <div class="form-floating my-3">
+                            <pre>
+                             <code><br />{{ fraud_action['technicalDetails']  | tojson(indent=4) | safe | empty_string_if_null }}</code>
+                          </pre>
+                          </div>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button"
+                                  class="btn btn-outline-primary"
+                                  data-bs-dismiss="modal">Fermer</button>
+                        </div>
+                      </form>
+                    </div>
                   </div>
                 </div>
-              </div>
+              {% endif %}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22148

## But de la pull request

Ajouter les revues manuelles dans le tableau du parcours d'inscription jeunes.

![image](https://github.com/pass-culture/pass-culture-main/assets/134523772/e95c7000-5bce-40a7-ac98-329c2c6f087e)

## Implémentation

- Ajout d'`eligibilityType` au modèle `BeneficiaryFraudReview`
- Création de la revue manuelle avec l'éligibilité associée + adaptation du code pour récupérer cette info (cf. `reviewed_eligibility` et `user_eligibility`)
- Tri par date et ajout aux tableaux du parcours d'inscription (par étape et global)
- **Testing :** un test a été ajouté pour tester que les revues manuelles sont bien ajoutées aux étapes du parcours d'inscription
  - Je n'arrive pas encore à tester tous les cas (si un jeune est marqué comme pas éligible et que la revue manuelle est OK, checker que le jeune est bien noté comme éligible ?)

## Modifications du schéma de la base de données

- Ajout d'`eligibilityType` au modèle `BeneficiaryFraudReview`

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
