### PR TITLE
(PC-21908)[PRO] feat: Wording des réservations, tags et statuts.

### DIFF
--- a/pro/src/screens/Bookings/BookingsRecapTable/utils/bookingStatusConverter.ts
+++ b/pro/src/screens/Bookings/BookingsRecapTable/utils/bookingStatusConverter.ts
@@ -15,7 +15,7 @@ const BOOKING_STATUS_DISPLAY_INFORMATIONS = [
   },
   {
     id: BOOKING_STATUS.CANCELLED,
-    status: 'annulé',
+    status: 'Annulée',
     label: 'Réservation annulée',
     historyClassName: 'bs-history-cancelled',
     statusClassName: styles['booking-status-cancelled'],


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21908

## But de la pull request


Pour qu'une réservation soit  affichée "Annulée", il faut créer une temporaire  en passant par la bd. Car s'il n'a pas des réservations de ce type, on voit pas ni statut "Annulée", ni  tag "annulée" .



## Informations supplémentaires


Time: 0.029s
484fb31224a0> select * from booking where status='CANCELLED'

<img width="973" alt="Capture d’écran 2023-06-07 à 13 48 03" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/007ae90e-35e1-4184-a257-e42536cfc38d">

<img width="524" alt="Capture d’écran 2023-06-07 à 13 46 43" src="https://github.com/pass-culture/pass-culture-main/assets/115089249/eb96feff-734a-47b5-bce6-9be6a6cc4f8e">

## Checklist :

- [ x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : PC-21908-wording-liste
  - PR : (PC-21908)[PRO] feat: Wording des réservations, tags et statuts.
  - Commit(s) : `(PC-21908)[PRO] feat: Wording des réservations, tags et statuts.