### PR TITLE
(PC-22674)[BO] fix: log email change only once in history + change icon

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/accounts.py
+++ b/api/src/pcapi/routes/backoffice_v3/accounts.py
@@ -785,7 +785,7 @@ def update_public_account(user_id: int) -> utils.BackofficeResponse:
         return render_public_account_details(user_id, form), 400
 
     if form.email.data and form.email.data != email_utils.sanitize_email(user.email):
-        old_email = user.email
+        # Do not log email change in snapshot, since it is already logged in user_email_history table
         try:
             email_update.full_email_update_by_admin(user, form.email.data)
         except users_exceptions.EmailExistsError:
@@ -793,7 +793,6 @@ def update_public_account(user_id: int) -> utils.BackofficeResponse:
             snapshot.log_update(save=True)
             flash("L'email est déjà associé à un autre utilisateur", "warning")
             return render_public_account_details(user_id, form), 400
-        snapshot.set("email", old=old_email, new=form.email.data)
 
         # TODO (prouzet) old email should also be updated, but there is no update_external_user by email
         external_attributes_api.update_external_user(user)

--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -96,9 +96,7 @@
               <div class="mb-1">
                 <div class="d-flex align-items-center">
                   <span class="fw-bold me-1">E-mail :</span> {{ user.email }}
-                  {% if user.email_history | length > 0 %}
-                    <i class="bi bi-exclamation-circle-fill text-warning ms-1 fs-4 pc-email-changed-icon"></i>
-                  {% endif %}
+                  {% if user.email_history | length > 0 %}<i class="bi bi-bag-check-fill text-warning ms-1 fs-4 pc-email-changed-icon"></i>{% endif %}
                 </div>
                 {% if resend_email_validation_form %}
                   <form action="{{ url_for('.resend_validation_email', user_id=user.id) }}"

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -882,6 +882,12 @@ class UpdatePublicAccountTest(PostEndpointHelper):
         assert user_to_edit.postalCode == expected_new_postal_code
         assert user_to_edit.city == expected_city
 
+        assert len(user_to_edit.email_history) == 1
+        history = user_to_edit.email_history[0]
+        assert history.oldEmail == old_email
+        assert history.newEmail == expected_new_email
+        assert history.eventType == users_models.EmailHistoryEventTypeEnum.ADMIN_UPDATE
+
         action = history_models.ActionHistory.query.one()
         assert action.actionType == history_models.ActionType.INFO_MODIFIED
         assert action.actionDate is not None
@@ -890,7 +896,6 @@ class UpdatePublicAccountTest(PostEndpointHelper):
         assert action.offererId is None
         assert action.venueId is None
         assert action.extraData["modified_info"] == {
-            "email": {"new_info": expected_new_email, "old_info": old_email},
             "phoneNumber": {"new_info": "+33836656565", "old_info": "None"},
             "postalCode": {"new_info": expected_new_postal_code, "old_info": "None"},
         }
@@ -941,6 +946,12 @@ class UpdatePublicAccountTest(PostEndpointHelper):
         assert user.departementCode == base_form["postal_code"][:2]
         assert user.city == base_form["city"]
 
+        assert len(user_to_edit.email_history) == 1
+        history = user_to_edit.email_history[0]
+        assert history.oldEmail == "ed@example.com"
+        assert history.newEmail == "mc@example.com"
+        assert history.eventType == users_models.EmailHistoryEventTypeEnum.ADMIN_UPDATE
+
         action = history_models.ActionHistory.query.one()
         assert action.actionType == history_models.ActionType.INFO_MODIFIED
         assert action.actionDate is not None
@@ -951,7 +962,6 @@ class UpdatePublicAccountTest(PostEndpointHelper):
         assert action.extraData["modified_info"] == {
             "firstName": {"new_info": "Comte", "old_info": "Edmond"},
             "lastName": {"new_info": "de Monte-Cristo", "old_info": "Dantès"},
-            "email": {"new_info": "mc@example.com", "old_info": "ed@example.com"},
             "validatedBirthDate": {
                 "new_info": base_form["birth_date"].isoformat(),
                 "old_info": date_of_birth.date().isoformat(),


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22674

## But de la pull request

- Changer l'icône indiquant que l'email a déjà été changé, sur la page de détails d'un jeune
- N'afficher qu'une fois le changement d'email depuis le BO dans l'historique : pas besoin de stocker ce changement dans la table `action_history` puisqu'il est déjà dans la table `user_email_history`.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
