### PR TITLE
(PC-22826)[PRO] fix: change duplicate template offer button wording

### DIFF
--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/DuplicateOfferCell.tsx
@@ -65,7 +65,7 @@ const DuplicateOfferCell = ({
         innerRef={buttonRef}
         hasTooltip
       >
-        Dupliquer
+        {isShowcase ? 'Créer une offre réservable' : 'Dupliquer'}
       </ListIconButton>
       {isModalOpen && shouldDisplayModal && (
         <DuplicateOfferDialog

--- a/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/Cells/DuplicateOfferCell/__specs__/DuplicateOfferCell.spec.tsx
@@ -81,11 +81,12 @@ describe('DuplicateOfferCell', () => {
   it('should close dialog when click on cancel button', async () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
-    const buttons = screen.getAllByRole('button', {
-      name: 'Dupliquer',
+
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable',
     })
 
-    await userEvent.click(buttons[0])
+    await userEvent.click(button)
 
     const modalCancelButton = screen.getByRole('button', {
       name: 'Annuler',
@@ -103,11 +104,11 @@ describe('DuplicateOfferCell', () => {
   it('should update local storage if user check option to not display modal again ', async () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
-    const buttons = screen.getAllByRole('button', {
-      name: 'Dupliquer',
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable',
     })
 
-    await userEvent.click(buttons[0])
+    await userEvent.click(button)
 
     const checkBox = screen.getByRole('checkbox', {
       name: 'Je ne souhaite plus voir cette information',
@@ -130,11 +131,11 @@ describe('DuplicateOfferCell', () => {
   it('should not update local storage if user does not check any option', async () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'false')
     renderDuplicateOfferCell()
-    const buttons = screen.getAllByRole('button', {
-      name: 'Dupliquer',
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable',
     })
 
-    await userEvent.click(buttons[0])
+    await userEvent.click(button)
 
     const modalConfirmButton = screen.getByRole('button', {
       name: 'Créer une offre réservable',
@@ -152,13 +153,13 @@ describe('DuplicateOfferCell', () => {
   it('should redirect to offer duplication if user has already check option to not display modal again', async () => {
     localStorage.setItem(LOCAL_STORAGE_HAS_SEEN_MODAL_KEY, 'true')
     renderDuplicateOfferCell()
-    const buttons = screen.getAllByRole('button', {
-      name: 'Dupliquer',
+    const button = screen.getByRole('button', {
+      name: 'Créer une offre réservable',
     })
 
     jest.spyOn(createFromTemplateUtils, 'createOfferFromTemplate')
 
-    await userEvent.click(buttons[0])
+    await userEvent.click(button)
 
     expect(createFromTemplateUtils.createOfferFromTemplate).toHaveBeenCalled()
   })
@@ -208,11 +209,11 @@ describe('DuplicateOfferCell', () => {
 
       renderDuplicateOfferCell()
 
-      const buttons = screen.getAllByRole('button', {
+      const button = screen.getByRole('button', {
         name: 'Dupliquer',
       })
 
-      await userEvent.click(buttons[1])
+      await userEvent.click(button)
 
       expect(api.duplicateCollectiveOffer).toHaveBeenCalledTimes(1)
 
@@ -226,11 +227,11 @@ describe('DuplicateOfferCell', () => {
 
       renderDuplicateOfferCell()
 
-      const buttons = screen.getAllByRole('button', {
+      const button = screen.getByRole('button', {
         name: 'Dupliquer',
       })
 
-      await userEvent.click(buttons[1])
+      await userEvent.click(button)
 
       const response = await getCollectiveOfferAdapter(offer.nonHumanizedId)
 
@@ -250,11 +251,11 @@ describe('DuplicateOfferCell', () => {
 
       renderDuplicateOfferCell()
 
-      const buttons = screen.getAllByRole('button', {
+      const button = screen.getByRole('button', {
         name: 'Dupliquer',
       })
 
-      await userEvent.click(buttons[1])
+      await userEvent.click(button)
 
       expect(notifyError).toHaveBeenCalledWith(
         'Une erreur est survenue lors de la création de votre offre'
@@ -275,11 +276,11 @@ describe('DuplicateOfferCell', () => {
 
       renderDuplicateOfferCell()
 
-      const buttons = screen.getAllByRole('button', {
+      const button = screen.getByRole('button', {
         name: 'Dupliquer',
       })
 
-      await userEvent.click(buttons[1])
+      await userEvent.click(button)
 
       expect(notifyError).toHaveBeenCalledWith(
         'Une ou plusieurs erreurs sont présentes dans le formulaire'
@@ -293,11 +294,11 @@ describe('DuplicateOfferCell', () => {
 
       renderDuplicateOfferCell()
 
-      const buttons = screen.getAllByRole('button', {
+      const button = screen.getByRole('button', {
         name: 'Dupliquer',
       })
 
-      await userEvent.click(buttons[1])
+      await userEvent.click(button)
 
       expect(notifyError).toHaveBeenNthCalledWith(1, GET_DATA_ERROR_MESSAGE)
     })

--- a/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
+++ b/pro/src/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.tsx
@@ -533,11 +533,11 @@ describe('src | components | pages | Offers | OfferItem', () => {
         renderOfferItem(props)
 
         const duplicateButton = screen.getByRole('button', {
-          name: 'Dupliquer',
+          name: 'Créer une offre réservable',
         })
         await userEvent.click(duplicateButton)
 
-        const modalTitle = screen.getAllByText('Dupliquer')
+        const modalTitle = screen.getAllByText('Créer une offre réservable')
         expect(modalTitle.length > 1).toBeTruthy()
       })
 
@@ -548,7 +548,7 @@ describe('src | components | pages | Offers | OfferItem', () => {
         renderOfferItem(props)
 
         const duplicateButton = screen.getByRole('button', {
-          name: 'Dupliquer',
+          name: 'Créer une offre réservable',
         })
         await userEvent.click(duplicateButton)
 


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22826

## But de la pull request

Changer le wording des boutons de duplication d'offre vitrine : 

Dupliquer -> Créer une offre réservable 

## Screen 

![Capture d’écran 2023-06-22 à 10 42 35](https://github.com/pass-culture/pass-culture-main/assets/71768799/92f3c91d-cb6a-47ac-a738-1d862109eeb2)