### PR TITLE
(BSR)[API] feat: Do no raise error if DMS application is draft

### DIFF
--- a/api/src/pcapi/use_cases/save_venue_bank_informations.py
+++ b/api/src/pcapi/use_cases/save_venue_bank_informations.py
@@ -115,6 +115,8 @@ class SaveVenueBankInformations:
                     format_error_to_demarches_simplifiees_text(api_errors),
                 )
                 return None
+            if application_details.status == BankInformationStatus.DRAFT:
+                return None
             raise api_errors
 
         if not bank_information:


### PR DESCRIPTION
When we receive a webhook notification from DMS about a change on an
application, we validate the application and populate the annotation
if there is an error. But when the application does not have the
annotation field (which is likely for old annotations), the error is
raised and pollutes Sentry.

There is no point in raising the error when the application is draft:
there is nothing we can do. We'll just wait for the application to be
accepted or rejected.