### PR TITLE
(PC-19326)[API] feat: Add route to mock Ubble for e2e tests

### DIFF
--- a/api/src/pcapi/routes/internal/__init__.py
+++ b/api/src/pcapi/routes/internal/__init__.py
@@ -7,6 +7,8 @@ def install_routes(app: Flask) -> None:
     # pylint: disable=unused-import
     from . import health_check
 
+    if settings.IS_RUNNING_TESTS or settings.IS_E2E_TESTS:
+        from . import e2e_ubble
     if settings.IS_DEV:
         from . import sandboxes
         from . import storage

--- a/api/src/pcapi/routes/internal/e2e_ubble.py
+++ b/api/src/pcapi/routes/internal/e2e_ubble.py
@@ -1,0 +1,63 @@
+import enum
+import urllib.parse
+import uuid
+
+from pcapi import settings
+from pcapi.core.fraud import factories as fraud_factories
+from pcapi.core.fraud import models as fraud_models
+from pcapi.core.fraud.ubble import api as ubble_fraud_api
+from pcapi.core.fraud.ubble import models as ubble_fraud_models
+from pcapi.core.subscription import api as subscription_api
+from pcapi.core.users import models as users_models
+from pcapi.repository import repository
+from pcapi.routes.native.security import authenticated_and_active_user_required
+from pcapi.routes.native.v1 import blueprint
+from pcapi.routes.serialization import BaseModel
+from pcapi.serialization.decorator import spectree_serialize
+
+
+class UbbleError(enum.Enum):
+    NETWORK_CONNECTION_ISSUE = 1201
+    BLURRY_VIDEO = 1310
+    LACK_OF_LUMINOSITY = 1320
+    ID_CHECK_EXPIRED = 2101
+    ID_CHECK_NOT_SUPPORTED = 2102
+    DOCUMENT_DAMAGED = 2103
+    ID_CHECK_NOT_AUTHENTIC = 2201
+
+
+class E2EUbbleIdCheck(BaseModel):
+    errors: list[UbbleError] | None = None
+
+
+@blueprint.native_v1.route("/ubble_identification/e2e", methods=["POST"])
+@spectree_serialize(on_success_status=204, api=blueprint.api)
+@authenticated_and_active_user_required
+def ubble_identification(user: users_models.User, body: E2EUbbleIdCheck) -> None:
+    content = make_identification_response(user, body.errors)
+    fraud_check = subscription_api.initialize_identity_fraud_check(
+        eligibility_type=user.eligibility,
+        fraud_check_type=fraud_models.FraudCheckType.UBBLE,
+        identity_content=content,
+        third_party_id=str(content.identification_id),
+        user=user,
+    )
+    repository.save(fraud_check)
+    ubble_fraud_api.on_ubble_result(fraud_check)
+    subscription_api.activate_beneficiary_if_no_missing_step(user=user)
+
+
+def make_identification_response(user: users_models.User, errors: list[UbbleError] | None) -> fraud_models.UbbleContent:
+    identification_id = str(uuid.uuid4())
+    identification_url = urllib.parse.urljoin(settings.UBBLE_API_URL, f"/identifications/{identification_id}")
+    return fraud_factories.UbbleContentFactory(
+        first_name=user.firstName,
+        last_name=user.lastName,
+        birth_date=user.birth_date.isoformat(),  # type: ignore [attr-defined]
+        identification_id=identification_id,
+        identification_url=identification_url,
+        id_document_number="12345678901234",
+        reason_codes=[fraud_models.UBBLE_REASON_CODE_MAPPING[error.value] for error in errors] if errors else None,
+        status=ubble_fraud_models.UbbleIdentificationStatus.PROCESSED,
+        score=ubble_fraud_models.UbbleScore.INVALID.value if errors else ubble_fraud_models.UbbleScore.VALID.value,
+    )

