### PR TITLE
(PC-22779)[API] feat: send cancellationLimitDate when booking CGR ticket

### DIFF
--- a/api/src/pcapi/connectors/cgr/cgr.py
+++ b/api/src/pcapi/connectors/cgr/cgr.py
@@ -61,6 +61,7 @@ def reservation_pass_culture(
         pPrenom=body.pPrenom,
         pEmail=body.pEmail,
         pToken=body.pToken,
+        pDateLimiteAnnul=body.pDateLimiteAnnul,
     )
     response = json.loads(response)
     _check_response_is_ok(response, "ReservationPassCulture")

--- a/api/src/pcapi/connectors/serialization/cgr_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cgr_serializers.py
@@ -51,6 +51,7 @@ class ReservationPassCultureBody(BaseModel):
     pPrenom: str
     pEmail: str
     pToken: str
+    pDateLimiteAnnul: datetime.datetime
 
 
 class ReservationPassCultureResponse(BaseModel):

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -32,6 +32,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
     def book_ticket(
         self, show_id: int, booking: bookings_models.Booking, beneficiary: users_models.User
     ) -> list[external_bookings_models.Ticket]:
+        assert booking.cancellationLimitDate  # for typing; a movie screening is always an event
         book_show_body = cgr_serializers.ReservationPassCultureBody(
             pIDSeances=show_id,
             pNumCinema=self.cgr_cinema_details.numCinema,
@@ -41,6 +42,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             pPrenom=beneficiary.firstName if beneficiary.firstName else "",
             pEmail=beneficiary.email,
             pToken=booking.token,
+            pDateLimiteAnnul=booking.cancellationLimitDate,
         )
         response = reservation_pass_culture(self.cgr_cinema_details, book_show_body)
         logger.info("Booked CGR Ticket", extra={"barcode": response.QrCode, "seat_number": response.Placement})

--- a/api/src/pcapi/routes/public/booking_token/v2/serialization.py
+++ b/api/src/pcapi/routes/public/booking_token/v2/serialization.py
@@ -26,9 +26,6 @@ class BookingFormula(str, Enum):
 
 class GetBookingResponse(BaseModel):
     bookingId: str
-    cancellationLimitDate: str | None = pydantic.Field(
-        description="Pour les offres de type événement, date limite d'annulation par le ou la bénéficiaire."
-    )
     dateOfBirth: str | None
     datetime: str  # avoid breaking legacy value "" returned for void date
     ean13: str | None
