### PR TITLE
[PC-22800] Choose Id provider at user generation in backoffice

### DIFF
--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -31,9 +31,6 @@ class SubscriptionStep(enum.Enum):
     IDENTITY_CHECK = "identity-check"
     HONOR_STATEMENT = "honor-statement"
 
-    def get_title(self) -> str:
-        return self.value.title().replace("-", " ")
-
 
 class SubscriptionStepTitle(enum.Enum):
     PHONE_VALIDATION = "Numéro de téléphone"

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -31,14 +31,6 @@ class SubscriptionStep(enum.Enum):
     IDENTITY_CHECK = "identity-check"
     HONOR_STATEMENT = "honor-statement"
 
-    @classmethod
-    def is_valid(cls, value: str) -> bool:
-        try:
-            cls(value)
-        except ValueError:
-            return False
-        return True
-
     def get_title(self) -> str:
         return self.value.title().replace("-", " ")
 

--- a/api/src/pcapi/core/users/generator.py
+++ b/api/src/pcapi/core/users/generator.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 from pcapi import settings
+import pcapi.core.fraud.models as fraud_models
 import pcapi.core.subscription.models as subscription_models
 import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
@@ -11,6 +12,7 @@ from . import exceptions
 @dataclasses.dataclass
 class GenerateUserData:
     age: int
+    id_provider: str
     is_beneficiary: bool
     step: subscription_models.SubscriptionStep | None = None
 
@@ -35,4 +37,5 @@ def generate_user(user_data: GenerateUserData) -> users_models.User:
     if user_data.is_beneficiary:
         factory = users_factories.BeneficiaryFactory
 
-    return factory(age=user_data.age)
+    id_provider = fraud_models.FraudCheckType[user_data.id_provider]
+    return factory(age=user_data.age, beneficiaryFraudChecks__type=id_provider)

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
@@ -37,6 +37,7 @@ def generate_user() -> utils.BackofficeResponse:
     try:
         user_data = users_generator.GenerateUserData(
             age=form.age.data,
+            id_provider=form.id_provider.data,
             step=form.step.data,
             is_beneficiary=form.is_beneficiary.data,
         )

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/blueprint.py
@@ -37,9 +37,8 @@ def generate_user() -> utils.BackofficeResponse:
     try:
         user_data = users_generator.GenerateUserData(
             age=form.age.data,
-            id_provider=form.id_provider.data,
-            step=form.step.data,
-            is_beneficiary=form.is_beneficiary.data,
+            id_provider=users_generator.GeneratedIdProvider[form.id_provider.data],
+            step=users_generator.GeneratedSubscriptionStep[form.step.data],
         )
         user = users_generator.generate_user(user_data=user_data)
     except users_exceptions.UserGenerationForbiddenException:

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
@@ -8,8 +8,7 @@ class UserGeneratorForm(utils.PCForm):
     age = fields.PCIntegerField("Age", default=users_constants.ELIGIBILITY_AGE_18)
     step = fields.PCSelectField(
         "Étape de validation",
-        choices=[(step.value, step.get_title()) for step in SubscriptionStep if step != SubscriptionStep.MAINTENANCE],
-        default=SubscriptionStep.EMAIL_VALIDATION.value,
-        coerce=lambda value: SubscriptionStep(value) if SubscriptionStep.is_valid(value) else None,
+        choices=[(step.name, step.get_title()) for step in SubscriptionStep if step != SubscriptionStep.MAINTENANCE],
+        default=SubscriptionStep.EMAIL_VALIDATION.name,
     )
     is_beneficiary = fields.PCSwitchBooleanField("Bénéficiaire", default=False)

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
@@ -1,6 +1,6 @@
-from pcapi.core.fraud.models import FraudCheckType
-from pcapi.core.subscription.models import SubscriptionStep
 from pcapi.core.users import constants as users_constants
+from pcapi.core.users.generator import GeneratedIdProvider
+from pcapi.core.users.generator import GeneratedSubscriptionStep
 from pcapi.routes.backoffice_v3.forms import fields
 from pcapi.routes.backoffice_v3.forms import utils
 
@@ -10,15 +10,21 @@ class UserGeneratorForm(utils.PCForm):
     id_provider = fields.PCSelectField(
         "Méthode d'identification",
         choices=[
-            (FraudCheckType.DMS.name, "DMS"),
-            (FraudCheckType.EDUCONNECT.name, "Educonnect"),
-            (FraudCheckType.UBBLE.name, "Ubble"),
+            (GeneratedIdProvider.DMS.name, "DMS"),
+            (GeneratedIdProvider.EDUCONNECT.name, "Educonnect"),
+            (GeneratedIdProvider.UBBLE.name, "Ubble"),
         ],
-        default=FraudCheckType.UBBLE.name,
+        default=GeneratedIdProvider.UBBLE.name,
     )
     step = fields.PCSelectField(
         "Étape de validation",
-        choices=[(step.name, step.get_title()) for step in SubscriptionStep if step != SubscriptionStep.MAINTENANCE],
-        default=SubscriptionStep.EMAIL_VALIDATION.name,
+        choices=[
+            (GeneratedSubscriptionStep.EMAIL_VALIDATION.name, "Email Validé"),
+            (GeneratedSubscriptionStep.PHONE_VALIDATION.name, "Téléphone validé"),
+            (GeneratedSubscriptionStep.PROFILE_COMPLETION.name, "Profil completé"),
+            (GeneratedSubscriptionStep.IDENTITY_CHECK.name, "Identité vérifiée"),
+            (GeneratedSubscriptionStep.HONOR_STATEMENT.name, "Attesté sur l'honneur"),
+            (GeneratedSubscriptionStep.BENEFICIARY.name, "Bénéficiaire"),
+        ],
+        default=GeneratedSubscriptionStep.EMAIL_VALIDATION.name,
     )
