### PR TITLE
Pc 22316 update email confirmation

### DIFF
--- a/api/src/pcapi/core/users/email/__init__.py
+++ b/api/src/pcapi/core/users/email/__init__.py
@@ -1,6 +1,5 @@
-from .send import send_beneficiary_confirmation_email_for_email_change  # noqa: F401
 from .send import send_pro_user_emails_for_email_change  # noqa: F401
-from .update import generate_token_expiration_date  # noqa: F401
+from .update import generate_email_change_token_expiration_date  # noqa: F401
 from .update import get_active_token_expiration  # noqa: F401
 from .update import request_email_update  # noqa: F401
 from .update import request_email_update_from_pro  # noqa: F401

--- a/api/src/pcapi/core/users/email/send.py
+++ b/api/src/pcapi/core/users/email/send.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import enum
 from urllib.parse import urlencode
 
 from pcapi import settings
@@ -7,54 +6,6 @@ import pcapi.core.mails.transactional as transactional_mails
 from pcapi.core.users.models import User
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.core.users.utils import encode_jwt_payload
-from pcapi.utils.urls import generate_firebase_dynamic_link
-
-
-class EmailChangeAction(enum.Enum):
-    CONFIRMATION = "changement-email/confirmation"
-    CANCELLATION = "suspension-compte/confirmation"
-
-
-def _build_link_for_email_change_action(
-    action: EmailChangeAction, current_email: str, new_email: str, expiration_date: datetime
-) -> str:
-    token = encode_jwt_payload({"current_email": current_email, "new_email": new_email}, expiration_date)
-    expiration = int(expiration_date.timestamp())
-
-    path = action.value
-    params = {
-        "token": token,
-        "expiration_timestamp": expiration,
-        "new_email": new_email,
-    }
-
-    return generate_firebase_dynamic_link(path, params)
-
-
-def send_beneficiary_confirmation_email_for_email_change(user: User, new_email: str, expiration_date: datetime) -> bool:
-    user_with_new_email = find_user_by_email(new_email)
-    if user_with_new_email:
-        return True
-
-    link_for_email_change_confirmation = _build_link_for_email_change_action(
-        EmailChangeAction.CONFIRMATION,
-        user.email,
-        new_email,
-        expiration_date,
-    )
-    link_for_email_change_cancellation = _build_link_for_email_change_action(
-        EmailChangeAction.CANCELLATION,
-        user.email,
-        new_email,
-        expiration_date,
-    )
-    success = transactional_mails.send_confirmation_email_change_email(
-        user,
-        link_for_email_change_confirmation,
-        link_for_email_change_cancellation,
-    )
-
-    return success
 
 
 def build_pro_link_for_email_change(current_email: str, new_email: str, user_id: int, expiration_date: datetime) -> str:

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -235,26 +235,6 @@ def check_and_expire_token(user: models.User, token: str, token_type: TokenType)
     app.redis_client.delete(token_key)  # type: ignore [attr-defined]
 
 
-def check_and_expire_or_create_token(
-    user: models.User, expiration_date: datetime
-) -> None:  # TODO Do not use this function replace it with create token and
-    """
-    Use a dummy counter to find out whether the user already has an
-    active token.
-
-    * If the incr command returns 1, there were none. Hence, set a TTL
-      (expiration_date, the lifetime of the validation token).
-    * If not, raise an error because there is already one.
-    """
-    key = get_token_key(user, TokenType.CONFIRMATION)
-    count = app.redis_client.incr(key)  # type: ignore [attr-defined]
-
-    if count > 1:
-        raise exceptions.EmailUpdateTokenExists()
-
-    app.redis_client.expireat(key, expiration_date)  # type: ignore [attr-defined]
-
-
 def get_active_token_expiration(user: models.User) -> datetime | None:
     confirmation_key = get_token_key(user, TokenType.CONFIRMATION)
     validation_key = get_token_key(user, TokenType.VALIDATION)

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -242,6 +242,15 @@ def check_and_desactivate_confirmation_token(user: models.User, token: str) -> N
     app.redis_client.delete(token_key)
 
 
+
+def check_and_desactivate_validation_token(user: models.User, token: str) -> None:
+    token_key = get_validation_token_key(user)
+    if app.redis_client.get(token_key) == token:  # type: ignore [attr-defined]
+        app.redis_client.delete(token_key)  # type: ignore [attr-defined]
+    else:
+        raise exceptions.InvalidToken()
+
+
 def check_no_active_token_exists(
     user: models.User, expiration_date: datetime
 ) -> None:  # TODO Do not use this function replace it with create token and

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -747,6 +747,10 @@ class UserEmailHistory(PcObject, Base, Model):
         return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.UPDATE_REQUEST)
 
     @classmethod
+    def build_confirmation(cls, user: User, new_email: str) -> "UserEmailHistory":
+        return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.CONFIRMATION)
+
+    @classmethod
     def build_validation(cls, user: User, new_email: str, by_admin: bool) -> "UserEmailHistory":
         if by_admin:
             return cls._build(user, new_email, event_type=EmailHistoryEventTypeEnum.ADMIN_VALIDATION)

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -18,7 +18,7 @@ from pcapi.core.users import constants
 from pcapi.core.users import email as email_api
 from pcapi.core.users import exceptions
 from pcapi.core.users.email import repository as email_repository
-from pcapi.core.users.email.update import check_and_desactivate_validation_token
+from pcapi.core.users.email.update import check_and_expire_validation_token
 from pcapi.core.users.email.update import check_email_address_does_not_exist
 import pcapi.core.users.models as users_models
 from pcapi.core.users.repository import find_user_by_email
@@ -164,7 +164,7 @@ def validate_user_email(body: serializers.ChangeBeneficiaryEmailBody) -> None:
         if not user:
             raise exceptions.InvalidEmailError()
         check_email_address_does_not_exist(new_email)
