### PR TITLE
(PC-22698)[BO] fix: edit latitude and longitude in venue address manual edition

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/venue.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/venue.py
@@ -48,7 +48,7 @@ class EditVenueForm(EditVirtualVenueForm):
         limit=10,
     )
     address = fields.PCHiddenField(
-        "address",
+        "Adresse",
         validators=(wtforms.validators.Length(max=200, message="doit contenir moins de %(max)d caractères"),),
     )
     city = fields.PCHiddenField(

--- a/api/src/pcapi/static/backofficev3/js/addons/pc-postal-address-autocomplete.js
+++ b/api/src/pcapi/static/backofficev3/js/addons/pc-postal-address-autocomplete.js
@@ -453,39 +453,33 @@ class PcPostalAddressAutocomplete extends PcAddOn {
     const $address = this.#getAddress($autoComplete)
     const $latitude = this.#getLatitude($autoComplete)
     const $longitude = this.#getLongitude($autoComplete)
-    const isManuelEditing = event.target.innerHTML.includes(PcPostalAddressAutocomplete.MANUAL_EDITION_OFF_LABEL)
+    const isManualEditing = event.target.innerHTML.includes(PcPostalAddressAutocomplete.MANUAL_EDITION_OFF_LABEL)
 
-    event.target.innerHTML = isManuelEditing ?
+    event.target.innerHTML = isManualEditing ?
       PcPostalAddressAutocomplete.MANUAL_EDITION_ON_LABEL :
       PcPostalAddressAutocomplete.MANUAL_EDITION_OFF_LABEL
-    $autoCompleteContainer.classList[isManuelEditing ? 'add' : 'remove']('d-none')
+    $autoCompleteContainer.classList[isManualEditing ? 'add' : 'remove']('d-none')
 
 
-    $autoComplete.required = required === false ? required : !isManuelEditing
-    $autoComplete.disabled = isManuelEditing
+    $autoComplete.required = required === false ? required : !isManualEditing
+    $autoComplete.disabled = isManualEditing
 
     if ($postalCode) {
-      $postalCode.parentElement.classList[isManuelEditing ? 'remove' : 'add']('d-none')
+      $postalCode.parentElement.classList[isManualEditing ? 'remove' : 'add']('d-none')
     }
     if ($city) {
-      $city.parentElement.classList[isManuelEditing ? 'remove' : 'add']('d-none')
+      $city.parentElement.classList[isManualEditing ? 'remove' : 'add']('d-none')
     }
     if ($address) {
-      $address.parentElement.classList[isManuelEditing ? 'remove' : 'add']('d-none')
+      $address.parentElement.classList[isManualEditing ? 'remove' : 'add']('d-none')
     }
-    if ($latitude && isManuelEditing) {
-      $latitude.value = ''
-      $latitude.disabled = true
-    } else if ($latitude && !isManuelEditing) {
-      $latitude.disabled = false
+    if ($latitude) {
+      $latitude.parentElement.classList[isManualEditing ? 'remove' : 'add']('d-none')
     }
-    if ($longitude && isManuelEditing) {
-      $longitude.value = ''
-      $longitude.disabled = true
-    } else if ($longitude && !isManuelEditing) {
-      $longitude.disabled = false
+    if ($longitude) {
+      $longitude.parentElement.classList[isManualEditing ? 'remove' : 'add']('d-none')
     }
-    if (!isManuelEditing) {
+    if (!isManualEditing) {
       this.#resetForm($autoComplete)
     }
   }

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -717,8 +717,8 @@ class UpdateVenueTest(PostEndpointHelper):
             "booking_email": venue.bookingEmail + ".update",
             "phone_number": "+33102030456",
             "is_permanent": True,
-            "latitude": "48.87056",
-            "longitude": "2.34767",
+            "latitude": "63.82850",
+            "longitude": "20.25473",
         }
 
         response = self.post_to_endpoint(authenticated_client, venue_id=venue.id, form=data)
@@ -737,8 +737,8 @@ class UpdateVenueTest(PostEndpointHelper):
         assert venue.bookingEmail == data["booking_email"]
         assert venue.contact.phone_number == data["phone_number"]
         assert venue.isPermanent == data["is_permanent"]
-        assert venue.latitude == Decimal("48.87056")
-        assert venue.longitude == Decimal("2.34767")
+        assert venue.latitude == Decimal("63.82850")
+        assert venue.longitude == Decimal("20.25473")
 
         # should not have been updated or erased
         assert venue.contact.email == contact_email
@@ -752,6 +752,8 @@ class UpdateVenueTest(PostEndpointHelper):
         assert update_snapshot["city"]["new_info"] == data["city"]
         assert update_snapshot["address"]["new_info"] == data["address"]
         assert update_snapshot["bookingEmail"]["new_info"] == data["booking_email"]
+        assert update_snapshot["latitude"]["new_info"] == data["latitude"]
+        assert update_snapshot["longitude"]["new_info"] == data["longitude"]
 
     def test_update_venue_contact_only(self, authenticated_client, offerer):
         contact_email = "contact.venue@example.com"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22698

## But de la pull request

Dans l'édition manuelle d'une adresse de lieu (sans _autocomplete_), permettre de modifier également les coordonnées GPS du lieu : latitude et longitude.

## Informations supplémentaires

Dans les tests, on ne peut pas tester la présence du champ, car l'état caché ou visible est du pur JS à l'exécution.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
