### PR TITLE
(PC-22994)[API] fix: eac: collective api: providers not offerers

### DIFF
--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -184,3 +184,7 @@ def is_external_ticket_applicable(offer: offers_models.Offer) -> bool:
         and offer.lastProviderId
         and db.session.query(get_cinema_venue_provider_query(offer.venueId).exists()).scalar()
     )
+
+
+def get_providers_venues(provider_id: int) -> BaseQuery:
+    return Venue.query.join(models.VenueProvider).filter(models.VenueProvider.providerId == provider_id)

--- a/api/src/pcapi/routes/public/collective/endpoints/venues.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/venues.py
@@ -1,6 +1,8 @@
 from typing import cast
 
 from pcapi.core.offerers import repository as offerers_repository
+from pcapi.core.providers import repository as providers_repository
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.public import blueprints
 from pcapi.routes.public.collective.serialization import offers as offers_serialization
 from pcapi.routes.public.collective.serialization import venues as venues_serialization
@@ -33,12 +35,14 @@ from pcapi.validation.routes.users_authentifications import current_api_key
 @api_key_required
 def list_venues() -> venues_serialization.CollectiveOffersListVenuesResponseModel:
     # in French, to be used by Swagger for the API documentation
-    """Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.
+    """Récupération de la liste des lieux associés au fournisseur authentifiée par le jeton d'API.
 
     Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.
     """
-    offerer_id = current_api_key.offererId
-    venues = offerers_repository.get_all_venues_by_offerer_id(offerer_id)
+    if FeatureToggle.ENABLE_PROVIDER_AUTHENTIFICATION.is_active():
+        venues = providers_repository.get_providers_venues(current_api_key.providerId)
+    else:
+        venues = offerers_repository.get_all_venues_by_offerer_id(current_api_key.offererId)
 
     return venues_serialization.CollectiveOffersListVenuesResponseModel(
         __root__=[venues_serialization.CollectiveOffersVenueResponseModel.from_orm(venue) for venue in venues]

--- a/api/tests/routes/public/blueprint_v2_openapi_test.py
+++ b/api/tests/routes/public/blueprint_v2_openapi_test.py
@@ -1174,7 +1174,7 @@ def test_public_api(client, app):
                         },
                     },
                     "security": [{"ApiKeyAuth": []}],
-                    "summary": "Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.",
+                    "summary": "Récupération de la liste des lieux associés au fournisseur authentifiée par le jeton d'API.",
                     "tags": ["API offres collectives BETA"],
                 }
             },

--- a/pro/src/apiClient/v2/services/ApiOffresCollectivesBetaService.ts
+++ b/pro/src/apiClient/v2/services/ApiOffresCollectivesBetaService.ts
@@ -236,7 +236,7 @@ export class ApiOffresCollectivesBetaService {
   }
 
   /**
-   * Récupération de la liste des lieux associés à la structure authentifiée par le jeton d'API.
+   * Récupération de la liste des lieux associés au fournisseur authentifiée par le jeton d'API.
    * Tous les lieux enregistrés, sont listés ici avec leurs coordonnées.
    * @returns CollectiveOffersListVenuesResponseModel La liste des lieux ou vous pouvez créer une offre.
    * @throws ApiError


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22994

## But de la pull request

Fix : récupérer les lieux depuis l'API collective doit maintenant se faire en se basant sur le fournisseur (_provider_) et non plus sur la structure (_offerer_).

Ce changement se fait via un FF, comme pour les offres.