--- a/api/tests/routes/internal/e2e_ubble_test.py
+++ b/api/tests/routes/internal/e2e_ubble_test.py
@@ -1,0 +1,33 @@
+import pytest
+
+import pcapi.core.fraud.models as fraud_models
+import pcapi.core.users.factories as users_factories
+
+
+@pytest.mark.usefixtures("db_session")
+class E2EUbbleIdentificationTest:
+    def get_ubble_fraud_check_status(self, user):
+        ubble_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.UBBLE
+        ]
+        if ubble_fraud_checks:
+            return ubble_fraud_checks[0].status
+        return None
+
+    def test_user_is_identified_if_no_errors(self, client):
+        user = users_factories.ProfileCompletedUserFactory(age=17)
+        client.with_token(email=user.email)
+        response = client.post("/native/v1/ubble_identification/e2e", {})
+        ubble_status = self.get_ubble_fraud_check_status(user)
+        assert response.status_code == 204
+        assert ubble_status == fraud_models.FraudCheckStatus.OK
+
+    def test_user_is_not_identified_if_errors(self, client):
+        user = users_factories.ProfileCompletedUserFactory(age=17)
+        client.with_token(email=user.email)
+        response = client.post("/native/v1/ubble_identification/e2e", {"errors": [1201, 2201]})
+        ubble_status = self.get_ubble_fraud_check_status(user)
+        assert response.status_code == 204
+        assert ubble_status in (fraud_models.FraudCheckStatus.KO, fraud_models.FraudCheckStatus.SUSPICIOUS)

--- a/api/tests/routes/native/v1/openapi_test.py
+++ b/api/tests/routes/native/v1/openapi_test.py
@@ -543,6 +543,17 @@ def test_public_api(client):
                     "title": "DomainsCredit",
                     "type": "object",
                 },
+                "E2EUbbleIdCheck": {
+                    "properties": {
+                        "errors": {
+                            "items": {"$ref": "#/components/schemas/UbbleError"},
+                            "nullable": True,
+                            "type": "array",
+                        }
+                    },
+                    "title": "E2EUbbleIdCheck",
+                    "type": "object",
+                },
                 "EligibilityType": {
                     "description": "An enumeration.",
                     "enum": ["underage", "age-18"],
@@ -1626,6 +1637,11 @@ def test_public_api(client):
                     "required": ["deviceId"],
                     "title": "TrustedDevice",
                     "type": "object",
+                },
+                "UbbleError": {
+                    "description": "An enumeration.",
+                    "enum": [1201, 1310, 1320, 2101, 2102, 2103, 2201],
+                    "title": "UbbleError",
                 },
                 "UpdateEmailTokenExpiration": {
                     "properties": {
@@ -3242,6 +3258,29 @@ def test_public_api(client):
                     },
                     "security": [{"JWTAuth": []}],
                     "summary": "start_identification_session <POST>",
+                    "tags": [],
+                }
+            },
+            "/native/v1/ubble_identification/e2e": {
+                "post": {
+                    "description": "",
+                    "operationId": "post_/native/v1/ubble_identification/e2e",
+                    "parameters": [],
+                    "requestBody": {
+                        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/E2EUbbleIdCheck"}}}
+                    },
+                    "responses": {
+                        "204": {"description": "No Content"},
+                        "403": {"description": "Forbidden"},
+                        "422": {
+                            "content": {
+                                "application/json": {"schema": {"$ref": "#/components/schemas/ValidationError"}}
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "security": [{"JWTAuth": []}],
+                    "summary": "ubble_identification <POST>",
                     "tags": [],
                 }
             },


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-19326

## But de la pull request

Dans le cadre des tests end-to-end, il est pratique (voire nécessaire) de mocker l'identification via Ubble.
Ici, au lieu de simuler le vrai comportement d'Ubble qui prend un certain pour traiter les requêtes en asynchrone, une seule requête à la route suffit à avoir une réponse qui correspond au type d'erreur voulu.

## Implémentation

- Ajout d'une route
- Appel des fonctions qui servent au workflow de l'identification via Ubble avec les infos de l'utilisateur

## Informations supplémentaires

- Utilisation de la factory UbbleContentFactory pour obtenir un modèle de réponse d'Ubble.

## Modifications du schéma de la base de données


## Checklist :

- [X] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [X] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