@@ -71,9 +68,6 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
     birth_date = isoformat(booking.user.birth_date) if booking.user.birth_date else None  # type: ignore [arg-type]
     return GetBookingResponse(
         bookingId=humanize(booking.id),  # type: ignore [arg-type]
-        cancellationLimitDate=(
-            format_into_utc_date(booking.cancellationLimitDate) if booking.cancellationLimitDate else None
-        ),
         dateOfBirth=birth_date,
         datetime=(format_into_utc_date(booking.stock.beginningDatetime) if booking.stock.beginningDatetime else ""),
         ean13=(

--- a/api/tests/connectors/cgr/soap_definitions.py
+++ b/api/tests/connectors/cgr/soap_definitions.py
@@ -30,6 +30,7 @@ WEB_SERVICE_DEFINITION = """<?xml version="1.0" encoding="UTF-8"?>
                     <xsd:element name="pPrenom" type="xsd:string"/>
                     <xsd:element name="pEmail" type="xsd:string"/>
                     <xsd:element name="pToken" type="xsd:string"/>
+                    <xsd:element name="pDateLimiteAnnul" type="xsd:dateTime"/>
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:element name="ReservationPassCulture" type="s0:tReservationPassCulture"/>

--- a/api/tests/core/external_bookings/cgr/test_client.py
+++ b/api/tests/core/external_bookings/cgr/test_client.py
@@ -5,6 +5,7 @@ import pytest
 from pcapi.connectors.cgr.exceptions import CGRAPIException
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.external_bookings.cgr.client as cgr_client
+import pcapi.core.offers.factories as offers_factories
 import pcapi.core.providers.factories as providers_factories
 import pcapi.core.users.factories as users_factories
 
@@ -16,7 +17,8 @@ from tests.local_providers.cinema_providers.cgr import fixtures
 class BookTicketTest:
     def test_should_book_one_ticket(self, requests_mock, app):
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1, amount=5.5)
+        showtime_stock = offers_factories.EventStockFactory()
+        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1, amount=5.5, stock=showtime_stock)
         venue_id = booking.venueId
         cinema_details = providers_factories.CGRCinemaDetailsFactory(
             cinemaUrl="http://cgr-cinema-0.example.com/web_service"
@@ -42,6 +44,10 @@ class BookTicketTest:
         assert "<pEmail>beneficiary@example.com</pEmail>" in post_adapter.last_request.text
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
+        assert (
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            in post_adapter.last_request.text
+        )
         redis_external_bookings = app.redis_client.lrange("api:external_bookings:barcodes", 0, -1)
         assert len(redis_external_bookings) == 1
         external_booking_info = json.loads(redis_external_bookings[0])
@@ -51,7 +57,8 @@ class BookTicketTest:
 
     def test_should_book_one_ticket_when_placement_is_disabled(self, requests_mock):
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1, amount=5.5)
+        showtime_stock = offers_factories.EventStockFactory()
+        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1, amount=5.5, stock=showtime_stock)
         cinema_details = providers_factories.CGRCinemaDetailsFactory(
             cinemaUrl="http://cgr-cinema-0.example.com/web_service"
         )
@@ -76,10 +83,15 @@ class BookTicketTest:
         assert "<pEmail>beneficiary@example.com</pEmail>" in post_adapter.last_request.text
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
+        assert (
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            in post_adapter.last_request.text
+        )
 
     def test_should_book_two_tickets(self, requests_mock):
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=2, amount=5.5)
+        showtime_stock = offers_factories.EventStockFactory()
+        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=2, amount=5.5, stock=showtime_stock)
         cinema_details = providers_factories.CGRCinemaDetailsFactory(
             cinemaUrl="http://cgr-cinema-0.example.com/web_service"
         )
@@ -106,10 +118,15 @@ class BookTicketTest:
         assert "<pEmail>beneficiary@example.com</pEmail>" in post_adapter.last_request.text
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
+        assert (
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            in post_adapter.last_request.text
+        )
 
     def test_should_book_two_tickets_when_placement_is_disabled(self, requests_mock):
         beneficiary = users_factories.BeneficiaryGrant18Factory(email="beneficiary@example.com")
-        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=2, amount=5.5)
+        showtime_stock = offers_factories.EventStockFactory()
+        booking = bookings_factories.BookingFactory(user=beneficiary, quantity=2, amount=5.5, stock=showtime_stock)
         cinema_details = providers_factories.CGRCinemaDetailsFactory(
             cinemaUrl="http://cgr-cinema-0.example.com/web_service"
         )
@@ -137,6 +154,10 @@ class BookTicketTest:
         assert "<pEmail>beneficiary@example.com</pEmail>" in post_adapter.last_request.text
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
+        assert (
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            in post_adapter.last_request.text
+        )
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/public/blueprint_v2_openapi_test.py
+++ b/api/tests/routes/public/blueprint_v2_openapi_test.py
@@ -151,12 +151,6 @@ def test_public_api(client, app):
                 "GetBookingResponse": {
                     "properties": {
                         "bookingId": {"title": "Bookingid", "type": "string"},
-                        "cancellationLimitDate": {
-                            "description": "Pour les offres de type événement, date limite d'annulation par le ou la bénéficiaire.",
-                            "nullable": True,
-                            "title": "Cancellationlimitdate",
-                            "type": "string",
-                        },
                         "dateOfBirth": {"nullable": True, "title": "Dateofbirth", "type": "string"},
                         "datetime": {"title": "Datetime", "type": "string"},
                         "ean13": {"nullable": True, "title": "Ean13", "type": "string"},

--- a/api/tests/routes/public/booking_token/v2/get_booking_by_token_v2_test.py
+++ b/api/tests/routes/public/booking_token/v2/get_booking_by_token_v2_test.py
@@ -51,7 +51,6 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json == {
             "bookingId": humanize(booking.id),
-            "cancellationLimitDate": format_into_utc_date(booking.cancellationLimitDate),
             "dateOfBirth": isoformat(booking.user.birth_date),
             "datetime": format_into_utc_date(booking.stock.beginningDatetime),
             "ean13": None,

--- a/pro/src/apiClient/v2/models/GetBookingResponse.ts
+++ b/pro/src/apiClient/v2/models/GetBookingResponse.ts
@@ -7,10 +7,6 @@ import type { BookingOfferType } from './BookingOfferType';
 
 export type GetBookingResponse = {
   bookingId: string;
-  /**
-   * Pour les offres de type événement, date limite d'annulation par le ou la bénéficiaire.
-   */
-  cancellationLimitDate?: string | null;
   dateOfBirth?: string | null;
   datetime: string;
   ean13?: string | null;


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22779

## But de la pull request

Fournir la date limite d'annulation lors de l'appel au webservice CGR.

## Implémentation

Modification du payload XML 

## Informations supplémentaires

Suppression de la modification de l'API CM qui ajoutait cet attribut.

