### PR TITLE
(PC-22860)[PRO] fix: add offer id when sending mail for new collectiv…

### DIFF
--- a/api/src/pcapi/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro.py
@@ -33,6 +33,6 @@ def get_data_request_made_by_redactor_to_pro(
             "REDACTOR_LASTNAME": request.educationalRedactor.lastName,
             "REDACTOR_EMAIL": request.educationalRedactor.email,
             "REDACTOR_PHONE_NUMBER": request.phoneNumber,
-            "OFFER_CREATION_URL": f"{settings.PRO_URL}/offre/collectif/creation/{request.id}/requete",
+            "OFFER_CREATION_URL": f"{settings.PRO_URL}/offre/collectif/creation/{request.collectiveOfferTemplateId}/requete/{request.id}",
         },
     )

--- a/api/tests/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro_test.py
+++ b/api/tests/core/mails/transactional/educational/eac_new_request_made_by_redactor_to_pro_test.py
@@ -46,5 +46,5 @@ class SendEacNewBookingEmailToProTest:
             "REDACTOR_LASTNAME": "Khteur",
             "REDACTOR_EMAIL": request.educationalRedactor.email,
             "REDACTOR_PHONE_NUMBER": None,
-            "OFFER_CREATION_URL": f"{settings.PRO_URL}/offre/collectif/creation/{request.id}/requete",
+            "OFFER_CREATION_URL": f"{settings.PRO_URL}/offre/collectif/creation/{request.collectiveOfferTemplateId}/requete/{request.id}",
         }


### PR DESCRIPTION
…e request

Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22860

## But de la pull request

Changer le lien de création d'offre envoyé par mail quand une nouvelle demande d'offre est formulée par un enseignant sur adage 

Lien attendu :  `/offre/collectif/creation/<offer_id>/requete/<request_id>`