### PR TITLE
(PC-22567)[API] fix: add column public name to venue

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
@@ -43,6 +43,7 @@
               {% endif %}
               <th scope="col">ID</th>
               <th scope="col">Nom</th>
+              <th scope="col">Nom d'usage</th>
               <th scope="col">Structure</th>
               <th scope="col">Lieu permanent</th>
               <th scope="col">Label</th>
@@ -74,6 +75,7 @@
                 {% endif %}
                 <td>{{ venue.id }}</td>
                 <td>{{ links.build_venue_name_to_details_link(venue) }}</td>
+                <td>{{ venue.publicName }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}</td>
                 <td>
                   {% if venue.isPermanent %}<span class="visually-hidden">Lieu permanent</span><i class="bi bi-check-circle-fill"></i>{% endif %}

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -59,6 +59,7 @@ def _get_venues(form: forms.GetVenuesListForm) -> list[offerers_models.Venue]:
         sa.orm.load_only(
             offerers_models.Venue.id,
             offerers_models.Venue.name,
+            offerers_models.Venue.publicName,
             offerers_models.Venue.dateCreated,
             offerers_models.Venue.postalCode,
             offerers_models.Venue.departementCode,

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -115,6 +115,7 @@ class ListVenuesTest(GetEndpointHelper):
         assert len(rows) == 1
         assert int(rows[0]["ID"]) == venues[0].id
         assert rows[0]["Nom"] == venues[0].name
+        assert rows[0]["Nom d'usage"] == venues[0].publicName
         assert rows[0]["Structure"] == venues[0].managingOfferer.name
         assert rows[0]["Lieu permanent"] == "Lieu permanent"
         assert rows[0]["Label"] == venues[0].venueLabel.label


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22567

## But de la pull request

Ajout de la colonne `Nom d'usage` (aka `venue.publicName`) dans la liste des actions sur les lieux

## Implémentation

NA

## Informations supplémentaires

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/eacbb701-d533-4868-a8a2-e25de53fa7d0)


## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
