### PR TITLE
(PC-22686)[API] feat: Do not tag transactional emails related to Ubble - tagged in SiB by marketing

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -84,21 +84,11 @@ class TransactionalEmail(Enum):
     )
 
     # UBBLE KO REMINDER
-    UBBLE_KO_REMINDER_ID_CHECK_DATA_MATCH = models.Template(
-        id_prod=824, id_not_prod=116, tags=["jeunes_relance_ubble_ko_infos_incorrectes"]
-    )
-    UBBLE_KO_REMINDER_ID_CHECK_EXPIRED = models.Template(
-        id_prod=831, id_not_prod=118, tags=["jeunes_relance_ubble_ko_document_expire"]
-    )
-    UBBLE_KO_REMINDER_ID_CHECK_NOT_AUTHENTIC = models.Template(
-        id_prod=821, id_not_prod=117, tags=["jeunes_relance_ubble_ko_document_non_authentique"]
-    )
-    UBBLE_KO_REMINDER_ID_CHECK_NOT_SUPPORTED = models.Template(
-        id_prod=825, id_not_prod=119, tags=["jeunes_relance_ubble_ko_document_non_supporte"]
-    )
-    UBBLE_KO_REMINDER_ID_CHECK_UNPROCESSABLE = models.Template(
-        id_prod=823, id_not_prod=115, tags=["jeunes_relance_ubble_ko_video_illisible"]
-    )
+    UBBLE_KO_REMINDER_ID_CHECK_DATA_MATCH = models.Template(id_prod=824, id_not_prod=116)
+    UBBLE_KO_REMINDER_ID_CHECK_EXPIRED = models.Template(id_prod=831, id_not_prod=118)
+    UBBLE_KO_REMINDER_ID_CHECK_NOT_AUTHENTIC = models.Template(id_prod=821, id_not_prod=117)
+    UBBLE_KO_REMINDER_ID_CHECK_NOT_SUPPORTED = models.Template(id_prod=825, id_not_prod=119)
+    UBBLE_KO_REMINDER_ID_CHECK_UNPROCESSABLE = models.Template(id_prod=823, id_not_prod=115)
 
     # PRO EMAIL
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22686

## But de la pull request

Supprimer les tags des mails templates #825, #831, #823, #821, #824, #828 dans le backend afin de synchroniser les remontées des statistiques sur leur tag attribué directement dans Sendinblue.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
