### PR TITLE
(BSR)[API] ci: Show diff in GitHub Action if API client must be updated.

### DIFF
--- a/.github/workflows/update-api-client-template.yml
+++ b/.github/workflows/update-api-client-template.yml
@@ -109,7 +109,11 @@ jobs:
         if: steps.evaluate-variables.outputs.should-run-cache == 'true'
         id: changes
         run: |
-          if ! [[ -z "$(git status --porcelain $STATUS_ARGS $PATHSPEC)" ]];
+            diff="$(git diff)"
+            if [[ "${diff}" != "" ]];
             then
-              exit 1
+                echo "Found changes in the API."
+                echo "${diff}" | awk '{ print "\t" $0 }'
+                echo "Please run 'yarn generate:api:client:local' and add the changes to the commit(s) that change the API."
+                exit 1
             fi


### PR DESCRIPTION
Rendu ([visible ici](https://github.com/pass-culture/pass-culture-main/actions/runs/5376741422/jobs/9754305650?pr=7048) pour cette PR) : 

![Screenshot 2023-06-26 at 12-05-47 (BSR) API ci Show diff in GitHub Action if API client must be updated  · pass-culture_pass-culture-main@5fa687c](https://github.com/pass-culture/pass-culture-main/assets/471321/86aef295-7e29-40a9-bc1f-9e290a29264a)

