### PR TITLE
(PC21855)[BO] feat: Make search field available even in details pages

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -102,8 +102,8 @@ def search_public_accounts() -> utils.BackofficeResponse:
 
     return render_template(
         "accounts/search_result.html",
-        dst=url_for(".search_public_accounts"),
-        form=form,
+        search_form=form,
+        search_dst=url_for(".search_public_accounts"),
         next_pages_urls=next_pages_urls,
         new_search_url=url_for(".search_public_accounts"),
         get_link_to_detail=get_public_account_link,
@@ -262,6 +262,8 @@ def render_public_account_details(
 
     return render_template(
         "accounts/get.html",
+        search_form=search_forms.SearchForm(),
+        search_dst=url_for(".search_public_accounts"),
         user=user,
         tunnel=tunnel,
         fraud_actions_desc=fraud_actions_desc,

--- a/api/src/pcapi/routes/backoffice_v3/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/admin/bo_users_blueprint.py
@@ -63,8 +63,8 @@ def search_bo_users() -> utils.BackofficeResponse:
 
     return render_template(
         "admin/bo_users.html",
-        form=form,
-        dst=url_for(".search_bo_users"),
+        search_form=form,
+        search_dst=url_for(".search_bo_users"),
         next_pages_urls=next_pages_urls,
         get_link_to_detail=get_admin_account_link,
         rows=paginated_rows,
@@ -112,6 +112,8 @@ def render_bo_user_page(user_id: int, edit_form: forms.EditBOUserForm | None = N
     return render_template(
         "accounts/get.html",
         layout="layouts/admin.html",
+        search_form=forms.BOUserSearchForm(),
+        search_dst=url_for(".search_bo_users"),
         user=user,
         edit_account_form=edit_form,
         edit_account_dst=url_for(".update_bo_user", user_id=user.id),

--- a/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers/offerer_blueprint.py
@@ -27,6 +27,8 @@ from . import forms as offerer_forms
 from . import serialization
 from .. import utils
 from ..forms import empty as empty_forms
+from ..forms import search as search_forms
+from ..serialization.search import TypeOptions
 
 
 offerer_blueprint = utils.child_backoffice_blueprint(
@@ -75,6 +77,8 @@ def render_offerer_details(
 
     return render_template(
         "offerer/get.html",
+        search_form=search_forms.ProSearchForm(pro_type=TypeOptions.OFFERER.value),
+        search_dst=url_for("backoffice_v3_web.search_pro"),
         offerer=offerer,
         region=regions_utils.get_region_name_from_postal_code(offerer.postalCode),
         bank_information_status=bank_information_status,

--- a/api/src/pcapi/routes/backoffice_v3/pro.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro.py
@@ -109,8 +109,8 @@ def search_pro() -> utils.BackofficeResponse:
 
     return render_template(
         "pro/search_result.html",
-        form=form,
-        dst=url_for(".search_pro"),
+        search_form=form,
+        search_dst=url_for(".search_pro"),
         result_type=search_model.pro_type.value,
         next_pages_urls=next_pages_urls,
         new_search_url=url_for(".search_pro"),

--- a/api/src/pcapi/routes/backoffice_v3/pro_users.py
+++ b/api/src/pcapi/routes/backoffice_v3/pro_users.py
@@ -19,7 +19,9 @@ import pcapi.utils.email as email_utils
 from . import utils
 from .forms import empty as empty_forms
 from .forms import pro_user as pro_user_forms
+from .forms import search as search_forms
 from .forms import user as user_forms
+from .serialization.search import TypeOptions
 
 
 pro_user_blueprint = utils.child_backoffice_blueprint(
@@ -51,6 +53,8 @@ def get(user_id: int) -> utils.BackofficeResponse:
 
     return render_template(
         "pro_user/get.html",
+        search_form=search_forms.ProSearchForm(pro_type=TypeOptions.USER.value),
+        search_dst=url_for("backoffice_v3_web.search_pro"),
         user=user,
         form=form,
         dst=dst,

--- a/api/src/pcapi/routes/backoffice_v3/templates/admin/bo_users.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/admin/bo_users.html
@@ -1,4 +1,5 @@
 {% extends "layouts/admin.html" %}
+{% from "components/search/result_form.html" import build_result_page_form %}
 {% block title %}
   Utilisateurs du BackOffice
 {% endblock title %}

--- a/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/search/result.html
@@ -1,4 +1,3 @@
-{% from "components/search/result_form.html" import build_result_page_form %}
 {% macro result_card_switch(row, result_type="public_account") %}
   {% if result_type == "offerer" %}
     {% include "components/search/result_card_offerer.html" %}
@@ -8,7 +7,6 @@
     {% include "components/search/result_card.html" %}
   {% endif %}
 {% endmacro %}
-{{ build_result_page_form(form, macro) }}
 <div>
   <div>
     <p class="lead">

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/accounts.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/accounts.html
@@ -1,10 +1,12 @@
 {% extends "layouts/connected.html" %}
+{% from "components/search/result_form.html" import build_result_page_form %}
 {% from "layouts/connected.html" import MENU_JGP_JEUNES_BENEFICAIRES_OU_A_VENIR with context %}
 {% set CURRENT_PATH = MENU_JGP_JEUNES_BENEFICAIRES_OU_A_VENIR %}
 {% block page %}
   <div class="py-4 px-5">
     <h1 class="text-muted mx-3">Jeunes bénéficiaires ou à venir</h1>
     <div class="container-fluid">
+      {% if search_form %}{{ build_result_page_form(search_form, search_dst) }}{% endif %}
       {% block main_content %}
       {% endblock main_content %}
     </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/admin.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/admin.html
@@ -1,8 +1,10 @@
 {% extends "layouts/connected.html" %}
+{% from "components/search/result_form.html" import build_result_page_form %}
 {% block page %}
   <div class="py-4 px-5">
     <h1 class="text-muted mx-3">Admin</h1>
     <div class="container-fluid">
+      {% if search_form %}{{ build_result_page_form(search_form, search_dst) }}{% endif %}
       {% block main_content %}
       {% endblock main_content %}
     </div>

--- a/api/src/pcapi/routes/backoffice_v3/templates/layouts/pro.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/layouts/pro.html
@@ -1,14 +1,14 @@
 {% extends "layouts/connected.html" %}
+{% from "components/search/result_form.html" import build_result_page_form %}
 {% from "layouts/connected.html" import MENU_AC_LISTE_ACTEURS_CULTURELS with context %}
 {% set CURRENT_PATH = MENU_AC_LISTE_ACTEURS_CULTURELS %}
 {% block page %}
   <div class="py-4 px-5">
     <div class="d-flex justify-content-between mx-3">
       <h1 class="text-muted">Acteurs culturels</h1>
-      {% block pro_extra_header %}
-      {% endblock pro_extra_header %}
     </div>
     <div class="container-fluid">
+      {% if search_form %}{{ build_result_page_form(search_form, search_dst) }}{% endif %}
       {% block pro_main_content %}
       {% endblock pro_main_content %}
     </div>

--- a/api/src/pcapi/routes/backoffice_v3/venues.py
+++ b/api/src/pcapi/routes/backoffice_v3/venues.py
@@ -39,8 +39,10 @@ from pcapi.utils.string import to_camelcase
 from . import autocomplete
 from . import utils
 from .forms import empty as empty_forms
+from .forms import search as search_forms
 from .forms import venue as forms
 from .serialization import venues as serialization
+from .serialization.search import TypeOptions
 
 
 venue_blueprint = utils.child_backoffice_blueprint(
@@ -202,6 +204,8 @@ def render_venue_details(
 
     return render_template(
         "venue/get.html",
+        search_form=search_forms.ProSearchForm(pro_type=TypeOptions.VENUE.value),
+        search_dst=url_for("backoffice_v3_web.search_pro"),
         venue=venue,
         edit_venue_form=edit_venue_form,
         region=region,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21855

## But de la pull request

Permettre de rechercher un compte jeune, un pro ou un utilisateur du backoffice à partir d'un champ directement dans la page de détails (à la même place que dans la page de résultats), afin d'éviter de retourner dans le menu à chaque rechercher.

Pas de test ajouté car les champs ajoutés dans les pages appellent les endpoints déjà largement testés.

![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/8971f8dc-d1bf-4086-9d98-3ce6480031e8)
![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/f0507b3a-7d4f-433a-abad-80215601cab0)
![image](https://github.com/pass-culture/pass-culture-main/assets/23212130/5b044744-cd98-46e5-b69d-d0be2c283215)

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
