### PR TITLE
(PC-21945)[API] feat: use ean for algolia indexing

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -385,7 +385,7 @@ class AlgoliaBackend(base.SearchBackend):
 
         # Field used by Algolia (not the frontend) to deduplicate results
         # https://www.algolia.com/doc/api-reference/api-parameters/distinct/
-        distinct = extra_data.get("isbn") or extra_data.get("visa") or extra_data.get("ean") or str(offer.id)
+        distinct = extra_data.get("visa") or extra_data.get("ean") or str(offer.id)
         distinct += extra_data.get("diffusionVersion") or ""
 
         music_type_label = None

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -39,7 +39,7 @@ def test_serialize_offer():
         description="Un LIVRE qu'il est bien pour le lire",
         extraData={
             "author": "Author",
-            "isbn": "2221001648",
+            "ean": "2221001648",
             "performer": "Performer",
             "speaker": "Speaker",
             "stageDirector": "Stage Director",
@@ -182,7 +182,6 @@ def test_serialize_offer_event():
     (
         [{}, "1"],
         [{"visa": "56070"}, "56070"],
-        [{"isbn": "123456789"}, "123456789"],
         [{"visa": "56070", "diffusionVersion": "VO"}, "56070VO"],
         [{"visa": "56070", "diffusionVersion": "VF"}, "56070VF"],
         [{"ean": "12345678"}, "12345678"],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21945

Suppression de l'utilisation de extraData["isbn"] pour l'indexation algolia