### PR TITLE
(PC-22981)[API] fix: correct collective offers labels

### DIFF
--- a/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice_v3/templates/collective_offer/details.html
@@ -43,10 +43,10 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">État :</span> {{ collective_offer.status | format_offer_status }}
+                  <span class="fw-bold">Statut :</span> {{ collective_offer.status | format_offer_status }}
                 </p>
                 <p class="mb-1">
-                  <span class="fw-bold">Conformité :</span> {{ collective_offer.validation | format_offer_validation_status }}
+                  <span class="fw-bold">État :</span> {{ collective_offer.validation | format_offer_validation_status }}
                 </p>
                 <p class="mb-1">
                   <span class="fw-bold">Prix :</span>

--- a/api/tests/routes/backoffice_v3/collective_offers_test.py
+++ b/api/tests/routes/backoffice_v3/collective_offers_test.py
@@ -522,8 +522,11 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             response = authenticated_client.get(url)
 
         # then
+        content_as_text = html_parser.content_as_text(response.data)
         assert response.status_code == 200
-        assert "Ajuster le prix de l'offre" in response.data.decode()
+        assert "Ajuster le prix de l'offre" in content_as_text
+        assert "Statut : Expirée" in content_as_text
+        assert "État : Validée" in content_as_text
 
     def test_processed_pricing(self, legit_user, authenticated_client):
         # when


### PR DESCRIPTION
Lien vers le ticket Jira : https://passculture.atlassian.net/browse/PC-22981

## But de la pull request

En tant que PM
J'aimerais changer le nom des champs sur les offres collectives
Afin de homogéiniser avec les offres indiv


## Implémentation

Dans une offre collective remplacer “etat” par “statut et “conformité” et “état”

## Informations supplémentaires

![image](https://github.com/pass-culture/pass-culture-main/assets/77674046/96001379-6309-4d14-9d7b-46c69508e7df)


## Modifications du schéma de la base de données

NA

## Checklist :

- [x] La branche est bien nommée et les commits réfèrent le ticket Jira
  - Branche : `pc-XXX-whatever-describe-the-branch`
  - PR : `(PC-XXX) Description rapide de l' US`
  - Commit(s) : `(PC-XXX)[PRO|API|…] description rapide du ticket`
- [x] J'ai écrit les tests nécessaires
- [ ] J'ai relu attentivement les migrations, en particulier pour éviter les _locks_
- [ ] J'ai mis à jour la **sandbox** afin que le développement ou la recette soient facilités
- [ ] J'ai tenté d'améliorer la dette technique (BSR, déplacement de modèles dans `pcapi.core`, etc)
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques (ex: Admin)
