### PR TITLE
(PC-21665)[API] feat: Convert suspicious login email time to users timezone

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
@@ -28,11 +28,7 @@ def send_reset_password_email_to_pro(user: users_models.User, token: users_model
 
 
 def get_reset_password_from_connected_pro_email_data(user: users_models.User) -> models.TransactionalEmailData:
-    departmentCode = user.departementCode
-    if departmentCode:
-        now = utc_datetime_to_department_timezone(datetime.utcnow(), departmentCode)
-    else:
-        now = utc_datetime_to_department_timezone(datetime.utcnow(), "75")
+    now = utc_datetime_to_department_timezone(datetime.utcnow(), user.departementCode)
 
     return models.TransactionalEmailData(
         template=TransactionalEmail.RESET_PASSWORD_TO_CONNECTED_PRO.value,

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -65,7 +65,7 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
 
         if users_api.is_suspicious_login(body.device_info, user):
             token = users_api.create_suspicious_login_email_token(login_history, user.id)
-            transactional_mails.send_suspicious_login_email(user.email, login_history, token)
+            transactional_mails.send_suspicious_login_email(user, login_history, token)
 
     users_api.update_last_connection_date(user)
     return authentication.SigninResponse(

--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -91,7 +91,7 @@ def get_department_timezone(departement_code: str | None) -> str:
     )
 
 
-def utc_datetime_to_department_timezone(date_time: datetime | None, departement_code: str) -> datetime:
+def utc_datetime_to_department_timezone(date_time: datetime | None, departement_code: str | None) -> datetime:
     from_zone = ZoneInfo(DEFAULT_STORED_TIMEZONE)
     to_zone = ZoneInfo(get_department_timezone(departement_code))
     utc_datetime = date_time.replace(tzinfo=from_zone)  # type: ignore [union-attr]

--- a/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
+++ b/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
@@ -7,6 +7,7 @@ import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.mails.transactional.users.suspicious_login_email import get_suspicious_login_email_data
 from pcapi.core.mails.transactional.users.suspicious_login_email import send_suspicious_login_email
+from pcapi.core.users.factories import UserFactory
 from pcapi.core.users.models import LoginDeviceHistory
 
 
@@ -24,8 +25,10 @@ class SendinblueSuspiciousLoginEmailTest:
     token = "suspicious_login_email_token"
     ACCOUNT_SECURING_LINK = f"https://passcultureapptestauto.page.link/?link=https%3A%2F%2Fwebapp-v2.example.com%2Fsecurisation-compte%3Ftoken%3D{token}"
 
-    def test_should_return_sendinblue_template_data(self):
+    def should_return_sendinblue_template_data(self):
+        user = UserFactory()
         suspicious_email_data = get_suspicious_login_email_data(
+            user,
             self.login_info,
             self.token,
         )
@@ -36,34 +39,62 @@ class SendinblueSuspiciousLoginEmailTest:
             "SOURCE": "iPhone 13",
             "OS": "iOS",
             "LOGIN_DATE": "29/05/2023",
-            "LOGIN_TIME": "17h05",
+            "LOGIN_TIME": "19h05",
             "ACCOUNT_SECURING_LINK": self.ACCOUNT_SECURING_LINK,
         }
 
-    def test_should_send_suspicious_login_email(self):
-        email = "123@test.com"
-        send_suspicious_login_email(email, self.login_info, self.token)
+    def should_send_suspicious_login_email(self):
+        user = UserFactory()
+        send_suspicious_login_email(user, self.login_info, self.token)
 
         assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
-        assert mails_testing.outbox[0].sent_data["To"] == email
+        assert mails_testing.outbox[0].sent_data["To"] == user.email
         assert mails_testing.outbox[0].sent_data["params"] == {
             "LOCATION": "Paris",
             "SOURCE": "iPhone 13",
             "OS": "iOS",
             "LOGIN_DATE": "29/05/2023",
-            "LOGIN_TIME": "17h05",
+            "LOGIN_TIME": "19h05",
             "ACCOUNT_SECURING_LINK": self.ACCOUNT_SECURING_LINK,
         }
 
-    @freeze_time("2023-05-29 17:05:00")
-    def test_should_send_suspicious_login_email_with_date_when_no_login_info(self):
-        email = "123@test.com"
-        send_suspicious_login_email(email, login_info=None, token=self.token)
+    @freeze_time("2023-06-08 14:10:00")
+    def should_send_suspicious_login_email_with_date_when_no_login_info(self):
+        user = UserFactory()
+        send_suspicious_login_email(user, login_info=None, token=self.token)
 
         assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
-        assert mails_testing.outbox[0].sent_data["To"] == email
+        assert mails_testing.outbox[0].sent_data["To"] == user.email
         assert mails_testing.outbox[0].sent_data["params"] == {
+            "LOGIN_DATE": "08/06/2023",
+            "LOGIN_TIME": "16h10",
+            "ACCOUNT_SECURING_LINK": self.ACCOUNT_SECURING_LINK,
+        }
+
+    def should_send_suspicious_login_email_for_user_living_in_domtom(self):
+        user = UserFactory(departementCode="987")
+        send_suspicious_login_email(user, self.login_info, self.token)
+
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
+        assert mails_testing.outbox[0].sent_data["To"] == user.email
+        assert mails_testing.outbox[0].sent_data["params"] == {
+            "LOCATION": "Paris",
+            "SOURCE": "iPhone 13",
+            "OS": "iOS",
             "LOGIN_DATE": "29/05/2023",
-            "LOGIN_TIME": "17h05",
+            "LOGIN_TIME": "07h05",
+            "ACCOUNT_SECURING_LINK": self.ACCOUNT_SECURING_LINK,
+        }
+
+    @freeze_time("2023-06-08 3:15:00")
+    def should_send_suspicious_login_email_for_user_living_in_domtom_with_date_when_no_login_info(self):
+        user = UserFactory(departementCode="972")
+        send_suspicious_login_email(user, login_info=None, token=self.token)
+
+        assert mails_testing.outbox[0].sent_data["template"] == TransactionalEmail.SUSPICIOUS_LOGIN.value.__dict__
+        assert mails_testing.outbox[0].sent_data["To"] == user.email
+        assert mails_testing.outbox[0].sent_data["params"] == {
+            "LOGIN_DATE": "07/06/2023",
+            "LOGIN_TIME": "23h15",
             "ACCOUNT_SECURING_LINK": self.ACCOUNT_SECURING_LINK,
         }


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21665

## But de la pull request

Utiliser le bon fuseau horaire dans l'email envoyé à l'utilisateur pour le notifier d'une connexion suspicieuse.

## Implémentation

## Informations supplémentaires

Correction du typage de la fonction `utc_datetime_to_department_timezone` :
- La sous-fonction qui utilise la variable `departement_code` permet de gérer le cas où elle vaut `None`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
