### PR TITLE
(PC-22508)[BO] test: better tests for cancel/uncancel booking rules

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
+++ b/api/src/pcapi/routes/backoffice_v3/individual_bookings.py
@@ -236,7 +236,8 @@ def mark_booking_as_cancelled(booking_id: int) -> utils.BackofficeResponse:
     except bookings_exceptions.BookingIsAlreadyCancelled:
         flash("Impossible d'annuler une réservation déjà annulée", "warning")
     except bookings_exceptions.BookingIsAlreadyRefunded:
-        flash("Impossible d'annuler une réservation remboursée", "warning")
+        # The same exception is issued when Pricing is PROCESSED or when INVOICED with Payment
+        flash("Impossible d'annuler une réservation déjà valorisée ou remboursée", "warning")
     except bookings_exceptions.BookingIsAlreadyUsed:
         flash("Impossible d'annuler une réservation déjà utilisée", "warning")
     except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22508

## But de la pull request

Clarifier dans les tests que les règles métier sont bien validées lors de l'annulation ou la désannulation d'une réservation. Un message d'erreur est aussi clarifié (« valorisé ou remboursé »).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
