### PR TITLE
(PC-22721)[BO] Fix None or empty venue publicName

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/get.html
@@ -93,7 +93,9 @@
               {% endif %}
             </div>
           </div>
-          {% if venue.publicName != venue.name %}<p class="card-subtitle text-muted mb-3 h5">Nom d'usage : {{ venue.publicName }}</p>{% endif %}
+          {% if venue.publicName and venue.publicName != venue.name %}
+            <p class="card-subtitle text-muted mb-3 h5">Nom d'usage : {{ venue.publicName }}</p>
+          {% endif %}
           <p class="card-subtitle text-muted mb-3 h5">Venue ID : {{ venue.id }}</p>
           <p class="card-subtitle text-muted mb-3 h5">SIRET : {{ links.build_siret_to_external_link(venue) }}</p>
           <div class="row pt-3">

--- a/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/venue/list.html
@@ -75,7 +75,7 @@
                 {% endif %}
                 <td>{{ venue.id }}</td>
                 <td>{{ links.build_venue_name_to_details_link(venue) }}</td>
-                <td>{{ venue.publicName }}</td>
+                <td>{{ venue.publicName | empty_string_if_null }}</td>
                 <td>{{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}</td>
                 <td>
                   {% if venue.isPermanent %}<span class="visually-hidden">Lieu permanent</span><i class="bi bi-check-circle-fill"></i>{% endif %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22721

## But de la pull request

- Ne pas afficher le nom d'usage dans la page d'un lieu s'il est définit à None ou si c'est un empty string.
- Dans la page Actions sur les lieux, ne rien afficher dans le tableau dans ce même cas

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
