### PR TITLE
(PC-23002)[API] feat: Expose Flask metrics to Prometheus

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -42,6 +42,8 @@ FROM python:3.10-slim AS lib
 RUN useradd -rm -d /home/pcapi -u 1000 pcapi
 
 ENV PATH=$PATH:/home/pcapi/.local/bin
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV FLASK_PROMETHEUS_EXPORTER_PORT 5002
 
 RUN apt-get update \
 	&& apt-get --no-install-recommends -y install \

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -11,4 +11,5 @@ exec gunicorn \
     --threads $GUNICORN_THREADS \
     --timeout $GUNICORN_TIMEOUT \
     --log-level $GUNICORN_LOG_LEVEL \
+    --config gunicorn.conf.py \
     ${GUNICORN_FLASK_APP:-pcapi.app:app}

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -1,0 +1,17 @@
+import os
+
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
+
+
+FLASK_PROMETHEUS_EXPORTER_PORT = int(os.environ.get("FLASK_PROMETHEUS_EXPORTER_PORT", "5002"))
+
+
+def when_ready(server):
+    if int(os.environ.get("ENABLE_FLASK_PROMETHEUS_EXPORTER", "0")):
+        GunicornPrometheusMetrics.start_http_server_when_ready(FLASK_PROMETHEUS_EXPORTER_PORT)
+        print(f"started Prometheus export server on port {FLASK_PROMETHEUS_EXPORTER_PORT}")
+
+
+def child_exit(server, worker):
+    if int(os.environ.get("ENABLE_FLASK_PROMETHEUS_EXPORTER", "0")):
+        GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -41,6 +41,7 @@ openpyxl
 pgcli # a tool not used in code. There is no point in pinning its version
 phonenumberslite==8.12.*
 Pillow>=8.1.1
+prometheus-flask-exporter
 psycopg2
 pydantic[email]<2.0.0
 PyJWT[crypto]==2.6.0

--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -4,6 +4,7 @@ from sentry_sdk import set_tag
 
 from pcapi import settings
 from pcapi.flask_app import app
+from pcapi.flask_app import setup_metrics
 
 
 app.config["SESSION_COOKIE_HTTPONLY"] = True
@@ -28,6 +29,8 @@ with app.app_context():
     import pcapi.utils.login_manager
 
     install_all_routes(app)
+
+    setup_metrics(app)
 
 
 if __name__ == "__main__":

--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -11,6 +11,7 @@ from sentry_sdk import set_tag
 
 from pcapi import settings
 from pcapi.flask_app import app
+from pcapi.flask_app import setup_metrics
 from pcapi.routes.backoffice_v3.scss import preprocess_scss
 
 
@@ -53,6 +54,8 @@ with app.app_context():
     app.register_blueprint(backoffice_v3_web, url_prefix="/")
 
     app.generate_error_response = generate_error_response  # type: ignore [attr-defined]
+
+    setup_metrics(app)
 
 
 if __name__ == "__main__":

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import time
 
@@ -12,6 +13,7 @@ from flask.logging import default_handler
 import flask.wrappers
 from flask_login import LoginManager
 from flask_login import current_user
+import prometheus_flask_exporter.multiprocess
 import redis
 import sentry_sdk
 from sqlalchemy import orm
@@ -42,6 +44,16 @@ init_sentry_sdk()
 
 
 app = Flask(__name__, static_url_path="/static")
+
+
+def setup_metrics(app_: Flask) -> None:
+    if not int(os.environ.get("ENABLE_FLASK_PROMETHEUS_EXPORTER", "0")):
+        return
+    prometheus_flask_exporter.multiprocess.GunicornPrometheusMetrics(
+        app_,
+        group_by="url_rule",
+    )
+    # An external export server is started by Gunicorn, see `gunicorn.conf.py`.
 
 
 # These `before_request()` and `after_request()` callbacks must be


### PR DESCRIPTION
Metrics are gathered by Flask through the `prometheus_flask_exporter`
library. For now, we gather the following basic metrics about HTTP
requests:

- request duration;
- number of requests;
- number of uncaught exceptions.

Labels are: HTTP method, URL route (e.g. `/venues/<id>` with literal
`<id>` to aggregate calls to this route for all venues) and HTTP
response code. These metrics and labels will probably be tweaked
later.

These metrics are exported by a server that is started by Gunicorn.
Port defaults to 5002.

All features (metrics gathering and export server) are controlled by
the `ENABLE_FLASK_PROMETHEUS_EXPORTER` environment variable. It is off
by default.