### PR TITLE
(PC-22640)[API] feat: Add index on offer.IdAtProvider

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 cf9c67b851f6 (pre) (head)
-36e81e25b30b (post) (head)
+ad2884071862 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230607T152412_ad2884071862_add_offer_idatprovider_index.py
+++ b/api/src/pcapi/alembic/versions/20230607T152412_ad2884071862_add_offer_idatprovider_index.py
@@ -1,0 +1,25 @@
+"""Add index on offer.idAtProvider
+"""
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ad2884071862"
+down_revision = "36e81e25b30b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # # We need to commit the transaction, because `CREATE INDEX
+    # # CONCURRENTLY` cannot run inside a transaction.
+    op.execute("COMMIT")
+    op.execute("""CREATE INDEX CONCURRENTLY "offer_idAtProvider" ON offer ("idAtProvider")""")
+
+
+def downgrade() -> None:
+    # We need to commit the transaction, because `DROP INDEX
+    # CONCURRENTLY` cannot run inside a transaction.
+    op.execute("COMMIT")
+    op.execute("""DROP INDEX CONCURRENTLY IF EXISTS "offer_idAtProvider";""")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -410,6 +410,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     withdrawalType = sa.Column(sa.Enum(WithdrawalTypeEnum), nullable=True)
 
     sa.Index("idx_offer_trgm_name", name, postgresql_using="gin")
+    sa.Index("offer_idAtProvider", idAtProvider)
     sa.Index("offer_ean_idx", extraData["ean"].astext)
     sa.Index("offer_visa_idx", extraData["visa"].astext)
     # FIXME: We shoud be able to remove the index on `venueId`, since this composite index


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22640

Add index on offer.IdAtProvider. 
I don't have any thoughts on using idx_tableName_column or tableName_column.

We have a venueId, idAtProvider index that is currently not used for all synchros. 
We should also adapt all LocalProvider descendent classes to override `get_existing_pc_obj` to filter by venue if it exists. 
This index will still be usefull for titelive products synchronisation (books and maybe cds later).

The query is made here : https://github.com/pass-culture/pass-culture-main/blob/8e2b542b56e46bef00a27c1be6e72e7028508cca/api/src/pcapi/repository/providable_queries.py#L52

"event_idAtProviders_key" UNIQUE CONSTRAINT, btree ("idAtProviders") on table Product
and "stock_idAtProviders_key" UNIQUE CONSTRAINT, btree ("idAtProviders") on table stock already exists