### PR TITLE
(PC-22657)[API] feat: Boost synchro store showtimes version (VF/VO) and format (3D) in stock.features

### DIFF
--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -11,9 +11,18 @@ from pcapi.core.offerers.models import Venue
 from pcapi.core.offers import models as offers_models
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.providers.models import VenueProvider
+from pcapi.local_providers.cinema_providers.constants import ShowtimeFeatures
 from pcapi.local_providers.local_provider import LocalProvider
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models import Model
+
+
+ACCEPTED_VERSIONS_MAPPING = {
+    "VF": ShowtimeFeatures.VF.value,
+    "VO": ShowtimeFeatures.VO.value,
+}
+
+ACCEPTED_FORMATS_MAPPING = {"3D": ShowtimeFeatures.THREE_D.value}
 
 
 class BoostStocks(LocalProvider):
@@ -118,6 +127,15 @@ class BoostStocks(LocalProvider):
         if "quantity" not in stock.fieldsUpdated:
             booked_quantity = 0 if is_new_stock_to_insert else stock.dnBookedQuantity
             stock.quantity = self.showtime_details.numberSeatsRemaining + booked_quantity
+
+        features = (
+            [ACCEPTED_VERSIONS_MAPPING.get(self.showtime_details.version["code"])]
+            if self.showtime_details.version["code"] in ACCEPTED_VERSIONS_MAPPING
+            else []
+        )
+        if self.showtime_details.format["title"] in ACCEPTED_FORMATS_MAPPING:
+            features.append(ACCEPTED_FORMATS_MAPPING.get(self.showtime_details.format["title"]))
+        stock.features = features
 
         if "price" not in stock.fieldsUpdated:
             assert self.pcu_pricing  # helps mypy

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_venue_provider_and_external_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_venue_provider_and_external_bookings.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def _cinema_stock_features(provider: Provider) -> list[str]:
     features = [random.choice(["VF", "VO"])]
     match provider.name:
-        case "CDSStocks":
+        case "CDSStocks" | "BoostStocks":
             if random.choice([True, False]):
                 features.append("3D")
         case "CGRStocks":

--- a/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/boost/boost_stocks_test.py
@@ -144,6 +144,7 @@ class BoostStocksTest:
         assert created_stocks[0].offer == created_offers[0]
         assert created_stocks[0].bookingLimitDatetime == datetime.datetime(2022, 11, 28, 8)
         assert created_stocks[0].beginningDatetime == datetime.datetime(2022, 11, 28, 8)
+        assert created_stocks[0].features == ["VF"]
 
         assert created_offers[1].name == "CHARLOTTE"
         assert created_offers[1].product == created_products[1]
@@ -166,6 +167,7 @@ class BoostStocksTest:
         assert created_stocks[1].offer == created_offers[1]
         assert created_stocks[1].bookingLimitDatetime == datetime.datetime(2022, 11, 28, 8)
         assert created_stocks[1].beginningDatetime == datetime.datetime(2022, 11, 28, 8)
+        assert created_stocks[1].features == ["VO", "3D"]
 
         assert all((category.price == decimal.Decimal("6.9") for category in created_price_categories))
         assert all(

--- a/api/tests/local_providers/cinema_providers/boost/fixtures.py
+++ b/api/tests/local_providers/cinema_providers/boost/fixtures.py
@@ -823,8 +823,8 @@ class ShowtimeDetailsEndpointResponse:
                 "userLastModification": "boost",
                 "lastModification": "2022-11-21T13:25:28+01:00",
             },
-            "format": {"id": 1, "title": "2D"},
-            "version": {"id": 1, "title": "Film Français", "code": "VF"},
+            "format": {"id": 1, "title": "3D"},
+            "version": {"id": 1, "title": "Film Français", "code": "VO"},
             "screen": {
                 "id": 5,
                 "auditoriumNumber": 5,


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22657

## But de la pull request
- Synchro Boost: remplir l'attribut Stock.features avec les spécificités de la séances. Avec la prise en compte de VO/VF/3D.
- Ajout des spécificités de séances en sandbox pour les offres Boost.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
