### PR TITLE
(PC-22537)[PRO] feat: use role for notifications

### DIFF
--- a/pro/src/components/Notification/Notification.tsx
+++ b/pro/src/components/Notification/Notification.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { NOTIFICATION_TRANSITION_DURATION } from 'core/Notification/constants'
-import useNotification from 'hooks/useNotification'
+import useNotification, { NotificationTypeEnum } from 'hooks/useNotification'
 import {
   isStickyBarOpenSelector,
   notificationSelector,
@@ -59,6 +59,14 @@ const Notification = (): JSX.Element | null => {
   } else if (type === 'information') {
     iconComponent = <InfoIcon />
   }
+
+  const notificationAttribute = {
+    [NotificationTypeEnum.ERROR]: 'alert',
+    [NotificationTypeEnum.SUCCESS]: 'status',
+    [NotificationTypeEnum.PENDING]: 'progressbar',
+    [NotificationTypeEnum.INFORMATION]: 'status',
+  }[type]
+
   if (isInDom) {
     return (
       <div
@@ -78,6 +86,7 @@ const Notification = (): JSX.Element | null => {
               styles['with-sticky-action-bar']
           )
         }
+        role={notificationAttribute ?? 'status'}
       >
         {iconComponent}
         {text}

--- a/pro/src/components/Notification/__specs__/Notification.spec.jsx
+++ b/pro/src/components/Notification/__specs__/Notification.spec.jsx
@@ -17,14 +17,20 @@ describe('src | components | layout | Notification', () => {
       },
     })
 
-  const notificationTypes = ['', 'success', 'error', 'information', 'pending']
+  const notificationTypes = [
+    { type: '', role: 'status' },
+    { type: 'success', role: 'status' },
+    { type: 'error', role: 'alert' },
+    { type: 'information', role: 'status' },
+    { type: 'pending', role: 'progressbar' },
+  ]
   it.each(notificationTypes)(
     'should display given %s text with icon',
-    async type => {
+    async notificationType => {
       // given
       const sentNotification = {
         text: 'Mon petit succès',
-        type,
+        type: notificationType.type,
         version: 2,
       }
 
@@ -35,7 +41,10 @@ describe('src | components | layout | Notification', () => {
       const notification = screen.getByText(sentNotification.text)
       expect(notification).toBeInTheDocument()
       expect(notification).toHaveClass('show')
-      expect(notification).toHaveClass(`is-${type || 'success'}`)
+      expect(notification).toHaveClass(
+        `is-${notificationType.type || 'success'}`
+      )
+      expect(notification).toHaveAttribute('role', notificationType.role)
     }
   )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22537

## But de la pull request

- Ajouter le role aux notifications
- Default = success = status
- Success: status
- Error: alert
- Pending: progressbar

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
