### PR TITLE
(PC-22592)[API] fix: upgrade titelive ftp folder version from 11 to 19

### DIFF
--- a/api/src/pcapi/local_providers/titelive_things/titelive_things.py
+++ b/api/src/pcapi/local_providers/titelive_things/titelive_things.py
@@ -23,58 +23,73 @@ logger = logging.getLogger(__name__)
 
 
 DATE_REGEXP = re.compile(r"([a-zA-Z]+)(\d+).tit")
-THINGS_FOLDER_NAME_TITELIVE = "livre3_11"
-NUMBER_OF_ELEMENTS_PER_LINE = 46  # (45 elements from line + \n)
+THINGS_FOLDER_NAME_TITELIVE = "livre3_19"
+THINGS_FOLDER_ENCODING_TITELIVE = "iso-8859-1"
+NUMBER_OF_ELEMENTS_PER_LINE = 61  # (62 elements from line + \n)
 PAPER_PRESS_TVA = "2,10"
-COLUMN_INDICES = (
-    {  #  this list all field as per in the v11 documentation provided by titelive, without renaming fields.
-        "ean": 0,
-        "isbn": 1,  #  deprecated, do not use, also not use at pass culture except in one unit test
-        "titre": 2,
-        "titre_court": 3,
-        "code_rayon_csr": 4,
-        "disponibilite": 5,
-        "collection": 6,
-        "num_in_collection": 7,
-        "categorie_de_prix": 8,  #  deprecated, do not use, also not use at pass culture
-        "prix_ttc": 9,
-        "editeur": 10,
-        "distributeur": 11,
-        "date_commercialisation": 12,
-        "code_support": 13,
-        "code_tva": 14,
-        "nb_pages": 15,
-        "longueur": 16,
-        "largeur": 17,
-        "epaisseur": 18,
-        "poids": 19,
-        "sujet": 20,  # not used at pass culture
-        "statut_fiche": 21,
-        "mise_en_vente": 22,  #  deprecated, do not use, also not used at pass culture
-        "auteurs": 23,
-        "date_creation": 24,
-        "date_derniere_maj": 25,
-        "taux_tva": 26,
-        "libelle_code_rayon_csr": 27,
-        "traducteur": 28,
-        "langue_vo": 29,
-        "critique_presse": 30,  #  deprecated, do not use, also not used at pass culture
-        "commentaire": 31,
-        "palmares_pro": 32,
-        "image": 33,
-        "code_edi_fournisseur": 34,
-        "libelle_serie": 35,
-        "id_genre_bd": 36,  #  deprecated, do not use, also not used at pass culture
-        "libelle_genre_bd": 37,  #  deprecated, do not use, also not used at pass culture
-        "numero_de_catalogue": 38,
-        "scolaire": 39,
-        "compteur_mp3": 40,
-        "url_feuilleteur": 41,
-        "id_auteur": 42,
-        "indice_dewey": 43,
-        "code_regroupement": 44,
-    }
-)
+COLUMN_INDICES = {
+    "ean": 0,
+    "titre": 1,
+    "code_rayon_csr": 2,
+    "disponibilite": 3,
+    "collection": 4,
+    "num_in_collection": 5,
+    "prix_ttc": 6,
+    "editeur": 7,
+    "distributeur": 8,
+    "date_commercialisation": 9,
+    "code_support": 10,
+    "code_tva": 11,
+    "nb_pages": 12,
+    "longueur": 13,
+    "largeur": 14,
+    "epaisseur": 15,
+    "poids": 16,
+    "auteurs": 17,
+    "date_creation": 18,
+    "date_derniere_maj": 19,
+    "taux_tva": 20,
+    "traducteur": 21,
+    "langue_vo": 22,
+    "commentaire": 23,
+    "palmares_pro": 24,
+    "image": 25,
+    "libelle_serie": 26,
+    "scolaire": 27,
+    "indice_dewey": 28,
+    "code_regroupement": 29,
+    "pure_numerique": 30,
+    "livre_etranger": 31,
+    "presence_presentation": 32,
+    "prix_litteraire": 33,
+    "presence_biographie": 34,
+    "image_4eme_de_couverture": 35,
+    "id_langue": 36,
+    "numerique": 37,
+    "compteur_pages_interieurs": 38,
+    "pdf_extrait": 39,
+    "pdf_premier_chapitre": 40,
+    "pdf_paragraphe": 41,
+    "liste_goodies": 42,
+    "impression_a_la_demande": 43,
+    "nouveau_code_langue": 44,
+    "id_lectorat": 45,
+    "compteur_mp3": 46,
+    "id_auteurs": 47,
+    "fonctions_auteurs": 48,
+    "livre_lu": 49,
+    "grands_caractères": 50,
+    "multilingue": 51,
+    "illustre": 52,
+    "luxe": 53,
+    "relie": 54,
+    "broche": 55,
+    "lu_par": 56,
+    "genre_tite_live": 57,
+    "code_clil": 58,
+    "fournisseur_edi": 59,
+    "statut_fiche": 60,
+}
 PAPER_PRESS_SUPPORT_CODE = "R"
 SCHOOL_RELATED_CSR_CODE = [
     "2700",
@@ -240,12 +255,6 @@ class TiteLiveThings(LocalProvider):
         extra_data = self.product_extra_data | get_extra_data_from_infos(self.product_infos)
         product.extraData = extra_data
 
-        if self.product_infos["url_extrait_pdf"] != "":
-            if product.mediaUrls is None:
-                product.mediaUrls = []
-
-            product.mediaUrls.append(self.product_infos["url_extrait_pdf"])
-
     def open_next_file(self):  # type: ignore [no-untyped-def]
         if self.products_file:
             file_date = get_date_from_filename(self.products_file, DATE_REGEXP)
@@ -270,7 +279,7 @@ def get_lines_from_thing_file(thing_file: str):  # type: ignore [no-untyped-def]
     data_file = BytesIO()
     data_wrapper = TextIOWrapper(
         data_file,
-        encoding="iso-8859-1",
+        encoding=THINGS_FOLDER_ENCODING_TITELIVE,
         line_buffering=True,
     )
     file_path = "RETR " + THINGS_FOLDER_NAME_TITELIVE + "/" + thing_file
@@ -339,7 +348,6 @@ def get_infos_from_data_line(elts: list) -> dict:
     infos = {}
     infos["ean13"] = elts[COLUMN_INDICES["ean"]]
     infos["titre"] = elts[COLUMN_INDICES["titre"]]
-    infos["titre_court"] = elts[COLUMN_INDICES["titre_court"]]
     infos["code_csr"] = elts[COLUMN_INDICES["code_rayon_csr"]]
     infos["code_dispo"] = elts[COLUMN_INDICES["disponibilite"]]
     infos["collection"] = elts[COLUMN_INDICES["collection"]]
@@ -360,19 +368,14 @@ def get_infos_from_data_line(elts: list) -> dict:
     infos["datetime_created"] = elts[COLUMN_INDICES["date_creation"]]
     infos["date_updated"] = elts[COLUMN_INDICES["date_derniere_maj"]]
     infos["taux_tva"] = elts[COLUMN_INDICES["taux_tva"]]
-    infos["libelle_csr"] = elts[COLUMN_INDICES["libelle_code_rayon_csr"]]
     infos["traducteur"] = elts[COLUMN_INDICES["traducteur"]]
     infos["langue_orig"] = elts[COLUMN_INDICES["langue_vo"]]
     infos["commentaire"] = elts[COLUMN_INDICES["commentaire"]]
     infos["classement_top"] = elts[COLUMN_INDICES["palmares_pro"]]
     infos["has_image"] = elts[COLUMN_INDICES["image"]]
-    infos["code_edi_fournisseur"] = elts[COLUMN_INDICES["code_edi_fournisseur"]]
-    infos["libelle_serie_bd"] = elts[COLUMN_INDICES["libelle_genre_bd"]]
-    infos["ref_editeur"] = elts[COLUMN_INDICES["numero_de_catalogue"]]
+    infos["code_edi_fournisseur"] = elts[COLUMN_INDICES["fournisseur_edi"]]
     infos["is_scolaire"] = elts[COLUMN_INDICES["scolaire"]]
     infos["n_extraits_mp3"] = elts[COLUMN_INDICES["compteur_mp3"]]
-    infos["url_extrait_pdf"] = elts[COLUMN_INDICES["url_feuilleteur"]]
-    infos["id_auteur"] = elts[COLUMN_INDICES["id_auteur"]]
     infos["indice_dewey"] = elts[COLUMN_INDICES["indice_dewey"]]
     infos["code_regroupement"] = elts[COLUMN_INDICES["code_regroupement"]]
     return infos
@@ -386,7 +389,6 @@ def get_extra_data_from_infos(infos: dict) -> offers_models.OfferExtraData:
         extra_data["dewey"] = infos["indice_dewey"]
     extra_data["titelive_regroup"] = infos["code_regroupement"]
     extra_data["prix_livre"] = infos["prix"].replace(",", ".")
-    extra_data["rayon"] = infos["libelle_csr"]
     if infos["is_scolaire"] == "1":
         extra_data["schoolbook"] = True
     if infos["classement_top"] != "":
@@ -395,8 +397,6 @@ def get_extra_data_from_infos(infos: dict) -> offers_models.OfferExtraData:
         extra_data["collection"] = infos["collection"]
     if infos["num_in_collection"] != "":
         extra_data["num_in_collection"] = infos["num_in_collection"]
-    if infos["libelle_serie_bd"] != "":
-        extra_data["comic_series"] = infos["libelle_serie_bd"]
     if infos["commentaire"] != "":
         extra_data["comment"] = trim_with_ellipsis(infos["commentaire"], 92)
     if infos["editeur"] != "":

--- a/api/tests/local_providers/titelive_things_test.py
+++ b/api/tests/local_providers/titelive_things_test.py
@@ -19,53 +19,70 @@ from pcapi.local_providers import TiteLiveThings
 from pcapi.local_providers.titelive_things.titelive_things import COLUMN_INDICES
 
 
+EAN_TEST = "9782809455069"
+EAN_TEST_TITLE = "Secret wars : marvel zombies n.1"
 BASE_DATA_LINE_PARTS = [
-    "9782895026310",
-    "2895026319",
-    "nouvelles du Chili",
-    "",
-    "0203",
+    EAN_TEST,
+    EAN_TEST_TITLE,
+    "1905",
+    "6",
+    "Secret Wars : Marvel Zombies",
     "1",
-    "",
-    "",
-    "",
-    "18,99",
-    "LES EDITIONS DE L'INSTANT MEME",
-    "EPAGINE",
-    "11/05/2011",
+    "4,90",
+    "Panini Comics Mag",
+    "Makassar",
+    "24/12/2015",
     "BL",
     "2",
     "0",
+    "26,0",
+    "17,0",
     "0,0",
-    "0,0",
-    "0,0",
-    "0",
-    "0",
-    "0",
-    "0",
+    "198",
     "Collectif",
-    "15/01/2013",
-    "02/03/2018",
+    "18/10/2015",
+    "30/04/2023",
     "5,50",
-    "Littérature Hispano-Portugaise",
     "",
-    "",
-    "",
+    "ANGLAIS (ETATS-UNIS)",
     "",
     "",
     "1",
-    "3012420280013",
+    "Non précisée",
     "",
     "",
-    "",
-    "",
-    "",
+    "5621564",
+    "0",
+    "0",
     "0",
     "",
-    "369",
-    "860",
-    "3694440",
+    "0",
+    "0",
+    "93",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
     "",
+    "0",
+    "20303",
+    "0",
+    "0",
+    "412952",
+    "",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "1",
+    "",
+    "3030400",
+    "4300",
+    "3012420280013",
+    "0",
 ]
 
 
@@ -91,7 +108,7 @@ class TiteliveThingsTest:
         product = offers_models.Product.query.one()
         assert product.extraData.get("bookFormat") == offers_models.BookFormat.BEAUX_LIVRES.value
         assert product.subcategoryId == subcategories.LIVRE_PAPIER.id
-        assert product.extraData.get("ean") == "9782895026310"
+        assert product.extraData.get("ean") == EAN_TEST
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")
@@ -103,7 +120,6 @@ class TiteliveThingsTest:
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
         DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
-        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         DATA_LINE_PARTS[COLUMN_INDICES["scolaire"]] = "1"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
@@ -128,7 +144,6 @@ class TiteliveThingsTest:
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
         DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
-        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         DATA_LINE_PARTS[COLUMN_INDICES["scolaire"]] = "1"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
@@ -158,7 +173,7 @@ class TiteliveThingsTest:
 
         offers_factories.ProductFactory(
             name="Old name",
-            idAtProviders="9782895026310",
+            idAtProviders=EAN_TEST,
             dateModifiedAtLastProvider=datetime(2001, 1, 1),
             lastProviderId=titelive_things_provider.id,
         )
@@ -169,7 +184,7 @@ class TiteliveThingsTest:
 
         # Then
         updated_product = offers_models.Product.query.first()
-        assert updated_product.name == "nouvelles du Chili"
+        assert updated_product.name == EAN_TEST_TITLE
         assert updated_product.extraData.get("bookFormat") == offers_models.BookFormat.BEAUX_LIVRES.value
 
     @pytest.mark.usefixtures("db_session")
@@ -196,7 +211,7 @@ class TiteliveThingsTest:
         # Given
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
-        data_line = "9782895026310"
+        data_line = EAN_TEST
         get_lines_from_thing_file.return_value = iter([data_line])
 
         providers_factories.TiteLiveThingsProviderFactory()
@@ -219,7 +234,6 @@ class TiteliveThingsTest:
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
         DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "LE"
-        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         DATA_LINE_PARTS[COLUMN_INDICES["scolaire"]] = "1"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
@@ -245,7 +259,6 @@ class TiteliveThingsTest:
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
         DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
         DATA_LINE_PARTS[COLUMN_INDICES["code_rayon_csr"]] = "2704"
-        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
@@ -270,13 +283,12 @@ class TiteliveThingsTest:
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
         DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "livre scolaire"
         DATA_LINE_PARTS[COLUMN_INDICES["code_rayon_csr"]] = "2704"
-        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
         titelive_provider = providers_factories.TiteLiveThingsProviderFactory()
         offers_factories.ProductFactory(
-            idAtProviders="9782895026310",
+            idAtProviders=EAN_TEST,
             dateModifiedAtLastProvider=datetime(2001, 1, 1),
             lastProviderId=titelive_provider.id,
             subcategoryId=subcategories.LIVRE_PAPIER.id,
@@ -303,14 +315,13 @@ class TiteliveThingsTest:
         DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "jeux de société"
         DATA_LINE_PARTS[COLUMN_INDICES["code_rayon_csr"]] = "1234"
         DATA_LINE_PARTS[COLUMN_INDICES["code_support"]] = "O"
-        DATA_LINE_PARTS[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         data_line = "~".join(DATA_LINE_PARTS)
         get_lines_from_thing_file.return_value = iter([data_line])
 
         titelive_provider = providers_factories.TiteLiveThingsProviderFactory()
         offers_factories.ProductFactory(
             subcategoryId=subcategories.LIVRE_PAPIER.id,
-            idAtProviders="9782895026310",
+            idAtProviders=EAN_TEST,
             dateModifiedAtLastProvider=datetime(2001, 1, 1),
             lastProviderId=titelive_provider.id,
         )
@@ -335,14 +346,13 @@ class TiteliveThingsTest:
         data_line_parts[COLUMN_INDICES["titre"]] = "jeux de société"
         data_line_parts[COLUMN_INDICES["code_rayon_csr"]] = "1234"
         data_line_parts[COLUMN_INDICES["code_support"]] = "O"
-        data_line_parts[COLUMN_INDICES["libelle_code_rayon_csr"]] = "Littérature scolaire"
         data_line = "~".join(data_line_parts)
         get_lines_from_thing_file.return_value = iter([data_line])
 
         provider = providers_factories.TiteLiveThingsProviderFactory()
         bookings_factories.BookingFactory(
             stock__offer__product__dateModifiedAtLastProvider=datetime(2001, 1, 1),
-            stock__offer__product__idAtProviders="9782895026310",
+            stock__offer__product__idAtProviders=EAN_TEST,
             stock__offer__product__lastProviderId=provider.id,
             stock__offer__product__subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
@@ -356,7 +366,7 @@ class TiteliveThingsTest:
         provider_log_error = providers_models.LocalProviderEvent.query.filter_by(
             type=providers_models.LocalProviderEventType.SyncError
         ).one()
-        assert provider_log_error.payload == "Error deleting product with EAN: 9782895026310"
+        assert provider_log_error.payload == f"Error deleting product with EAN: {EAN_TEST}"
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")
@@ -387,7 +397,7 @@ class TiteliveThingsTest:
 
         # Then
         assert len(products) == 1
-        assert product.extraData["ean"] == "9782895026310"
+        assert product.extraData["ean"] == EAN_TEST
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.titelive_things.titelive_things.get_files_to_process_from_titelive_ftp")
@@ -406,7 +416,7 @@ class TiteliveThingsTest:
 
         titelive_provider = providers_factories.TiteLiveThingsProviderFactory()
         offers_factories.ProductFactory(
-            idAtProviders="9782895026310",
+            idAtProviders=EAN_TEST,
             dateModifiedAtLastProvider=datetime(2001, 1, 1),
             lastProviderId=titelive_provider.id,
             subcategoryId=subcategories.LIVRE_PAPIER.id,
@@ -440,7 +450,7 @@ class TiteliveThingsTest:
         offerer = offerers_factories.OffererFactory(siren="123456789")
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         product = ThingProductFactory(
-            idAtProviders="9782895026310",
+            idAtProviders=EAN_TEST,
             name="Presse papier",
             subcategoryId=subcategories.LIVRE_PAPIER.id,
             dateModifiedAtLastProvider=datetime(2001, 1, 1),
@@ -491,10 +501,10 @@ class TiteliveThingsTest:
     ):
         get_files_to_process_from_titelive_ftp.return_value = ["Quotidien30.tit"]
 
-        book_ean = "9782895026310"
+        book_ean = EAN_TEST
 
         DATA_LINE_PARTS = BASE_DATA_LINE_PARTS[:]
-        DATA_LINE_PARTS[COLUMN_INDICES["isbn"]] = book_ean
+        DATA_LINE_PARTS[COLUMN_INDICES["ean"]] = book_ean
         DATA_LINE_PARTS[COLUMN_INDICES["titre"]] = "xxx"
         DATA_LINE_PARTS[COLUMN_INDICES["auteurs"]] = "Xxx"
         data_line = "~".join(DATA_LINE_PARTS)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22592

## But de la pull request

Migration de la version 11 à 19 du dossier ftp titelive

## Implémentation

Les champs supprimés n'étaient pas utilisé ou sont devenus obselète (csr entre autre)

## Informations supplémentaires

https://www.notion.so/passcultureapp/Mise-jour-de-titelive_things-synchronisation-version-2019-19-cddfb66ac8ee4e1bb935a40e7a8fa0e4

## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
