### PR TITLE
(PC-22700)[BO] Split fraud actions into beneficiary/pro fraud actions…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-17adb47d509c (pre) (head)
+893524dbab24 (pre) (head)
 ad2884071862 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230612T140537_893524dbab24_rename_fraud_actions_permission.py
+++ b/api/src/pcapi/alembic/versions/20230612T140537_893524dbab24_rename_fraud_actions_permission.py
@@ -1,0 +1,19 @@
+"""Rename 'FRAUD_ACTIONS' to 'PRO_FRAUD_ACTIONS'
+"""
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "893524dbab24"
+down_revision = "17adb47d509c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE permission SET name = 'PRO_FRAUD_ACTIONS' WHERE name = 'FRAUD_ACTIONS'")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE permission SET name = 'FRAUD_ACTIONS' WHERE name = 'PRO_FRAUD_ACTIONS'")

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -23,7 +23,8 @@ class Permissions(enum.Enum):
     MANAGE_ADMIN_ACCOUNTS = "gérer les comptes admin"
     FEATURE_FLIPPING = "activer/désactiver les feature flags"
 
-    FRAUD_ACTIONS = "actions exclusives à l'équipe Fraude et Conformité"
+    PRO_FRAUD_ACTIONS = "actions exclusives à l'équipe Fraude et Conformité (PRO)"
+    BENEFICIARY_FRAUD_ACTIONS = "actions exclusives à l'équipe Fraude et Conformité (jeune)"
 
     READ_PUBLIC_ACCOUNT = "visualiser un compte bénéficiaire/grand public"
     MANAGE_PUBLIC_ACCOUNT = "gérer un compte bénéficiaire/grand public"

--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -883,7 +883,7 @@ def send_validation_code(user_id: int) -> utils.BackofficeResponse:
 
 
 @public_accounts_blueprint.route("/<int:user_id>/review", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT)
+@utils.permission_required(perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS)
 def review_public_account(user_id: int) -> utils.BackofficeResponse:
     user = users_models.User.query.get_or_404(user_id)
 

