### PR TITLE
(PC-22026)[API] feat: send mail to inactive offerers

### DIFF
--- a/api/src/pcapi/core/mails/transactional/__init__.py
+++ b/api/src/pcapi/core/mails/transactional/__init__.py
@@ -46,6 +46,7 @@ from .pro.reset_password_to_pro import send_reset_password_email_to_connected_pr
 from .pro.reset_password_to_pro import send_reset_password_email_to_pro
 from .pro.venue_provider_deleted import send_venue_provider_deleted_email
 from .pro.venue_provider_disabled import send_venue_provider_disabled_email
+from .pro.wake_up_after_inactivity_to_pro import send_wake_up_after_inactivity_to_pros
 from .pro.welcome_to_pro import send_welcome_to_pro_email
 from .send_transactional_email import send_transactional_email
 from .users.accepted_as_beneficiary import send_accepted_as_beneficiary_email

--- a/api/src/pcapi/core/mails/transactional/pro/wake_up_after_inactivity_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/wake_up_after_inactivity_to_pro.py
@@ -1,0 +1,46 @@
+import datetime
+
+from pcapi.core import mails
+from pcapi.core.mails import models
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+import pcapi.core.users.repository as users_repository
+
+
+def send_wake_up_after_inactivity_to_pros() -> None:
+    fourty_days_ago = datetime.date.today() - datetime.timedelta(days=40)
+
+    email_data_tuples = users_repository.get_emails_without_active_offers(fourty_days_ago)
+    mail_params_by_email = _aggregate_duplicate_mails(email_data_tuples)
+    recipients_by_param_tuple = _group_by_mail_params(mail_params_by_email)
+
+    for (can_last_offer_expire, is_last_offer_event), recipients in recipients_by_param_tuple.items():
+        mails.send(
+            recipients=recipients,
+            data=models.TransactionalEmailData(
+                template=TransactionalEmail.WAKE_UP_AFTER_INACTIVITY.value,
+                params={"CAN_EXPIRE": can_last_offer_expire, "IS_EVENT": is_last_offer_event},
+            ),
+        )
+
+
+def _aggregate_duplicate_mails(email_data_tuples: list[tuple[str, bool, bool]]) -> dict[str, dict[str, bool]]:
+    mail_params_by_email = {}
+    for email, can_last_offer_expire, is_last_offer_event in email_data_tuples:
+        if email not in mail_params_by_email:
+            mail_params_by_email[email] = {"CAN_EXPIRE": False, "IS_EVENT": False}
+        mail_params = mail_params_by_email[email]
+        mail_params_by_email[email] = {
+            "CAN_EXPIRE": mail_params["CAN_EXPIRE"] or can_last_offer_expire,
+            "IS_EVENT": mail_params["IS_EVENT"] or is_last_offer_event,
+        }
+    return mail_params_by_email
+
+
+def _group_by_mail_params(mail_params_by_email: dict[str, dict[str, bool]]) -> dict[tuple[bool, bool], list[str]]:
+    recipients_by_param_tuple: dict[tuple[bool, bool], list[str]] = {}
+    for email, mail_params in mail_params_by_email.items():
+        param_tuple = (mail_params["CAN_EXPIRE"], mail_params["IS_EVENT"])
+        if param_tuple not in recipients_by_param_tuple:
+            recipients_by_param_tuple[param_tuple] = []
+        recipients_by_param_tuple[param_tuple].append(email)
+    return recipients_by_param_tuple

--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -162,3 +162,4 @@ class TransactionalEmail(Enum):
     VENUE_NEEDS_PICTURE = models.TemplatePro(id_prod=782, id_not_prod=113, tags=["pro_lieu_permanent"])
     VENUE_SYNC_DISABLED = models.TemplatePro(id_prod=883, id_not_prod=122, tags=["pro_pause_synchro"])
     VENUE_SYNC_DELETED = models.TemplatePro(id_prod=865, id_not_prod=123, tags=["pro_suppression_synchro"])
+    WAKE_UP_AFTER_INACTIVITY = models.TemplatePro(id_prod=932, id_not_prod=131, tags=["pro_inactivite"])

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -153,8 +153,8 @@ def get_emails_without_active_offers(since_date: date) -> list[tuple[str, bool, 
     Returns emails whose last active offer expired since_date.
     The additional tuple fields are the properties of the last active offer needed for pro reminder mails.
     """
-    offer_id_query = repository.db.session.query(offers_models.Stock.offerId.distinct()).filter(
-        sa.cast(offers_models.Stock.dateModified, sa.Date) == since_date
+    offer_id_query = repository.db.session.query(offers_models.Offer.id).filter(
+        offers_models.Offer.isReleased.is_(True), sa.cast(offers_models.Stock.dateModified, sa.Date) == since_date
     )
     offer_ids = [offer_id for offer_id, in offer_id_query]
 

--- a/api/src/pcapi/scheduled_tasks/commands.py
+++ b/api/src/pcapi/scheduled_tasks/commands.py
@@ -424,3 +424,9 @@ def _send_notification_favorites_not_booked() -> None:
         except Exception:  # pylint: disable=broad-except
             log_extra = {"offer": row.offer_id, "users": row.user_ids, "count": len(row.user_ids)}
             logger.error("Favorites not booked: failed to send notification", extra=log_extra)
+
+
+@blueprint.cli.command("send_wake_up_mail_after_last_active_offer")
+@log_cron_with_transaction
+def send_wake_up_mail_after_last_active_offer() -> None:
+    transactional_mails.send_wake_up_after_inactivity_to_pros()

--- a/api/tests/core/mails/transactional/pro/wake_up_after_inactivity_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/wake_up_after_inactivity_to_pro_test.py
@@ -1,0 +1,33 @@
+import datetime
+
+import pytest
+
+from pcapi.core.mails import testing as mails_testing
+from pcapi.core.mails.transactional.pro.wake_up_after_inactivity_to_pro import send_wake_up_after_inactivity_to_pros
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
+from pcapi.repository.repository import db
+
+
+@pytest.mark.usefixtures("db_session")
+class SendWakeUpEmailToOffererTest:
+    fourty_days_ago = datetime.date.today() - datetime.timedelta(days=40)
+
+    def test_send_send_mail_with_params_aggregated(self):
+        user_offerer = offerers_factories.UserOffererFactory()
+
+        expired_event_offer = offers_factories.EventOfferFactory(venue__managingOfferer=user_offerer.offerer)
+        expired_event_stock = offers_factories.EventStockFactory(offer=expired_event_offer, quantity=0)
+        expired_event_stock.dateModified = self.fourty_days_ago
+
+        expired_product_offer = offers_factories.ThingOfferFactory(venue__managingOfferer=user_offerer.offerer)
+        expired_product_stock = offers_factories.ThingStockFactory(offer=expired_product_offer, quantity=0)
+        expired_product_stock.dateModified = self.fourty_days_ago
+
+        db.session.add_all([expired_event_stock, expired_product_stock])
+
+        send_wake_up_after_inactivity_to_pros()
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0].sent_data["To"] == user_offerer.user.email
+        assert mails_testing.outbox[0].sent_data["params"] == {"CAN_EXPIRE": True, "IS_EVENT": True}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22026

## But de la pull request

Ajout des mails des pros qui n'ont pas d'offres actives depuis 40 jours dans une liste Brevo.

## Implémentation

Le coeur du calcul est réalisé par l'équipe Data : https://github.com/pass-culture/data-gcp/pull/1675

On récupère leur résultat à travers Big Query