### PR TITLE
PC-22580 update 'change email' confirmation checks order

### DIFF
--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -157,13 +157,13 @@ def cancel_email_update_request(token: str) -> None:
     user = users_repository.find_user_by_email(current_email)
     if not user:
         raise exceptions.InvalidEmailError()
-    check_and_expire_token(user, token, TokenType.CONFIRMATION)
-    with transaction():
-        models.UserEmailHistory.build_cancellation(user, new_email)
-        api.suspend_account(
-            user, constants.SuspensionReason.FRAUD_SUSPICION, user, "Suspension suite à un changement d'email annulé"
-        )
-        transactional_mails.send_email_update_cancellation_email(user)
+    _check_token(user, token, TokenType.CONFIRMATION)
+    api.suspend_account(
+        user, constants.SuspensionReason.FRAUD_SUSPICION, user, "Suspension suite à un changement d'email annulé"
+    )
+    transactional_mails.send_email_update_cancellation_email(user)
+    models.UserEmailHistory.build_cancellation(user, new_email)
+    _expire_token(user, TokenType.CONFIRMATION)
 
 
 def request_email_update_from_pro(user: models.User, email: str, password: str) -> None:

--- a/api/tests/core/users/email/test_update.py
+++ b/api/tests/core/users/email/test_update.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pcapi.core.users import factories as users_factories
-from pcapi.core.users.email.update import request_email_update
+import pcapi.core.users.email.update as email_update
 from pcapi.core.users.models import EmailHistoryEventTypeEnum
 from pcapi.core.users.models import User
 
@@ -9,19 +9,20 @@ from pcapi.core.users.models import User
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-def test_request_email_update_history():
-    old_email = "py@test.com"
-    password = "p@ssword"
-    user = users_factories.UserFactory(email=old_email, password=password)
-    new_email = "pypy@test.com"
+class RequestEmailUpdateTest:
+    def test_request_email_update_history(self):
+        old_email = "py@test.com"
+        password = "p@ssword"
+        user = users_factories.UserFactory(email=old_email, password=password)
+        new_email = "pypy@test.com"
 
-    request_email_update(user, new_email, password)
+        email_update.request_email_update(user, new_email, password)
 
-    reloaded_user = User.query.get(user.id)
-    assert len(reloaded_user.email_history) == 1
+        reloaded_user = User.query.get(user.id)
+        assert len(reloaded_user.email_history) == 1
 
-    history = reloaded_user.email_history[0]
-    assert history.oldEmail == old_email
-    assert history.newEmail == new_email
-    assert history.eventType == EmailHistoryEventTypeEnum.UPDATE_REQUEST
-    assert history.id is not None
+        history = reloaded_user.email_history[0]
+        assert history.oldEmail == old_email
+        assert history.newEmail == new_email
+        assert history.eventType == EmailHistoryEventTypeEnum.UPDATE_REQUEST
+        assert history.id is not None

--- a/api/tests/core/users/email/test_update.py
+++ b/api/tests/core/users/email/test_update.py
@@ -1,12 +1,33 @@
-import pytest
+import dataclasses
+import datetime
+from unittest.mock import patch
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from pcapi.core.mails import testing as mails_testing
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.users import factories as users_factories
+import pcapi.core.users.constants as users_constants
 import pcapi.core.users.email.update as email_update
+import pcapi.core.users.exceptions as users_exceptions
 from pcapi.core.users.models import EmailHistoryEventTypeEnum
 from pcapi.core.users.models import User
+from pcapi.core.users.utils import encode_jwt_payload
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def _initialize_token(user, app, new_email):
+    expiration_date = datetime.datetime.utcnow() + users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
+    token = encode_jwt_payload({"current_email": user.email, "new_email": new_email}, expiration_date)
+    app.redis_client.set(
+        email_update.get_token_key(user, email_update.TokenType.CONFIRMATION),
+        token,
+        ex=users_constants.EMAIL_CHANGE_TOKEN_LIFE_TIME,
+    )
+    return token
 
 
 class RequestEmailUpdateTest:
