### PR TITLE
(PC-22491)[PRO] feat: uncheck only in my department when venue filter

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -113,6 +113,14 @@ export const OfferFilters = ({
   }
 
   useEffect(() => {
+    if (venueFilter) {
+      dispatchCurrentFilters({
+        type: 'RESET_ONLY_IN_MY_DEPARTMENT',
+      })
+    }
+  }, [venueFilter])
+
+  useEffect(() => {
     const loadFiltersOptions = async () => {
       const [categoriesResponse, domainsResponse] = await Promise.all([
         getEducationalCategoriesOptionsAdapter(null),

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -285,4 +285,25 @@ describe('offersSearch component', () => {
     expect(parisFilterTag).not.toBeInTheDocument()
     expect(gardFilterTag).toBeInTheDocument()
   })
+
+  it('should not check only in my dpt checkbox when venue filter is selected', async () => {
+    renderOffersSearchComponent(
+      {
+        ...props,
+        venueFilter: {
+          id: 1,
+          name: 'Mon lieu',
+          relative: [],
+        },
+      },
+      user
+    )
+
+    const checkbox = screen.getByLabelText(
+      'Les acteurs qui se déplacent dans mon établissement',
+      { exact: false }
+    )
+
+    expect(checkbox).not.toBeChecked()
+  })
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22491

## But de la pull request

Décocher la case `Les acteurs culturels de mon département` quand un filtre de lieu est présent dans l'iframe adage. 

Pour ajouter le filtre ajouter un paramètre `venue=<venueId>` dans l'url