### PR TITLE
(PC-22642)[PRO] feat: add bannerInvisibleSiren to offerer siret validation 

### DIFF
--- a/pro/src/components/Banner/BannerInvisibleSiren.tsx
+++ b/pro/src/components/Banner/BannerInvisibleSiren.tsx
@@ -2,18 +2,27 @@ import React from 'react'
 
 import Banner from 'ui-kit/Banners/Banner'
 
-const BannerInvisibleSiren = (): JSX.Element => (
+interface BannerInvisibleSirenProps {
+  isNewOnboarding?: boolean
+}
+
+const BannerInvisibleSiren = ({
+  isNewOnboarding = false,
+}: BannerInvisibleSirenProps): JSX.Element => (
   <Banner
     links={[
       {
         href: 'https://statut-diffusion-sirene.insee.fr/',
-        linkTitle: 'Modifier la visibilité de mon SIREN',
+        linkTitle: `Modifier la visibilité de mon ${
+          isNewOnboarding ? 'SIRET' : 'SIREN'
+        }`,
       },
     ]}
     type="attention"
   >
-    Le SIREN doit être rendu visible pour valider votre inscription. Vous pouvez
-    effectuer cette démarche sur le site de l’INSEE.
+    Le {isNewOnboarding ? 'SIRET' : 'SIREN'} doit être rendu visible pour
+    valider votre inscription. Vous pouvez effectuer cette démarche sur le site
+    de l’INSEE.
   </Banner>
 )
 

--- a/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/Offerer.tsx
@@ -2,6 +2,7 @@ import { FormikProvider, useFormik } from 'formik'
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { BannerInvisibleSiren } from 'components/Banner'
 import FormLayout from 'components/FormLayout'
 import { SIGNUP_JOURNEY_STEP_IDS } from 'components/SignupJourneyBreadcrumb/constants'
 import { OnboardingFormNavigationAction } from 'components/SignupJourneyFormLayout/constants'
@@ -29,6 +30,7 @@ const Offerer = (): JSX.Element => {
   const navigate = useNavigate()
   const { offerer, setOfferer } = useSignupJourneyContext()
   const [showIsAppUserDialog, setShowIsAppUserDialog] = useState<boolean>(false)
+  const [showInvisibleBanner, setShowInvisibleBanner] = useState<boolean>(false)
 
   const initialValues: IOffererFormValues = offerer
     ? { siret: offerer.siret }
@@ -109,7 +111,9 @@ const Offerer = (): JSX.Element => {
   const formik = useFormik({
     initialValues,
     onSubmit: onSubmitOfferer,
-    validationSchema,
+    validationSchema: validationSchema(showBanner =>
+      setShowInvisibleBanner(showBanner)
+    ),
     enableReinitialize: true,
   })
 
@@ -125,6 +129,9 @@ const Offerer = (): JSX.Element => {
             data-testid="signup-offerer-form"
           >
             <OffererForm />
+            {showInvisibleBanner && (
+              <BannerInvisibleSiren isNewOnboarding={true} />
+            )}
             <Banner
               type="notification-info"
               className={styles['siret-banner']}

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -128,6 +128,10 @@ describe('screens:SignupJourney::Offerer', () => {
     ).not.toBeInTheDocument()
 
     expect(
+      screen.queryByText('Modifier la visibilité de mon SIRET')
+    ).not.toBeInTheDocument()
+
+    expect(
       await screen.getByText(
         "Vous êtes un équipement d’une collectivité ou d'un établissement public ?"
       )
@@ -264,6 +268,45 @@ describe('screens:SignupJourney::Offerer', () => {
     await waitFor(() => {
       expect(screen.getByText('Une erreur est survenue')).toBeInTheDocument()
     })
+  })
+
+  it('should display BannerInvisibleSiren on error 400 with specific message', async () => {
+    jest.spyOn(api, 'getSiretInfo').mockRejectedValue(
+      new ApiError(
+        {} as ApiRequestOptions,
+        {
+          status: 400,
+          body: {
+            global: [
+              'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.',
+            ],
+          },
+        } as ApiResult,
+        ''
+      )
+    )
+    renderOffererScreen(contextValue)
+
+    expect(
+      screen.queryByText('Modifier la visibilité de mon SIRET')
+    ).not.toBeInTheDocument()
+
+    await userEvent.type(
+      screen.getByLabelText('Numéro de SIRET à 14 chiffres'),
+      '12345678933367'
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Numéro de SIRET à 14 chiffres')
+      ).toHaveValue('123 456 789 33367')
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
+
+    expect(api.getSiretInfo).toHaveBeenCalled()
+    expect(
+      screen.getByText('Modifier la visibilité de mon SIRET')
+    ).toBeInTheDocument()
   })
 
   it('should not display MaybeAppUserDialog component on submit with valid apeCode', async () => {

--- a/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/__specs__/OffererForm.spec.tsx
@@ -72,7 +72,7 @@ const renderOffererForm = ({
       <Formik
         initialValues={initialValues}
         onSubmit={onSubmit}
-        validationSchema={validationSchema}
+        validationSchema={validationSchema(jest.fn())}
       >
         <Form>
           <OffererForm />

--- a/pro/src/screens/SignupJourneyForm/Offerer/validationSchema.tsx
+++ b/pro/src/screens/SignupJourneyForm/Offerer/validationSchema.tsx
@@ -3,17 +3,24 @@ import * as yup from 'yup'
 import { valideSiretLength } from 'components/VenueForm/Informations/SiretOrCommentFields/validationSchema'
 import siretApiValidate from 'core/Venue/siretApiValidate'
 
-export const validationSchema = yup.object().shape({
-  siret: yup
-    .string()
-    .required('Veuillez renseigner un SIRET')
-    .test(
-      'len',
-      'Le SIRET doit comporter 14 caractères',
-      siret => !!siret && valideSiretLength(siret)
-    )
-    .test('apiSiretValid', 'Le SIRET n’existe pas', async siret => {
-      const response = await siretApiValidate(siret || '')
-      return !response
-    }),
-})
+export const validationSchema = (
+  displayInvisibleSirenBanner: (showBanner: boolean) => void
+) =>
+  yup.object().shape({
+    siret: yup
+      .string()
+      .required('Veuillez renseigner un SIRET')
+      .test(
+        'len',
+        'Le SIRET doit comporter 14 caractères',
+        siret => !!siret && valideSiretLength(siret)
+      )
+      .test('apiSiretValid', 'Le SIRET n’existe pas', async siret => {
+        const response = await siretApiValidate(siret || '')
+        displayInvisibleSirenBanner(
+          response ===
+            'Les informations relatives à ce SIREN ou SIRET ne sont pas accessibles.'
+        )
+        return !response
+      }),
+  })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22642

## But de la pull request

- Ajout message spécifique aux AE qui n'ont pas souhaité rendre leur SIRET visible au moment de l'inscription

## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/30546419-7703-48f5-9c3d-3f718c7ae906)

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
