### PR TITLE
(PC-22779)[API] fix: use correct XML type and format

### DIFF
--- a/api/src/pcapi/connectors/serialization/cgr_serializers.py
+++ b/api/src/pcapi/connectors/serialization/cgr_serializers.py
@@ -51,7 +51,7 @@ class ReservationPassCultureBody(BaseModel):
     pPrenom: str
     pEmail: str
     pToken: str
-    pDateLimiteAnnul: datetime.datetime
+    pDateLimiteAnnul: str
 
 
 class ReservationPassCultureResponse(BaseModel):

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -42,7 +42,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             pPrenom=beneficiary.firstName if beneficiary.firstName else "",
             pEmail=beneficiary.email,
             pToken=booking.token,
-            pDateLimiteAnnul=booking.cancellationLimitDate,
+            pDateLimiteAnnul=booking.cancellationLimitDate.isoformat(),
         )
         response = reservation_pass_culture(self.cgr_cinema_details, book_show_body)
         logger.info("Booked CGR Ticket", extra={"barcode": response.QrCode, "seat_number": response.Placement})

--- a/api/tests/connectors/cgr/soap_definitions.py
+++ b/api/tests/connectors/cgr/soap_definitions.py
@@ -30,7 +30,7 @@ WEB_SERVICE_DEFINITION = """<?xml version="1.0" encoding="UTF-8"?>
                     <xsd:element name="pPrenom" type="xsd:string"/>
                     <xsd:element name="pEmail" type="xsd:string"/>
                     <xsd:element name="pToken" type="xsd:string"/>
-                    <xsd:element name="pDateLimiteAnnul" type="xsd:dateTime"/>
+                    <xsd:element name="pDateLimiteAnnul" type="xsd:string"/>
                 </xsd:sequence>
             </xsd:complexType>
             <xsd:element name="ReservationPassCulture" type="s0:tReservationPassCulture"/>

--- a/api/tests/core/external_bookings/cgr/test_client.py
+++ b/api/tests/core/external_bookings/cgr/test_client.py
@@ -45,7 +45,7 @@ class BookTicketTest:
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
         assert (
-            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.strftime('%Y-%m-%dT%H:%M:%S.%f')}</pDateLimiteAnnul>"
             in post_adapter.last_request.text
         )
         redis_external_bookings = app.redis_client.lrange("api:external_bookings:barcodes", 0, -1)
@@ -84,7 +84,7 @@ class BookTicketTest:
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
         assert (
-            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.strftime('%Y-%m-%dT%H:%M:%S.%f')}</pDateLimiteAnnul>"
             in post_adapter.last_request.text
         )
 
@@ -119,7 +119,7 @@ class BookTicketTest:
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
         assert (
-            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.strftime('%Y-%m-%dT%H:%M:%S.%f')}</pDateLimiteAnnul>"
             in post_adapter.last_request.text
         )
 
@@ -155,7 +155,7 @@ class BookTicketTest:
         assert "<pPUTTC>5.50</pPUTTC>" in post_adapter.last_request.text
         assert "<pIDSeances>177182</pIDSeances>" in post_adapter.last_request.text
         assert (
-            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.isoformat()}</pDateLimiteAnnul>"
+            f"<pDateLimiteAnnul>{booking.cancellationLimitDate.strftime('%Y-%m-%dT%H:%M:%S.%f')}</pDateLimiteAnnul>"
             in post_adapter.last_request.text
         )
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22779

## But de la pull request

Corriger le type XML du payload de réservation CGR

## Informations supplémentaires

- Pour éviter un cast inopiné par `zeep`, les tests utilisent un `strftime()` avec un format explicite, au lieu de `isoformat()`, qui négligeait le séparareteur `T`
