### PR TITLE
(PC-21660)[API] feat: Save location from headers in device login history

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -7,6 +7,7 @@ import secrets
 import typing
 
 from dateutil.relativedelta import relativedelta
+from flask import request
 from flask_jwt_extended import create_access_token
 from flask_sqlalchemy import BaseQuery
 import sqlalchemy as sa
@@ -1253,11 +1254,14 @@ def update_login_device_history(
         )
         return None
 
+    location = users_utils.format_login_location(request.headers.get("X-Country"), request.headers.get("X-City"))
+
     login_device = users_models.LoginDeviceHistory(
         deviceId=device_info.device_id,
         os=device_info.os,
         source=device_info.source,
         user=user,
+        location=location,
     )
     repository.save(login_device)
 

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -44,3 +44,10 @@ def get_age_at_date(birth_date: date, specified_datetime: datetime) -> int:
 
 def get_age_from_birth_date(birth_date: date) -> int:
     return get_age_at_date(birth_date, datetime.utcnow())
+
+
+def format_login_location(country_name: str | None, city_name: str | None) -> str | None:
+    if city_name:
+        return f"{city_name}, {country_name}" if country_name else city_name
+
+    return country_name

--- a/api/tests/core/users/test_utils.py
+++ b/api/tests/core/users/test_utils.py
@@ -8,6 +8,7 @@ from pcapi.core.users.utils import ALGORITHM_HS_256
 from pcapi.core.users.utils import ALGORITHM_RS_256
 from pcapi.core.users.utils import decode_jwt_token_rs256
 from pcapi.core.users.utils import encode_jwt_payload
+from pcapi.core.users.utils import format_login_location
 
 from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
@@ -54,3 +55,16 @@ class DecodeJWTPayloadRS256Test:
             decode_jwt_token_rs256(corrupted_token)
 
         assert "Signature verification failed" in str(error.value)
+
+
+class FormatLoginLocationTest:
+    @pytest.mark.parametrize("country_name", ["France", None])
+    def should_return_country_name_when_no_city_name(self, country_name):
+        assert format_login_location(country_name, city_name=None) == country_name
+
+    @pytest.mark.parametrize("city_name", ["Paris", None])
+    def should_return_city_name_when_no_country_name(self, city_name):
+        assert format_login_location(country_name=None, city_name=city_name) == city_name
+
+    def should_return_country_and_city_separated_by_comma_when_both_are_available(self):
+        assert format_login_location(country_name="France", city_name="Paris") == "Paris, France"


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21660

## But de la pull request

Le but de cette PR est de sauvegarder la localisation depuis laquelle une connexion a été faite dans la table d'historique des appareils de connexions.

La localisation est utilisée dans les mails envoyés en cas de connexion suspicieuse, et sera utilisée dans un deuxième temps dans l’application native et la webapp pour afficher l’historique de connexions de l’utilisateur.

## Implémentation

Récupération du pays et de la ville depuis les headers des requêtes venant du frontend (`X-Country` et `X-City`, insérés côté OPS avec NGINX).

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
