### PR TITLE
(PC-22780) do not check ean if offer already has ean

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -267,7 +267,7 @@ def update_offer(
     validation.check_validation_status(offer)
     if extraData is not UNCHANGED:
         formatted_extra_data = _format_extra_data(offer.subcategoryId, extraData)
-        validation.check_offer_extra_data(offer.subcategoryId, formatted_extra_data, offer.venue)
+        validation.check_offer_extra_data(offer.subcategoryId, formatted_extra_data, offer.venue, offer)
     if isDuo is not UNCHANGED:
         validation.check_is_duo_compliance(isDuo, offer.subcategory)
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -419,7 +419,10 @@ def check_booking_limit_datetime(
 
 
 def check_offer_extra_data(
-    subcategory_id: str, extra_data: models.OfferExtraData | None, venue: offerers_models.Venue
+    subcategory_id: str,
+    extra_data: models.OfferExtraData | None,
+    venue: offerers_models.Venue,
+    offer: models.Offer | None = None,
 ) -> None:
     errors = api_errors.ApiErrors()
 
@@ -438,7 +441,7 @@ def check_offer_extra_data(
 
     try:
         ean = extra_data.get(ExtraDataFieldEnum.EAN.value)
-        if ean:
+        if ean and (not offer or (offer.extraData and ean != offer.extraData.get(ExtraDataFieldEnum.EAN.value))):
             _check_ean_field(extra_data, ExtraDataFieldEnum.EAN.value)
             check_ean_does_not_exist(ean, venue)
     except (exceptions.EanFormatException, exceptions.OfferAlreadyExists) as e:

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -908,6 +908,36 @@ class UpdateOfferTest:
         assert offer.name == "New name"
         assert product.name == "Old name"
 
+    def test_update_offer_with_existing_ean(self):
+        offer = factories.OfferFactory(
+            name="Old name",
+            extraData={"ean": "1234567890123"},
+            subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id,
+        )
+
+        offer = api.update_offer(offer, name="New name", description="new Description")
+
+        assert offer.name == "New name"
+        assert offer.description == "new Description"
+
+    def test_raise_error_if_update_ean_for_offer_with_existing_ean(self):
+        offer = factories.OfferFactory(
+            name="Old name",
+            extraData={"ean": "1234567890123", "musicSubType": 524, "musicType": 520},
+            subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE.id,
+        )
+
+        offer = api.update_offer(
+            offer,
+            name="New name",
+            description="new Description",
+            extraData={"ean": "1234567890124", "musicType": 520, "musicSubType": 524},
+        )
+
+        assert offer.name == "New name"
+        assert offer.description == "new Description"
+        assert offer.extraData == {"ean": "1234567890124", "musicType": 520, "musicSubType": 524}
+
     def test_cannot_update_with_name_too_long(self):
         offer = factories.OfferFactory(name="Old name")
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22780

## But de la pull request

Fix du bug de modification d'offre ayant déjà un ean
