### PR TITLE
(PC-22567)[API] feat: add sort by id asc/desc to venue

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -101,7 +101,7 @@ def _get_all_venue_labels_query() -> sa.orm.Query:
     return offerers_models.VenueLabel.query.order_by(offerers_models.VenueLabel.label)
 
 
-class GetVenuesListForm(FlaskForm):
+class GetVenuesListForm(utils.PCForm):
     class Meta:
         csrf = False
 
@@ -123,6 +123,9 @@ class GetVenuesListForm(FlaskForm):
         default="100",
         coerce=int,
         validators=(wtforms.validators.Optional(),),
+    )
+    order = wtforms.HiddenField(
+        "order", default="desc", validators=(wtforms.validators.Optional(), wtforms.validators.AnyOf(("asc", "desc")))
     )
 
     def is_empty(self) -> bool:

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
@@ -47,7 +47,18 @@
               <th scope="col">Lieu permanent</th>
               <th scope="col">Label</th>
               <th scope="col">Tags</th>
-              <th scope="col">Date de création</th>
+              <th scope="col">
+                {% if date_created_sort_url %}
+                  <a href="{{ date_created_sort_url }}"
+                     class="text-decoration-none"
+                     title="Changer pour un tri {{ 'croissant' if request.args.get('order') == 'desc' else 'décroissant' }}">
+                    Date de création
+                    <i class="bi bi-sort-{{ 'down' if request.args.get('order') == 'desc' else 'up' }}-alt"></i>
+                  </a>
+                {% else %}
+                  Date de création
+                {% endif %}
+              </th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22567

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/868fa07f-1d57-4805-aab8-a2203a0f267f)


## But de la pull request

- Le tri par défaut est ID desc
- Ajouter un lien pour trier sur la date de création

## Implémentation

- On utilisera l'ID pour determiner l'ordre, la date de création n'étant pas indexé

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
