### PR TITLE
(PC-22547)[API] feat: Add expiration date to account suspension token

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1295,12 +1295,16 @@ def is_suspicious_login(device_info: "account_serialization.TrustedDevice | None
 
 
 def create_suspicious_login_email_token(login_info: users_models.LoginDeviceHistory | None, user_id: int) -> str:
+    current_datetime = datetime.datetime.utcnow()
+    expiration_date = current_datetime + datetime.timedelta(weeks=1)
+
     if login_info is None:
         return users_utils.encode_jwt_payload(
             token_payload={
                 "userId": user_id,
-                "dateCreated": datetime.datetime.utcnow().strftime(date_utils.DATE_ISO_FORMAT),
-            }
+                "dateCreated": current_datetime.strftime(date_utils.DATE_ISO_FORMAT),
+            },
+            expiration_date=expiration_date,
         )
 
     return users_utils.encode_jwt_payload(
@@ -1310,5 +1314,6 @@ def create_suspicious_login_email_token(login_info: users_models.LoginDeviceHist
             "location": login_info.location,
             "os": login_info.os,
             "source": login_info.source,
-        }
+        },
+        expiration_date=expiration_date,
     )

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -321,10 +321,12 @@ def suspend_account(user: users_models.User) -> None:
 
 
 @blueprint.native_v1.route("/account/suspend/token_validation/<token>", methods=["GET"])
-@spectree_serialize(on_success_status=204, api=blueprint.api, on_error_statuses=[400])
+@spectree_serialize(on_success_status=204, api=blueprint.api, on_error_statuses=[400, 401])
 def account_suspension_token_validation(token: str) -> None:
     try:
         decode_jwt_token(token)
+    except jwt.ExpiredSignatureError:
+        raise api_errors.ApiErrors({"reason": "Le token a expiré."}, status_code=401)
     except (jwt.InvalidTokenError, jwt.InvalidSignatureError):
         raise api_errors.ApiErrors({"reason": "Le token est invalide."})
 

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1451,6 +1451,7 @@ class IsSuspiciousLoginTest:
 
 
 class CreateSuspiciousLoginEmailTokenTest:
+    @freeze_time("2023-06-19 10:30:00")
     def should_encode_login_info_in_token(self):
         user = users_factories.UserFactory()
         login_info = users_models.LoginDeviceHistory(
@@ -1458,7 +1459,7 @@ class CreateSuspiciousLoginEmailTokenTest:
             source="iPhone 13",
             os="iOS",
             location="Paris",
-            dateCreated=datetime.datetime(2023, 6, 2, 16, 10),
+            dateCreated=datetime.datetime(2023, 6, 19, 10, 30),
         )
 
         jwt_token = users_api.create_suspicious_login_email_token(login_info, user.id)
@@ -1467,10 +1468,11 @@ class CreateSuspiciousLoginEmailTokenTest:
 
         assert decoded == {
             "userId": user.id,
-            "dateCreated": "2023-06-02T16:10:00.000000Z",
+            "dateCreated": "2023-06-19T10:30:00.000000Z",
             "location": "Paris",
             "source": "iPhone 13",
             "os": "iOS",
+            "exp": datetime.datetime(2023, 6, 26, 10, 30).timestamp(),
         }
 
     @freeze_time("2023-06-02 16:10:00")
@@ -1484,4 +1486,5 @@ class CreateSuspiciousLoginEmailTokenTest:
         assert decoded == {
             "userId": user.id,
             "dateCreated": "2023-06-02T16:10:00.000000Z",
+            "exp": datetime.datetime(2023, 6, 9, 16, 10).timestamp(),
         }

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1926,3 +1926,15 @@ class SuspensionTokenValidationTest:
         response = client.get(f"/native/v1/account/suspend/token_validation/{token}")
 
         assert response.status_code == 204
+
+    def test_error_when_token_is_expired(self, client):
+        passed_expiration_date = (datetime.utcnow() - timedelta(days=1)).timestamp()
+        token = jwt.encode(
+            {"userId": 1, "exp": passed_expiration_date},
+            settings.JWT_SECRET_KEY,
+            algorithm=ALGORITHM_HS_256,
+        )
+        response = client.get(f"/native/v1/account/suspend/token_validation/{token}")
+
+        assert response.status_code == 401
+        assert response.json["reason"] == "Le token a expiré."

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -2012,6 +2012,7 @@ def test_public_api(client):
                     "responses": {
                         "204": {"description": "No Content"},
                         "400": {"description": "Bad Request"},
+                        "401": {"description": "Unauthorized"},
                         "403": {"description": "Forbidden"},
                         "422": {
                             "content": {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22547

## But de la pull request

Ajouter une date d'expiration au token utilisé pour la suspension/sécurisation de compte, pour ne pas pouvoir utiliser le token dans le lien reçu par mail après une semaine.
## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
