### PR TITLE
(PC-22650)[BO] Add script to fill eligibility of fraud reviews

### DIFF
--- a/api/src/pcapi/scripts/fill_fraud_review_eligibility_type.py
+++ b/api/src/pcapi/scripts/fill_fraud_review_eligibility_type.py
@@ -1,0 +1,93 @@
+import argparse
+from datetime import timedelta
+
+from sqlalchemy import extract
+from sqlalchemy import func
+
+from pcapi.core.finance import models as finance_models
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.users import models as users_models
+from pcapi.flask_app import app
+from pcapi.models import db
+
+
+def get_log_message(
+    fraud_review: fraud_models.BeneficiaryFraudReview, eligibility: users_models.EligibilityType
+) -> str:
+    return f"Review from {fraud_review.author.full_name} on {fraud_review.user.full_name} ID: {fraud_review.userId} ({fraud_review.dateReviewed}) -> Expected eligibility: {eligibility}"
+
+
+def add_eligibility_to_reviews_based_on_deposit(do_update: bool) -> None:
+    # Search for deposits that was created less than one minute after fraud review
+    query = (
+        fraud_models.BeneficiaryFraudReview.query.filter_by(eligibilityType=None)
+        .join(
+            finance_models.Deposit,
+            fraud_models.BeneficiaryFraudReview.userId == finance_models.Deposit.userId,
+        )
+        .filter(finance_models.Deposit.dateCreated >= fraud_models.BeneficiaryFraudReview.dateReviewed)
+        .filter(
+            finance_models.Deposit.dateCreated < fraud_models.BeneficiaryFraudReview.dateReviewed + timedelta(minutes=1)
+        )
+        .with_entities(fraud_models.BeneficiaryFraudReview, finance_models.Deposit.type)
+    )
+
+    fraud_reviews_to_update = []
+
+    for fraud_review, deposit_type in query:
+        eligibility = (
+            users_models.EligibilityType.AGE18
+            if deposit_type == finance_models.DepositType.GRANT_18
+            else users_models.EligibilityType.UNDERAGE
+        )
+        fraud_reviews_to_update.append(
+            {
+                "id": fraud_review.id,
+                "eligibilityType": eligibility,
+            }
+        )
+        print(get_log_message(fraud_review, eligibility))
+
+    if do_update:
+        db.session.bulk_update_mappings(fraud_models.BeneficiaryFraudReview, fraud_reviews_to_update)
+        db.session.commit()
+
+
+def add_eligibility_to_reviews_based_on_beneficiary_age(do_update: bool) -> None:
+    base_query = fraud_models.BeneficiaryFraudReview.query.filter_by(eligibilityType=None).join(
+        users_models.User, fraud_models.BeneficiaryFraudReview.userId == users_models.User.id
+    )
+    reviews_on_adult_beneficiaries_query = base_query.filter(
+        extract("years", func.age(fraud_models.BeneficiaryFraudReview.dateReviewed, users_models.User.dateOfBirth))
+        >= 18
+    )
+    reviews_on_underage_beneficiaries_query = base_query.filter(
+        extract("years", func.age(fraud_models.BeneficiaryFraudReview.dateReviewed, users_models.User.dateOfBirth)) < 18
+    )
+
+    fraud_reviews_to_update = []
+
+    for fraud_review in reviews_on_adult_beneficiaries_query:
+        fraud_reviews_to_update.append({"id": fraud_review.id, "eligibilityType": users_models.EligibilityType.AGE18})
+        print(get_log_message(fraud_review, users_models.EligibilityType.AGE18))
+
+    for fraud_review in reviews_on_underage_beneficiaries_query:
+        fraud_reviews_to_update.append(
+            {"id": fraud_review.id, "eligibilityType": users_models.EligibilityType.UNDERAGE}
+        )
+        print(get_log_message(fraud_review, users_models.EligibilityType.UNDERAGE))
+
+    if do_update:
+        db.session.bulk_update_mappings(fraud_models.BeneficiaryFraudReview, fraud_reviews_to_update)
+        db.session.commit()
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser(description="Fix pro roles in User table")
+    parser.add_argument("--not-dry", action="store_true", help="set to really process (dry-run by default)")
+    args = parser.parse_args()
+
+    add_eligibility_to_reviews_based_on_deposit(do_update=args.not_dry)
+    add_eligibility_to_reviews_based_on_beneficiary_age(do_update=args.not_dry)

