### PR TITLE
(PC-20748)[PRO] feat: use name instead of public name for princing point

### DIFF
--- a/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/fields/PricingPoint/PricingPoint.tsx
@@ -63,7 +63,7 @@ const PricingPoint = ({
     .forEach(venue =>
       pricingPointOptions.push({
         value: venue.nonHumanizedId.toString(),
-        label: `${venue.publicName || venue.name} - ${venue.siret}`,
+        label: `${venue.name} - ${venue.siret}`,
       })
     )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20748

## But de la pull request

- Afficher la liste des points de valorisation disponibles avec comme info la raison sociale (name) au lieu du nom d’affichage (public name).