--- a/api/src/pcapi/routes/backoffice_v3/collective_offer_templates.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offer_templates.py
@@ -135,7 +135,7 @@ def list_collective_offer_templates() -> utils.BackofficeResponse:
 
 
 @list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/validate", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_validate_collective_offer_template_form(collective_offer_template_id: int) -> utils.BackofficeResponse:
     collective_offer_template = educational_models.CollectiveOfferTemplate.query.get_or_404(
         collective_offer_template_id
@@ -157,7 +157,7 @@ def get_validate_collective_offer_template_form(collective_offer_template_id: in
 
 
 @list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/validate", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def validate_collective_offer_template(collective_offer_template_id: int) -> utils.BackofficeResponse:
     _batch_validate_or_reject_collective_offer_templates(OfferValidationStatus.APPROVED, [collective_offer_template_id])
     return redirect(
@@ -167,7 +167,7 @@ def validate_collective_offer_template(collective_offer_template_id: int) -> uti
 
 
 @list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/reject", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_reject_collective_offer_template_form(collective_offer_template_id: int) -> utils.BackofficeResponse:
     collective_offer_template = educational_models.CollectiveOfferTemplate.query.get_or_404(
         collective_offer_template_id
@@ -189,7 +189,7 @@ def get_reject_collective_offer_template_form(collective_offer_template_id: int)
 
 
 @list_collective_offer_templates_blueprint.route("/<int:collective_offer_template_id>/reject", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def reject_collective_offer_template(collective_offer_template_id: int) -> utils.BackofficeResponse:
     _batch_validate_or_reject_collective_offer_templates(OfferValidationStatus.REJECTED, [collective_offer_template_id])
     return redirect(
@@ -273,7 +273,7 @@ def _batch_validate_or_reject_collective_offer_templates(
 
 
 @list_collective_offer_templates_blueprint.route("/batch/validate", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_batch_validate_collective_offer_templates_form() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     return render_template(
@@ -287,7 +287,7 @@ def get_batch_validate_collective_offer_templates_form() -> utils.BackofficeResp
 
 
 @list_collective_offer_templates_blueprint.route("/batch/reject", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_batch_reject_collective_offer_templates_form() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     return render_template(
@@ -301,7 +301,7 @@ def get_batch_reject_collective_offer_templates_form() -> utils.BackofficeRespon
 
 
 @list_collective_offer_templates_blueprint.route("/batch/validate", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def batch_validate_collective_offer_templates() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
 
@@ -319,7 +319,7 @@ def batch_validate_collective_offer_templates() -> utils.BackofficeResponse:
 
 
 @list_collective_offer_templates_blueprint.route("/batch/reject", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def batch_reject_collective_offer_templates() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
 

--- a/api/src/pcapi/routes/backoffice_v3/collective_offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/collective_offers.py
@@ -140,7 +140,7 @@ def list_collective_offers() -> utils.BackofficeResponse:
 
 
 @list_collective_offers_blueprint.route("/<int:collective_offer_id>/validate", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_validate_collective_offer_form(collective_offer_id: int) -> utils.BackofficeResponse:
     collective_offer = educational_models.CollectiveOffer.query.get_or_404(collective_offer_id)
 
@@ -159,7 +159,7 @@ def get_validate_collective_offer_form(collective_offer_id: int) -> utils.Backof
 
 
 @list_collective_offers_blueprint.route("/<int:collective_offer_id>/validate", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def validate_collective_offer(collective_offer_id: int) -> utils.BackofficeResponse:
     _batch_validate_or_reject_collective_offers(OfferValidationStatus.APPROVED, [collective_offer_id])
     return redirect(request.referrer or url_for("backoffice_v3_web.collective_offer.list_collective_offers"), 303)
@@ -243,7 +243,7 @@ def _batch_validate_or_reject_collective_offers(
 
 
 @list_collective_offers_blueprint.route("/<int:collective_offer_id>/reject", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_reject_collective_offer_form(collective_offer_id: int) -> utils.BackofficeResponse:
     collective_offer = educational_models.CollectiveOffer.query.get_or_404(collective_offer_id)
 
@@ -262,14 +262,14 @@ def get_reject_collective_offer_form(collective_offer_id: int) -> utils.Backoffi
 
 
 @list_collective_offers_blueprint.route("/<int:collective_offer_id>/reject", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def reject_collective_offer(collective_offer_id: int) -> utils.BackofficeResponse:
     _batch_validate_or_reject_collective_offers(OfferValidationStatus.REJECTED, [collective_offer_id])
     return redirect(request.referrer or url_for("backoffice_v3_web.collective_offer.list_collective_offers"), 303)
 
 
 @list_collective_offers_blueprint.route("/batch/validate", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_batch_validate_collective_offers_form() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     return render_template(
@@ -283,7 +283,7 @@ def get_batch_validate_collective_offers_form() -> utils.BackofficeResponse:
 
 
 @list_collective_offers_blueprint.route("/batch/reject", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_batch_reject_collective_offers_form() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     return render_template(
@@ -297,7 +297,7 @@ def get_batch_reject_collective_offers_form() -> utils.BackofficeResponse:
 
 
 @list_collective_offers_blueprint.route("/batch/validate", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def batch_validate_collective_offers() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
 
@@ -310,7 +310,7 @@ def batch_validate_collective_offers() -> utils.BackofficeResponse:
 
 
 @list_collective_offers_blueprint.route("/batch/reject", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def batch_reject_collective_offers() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
 

--- a/api/src/pcapi/routes/backoffice_v3/fraud.py
+++ b/api/src/pcapi/routes/backoffice_v3/fraud.py
@@ -27,7 +27,7 @@ fraud_blueprint = utils.child_backoffice_blueprint(
     "fraud",
     __name__,
     url_prefix="/fraud",
-    permission=perm_models.Permissions.FRAUD_ACTIONS,
+    permission=perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
 )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/home.py
+++ b/api/src/pcapi/routes/backoffice_v3/home.py
@@ -65,7 +65,7 @@ def home() -> utils.BackofficeResponse:
 
     data = {}
 
-    if utils.has_current_user_permission(perm_models.Permissions.FRAUD_ACTIONS):
+    if utils.has_current_user_permission(perm_models.Permissions.PRO_FRAUD_ACTIONS):
         data.update(_get_pending_offers_stats())
 
     return render_template("home/home.html", **data)

--- a/api/src/pcapi/routes/backoffice_v3/multiple_offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/multiple_offers/blueprint.py
@@ -131,7 +131,7 @@ def add_criteria_to_offers() -> utils.BackofficeResponse:
 
 
 @multiple_offers_blueprint.route("/set-product-gcu-incompatible", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def set_product_gcu_incompatible() -> utils.BackofficeResponse:
     form = forms.HiddenEanForm()
 

--- a/api/src/pcapi/routes/backoffice_v3/offer_validation_rules/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offer_validation_rules/blueprint.py
@@ -15,7 +15,7 @@ offer_validation_rules_blueprint = utils.child_backoffice_blueprint(
     "offer_validation_rules",
     __name__,
     url_prefix="/offer-validation-rules",
-    permission=perm_models.Permissions.FRAUD_ACTIONS,
+    permission=perm_models.Permissions.PRO_FRAUD_ACTIONS,
 )
 
 

--- a/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
@@ -135,7 +135,7 @@ def get_stats(offerer_id: int) -> utils.BackofficeResponse:
 
 
 @offerer_blueprint.route("/suspend", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def suspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
     offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
     form = offerer_forms.SuspendOffererForm()
@@ -154,7 +154,7 @@ def suspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
 
 
 @offerer_blueprint.route("/unsuspend", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def unsuspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
     offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
     form = offerer_forms.SuspendOffererForm()

--- a/api/src/pcapi/routes/backoffice_v3/offers.py
+++ b/api/src/pcapi/routes/backoffice_v3/offers.py
@@ -239,7 +239,7 @@ def get_edit_offer_form(offer_id: int) -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/batch/validate", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_batch_validate_offers_form() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     return render_template(
@@ -253,7 +253,7 @@ def get_batch_validate_offers_form() -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/batch-validate", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def batch_validate_offers() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     if not form.validate():
@@ -266,7 +266,7 @@ def batch_validate_offers() -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/batch/reject", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_batch_reject_offers_form() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     return render_template(
@@ -280,7 +280,7 @@ def get_batch_reject_offers_form() -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/batch-reject", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def batch_reject_offers() -> utils.BackofficeResponse:
     form = empty_forms.BatchForm()
     if not form.validate():
@@ -386,7 +386,7 @@ def edit_offer(offer_id: int) -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/<int:offer_id>/validate", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_validate_offer_form(offer_id: int) -> utils.BackofficeResponse:
     offer = offers_models.Offer.query.filter_by(id=offer_id).one_or_none()
 
@@ -406,7 +406,7 @@ def get_validate_offer_form(offer_id: int) -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/<int:offer_id>/validate", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def validate_offer(offer_id: int) -> utils.BackofficeResponse:
     _batch_validate_offers([offer_id])
     flash("L'offre a été validée avec succès", "success")
@@ -414,7 +414,7 @@ def validate_offer(offer_id: int) -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/<int:offer_id>/reject", methods=["GET"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def get_reject_offer_form(offer_id: int) -> utils.BackofficeResponse:
     offer = offers_models.Offer.query.filter_by(id=offer_id).one_or_none()
 
@@ -434,7 +434,7 @@ def get_reject_offer_form(offer_id: int) -> utils.BackofficeResponse:
 
 
 @list_offers_blueprint.route("/<int:offer_id>/reject", methods=["POST"])
-@utils.permission_required(perm_models.Permissions.FRAUD_ACTIONS)
+@utils.permission_required(perm_models.Permissions.PRO_FRAUD_ACTIONS)
 def reject_offer(offer_id: int) -> utils.BackofficeResponse:
     _batch_reject_offers([offer_id])
     flash("L'offre a été rejetée avec succès", "success")

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/list.html
@@ -74,7 +74,7 @@
                          data-id="{{ collective_offer.id }}" />
                 </td>
                 <td>
-                  {% if has_permission("FRAUD_ACTIONS") %}
+                  {% if has_permission("PRO_FRAUD_ACTIONS") %}
                     <div class="dropdown">
                       <button type="button"
                               data-bs-toggle="dropdown"

--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer_template/list.html
@@ -73,7 +73,7 @@
                          data-id="{{ collective_offer_template.id }}" />
                 </td>
                 <td>
-                  {% if has_permission("FRAUD_ACTIONS") %}
+                  {% if has_permission("PRO_FRAUD_ACTIONS") %}
                     <div class="dropdown">
                       <button type="button"
                               data-bs-toggle="dropdown"

--- a/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/home/home.html
@@ -29,7 +29,7 @@
 {% block page %}
   <div class="py-4 px-5">
     <h1 class="text-muted mt-5">Bonjour {{ current_user.firstName | empty_string_if_null }} !</h1>
-    {% if has_permission("FRAUD_ACTIONS") %}
+    {% if has_permission("PRO_FRAUD_ACTIONS") %}
       <div class="row row-cols-4 g-3 py-4">
         {{ stats_card(
         pending_individual_offers_count,

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/connected.html
@@ -88,7 +88,7 @@
                   {% if has_permission("MULTIPLE_OFFERS_ACTIONS") %}
                     {{ menu_section_item("Opérations sur plusieurs offres", "backoffice_v3_web.multiple_offers.multiple_offers_home") }}
                   {% endif %}
-                  {% if has_permission("FRAUD_ACTIONS") %}
+                  {% if has_permission("PRO_FRAUD_ACTIONS") %}
                     {{ menu_section_item("Recherche EAN via Tite Live", "backoffice_v3_web.titelive.search_titelive") }}
                   {% endif %}
                   {% if has_permission("MANAGE_OFFERS_AND_VENUES_TAGS") %}
@@ -124,11 +124,15 @@
                 </div>
                 <hr />
               {% endif %}
-              {% if has_permission("FRAUD_ACTIONS") %}
+              {% if has_permission("PRO_FRAUD_ACTIONS") or has_permission("BENEFICIARY_FRAUD_ACTIONS") %}
                 <div class="nav nav-pills flex-column">
                   {% call menu_section("Fraude et conformité") %}
-                    {{ menu_section_item("Règles de validation d'offres", "backoffice_v3_web.offer_validation_rules.list_rules") }}
-                    {{ menu_section_item("Suspension de comptes jeunes", "backoffice_v3_web.fraud.list_blacklisted_domain_names") }}
+                    {% if has_permission("PRO_FRAUD_ACTIONS") %}
+                      {{ menu_section_item("Règles de validation d'offres", "backoffice_v3_web.offer_validation_rules.list_rules") }}
+                    {% endif %}
+                    {% if has_permission("BENEFICIARY_FRAUD_ACTIONS") %}
+                      {{ menu_section_item("Suspension de comptes jeunes", "backoffice_v3_web.fraud.list_blacklisted_domain_names") }}
+                    {% endif %}
                   {% endcall %}
                 </div>
                 <hr />

--- a/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/multiple_offers/search_result.html
@@ -61,7 +61,7 @@
               <p>
                 <b>EAN-13 :</b> {{ ean }}
               </p>
-              {% if has_permission("FRAUD_ACTIONS") and (product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0) %}
+              {% if has_permission("PRO_FRAUD_ACTIONS") and (product_compatibility != 'incompatible_products' or approved_active_offers_count + approved_inactive_offers_count + pending_offers_count > 0) %}
                 <div>
                   {{ build_modal_form("set-gcu-incompatible", url_for('.set_product_gcu_incompatible'), incompatibility_form,
                   "Rendre le livre et les offres associées incompatibles avec les CGU", "Confirmer",

--- a/api/src/pcapi/routes/backoffice_v3/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offer/list.html
@@ -13,7 +13,7 @@
             {{ rows | length }}{{ "+" if rows | length > 100 else "" }}
             résultat{{ "s" if rows | length > 1 else "" }}
           </p>
-          {% if has_permission("FRAUD_ACTIONS") %}
+          {% if has_permission("PRO_FRAUD_ACTIONS") %}
             <div class="btn-group btn-group-sm"
                  data-toggle="pc-batch-confirm-btn-group"
                  data-toggle-id="table-container-individual-offer-fraud-btn-group"
@@ -107,7 +107,7 @@
                              data-bs-target="#edit-offer-modal-{{ offer.id }}">Modifier</a>
                         </li>
                       {% endif %}
-                      {% if has_permission("FRAUD_ACTIONS") %}
+                      {% if has_permission("PRO_FRAUD_ACTIONS") %}
                         <li class="dropdown-item">
                           <a class="btn btn-sm d-block w-100 text-start px-3"
                              data-bs-toggle="modal"

--- a/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/offerer/get.html
@@ -50,7 +50,7 @@
                   </div>
                 </div>
               {% endif %}
-              {% if has_permission("FRAUD_ACTIONS") %}
+              {% if has_permission("PRO_FRAUD_ACTIONS") %}
                 {% if offerer.isActive %}
                   {{ build_modal_form("suspend", url_for("backoffice_v3_web.offerer.suspend_offerer", offerer_id=offerer.id),
                   suspension_form, "Suspendre la structure", "Confirmer la suspension") }}

--- a/api/src/pcapi/routes/backoffice_v3/titelive/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/titelive/blueprint.py
@@ -22,7 +22,7 @@ titelive_blueprint = utils.child_backoffice_blueprint(
     "titelive",
     __name__,
     url_prefix="/pro/titelive",
-    permission=perm_models.Permissions.FRAUD_ACTIONS,
+    permission=perm_models.Permissions.PRO_FRAUD_ACTIONS,
 )
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -32,7 +32,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.MANAGE_PROVIDERS,
     ],
     "fraude-conformite": [
-        perm_models.Permissions.FRAUD_ACTIONS,
+        perm_models.Permissions.PRO_FRAUD_ACTIONS,
+        perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.SUSPEND_USER,
         perm_models.Permissions.UNSUSPEND_USER,

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -1204,7 +1204,7 @@ class SendValidationCodeTest(PostEndpointHelper):
 class UpdatePublicAccountReviewTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.public_accounts.review_public_account"
     endpoint_kwargs = {"user_id": 1}
-    needed_permission = perm_models.Permissions.MANAGE_PUBLIC_ACCOUNT
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_add_new_fraud_review_to_account(self, authenticated_client, legit_user):
         user = users_factories.UserFactory()

--- a/api/tests/routes/backoffice_v3/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offer_templates_test.py
@@ -235,7 +235,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
 class ValidateCollectiveOfferTemplateTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.validate_collective_offer_template"
     endpoint_kwargs = {"collective_offer_template_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_validate_collective_offer_template(self, legit_user, authenticated_client):
         collective_offer_template_to_validate = educational_factories.CollectiveOfferTemplateFactory(
@@ -302,7 +302,7 @@ class ValidateCollectiveOfferTemplateTest(PostEndpointHelper):
 class ValidateCollectiveOfferTemplateFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.get_validate_collective_offer_template_form"
     endpoint_kwargs = {"collective_offer_template_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_validate_form_test(self, legit_user, authenticated_client):
         collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
@@ -317,7 +317,7 @@ class ValidateCollectiveOfferTemplateFormTest(GetEndpointHelper):
 class RejectCollectiveOfferTemplateTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.reject_collective_offer_template"
     endpoint_kwargs = {"collective_offer_template_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_reject_collective_offer_template(self, legit_user, authenticated_client):
         collective_offer_template_to_reject = educational_factories.CollectiveOfferTemplateFactory(
@@ -384,7 +384,7 @@ class RejectCollectiveOfferTemplateTest(PostEndpointHelper):
 class RejectCollectiveOfferTemplateFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.get_reject_collective_offer_template_form"
     endpoint_kwargs = {"collective_offer_template_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_reject_form_test(self, legit_user, authenticated_client):
         collective_offer_template = educational_factories.CollectiveOfferTemplateFactory()
@@ -398,7 +398,7 @@ class RejectCollectiveOfferTemplateFormTest(GetEndpointHelper):
 
 class BatchCollectiveOfferTemplatesValidateTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.batch_validate_collective_offer_templates"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_batch_validate_collective_offer_templates(self, legit_user, authenticated_client):
         collective_offer_templates = educational_factories.CollectiveOfferTemplateFactory.create_batch(
@@ -452,7 +452,7 @@ class BatchCollectiveOfferTemplatesValidateTest(PostEndpointHelper):
 
 class BatchCollectiveOfferTemplatesRejectTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.batch_reject_collective_offer_templates"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_batch_reject_offers(self, legit_user, authenticated_client):
         collective_offer_templates = educational_factories.CollectiveOfferTemplateFactory.create_batch(
@@ -510,7 +510,7 @@ class BatchCollectiveOfferTemplatesRejectTest(PostEndpointHelper):
 
 class GetBatchCollectiveOfferTemplatesApproveFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.get_batch_validate_collective_offer_templates_form"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_batch_collective_offer_templates_approve_form(self, legit_user, authenticated_client):
         # when
@@ -523,7 +523,7 @@ class GetBatchCollectiveOfferTemplatesApproveFormTest(GetEndpointHelper):
 
 class GetBatchCollectiveOfferTemplatesRejectFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer_template.get_batch_reject_collective_offer_templates_form"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_batch_collective_offer_templates_reject_form(self, legit_user, authenticated_client):
         # when

--- a/api/tests/routes/backoffice_v3/collective_offers_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offers_test.py
@@ -237,7 +237,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
 class ValidateCollectiveOfferTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.validate_collective_offer"
     endpoint_kwargs = {"collective_offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_validate_collective_offer(self, legit_user, authenticated_client):
         collective_offer_to_validate = educational_factories.CollectiveOfferFactory(
@@ -294,7 +294,7 @@ class ValidateCollectiveOfferTest(PostEndpointHelper):
 class ValidateCollectiveOfferFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.get_validate_collective_offer_form"
     endpoint_kwargs = {"collective_offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_validate_form_test(self, legit_user, authenticated_client):
         collective_offer = educational_factories.CollectiveOfferFactory()
@@ -309,7 +309,7 @@ class ValidateCollectiveOfferFormTest(GetEndpointHelper):
 class RejectCollectiveOfferTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.reject_collective_offer"
     endpoint_kwargs = {"collective_offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_reject_collective_offer(self, legit_user, authenticated_client):
         collective_offer_to_reject = educational_factories.CollectiveOfferFactory(
@@ -362,7 +362,7 @@ class RejectCollectiveOfferTest(PostEndpointHelper):
 class RejectCollectiveOfferFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.get_reject_collective_offer_form"
     endpoint_kwargs = {"collective_offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_reject_form_test(self, legit_user, authenticated_client):
         collective_offer = educational_factories.CollectiveOfferFactory()
@@ -376,7 +376,7 @@ class RejectCollectiveOfferFormTest(GetEndpointHelper):
 
 class BatchCollectiveOffersValidateTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.batch_validate_collective_offers"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_batch_validate_collective_offers(self, legit_user, authenticated_client):
         collective_offers = educational_factories.CollectiveOfferFactory.create_batch(
@@ -427,7 +427,7 @@ class BatchCollectiveOffersValidateTest(PostEndpointHelper):
 
 class BatchCollectiveOffersRejectTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.batch_reject_collective_offers"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_batch_reject_offers(self, legit_user, authenticated_client):
         collective_offers = educational_factories.CollectiveOfferFactory.create_batch(
@@ -479,7 +479,7 @@ class BatchCollectiveOffersRejectTest(PostEndpointHelper):
 
 class GetBatchCollectiveOffersApproveFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.get_batch_validate_collective_offers_form"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_batch_collective_offers_approve_form(self, legit_user, authenticated_client):
         # when
@@ -492,7 +492,7 @@ class GetBatchCollectiveOffersApproveFormTest(GetEndpointHelper):
 
 class GetBatchCollectiveOffersRejectFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.collective_offer.get_batch_reject_collective_offers_form"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_batch_collective_offers_reject_form(self, legit_user, authenticated_client):
         # when

--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -32,7 +32,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.DELETE_OFFERER_TAG,
         perm_models.Permissions.MANAGE_OFFERER_TAG,
         perm_models.Permissions.MANAGE_OFFERS_AND_VENUES_TAGS,
-        perm_models.Permissions.FRAUD_ACTIONS,
+        perm_models.Permissions.PRO_FRAUD_ACTIONS,
+        perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
     ],
     "support-N1": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
@@ -56,7 +57,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.MANAGE_PROVIDERS,
     ],
     "fraude-conformite": [
-        perm_models.Permissions.FRAUD_ACTIONS,
+        perm_models.Permissions.PRO_FRAUD_ACTIONS,
+        perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
         perm_models.Permissions.SUSPEND_USER,
         perm_models.Permissions.UNSUSPEND_USER,

--- a/api/tests/routes/backoffice_v3/fraud_test.py
+++ b/api/tests/routes/backoffice_v3/fraud_test.py
@@ -26,7 +26,7 @@ pytestmark = [
 
 class ListBlacklistedDomainNamesTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.list_blacklisted_domain_names"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_list_blacklisted_domain_names(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory(email="user@example.fr")
@@ -59,7 +59,7 @@ class ListBlacklistedDomainNamesTest(GetEndpointHelper):
 
 class PrepareBlacklistDomainNamesTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.prepare_blacklist_domain_name"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_prepare_blacklist_domain_name(self, authenticated_client):
         user = users_factories.BeneficiaryGrant18Factory(email="user@example.fr")
@@ -84,7 +84,7 @@ class PrepareBlacklistDomainNamesTest(GetEndpointHelper):
 class BlacklistDomainNameTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.blacklist_domain_name"
     endpoint_kwargs = {"domain": "example.fr"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_blacklist_domain_name(self, authenticated_client):
         user = bookings_factories.BookingFactory(user__email="user@example.fr").user
@@ -125,7 +125,7 @@ class BlacklistDomainNameTest(PostEndpointHelper):
 class RemoveBlacklistedDomainNameTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.fraud.remove_blacklisted_domain_name"
     endpoint_kwargs = {"domain": "example.fr"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS
 
     def test_remove_blacklisted_domain(self, authenticated_client):
         domain = fraud_factories.BlacklistedDomainNameFactory().domain

--- a/api/tests/routes/backoffice_v3/multiple_offers_test.py
+++ b/api/tests/routes/backoffice_v3/multiple_offers_test.py
@@ -201,7 +201,7 @@ class AddCriteriaToOffersTest(PostEndpointHelper):
 
 
 class SetProductGcuIncompatibleButtonTest(button_helpers.ButtonHelper):
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
     button_label = "Rendre le livre et les offres associées incompatibles avec les CGU"
 
     @property
@@ -213,7 +213,7 @@ class SetProductGcuIncompatibleButtonTest(button_helpers.ButtonHelper):
 class SetProductGcuIncompatibleTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.multiple_offers.set_product_gcu_incompatible"
     endpoint_kwargs = {"ean": "9781234567890"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     @pytest.mark.parametrize(
         "validation_status",

--- a/api/tests/routes/backoffice_v3/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice_v3/offer_validation_rules_test.py
@@ -19,7 +19,7 @@ pytestmark = [
 
 class ListTagsTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.offer_validation_rules.list_rules"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_list_rules(self, authenticated_client):
         rule = offers_factories.OfferValidationRuleFactory(

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -160,7 +160,7 @@ class GetOffererTest(GetEndpointHelper):
 class SuspendOffererTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.offerer.suspend_offerer"
     endpoint_kwargs = {"offerer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_suspend_offerer(self, legit_user, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -206,7 +206,7 @@ class SuspendOffererTest(PostEndpointHelper):
 class UnsuspendOffererTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.offerer.unsuspend_offerer"
     endpoint_kwargs = {"offerer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_unsuspend_offerer(self, legit_user, authenticated_client):
         offerer = offerers_factories.OffererFactory(isActive=False)

--- a/api/tests/routes/backoffice_v3/offers_test.py
+++ b/api/tests/routes/backoffice_v3/offers_test.py
@@ -561,7 +561,7 @@ class BatchEditOfferTest(PostEndpointHelper):
 class ValidateOfferTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.offer.validate_offer"
     endpoint_kwargs = {"offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_validate_offer(self, legit_user, authenticated_client):
         offer_to_validate = offers_factories.OfferFactory(validation=offers_models.OfferValidationStatus.REJECTED)
@@ -588,7 +588,7 @@ class ValidateOfferTest(PostEndpointHelper):
 class GetValidateOfferFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.offer.get_validate_offer_form"
     endpoint_kwargs = {"offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_validate_form_test(self, legit_user, authenticated_client):
         offer = offers_factories.OfferFactory()
@@ -603,7 +603,7 @@ class GetValidateOfferFormTest(GetEndpointHelper):
 class RejectOfferTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.offer.reject_offer"
     endpoint_kwargs = {"offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_reject_offer(self, legit_user, authenticated_client):
         offer_to_reject = offers_factories.OfferFactory(validation=offers_models.OfferValidationStatus.APPROVED)
@@ -630,7 +630,7 @@ class RejectOfferTest(PostEndpointHelper):
 class GetRejectOfferFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.offer.get_reject_offer_form"
     endpoint_kwargs = {"offer_id": 1}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_edit_form_test(self, legit_user, authenticated_client):
         offer = offers_factories.OfferFactory()
@@ -644,7 +644,7 @@ class GetRejectOfferFormTest(GetEndpointHelper):
 
 class BatchOfferValidateTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.offer.batch_validate_offers"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_batch_validate_offers(self, legit_user, authenticated_client):
         offers = offers_factories.OfferFactory.create_batch(3, validation=offers_models.OfferValidationStatus.DRAFT)
@@ -662,7 +662,7 @@ class BatchOfferValidateTest(PostEndpointHelper):
 
 class BatchOfferRejectTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.offer.batch_reject_offers"
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_batch_reject_offers(self, legit_user, authenticated_client):
         beneficiary = users_factories.BeneficiaryGrant18Factory()

--- a/api/tests/routes/backoffice_v3/titelive_test.py
+++ b/api/tests/routes/backoffice_v3/titelive_test.py
@@ -24,7 +24,7 @@ pytestmark = [
 class SearchEanTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.titelive.search_titelive"
     endpoint_kwargs = {"ean": "9782070455379"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_search_ean_initial(self, authenticated_client):
         response = authenticated_client.get(url_for(self.endpoint))
@@ -92,7 +92,7 @@ class SearchEanTest(GetEndpointHelper):
 class ProductBlackListFormTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.titelive.get_add_product_whitelist_confirmation_form"
     endpoint_kwargs = {"ean": "9782070455379", "title": "Immortelle randonnée ; Compostelle malgré moi"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     def test_get_search_form(self, authenticated_client):
         response = authenticated_client.get(url_for(self.endpoint, **self.endpoint_kwargs))
@@ -102,7 +102,7 @@ class ProductBlackListFormTest(GetEndpointHelper):
 class AddProductWhitelistTest(PostEndpointHelper):
     endpoint = "backoffice_v3_web.titelive.add_product_whitelist"
     endpoint_kwargs = {"ean": "9782070455379", "title": "Immortelle randonnée ; Compostelle malgré moi"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
     form_data = {"comment": "OK!"}
 
     @patch("pcapi.routes.backoffice_v3.titelive.blueprint.get_by_ean13")
@@ -150,7 +150,7 @@ class AddProductWhitelistTest(PostEndpointHelper):
 class DeleteProductWhitelistTest(GetEndpointHelper):
     endpoint = "backoffice_v3_web.titelive.delete_product_whitelist"
     endpoint_kwargs = {"ean": "9782070455379"}
-    needed_permission = perm_models.Permissions.FRAUD_ACTIONS
+    needed_permission = perm_models.Permissions.PRO_FRAUD_ACTIONS
 
     @patch("pcapi.routes.backoffice_v3.titelive.blueprint.get_by_ean13")
     def test_delete_product_whitelist(self, mock_get_by_ean13, authenticated_client):


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22700

## But de la pull request

- Ajout d'une nouvelle permission `BENEFICIARY_FRAUD_ACTIONS`
- Remplacement de `FRAUD_ACTIONS` par `PRO_FRAUD_ACTIONS`
- Changement de la permission requise pour les revues manuelles
- Adaptation des `permissions_required` et permissions dans les blueprint pour séparer les actions sur les pros et sur les jeunes

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [x] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
