### PR TITLE
(PC-22753)[API] fix: improve titelive http api session using redis

### DIFF
--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -6,55 +6,70 @@ from urllib3 import exceptions as urllib3_exceptions
 from pcapi import settings
 from pcapi.core import logging as core_logging
 from pcapi.utils import requests
+from pcapi.utils.cache import get_from_cache
 
 
 logger = logging.getLogger(__name__)
 
 
-def get_jwt() -> str:
+def get_jwt_token() -> str:
+    TITELIVE_JWT_CACHE_KEY = "api:titelive_jwt:cache"
+    TITELIVE_JWT_CACHE_TIMEOUT = 5 * 60  # 5 minutes
     url = f"{settings.TITELIVE_EPAGINE_API_AUTH_URL}/login/{settings.TITELIVE_EPAGINE_API_USERNAME}/token"
-
     payload = {"password": settings.TITELIVE_EPAGINE_API_PASSWORD}
 
-    try:
-        response = requests.post(url, json=payload)
-    except (urllib3_exceptions.HTTPError, requests.exceptions.RequestException) as e:
-        core_logging.log_for_supervision(
-            logger,
-            logging.ERROR,
-            "Titelive get jwt: Network error",
-            extra={
-                "exception": e,
-                "alert": "Titelive error",
-                "error_type": "network",
-                "request_type": "get-jwt",
-            },
-        )
-        raise requests.ExternalAPIException(is_retryable=True) from e
-
-    if not response.ok:
-        if 400 <= response.status_code < 500:
+    def _get_new_jwt_token() -> str:
+        try:
+            response = requests.post(url, json=payload)
+        except (urllib3_exceptions.HTTPError, requests.exceptions.RequestException) as e:
             core_logging.log_for_supervision(
                 logger,
                 logging.ERROR,
-                "Titelive get jwt: External error: %s",
-                response.status_code,
+                "Titelive get jwt: Network error",
                 extra={
+                    "exception": e,
                     "alert": "Titelive error",
-                    "error_type": "http",
-                    "status_code": response.status_code,
+                    "error_type": "network",
                     "request_type": "get-jwt",
-                    "response_text": response.text,
                 },
             )
-            raise requests.ExternalAPIException(True, {"status_code": response.status_code})
+            raise requests.ExternalAPIException(is_retryable=True) from e
 
-    return response.json()["token"]
+        if not response.ok:
+            if 400 <= response.status_code < 500:
+                core_logging.log_for_supervision(
+                    logger,
+                    logging.ERROR,
+                    "Titelive get jwt: External error: %s",
+                    response.status_code,
+                    extra={
+                        "alert": "Titelive error",
+                        "error_type": "http",
+                        "status_code": response.status_code,
+                        "request_type": "get-jwt",
+                        "response_text": response.text,
+                    },
+                )
+                raise requests.ExternalAPIException(True, {"status_code": response.status_code})
+
+        return response.json()["token"]
+
+    jwt_token = typing.cast(
+        str,
+        get_from_cache(
+            key_template=TITELIVE_JWT_CACHE_KEY,
+            retriever=_get_new_jwt_token,
+            expire=TITELIVE_JWT_CACHE_TIMEOUT,
+            return_type=str,
+        ),
+    )
+
+    return jwt_token
 
 
 def get_by_ean13(ean13: str) -> dict[str, typing.Any]:
     url = f"{settings.TITELIVE_EPAGINE_API_URL}/ean/{ean13}"
-    headers = {"Content-Type": "application/json", "Authorization": "Bearer {}".format(get_jwt())}
+    headers = {"Content-Type": "application/json", "Authorization": "Bearer {}".format(get_jwt_token())}
 
     try:
         response = requests.get(url, headers=headers)

--- a/api/src/pcapi/utils/cache.py
+++ b/api/src/pcapi/utils/cache.py
@@ -39,7 +39,7 @@ def get_from_cache(
     :param key_template: A template to generate the key. This must be compatible with printf style string formatting
         see for documentation: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
     :param key_args: `list` or `dict` of `str` to fill the template.
-    :param retriever: Function to call to retrive the data if they are not in the cache. As it does not take args you
+    :param retriever: Function to call to retrieve the data if they are not in the cache. As it does not take args you
         can use functools.partial to prefill its arguments. It must return a pydantic.BaseModel child or str.
     :param expire: The number of seconds before the cache expires. If None it will be set to never expire.
         It's default value is 86400 (24h).
@@ -79,17 +79,17 @@ def cached_view(
     ignore_args: bool = False,
 ) -> Callable:
     """
-    Décorator to cache a view. This decorator MUST be set after spectree_serialize
+    Decorator to cache a view. This decorator MUST be set after spectree_serialize
 
-    By default it only caches the case where no arguments are passed to the view and the cache liftime is set to 24h.
+    By default, it only caches the case where no arguments are passed to the view and the cache lifetime is set to 24h.
 
     :param prefix: String to differentiate multiple view with the same name.
     :param expire: The number of seconds before the cache expires. If None it will be set to never expire.
         It's default value is 86400 (24h).
     :param cache_only_if_no_arguments: When True only the case when there are no args or kwargs is cached, any other
         case will be a passthrough. Default to True
-    :param: ignore_args: If True, the decorator will not look a the args to generate the key and it will always
-        considere the args as the default ones. This argument is dangerous, you should not use it.
+    :param: ignore_args: If True, the decorator will not look the args to generate the key, and it will always
+        consider the args as the default ones. This argument is dangerous, you should not use it.
     """
 
     def decorator(function: Callable[[Any], pydantic.BaseModel]) -> Callable:

--- a/api/tests/connectors/titelive/titelive_test.py
+++ b/api/tests/connectors/titelive/titelive_test.py
@@ -6,12 +6,12 @@ from tests.connectors.titelive import fixtures
 
 @override_settings(TITELIVE_EPAGINE_API_USERNAME="test@example.com")
 @override_settings(TITELIVE_EPAGINE_API_PASSWORD="qwerty123")
-def test_get_jwt(requests_mock):
+def test_get_jwt_token(requests_mock):
     requests_mock.post(
         "https://login.epagine.fr/v1/login/test@example.com/token",
         json={"token": "XYZ"},
     )
-    assert titelive.get_jwt() == "XYZ"
+    assert titelive.get_jwt_token() == "XYZ"
 
 
 @override_settings(TITELIVE_EPAGINE_API_USERNAME="test@example.com")


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22753

## But de la pull request

Utilise redis pour stocker le JWT titelive d'une durée de validité de 5 minutes

## Implémentation

NA

## Informations supplémentaires

Un refresh token est également disponible dans un cookie de la réponse du login. Sa validité étant de 5 minutes, il ne sera pas implémenté au profit d'un nouveau login donc jwt.

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
