### PR TITLE
(PC-22598)[API] fix: add draft and pending offer to inactive count

### DIFF
--- a/api/tests/routes/backoffice_v3/conftest.py
+++ b/api/tests/routes/backoffice_v3/conftest.py
@@ -292,13 +292,19 @@ def offerer_active_individual_offers_fixture(offerer, venue_with_accepted_bank_i
         venue=venue_with_accepted_bank_info,
         validation=offers_models.OfferValidationStatus.APPROVED.value,
     )
-
     rejected_offer = offers_factories.OfferFactory(
         venue=venue_with_accepted_bank_info,
         validation=offers_models.OfferValidationStatus.REJECTED.value,
     )
-
-    return approved_offers + [rejected_offer]
+    pending_offer = offers_factories.OfferFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.PENDING.value,
+    )
+    draft_offer = offers_factories.OfferFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.DRAFT.value,
+    )
+    return approved_offers + [rejected_offer, pending_offer, draft_offer]
 
 
 @pytest.fixture(name="offerer_inactive_individual_offers")
@@ -309,14 +315,22 @@ def offerer_inactive_individual_offers_fixture(offerer, venue_with_accepted_bank
         isActive=False,
         validation=offers_models.OfferValidationStatus.APPROVED.value,
     )
-
     rejected_offer = offers_factories.OfferFactory(
         venue=venue_with_accepted_bank_info,
         isActive=False,
         validation=offers_models.OfferValidationStatus.REJECTED.value,
     )
-
-    return approved_offers + [rejected_offer]
+    pending_offer = offers_factories.OfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.PENDING.value,
+    )
+    draft_offer = offers_factories.OfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.DRAFT.value,
+    )
+    return approved_offers + [rejected_offer, pending_offer, draft_offer]
 
 
 @pytest.fixture(name="offerer_active_collective_offers")
@@ -326,13 +340,19 @@ def offerer_active_collective_offers_fixture(offerer, venue_with_accepted_bank_i
         venue=venue_with_accepted_bank_info,
         validation=offers_models.OfferValidationStatus.APPROVED.value,
     )
-
     rejected_offer = educational_factories.CollectiveOfferFactory(
         venue=venue_with_accepted_bank_info,
         validation=offers_models.OfferValidationStatus.REJECTED.value,
     )
-
-    return approved_offers + [rejected_offer]
+    pending_offer = educational_factories.CollectiveOfferFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.PENDING.value,
+    )
+    draft_offer = educational_factories.CollectiveOfferFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.DRAFT.value,
+    )
+    return approved_offers + [rejected_offer, pending_offer, draft_offer]
 
 
 @pytest.fixture(name="offerer_inactive_collective_offers")
@@ -343,14 +363,22 @@ def offerer_inactive_collective_offers_fixture(offerer, venue_with_accepted_bank
         isActive=False,
         validation=offers_models.OfferValidationStatus.APPROVED.value,
     )
-
     rejected_offer = educational_factories.CollectiveOfferFactory(
         venue=venue_with_accepted_bank_info,
         isActive=False,
         validation=offers_models.OfferValidationStatus.REJECTED.value,
     )
-
-    return approved_offers + [rejected_offer]
+    pending_offer = educational_factories.CollectiveOfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.PENDING.value,
+    )
+    draft_offer = educational_factories.CollectiveOfferFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.DRAFT.value,
+    )
+    return approved_offers + [rejected_offer, pending_offer, draft_offer]
 
 
 @pytest.fixture(name="offerer_active_collective_offer_templates")
@@ -365,7 +393,16 @@ def offerer_active_collective_offer_templates_fixture(offerer, venue_with_accept
         validation=offers_models.OfferValidationStatus.REJECTED.value,
     )
 
