### PR TITLE
PC-21550 rm is public api

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 60d5208fd945 (pre) (head)
-4fb121d642ef (post) (head)
+49e118a9dd48 (post) (head)

--- a/api/src/pcapi/alembic/versions/20230621T192232_49e118a9dd48_rm_collective_offer_ispublicapi.py
+++ b/api/src/pcapi/alembic/versions/20230621T192232_49e118a9dd48_rm_collective_offer_ispublicapi.py
@@ -1,0 +1,24 @@
+"""
+Remove the isPublicApi column from collective_offer.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "49e118a9dd48"
+down_revision = "4fb121d642ef"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("collective_offer", "isPublicApi")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "collective_offer",
+        sa.Column("isPublicApi", sa.BOOLEAN(), server_default=sa.text("false"), autoincrement=False, nullable=False),
+    )

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -353,6 +353,12 @@ class CollectiveOffer(
         "OfferValidationRule", secondary="validation_rule_collective_offer_link", back_populates="collectiveOffers"
     )
 
+    # TODO(jeremieb): remove this property once the front end client
+    # does not need this field anymore.
+    @property
+    def isPublicApi(self) -> bool:
+        return self.providerId is not None
+
     @property
     def isEducational(self) -> bool:
         # FIXME (rpaoloni, 2022-03-7): Remove legacy support layer

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -323,8 +323,6 @@ class CollectiveOffer(
         "CollectiveOfferTemplate", foreign_keys=[templateId], back_populates="collectiveOffers"
     )
 
-    isPublicApi: bool = sa.Column(sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False)
-
     teacherId: int | None = sa.Column(
         sa.BigInteger,
         sa.ForeignKey("educational_redactor.id"),

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -123,7 +123,7 @@ def check_collective_offer_number_of_collective_stocks(
 
 
 def check_if_offer_is_not_public_api(offer: models.CollectiveOffer) -> None:
-    if offer.isPublicApi:
+    if offer.providerId:
         raise exceptions.CollectiveOfferIsPublicApi()
 
 

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -201,13 +201,9 @@ def post_collective_offer_public(
             )
 
     try:
-        if FeatureToggle.ENABLE_PROVIDER_AUTHENTIFICATION.is_active():
-            requested_id = current_api_key.providerId
-        else:
-            requested_id = current_api_key.offererId
-
         offer = educational_api_offer.create_collective_offer_public(
-            requested_id=requested_id,
+            provider_id=current_api_key.providerId,
+            offerer_id=current_api_key.offererId,
             body=body,
         )
 
@@ -517,7 +513,7 @@ def patch_collective_offer_public(
     # real edition
     try:
         offer = educational_api_offer.edit_collective_offer_public(
-            offerer_id=current_api_key.offererId,
+            provider_id=current_api_key.providerId,
             new_values=new_values,
             offer=offer,
         )

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_collective_api_provider.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_collective_api_provider.py
@@ -1,0 +1,21 @@
+from typing import Sequence
+
+import factory
+
+from pcapi.core.offerers.factories import ApiKeyFactory
+from pcapi.core.offerers.models import Venue
+from pcapi.core.providers.factories import APIProviderFactory
+from pcapi.core.providers.factories import VenueProviderFactory
+from pcapi.core.providers.models import Provider
+
+
+def create_collective_api_provider(venues: Sequence[Venue]) -> Provider:
+    provider = APIProviderFactory(name=factory.Sequence("Collectie API Provider {}".format))
+
+    for venue in venues:
+        VenueProviderFactory(venue=venue, provider=provider)
+
+    offerer = venues[0].managingOfferer
+    ApiKeyFactory.create(offerer=offerer, provider=provider, prefix=f"collective_api_prefix_for_{provider.id}")
+
+    return provider

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -8,9 +8,12 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 import pcapi.core.finance.factories as finance_factories
 from pcapi.core.offerers import models as offerers_models
+import pcapi.core.providers.models as providers_models
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.utils.image_conversion import DO_NOT_CROP
+
+from .create_collective_api_provider import create_collective_api_provider
 
 
 def create_offers(
@@ -22,7 +25,9 @@ def create_offers(
 
     # eac_1
     offerer = next(offerers_iterator)
+    provider = create_collective_api_provider(offerer.managedVenues)
     create_offers_base_list(
+        provider=provider,
         offerer=offerer,
         institutions=institutions,
         domains=domains,
@@ -34,7 +39,9 @@ def create_offers(
     )
     # eac_2
     offerer = next(offerers_iterator)
+    provider = create_collective_api_provider(offerer.managedVenues)
     create_offers_base_list(
+        provider=provider,
         offerer=offerer,
         institutions=institutions,
         domains=domains,
@@ -47,7 +54,9 @@ def create_offers(
 
     # eac_pending_bank_informations
     offerer = next(offerers_iterator)
+    provider = create_collective_api_provider(offerer.managedVenues)
     create_offers_base_list(
+        provider=provider,
         offerer=offerer,
         institutions=institutions,
         domains=domains,
@@ -61,7 +70,9 @@ def create_offers(
 
     # eac_no_cb
     offerer = next(offerers_iterator)
+    provider = create_collective_api_provider(offerer.managedVenues)
     create_offers_base_list(
+        provider=provider,
         offerer=offerer,
         institutions=institutions,
         domains=domains,
@@ -75,6 +86,7 @@ def create_offers(
 
 
 def create_offers_base_list(
+    provider: providers_models.Provider,
     offerer: offerers_models.Offerer,
     institutions: list[educational_models.EducationalInstitution],
     domains: list[educational_models.EducationalDomain],
@@ -155,7 +167,7 @@ def create_offers_base_list(
                 collectiveOffer__venue=next(venue_iterator),
                 collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__interventionArea=[],
-                collectiveOffer__isPublicApi=True,
+                collectiveOffer__provider=provider,
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 beginningDatetime=datetime.utcnow() + timedelta(days=60),
             )

--- a/api/tests/routes/pro/get_all_collective_offers_test.py
+++ b/api/tests/routes/pro/get_all_collective_offers_test.py
@@ -6,6 +6,7 @@ import pytest
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
 import pcapi.core.offerers.factories as offerer_factories
+import pcapi.core.providers.factories as providers_factories
 import pcapi.core.users.factories as users_factories
 
 from tests.conftest import TestClient
@@ -42,7 +43,6 @@ class Returns200Test:
         assert response_json[0]["educationalInstitution"]["name"] == institution.name
         assert response_json[0]["imageCredit"] is None
         assert response_json[0]["imageUrl"] is None
-        assert response_json[0]["isPublicApi"] is False
 
     def test_one_inactive_offer(self, client):
         # Given
@@ -96,21 +96,20 @@ class Returns200Test:
 
     def test_if_collective_offer_is_public_api(self, app):
         # Given
+        provider = providers_factories.ProviderFactory()
         user = users_factories.UserFactory()
         offerer = offerer_factories.OffererFactory()
         offerer_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerer_factories.VenueFactory(managingOfferer=offerer)
         institution = educational_factories.EducationalInstitutionFactory()
-        educational_factories.CollectiveOfferFactory(venue=venue, offerId=1, institution=institution, isPublicApi=True)
+        educational_factories.CollectiveOfferFactory(venue=venue, offerId=1, institution=institution, provider=provider)
 
         # When
         client = TestClient(app.test_client()).with_session_auth(email=user.email)
         response = client.get("/collective/offers")
 
         # Then
-        response_json = response.json
         assert response.status_code == 200
-        assert response_json[0]["isPublicApi"] is True
 
     def test_one_simple_collective_offer_template(self, app):
         # Given

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -43,7 +43,6 @@ class Returns200Test:
         assert response_json["id"] == offer.id
         assert response_json["lastBookingStatus"] is None
         assert response_json["lastBookingId"] is None
-        assert response_json["isPublicApi"] is False
         assert response_json["teacher"] == {
             "email": offer.teacher.email,
             "firstName": offer.teacher.firstName,

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -17,6 +17,7 @@ from pcapi.core.educational.models import StudentLevels
 import pcapi.core.educational.testing as adage_api_testing
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers.models import OfferValidationStatus
+import pcapi.core.providers.factories as providers_factories
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 import pcapi.core.users.factories as users_factories
@@ -509,7 +510,8 @@ class Returns403Test:
 
     def test_cannot_update_offer_created_by_public_api(self, client):
         # Given
-        offer = CollectiveOfferFactory(isPublicApi=True)
+        provider = providers_factories.ProviderFactory()
+        offer = CollectiveOfferFactory(provider=provider)
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=offer.venue.managingOfferer,

--- a/api/tests/routes/pro/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/patch_collective_stock_test.py
@@ -11,6 +11,7 @@ from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.educational.models import StudentLevels
 import pcapi.core.educational.testing as adage_api_testing
 import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.providers.factories as providers_factories
 from pcapi.core.testing import override_settings
 from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingEdition
 from pcapi.routes.adage.v1.serialization.prebooking import serialize_collective_booking
@@ -301,7 +302,7 @@ class Return403Test:
 
     def test_edit_collective_stocks_should_not_be_possible_when_offer_created_by_public_api(self, client):
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=providers_factories.ProviderFactory(),
         )
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -95,6 +95,7 @@ class Returns200Test:
             "offerId": None,
             "isActive": False,
             "isEditable": True,
+            "isPublicApi": False,
             "id": duplicate.id,
             "name": offer.name,
             "subcategoryId": offer.subcategoryId,
@@ -141,7 +142,6 @@ class Returns200Test:
             "lastBookingStatus": None,
             "lastBookingId": None,
             "teacher": None,
-            "isPublicApi": False,
         }
 
     def test_duplicate_collective_offer_draft_offer(self, client):

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_public_offerer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_public_offerer_test.py
@@ -10,6 +10,7 @@ from pcapi import settings
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.providers import factories as providers_factories
 from pcapi.core.testing import override_features
 
 import tests
@@ -37,13 +38,13 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
             collectiveOffer__imageCredit="pouet",
             collectiveOffer__imageId="123456789",
             collectiveOffer__venue=venue,
@@ -149,10 +150,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
             collectiveOffer__imageCredit="pouet",
             collectiveOffer__imageId="123456789",
             collectiveOffer__venue=venue,
@@ -184,11 +185,12 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider,
+            collectiveOffer__venue=venue,
         )
 
         payload = {
@@ -223,11 +225,11 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         educational_institution = educational_factories.EducationalInstitutionFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {
@@ -255,7 +257,9 @@ class CollectiveOffersPublicPatchOfferTest:
         offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=False, collectiveOffer__venue=venue, collectiveOffer__name="old_name"
+            collectiveOffer__provider=providers_factories.ProviderFactory(),
+            collectiveOffer__venue=venue,
+            collectiveOffer__name="old_name",
         )
 
         payload = {
@@ -279,11 +283,11 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         educational_institution = educational_factories.EducationalInstitutionFactory(institutionId="UAI123")
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {
@@ -308,11 +312,11 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         educational_institution = educational_factories.EducationalInstitutionFactory(institutionId="UAI123")
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {
@@ -337,11 +341,11 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         educational_institution = educational_factories.EducationalInstitutionFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {
@@ -387,7 +391,7 @@ class CollectiveOffersPublicPatchOfferTest:
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=providers_factories.ProviderFactory(), collectiveOffer__venue=venue
         )
 
         payload = {
@@ -429,12 +433,12 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         offerers_factories.VenueFactory(managingOfferer=offerer)
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
         )
 
         payload = {
@@ -476,10 +480,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
         )
 
         payload = {
@@ -500,13 +504,13 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer)
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory(isActive=False)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
             collectiveOffer__imageCredit="pouet",
             collectiveOffer__imageCrop={"crop_data": 12},
             collectiveOffer__venue=venue,
@@ -556,10 +560,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {"imageCredit": "a great artist", "imageFile": image_data.GOOD_IMAGE}
@@ -582,10 +586,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {"name": "pouet", "imageCredit": "a great artist", "imageFile": image_data.WRONG_IMAGE_SIZE}
@@ -609,10 +613,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
 
         payload = {"name": "pouet", "imageCredit": "a great artist", "imageFile": image_data.WRONG_IMAGE_TYPE}
@@ -636,10 +640,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # SETUP
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True, collectiveOffer__venue=venue
+            collectiveOffer__provider=api_key.provider, collectiveOffer__venue=venue
         )
         payload = {"imageCredit": "a great artist", "imageFile": image_data.GOOD_IMAGE}
         with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
@@ -668,11 +672,11 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         domain = educational_factories.EducationalDomainFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
             collectiveOffer__imageCredit="pouet",
             collectiveOffer__imageId="123456789",
             collectiveOffer__venue=venue,
@@ -699,11 +703,11 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         educational_institution = educational_factories.EducationalInstitutionFactory()
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
             collectiveOffer__imageCredit="pouet",
             collectiveOffer__imageId="123456789",
             collectiveOffer__venue=venue,
@@ -731,10 +735,10 @@ class CollectiveOffersPublicPatchOfferTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        api_key = offerers_factories.ApiKeyFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__isPublicApi=True,
+            collectiveOffer__provider=api_key.provider,
             collectiveOffer__imageCredit="pouet",
             collectiveOffer__imageId="123456789",
             collectiveOffer__venue=venue,

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_public_provider_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_public_provider_test.py
@@ -12,6 +12,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers import factories as provider_factories
 from pcapi.core.testing import override_features
+from pcapi.models.offer_mixin import OfferValidationStatus
 
 import tests
 from tests.routes import image_data
@@ -44,7 +45,7 @@ class CollectiveOffersPublicPatchOfferTest:
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -152,7 +153,6 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True,
             imageCredit="pouet",
             imageId="123456789",
             venue=venue,
@@ -192,7 +192,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -233,9 +233,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         educational_institution = educational_factories.EducationalInstitutionFactory()
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, venue=venue, provider=venue_provider.provider
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -263,10 +261,10 @@ class CollectiveOffersPublicPatchOfferTest:
         venue_provider = provider_factories.VenueProviderFactory()
         venue = offerers_factories.VenueFactory(venueProviders=[venue_provider])
 
-        offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
+        api_key = offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
 
         offer = educational_factories.CollectiveOfferFactory(
-            name="old_name", isPublicApi=False, venue=venue, provider=venue_provider.provider
+            validation=OfferValidationStatus.PENDING, name="old_name", venue=venue, provider=api_key.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -296,7 +294,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -331,7 +329,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         educational_institution = educational_factories.EducationalInstitutionFactory(institutionId="UAI123")
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -363,7 +361,7 @@ class CollectiveOffersPublicPatchOfferTest:
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         educational_institution = educational_factories.EducationalInstitutionFactory()
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -412,7 +410,7 @@ class CollectiveOffersPublicPatchOfferTest:
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -461,10 +459,7 @@ class CollectiveOffersPublicPatchOfferTest:
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True,
-            venue=venue,
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=provider_factories.ProviderFactory())
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -511,9 +506,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
 
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, venue=venue, provider=venue_provider.provider
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -542,7 +535,7 @@ class CollectiveOffersPublicPatchOfferTest:
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory(isActive=False)
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
+            imageCredit="pouet", imageId="123456789", venue=venue, provider=venue_provider.provider
         )
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
@@ -595,9 +588,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
 
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, venue=venue, provider=venue_provider.provider
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -625,9 +616,7 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
 
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, venue=venue, provider=venue_provider.provider
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -655,9 +644,7 @@ class CollectiveOffersPublicPatchOfferTest:
         venue = offerers_factories.VenueFactory(venueProviders=[venue_provider])
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, venue=venue, provider=venue_provider.provider
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -685,9 +672,7 @@ class CollectiveOffersPublicPatchOfferTest:
         venue = offerers_factories.VenueFactory(venueProviders=[venue_provider])
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
-        offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True, venue=venue, provider=venue_provider.provider
-        )
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(
             collectiveOffer=offer,
         )
@@ -724,7 +709,6 @@ class CollectiveOffersPublicPatchOfferTest:
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         domain = educational_factories.EducationalDomainFactory()
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True,
             imageCredit="pouet",
             imageId="123456789",
             venue=venue,
@@ -759,7 +743,6 @@ class CollectiveOffersPublicPatchOfferTest:
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         educational_institution = educational_factories.EducationalInstitutionFactory()
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True,
             venue=venue,
             imageId="123456789",
             imageCredit="pouet",
@@ -794,7 +777,6 @@ class CollectiveOffersPublicPatchOfferTest:
 
         offerers_factories.ApiKeyFactory(provider=venue_provider.provider)
         offer = educational_factories.CollectiveOfferFactory(
-            isPublicApi=True,
             imageCredit="pouet",
             imageId="123456789",
             venue=venue,

--- a/api/tests/routes/public/collective/endpoints/post_collective_offer_public_offerer_test.py
+++ b/api/tests/routes/public/collective/endpoints/post_collective_offer_public_offerer_test.py
@@ -9,6 +9,7 @@ from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.providers import factories as providers_factories
 from pcapi.core.testing import override_features
 
 import tests
@@ -36,7 +37,7 @@ class CollectiveOffersPublicPostOfferOffererTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        offerers_factories.ApiKeyFactory(offerer=offerer, provider=providers_factories.APIProviderFactory())
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory()
@@ -95,8 +96,8 @@ class CollectiveOffersPublicPostOfferOffererTest:
             "addressType": "offererVenue",
             "otherAddress": "",
         }
-        assert offer.isPublicApi is True
         assert offer.hasImage is True
+        assert offer.isPublicApi
         assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists()
 
     @override_features(ENABLE_PROVIDER_AUTHENTIFICATION=False)
@@ -158,7 +159,7 @@ class CollectiveOffersPublicPostOfferOffererTest:
         # Given
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer)
-        offerers_factories.ApiKeyFactory(offerer=offerer)
+        offerers_factories.ApiKeyFactory(offerer=offerer, provider=providers_factories.APIProviderFactory())
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         domain = educational_factories.EducationalDomainFactory()
         educational_institution = educational_factories.EducationalInstitutionFactory(institutionId="UAI123")
@@ -217,8 +218,8 @@ class CollectiveOffersPublicPostOfferOffererTest:
             "addressType": "offererVenue",
             "otherAddress": "",
         }
-        assert offer.isPublicApi is True
         assert offer.hasImage is True
+        assert offer.isPublicApi
         assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists()
 
     @override_features(ENABLE_PROVIDER_AUTHENTIFICATION=False)


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21550

## But de la pull request

Suppression de la colonne `isPublicApi` de `collective_offer` : il faut dorénavant utiliser `provider`/`providerId` (si présent, cela correspondait au cas `isPublicApi == True` et à `isPublicApi == False` sinon).

Deux commits : un premier pour nettoyer le code, un second pour la migration.

### Mise à jour

La colonne est supprimée et transformée en propriété car le front en a encore besoin. On considère donc `isPublicApi` vaut True si l'offre (collective) a un `providerId`.