### PR TITLE
(PC-22926)[PRO] fix: use password input preview message

### DIFF
--- a/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
@@ -27,6 +27,7 @@ const ChangePasswordForm = ({ onSubmit }: IChangePasswordForm): JSX.Element => {
                 <PasswordInput
                   label="Nouveau mot de passe"
                   name="newPasswordValue"
+                  withErrorPreview
                 />
               </FormLayout.Row>
               <SubmitButton isLoading={formik.isSubmitting}>

--- a/pro/src/pages/ResetPassword/ChangePasswordForm/validationSchema.ts
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/validationSchema.ts
@@ -1,17 +1,18 @@
 import * as yup from 'yup'
 
-import { isPasswordValid } from 'core/shared/utils/validation'
-
-const passwordErrorMessage = `Votre mot de passe doit contenir au moins :
-      - 12 caractères
-      - Un chiffre
-      - Une majuscule et une minuscule
-      - Un caractère spécial
-`
+import { passwordValidationStatus } from 'core/shared/utils/validation'
 
 export const validationSchema = yup.object().shape({
   newPasswordValue: yup
     .string()
     .required('Veuillez renseigner un mot de passe')
-    .test('isPasswordValid', passwordErrorMessage, isPasswordValid),
+    .test(
+      'isPasswordValid',
+      'Veuillez renseigner un mot de passe valide avec : ',
+      paswordValue => {
+        const errors = passwordValidationStatus(paswordValue)
+        const hasError = Object.values(errors).some(e => e === true)
+        return !hasError
+      }
+    ),
 })


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22926

## But de la pull request

- Utiliser le même message de validation
 
## Implémentation

![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/75c06c9e-e419-41f3-8cc4-2daaa001a515)
![image](https://github.com/pass-culture/pass-culture-main/assets/106379750/cca10ad3-3d28-4abf-b9ab-bee546deea90)

## Checklist :

- [ ] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