-        check_and_desactivate_validation_token(user, body.token)
+        check_and_expire_validation_token(user, body.token)
         api.change_user_email(current_email, new_email)
     except pydantic.ValidationError:
         raise api_errors.ApiErrors(

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -18,7 +18,8 @@ from pcapi.core.users import constants
 from pcapi.core.users import email as email_api
 from pcapi.core.users import exceptions
 from pcapi.core.users.email import repository as email_repository
-from pcapi.core.users.email.update import check_and_expire_validation_token
+from pcapi.core.users.email.update import TokenType
+from pcapi.core.users.email.update import check_and_expire_token
 from pcapi.core.users.email.update import check_email_address_does_not_exist
 import pcapi.core.users.models as users_models
 from pcapi.core.users.repository import find_user_by_email
@@ -164,7 +165,7 @@ def validate_user_email(body: serializers.ChangeBeneficiaryEmailBody) -> None:
         if not user:
             raise exceptions.InvalidEmailError()
         check_email_address_does_not_exist(new_email)
-        check_and_expire_validation_token(user, body.token)
+        check_and_expire_token(user, body.token, TokenType.VALIDATION)
         api.change_user_email(current_email, new_email)
     except pydantic.ValidationError:
         raise api_errors.ApiErrors(

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -224,7 +224,7 @@ class UserProfileUpdateRequest(BaseModel):
 
 
 class UserProfileEmailUpdate(BaseModel):
-    email: pydantic.EmailStr
+    email: pydantic.EmailStr  # the new email address
     if typing.TYPE_CHECKING:  # https://github.com/pydantic/pydantic/issues/156
         password: str
     else:

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -902,6 +902,25 @@ class GetEMailUpdateStatusTest:
         assert response.json["expired"] is True
         assert response.json["status"] == users_models.EmailHistoryEventTypeEnum.UPDATE_REQUEST.value
 
+    def test_get_active_token_expiration_no_token(self):
+        assert email_update.get_active_token_expiration(users_factories.UserFactory()) is None
+
+    def test_get_active_token_expiration_confirmation_token(self):
+        user = users_factories.UserFactory()
+        expiration_date = datetime.utcnow() + users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
+        email_update.generate_email_change_token(
+            user, "example@example.com", expiration_date, email_update.TokenType.CONFIRMATION
+        )
+        assert email_update.get_active_token_expiration(user) is not None
+
+    def test_get_active_token_expiration_validation_token(self):
+        user = users_factories.UserFactory()
+        expiration_date = datetime.utcnow() + users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
+        email_update.generate_email_change_token(
+            user, "example@example.com", expiration_date, email_update.TokenType.VALIDATION
+        )
+        assert email_update.get_active_token_expiration(user) is not None
+
 
 class ValidateEmailTest:
     old_email = "old@email.com"

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -829,7 +829,7 @@ class GetEMailUpdateStatusTest:
         user = users_factories.UserFactory(email=self.old_email)
         request_email_update(user, self.new_email, settings.TEST_DEFAULT_PASSWORD)
 
-        redis_key = email_update.get_no_active_token_key(user)
+        redis_key = email_update.get_confirmation_token_key(user)
         redis_value = app.redis_client.get(redis_key)
         redis_expiration = app.redis_client.ttl(redis_key)
         app.redis_client.delete(redis_key)
@@ -920,7 +920,7 @@ class GetTokenExpirationTest:
         user = users_factories.UserFactory(email=self.email)
 
         expiration_date = datetime.utcnow() + timedelta(hours=15)
-        key = email_update.get_no_active_token_key(user)
+        key = email_update.get_confirmation_token_key(user)
 
         app.redis_client.incr(key)
         app.redis_client.expireat(key, expiration_date)

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -2735,6 +2735,31 @@ def test_public_api(client):
                     "tags": [],
                 }
             },
+            "/native/v1/profile/email_update/confirm": {
+                "post": {
+                    "description": "",
+                    "operationId": "post_/native/v1/profile/email_update/confirm",
+                    "parameters": [],
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/ChangeBeneficiaryEmailBody"}}
+                        }
+                    },
+                    "responses": {
+                        "204": {"description": "No Content"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "security": [{"JWTAuth": []}],
+                    "summary": "confirm_email_update <POST>",
+                    "tags": [],
+                }
+            },
             "/native/v1/profile/validate_email": {
                 "put": {
                     "description": "",

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -2760,10 +2760,10 @@ def test_public_api(client):
                     "tags": [],
                 }
             },
-            "/native/v1/profile/validate_email": {
+            "/native/v1/profile/email_update/validate": {
                 "put": {
                     "description": "",
-                    "operationId": "put_/native/v1/profile/validate_email",
+                    "operationId": "put_/native/v1/profile/email_update/validate",
                     "parameters": [],
                     "requestBody": {
                         "content": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22316

## But de la pull request

Confirming email update

## Implémentation

Created a new route '/native/v1/profile/email_update/confirm'

## Informations supplémentaires

la modification d'email est actuellement désactivé est les utilisateurs ont une limite de 24h pour finir la procédure. Il n'y a donc pas d'utilisateurs qui ont commencé la procédure et qui se retrouverons avec des problème avec la nouvelle procédure

## Modifications de la gestion des tokens pour l'update email:

ancienne procédure: un seul type de token avec uns seul clé redis associé qui stock un compteur du nombre de fois où la clé a été vérifié

nouvelle procédure:
Deux tokens différents sont générés à deux étapes différentes du changement d'email. les tokens ont chacun un clé redis associé qui est différentes. sur Redis on stock cette fois ci le token_jwt et pas juste un nombre. un fois le token utilisé en supprime la clé de redis.