### PR TITLE
(PC-22823)[API] fix: use named column to map indice

### DIFF
--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -26,6 +26,55 @@ DATE_REGEXP = re.compile(r"([a-zA-Z]+)(\d+).tit")
 THINGS_FOLDER_NAME_TITELIVE = "livre3_11"
 NUMBER_OF_ELEMENTS_PER_LINE = 46  # (45 elements from line + \n)
 PAPER_PRESS_TVA = "2,10"
+COLUMN_INDICES = (
+    {  #  this list all field as per in the v11 documentation provided by titelive, without renaming fields.
+        "ean": 0,
+        "isbn": 1,  #  deprecated, do not use, also not use at pass culture except in one unit test
+        "titre": 2,
+        "titre_court": 3,
+        "code_rayon_csr": 4,
+        "disponibilite": 5,
+        "collection": 6,
+        "num_in_collection": 7,
+        "categorie_de_prix": 8,  #  deprecated, do not use, also not use at pass culture
+        "prix_ttc": 9,
+        "editeur": 10,
+        "distributeur": 11,
+        "date_commercialisation": 12,
+        "code_support": 13,
+        "code_tva": 14,
+        "nb_pages": 15,
+        "longueur": 16,
+        "largeur": 17,
+        "epaisseur": 18,
+        "poids": 19,
+        "sujet": 20,  # not used at pass culture
+        "statut_fiche": 21,
+        "mise_en_vente": 22,  #  deprecated, do not use, also not used at pass culture
+        "auteurs": 23,
+        "date_creation": 24,
+        "date_derniere_maj": 25,
+        "taux_tva": 26,
+        "libelle_code_rayon_csr": 27,
+        "traducteur": 28,
+        "langue_vo": 29,
+        "critique_presse": 30,  #  deprecated, do not use, also not used at pass culture
+        "commentaire": 31,
+        "palmares_pro": 32,
+        "image": 33,
+        "code_edi_fournisseur": 34,
+        "libelle_serie": 35,
+        "id_genre_bd": 36,  #  deprecated, do not use, also not used at pass culture
+        "libelle_genre_bd": 37,  #  deprecated, do not use, also not used at pass culture
+        "numero_de_catalogue": 38,
+        "scolaire": 39,
+        "compteur_mp3": 40,
+        "url_feuilleteur": 41,
+        "id_auteur": 42,
+        "indice_dewey": 43,
+        "code_regroupement": 44,
+    }
+)
 PAPER_PRESS_SUPPORT_CODE = "R"
 SCHOOL_RELATED_CSR_CODE = [
     "2700",
@@ -288,44 +337,44 @@ def get_subcategory_and_extra_data_from_titelive_type(titelive_type: str) -> tup
 
 def get_infos_from_data_line(elts: list) -> dict:
     infos = {}
-    infos["ean13"] = elts[0]
-    infos["titre"] = elts[2]
-    infos["titre_court"] = elts[3]
-    infos["code_csr"] = elts[4]
-    infos["code_dispo"] = elts[5]
-    infos["collection"] = elts[6]
-    infos["num_in_collection"] = elts[7]
-    infos["prix"] = elts[9]
-    infos["editeur"] = elts[10]
-    infos["distributeur"] = elts[11]
-    infos["date_parution"] = elts[12]
-    infos["code_support"] = elts[13]
-    infos["code_tva"] = elts[14]
-    infos["n_pages"] = elts[15]
-    infos["longueur"] = elts[16]
-    infos["largeur"] = elts[17]
-    infos["epaisseur"] = elts[18]
-    infos["poids"] = elts[19]
-    infos["is_update"] = elts[21]
-    infos["auteurs"] = elts[23]
-    infos["datetime_created"] = elts[24]
-    infos["date_updated"] = elts[25]
-    infos["taux_tva"] = elts[26]
-    infos["libelle_csr"] = elts[27]
-    infos["traducteur"] = elts[28]
-    infos["langue_orig"] = elts[29]
-    infos["commentaire"] = elts[31]
-    infos["classement_top"] = elts[32]
-    infos["has_image"] = elts[33]
-    infos["code_edi_fournisseur"] = elts[34]
-    infos["libelle_serie_bd"] = elts[35]
-    infos["ref_editeur"] = elts[38]
-    infos["is_scolaire"] = elts[39]
-    infos["n_extraits_mp3"] = elts[40]
-    infos["url_extrait_pdf"] = elts[41]
-    infos["id_auteur"] = elts[42]
-    infos["indice_dewey"] = elts[43]
-    infos["code_regroupement"] = elts[44]
+    infos["ean13"] = elts[COLUMN_INDICES["ean"]]
+    infos["titre"] = elts[COLUMN_INDICES["titre"]]
+    infos["titre_court"] = elts[COLUMN_INDICES["titre_court"]]
+    infos["code_csr"] = elts[COLUMN_INDICES["code_rayon_csr"]]
+    infos["code_dispo"] = elts[COLUMN_INDICES["disponibilite"]]
+    infos["collection"] = elts[COLUMN_INDICES["collection"]]
+    infos["num_in_collection"] = elts[COLUMN_INDICES["num_in_collection"]]
+    infos["prix"] = elts[COLUMN_INDICES["prix_ttc"]]
+    infos["editeur"] = elts[COLUMN_INDICES["editeur"]]
+    infos["distributeur"] = elts[COLUMN_INDICES["distributeur"]]
+    infos["date_parution"] = elts[COLUMN_INDICES["date_commercialisation"]]
+    infos["code_support"] = elts[COLUMN_INDICES["code_support"]]
+    infos["code_tva"] = elts[COLUMN_INDICES["code_tva"]]
+    infos["n_pages"] = elts[COLUMN_INDICES["nb_pages"]]
+    infos["longueur"] = elts[COLUMN_INDICES["longueur"]]
+    infos["largeur"] = elts[COLUMN_INDICES["largeur"]]
+    infos["epaisseur"] = elts[COLUMN_INDICES["epaisseur"]]
+    infos["poids"] = elts[COLUMN_INDICES["poids"]]
+    infos["is_update"] = elts[COLUMN_INDICES["statut_fiche"]]
+    infos["auteurs"] = elts[COLUMN_INDICES["auteurs"]]
+    infos["datetime_created"] = elts[COLUMN_INDICES["date_creation"]]
+    infos["date_updated"] = elts[COLUMN_INDICES["date_derniere_maj"]]
+    infos["taux_tva"] = elts[COLUMN_INDICES["taux_tva"]]
+    infos["libelle_csr"] = elts[COLUMN_INDICES["libelle_code_rayon_csr"]]
+    infos["traducteur"] = elts[COLUMN_INDICES["traducteur"]]
+    infos["langue_orig"] = elts[COLUMN_INDICES["langue_vo"]]
+    infos["commentaire"] = elts[COLUMN_INDICES["commentaire"]]
+    infos["classement_top"] = elts[COLUMN_INDICES["palmares_pro"]]
+    infos["has_image"] = elts[COLUMN_INDICES["image"]]
+    infos["code_edi_fournisseur"] = elts[COLUMN_INDICES["code_edi_fournisseur"]]
+    infos["libelle_serie_bd"] = elts[COLUMN_INDICES["libelle_genre_bd"]]
+    infos["ref_editeur"] = elts[COLUMN_INDICES["numero_de_catalogue"]]
+    infos["is_scolaire"] = elts[COLUMN_INDICES["scolaire"]]
+    infos["n_extraits_mp3"] = elts[COLUMN_INDICES["compteur_mp3"]]
+    infos["url_extrait_pdf"] = elts[COLUMN_INDICES["url_feuilleteur"]]
+    infos["id_auteur"] = elts[COLUMN_INDICES["id_auteur"]]
+    infos["indice_dewey"] = elts[COLUMN_INDICES["indice_dewey"]]
+    infos["code_regroupement"] = elts[COLUMN_INDICES["code_regroupement"]]
     return infos
 
 

--- a/api/tests/local_providers/titelive_things_test.py
+++ b/api/tests/local_providers/titelive_things_test.py
@@ -16,6 +16,7 @@ import pcapi.core.providers.factories as providers_factories
 import pcapi.core.providers.models as providers_models
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.local_providers import TiteLiveThings
+from pcapi.local_providers.titelive_things.titelive_things import COLUMN_INDICES
 
 
 BASE_DATA_LINE_PARTS = [
@@ -101,10 +102,10 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[2] = "livre scolaire"
-        DATA_LINE_PARTS[27] = "Littérature scolaire"
-        DATA_LINE_PARTS[39] = "1"
-        DATA_LINE_PARTS[40] = "0"
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["scolaire"]] = "1"
+        DATA_LINE_PARTS[COLUMN_INDICES["compteur_mp3"]] = "0"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -127,10 +128,10 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[2] = "livre scolaire"
-        DATA_LINE_PARTS[27] = "Littérature scolaire"
-        DATA_LINE_PARTS[39] = "1"
-        DATA_LINE_PARTS[40] = "0"
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["scolaire"]] = "1"
+        DATA_LINE_PARTS[COLUMN_INDICES["compteur_mp3"]] = "0"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -219,10 +220,10 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[13] = "LE"
-        DATA_LINE_PARTS[27] = "Littérature scolaire"
-        DATA_LINE_PARTS[39] = "1"
-        DATA_LINE_PARTS[40] = "0"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "LE"
+        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["scolaire"]] = "1"
+        DATA_LINE_PARTS[COLUMN_INDICES["compteur_mp3"]] = "0"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -245,10 +246,10 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[2] = "livre scolaire"
-        DATA_LINE_PARTS[4] = "2704"
-        DATA_LINE_PARTS[27] = "Littérature scolaire"
-        DATA_LINE_PARTS[40] = ""
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_rayon_csr"]] = "2704"
+        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["compteur_mp3"]] = ""
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -271,10 +272,10 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[2] = "livre scolaire"
-        DATA_LINE_PARTS[4] = "2704"
-        DATA_LINE_PARTS[27] = "Littérature scolaire"
-        DATA_LINE_PARTS[40] = ""
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_rayon_csr"]] = "2704"
+        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["compteur_mp3"]] = ""
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -304,11 +305,11 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[2] = "jeux de société"
-        DATA_LINE_PARTS[4] = "1234"
-        DATA_LINE_PARTS[13] = "O"
-        DATA_LINE_PARTS[27] = "Littérature scolaire"
-        DATA_LINE_PARTS[40] = ""
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "jeux de société"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_rayon_csr"]] = "1234"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "O"
+        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        DATA_LINE_PARTS[COLUMN_INDICES["compteur_mp3"]] = ""
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -337,11 +338,11 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         data_line_parts = BASE_DATA_LINE_PARTS[:]
-        data_line_parts[2] = "jeux de société"
-        data_line_parts[4] = "1234"
-        data_line_parts[13] = "O"
-        data_line_parts[27] = "Littérature scolaire"
-        data_line_parts[40] = ""
+        data_line_parts[COLUMN_INDICES["titre"]] = "jeux de société"
+        data_line_parts[COLUMN_INDICES["code_rayon_csr"]] = "1234"
+        data_line_parts[COLUMN_INDICES["code_support"]] = "O"
+        data_line_parts[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
+        data_line_parts[COLUMN_INDICES["compteur_mp3"]] = ""
         data_line = "~".join(data_line_parts)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -374,12 +375,12 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[1] = "9136205982"
-        DATA_LINE_PARTS[13] = "R"
-        DATA_LINE_PARTS[26] = "2,10"
+        DATA_LINE_PARTS[COLUMN_INDICES["isbn"]] = "9136205982"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "R"
+        DATA_LINE_PARTS[COLUMN_INDICES["taux_tva"]] = "2,10"
         data_line_1 = "~".join(DATA_LINE_PARTS)
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[26] = "2,10"
+        DATA_LINE_PARTS[COLUMN_INDICES["taux_tva"]] = "2,10"
         data_line_2 = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line_1, data_line_2])
 