@@ -26,3 +47,102 @@ class RequestEmailUpdateTest:
         assert history.newEmail == new_email
         assert history.eventType == EmailHistoryEventTypeEnum.UPDATE_REQUEST
         assert history.id is not None
+
+
+class EmailUpdateConfirmationTest:
+    def test_email_update_confirmation(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
+        token = _initialize_token(user, app, email_update_request.newEmail)
+
+        # When
+        email_update.confirm_email_update_request(token)
+
+        # Then
+        # Email history is updated
+        email_history = user.email_history
+        assert len(email_history) == 2
+        assert email_history[0].eventType == EmailHistoryEventTypeEnum.UPDATE_REQUEST
+        assert email_history[1].eventType == EmailHistoryEventTypeEnum.CONFIRMATION
+
+        # Confirmation email is sent
+        assert len(mails_testing.outbox) == 1
+        email_sent = mails_testing.outbox[0]
+        assert email_sent.sent_data["To"] == email_update_request.newEmail
+        assert email_sent.sent_data["template"] == dataclasses.asdict(
+            TransactionalEmail.EMAIL_CHANGE_CONFIRMATION.value
+        )
+
+        # Token is deleted
+        assert app.redis_client.get(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)) is None
+
+    def test_update_email_confirmation_with_invalid_token(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        email_update_request = users_factories.EmailUpdateEntryFactory(user=user)  # existing confirmation token
+        _initialize_token(user, app, email_update_request.newEmail)
+        invalid_token = encode_jwt_payload({"current_email": user.email, "new_email": "new@e.mail"})
+
+        # When
+        with pytest.raises(users_exceptions.InvalidToken):
+            email_update.confirm_email_update_request(invalid_token)
+
+        # Then
+        # Email history is not updated
+        email_history = user.email_history
+        assert len(email_history) == 1
+        assert email_history[0].eventType == EmailHistoryEventTypeEnum.UPDATE_REQUEST
+
+        # Confirmation email is not sent
+        assert len(mails_testing.outbox) == 0
+
+        # Token is not deleted
+        assert app.redis_client.get(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)) is not None
+
+    def test_update_email_confirmation_email_already_exists(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
+        token = _initialize_token(user, app, email_update_request.newEmail)
+        users_factories.UserFactory(email=email_update_request.newEmail)
+
+        # When
+        with pytest.raises(users_exceptions.EmailExistsError):
+            email_update.confirm_email_update_request(token)
+
+        # Then
+        # Email history is not updated
+        email_history = user.email_history
+        assert len(email_history) == 1
+        assert email_history[0].eventType == EmailHistoryEventTypeEnum.UPDATE_REQUEST
+
+        # Confirmation email is not sent
+        assert len(mails_testing.outbox) == 0
+
+        # Token is not deleted
+        assert app.redis_client.get(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)) is not None
+
+    def test_update_email_confirmation_update_history_failed(self, app):
+        # Given
+        user = users_factories.UserFactory()
+        email_update_request = users_factories.EmailUpdateEntryFactory(user=user)
+        token = _initialize_token(user, app, email_update_request.newEmail)
+
+        with pytest.raises(Exception):
+            with patch(
+                "pcapi.core.users.models.UserEmailHistory.build_confirmation",
+                side_effect=IntegrityError(statement="", params=(), orig=None),
+            ):
+                email_update.confirm_email_update_request(token)
+
+        # Then
+        # Email history is not updated
+        email_history = user.email_history
+        assert len(email_history) == 1
+
+        # Confirmation email is already sent
+        assert len(mails_testing.outbox) == 1
+
+        # Token is not deleted
+        assert app.redis_client.get(email_update.get_token_key(user, email_update.TokenType.CONFIRMATION)) is not None


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22580

## But de la pull request

Suite à un BPMN, on corrige l'ordre des vérifications (token, email, etc) pour que ce soit cohérent pour le front et les utilisateurs
En cas de fail, on gère mieux le retry car les token ne sont expirés qu'en cas de succès

## Implémentation

- CF strat tech du ticket

## Informations supplémentaires

- None

## Modifications du schéma de la base de données

- None

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [x] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
