### PR TITLE
(BSR)[API] chore: set maximum pydantic version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -42,7 +42,7 @@ pgcli # a tool not used in code. There is no point in pinning its version
 phonenumberslite==8.12.*
 Pillow>=8.1.1
 psycopg2
-pydantic[email]
+pydantic[email]<2.0.0
 PyJWT[crypto]==2.6.0
 pylint
 pylint-pydantic


### PR DESCRIPTION
## But de la pull request

Fixer la version  de pydantic à <2.0.0