@@ -405,8 +406,8 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[13] = "R"
-        DATA_LINE_PARTS[26] = "2,10"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "R"
+        DATA_LINE_PARTS[COLUMN_INDICES["taux_tva"]] = "2,10"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -436,8 +437,8 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[13] = "R"
-        DATA_LINE_PARTS[26] = "2,10"
+        DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "R"
+        DATA_LINE_PARTS[COLUMN_INDICES["taux_tva"]] = "2,10"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -475,8 +476,8 @@ class TiteliveThingsTest:
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[2] = "xxx"
-        DATA_LINE_PARTS[23] = "Xxx"
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "xxx"
+        DATA_LINE_PARTS[COLUMN_INDICES["auteurs"]] = "Xxx"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -500,9 +501,9 @@ class TiteliveThingsTest:
         book_ean = "9782895026310"
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[1] = book_ean
-        DATA_LINE_PARTS[2] = "xxx"
-        DATA_LINE_PARTS[23] = "Xxx"
+        DATA_LINE_PARTS[COLUMN_INDICES["isbn"]] = book_ean
+        DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "xxx"
+        DATA_LINE_PARTS[COLUMN_INDICES["auteurs"]] = "Xxx"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22823

## But de la pull request

Simplifié la migration v11 vers v19 du fichier titelive ftp.

## Implémentation

Ajout d'un dict `COLUMN_INDICES`  qui map le nom de colonne avec son indices

## Informations supplémentaires

Suppression de ligne obselète dans les tests (isbn, compteur mp3)

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
