### PR TITLE
(PC-20651)[BO] feat: search for offerer and venues by SIREN/SIRET with spaces

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/forms/search.py
+++ b/api/src/pcapi/routes/backoffice_v3/forms/search.py
@@ -1,3 +1,5 @@
+import re
+
 from flask_wtf import FlaskForm
 import wtforms
 from wtforms import validators
@@ -6,6 +8,9 @@ from pcapi.routes.backoffice_v3.serialization.search import TypeOptions
 
 from . import fields
 from . import utils
+
+
+DIGITS_AND_WHITESPACES_REGEX = re.compile(r"^[\d\s]+$")
 
 
 class SearchForm(FlaskForm):
@@ -46,3 +51,9 @@ class ProSearchForm(SearchForm):
     pro_type = fields.PCSelectField(
         "Type", choices=utils.values_from_enum(TypeOptions), default=TypeOptions.OFFERER.value
     )
+
+    def filter_terms(self, value: str | None) -> str | None:
+        # Remove spaces from SIREN, SIRET and IDs
+        if value and DIGITS_AND_WHITESPACES_REGEX.match(value):
+            return re.sub(r"\s+", "", value)
+        return value

--- a/api/src/pcapi/routes/backoffice_v3/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice_v3/offerers/forms.py
@@ -1,3 +1,5 @@
+import re
+
 from flask_wtf import FlaskForm
 import sqlalchemy as sa
 import wtforms
@@ -14,6 +16,7 @@ from ..forms.empty import BatchForm
 
 
 TAG_NAME_REGEX = r"^[^\s]+$"
+DIGITS_AND_WHITESPACES_REGEX = re.compile(r"^[\d\s]+$")
 
 
 def _get_all_tags_query() -> sa.orm.Query:
@@ -112,10 +115,14 @@ class OffererValidationListForm(utils.PCForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9, 12):
-            raise wtforms.validators.ValidationError(
-                "Le nombre de chiffres ne correspond pas à un SIREN, code postal, département ou ID DMS CB"
-            )
+        if q.data:
+            # Remove spaces from SIREN, IDs, postal code
+            if DIGITS_AND_WHITESPACES_REGEX.match(q.data):
+                q.data = re.sub(r"\s+", "", q.data)
+            if q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9, 12):
+                raise wtforms.validators.ValidationError(
+                    "Le nombre de chiffres ne correspond pas à un SIREN, code postal, département ou ID DMS CB"
+                )
         return q
 
 
@@ -157,10 +164,14 @@ class UserOffererValidationListForm(utils.PCForm):
     )
 
     def validate_q(self, q: fields.PCOptSearchField) -> fields.PCOptSearchField:
-        if q.data and q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
-            raise wtforms.validators.ValidationError(
-                "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
-            )
+        if q.data:
+            # Remove spaces from SIREN, IDs, postal code
+            if DIGITS_AND_WHITESPACES_REGEX.match(q.data):
+                q.data = re.sub(r"\s+", "", q.data)
+            if q.data.isnumeric() and len(q.data) not in (2, 3, 5, 9):
+                raise wtforms.validators.ValidationError(
+                    "Le nombre de chiffres ne correspond pas à un SIREN, code postal ou département"
+                )
         return q
 
 

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -1306,7 +1306,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             assert response.status_code == 400
             assert "Date invalide" in response.data.decode("utf-8")
 
-        @pytest.mark.parametrize("search", ["123004004", "  123004004 ", "123004004\n"])
+        @pytest.mark.parametrize("search", ["123004004", "123 004 004", "  123004004 ", "123004004\n"])
         def test_list_search_by_siren(self, authenticated_client, offerers_to_be_validated, search):
             # when
             with assert_num_queries(self.expected_num_queries):
@@ -1319,11 +1319,12 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             rows = html_parser.extract_table_rows(response.data)
             assert {row["Nom de la structure"] for row in rows} == {"D"}
 
-        def test_list_search_by_postal_code(self, authenticated_client, offerers_to_be_validated):
+        @pytest.mark.parametrize("postal_code", ["35400", "35 400"])
+        def test_list_search_by_postal_code(self, authenticated_client, offerers_to_be_validated, postal_code):
             # when
             with assert_num_queries(self.expected_num_queries):
                 response = authenticated_client.get(
-                    url_for("backoffice_v3_web.validation.list_offerers_to_validate", q="35400")
+                    url_for("backoffice_v3_web.validation.list_offerers_to_validate", q=postal_code)
                 )
 
             # then
@@ -2197,10 +2198,11 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert [int(row["ID Compte pro"]) for row in rows] == [uo.user.id for uo in (user_offerer_3, user_offerer_2)]
 
-    def test_list_search_by_postal_code(self, authenticated_client, user_offerer_to_be_validated):
+    @pytest.mark.parametrize("postal_code", ["97100", "97 100"])
+    def test_list_search_by_postal_code(self, authenticated_client, user_offerer_to_be_validated, postal_code):
         # when
         with assert_no_duplicated_queries():
-            response = authenticated_client.get(url_for(self.endpoint, q="97100"))
+            response = authenticated_client.get(url_for(self.endpoint, q=postal_code))
 
         # then
         assert response.status_code == 200

--- a/api/tests/routes/backoffice_v3/pro_test.py
+++ b/api/tests/routes/backoffice_v3/pro_test.py
@@ -233,12 +233,13 @@ class SearchOffererTest:
         assert len(cards_text) == 1
         assert_offerer_equals(cards_text[0], self.offerers[2])
 
-    def test_can_search_offerer_by_siren(self, authenticated_client):
+    @pytest.mark.parametrize("siren", ["123456003", "123 456 003 "])
+    def test_can_search_offerer_by_siren(self, authenticated_client, siren):
         # given
         self._create_offerers()
 
         # when
-        response = authenticated_client.get(url_for(self.endpoint, terms=self.offerers[3].siren, pro_type="offerer"))
+        response = authenticated_client.get(url_for(self.endpoint, terms=siren, pro_type="offerer"))
 
         # then
         assert response.status_code == 200
@@ -318,12 +319,13 @@ class SearchVenueTest:
         assert len(cards_text) == 1
         assert_venue_equals(cards_text[0], self.venues[2])
 
-    def test_can_search_venue_by_siret(self, authenticated_client):
+    @pytest.mark.parametrize("siret", ["12345600300003", "123 456 003 00003"])
+    def test_can_search_venue_by_siret(self, authenticated_client, siret):
         # given
         self._create_venues()
 
         # when
-        response = authenticated_client.get(url_for(self.endpoint, terms=self.venues[3].siret, pro_type="venue"))
+        response = authenticated_client.get(url_for(self.endpoint, terms=siret, pro_type="venue"))
 
         # then
         assert response.status_code == 200


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-20651

## But de la pull request

Permettre les espaces à l'intérieur des SIREN/SIRET lors d'une recherche de structure ou lieu dans le backoffice.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
