### PR TITLE
(PC-22805)[BO] feat: show deposit expiration date in beneficiary details page

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/accounts/get/general.html
@@ -72,6 +72,11 @@
               <p class="mb-1">
                 <span class="fw-bold">Crédité le :</span> {{ user.deposit_activation_date | format_date }}
               </p>
+              {% if user.deposit %}
+                <p class="mb-1">
+                  <span class="fw-bold">Date d'expiration du crédit :</span> {{ user.deposit.expirationDate | format_date_time }}
+                </p>
+              {% endif %}
             {% endif %}
             <p class="mb-1">
               <span class="fw-bold">Date de création du compte :</span> {{ user.dateCreated | format_date }}

--- a/api/tests/routes/backoffice_v3/accounts_test.py
+++ b/api/tests/routes/backoffice_v3/accounts_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 from dateutil.relativedelta import relativedelta
 from flask import url_for
 import pytest
+import pytz
 
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.fraud import factories as fraud_factories
@@ -444,6 +445,15 @@ class GetPublicAccountTest(GetEndpointHelper):
         if user.dateOfBirth:
             assert f"Date de naissance {user.dateOfBirth.strftime('%d/%m/%Y')}" in content
         assert "Date de naissance déclarée à l'inscription" not in content
+        if user.deposit:
+            assert (
+                f"Crédité le : {user.deposit.dateCreated.astimezone(tz=pytz.timezone('Europe/Paris')).strftime('%d/%m/%Y')}"
+                in content
+            )
+            assert (
+                f"Date d'expiration du crédit : {user.deposit.expirationDate.astimezone(tz=pytz.timezone('Europe/Paris')).strftime('%d/%m/%Y à %Hh%M')}"
+                in content
+            )
         assert f"Date de création du compte : {user.dateCreated.strftime('%d/%m/%Y')}" in content
         assert (
             f"Date de dernière connexion : {user.lastConnectionDate.strftime('%d/%m/%Y') if user.lastConnectionDate else ''}"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22805

## But de la pull request

Afficher date et heure d'expiration du crédit sur la page de détails d'un jeune bénéficiaire (s'il a effectivement un crédit).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
