### PR TITLE
(PC-22738)[BO] feat: Annuaire des Entreprises instead of societe.com

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/components/links.html
@@ -53,17 +53,17 @@
 {# ----- external links ----- #}
 {% macro build_siren_to_external_link(offerer) %}
   {% if offerer.siren %}
-    <a href="https://www.societe.com/cgi-bin/fiche?rncs={{ offerer.siren }}"
+    <a href="https://annuaire-entreprises.data.gouv.fr/entreprise/{{ offerer.siren }}"
        target="_blank"
-       title="Visualiser sur societe.com"
+       title="Visualiser dans l'Annuaire des Entreprises"
        class="link-primary">{{ offerer.siren }}</a>
   {% endif %}
 {% endmacro %}
 {% macro build_siret_to_external_link(venue) %}
   {% if venue.siret %}
-    <a href="https://www.societe.com/etablissement/{{ venue.name | lower | replace(" ", "-") }}-{{ venue.siret }}.html"
+    <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ venue.siret }}"
        target="_blank"
-       title="Visualiser sur societe.com"
+       title="Visualiser dans l'Annuaire des Entreprises"
        class="link-primary">{{ venue.siret }}</a>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22738

## But de la pull request

Faire pointer les liens SIREN et SIRET du backoffice vers l'Annuaire des Entreprises au lieu de societe.com

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
