### PR TITLE
(PC-21219)[API] fix: manage venues indexing when batch edited

### DIFF
--- a/api/src/pcapi/admin/custom_views/venue_view.py
+++ b/api/src/pcapi/admin/custom_views/venue_view.py
@@ -410,14 +410,7 @@ class VenueView(BaseAdminView):
             criteria_ids = [crit.id for crit in criteria]
             criteria_api.VenueUpdate(venue_ids, criteria_ids, replace_tags=remove_other_tags).run()
 
-            # Immediately index venues if tags (criteria) are involved:
-            # tags are used by other tools (eg. building playlists for the
-            # home page) and waiting N minutes for the next indexing
-            # cron tasks is painful.
-            if criteria or remove_other_tags:
-                search.reindex_venue_ids(venue_ids)
-            else:
-                search.async_index_venue_ids(venue_ids)
+            search.async_index_venue_ids(venue_ids)
 
             db.session.commit()
             return redirect(url)

--- a/api/tests/routes/backoffice_v3/venues_test.py
+++ b/api/tests/routes/backoffice_v3/venues_test.py
@@ -1317,7 +1317,15 @@ class BatchEditVenuesTest(PostEndpointHelper):
         assert venue.isPermanent is is_permanent  # unchanged
 
     @pytest.mark.parametrize("set_permanent", [True, False])
-    def test_batch_edit_venues(self, legit_user, authenticated_client, criteria, set_permanent):
+    @patch("pcapi.core.search.async_index_venue_ids")
+    def test_batch_edit_venues(
+        self,
+        mock_async_index_venue_ids,
+        legit_user,
+        authenticated_client,
+        criteria,
+        set_permanent,
+    ):
         new_criterion = criteria_factories.CriterionFactory()
         venues = [
             offerers_factories.VenueFactory(criteria=criteria[:2], isPermanent=set_permanent),
@@ -1339,3 +1347,5 @@ class BatchEditVenuesTest(PostEndpointHelper):
 
         assert set(venues[1].criteria) == {criteria[0], criteria[2], new_criterion}  # 1 kept, 1 added
         assert venues[1].isPermanent is set_permanent
+
+        mock_async_index_venue_ids.assert_called_once()


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-21219

## But de la pull request

Corriger les problèmes d'indexation des lieu lors d'une édition par lot

## Implémentation

- désindexation des lieux passés en non-permanent lors d'une édition par lot sur FlaskAdmin
- désindexation des lieux passés en non-permanent lors d'une édition par lot sur le backoffice v3
- indexation des lieux passés en permanent lors d'une édition par lot sur le backoffice v3

## Informations supplémentaires

RAS

## Modifications du schéma de la base de données

RAS

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
