### PR TITLE
(BSR)[BO] fix: temporary hotfix: avoid 502 Bad Gateway on offerer attachments page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/offerer.py
@@ -144,7 +144,7 @@ class UserOffererValidationListForm(utils.PCForm):
     per_page = fields.PCSelectField(
         "Par page",
         choices=(("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")),
-        default="100",
+        default="25",
         validators=(wtforms.validators.Optional(),),
     )
     order = wtforms.HiddenField(

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -2014,7 +2014,7 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
             (31, {"per_page": 10, "page": 3}, 4, 3, 10),
             (31, {"per_page": 10, "page": 4}, 4, 4, 1),
             (20, {"per_page": 10, "page": 1}, 2, 1, 10),
-            (27, {"page": 1}, 1, 1, 27),
+            (27, {"page": 1}, 2, 1, 25),
             (10, {"per_page": 25, "page": 1}, 1, 1, 10),
             (1, {"per_page": None, "page": 1}, 1, 1, 1),
             (1, {"per_page": "", "page": 1}, 1, 1, 1),  # ensure that it does not crash (fallbacks to default)


### PR DESCRIPTION
## But de la pull request

HOTFIX : Contournement temporaire pour éviter une erreur 502 Bad Gateway
dans l'attente de la correction du ticket https://passculture.atlassian.net/browse/PC-22720

## Implémentation

25 résultats au lieu de 100 par défaut sur les rattachements à valider.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
