### PR TITLE
(PC-22940)[API] fix: eac: create redactor if missing

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -38,9 +38,7 @@ logger = logging.getLogger(__name__)
 def book_collective_offer(
     redactor_informations: RedactorInformation, stock_id: int
 ) -> educational_models.CollectiveBooking:
-    redactor = educational_repository.find_redactor_by_email(redactor_informations.email)
-    if not redactor:
-        redactor = _create_redactor(redactor_informations)
+    redactor = educational_repository.find_or_create_redactor(redactor_informations)
 
     educational_institution = educational_repository.find_educational_institution_by_uai_code(redactor_informations.uai)
     if not educational_institution:
@@ -329,17 +327,6 @@ def notify_pro_pending_booking_confirmation_limit_in_3_days() -> None:
                 "Could not notify offerer three days before booking confirmation limit date",
                 extra={"collectiveBooking": booking.id},
             )
-
-
-def _create_redactor(redactor_informations: RedactorInformation) -> educational_models.EducationalRedactor:
-    redactor = educational_models.EducationalRedactor(
-        email=redactor_informations.email,
-        firstName=redactor_informations.firstname,
-        lastName=redactor_informations.lastname,
-        civility=redactor_informations.civility,
-    )
-    repository.save(redactor)
-    return redactor
 
 
 def _cancel_collective_booking(

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -22,6 +22,8 @@ from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models import offer_mixin
 from pcapi.models.feature import FeatureToggle
+from pcapi.repository import repository
+from pcapi.routes.adage_iframe.serialization.adage_authentication import RedactorInformation
 from pcapi.utils.clean_accents import clean_accents
 
 
@@ -242,6 +244,22 @@ def find_redactor_by_email(redactor_email: str) -> educational_models.Educationa
     return educational_models.EducationalRedactor.query.filter(
         educational_models.EducationalRedactor.email == redactor_email
     ).one_or_none()
+
+
+def find_or_create_redactor(information: RedactorInformation) -> educational_models.EducationalRedactor:
+    redactor = find_redactor_by_email(information.email)
+    if redactor:
+        return redactor
+
+    redactor = educational_models.EducationalRedactor(
+        email=information.email,
+        firstName=information.firstname,
+        lastName=information.lastname,
+        civility=information.civility,
+    )
+
+    repository.save(redactor)
+    return redactor
 
 
 def find_active_collective_booking_by_offer_id(

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -426,10 +426,9 @@ class TestClient:
         }
         return self
 
-    def with_adage_token(self, email: str, uai: str) -> "TestClient":
+    def with_adage_token(self, email: str, uai: str, **redactor_information) -> "TestClient":
         adage_jwt_fake_valid_token = create_adage_valid_token_with_email(
-            email=email,
-            uai=uai,
+            email=email, uai=uai, **{k: v for k, v in redactor_information.items() if v}
         )
         self.auth_header = {
             "Authorization": f"Bearer {adage_jwt_fake_valid_token}",


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22940

## But de la pull request

Fix : créer un rédacteur lorsque celui-ci est manquant. Ceci ne doit se faire qu'au cas par cas. Ici, lors de la création d'une demande de contact au sujet d'une offre collective.

## Au passage

1. fusionner les deux classes de tests (Return200/Return400), c'est ce qui se fait ailleurs;
2. renommer le fichier de test pour quelque chose de plus standard et commun au reste des tests de l'api.