-    is_beneficiary = fields.PCSwitchBooleanField("Bénéficiaire", default=False)

--- a/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/user_generation/forms.py
@@ -1,3 +1,4 @@
+from pcapi.core.fraud.models import FraudCheckType
 from pcapi.core.subscription.models import SubscriptionStep
 from pcapi.core.users import constants as users_constants
 from pcapi.routes.backoffice_v3.forms import fields
@@ -6,6 +7,15 @@ from pcapi.routes.backoffice_v3.forms import utils
 
 class UserGeneratorForm(utils.PCForm):
     age = fields.PCIntegerField("Age", default=users_constants.ELIGIBILITY_AGE_18)
+    id_provider = fields.PCSelectField(
+        "Méthode d'identification",
+        choices=[
+            (FraudCheckType.DMS.name, "DMS"),
+            (FraudCheckType.EDUCONNECT.name, "Educonnect"),
+            (FraudCheckType.UBBLE.name, "Ubble"),
+        ],
+        default=FraudCheckType.UBBLE.name,
+    )
     step = fields.PCSelectField(
         "Étape de validation",
         choices=[(step.name, step.get_title()) for step in SubscriptionStep if step != SubscriptionStep.MAINTENANCE],

--- a/api/tests/core/users/test_generator.py
+++ b/api/tests/core/users/test_generator.py
@@ -1,7 +1,6 @@
 import pytest
 
 import pcapi.core.fraud.models as fraud_models
-import pcapi.core.subscription.models as subscription_models
 from pcapi.core.users import constants as users_constants
 import pcapi.core.users.generator as users_generator
 import pcapi.core.users.models as users_models
@@ -20,7 +19,6 @@ class UserGeneratorTest:
 
     def assert_user_passed_email_validation(self, user: users_models.User):
         assert user.isEmailValidated is True
-        assert user.is_beneficiary is False
 
     def assert_user_passed_phone_validation(self, user: users_models.User):
         self.assert_user_passed_email_validation(user)
@@ -53,12 +51,24 @@ class UserGeneratorTest:
         self.assert_user_passed_identity_check(user)
         assert self.has_fraud_check_validated(user, fraud_models.FraudCheckType.HONOR_STATEMENT)
 
-    def test_generate_default_user(self):
-        user_data = users_generator.GenerateUserData(
-            age=users_constants.ELIGIBILITY_AGE_18,
-            step=subscription_models.SubscriptionStep.EMAIL_VALIDATION,
-            is_beneficiary=False,
+    def assert_user_is_beneficiary(self, user: users_models.User):
+        self.assert_user_passed_honor_statement(user)
+        expected_role = (
+            users_models.UserRole.BENEFICIARY
+            if user.age == users_constants.ELIGIBILITY_AGE_18
+            else users_models.UserRole.UNDERAGE_BENEFICIARY
         )
+        expected_deposit_type = (
+            users_models.DepositType.GRANT_18
+            if user.age == users_constants.ELIGIBILITY_AGE_18
+            else users_models.DepositType.GRANT_15_17
+        )
+        assert user.is_beneficiary is True
+        assert expected_role in user.roles
+        assert user.deposit.type == expected_deposit_type
+
+    def test_generate_default_user(self):
+        user_data = users_generator.GenerateUserData()
         user = users_generator.generate_user(user_data)
 
         assert user.isEmailValidated is True
@@ -66,17 +76,10 @@ class UserGeneratorTest:
         assert user.is_beneficiary is False
 
     def test_generate_beneficiary_user(self):
-        user_data = users_generator.GenerateUserData(
-            age=users_constants.ELIGIBILITY_AGE_18,
-            is_beneficiary=True,
-        )
+        user_data = users_generator.GenerateUserData(step=users_generator.GeneratedSubscriptionStep.BENEFICIARY)
         user = users_generator.generate_user(user_data)
 
-        assert user.isEmailValidated is True
-        assert user.age == users_constants.ELIGIBILITY_AGE_18
-        assert user.is_beneficiary is True
-        assert users_models.UserRole.BENEFICIARY in user.roles
-        assert user.deposit.type == users_models.DepositType.GRANT_18
+        self.assert_user_is_beneficiary(user)
 
     @pytest.mark.parametrize(
         "age",
@@ -90,21 +93,39 @@ class UserGeneratorTest:
     @pytest.mark.parametrize(
         "step, tests",
         [
-            (subscription_models.SubscriptionStep.EMAIL_VALIDATION, assert_user_passed_email_validation),
-            (subscription_models.SubscriptionStep.PHONE_VALIDATION, assert_user_passed_phone_validation),
-            (subscription_models.SubscriptionStep.PROFILE_COMPLETION, assert_user_passed_profile_completion),
-            (subscription_models.SubscriptionStep.IDENTITY_CHECK, assert_user_passed_identity_check),
-            (subscription_models.SubscriptionStep.HONOR_STATEMENT, assert_user_passed_honor_statement),
+            (users_generator.GeneratedSubscriptionStep.EMAIL_VALIDATION, assert_user_passed_email_validation),
+            (users_generator.GeneratedSubscriptionStep.PHONE_VALIDATION, assert_user_passed_phone_validation),
+            (users_generator.GeneratedSubscriptionStep.PROFILE_COMPLETION, assert_user_passed_profile_completion),
+            (users_generator.GeneratedSubscriptionStep.IDENTITY_CHECK, assert_user_passed_identity_check),
+            (users_generator.GeneratedSubscriptionStep.HONOR_STATEMENT, assert_user_passed_honor_statement),
+            (users_generator.GeneratedSubscriptionStep.BENEFICIARY, assert_user_is_beneficiary),
         ],
     )
     def test_generate_user_at_step(self, age, step, tests):
         user_data = users_generator.GenerateUserData(
             age=age,
+            id_provider=users_generator.GeneratedIdProvider.UBBLE,
             step=step,
-            is_beneficiary=False,
         )
         user = users_generator.generate_user(user_data)
         tests(self, user)
+
+    @pytest.mark.parametrize(
+        "id_provider",
+        [
+            users_generator.GeneratedIdProvider.DMS,
+            users_generator.GeneratedIdProvider.EDUCONNECT,
+            users_generator.GeneratedIdProvider.UBBLE,
+        ],
+    )
+    def test_user_generated_with_id_provider(self, id_provider: users_generator.GeneratedIdProvider):
+        user_data = users_generator.GenerateUserData(
+            age=users_constants.ELIGIBILITY_AGE_18,
+            id_provider=id_provider,
+            step=users_generator.GeneratedSubscriptionStep.IDENTITY_CHECK,
+        )
+        user = users_generator.generate_user(user_data)
+        self.has_fraud_check_validated(user, id_provider.value)
 
     @pytest.mark.parametrize(
         "age",
@@ -117,12 +138,9 @@ class UserGeneratorTest:
     def test_generate_underage_beneficiary_user(self, age):
         user_data = users_generator.GenerateUserData(
             age=age,
-            is_beneficiary=True,
+            step=users_generator.GeneratedSubscriptionStep.BENEFICIARY,
         )
         user = users_generator.generate_user(user_data)
 
-        assert user.isEmailValidated is True
         assert user.age == age
-        assert user.is_beneficiary is True
-        assert users_models.UserRole.UNDERAGE_BENEFICIARY in user.roles
-        assert user.deposit.type == users_models.DepositType.GRANT_15_17
+        self.assert_user_is_beneficiary(user)

--- a/api/tests/routes/backoffice_v3/user_generation_test.py
+++ b/api/tests/routes/backoffice_v3/user_generation_test.py
@@ -33,6 +33,6 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
 
     @override_settings(ENABLE_TEST_USER_GENERATION=False)
     def test_returns_not_found_if_generation_disabled(self, authenticated_client):
-        form = {"age": "18", "is_beneficiary": "0", "id_provider": "UBBLE", "step": "email-validation"}
+        form = {"age": "18", "id_provider": "UBBLE", "step": "BENEFICIARY"}
         response = self.post_to_endpoint(authenticated_client, form=form)
         assert response.status_code == 404

--- a/api/tests/routes/backoffice_v3/user_generation_test.py
+++ b/api/tests/routes/backoffice_v3/user_generation_test.py
@@ -33,6 +33,6 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
 
     @override_settings(ENABLE_TEST_USER_GENERATION=False)
     def test_returns_not_found_if_generation_disabled(self, authenticated_client):
-        form = {"age": "18", "is_beneficiary": "0", "step": "email-validation"}
+        form = {"age": "18", "is_beneficiary": "0", "id_provider": "UBBLE", "step": "email-validation"}
         response = self.post_to_endpoint(authenticated_client, form=form)
         assert response.status_code == 404


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22800

## But de la pull request

Dans le formulaire de génération d'utilisateurs dans le backoffice, permettre de choisir la méthode d'identification par laquelle est passé l'utilisateur généré (le cas échéant).

## Implémentation

- Ajout d'un champ dans le formulaire
- Remplacement des enum existantes par des nouvelles enum propre au module générateur d'utilisateur
- Nettoyage du code

## Informations supplémentaires

## Modifications du schéma de la base de données

## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)

![image](https://github.com/pass-culture/pass-culture-main/assets/128476306/c870bea6-1e18-4978-9f7b-cfb5a2367152)
