### PR TITLE
(BSR)[API] fix: Add "if not exists" on "offer_idAtProvider" index creation

### DIFF
--- a/api/src/pcapi/alembic/versions/20230607T152412_ad2884071862_add_offer_idatprovider_index.py
+++ b/api/src/pcapi/alembic/versions/20230607T152412_ad2884071862_add_offer_idatprovider_index.py
@@ -15,7 +15,7 @@ def upgrade() -> None:
     # # We need to commit the transaction, because `CREATE INDEX
     # # CONCURRENTLY` cannot run inside a transaction.
     op.execute("COMMIT")
-    op.execute("""CREATE INDEX CONCURRENTLY "offer_idAtProvider" ON offer ("idAtProvider")""")
+    op.execute("""CREATE INDEX CONCURRENTLY IF NOT EXISTS "offer_idAtProvider" ON offer ("idAtProvider")""")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Deployment failed on staging because it took too long: the index was
created (although in the "invalid" state) but the migration failed
(and was thus not recorded in `alembic_version`). When we tried to
deploy again, the migration was executed again, but failed because the
index already existed.