### PR TITLE
(PC-22633)[API] feat: use ean instead of isbn

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -134,7 +134,11 @@ def get_id_converter(labels_by_id: dict, field_name: str) -> Callable[[str | Non
 class OfferExtraData(BaseModel):
     author: str | None
     durationMinutes: int | None
+    # FIXME (mageoffray, 06-06-2023)
+    # ISBN should be replace by EAN. Until next app force update we need
+    # to keep isbn field
     isbn: str | None
+    ean: str | None
     musicSubType: str | None
     musicType: str | None
     performer: str | None
@@ -189,6 +193,11 @@ class OfferResponse(BaseModel):
         result = super().from_orm(offer)
 
         if result.extraData:
+            # FIXME (mageoffray, 06-06-2023)
+            # ISBN should be replace by EAN. Until next app force update we need
+            # to keep isbn field
+            if result.extraData.ean:
+                result.extraData.isbn = result.extraData.ean
             result.extraData.durationMinutes = offer.durationMinutes
         else:
             result.extraData = OfferExtraData(durationMinutes=offer.durationMinutes)  # type: ignore [call-arg]

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -38,7 +38,7 @@ class OffersTest:
     def test_get_event_offer(self, app):
         extra_data = {
             "author": "mandibule",
-            "isbn": "3838",
+            "ean": "3838",
             "musicSubType": "502",
             "musicType": "501",
             "performer": "interprète",
@@ -170,6 +170,7 @@ class OffersTest:
         assert response.json["extraData"] == {
             "author": "mandibule",
             "isbn": "3838",
+            "ean": "3838",
             "durationMinutes": 33,
             "musicSubType": "Acid Jazz",
             "musicType": "Jazz",

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -824,6 +824,7 @@ def test_public_api(client):
                     "properties": {
                         "author": {"nullable": True, "title": "Author", "type": "string"},
                         "durationMinutes": {"nullable": True, "title": "Durationminutes", "type": "integer"},
+                        "ean": {"nullable": True, "title": "Ean", "type": "string"},
                         "isbn": {"nullable": True, "title": "Isbn", "type": "string"},
                         "musicSubType": {"nullable": True, "title": "Musicsubtype", "type": "string"},
                         "musicType": {"nullable": True, "title": "Musictype", "type": "string"},


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22633

There is a warning about changing this route, is there a problem to add "ean" to offerExtraData fields ?
If it is the case i can only keep this part to copy ean in isbn field
```
if result.extraData.ean:
        result.extraData.isbn = result.extraData.ean
```