--- a/api/tests/scripts/fill_fraud_review_eligibility_type_test.py
+++ b/api/tests/scripts/fill_fraud_review_eligibility_type_test.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from datetime import timedelta
+
+from dateutil.relativedelta import relativedelta
+import pytest
+
+from pcapi.core.finance.enum import DepositType
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.factories import BeneficiaryFraudReviewFactory
+from pcapi.core.users import models as users_models
+from pcapi.core.users.factories import DepositGrantFactory
+from pcapi.core.users.factories import UserFactory
+from pcapi.scripts.fill_fraud_review_eligibility_type import add_eligibility_to_reviews_based_on_beneficiary_age
+from pcapi.scripts.fill_fraud_review_eligibility_type import add_eligibility_to_reviews_based_on_deposit
+
+
+@pytest.mark.usefixtures("db_session")
+class FillFraudReviewEligibilityTypeTest:
+    @pytest.mark.parametrize(
+        "deposit_type",
+        [DepositType.GRANT_18, DepositType.GRANT_15_17],
+    )
+    def test_add_eligibility_to_reviews_based_on_deposit(self, deposit_type: DepositType) -> None:
+        beneficiary = UserFactory()
+        BeneficiaryFraudReviewFactory(user=beneficiary, eligibilityType=None)
+        DepositGrantFactory(user=beneficiary, type=deposit_type)
+
+        add_eligibility_to_reviews_based_on_deposit(do_update=True)
+
+        fraud_review: fraud_models.BeneficiaryFraudReview = fraud_models.BeneficiaryFraudReview.query.first()
+
+        assert (
+            fraud_review.eligibilityType == users_models.EligibilityType.AGE18
+            if deposit_type == DepositType.GRANT_18
+            else users_models.EligibilityType.UNDERAGE
+        )
+
+    @pytest.mark.parametrize(
+        "deposit_creation_date",
+        [datetime.utcnow() + timedelta(minutes=30), datetime.utcnow() - timedelta(minutes=1)],
+    )
+    def test_not_add_eligibility_to_reviews_based_on_deposit(self, deposit_creation_date: datetime) -> None:
+        beneficiary = UserFactory()
+        BeneficiaryFraudReviewFactory(user=beneficiary, eligibilityType=None)
+        DepositGrantFactory(user=beneficiary, dateCreated=deposit_creation_date)
+
+        add_eligibility_to_reviews_based_on_deposit(do_update=True)
+
+        fraud_review: fraud_models.BeneficiaryFraudReview = fraud_models.BeneficiaryFraudReview.query.first()
+
+        assert fraud_review.eligibilityType is None
+
+    @pytest.mark.parametrize(
+        "beneficiary_age",
+        [19, 18, 17, 16, 15],
+    )
+    def test_add_eligibility_to_reviews_based_on_beneficiary(self, beneficiary_age: int) -> None:
+        beneficiary = UserFactory(dateOfBirth=(datetime.utcnow() - relativedelta(years=beneficiary_age)).date())
+        BeneficiaryFraudReviewFactory(user=beneficiary, eligibilityType=None)
+
+        add_eligibility_to_reviews_based_on_beneficiary_age(do_update=True)
+
+        fraud_review: fraud_models.BeneficiaryFraudReview = fraud_models.BeneficiaryFraudReview.query.first()
+        expected_eligibility = (
+            users_models.EligibilityType.AGE18 if beneficiary_age >= 18 else users_models.EligibilityType.UNDERAGE
+        )
+
+        assert fraud_review.eligibilityType == expected_eligibility


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22650

## But de la pull request

Créer un script pour remplir la nouvelle colonne `eligibilityType`  du modèle `BeneficiaryFraudReview` (spécifique aux anciennes revues manuelles ayant le champ à `None`).

## Informations supplémentaires

- Premier cas : les revues ont engendré dans la minute la création d'un crédit (`Deposit`) pour le jeune (récupération du type de crédit pour déduire l'éligibilité de la revue)
- Deuxième cas : à la date de la revue, le jeune avait moins de 18 ans -> éligibilité 15-17; sinon éligibilité 18 renseignée
- Création de tests

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
