### PR TITLE
(PC-23002)[API] build: Bump chart version on perf to 0.21.8

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -33,4 +33,4 @@ environments:
       - chartVersion: 0.21.7
   perf:
     values:
-      - chartVersion: 0.21.7
+      - chartVersion: 0.21.8


### PR DESCRIPTION
This chart version enables a new port for Prometheus metrics.