### PR TITLE
(BSR)[API] perf: Avoid extra HTTP request that fetches GraphQL schema

### DIFF
--- a/api/src/pcapi/connectors/dms/api.py
+++ b/api/src/pcapi/connectors/dms/api.py
@@ -37,7 +37,7 @@ class DMSGraphQLClient:
             headers={"Authorization": f"Bearer {settings.DMS_TOKEN}"},
             retries=3,
         )
-        self.client = gql.Client(transport=transport, fetch_schema_from_transport=not settings.IS_RUNNING_TESTS)
+        self.client = gql.Client(transport=transport)
 
     def build_query(self, query_name: str) -> str:
         return (GRAPHQL_DIRECTORY / f"{query_name}.graphql").read_text()


### PR DESCRIPTION
Fetching the schema is only useful to:

- validate our request on the client side [1]: We don't catch
  client-side validation errors, just like we don't catch server-side
  ones. Thus, validating client side is not useful to us.

- handle custom scalars and enums [2]: DMS GraphQL API does not use
  them.

We can thus avoid fetching the schema, which saves an HTTP
request (that takes between 300 and 600 ms) for each call to the
GraphQL API (since we do not reuse the GraphQL client, and the schema
was not cached).

[1] https://gql.readthedocs.io/en/stable/usage/validation.html
[2] https://gql.readthedocs.io/en/stable/usage/custom_scalars_and_enums.html