### PR TITLE
(BSR)[API] feat: CDS sort features list to have always same order of features for all providers

### DIFF
--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -169,7 +169,10 @@ class CDSStocks(LocalProvider):
             if self.media_options.get(option.media_options_id.id) in ACCEPTED_MEDIA_OPTIONS_TICKET_LABEL
         ]
 
-        cds_stock.features = [ACCEPTED_MEDIA_OPTIONS_TICKET_LABEL.get(feature) for feature in features if feature]
+        # sort features list to have always same order for all providers VO/VF then 3D
+        cds_stock.features = sorted(
+            [ACCEPTED_MEDIA_OPTIONS_TICKET_LABEL.get(feature) for feature in features if feature], reverse=True
+        )
 
         if "price" not in cds_stock.fieldsUpdated:
             cds_stock.price = show_price

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -237,7 +237,7 @@ class CDSStocksTest:
         assert created_stocks[0].offer == created_offers[0]
         assert created_stocks[0].bookingLimitDatetime == datetime(2022, 6, 20, 9)
         assert created_stocks[0].beginningDatetime == datetime(2022, 6, 20, 9)
-        assert created_stocks[0].features == ["3D", "VF"]
+        assert created_stocks[0].features == ["VF", "3D"]
 
         assert created_offers[1].name == "Top Gun"
         assert created_offers[1].product == created_products[1]


### PR DESCRIPTION
## But de la pull request

Trier `Stock.features` pour la synchro CDS afin d'avoir toujours le même ordres d'attributs entre toutes les synchro.

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
