### PR TITLE
(PC-22752)[API] feat: enable product_whitelist usage

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1209,6 +1209,20 @@ def update_stock_quantity_to_match_cinema_venue_provider_remaining_places(offer:
         search.async_index_offer_ids([offer.id])
 
 
+def whitelist_existing_product(idAtProviders: str) -> None:
+    product = (
+        models.Product.query.filter(models.Product.can_be_synchronized == False)
+        .filter_by(idAtProviders=idAtProviders)
+        .one_or_none()
+    )
+    if not product:
+        return
+
+    product.isGcuCompatible = True
+    product.isSynchronizationCompatible = True
+    repository.save(product)
+
+
 def delete_unwanted_existing_product(idAtProviders: str) -> None:
     product_has_at_least_one_booking = (
         models.Product.query.filter_by(idAtProviders=idAtProviders)

--- a/api/src/pcapi/routes/backoffice_v3/titelive/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/titelive/blueprint.py
@@ -9,6 +9,8 @@ from sqlalchemy import orm
 
 from pcapi.connectors.titelive import get_by_ean13
 from pcapi.core.fraud import models as fraud_models
+from pcapi.core.offers.api import delete_unwanted_existing_product
+from pcapi.core.offers.api import whitelist_existing_product
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
@@ -97,6 +99,7 @@ def add_product_whitelist(ean: str, title: str) -> utils.BackofficeResponse:
 
         db.session.add(product_whitelist)
         db.session.commit()
+        whitelist_existing_product(ean)
     except sa.exc.IntegrityError:
         db.session.rollback()
         flash(f'L\'EAN "{ean}" est déjà dans la whitelist', "warning")
@@ -117,6 +120,7 @@ def delete_product_whitelist(ean: str) -> utils.BackofficeResponse:
         else:
             db.session.delete(product_whitelist)
             db.session.commit()
+            delete_unwanted_existing_product(ean)
     except sa.exc.IntegrityError:
         db.session.rollback()
         flash("Impossible de supprimer l'EAN de la whitelist", "danger")

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2060,6 +2060,21 @@ class DeleteUnwantedExistingProductTest:
 
 
 @pytest.mark.usefixtures("db_session")
+class WhitelistExistingProductTest:
+    def test_modify_product_if_existing_and_not_cgcompatible_nor_synchronizable(self):
+        isbn = "1111111111111"
+        product = factories.ProductFactory(
+            idAtProviders=isbn,
+            isGcuCompatible=False,
+            isSynchronizationCompatible=False,
+        )
+        api.whitelist_existing_product(isbn)
+        assert models.Product.query.one() == product
+        assert product.isGcuCompatible
+        assert product.isSynchronizationCompatible
+
+
+@pytest.mark.usefixtures("db_session")
 class DeleteDraftOffersTest:
     def test_delete_draft_with_mediation_offer_criterion_activation_code_and_stocks(self, client):
         criterion = criteria_factories.CriterionFactory()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22752

## But de la pull request

Suite de la PR https://passculture.atlassian.net/browse/PC-22270 ou la table `product_whitelist` a été rajouté:

- Utilisation des `ean` de la table `product_whitelist` lors de la syncro `titelive_thing`.
- Utilisation des `ean` de la table `product_whitelist` lors de l'ajout dans la whitelist, pour mettre à jour `isGcuCompatible` et `isSynchronizationCompatible` des entités de la table `product`.
- Utilisation des `ean` de la table `product_whitelist` lors de la suppression de la whitelist, pour mettre à jour `isGcuCompatible` et `isSynchronizationCompatible` des entités de la table `product` si des offres avec bookings existent, sinon pour supprimer le produit.

## Implémentation

NA

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
