### PR TITLE
(PC-22689)[API] feat: eac (pro): add more detailed information

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -744,9 +744,7 @@ def get_collective_offer_request_by_id(request_id: int) -> educational_models.Co
                 educational_models.EducationalRedactor.lastName,
                 educational_models.EducationalRedactor.email,
             ),
-            sa.orm.joinedload(educational_models.CollectiveOfferRequest.educationalInstitution).load_only(
-                educational_models.EducationalInstitution.institutionId
-            ),
+            sa.orm.joinedload(educational_models.CollectiveOfferRequest.educationalInstitution),
         )
 
         return query.one()

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -124,6 +124,7 @@ def get_collective_offer_request(request_id: int) -> collective_offers_serialize
     offerer_id = collective_offer_request.collectiveOfferTemplate.venue.managingOffererId
     check_user_has_access_to_offerer(current_user, offerer_id)
 
+    institution = collective_offer_request.educationalInstitution
     return collective_offers_serialize.GetCollectiveOfferRequestResponseModel(
         redactor=collective_offers_serialize.CollectiveOfferRedactorModel(
             firstName=collective_offer_request.educationalRedactor.firstName,
@@ -135,8 +136,14 @@ def get_collective_offer_request(request_id: int) -> collective_offers_serialize
         totalTeachers=collective_offer_request.totalTeachers,
         comment=collective_offer_request.comment,
         phoneNumber=collective_offer_request.phoneNumber,  # type: ignore
-        institutionId=collective_offer_request.educationalInstitution.institutionId,
         dateCreated=collective_offer_request.dateCreated,
+        institution=collective_offers_serialize.CollectiveOfferInstitutionModel(
+            institutionId=institution.institutionId,
+            institutionType=institution.institutionType,
+            name=institution.name,
+            city=institution.city,
+            postalCode=institution.postalCode,
+        ),
     )
 
 

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -365,6 +365,14 @@ class CollectiveOfferRedactorModel(BaseModel):
     email: str
 
 
+class CollectiveOfferInstitutionModel(BaseModel):
+    institutionId: str
+    institutionType: str
+    name: str
+    city: str
+    postalCode: str
+
+
 class GetCollectiveOfferRequestResponseModel(BaseModel):
     redactor: CollectiveOfferRedactorModel
     requestedDate: date | None
@@ -372,8 +380,8 @@ class GetCollectiveOfferRequestResponseModel(BaseModel):
     totalTeachers: int | None
     phoneNumber: str | None
     comment: str
-    institutionId: str
     dateCreated: date | None
+    institution: CollectiveOfferInstitutionModel
 
     class Config:
         allow_population_by_field_name = True

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -227,8 +227,14 @@ class GetCollectiveOfferRequestTest:
             "totalTeachers": request.totalTeachers,
             "comment": request.comment,
             "phoneNumber": request.phoneNumber,
-            "institutionId": request.educationalInstitution.institutionId,
             "dateCreated": request.dateCreated.isoformat(),
+            "institution": {
+                "institutionId": request.educationalInstitution.institutionId,
+                "institutionType": request.educationalInstitution.institutionType,
+                "name": request.educationalInstitution.name,
+                "city": request.educationalInstitution.city,
+                "postalCode": request.educationalInstitution.postalCode,
+            },
         }
 
     def test_old_request_without_date_created(self, client):

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -34,6 +34,7 @@ export type { CollectiveBookingEducationalRedactorResponseModel } from './models
 export type { CollectiveBookingResponseModel } from './models/CollectiveBookingResponseModel';
 export { CollectiveBookingStatus } from './models/CollectiveBookingStatus';
 export { CollectiveBookingStatusFilter } from './models/CollectiveBookingStatusFilter';
+export type { CollectiveOfferInstitutionModel } from './models/CollectiveOfferInstitutionModel';
 export type { CollectiveOfferOfferVenueResponseModel } from './models/CollectiveOfferOfferVenueResponseModel';
 export type { CollectiveOfferRedactorModel } from './models/CollectiveOfferRedactorModel';
 export type { CollectiveOfferResponseIdModel } from './models/CollectiveOfferResponseIdModel';

--- a/pro/src/apiClient/v1/models/CollectiveOfferInstitutionModel.ts
+++ b/pro/src/apiClient/v1/models/CollectiveOfferInstitutionModel.ts
@@ -1,0 +1,12 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CollectiveOfferInstitutionModel = {
+  city: string;
+  institutionId: string;
+  institutionType: string;
+  name: string;
+  postalCode: string;
+};
+

--- a/pro/src/apiClient/v1/models/GetCollectiveOfferRequestResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetCollectiveOfferRequestResponseModel.ts
@@ -2,12 +2,13 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { CollectiveOfferInstitutionModel } from './CollectiveOfferInstitutionModel';
 import type { CollectiveOfferRedactorModel } from './CollectiveOfferRedactorModel';
 
 export type GetCollectiveOfferRequestResponseModel = {
   comment: string;
   dateCreated?: string | null;
-  institutionId: string;
+  institution: CollectiveOfferInstitutionModel;
   phoneNumber?: string | null;
   redactor: CollectiveOfferRedactorModel;
   requestedDate?: string | null;


### PR DESCRIPTION
Add information regarding the collective offer request's institution.

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22689

## But de la pull request

Renvoyer des informations plus détaillées au sujet de l'établissement concerné par le formulaire de contact au sujet d'une offre vitrine (collective).

## Au passage

Suppression de `load_only` pour la relation `educationalInstitution` puisqu'on a désormais de presque toutes les colonnes.