### PR TITLE
(PC-22316)[API] fix: use redis ex instead of exat to set token

### DIFF
--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -224,7 +224,7 @@ def generate_email_change_token(
 ) -> str:
     token = encode_jwt_payload({"current_email": user.email, "new_email": new_email}, expiration_date)
     key = get_token_key(user, token_type)
-    app.redis_client.set(key, token, exat=expiration_date)  # type: ignore [attr-defined]
+    app.redis_client.set(key, token, ex=constants.EMAIL_CHANGE_TOKEN_LIFE_TIME)  # type: ignore [attr-defined]
     return token
 
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -648,7 +648,9 @@ class ConfirmUpdateUserEmailTest:
         expiration_date = datetime.utcnow() + users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
         token = encode_jwt_payload({"current_email": user.email, "new_email": new_email}, expiration_date)
         app.redis_client.set(
-            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION), token, exat=expiration_date
+            email_update.get_token_key(user, email_update.TokenType.CONFIRMATION),
+            token,
+            ex=users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME,
         )
         return token
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22316

## But de la pull request

Corriger une syntax error: https://sentry.passculture.team/organizations/sentry/issues/418817/?environment=testing&query=is%3Aunresolved

## Implémentation

- _Exemples: Ajouts de modèles, de routes, Changements significatifs_

## Informations supplémentaires

- _Exemples: nettoyage de code, utilisation de factories, Boy Scout Rule_
- _Explications sur l'utilisation d'outils peu communs (ex.: psql window function, metaclasses, yield from)_

## Modifications du schéma de la base de données

- _Exemples: suppressions de telles colonnes, migration d'une information dans une nouvelle table_
- _A destination des Data Analysts, exposer le résultat final (tables et colonnes), sans détailler l'implémentation technique_

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
