### PR TITLE
(PC-22562)[API] feat: provider without siret

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 29244daf23a5 (pre) (head)
-ad2884071862 (post) (head)
+e84fda00f67c (post) (head)

--- a/api/src/pcapi/alembic/versions/20230616T081353_e84fda00f67c_make_venueprovider_idatprovider_nullable.py
+++ b/api/src/pcapi/alembic/versions/20230616T081353_e84fda00f67c_make_venueprovider_idatprovider_nullable.py
@@ -1,0 +1,20 @@
+"""Make venue_provider venueIdAtOfferProvider column nullable"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e84fda00f67c"
+down_revision = "ad2884071862"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("venue_provider", "venueIdAtOfferProvider", existing_type=sa.VARCHAR(length=70), nullable=True)
+
+
+def downgrade() -> None:
+    # Do not restore NOT NULL constraint.
+    pass

--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -199,7 +199,13 @@ def update_allocine_venue_provider(
 def connect_venue_to_provider(
     venue: offerers_models.Venue, provider: providers_models.Provider, venueIdAtOfferProvider: str = None
 ) -> providers_models.VenueProvider:
-    id_at_provider = _get_siret(venueIdAtOfferProvider, venue.siret)
+    if provider.hasOffererProvider:
+        # FIXME (mageoffray, 16-06-2023): Column is not nullable but not
+        # needed for new provider apis. We will have few venues to sync
+        # without siret before the column is nullable.
+        id_at_provider = "dummyIdAtProvider"
+    else:
+        id_at_provider = _get_siret(venueIdAtOfferProvider, venue.siret)
 
     _check_provider_can_be_connected(provider, id_at_provider)
 

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -117,7 +117,7 @@ class VenueProvider(PcObject, Base, Model, ProvidableMixin, DeactivableMixin):
 
     provider: sa_orm.Mapped["Provider"] = relationship("Provider", foreign_keys=[providerId], backref="venueProviders")
 
-    venueIdAtOfferProvider: str = Column(String(70), nullable=False)
+    venueIdAtOfferProvider: str = Column(String(70), nullable=True)
 
     lastSyncDate = Column(DateTime, nullable=True)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22562

two commits to allow venues without siret to sync to new providers. 
The first commit might need to be hotfixed, the second commit is the long term fix. 
At first we will allow to create venueProvider with a dummy idAtProvider, once the column is nullable we will change this idAtProvider to a null value