### PR TITLE
(PC-22962)[PRO] fix: remove special char from algolia user token

### DIFF
--- a/pro/src/pages/AdageIframe/app/App.tsx
+++ b/pro/src/pages/AdageIframe/app/App.tsx
@@ -89,7 +89,8 @@ export const App = (): JSX.Element => {
   const uniqueId = useId()
   const isNewHeaderActive = useActiveFeature('WIP_ENABLE_NEW_ADAGE_HEADER')
   useEffect(() => {
-    initAlgoliaAnalytics(uniqueId)
+    // User token can not contains special characters
+    initAlgoliaAnalytics(uniqueId.replace(/[\W_]/g, '_'))
   }, [])
 
   if (isLoading) {


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22962

## But de la pull request

Fix la façon de générer le token Algolia pour les utilisateurs. Ce token ne doit pas contenir de caractères spéciaux. 

Note : à priori useId wrap un id alphanumérique entre les caractères `:` c'est donc le seul caractère qui devrait être remplacé en pratique 