-    return [approved_offers, rejected_offer]
+    pending_offer = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.PENDING.value,
+    )
+
+    draft_offer = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        validation=offers_models.OfferValidationStatus.DRAFT.value,
+    )
+    return [approved_offers, rejected_offer, pending_offer, draft_offer]
 
 
 @pytest.fixture(name="offerer_inactive_collective_offer_templates")
@@ -383,7 +420,19 @@ def offerer_inactive_collective_offer_templates_fixture(offerer, venue_with_acce
         validation=offers_models.OfferValidationStatus.REJECTED.value,
     )
 
-    return approved_offers + [rejected_offer]
+    pending_offer = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.PENDING.value,
+    )
+
+    draft_offer = educational_factories.CollectiveOfferTemplateFactory(
+        venue=venue_with_accepted_bank_info,
+        isActive=False,
+        validation=offers_models.OfferValidationStatus.DRAFT.value,
+    )
+
+    return approved_offers + [rejected_offer, pending_offer, draft_offer]
 
 
 @pytest.fixture(name="offerer_stocks")

--- a/api/tests/routes/backoffice_v3/offerers_test.py
+++ b/api/tests/routes/backoffice_v3/offerers_test.py
@@ -438,8 +438,8 @@ class GetOffererStatsDataTest:
 
         assert stats.active.individual == 2
         assert stats.active.collective == 5
-        assert stats.inactive.individual == 3
-        assert stats.inactive.collective == 7
+        assert stats.inactive.individual == 5
+        assert stats.inactive.collective == 11
 
         total_revenue = data.total_revenue
 
@@ -463,7 +463,7 @@ class GetOffererStatsDataTest:
 
         assert stats.active.individual == 2
         assert stats.active.collective == 0
-        assert stats.inactive.individual == 3
+        assert stats.inactive.individual == 5
         assert stats.inactive.collective == 0
 
         total_revenue = data.total_revenue
@@ -489,7 +489,7 @@ class GetOffererStatsDataTest:
         assert stats.active.individual == 0
         assert stats.active.collective == 4
         assert stats.inactive.individual == 0
-        assert stats.inactive.collective == 5
+        assert stats.inactive.collective == 7
 
         total_revenue = data.total_revenue
 
@@ -536,8 +536,8 @@ class GetOffererStatsDataTest:
 
         assert stats.active.individual == 0
         assert stats.active.collective == 0
-        assert stats.inactive.individual == 3
-        assert stats.inactive.collective == 5
+        assert stats.inactive.individual == 5
+        assert stats.inactive.collective == 7
 
         total_revenue = data.total_revenue
 

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -440,8 +440,8 @@ class GetVenueStatsDataTest:
 
         assert stats.active.individual == 2
         assert stats.active.collective == 4
-        assert stats.inactive.individual == 3
-        assert stats.inactive.collective == 5
+        assert stats.inactive.individual == 5
+        assert stats.inactive.collective == 7
         assert not stats.lastSync.date
         assert not stats.lastSync.provider
 
@@ -551,7 +551,7 @@ class GetVenueStatsTest(GetEndpointHelper):
         # then
         assert response.status_code == 200
         cards_text = html_parser.extract_cards_text(response.data)
-        assert "7 offres actives (2 IND / 5 EAC) 10 offres inactives (3 IND / 7 EAC)" in cards_text
+        assert "7 offres actives (2 IND / 5 EAC) 16 offres inactives (5 IND / 11 EAC)" in cards_text
 
     def test_venue_offers_stats_0_if_no_offer(self, authenticated_client, venue_with_accepted_bank_info):
         # when


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22598

## But de la pull request

En tant que CT, j'aimerais voir si l’acteur a déjà créé des offres, afin de l’accompagner au mieux

## Implémentation

Sur les pages structures et lieux, modifier le compteur des offres “inactives”

Dans le compteur des offres inactives ajouter : 

- Offre en brouillon : créé par l'acteur mais pas encore terminé
- Offre en attente : offre qui demande une validation côté conformité, en attente de validation/rejet

## Informations supplémentaires

NA

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
