### PR TITLE
(BSR)[API] feat: add commands to handle single applications for retry purposes

### DIFF
--- a/api/src/pcapi/core/subscription/dms/commands.py
+++ b/api/src/pcapi/core/subscription/dms/commands.py
@@ -1,0 +1,26 @@
+import click
+
+import pcapi.connectors.dms.api as dms_connector_api
+import pcapi.core.subscription.api as subscription_api
+import pcapi.core.subscription.dms.api as dms_api
+import pcapi.core.users.models as users_models
+from pcapi.utils.blueprint import Blueprint
+
+
+blueprint = Blueprint(__name__, __name__)
+
+
+@blueprint.cli.command("import_dms_application")
+@click.argument("application_number", type=int, required=True)
+def import_dms_application(application_number: int) -> None:
+    dms_application = dms_connector_api.DMSGraphQLClient().get_single_application_details(application_number)
+    dms_api.handle_dms_application(dms_application)
+
+
+@blueprint.cli.command("activate_user")
+@click.argument("user_id", type=int, required=True)
+def activate_user(user_id: int) -> None:
+    user = users_models.User.query.get(user_id)
+    if user is None:
+        raise ValueError(f"User {user_id} not found")
+    subscription_api.activate_beneficiary_if_no_missing_step(user)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-XXXXX

## But de la pull request

Ajouter des commandes pour activer un utilisateur et pour importer son dossier DMS
Le but est de simplifier la gestion manuelle de cas limites et a terme de rendre le support plus autonome pour ces cas

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
