### PR TITLE
(BSR)[BO] fix: avoir crash in venue page when DMS in unavailable

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -11,6 +11,7 @@ from flask_login import current_user
 import gql.transport.exceptions as gql_exceptions
 from markupsafe import Markup
 import sqlalchemy as sa
+import urllib3.exceptions
 from werkzeug.exceptions import NotFound
 
 from pcapi import settings
@@ -127,7 +128,7 @@ def get_dms_stats(dms_application_id: int | None) -> serialization.VenueDmsStats
 
     try:
         dms_stats = DMSGraphQLClient().get_bank_info_status(dms_application_id)
-    except (gql_exceptions.TransportError, gql_exceptions.TransportQueryError):
+    except (gql_exceptions.TransportError, gql_exceptions.TransportQueryError, urllib3.exceptions.HTTPError):
         return None
 
     return serialization.VenueDmsStats(


### PR DESCRIPTION
## But de la pull request

Éviter de casser la page de détails d'un lieu du backoffice lorsque l'API DMS est en maintenance.
Erreur Sentry : https://sentry.passculture.team/organizations/sentry/issues/418168/

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
