### PR TITLE
(PC-22735)[PRO] fix: select filter exceeds the iframe

### DIFF
--- a/pro/src/pages/AdageIframe/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss
+++ b/pro/src/pages/AdageIframe/app/ui-kit/MultiSelectAutoComplete/MultiSelectAutocomplete.scss
@@ -43,7 +43,6 @@
   .multi-select-autocomplete__menu {
     margin: 0;
     width: rem.torem(256px);
-    right: 0;
     font-size: rem.torem(15px);
     box-shadow: 0 rem.torem(2px) rem.torem(16px) rgb(37 2 108 / 15%);
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22735

## But de la pull request

Faire commencer la div des options du select au même endroit que le select

Avant : 

<img width="472" alt="Capture d’écran 2023-06-09 à 15 25 13" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/581107b8-5a8a-45fd-8182-3dfc488101d4">

Après : 

<img width="472" alt="Capture d’écran 2023-06-09 à 15 24 49" src="https://github.com/pass-culture/pass-culture-main/assets/119043808/1a87aa02-a45c-484d-bf13-da19e278e3f0">